### PR TITLE
fix(glossary): address Crowdin live glossary Codex review

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.shared.ts
@@ -24,7 +24,7 @@ import type { ApiAuthContext } from "@/api/auth/workos";
 import { hasCapability } from "@/api/auth/policy";
 import { db, schema } from "@/lib/database";
 import type { Glossary as GlossaryRecord } from "@/lib/database/types";
-import { listTmsProviderLiveGlossaries } from "@/lib/providers/jobs/tms-provider-live";
+import { getTmsProviderLiveGlossary } from "@/lib/providers/jobs/tms-provider-live";
 import { parseLiveProviderGlossaryId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 export function invalidGlossaryPayloadResponse(c: { json: JsonContext["json"] }) {
@@ -74,11 +74,13 @@ export async function ownedGlossaryWhere(auth: ApiAuthContext, glossaryId: strin
 export async function getOwnedGlossary(auth: ApiAuthContext, glossaryId: string) {
   const liveId = parseLiveProviderGlossaryId(glossaryId);
   if (liveId?.providerKind === "crowdin") {
-    const liveGlossary = (
-      await listTmsProviderLiveGlossaries(auth.organization.localOrganizationId, {
+    const liveGlossary = await getTmsProviderLiveGlossary(
+      auth.organization.localOrganizationId,
+      glossaryId,
+      {
         actorUserId: auth.user.localUserId,
-      })
-    ).find((candidate) => candidate.id === glossaryId);
+      },
+    );
     if (!liveGlossary) return null;
 
     const now = new Date();

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-language.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-language.test.ts
@@ -55,9 +55,9 @@ describe("Crowdin glossary language mapping", () => {
     expect(toNativeGlossaryLocale("fr")).toBe("fr-FR");
   });
 
-  it("rejects unsupported locales", () => {
-    expect(() => toCrowdinGlossaryLanguageId("xx-XX")).toThrow(
-      "unsupported_crowdin_language:xx-XX",
-    );
+  it("passes through Crowdin custom language IDs and unknown locales", () => {
+    expect(toCrowdinGlossaryLanguageId("xx-XX")).toBe("xx-XX");
+    expect(toCrowdinGlossaryLanguageId("brand-voice")).toBe("brand-voice");
+    expect(toNativeGlossaryLocale("brand-voice", ["en-US", "brand-voice"])).toBe("brand-voice");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-language.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-language.ts
@@ -4149,7 +4149,9 @@ export function toCrowdinGlossaryLanguageId(locale: string): string {
   if (genericMatch) return genericMatch.id;
   if (baseMatches.length === 1) return baseMatches[0].id;
 
-  throw new Error(`unsupported_crowdin_language:${locale}`);
+  // Custom Crowdin language IDs are absent from the built-in catalog.
+  // Pass them through so glossary mutations and concordance keep working.
+  return normalized;
 }
 
 export function toNativeGlossaryLocale(
@@ -4157,13 +4159,9 @@ export function toNativeGlossaryLocale(
   preferredLocales: readonly string[] = [],
 ) {
   const normalizedId = languageId.trim().toLowerCase();
-  const preferred = preferredLocales.find((locale) => {
-    try {
-      return toCrowdinGlossaryLanguageId(locale).toLowerCase() === normalizedId;
-    } catch {
-      return false;
-    }
-  });
+  const preferred = preferredLocales.find(
+    (locale) => toCrowdinGlossaryLanguageId(locale).toLowerCase() === normalizedId,
+  );
   if (preferred) return preferred;
 
   return crowdinByNormalizedId.get(normalizedId)?.locale ?? languageId;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -611,4 +611,117 @@ describe("Crowdin live glossary concepts", () => {
       ],
     ]);
   });
+
+  it("filters Crowdin glossaries by project before paginating", async () => {
+    const glossaryPayload = (
+      id: number,
+      projectIds: number[],
+      defaultProjectIds: number[] = [],
+    ) => ({
+      data: {
+        id,
+        name: `Glossary ${id}`,
+        description: null,
+        languageId: "en",
+        languageIds: ["en", "fr"],
+        terms: 4,
+        projectIds,
+        defaultProjectIds,
+        webUrl: `https://crowdin.test/glossary/${id}`,
+      },
+    });
+
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url).replace("https://api.crowdin.test/api/v2", "");
+
+      if (path === "/user") {
+        return new Response(JSON.stringify({ data: { id: 99 } }), { status: 200 });
+      }
+
+      if (path.startsWith("/glossaries?")) {
+        const offset = Number(new URL(`https://api.crowdin.test${path}`).searchParams.get("offset"));
+        const glossaries =
+          offset === 0
+            ? [
+                glossaryPayload(2, [42]),
+                ...Array.from({ length: 24 }, (_, index) => glossaryPayload(100 + index, [99])),
+              ]
+            : [glossaryPayload(3, [], [42]), glossaryPayload(4, [42])];
+
+        return new Response(JSON.stringify({ data: glossaries }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected Crowdin request: ${path}`);
+    }) as unknown as typeof fetch;
+
+    const firstPage = await crowdinTmsProvider.fetchGlossariesPage({
+      organizationId: "organization-1",
+      credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+      secretMaterial: "test-token",
+      fetchFn: fetchMock,
+      projectId: "42",
+      limit: 2,
+      offset: 0,
+    });
+
+    expect(firstPage.glossaries.map((glossary) => glossary.externalGlossaryId)).toEqual(["2", "3"]);
+    expect(firstPage).toMatchObject({ offset: 0, limit: 2, hasMore: true });
+
+    const secondPage = await crowdinTmsProvider.fetchGlossariesPage({
+      organizationId: "organization-1",
+      credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+      secretMaterial: "test-token",
+      fetchFn: fetchMock,
+      projectId: "42",
+      limit: 2,
+      offset: 2,
+    });
+
+    expect(secondPage.glossaries.map((glossary) => glossary.externalGlossaryId)).toEqual(["4"]);
+    expect(secondPage).toMatchObject({ offset: 2, limit: 2, hasMore: false });
+  });
+
+  it("loads a live Crowdin glossary by id without listing the account", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url).replace("https://api.crowdin.test/api/v2", "");
+      if (path === "/glossaries/31") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 31,
+              name: "Page two glossary",
+              description: "Beyond the first page",
+              languageId: "en",
+              languageIds: ["en", "vi"],
+              terms: 8,
+              projectIds: [42],
+              defaultProjectIds: [],
+              webUrl: "https://crowdin.test/glossary/31",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      throw new Error(`Unexpected Crowdin request: ${path}`);
+    }) as unknown as typeof fetch;
+
+    const glossary = await crowdinTmsProvider.fetchLiveGlossaryMetadata(
+      {
+        organizationId: "organization-1",
+        credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+        secretMaterial: "test-token",
+        fetchFn: fetchMock,
+      },
+      31,
+    );
+
+    expect(glossary).toMatchObject({
+      externalGlossaryId: "31",
+      name: "Page two glossary",
+      sourceLocale: "en-US",
+      externalProjectIds: ["42"],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -639,7 +639,9 @@ describe("Crowdin live glossary concepts", () => {
       }
 
       if (path.startsWith("/glossaries?")) {
-        const offset = Number(new URL(`https://api.crowdin.test${path}`).searchParams.get("offset"));
+        const offset = Number(
+          new URL(`https://api.crowdin.test${path}`).searchParams.get("offset"),
+        );
         const glossaries =
           offset === 0
             ? [
@@ -719,7 +721,7 @@ describe("Crowdin live glossary concepts", () => {
     expect(glossary).toMatchObject({
       externalGlossaryId: "31",
       name: "Page two glossary",
-      sourceLocale: "en-US",
+      sourceLocale: "en",
       externalProjectIds: ["42"],
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -32,6 +32,7 @@ import {
   providerSourcePath,
 } from "@/lib/providers/adapters/source-file-upload-shared";
 import {
+  CROWDIN_GLOSSARY_LIST_LIMIT,
   CrowdinApiClient,
   CrowdinApiError,
   escapeCrowdinCroqlString,
@@ -699,6 +700,30 @@ export class CrowdinTmsProvider extends TmsProvider {
     return results.flat();
   }
 
+  private mapCrowdinGlossaryPageItem(glossary: CrowdinGlossary) {
+    const sourceLocale = toNativeGlossaryLocale(glossary.languageId, ["en"]);
+    const preferredLocales = [sourceLocale, ...glossary.languageIds];
+    const localeCoverage = this.uniqueLocales([
+      sourceLocale,
+      ...glossary.languageIds.map((languageId) =>
+        toNativeGlossaryLocale(languageId, preferredLocales),
+      ),
+    ]);
+    const targetLocale = localeCoverage.find((locale) => locale !== sourceLocale) ?? sourceLocale;
+
+    return {
+      externalGlossaryId: String(glossary.id),
+      name: glossary.name,
+      description: glossary.description ?? null,
+      sourceLocale,
+      targetLocale,
+      localeCoverage,
+      termCount: glossary.terms,
+      externalUrl: glossary.webUrl ?? null,
+      externalProjectIds: [...glossary.projectIds, ...glossary.defaultProjectIds].map(String),
+    };
+  }
+
   /** Lists the account's glossaries using Crowdin's native pagination and filtering. */
   async fetchGlossariesPage(
     scope: Pick<
@@ -710,45 +735,85 @@ export class CrowdinTmsProvider extends TmsProvider {
       offset?: number;
       orderBy?: string;
       filter?: string;
+      projectId?: string;
     },
   ): Promise<CrowdinLiveGlossaryPage> {
     const client = this.createClient(scope);
     const authenticatedUser = await client.getAuthenticatedUser();
-    const page = await client.listGlossariesPage({
-      limit: scope.limit,
-      offset: scope.offset,
-      orderBy: scope.orderBy,
-      filter: scope.filter,
-      userId: authenticatedUser.id,
-    });
+    const requestedLimit = scope.limit ?? CROWDIN_GLOSSARY_LIST_LIMIT;
+    const requestedOffset = scope.offset ?? 0;
+    const fetchRawPage = (limit: number, offset: number) =>
+      client.listGlossariesPage({
+        limit,
+        offset,
+        orderBy: scope.orderBy,
+        filter: scope.filter,
+        userId: authenticatedUser.id,
+      });
+
+    if (!scope.projectId) {
+      const page = await fetchRawPage(requestedLimit, requestedOffset);
+      return {
+        ...page,
+        glossaries: page.glossaries.map((glossary) => this.mapCrowdinGlossaryPageItem(glossary)),
+      };
+    }
+
+    const matching: CrowdinGlossary[] = [];
+    let crowdinOffset = 0;
+    let skipped = 0;
+    let hasMoreMatches = false;
+
+    while (true) {
+      const page = await fetchRawPage(CROWDIN_GLOSSARY_LIST_LIMIT, crowdinOffset);
+      for (const glossary of page.glossaries) {
+        const linkedProjectIds = [...glossary.projectIds, ...glossary.defaultProjectIds].map(
+          String,
+        );
+        if (!linkedProjectIds.includes(scope.projectId)) {
+          continue;
+        }
+
+        if (skipped < requestedOffset) {
+          skipped += 1;
+          continue;
+        }
+
+        if (matching.length < requestedLimit) {
+          matching.push(glossary);
+          continue;
+        }
+
+        hasMoreMatches = true;
+        break;
+      }
+
+      if (hasMoreMatches || !page.hasMore) {
+        break;
+      }
+
+      crowdinOffset += page.limit;
+    }
 
     return {
-      ...page,
-      glossaries: page.glossaries.map((glossary: CrowdinGlossary) => {
-        const sourceLocale = toNativeGlossaryLocale(glossary.languageId, ["en"]);
-        const preferredLocales = [sourceLocale, ...glossary.languageIds];
-        const localeCoverage = this.uniqueLocales([
-          sourceLocale,
-          ...glossary.languageIds.map((languageId) =>
-            toNativeGlossaryLocale(languageId, preferredLocales),
-          ),
-        ]);
-        const targetLocale =
-          localeCoverage.find((locale) => locale !== sourceLocale) ?? sourceLocale;
-
-        return {
-          externalGlossaryId: String(glossary.id),
-          name: glossary.name,
-          description: glossary.description ?? null,
-          sourceLocale,
-          targetLocale,
-          localeCoverage,
-          termCount: glossary.terms,
-          externalUrl: glossary.webUrl ?? null,
-          externalProjectIds: [...glossary.projectIds, ...glossary.defaultProjectIds].map(String),
-        };
-      }),
+      glossaries: matching.map((glossary) => this.mapCrowdinGlossaryPageItem(glossary)),
+      offset: requestedOffset,
+      limit: requestedLimit,
+      hasMore: hasMoreMatches,
     };
+  }
+
+  async fetchLiveGlossaryMetadata(
+    scope: Pick<
+      CrowdinLiveGlossaryScope,
+      "organizationId" | "credential" | "secretMaterial" | "signal"
+    > & {
+      fetchFn?: typeof fetch;
+    },
+    glossaryId: number,
+  ) {
+    const glossary = await this.createClient(scope).getGlossary(glossaryId);
+    return this.mapCrowdinGlossaryPageItem(glossary);
   }
 
   async fetchLiveGlossary(scope: CrowdinLiveGlossaryScope, glossaryId: number) {

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -36,6 +36,7 @@ import {
 import { legacyProviderCatSegmentLimit } from "@/api/routes/project/project.schema";
 import {
   buildCrowdinFileQueueCroql,
+  CROWDIN_GLOSSARY_LIST_LIMIT,
   CrowdinApiClient,
   CrowdinApiError,
   extractCrowdinApiErrorSummary,
@@ -104,6 +105,7 @@ import { extractProviderFileIds } from "@/lib/providers/jobs/job-provider-source
 import {
   encodeProviderJobId,
   encodeProviderProjectId,
+  parseLiveProviderGlossaryId,
   parseProviderJobId,
   parseProviderProjectId,
   type EncodedProviderProjectId,
@@ -4093,12 +4095,114 @@ export type TmsProviderLiveGlossariesPage = {
   hasMore: boolean;
 };
 
+function mapCrowdinLiveGlossaryPageItem(input: {
+  glossary: {
+    externalGlossaryId: string;
+    name: string;
+    description: string | null;
+    sourceLocale: string;
+    targetLocale: string;
+    localeCoverage: string[];
+    termCount: number | null;
+    externalUrl: string | null;
+    externalProjectIds: string[];
+  };
+  projectById: Map<string, { name: string }>;
+  externalProjectId?: string;
+}): TmsProviderLiveGlossary | null {
+  const linkedProjectIds = input.glossary.externalProjectIds.filter((projectId) =>
+    input.projectById.has(projectId),
+  );
+  if (input.externalProjectId && !linkedProjectIds.includes(input.externalProjectId)) {
+    return null;
+  }
+
+  const externalProjectId =
+    input.externalProjectId ?? linkedProjectIds[0] ?? input.glossary.externalProjectIds[0] ?? "";
+  const project = input.projectById.get(externalProjectId);
+
+  return mapLiveGlossary({
+    glossary: {
+      externalGlossaryId: input.glossary.externalGlossaryId,
+      name: input.glossary.name,
+      description: input.glossary.description ?? undefined,
+      sourceLocale: input.glossary.sourceLocale,
+      targetLocale: input.glossary.targetLocale,
+      localeCoverage: input.glossary.localeCoverage,
+      termCount: input.glossary.termCount,
+      externalUrl: input.glossary.externalUrl,
+    },
+    externalProjectId,
+    projectName: project?.name ?? null,
+    providerKind: "crowdin",
+  });
+}
+
 export async function listTmsProviderLiveGlossaries(
   organizationId: string,
   options?: { externalProjectId?: string; actorUserId?: string | null },
 ): Promise<TmsProviderLiveGlossary[]> {
-  const page = await listTmsProviderLiveGlossariesPage(organizationId, options);
-  return page.glossaries;
+  const glossaries: TmsProviderLiveGlossary[] = [];
+  let offset = 0;
+
+  while (true) {
+    const page = await listTmsProviderLiveGlossariesPage(organizationId, {
+      ...options,
+      limit: CROWDIN_GLOSSARY_LIST_LIMIT,
+      offset,
+    });
+    glossaries.push(...page.glossaries);
+    if (!page.hasMore || page.limit <= 0) {
+      return dedupeGlossaries(glossaries);
+    }
+    offset += page.limit;
+  }
+}
+
+export async function getTmsProviderLiveGlossary(
+  organizationId: string,
+  glossaryId: string,
+  options?: { actorUserId?: string | null },
+): Promise<TmsProviderLiveGlossary | null> {
+  const liveId = parseLiveProviderGlossaryId(glossaryId);
+  if (liveId?.providerKind !== "crowdin") {
+    return null;
+  }
+
+  const externalGlossaryId = Number(liveId.externalGlossaryId);
+  if (!Number.isFinite(externalGlossaryId) || externalGlossaryId <= 0) {
+    return null;
+  }
+
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  if (context.providerKind !== "crowdin") {
+    return null;
+  }
+
+  const projects = await fetchLiveProjectsCached(context, options);
+  const projectById = new Map(projects.map((project) => [project.externalProjectId, project]));
+
+  try {
+    const glossary = await crowdinTmsProvider.fetchLiveGlossaryMetadata(
+      {
+        organizationId: context.organizationId,
+        credential: context.credential,
+        secretMaterial: context.secretMaterial,
+      },
+      externalGlossaryId,
+    );
+    return mapCrowdinLiveGlossaryPageItem({
+      glossary,
+      projectById,
+    });
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 404) {
+      return null;
+    }
+    rethrowProviderFetcherError(error);
+  }
 }
 
 export async function listTmsProviderLiveGlossariesPage(
@@ -4135,37 +4239,16 @@ export async function listTmsProviderLiveGlossariesPage(
       offset: options?.offset,
       orderBy: options?.orderBy,
       filter: options?.filter,
+      projectId: options?.externalProjectId,
     });
 
     const glossaries = crowdinPage.glossaries.flatMap((glossary) => {
-      const linkedProjectIds = glossary.externalProjectIds.filter((projectId) =>
-        projectById.has(projectId),
-      );
-      if (options?.externalProjectId && !linkedProjectIds.includes(options.externalProjectId)) {
-        return [];
-      }
-
-      const externalProjectId =
-        options?.externalProjectId ?? linkedProjectIds[0] ?? glossary.externalProjectIds[0] ?? "";
-      const project = projectById.get(externalProjectId);
-
-      return [
-        mapLiveGlossary({
-          glossary: {
-            externalGlossaryId: glossary.externalGlossaryId,
-            name: glossary.name,
-            description: glossary.description ?? undefined,
-            sourceLocale: glossary.sourceLocale,
-            targetLocale: glossary.targetLocale,
-            localeCoverage: glossary.localeCoverage,
-            termCount: glossary.termCount,
-            externalUrl: glossary.externalUrl,
-          },
-          externalProjectId,
-          projectName: project?.name ?? null,
-          providerKind: context.providerKind,
-        }),
-      ];
+      const mapped = mapCrowdinLiveGlossaryPageItem({
+        glossary,
+        projectById,
+        externalProjectId: options?.externalProjectId,
+      });
+      return mapped ? [mapped] : [];
     });
 
     return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Addresses the [Codex review](https://github.com/hyperlocalise/hyperlocalise/pull/1964#pullrequestreview-4992421627) on #1964.

- Resolve live Crowdin glossary details by id instead of the first 25-item list page, so glossaries beyond page 1 still open and mutate.
- Walk Crowdin pages until a project-scoped page is filled when `externalProjectId` is set, and report `hasMore` for that project rather than the unfiltered account.
- Restore exhaustive listing for `listTmsProviderLiveGlossaries`.
- Pass through Crowdin custom language IDs instead of treating them as unsupported.

## How to test

- `vp test src/lib/providers/adapters/crowdin/crowdin-glossary-language.test.ts src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts` — 23 passed
- `vp check --fix` — 0 errors, 12 existing warnings

## Checklist

- [x] I ran relevant checks locally (`vp test` for the changed glossary files; `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Fixes review comments on #1964:
- https://github.com/hyperlocalise/hyperlocalise/pull/1964#discussion_r3829527493
- https://github.com/hyperlocalise/hyperlocalise/pull/1964#discussion_r3829527501
- https://github.com/hyperlocalise/hyperlocalise/pull/1964#discussion_r3829527508

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02404-5d0a-72bb-91e9-38f079751c91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02404-5d0a-72bb-91e9-38f079751c91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

