### PR TITLE
fix(crowdin): add TargetLanguageID parity to StringCommentsListOptions

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-31 - Add TargetLanguageID parity to StringCommentsListOptions
+
+**Learning:** In Crowdin API v2, the List String Comments endpoint (`GET /api/v2/projects/{projectId}/comments`) accepts an optional `targetLanguageId` query parameter to filter comments and issues for a specific target language. The SDK's `StringCommentsListOptions` previously lacked `TargetLanguageID`, preventing callers from filtering comments by target language.
+
+**Action:** Added `TargetLanguageID string json:"targetLanguageId,omitempty"` to `StringCommentsListOptions` in `third_party/crowdin-api-client-go/crowdin/model/string_comments.go` and updated its `Values()` query serialization method to encode `targetLanguageId`. Added unit test assertions in `model/string_comments_test.go` and `string_comments_test.go`.
+
 ## 2026-12-31 - Add FileID, LabelIDs, and CroQL parity to StringTranslationsListOptions
 
 **Learning:** In Crowdin API v2, the List String Translations endpoint (`GET /api/v2/projects/{projectId}/translations`) accepts filtering by `fileId`, `labelIds`, and `croql` in addition to `stringId` and `languageId`. Omission of these query parameters from `StringTranslationsListOptions` prevented callers from listing string translations for specific files, label filters, or CroQL query expressions.

--- a/third_party/crowdin-api-client-go/crowdin/model/string_comments.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_comments.go
@@ -66,6 +66,8 @@ type StringCommentsListOptions struct {
 	OrderBy string `json:"orderBy,omitempty"`
 	// String Identifier.
 	StringID int `json:"stringId,omitempty"`
+	// Target Language Identifier.
+	TargetLanguageID string `json:"targetLanguageId,omitempty"`
 	// Defines string comment type.
 	// Enum: comment, issue.
 	// Note: `type=comment` can't be used with `issueType` or `issueStatus`
@@ -96,6 +98,9 @@ func (o *StringCommentsListOptions) Values() (url.Values, bool) {
 	}
 	if o.StringID != 0 {
 		v.Set("stringId", strconv.Itoa(o.StringID))
+	}
+	if o.TargetLanguageID != "" {
+		v.Set("targetLanguageId", o.TargetLanguageID)
 	}
 	if o.Type != "" {
 		v.Set("type", o.Type)

--- a/third_party/crowdin-api-client-go/crowdin/model/string_comments_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_comments_test.go
@@ -23,13 +23,20 @@ func TestStringCommentsListOptionsValues(t *testing.T) {
 			out:  "",
 		},
 		{
+			name: "with targetLanguageId",
+			opts: &StringCommentsListOptions{
+				TargetLanguageID: "de",
+			},
+			out: "targetLanguageId=de",
+		},
+		{
 			name: "with all options",
 			opts: &StringCommentsListOptions{
-				OrderBy: "createdAt desc,text", StringID: 1, Type: "comment",
+				OrderBy: "createdAt desc,text", StringID: 1, TargetLanguageID: "uk", Type: "comment",
 				IssueType: []string{"general_question", "translation_mistake"}, IssueStatus: "resolved",
 				ListOptions: ListOptions{Offset: 1, Limit: 10},
 			},
-			out: "issueStatus=resolved&issueType=general_question%2Ctranslation_mistake&limit=10&offset=1&orderBy=createdAt+desc%2Ctext&stringId=1&type=comment",
+			out: "issueStatus=resolved&issueType=general_question%2Ctranslation_mistake&limit=10&offset=1&orderBy=createdAt+desc%2Ctext&stringId=1&targetLanguageId=uk&type=comment",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/string_comments_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/string_comments_test.go
@@ -74,15 +74,16 @@ func TestStringCommentsService_List(t *testing.T) {
 		{
 			name: "with options 1",
 			opts: &model.StringCommentsListOptions{
-				OrderBy:  "createdAt desc,text",
-				StringID: 1,
-				Type:     "comment",
+				OrderBy:          "createdAt desc,text",
+				StringID:         1,
+				TargetLanguageID: "es",
+				Type:             "comment",
 				ListOptions: model.ListOptions{
 					Limit:  10,
 					Offset: 10,
 				},
 			},
-			expect: "?limit=10&offset=10&orderBy=createdAt+desc%2Ctext&stringId=1&type=comment",
+			expect: "?limit=10&offset=10&orderBy=createdAt+desc%2Ctext&stringId=1&targetLanguageId=es&type=comment",
 		},
 		{
 			name: "with options 2",


### PR DESCRIPTION
- What: Added TargetLanguageID string json:"targetLanguageId,omitempty" to StringCommentsListOptions in third_party/crowdin-api-client-go/crowdin/model/string_comments.go and updated its Values() query serialization helper.
- Why: In Crowdin API v2, the List String Comments endpoint (GET /api/v2/projects/{projectId}/comments) accepts filtering by targetLanguageId. Omission of this query parameter from StringCommentsListOptions prevented callers from listing string comments or issues filtered by target language.
- Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.comments.getMany
- Scope: third_party/crowdin-api-client-go/crowdin/model/string_comments.go, third_party/crowdin-api-client-go/crowdin/model/string_comments_test.go, third_party/crowdin-api-client-go/crowdin/string_comments_test.go, .jules/crowdin-steward.md
- Tests: go test ./... passed across third_party/crowdin-api-client-go and the repository.
- Confidence: Ensures full parity with official Crowdin API v2 specification when filtering string comments by target language.

---
*PR created automatically by Jules for task [5478804741368801797](https://jules.google.com/task/5478804741368801797) started by @cungminh2710*