### PR TITLE
fix(crowdin): create glossary concepts through terms

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -315,13 +315,12 @@ describe("CrowdinApiClient", () => {
     const client = createClient(fetchMock);
     expect((await client.listGlossaryConcepts(7))[0]?.id).toBe(8);
     expect((await client.getGlossaryConcept(7, 8)).figure).toBe("");
-    await client.addGlossaryConcept(7, { subject: "product", figure: "" });
     await client.updateGlossaryConcept(7, 8, {
       figure: "https://example.com/figure.png",
     });
     await client.deleteGlossaryConcept(7, 8);
 
-    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it("lists branches with pagination", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -2234,17 +2234,6 @@ export class CrowdinApiClient {
     return response.data;
   }
 
-  async addGlossaryConcept(
-    glossaryId: number,
-    input: CrowdinGlossaryConceptInput,
-  ): Promise<CrowdinGlossaryConcept> {
-    const response = await this.post<CrowdinGetResponse<CrowdinGlossaryConcept>>(
-      `/glossaries/${glossaryId}/concepts`,
-      input,
-    );
-    return response.data;
-  }
-
   async updateGlossaryConcept(
     glossaryId: number,
     conceptId: number,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -262,9 +262,13 @@ describe("Crowdin live glossary concepts", () => {
 
   it("selects the Crowdin source term when sourceLocale is a BCP-47 locale", async () => {
     const termBodies: Array<Record<string, unknown>> = [];
+    const conceptUpdateBodies: Array<Record<string, unknown>> = [];
+    const requests: string[] = [];
     const fetchMock = vi.fn(async (url, init) => {
       const path = String(url).replace("https://api.crowdin.test/api/v2", "");
-      if (path === "/glossaries/7/concepts" && init?.method === "POST") {
+      requests.push(`${init?.method ?? "GET"} ${path}`);
+      if (path === "/glossaries/7/concepts/8" && init?.method === "PUT") {
+        conceptUpdateBodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
         return new Response(
           JSON.stringify({
             data: {
@@ -374,10 +378,73 @@ describe("Crowdin live glossary concepts", () => {
     );
 
     expect(termBodies).toEqual([
-      expect.objectContaining({ languageId: "en", text: "Checkout", conceptId: 8 }),
+      expect.objectContaining({ languageId: "en", text: "Checkout" }),
       expect.objectContaining({ languageId: "vi", text: "Thanh toán", conceptId: 8 }),
     ]);
+    expect(termBodies[0]).not.toHaveProperty("conceptId");
+    expect(conceptUpdateBodies).toEqual([{}]);
     expect(termBodies).toHaveLength(2);
+    expect(requests).toEqual([
+      "POST /glossaries/7/terms",
+      "PUT /glossaries/7/concepts/8",
+      "POST /glossaries/7/terms",
+      "GET /glossaries/7/concepts?limit=500&offset=0",
+      "GET /glossaries/7/terms?limit=500&offset=0",
+    ]);
+  });
+
+  it("preserves the created concept when metadata update fails", async () => {
+    const termBodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url).replace("https://api.crowdin.test/api/v2", "");
+      if (path === "/glossaries/7/terms" && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+        termBodies.push(body);
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 21,
+              glossaryId: 7,
+              languageId: body.languageId,
+              text: body.text,
+              conceptId: 8,
+            },
+          }),
+          { status: 201 },
+        );
+      }
+
+      if (path === "/glossaries/7/concepts/8" && init?.method === "PUT") {
+        return new Response(JSON.stringify({ error: { code: 400, message: "invalid metadata" } }), {
+          status: 400,
+        });
+      }
+
+      throw new Error(`Unexpected Crowdin request: ${path}`);
+    }) as unknown as typeof fetch;
+
+    await expect(
+      crowdinTmsProvider.createLiveGlossaryConcept(
+        {
+          organizationId: "organization-1",
+          credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+          secretMaterial: "test-token",
+          projectId: "project-42",
+          externalProjectId: "42",
+          sourceLocale: "en-US",
+          fetchFn: fetchMock,
+        },
+        7,
+        {
+          primaryTerm: "Checkout",
+          sourceLocale: "en-US",
+          terms: [{ languageId: "en", text: "Checkout", status: "preferred" }],
+        },
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(termBodies).toEqual([expect.objectContaining({ languageId: "en", text: "Checkout" })]);
+    expect(termBodies[0]).not.toHaveProperty("conceptId");
   });
 
   it("treats native locales and Crowdin IDs as the same language on term update", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -953,19 +953,6 @@ export class CrowdinTmsProvider extends TmsProvider {
     input: CrowdinGlossaryConcept,
   ) {
     const client = this.createClient(scope);
-    const remoteConcept = await client.addGlossaryConcept(glossaryId, {
-      subject: input.subject,
-      definition: input.definition,
-      translatable: input.translatable,
-      note: input.note,
-      url: input.url ?? undefined,
-      figure: input.figure ?? undefined,
-      languagesDetails: input.languageDetails?.map((detail) => ({
-        languageId: toCrowdinGlossaryLanguageId(detail.languageId),
-        definition: detail.definition,
-        note: detail.note,
-      })),
-    });
     const sourceLanguageId = toCrowdinGlossaryLanguageId(input.sourceLocale);
     const source = input.terms.find(
       (term) => toCrowdinGlossaryLanguageId(term.languageId) === sourceLanguageId,
@@ -983,9 +970,24 @@ export class CrowdinTmsProvider extends TmsProvider {
       gender: source.gender,
       note: source.note ?? input.note,
       url: source.url,
-      conceptId: remoteConcept.id,
     });
-    const conceptId = remoteConcept.id || createdSource.conceptId || createdSource.id;
+
+    // Crowdin creates a concept implicitly when the first term omits
+    // conceptId. Concept metadata must be written after that term exists.
+    const conceptId = createdSource.conceptId;
+    await client.updateGlossaryConcept(glossaryId, conceptId, {
+      subject: input.subject,
+      definition: input.definition,
+      translatable: input.translatable,
+      note: input.note,
+      url: input.url ?? undefined,
+      figure: input.figure ?? undefined,
+      languagesDetails: input.languageDetails?.map((detail) => ({
+        languageId: toCrowdinGlossaryLanguageId(detail.languageId),
+        definition: detail.definition,
+        note: detail.note,
+      })),
+    });
     for (const term of input.terms.filter((item) => item !== source)) {
       await client.addGlossaryTerm(glossaryId, {
         languageId: toCrowdinGlossaryLanguageId(term.languageId),

--- a/docs/adr/2026-08-21-crowdin-glossary-concept-creation-design.md
+++ b/docs/adr/2026-08-21-crowdin-glossary-concept-creation-design.md
@@ -1,0 +1,22 @@
+# Crowdin glossary concept creation
+
+## Decision
+
+Create a Crowdin glossary concept by adding its source term without a
+`conceptId`. Crowdin creates the concept and returns its `conceptId`.
+
+Then update the generated concept with concept-level metadata and add any
+remaining terms using the returned `conceptId`.
+
+## Failure behavior
+
+The provider does not delete the created concept when a later metadata or term
+request fails. This preserves the provider state and lets the user retry or
+repair the partially created concept.
+
+## Verification
+
+Provider tests assert that the source term omits `conceptId`, metadata uses
+`PUT /glossaries/{glossaryId}/concepts/{conceptId}`, and subsequent terms use
+the generated concept ID. A failure test verifies that the source term remains
+created when metadata update fails.


### PR DESCRIPTION
## What changed

- Create Crowdin glossary concepts by adding the source term without a `conceptId`.
- Update the generated concept metadata with `PUT /glossaries/{glossaryId}/concepts/{conceptId}`.
- Add remaining terms using the generated `conceptId`.
- Remove the unsupported `POST /glossaries/{glossaryId}/concepts` client method.
- Add request-order and partial-failure regression tests.
- Move the design record to `docs/adr`.

## Root cause

Crowdin does not expose a concept-creation POST endpoint. The previous adapter called `POST /glossaries/718785/concepts`, which returned HTTP 405 and was surfaced by Hyperlocalise as a generic HTTP 500.

## Failure behavior

If metadata or an additional term fails after the source term is created, the provider does not delete the Crowdin concept. This preserves the remote state for retry or manual repair.

## Verification

- `vp check --fix`: passed; 12 pre-existing warnings remain in unrelated files.
- Focused Crowdin suites: 68 tests passed.
- Full `vp test`: 595 tests passed; 127 suites were blocked by unavailable local Postgres (`:5432`) and dev server (`:3000`).
