### PR TITLE
feat(glossary): surface live provider metadata

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -23,6 +23,14 @@ import { db, schema } from "@/lib/database";
 import { GlossaryValidationError, type NativeGlossary } from "@/lib/glossary/glossary";
 import { getGlossaryProduct } from "@/lib/glossary/glossary-provider";
 import { toGlossaryRecord } from "@/lib/glossary/glossary-records";
+import {
+  queryGlossaryProjectCount,
+  queryGlossaryProjectCounts,
+} from "@/lib/glossary/query-glossary-project-counts";
+import {
+  queryNativeGlossaryTermCountForGlossary,
+  queryNativeGlossaryTermCounts,
+} from "@/lib/glossary/query-glossary-term-counts";
 import { listGlossaryTermsByGlossaryId } from "@/lib/glossary/query-glossary-terms";
 import {
   queryNativeGlossaryLanguages,
@@ -67,6 +75,8 @@ type GlossaryListResult = {
   glossaries: NativeGlossary[];
   total: number;
   languagesByGlossaryId: Map<string, ReturnType<typeof toGlossaryRecord>["languages"]>;
+  termCountsByGlossaryId: Map<string, number>;
+  projectCountsByGlossaryId: Map<string, number>;
 };
 
 async function listGlossaries(
@@ -88,10 +98,19 @@ async function listGlossaries(
     db.select({ value: count() }).from(schema.glossaries).where(where),
   ]);
 
+  const [languagesByGlossaryId, termCountsByGlossaryId, projectCountsByGlossaryId] =
+    await Promise.all([
+      queryNativeGlossaryLanguages(glossaries),
+      queryNativeGlossaryTermCounts(glossaries),
+      queryGlossaryProjectCounts(glossaries),
+    ]);
+
   return {
     glossaries,
     total: totalRow[0]?.value ?? 0,
-    languagesByGlossaryId: await queryNativeGlossaryLanguages(glossaries),
+    languagesByGlossaryId,
+    termCountsByGlossaryId,
+    projectCountsByGlossaryId,
   };
 }
 
@@ -287,17 +306,31 @@ export function createGlossaryRoutes() {
     .route("/:glossaryId/concepts", createGlossaryConceptRoutes())
     .get("/", validateListGlossaryQuery, async (c) => {
       const query = c.req.valid("query");
-      const { glossaries, total, languagesByGlossaryId } = await listGlossaries(c.var.auth, query);
+      const {
+        glossaries,
+        total,
+        languagesByGlossaryId,
+        termCountsByGlossaryId,
+        projectCountsByGlossaryId,
+      } = await listGlossaries(c.var.auth, query);
       const records = await mapWithConcurrency(glossaries, 5, async (glossary) => {
         const product = getGlossaryProduct({ auth: c.var.auth, glossary });
+        const termCount =
+          glossary.source === "native" ? (termCountsByGlossaryId.get(glossary.id) ?? 0) : undefined;
+        const projectCount = projectCountsByGlossaryId.get(glossary.id) ?? 0;
         if (product) {
           const remote = await product.get();
           const languages = languagesByGlossaryId.get(glossary.id);
           return languages
-            ? toGlossaryRecord(remote ?? glossary, languages)
-            : toGlossaryRecord(remote ?? glossary);
+            ? toGlossaryRecord(remote ?? glossary, languages, termCount, projectCount)
+            : toGlossaryRecord(remote ?? glossary, undefined, termCount, projectCount);
         }
-        return toGlossaryRecord(glossary, languagesByGlossaryId.get(glossary.id));
+        return toGlossaryRecord(
+          glossary,
+          languagesByGlossaryId.get(glossary.id),
+          termCount,
+          projectCount,
+        );
       });
       return c.json(
         {
@@ -333,7 +366,7 @@ export function createGlossaryRoutes() {
         payload,
         projects.flatMap((project) => (project ? [project.id] : [])),
       );
-      return c.json({ glossary: toGlossaryRecord(glossary) }, 201);
+      return c.json({ glossary: toGlossaryRecord(glossary, undefined, 0, 0) }, 201);
     })
     .get("/:glossaryId", validateGlossaryParams, async (c) => {
       const params = c.req.valid("param");
@@ -344,6 +377,11 @@ export function createGlossaryRoutes() {
       }
 
       const product = getGlossaryProduct({ auth: c.var.auth, glossary });
+      const termCount =
+        glossary.source === "native"
+          ? await queryNativeGlossaryTermCountForGlossary(glossary)
+          : undefined;
+      const projectCount = await queryGlossaryProjectCount(glossary);
       if (product) {
         const remote = await product.get();
         const languages =
@@ -353,14 +391,17 @@ export function createGlossaryRoutes() {
         return c.json(
           {
             glossary: languages
-              ? toGlossaryRecord(remote ?? glossary, languages)
-              : toGlossaryRecord(remote ?? glossary),
+              ? toGlossaryRecord(remote ?? glossary, languages, termCount, projectCount)
+              : toGlossaryRecord(remote ?? glossary, undefined, termCount, projectCount),
           },
           200,
         );
       }
 
-      return c.json({ glossary: toGlossaryRecord(glossary) }, 200);
+      return c.json(
+        { glossary: toGlossaryRecord(glossary, undefined, termCount, projectCount) },
+        200,
+      );
     })
     .get("/:glossaryId/terms", validateGlossaryParams, async (c) => {
       const params = c.req.valid("param");
@@ -607,7 +648,15 @@ export function createGlossaryRoutes() {
         return glossaryNotFoundResponse(c);
       }
 
-      return c.json({ glossary: toGlossaryRecord(updated) }, 200);
+      const termCount =
+        updated.source === "native"
+          ? await queryNativeGlossaryTermCountForGlossary(updated)
+          : undefined;
+      const projectCount = await queryGlossaryProjectCount(updated);
+      return c.json(
+        { glossary: toGlossaryRecord(updated, undefined, termCount, projectCount) },
+        200,
+      );
     })
     .delete("/:glossaryId", validateGlossaryParams, async (c) => {
       if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -229,6 +229,7 @@ export const glossaryRecordSchema = z.object({
     }),
   ),
   termCount: z.number().int().nullable(),
+  projectCount: z.number().int().optional(),
   syncState: z.string().nullable(),
   termCapabilities: z.record(z.string(), z.unknown()),
   externalUrl: z.string().nullable(),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -141,6 +141,10 @@ const emptyTermDraft: TermDraft = {
   url: "",
 };
 
+function createCreatingTermDraft(locale: string, id: string): CreatingTermDraft {
+  return { ...emptyTermDraft, id, locale };
+}
+
 function conceptDraftFromRecord(concept: GlossaryConceptRecord): ConceptDraft {
   return {
     primaryTerm: concept.primaryTerm,
@@ -169,10 +173,6 @@ function normalizePartOfSpeech(value: string) {
   const normalized = value.trim().toLowerCase();
   if (!normalized) return undefined;
   return (normalized === "preposition" ? "adposition" : normalized) as GlossaryPartOfSpeech;
-}
-
-function isValidPartOfSpeech(value: string | undefined): value is GlossaryPartOfSpeech {
-  return value !== undefined && partOfSpeechOptions.includes(value as GlossaryPartOfSpeech);
 }
 
 function areTermDraftsEqual(left: TermDraft, right: TermDraft) {
@@ -263,7 +263,6 @@ function GenderMark({ value }: { value: string }) {
 }
 
 function PartOfSpeechDisplay({ value }: { value: string | null | undefined }) {
-  const intl = useIntl();
   if (!value) {
     return <span className="truncate text-muted-foreground">—</span>;
   }
@@ -372,7 +371,6 @@ function PartOfSpeechPicker({
 }
 
 function GenderDisplay({ value }: { value: string | null | undefined }) {
-  const intl = useIntl();
   if (!value) {
     return <span className="truncate text-muted-foreground">—</span>;
   }
@@ -480,7 +478,6 @@ function termTypeMark(value: string) {
 }
 
 function TermTypeDisplay({ value }: { value: string | null | undefined }) {
-  const intl = useIntl();
   if (!value) {
     return <span className="truncate text-muted-foreground">—</span>;
   }
@@ -767,7 +764,7 @@ function ConceptDetailSkeleton() {
           <Skeleton className="h-8 w-64 max-w-full" />
           <Skeleton className="h-4 w-40" />
         </div>
-        <div className="grid min-h-[36rem] gap-5 lg:grid-cols-[minmax(15rem,0.75fr)_minmax(0,1.5fr)]">
+        <div className="grid min-h-[36rem] gap-5 lg:grid-cols-[minmax(13rem,0.6fr)_minmax(0,1.8fr)]">
           <div className="grid content-start gap-4 border-b border-border pb-5 lg:border-r lg:border-b-0 lg:pr-5 lg:pb-0">
             <Skeleton className="h-4 w-24" />
             <Skeleton className="h-9 w-full" />
@@ -872,6 +869,11 @@ export function GlossaryDetailPageContent({
     glossary?.source === "external_tms" && glossary.externalProviderKind === "crowdin";
   const isConceptGlossary = isNative || isLiveCrowdin;
   const canEdit = canManageGlossaries && isConceptGlossary;
+  const sourceLanguage = glossary?.languages.find((language) => language.isSource) ?? {
+    locale: glossary?.sourceLocale ?? "",
+    name: getLocaleLabel(glossary?.sourceLocale ?? ""),
+    isSource: true,
+  };
 
   useEffect(() => {
     if (glossary) setNameDraft(glossary.name);
@@ -944,13 +946,17 @@ export function GlossaryDetailPageContent({
     if (conceptId === "new") {
       setConceptDraft(emptyConceptDraft);
       setTermDrafts({});
-      setCreatingTermDrafts([]);
+      setCreatingTermDrafts(
+        sourceLanguage.locale
+          ? [createCreatingTermDraft(sourceLanguage.locale, `new-source-${sourceLanguage.locale}`)]
+          : [],
+      );
       setNewTermLocale(null);
       setNewTermDraft(emptyTermDraft);
       setExpandedTermIds(new Set());
       setExpandedCreatingTermIds(new Set());
     }
-  }, [conceptId]);
+  }, [conceptId, sourceLanguage.locale]);
 
   useEffect(() => {
     if (selectedConcept) {
@@ -968,6 +974,11 @@ export function GlossaryDetailPageContent({
       setIsCreatingConcept(false);
     }
   }, [selectedConcept]);
+
+  const sourceTermDraft = isCreatingConcept
+    ? creatingTermDrafts.find((term) => term.locale === sourceLanguage.locale)
+    : undefined;
+  const sourceTermText = sourceTermDraft?.term ?? "";
 
   const goBack = () => {
     if (conceptPageMode) router.push(glossaryHref);
@@ -995,6 +1006,8 @@ export function GlossaryDetailPageContent({
       let concept: GlossaryConceptRecord;
       let created = false;
       if (isCreatingConcept) {
+        const primaryTerm = sourceTermText.trim();
+        if (!primaryTerm) throw new Error(intl.formatMessage(messages.saveConceptFailed));
         const terms: NonNullable<CreateGlossaryConceptBody["terms"]> = creatingTermDrafts
           .filter(({ term }) => term.trim())
           .map(({ id: _id, ...term }) => ({
@@ -1010,15 +1023,13 @@ export function GlossaryDetailPageContent({
             caseSensitive: false,
             forbidden: false,
           }));
-        if (terms.some((term) => !isValidPartOfSpeech(term.partOfSpeech))) {
-          throw new Error(intl.formatMessage(messages.partOfSpeechRequired));
-        }
         const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
           ":glossaryId"
         ].concepts.$post({
           param: { organizationSlug, glossaryId },
           json: {
             ...draft,
+            primaryTerm,
             url: draft.url || undefined,
             terms: terms.map((term) => ({
               ...term,
@@ -1067,9 +1078,6 @@ export function GlossaryDetailPageContent({
             caseSensitive: false,
             forbidden: false,
           });
-        }
-        if (terms.some((term) => !isValidPartOfSpeech(term.partOfSpeech))) {
-          throw new Error(intl.formatMessage(messages.partOfSpeechRequired));
         }
         const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
           ":glossaryId"
@@ -1278,14 +1286,12 @@ export function GlossaryDetailPageContent({
   const allSelected =
     filteredConcepts.length > 0 &&
     filteredConcepts.every((concept) => selectedConceptIds.has(concept.id));
-  const sourceLanguage = glossary.languages.find((language) => language.isSource) ?? {
-    locale: glossary.sourceLocale,
-    name: getLocaleLabel(glossary.sourceLocale),
-    isSource: true,
-  };
   const normalizedLanguageFilter = languageFilter.trim().toLowerCase();
+  const creatingTermLocales = new Set(creatingTermDrafts.map((term) => term.locale));
   const availableTermLocales = isCreatingConcept
-    ? COMMON_LOCALES
+    ? COMMON_LOCALES.filter(
+        (locale) => locale !== sourceLanguage.locale && !creatingTermLocales.has(locale),
+      )
     : COMMON_LOCALES.filter((locale) => !selected?.terms.some((term) => term.locale === locale));
   const termGroups = (selected?.terms ?? [])
     .filter(
@@ -1309,8 +1315,21 @@ export function GlossaryDetailPageContent({
   ) {
     termGroups.push({ locale: newTermLocale, terms: [] });
   }
+  const creatingTermGroups = creatingTermDrafts
+    .filter(
+      (term) =>
+        !normalizedLanguageFilter ||
+        getLocaleLabel(term.locale).toLowerCase().includes(normalizedLanguageFilter) ||
+        term.locale.toLowerCase().includes(normalizedLanguageFilter),
+    )
+    .reduce<Array<{ locale: string; terms: CreatingTermDraft[] }>>((groups, term) => {
+      const group = groups.find((item) => item.locale === term.locale);
+      if (group) group.terms.push(term);
+      else groups.push({ locale: term.locale, terms: [term] });
+      return groups;
+    }, []);
   const conceptIsDirty = isCreatingConcept
-    ? Boolean(conceptDraft.primaryTerm.trim())
+    ? Boolean(sourceTermText.trim())
     : selectedConcept
       ? !areConceptDraftsEqual(conceptDraft, conceptDraftFromRecord(selectedConcept))
       : false;
@@ -1626,18 +1645,24 @@ export function GlossaryDetailPageContent({
                   </DialogDescription>
                 </DialogHeader>
               )}
-              <div className="grid min-h-0 gap-5 lg:grid-cols-[minmax(15rem,0.75fr)_minmax(0,1.5fr)]">
+              <div className="grid min-h-0 gap-5 lg:grid-cols-[minmax(13rem,0.6fr)_minmax(0,1.8fr)]">
                 <div className="flex min-w-0 flex-col gap-4 border-b border-border pb-5 lg:border-r lg:border-b-0 lg:pr-5 lg:pb-0">
                   <Field className="gap-1.5">
                     <FieldLabel>
                       <FormattedMessage {...messages.primaryTermLabel} />
                     </FieldLabel>
                     <Input
-                      value={conceptDraft.primaryTerm}
-                      onChange={(event) =>
-                        setConceptDraft((draft) => ({ ...draft, primaryTerm: event.target.value }))
-                      }
-                      disabled={!canEdit}
+                      value={isCreatingConcept ? sourceTermText : conceptDraft.primaryTerm}
+                      onChange={(event) => {
+                        if (!isCreatingConcept) {
+                          setConceptDraft((draft) => ({
+                            ...draft,
+                            primaryTerm: event.target.value,
+                          }));
+                        }
+                      }}
+                      disabled={!canEdit || isCreatingConcept}
+                      readOnly={isCreatingConcept}
                     />
                   </Field>
                   <Field className="gap-1.5">
@@ -1777,308 +1802,342 @@ export function GlossaryDetailPageContent({
                   </Dialog>
                   <div className="max-h-[calc(100dvh-18rem)] overflow-y-auto pr-1">
                     <div className="grid gap-4">
-                      {isCreatingConcept && creatingTermDrafts.length > 0 ? (
-                        <div className="overflow-hidden rounded-lg border border-border">
-                          <div className="border-b border-border bg-muted/30 px-3 py-2 text-sm font-medium">
-                            <FormattedMessage {...messages.termsTitle} />
-                          </div>
-                          <div className="overflow-x-auto">
-                            <table className="min-w-[680px] w-full text-left text-xs">
-                              <thead className="text-muted-foreground">
-                                <tr>
-                                  <th className="px-3 py-2">Language</th>
-                                  <th className="px-3 py-2">
-                                    <FormattedMessage {...messages.termLabel} />
-                                  </th>
-                                  <th className="px-3 py-2">
-                                    <FormattedMessage {...messages.partOfSpeechLabel} />
-                                  </th>
-                                  <th className="px-3 py-2">
-                                    <FormattedMessage {...messages.genderLabel} />
-                                  </th>
-                                  <th className="px-3 py-2">
-                                    <FormattedMessage {...messages.typeLabel} />
-                                  </th>
-                                  <th className="px-3 py-2">
-                                    <FormattedMessage {...messages.statusLabel} />
-                                  </th>
-                                  <th className="w-10 px-3 py-2" />
-                                </tr>
-                              </thead>
-                              <tbody>
-                                {creatingTermDrafts.map((term) => {
-                                  const isExpanded = expandedCreatingTermIds.has(term.id);
-                                  return (
-                                    <Fragment key={term.id}>
-                                      <tr className="border-t border-border">
-                                        <td className="px-3 py-2">
-                                          <span className="font-medium">
-                                            {getLocaleLabel(term.locale)}
-                                          </span>
-                                          <span className="ml-1 text-muted-foreground">
-                                            {term.locale}
-                                          </span>
-                                        </td>
-                                        <td className="px-3 py-2">
-                                          <Textarea
-                                            autoFocus={creatingTermDrafts.at(-1)?.id === term.id}
-                                            className="w-48 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
-                                            placeholder={intl.formatMessage(messages.termLabel)}
-                                            value={term.term}
-                                            onChange={(event) =>
-                                              setCreatingTermDrafts((drafts) =>
-                                                drafts.map((draft) =>
-                                                  draft.id === term.id
-                                                    ? { ...draft, term: event.target.value }
-                                                    : draft,
-                                                ),
-                                              )
-                                            }
-                                          />
-                                        </td>
-                                        <td className="px-3 py-2">
-                                          <PartOfSpeechPicker
-                                            value={term.partOfSpeech}
-                                            onValueChange={(value) =>
-                                              setCreatingTermDrafts((drafts) =>
-                                                drafts.map((draft) =>
-                                                  draft.id === term.id
-                                                    ? { ...draft, partOfSpeech: value }
-                                                    : draft,
-                                                ),
-                                              )
-                                            }
-                                          />
-                                        </td>
-                                        <td className="px-3 py-2">
-                                          <GenderPicker
-                                            value={term.gender ?? ""}
-                                            onValueChange={(value) =>
-                                              setCreatingTermDrafts((drafts) =>
-                                                drafts.map((draft) =>
-                                                  draft.id === term.id
-                                                    ? { ...draft, gender: value }
-                                                    : draft,
-                                                ),
-                                              )
-                                            }
-                                          />
-                                        </td>
-                                        <td className="px-3 py-2">
-                                          <TermTypePicker
-                                            value={term.termType ?? ""}
-                                            onValueChange={(value) =>
-                                              setCreatingTermDrafts((drafts) =>
-                                                drafts.map((draft) =>
-                                                  draft.id === term.id
-                                                    ? { ...draft, termType: value }
-                                                    : draft,
-                                                ),
-                                              )
-                                            }
-                                          />
-                                        </td>
-                                        <td className="px-3 py-2">
-                                          <Select
-                                            value={term.status}
-                                            onValueChange={(value) =>
-                                              setCreatingTermDrafts((drafts) =>
-                                                drafts.map((draft) =>
-                                                  draft.id === term.id
-                                                    ? {
-                                                        ...draft,
-                                                        status: (value ??
-                                                          "draft") as TermDraft["status"],
-                                                      }
-                                                    : draft,
-                                                ),
-                                              )
-                                            }
-                                          >
-                                            <SelectTrigger
-                                              showIcon={false}
-                                              className={statusPickerTriggerClass()}
-                                            >
-                                              <SelectValue>
-                                                <StatusLabel status={term.status} />
-                                              </SelectValue>
-                                            </SelectTrigger>
-                                            <SelectContent className={statusPickerContentClassName}>
-                                              {statusOptions.map((option) => (
-                                                <SelectItem
-                                                  key={option}
-                                                  value={option}
-                                                  className={statusPickerItemClass(option)}
-                                                >
-                                                  <StatusLabel status={option} />
-                                                </SelectItem>
-                                              ))}
-                                            </SelectContent>
-                                          </Select>
-                                        </td>
-                                        <td className="px-3 py-2 text-right">
-                                          <Button
-                                            type="button"
-                                            size="icon-xs"
-                                            variant="outline"
-                                            aria-expanded={isExpanded}
-                                            aria-label={intl.formatMessage(
-                                              isExpanded
-                                                ? messages.collapseTerm
-                                                : messages.expandTerm,
-                                            )}
-                                            onClick={() =>
-                                              setExpandedCreatingTermIds((current) => {
-                                                const next = new Set(current);
-                                                if (next.has(term.id)) next.delete(term.id);
-                                                else next.add(term.id);
-                                                return next;
-                                              })
-                                            }
-                                          >
-                                            <HugeiconsIcon
-                                              icon={ArrowDown01Icon}
-                                              strokeWidth={1.8}
-                                              className={isExpanded ? "" : "-rotate-90"}
-                                            />
-                                          </Button>
-                                        </td>
+                      {isCreatingConcept && creatingTermGroups.length > 0
+                        ? creatingTermGroups.map((group) => {
+                            const isSource = group.locale === sourceLanguage.locale;
+                            return (
+                              <div
+                                key={group.locale}
+                                className="overflow-hidden rounded-lg border border-border"
+                              >
+                                <div
+                                  className={`flex items-center justify-between gap-2 border-b border-border px-3 py-2 text-sm font-medium ${isSource ? "bg-emerald-500/5" : "bg-amber-500/5"}`}
+                                >
+                                  <span>
+                                    {getLocaleLabel(group.locale)}{" "}
+                                    <span className="text-xs text-muted-foreground">
+                                      {group.locale}
+                                    </span>
+                                    {isSource ? (
+                                      <Badge
+                                        variant="outline"
+                                        className="ml-2 border-emerald-500/30 text-emerald-700"
+                                      >
+                                        <FormattedMessage {...messages.sourceBadge} />
+                                      </Badge>
+                                    ) : null}
+                                  </span>
+                                </div>
+                                <div className="overflow-x-auto">
+                                  <table className="min-w-[680px] w-full text-left text-xs">
+                                    <thead className="text-muted-foreground">
+                                      <tr>
+                                        <th className="px-3 py-2">
+                                          <FormattedMessage {...messages.termLabel} />
+                                        </th>
+                                        <th className="px-3 py-2">
+                                          <FormattedMessage {...messages.partOfSpeechLabel} />
+                                        </th>
+                                        <th className="px-3 py-2">
+                                          <FormattedMessage {...messages.genderLabel} />
+                                        </th>
+                                        <th className="px-3 py-2">
+                                          <FormattedMessage {...messages.typeLabel} />
+                                        </th>
+                                        <th className="px-3 py-2">
+                                          <FormattedMessage {...messages.statusLabel} />
+                                        </th>
+                                        <th className="w-10 px-3 py-2" />
                                       </tr>
-                                      {isExpanded ? (
-                                        <tr className="border-t border-border bg-muted/10">
-                                          <td colSpan={7} className="px-3 py-4">
-                                            <div className="grid gap-4">
-                                              <div className="grid gap-4 sm:grid-cols-[minmax(0,2fr)_minmax(14rem,1fr)]">
-                                                <Field className="gap-1.5">
-                                                  <FieldLabel>
-                                                    <FormattedMessage
-                                                      {...messages.descriptionLabel}
-                                                    />
-                                                  </FieldLabel>
-                                                  <Textarea
-                                                    rows={3}
-                                                    placeholder={intl.formatMessage(
-                                                      messages.termDescriptionPlaceholder,
-                                                    )}
-                                                    value={term.description}
-                                                    onChange={(event) =>
-                                                      setCreatingTermDrafts((drafts) =>
-                                                        drafts.map((draft) =>
-                                                          draft.id === term.id
-                                                            ? {
-                                                                ...draft,
-                                                                description: event.target.value,
-                                                              }
-                                                            : draft,
-                                                        ),
-                                                      )
-                                                    }
-                                                  />
-                                                </Field>
-                                                <Field className="gap-1.5">
-                                                  <FieldLabel>
-                                                    <FormattedMessage {...messages.urlLabel} />
-                                                  </FieldLabel>
-                                                  <div className="flex gap-2">
-                                                    <Input
-                                                      placeholder={intl.formatMessage(
-                                                        messages.termUrlPlaceholder,
-                                                      )}
-                                                      value={term.url}
-                                                      onChange={(event) =>
-                                                        setCreatingTermDrafts((drafts) =>
-                                                          drafts.map((draft) =>
-                                                            draft.id === term.id
-                                                              ? {
-                                                                  ...draft,
-                                                                  url: event.target.value,
-                                                                }
-                                                              : draft,
-                                                          ),
-                                                        )
-                                                      }
-                                                    />
-                                                    <Button
-                                                      type="button"
-                                                      size="icon"
-                                                      variant="secondary"
-                                                      aria-label={intl.formatMessage(
-                                                        messages.openTermUrl,
-                                                      )}
-                                                      disabled={!term.url}
-                                                      onClick={() =>
-                                                        window.open(
-                                                          term.url,
-                                                          "_blank",
-                                                          "noopener,noreferrer",
-                                                        )
-                                                      }
-                                                    >
-                                                      <HugeiconsIcon
-                                                        icon={Link01Icon}
-                                                        strokeWidth={1.8}
-                                                      />
-                                                    </Button>
-                                                  </div>
-                                                </Field>
-                                              </div>
-                                              <Field className="gap-1.5">
-                                                <FieldLabel>
-                                                  <FormattedMessage {...messages.noteLabel} />
-                                                </FieldLabel>
+                                    </thead>
+                                    <tbody>
+                                      {group.terms.map((term) => {
+                                        const isExpanded = expandedCreatingTermIds.has(term.id);
+                                        const isSourceTerm = term.locale === sourceLanguage.locale;
+                                        return (
+                                          <Fragment key={term.id}>
+                                            <tr className="border-t border-border">
+                                              <td className="px-3 py-2">
                                                 <Textarea
-                                                  rows={2}
+                                                  autoFocus={
+                                                    creatingTermDrafts.at(-1)?.id === term.id
+                                                  }
+                                                  className="w-48 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
                                                   placeholder={intl.formatMessage(
-                                                    messages.termNotePlaceholder,
+                                                    messages.termLabel,
                                                   )}
-                                                  value={term.note}
+                                                  value={term.term}
+                                                  required={isSourceTerm}
                                                   onChange={(event) =>
                                                     setCreatingTermDrafts((drafts) =>
                                                       drafts.map((draft) =>
                                                         draft.id === term.id
-                                                          ? { ...draft, note: event.target.value }
+                                                          ? { ...draft, term: event.target.value }
                                                           : draft,
                                                       ),
                                                     )
                                                   }
                                                 />
-                                              </Field>
-                                              <div className="flex justify-end border-t border-border pt-3">
+                                              </td>
+                                              <td className="px-3 py-2">
+                                                <PartOfSpeechPicker
+                                                  value={term.partOfSpeech}
+                                                  onValueChange={(value) =>
+                                                    setCreatingTermDrafts((drafts) =>
+                                                      drafts.map((draft) =>
+                                                        draft.id === term.id
+                                                          ? { ...draft, partOfSpeech: value }
+                                                          : draft,
+                                                      ),
+                                                    )
+                                                  }
+                                                />
+                                              </td>
+                                              <td className="px-3 py-2">
+                                                <GenderPicker
+                                                  value={term.gender ?? ""}
+                                                  onValueChange={(value) =>
+                                                    setCreatingTermDrafts((drafts) =>
+                                                      drafts.map((draft) =>
+                                                        draft.id === term.id
+                                                          ? { ...draft, gender: value }
+                                                          : draft,
+                                                      ),
+                                                    )
+                                                  }
+                                                />
+                                              </td>
+                                              <td className="px-3 py-2">
+                                                <TermTypePicker
+                                                  value={term.termType ?? ""}
+                                                  onValueChange={(value) =>
+                                                    setCreatingTermDrafts((drafts) =>
+                                                      drafts.map((draft) =>
+                                                        draft.id === term.id
+                                                          ? { ...draft, termType: value }
+                                                          : draft,
+                                                      ),
+                                                    )
+                                                  }
+                                                />
+                                              </td>
+                                              <td className="px-3 py-2">
+                                                <Select
+                                                  value={term.status}
+                                                  onValueChange={(value) =>
+                                                    setCreatingTermDrafts((drafts) =>
+                                                      drafts.map((draft) =>
+                                                        draft.id === term.id
+                                                          ? {
+                                                              ...draft,
+                                                              status: (value ??
+                                                                "draft") as TermDraft["status"],
+                                                            }
+                                                          : draft,
+                                                      ),
+                                                    )
+                                                  }
+                                                >
+                                                  <SelectTrigger
+                                                    showIcon={false}
+                                                    className={statusPickerTriggerClass()}
+                                                  >
+                                                    <SelectValue>
+                                                      <StatusLabel status={term.status} />
+                                                    </SelectValue>
+                                                  </SelectTrigger>
+                                                  <SelectContent
+                                                    className={statusPickerContentClassName}
+                                                  >
+                                                    {statusOptions.map((option) => (
+                                                      <SelectItem
+                                                        key={option}
+                                                        value={option}
+                                                        className={statusPickerItemClass(option)}
+                                                      >
+                                                        <StatusLabel status={option} />
+                                                      </SelectItem>
+                                                    ))}
+                                                  </SelectContent>
+                                                </Select>
+                                              </td>
+                                              <td className="px-3 py-2 text-right">
                                                 <Button
                                                   type="button"
-                                                  variant="destructive"
-                                                  onClick={() => {
-                                                    setCreatingTermDrafts((drafts) =>
-                                                      drafts.filter(
-                                                        (draft) => draft.id !== term.id,
-                                                      ),
-                                                    );
+                                                  size="icon-xs"
+                                                  variant="outline"
+                                                  aria-expanded={isExpanded}
+                                                  aria-label={intl.formatMessage(
+                                                    isExpanded
+                                                      ? messages.collapseTerm
+                                                      : messages.expandTerm,
+                                                  )}
+                                                  onClick={() =>
                                                     setExpandedCreatingTermIds((current) => {
                                                       const next = new Set(current);
-                                                      next.delete(term.id);
+                                                      if (next.has(term.id)) next.delete(term.id);
+                                                      else next.add(term.id);
                                                       return next;
-                                                    });
-                                                  }}
+                                                    })
+                                                  }
                                                 >
                                                   <HugeiconsIcon
-                                                    icon={Delete02Icon}
+                                                    icon={ArrowDown01Icon}
                                                     strokeWidth={1.8}
+                                                    className={isExpanded ? "" : "-rotate-90"}
                                                   />
-                                                  <FormattedMessage {...messages.deleteTerm} />
                                                 </Button>
-                                              </div>
-                                            </div>
-                                          </td>
-                                        </tr>
-                                      ) : null}
-                                    </Fragment>
-                                  );
-                                })}
-                              </tbody>
-                            </table>
-                          </div>
-                        </div>
-                      ) : null}
+                                              </td>
+                                            </tr>
+                                            {isExpanded ? (
+                                              <tr className="border-t border-border bg-muted/10">
+                                                <td colSpan={6} className="px-3 py-4">
+                                                  <div className="grid gap-4">
+                                                    <div className="grid gap-4 sm:grid-cols-[minmax(0,2fr)_minmax(14rem,1fr)]">
+                                                      <Field className="gap-1.5">
+                                                        <FieldLabel>
+                                                          <FormattedMessage
+                                                            {...messages.descriptionLabel}
+                                                          />
+                                                        </FieldLabel>
+                                                        <Textarea
+                                                          rows={3}
+                                                          placeholder={intl.formatMessage(
+                                                            messages.termDescriptionPlaceholder,
+                                                          )}
+                                                          value={term.description}
+                                                          onChange={(event) =>
+                                                            setCreatingTermDrafts((drafts) =>
+                                                              drafts.map((draft) =>
+                                                                draft.id === term.id
+                                                                  ? {
+                                                                      ...draft,
+                                                                      description:
+                                                                        event.target.value,
+                                                                    }
+                                                                  : draft,
+                                                              ),
+                                                            )
+                                                          }
+                                                        />
+                                                      </Field>
+                                                      <Field className="gap-1.5">
+                                                        <FieldLabel>
+                                                          <FormattedMessage
+                                                            {...messages.urlLabel}
+                                                          />
+                                                        </FieldLabel>
+                                                        <div className="flex gap-2">
+                                                          <Input
+                                                            placeholder={intl.formatMessage(
+                                                              messages.termUrlPlaceholder,
+                                                            )}
+                                                            value={term.url}
+                                                            onChange={(event) =>
+                                                              setCreatingTermDrafts((drafts) =>
+                                                                drafts.map((draft) =>
+                                                                  draft.id === term.id
+                                                                    ? {
+                                                                        ...draft,
+                                                                        url: event.target.value,
+                                                                      }
+                                                                    : draft,
+                                                                ),
+                                                              )
+                                                            }
+                                                          />
+                                                          <Button
+                                                            type="button"
+                                                            size="icon"
+                                                            variant="secondary"
+                                                            aria-label={intl.formatMessage(
+                                                              messages.openTermUrl,
+                                                            )}
+                                                            disabled={!term.url}
+                                                            onClick={() =>
+                                                              window.open(
+                                                                term.url,
+                                                                "_blank",
+                                                                "noopener,noreferrer",
+                                                              )
+                                                            }
+                                                          >
+                                                            <HugeiconsIcon
+                                                              icon={Link01Icon}
+                                                              strokeWidth={1.8}
+                                                            />
+                                                          </Button>
+                                                        </div>
+                                                      </Field>
+                                                    </div>
+                                                    <Field className="gap-1.5">
+                                                      <FieldLabel>
+                                                        <FormattedMessage {...messages.noteLabel} />
+                                                      </FieldLabel>
+                                                      <Textarea
+                                                        rows={2}
+                                                        placeholder={intl.formatMessage(
+                                                          messages.termNotePlaceholder,
+                                                        )}
+                                                        value={term.note}
+                                                        onChange={(event) =>
+                                                          setCreatingTermDrafts((drafts) =>
+                                                            drafts.map((draft) =>
+                                                              draft.id === term.id
+                                                                ? {
+                                                                    ...draft,
+                                                                    note: event.target.value,
+                                                                  }
+                                                                : draft,
+                                                            ),
+                                                          )
+                                                        }
+                                                      />
+                                                    </Field>
+                                                    {!isSourceTerm ? (
+                                                      <div className="flex justify-end border-t border-border pt-3">
+                                                        <Button
+                                                          type="button"
+                                                          variant="destructive"
+                                                          onClick={() => {
+                                                            setCreatingTermDrafts((drafts) =>
+                                                              drafts.filter(
+                                                                (draft) => draft.id !== term.id,
+                                                              ),
+                                                            );
+                                                            setExpandedCreatingTermIds(
+                                                              (current) => {
+                                                                const next = new Set(current);
+                                                                next.delete(term.id);
+                                                                return next;
+                                                              },
+                                                            );
+                                                          }}
+                                                        >
+                                                          <HugeiconsIcon
+                                                            icon={Delete02Icon}
+                                                            strokeWidth={1.8}
+                                                          />
+                                                          <FormattedMessage
+                                                            {...messages.deleteTerm}
+                                                          />
+                                                        </Button>
+                                                      </div>
+                                                    ) : null}
+                                                  </div>
+                                                </td>
+                                              </tr>
+                                            ) : null}
+                                          </Fragment>
+                                        );
+                                      })}
+                                    </tbody>
+                                  </table>
+                                </div>
+                              </div>
+                            );
+                          })
+                        : null}
                       {termGroups.map((group) => {
                         const isSource = group.locale === glossary.sourceLocale;
                         return (
@@ -2626,7 +2685,9 @@ export function GlossaryDetailPageContent({
                       type="button"
                       aria-busy={saveConcept.isPending}
                       disabled={
-                        !conceptDraft.primaryTerm.trim() || !isDirty || saveConcept.isPending
+                        (isCreatingConcept && !sourceTermText.trim()) ||
+                        !isDirty ||
+                        saveConcept.isPending
                       }
                       onClick={() => saveConcept.mutate(conceptDraft)}
                     >

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
@@ -402,11 +402,11 @@ export function GlossariesPageView({
           />
           {liveProjectSelectionRequired ? (
             <section aria-label={externalSectionTitle} className="min-w-0">
-              <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div className="mb-3 flex flex-col items-start gap-3">
                 <h2 className="text-sm font-semibold tracking-[-0.01em] text-foreground">
                   {externalSectionTitle}
                 </h2>
-                {liveProviderControls}
+                <div className="w-full">{liveProviderControls}</div>
               </div>
               <div className="space-y-3 rounded-lg border border-border px-5 py-8">
                 <TypographyP className="text-sm font-medium text-foreground">
@@ -424,6 +424,7 @@ export function GlossariesPageView({
               organizationSlug={organizationSlug}
               title={externalSectionTitle}
               headerActions={liveProviderControls}
+              headerActionsBelowTitle
               count={externalTotal}
               emptyTitle={externalEmptyTitle}
               emptyDescription={externalEmptyDescription}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.messages.ts
@@ -65,6 +65,11 @@ export const glossariesTableMessages = defineMessages({
     id: "unWMnZBm3r",
     description: "External project id shown in a glossary row source detail",
   },
+  projectDetail: {
+    defaultMessage: "{projectName} · Project {projectId}",
+    id: "v5J8nR2qLm",
+    description: "External project name and id shown in a glossary row source detail",
+  },
   viewLinkedProject: {
     defaultMessage: "View linked project",
     id: "n0lpKxJnLj",
@@ -110,10 +115,35 @@ export const glossariesTableMessages = defineMessages({
     id: "ohFSHTwja2",
     description: "Metadata label for glossary update time",
   },
+  createdLabel: {
+    defaultMessage: "Created",
+    id: "m4R7pK2sVx",
+    description: "Metadata label for a live provider glossary creation time",
+  },
+  usageLabel: {
+    defaultMessage: "Usage",
+    id: "sA9Q2pY8cL",
+    description: "Metadata label for glossary workspace usage",
+  },
+  providerProjectLabel: {
+    defaultMessage: "Provider project",
+    id: "q6T4wN8rLs",
+    description: "Metadata label for a glossary's live provider project",
+  },
   integrationLabel: {
     defaultMessage: "Integration",
     id: "4qHimvs9Xc",
-    description: "Metadata label for glossary integration status",
+    description: "Metadata label for a live Crowdin glossary integration",
+  },
+  usedInProjects: {
+    defaultMessage: "{count, plural, =0 {Not used yet} one {# project} other {# projects}}",
+    id: "h9B6mP2sQe",
+    description: "Workspace project usage count for a glossary",
+  },
+  liveApi: {
+    defaultMessage: "Live API",
+    id: "j3Q7kL5vNd",
+    description: "Badge for a glossary backed by a live provider API",
   },
   connectProvider: {
     defaultMessage: "Connect a provider",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.messages.ts
@@ -67,7 +67,7 @@ export const glossariesTableMessages = defineMessages({
   },
   projectDetail: {
     defaultMessage: "{projectName} · Project {projectId}",
-    id: "v5J8nR2qLm",
+    id: "f4hLje7+7r",
     description: "External project name and id shown in a glossary row source detail",
   },
   viewLinkedProject: {
@@ -117,32 +117,32 @@ export const glossariesTableMessages = defineMessages({
   },
   createdLabel: {
     defaultMessage: "Created",
-    id: "m4R7pK2sVx",
+    id: "wJduDnIsm8",
     description: "Metadata label for a live provider glossary creation time",
   },
   usageLabel: {
     defaultMessage: "Usage",
-    id: "sA9Q2pY8cL",
+    id: "oVK9Szp59h",
     description: "Metadata label for glossary workspace usage",
   },
   providerProjectLabel: {
     defaultMessage: "Provider project",
-    id: "q6T4wN8rLs",
+    id: "OmVf26hhof",
     description: "Metadata label for a glossary's live provider project",
   },
   integrationLabel: {
     defaultMessage: "Integration",
-    id: "4qHimvs9Xc",
+    id: "BK7MTjV8FM",
     description: "Metadata label for a live Crowdin glossary integration",
   },
   usedInProjects: {
     defaultMessage: "{count, plural, =0 {Not used yet} one {# project} other {# projects}}",
-    id: "h9B6mP2sQe",
+    id: "qwBzCi54cg",
     description: "Workspace project usage count for a glossary",
   },
   liveApi: {
     defaultMessage: "Live API",
-    id: "j3Q7kL5vNd",
+    id: "DbP96xw9zS",
     description: "Badge for a glossary backed by a live provider API",
   },
   connectProvider: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -84,14 +84,6 @@ function ResourceTypeBadge({ glossary }: { glossary: GlossaryListRow }) {
   );
 }
 
-function TermCapabilityBadge({ glossary }: { glossary: GlossaryListRow }) {
-  return (
-    <Badge variant="outline" className={toneClass(glossary.termCapabilityTone)}>
-      {glossary.termCapabilityLabel}
-    </Badge>
-  );
-}
-
 function LiveApiBadge({ glossary }: { glossary: GlossaryListRow }) {
   return (
     <Badge
@@ -99,7 +91,7 @@ function LiveApiBadge({ glossary }: { glossary: GlossaryListRow }) {
       className="border-grove-700/25 bg-grove-100 text-grove-900 dark:border-grove-500/30 dark:bg-grove-100 dark:text-grove-900"
     >
       <HugeiconsIcon icon={Link01Icon} strokeWidth={1.8} className="size-3.5" aria-hidden="true" />
-      {glossary.termCapabilityLabel}
+      <FormattedMessage {...glossariesTableMessages.liveApi} />
     </Badge>
   );
 }
@@ -271,6 +263,7 @@ function GlossaryRow({
   organizationSlug: string;
 }) {
   const intl = useIntl();
+  const isCrowdinLiveApi = glossary.isLiveApi && glossary.externalProviderKind === "crowdin";
   const detailId = glossary.detailId;
   const sourceDetail =
     glossary.source === "native"
@@ -283,9 +276,14 @@ function GlossaryRow({
             ? providerLabel(glossary.externalProviderKind)
             : intl.formatMessage(glossariesTableMessages.providerFallback),
           glossary.externalProjectId
-            ? intl.formatMessage(glossariesTableMessages.projectId, {
-                projectId: glossary.externalProjectId,
-              })
+            ? glossary.externalProjectName
+              ? intl.formatMessage(glossariesTableMessages.projectDetail, {
+                  projectName: glossary.externalProjectName,
+                  projectId: glossary.externalProjectId,
+                })
+              : intl.formatMessage(glossariesTableMessages.projectId, {
+                  projectId: glossary.externalProjectId,
+                })
             : null,
         ]
           .filter(Boolean)
@@ -343,18 +341,48 @@ function GlossaryRow({
             values={{ countLabel: glossary.termCountLabel }}
           />
         </GlossaryInfoCell>
-        <GlossaryInfoCell label={intl.formatMessage(glossariesTableMessages.updatedLabel)}>
+        <GlossaryInfoCell
+          label={intl.formatMessage(
+            isCrowdinLiveApi
+              ? glossariesTableMessages.createdLabel
+              : glossariesTableMessages.updatedLabel,
+          )}
+        >
           <span className="text-muted-foreground">
-            {glossary.lastSyncedAt ?? glossary.updatedAt}
+            {isCrowdinLiveApi ? glossary.createdAt : (glossary.lastSyncedAt ?? glossary.updatedAt)}
           </span>
         </GlossaryInfoCell>
-        <GlossaryInfoCell label={intl.formatMessage(glossariesTableMessages.integrationLabel)}>
-          <div className="flex flex-wrap gap-1.5">
+        <GlossaryInfoCell
+          label={intl.formatMessage(
+            isCrowdinLiveApi
+              ? glossariesTableMessages.integrationLabel
+              : glossary.isLiveApi
+                ? glossariesTableMessages.providerProjectLabel
+                : glossariesTableMessages.usageLabel,
+          )}
+        >
+          <div className="flex flex-wrap items-center gap-1.5">
+            {isCrowdinLiveApi ? null : glossary.isLiveApi ? (
+              <span className="truncate text-muted-foreground">
+                {glossary.externalProjectName ??
+                  (glossary.externalProjectId
+                    ? intl.formatMessage(glossariesTableMessages.projectId, {
+                        projectId: glossary.externalProjectId,
+                      })
+                    : intl.formatMessage(glossariesTableMessages.providerFallback))}
+              </span>
+            ) : glossary.projectCount === null ? (
+              <span className="text-muted-foreground">—</span>
+            ) : (
+              <FormattedMessage
+                {...glossariesTableMessages.usedInProjects}
+                values={{ count: glossary.projectCount }}
+              />
+            )}
             {glossary.isLiveApi ? <LiveApiBadge glossary={glossary} /> : null}
             {!glossary.isLiveApi && glossary.syncState ? (
               <SyncStateBadge syncState={glossary.syncState} />
             ) : null}
-            {!glossary.isLiveApi ? <TermCapabilityBadge glossary={glossary} /> : null}
           </div>
         </GlossaryInfoCell>
         <GlossaryRowActions glossary={glossary} organizationSlug={organizationSlug} />
@@ -369,6 +397,7 @@ export function GlossariesTable({
   organizationSlug,
   title,
   headerActions,
+  headerActionsBelowTitle = false,
   count,
   emptyTitle,
   emptyDescription,
@@ -379,6 +408,7 @@ export function GlossariesTable({
   organizationSlug: string;
   title?: string;
   headerActions?: ReactNode;
+  headerActionsBelowTitle?: boolean;
   count?: number;
   emptyTitle: string;
   emptyDescription: string;
@@ -392,14 +422,19 @@ export function GlossariesTable({
       className="min-w-0"
     >
       {title ? (
-        <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div
+          className={cn(
+            "mb-3 flex flex-col gap-3",
+            headerActionsBelowTitle ? "items-start" : "sm:flex-row sm:items-end sm:justify-between",
+          )}
+        >
           <div className="flex items-baseline gap-2">
             <h2 className="text-sm font-semibold tracking-[-0.01em] text-foreground">{title}</h2>
             {count !== undefined ? (
               <span className="text-xs tabular-nums text-muted-foreground">{count}</span>
             ) : null}
           </div>
-          {headerActions}
+          {headerActionsBelowTitle ? <div className="w-full">{headerActions}</div> : headerActions}
         </div>
       ) : null}
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -84,7 +84,7 @@ function ResourceTypeBadge({ glossary }: { glossary: GlossaryListRow }) {
   );
 }
 
-function LiveApiBadge({ glossary }: { glossary: GlossaryListRow }) {
+function LiveApiBadge() {
   return (
     <Badge
       variant="outline"
@@ -379,7 +379,7 @@ function GlossaryRow({
                 values={{ count: glossary.projectCount }}
               />
             )}
-            {glossary.isLiveApi ? <LiveApiBadge glossary={glossary} /> : null}
+            {glossary.isLiveApi ? <LiveApiBadge /> : null}
             {!glossary.isLiveApi && glossary.syncState ? (
               <SyncStateBadge syncState={glossary.syncState} />
             ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.messages.ts
@@ -51,37 +51,6 @@ export const glossaryListMessages = defineMessages({
     id: "QR/HxiItgI",
     description: "Resource type badge for a term base resource",
   },
-  capabilityPreferred: {
-    defaultMessage: "Preferred",
-    id: "/avsY2MZtR",
-    description: "Term capability badge part when preferred terms are supported",
-  },
-  capabilityNoPreferred: {
-    defaultMessage: "No preferred",
-    id: "HJHu415ivO",
-    description: "Term capability badge part when preferred terms are not supported",
-  },
-  capabilityForbidden: {
-    defaultMessage: "Forbidden",
-    id: "PT4ucYt9VV",
-    description: "Term capability badge part when forbidden terms are supported",
-  },
-  capabilityNoForbidden: {
-    defaultMessage: "No forbidden",
-    id: "Xx/womTY6W",
-    description: "Term capability badge part when forbidden terms are not supported",
-  },
-  capabilityUnknown: {
-    defaultMessage: "Capabilities unknown",
-    id: "cKwH9F0Z5s",
-    description: "Term capability badge when provider capabilities are unknown",
-  },
-  capabilityLiveApi: {
-    defaultMessage: "Live API",
-    id: "FgAIhNIP18",
-    description:
-      "Term capability badge for glossaries loaded and changed through a live provider API",
-  },
   unavailableTimestamp: {
     defaultMessage: "—",
     id: "kxi2ohyZnf",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.test.ts
@@ -94,11 +94,11 @@ describe("glossary-list", () => {
     );
 
     expect(native.resourceTypeLabel).toBe("Workspace glossary");
-    expect(native.termCapabilityLabel).toBe("Preferred · Forbidden");
     expect(native.localeSummary).toBe("English (en), German (de)");
     expect(native.sourceLocaleLabel).toBe("English");
     expect(native.secondaryLocaleSummary).toBe("German");
     expect(native.termCountLabel).toBe("120");
+    expect(native.projectCount).toBe(0);
     expect(native.isLiveApi).toBe(false);
     expect(native.providerLogoSrc).toBe("/images/logo.png");
     expect(provider.resourceTypeLabel).toBe("Term base");
@@ -125,12 +125,14 @@ describe("glossary-list", () => {
         externalUrl: "https://crowdin.com/project/acme/glossary/gl-99",
         externalProjectId: "crowdin-project-1",
         projectName: "Acme",
+        createdAt: "2026-08-20T00:00:00.000Z",
       },
       "crowdin",
     );
 
-    expect(row.termCapabilityLabel).toBe("Live API");
     expect(row.isLiveApi).toBe(true);
+    expect(row.projectCount).toBeNull();
+    expect(row.externalProjectName).toBe("Acme");
     expect(row.providerLogoSrc).toBe("/images/tms/crowdin.png");
     expect(row.detailId).toBe("crowdin:glossary:gl-99");
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.ts
@@ -17,10 +17,7 @@ import { getLocaleLabel } from "@/lib/i18n/locales";
 import type { ExternalTmsProviderKind } from "@/lib/providers/credentials/organization-external-tms-provider-credentials";
 import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import type { TmsProviderLiveGlossary } from "@/lib/providers/jobs/tms-provider-live";
-import {
-  parseTermCapabilitySupport,
-  type TermCapabilitySupport,
-} from "@/lib/glossary/term-capabilities";
+import { toNativeGlossaryLocale } from "@/lib/providers/adapters/crowdin/crowdin-glossary-language";
 
 import { glossaryListMessages } from "./glossary-list.messages";
 
@@ -50,6 +47,7 @@ export type GlossaryListRow = {
   externalProviderKind: ApiGlossary["externalProviderKind"];
   providerLogoSrc: string | null;
   externalProjectId: string | null;
+  externalProjectName: string | null;
   externalGlossaryId: string | null;
   externalResourceType: ApiGlossary["externalResourceType"];
   resourceTypeLabel: string;
@@ -63,9 +61,9 @@ export type GlossaryListRow = {
   secondaryLocaleSummary: string;
   termCount: number | null;
   termCountLabel: string;
+  projectCount: number | null;
+  createdAt: string;
   syncState: string | null;
-  termCapabilityLabel: string;
-  termCapabilityTone: "watch" | "safe";
   externalUrl: string | null;
   lastSyncedAt: string | null;
   lastSyncErrorAt: string | null;
@@ -173,34 +171,6 @@ function resourceTypeLabelFor(glossary: ApiGlossary, intl?: GlossaryListIntl) {
   return resolveMessage(intl, glossaryListMessages.resourceTypeGlossary);
 }
 
-function termCapabilityToneFor(support: TermCapabilitySupport): "watch" | "safe" {
-  if (support.preferred === null && support.forbidden === null) return "watch";
-  if (support.preferred === false || support.forbidden === false) return "watch";
-  return "safe";
-}
-
-function formatTermCapabilityLabel(support: TermCapabilitySupport, intl?: GlossaryListIntl) {
-  const parts: string[] = [];
-
-  if (support.preferred === true) {
-    parts.push(resolveMessage(intl, glossaryListMessages.capabilityPreferred));
-  } else if (support.preferred === false) {
-    parts.push(resolveMessage(intl, glossaryListMessages.capabilityNoPreferred));
-  }
-
-  if (support.forbidden === true) {
-    parts.push(resolveMessage(intl, glossaryListMessages.capabilityForbidden));
-  } else if (support.forbidden === false) {
-    parts.push(resolveMessage(intl, glossaryListMessages.capabilityNoForbidden));
-  }
-
-  if (parts.length === 0) {
-    return resolveMessage(intl, glossaryListMessages.capabilityUnknown);
-  }
-
-  return parts.join(" · ");
-}
-
 export function externalProjectLookupKey(
   providerKind: string | null | undefined,
   externalProjectId: string | null | undefined,
@@ -214,15 +184,27 @@ export function mapGlossaryToListRow(
   projectIdByExternalKey: ReadonlyMap<string, string>,
   intl?: GlossaryListIntl,
 ): GlossaryListRow {
+  const resolvedLanguages =
+    glossary.source === "native" && glossary.languages.length === 0
+      ? [
+          {
+            locale: glossary.sourceLocale,
+            name: getLocaleLabel(glossary.sourceLocale),
+            isSource: true,
+          },
+        ]
+      : glossary.languages;
+  const localeCoverage =
+    glossary.source === "native"
+      ? [...new Set(resolvedLanguages.map(({ locale }) => locale))]
+      : glossary.localeCoverage;
+  const secondaryLocaleCoverage = localeCoverage.filter(
+    (locale) => locale !== glossary.sourceLocale,
+  );
   const lookupKey = externalProjectLookupKey(
     glossary.externalProviderKind,
     glossary.externalProjectId,
   );
-  const termCapabilitySupport = parseTermCapabilitySupport(
-    glossary.termCapabilities,
-    glossary.source,
-  );
-
   return {
     id: glossary.id,
     detailId: glossary.id,
@@ -236,6 +218,7 @@ export function mapGlossaryToListRow(
       glossary.source === "native" ? "native" : glossary.externalProviderKind,
     ),
     externalProjectId: glossary.externalProjectId,
+    externalProjectName: null,
     externalGlossaryId: glossary.externalGlossaryId,
     externalResourceType: glossary.externalResourceType,
     resourceTypeLabel: resourceTypeLabelFor(glossary, intl),
@@ -244,11 +227,11 @@ export function mapGlossaryToListRow(
     localePairLabel: glossary.targetLocale
       ? `${glossary.sourceLocale} → ${glossary.targetLocale}`
       : glossary.sourceLocale,
-    localeCoverage: glossary.localeCoverage,
-    languages: glossary.languages,
+    localeCoverage,
+    languages: resolvedLanguages,
     localeSummary:
       glossary.source === "native"
-        ? formatLanguages(glossary.languages, intl)
+        ? formatLanguages(resolvedLanguages, intl)
         : formatLocaleCoverage(
             glossary.localeCoverage,
             glossary.sourceLocale,
@@ -256,17 +239,17 @@ export function mapGlossaryToListRow(
             intl,
           ),
     sourceLocaleLabel: getLocaleLabel(glossary.sourceLocale),
-    secondaryLocaleSummary: formatLocaleCoverage(
-      glossary.localeCoverage.filter((locale) => locale !== glossary.sourceLocale),
-      "",
-      glossary.targetLocale,
-      intl,
-    ),
+    secondaryLocaleSummary:
+      secondaryLocaleCoverage.length > 0
+        ? formatLocaleCoverage(secondaryLocaleCoverage, "", glossary.targetLocale, intl)
+        : "",
     termCount: glossary.termCount,
     termCountLabel: formatTermCount(glossary.termCount, intl),
+    projectCount: glossary.projectCount ?? 0,
+    createdAt:
+      formatRelativeTimestamp(glossary.createdAt) ??
+      resolveMessage(intl, glossaryListMessages.unavailableTimestamp),
     syncState: glossary.syncState,
-    termCapabilityLabel: formatTermCapabilityLabel(termCapabilitySupport, intl),
-    termCapabilityTone: termCapabilityToneFor(termCapabilitySupport),
     externalUrl: glossary.externalUrl,
     lastSyncedAt: formatRelativeTimestamp(glossary.lastSyncedAt),
     lastSyncErrorAt: formatRelativeTimestamp(glossary.lastSyncErrorAt),
@@ -283,6 +266,22 @@ export function mapLiveTmsProviderGlossaryToListRow(
   providerKind: ExternalTmsProviderKind,
   intl?: GlossaryListIntl,
 ): GlossaryListRow {
+  const isCrowdin = providerKind === "crowdin";
+  const sourceLocale = isCrowdin
+    ? toNativeGlossaryLocale(glossary.sourceLocale)
+    : glossary.sourceLocale;
+  const targetLocale = isCrowdin
+    ? toNativeGlossaryLocale(glossary.targetLocale)
+    : glossary.targetLocale;
+  const localeCoverage = isCrowdin
+    ? [
+        ...new Set([
+          sourceLocale,
+          ...glossary.localeCoverage.map((locale) => toNativeGlossaryLocale(locale)),
+        ]),
+      ]
+    : glossary.localeCoverage;
+
   return {
     id: glossary.id,
     detailId: glossary.providerKind === "crowdin" ? glossary.id : null,
@@ -294,41 +293,39 @@ export function mapLiveTmsProviderGlossaryToListRow(
     externalProviderKind: providerKind,
     providerLogoSrc: providerLogoSource(providerKind),
     externalProjectId: glossary.externalProjectId,
+    externalProjectName: glossary.projectName?.trim() || null,
     externalGlossaryId: glossary.id.split(":").at(-1) ?? glossary.id,
     externalResourceType: "glossary",
     resourceTypeLabel: resolveMessage(intl, glossaryListMessages.resourceTypeGlossary),
-    sourceLocale: glossary.sourceLocale,
-    targetLocale: glossary.targetLocale,
-    localePairLabel: `${glossary.sourceLocale} → ${glossary.targetLocale}`,
-    localeCoverage: glossary.localeCoverage,
+    sourceLocale,
+    targetLocale,
+    localePairLabel: `${sourceLocale} → ${targetLocale}`,
+    localeCoverage,
     languages: [
       {
-        locale: glossary.sourceLocale,
-        name: getLocaleLabel(glossary.sourceLocale),
+        locale: sourceLocale,
+        name: getLocaleLabel(sourceLocale),
         isSource: true,
       },
-      ...glossary.localeCoverage
-        .filter((locale) => locale !== glossary.sourceLocale)
+      ...localeCoverage
+        .filter((locale) => locale !== sourceLocale)
         .map((locale) => ({ locale, name: getLocaleLabel(locale), isSource: false })),
     ],
-    localeSummary: formatLocaleCoverage(
-      glossary.localeCoverage,
-      glossary.sourceLocale,
-      glossary.targetLocale,
-      intl,
-    ),
-    sourceLocaleLabel: getLocaleLabel(glossary.sourceLocale),
+    localeSummary: formatLocaleCoverage(localeCoverage, sourceLocale, targetLocale, intl),
+    sourceLocaleLabel: getLocaleLabel(sourceLocale),
     secondaryLocaleSummary: formatLocaleCoverage(
-      glossary.localeCoverage.filter((locale) => locale !== glossary.sourceLocale),
+      localeCoverage.filter((locale) => locale !== sourceLocale),
       "",
-      glossary.targetLocale,
+      targetLocale,
       intl,
     ),
     termCount: glossary.termCount,
     termCountLabel: formatTermCount(glossary.termCount, intl),
+    projectCount: null,
+    createdAt:
+      formatRelativeTimestamp(glossary.createdAt) ??
+      resolveMessage(intl, glossaryListMessages.unavailableTimestamp),
     syncState: null,
-    termCapabilityLabel: resolveMessage(intl, glossaryListMessages.capabilityLiveApi),
-    termCapabilityTone: "safe",
     externalUrl: glossary.externalUrl,
     lastSyncedAt: null,
     lastSyncErrorAt: null,

--- a/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
@@ -109,7 +109,7 @@ export function toCrowdinConceptInput(concept: GlossaryConcept): CrowdinGlossary
     languageId: toCrowdinGlossaryLanguageId(term.locale),
     text: term === primaryTerm && concept.primaryTerm ? concept.primaryTerm : term.text,
     description: term.description,
-    partOfSpeech: normalizeGlossaryPartOfSpeech(term.partOfSpeech),
+    partOfSpeech: normalizeGlossaryPartOfSpeech(term.partOfSpeech, { required: false }),
     status:
       term === primaryTerm && term.locale === concept.sourceLocale && !hasPreferredSourceTerm
         ? "preferred"
@@ -179,7 +179,7 @@ function normalizeCrowdinTerm(term: NativeGlossaryTermInput): CrowdinGlossaryTer
     note: term.note,
     url: term.url,
     lemma: term.lemma,
-    partOfSpeech: normalizeGlossaryPartOfSpeech(term.partOfSpeech),
+    partOfSpeech: normalizeGlossaryPartOfSpeech(term.partOfSpeech, { required: false }),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary-records.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary-records.ts
@@ -18,7 +18,11 @@ import { sanitizeExternalUrl } from "@/lib/security/safe-external-url";
 export function toGlossaryRecord(
   glossary: Glossary,
   languages: GlossaryRecord["languages"] = defaultGlossaryLanguages(glossary),
+  termCount: number | null = glossary.termCount,
+  projectCount = 0,
 ): GlossaryRecord {
+  const resolvedLanguages = languages.length > 0 ? languages : defaultGlossaryLanguages(glossary);
+
   return {
     id: glossary.id,
     organizationId: glossary.organizationId,
@@ -27,7 +31,7 @@ export function toGlossaryRecord(
     description: glossary.description,
     sourceLocale: glossary.sourceLocale,
     targetLocale: glossary.targetLocale,
-    languages,
+    languages: resolvedLanguages,
     status: glossary.status,
     source: glossary.source,
     externalProviderKind: glossary.externalProviderKind,
@@ -35,7 +39,8 @@ export function toGlossaryRecord(
     externalResourceType: glossary.externalResourceType,
     externalGlossaryId: glossary.externalGlossaryId,
     localeCoverage: glossary.localeCoverage,
-    termCount: glossary.termCount,
+    termCount,
+    projectCount,
     syncState: glossary.syncState,
     termCapabilities: glossary.termCapabilities,
     externalUrl: sanitizeExternalUrl(glossary.externalUrl),

--- a/apps/hyperlocalise-web/src/lib/glossary/query-glossary-languages.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/query-glossary-languages.ts
@@ -34,7 +34,6 @@ export async function queryNativeGlossaryLanguages(glossaries: Glossary[]) {
           schema.glossaryTerms.glossaryId,
           nativeGlossaries.map((glossary) => glossary.id),
         ),
-        isNotNull(schema.glossaryTerms.conceptId),
         isNotNull(schema.glossaryTerms.locale),
       ),
     );

--- a/apps/hyperlocalise-web/src/lib/glossary/query-glossary-project-counts.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/query-glossary-project-counts.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { count, inArray } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { Glossary } from "@/lib/database/types";
+
+export async function queryGlossaryProjectCounts(glossaries: Glossary[]) {
+  const projectCountsByGlossaryId = new Map<string, number>();
+
+  for (const glossary of glossaries) {
+    projectCountsByGlossaryId.set(glossary.id, 0);
+  }
+
+  if (glossaries.length === 0) return projectCountsByGlossaryId;
+
+  const rows = await db
+    .select({
+      glossaryId: schema.projectGlossaries.glossaryId,
+      projectCount: count(),
+    })
+    .from(schema.projectGlossaries)
+    .where(
+      inArray(
+        schema.projectGlossaries.glossaryId,
+        glossaries.map((glossary) => glossary.id),
+      ),
+    )
+    .groupBy(schema.projectGlossaries.glossaryId);
+
+  for (const row of rows) {
+    projectCountsByGlossaryId.set(row.glossaryId, Number(row.projectCount));
+  }
+
+  return projectCountsByGlossaryId;
+}
+
+export async function queryGlossaryProjectCount(glossary: Glossary) {
+  const counts = await queryGlossaryProjectCounts([glossary]);
+  return counts.get(glossary.id) ?? 0;
+}

--- a/apps/hyperlocalise-web/src/lib/glossary/query-glossary-term-counts.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/query-glossary-term-counts.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { count, inArray } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { Glossary } from "@/lib/database/types";
+
+export async function queryNativeGlossaryTermCounts(glossaries: Glossary[]) {
+  const nativeGlossaries = glossaries.filter((glossary) => glossary.source === "native");
+  const termCountsByGlossaryId = new Map<string, number>();
+
+  for (const glossary of nativeGlossaries) {
+    termCountsByGlossaryId.set(glossary.id, 0);
+  }
+
+  if (nativeGlossaries.length === 0) {
+    return termCountsByGlossaryId;
+  }
+
+  const rows = await db
+    .select({
+      glossaryId: schema.glossaryTerms.glossaryId,
+      termCount: count(),
+    })
+    .from(schema.glossaryTerms)
+    .where(
+      inArray(
+        schema.glossaryTerms.glossaryId,
+        nativeGlossaries.map((glossary) => glossary.id),
+      ),
+    )
+    .groupBy(schema.glossaryTerms.glossaryId);
+
+  for (const row of rows) {
+    termCountsByGlossaryId.set(row.glossaryId, Number(row.termCount));
+  }
+
+  return termCountsByGlossaryId;
+}
+
+export async function queryNativeGlossaryTermCountForGlossary(glossary: Glossary) {
+  const counts = await queryNativeGlossaryTermCounts([glossary]);
+  return counts.get(glossary.id) ?? 0;
+}

--- a/apps/hyperlocalise-web/src/lib/glossary/query-glossary-terms.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/query-glossary-terms.test.ts
@@ -23,6 +23,7 @@ vi.hoisted(() => {
 
 import { db, schema } from "@/lib/database";
 
+import { queryNativeGlossaryTermCounts } from "./query-glossary-term-counts";
 import { listGlossaryTermsForProject } from "./query-glossary-terms";
 
 const createdOrganizationIds = new Set<string>();
@@ -232,5 +233,52 @@ describe("listGlossaryTermsForProject", () => {
       targetTerm: "paiement",
       targetLocale: "fr",
     });
+  });
+});
+
+describe("queryNativeGlossaryTermCounts", () => {
+  it("counts native glossary terms and returns zero for empty glossaries", async () => {
+    const organization = await createOrganization();
+    const [emptyGlossary, populatedGlossary] = await db
+      .insert(schema.glossaries)
+      .values([
+        {
+          organizationId: organization.id,
+          name: "Empty glossary",
+          description: "",
+          sourceLocale: "en",
+        },
+        {
+          organizationId: organization.id,
+          name: "Populated glossary",
+          description: "",
+          sourceLocale: "en",
+        },
+      ])
+      .returning();
+
+    await db.insert(schema.glossaryTerms).values([
+      {
+        glossaryId: populatedGlossary.id,
+        sourceTerm: "checkout",
+        targetTerm: "caisse",
+        description: "",
+        provenance: "manual",
+        reviewStatus: "approved",
+      },
+      {
+        glossaryId: populatedGlossary.id,
+        sourceTerm: "payment",
+        targetTerm: "paiement",
+        description: "",
+        provenance: "manual",
+        reviewStatus: "approved",
+      },
+    ]);
+
+    const counts = await queryNativeGlossaryTermCounts([emptyGlossary, populatedGlossary]);
+
+    expect(counts.get(emptyGlossary.id)).toBe(0);
+    expect(counts.get(populatedGlossary.id)).toBe(2);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -485,6 +485,7 @@ export interface CrowdinGlossary {
   id: number;
   name: string;
   description: string | null;
+  createdAt?: string | null;
   languageId: string;
   languageIds: string[];
   terms: number;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -370,6 +370,9 @@ describe("Crowdin live glossary concepts", () => {
       {
         primaryTerm: "Checkout",
         sourceLocale: "en-US",
+        subject: "Commerce",
+        definition: "A payment step",
+        note: "Concept-level note",
         terms: [
           { languageId: "en", text: "Checkout", status: "preferred" },
           { languageId: "vi", text: "Thanh toán", status: "draft" },
@@ -382,7 +385,16 @@ describe("Crowdin live glossary concepts", () => {
       expect.objectContaining({ languageId: "vi", text: "Thanh toán", conceptId: 8 }),
     ]);
     expect(termBodies[0]).not.toHaveProperty("conceptId");
-    expect(conceptUpdateBodies).toEqual([{}]);
+    expect(termBodies[0]).not.toHaveProperty("partOfSpeech");
+    expect(termBodies[0]).not.toHaveProperty("description");
+    expect(termBodies[0]).not.toHaveProperty("note");
+    expect(conceptUpdateBodies).toEqual([
+      {
+        subject: "Commerce",
+        definition: "A payment step",
+        note: "Concept-level note",
+      },
+    ]);
     expect(termBodies).toHaveLength(2);
     expect(requests).toEqual([
       "POST /glossaries/7/terms",

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -683,10 +683,6 @@ describe("Crowdin live glossary concepts", () => {
         { op: "replace", path: "/description", value: "Updated" },
         { op: "replace", path: "/partOfSpeech", value: "noun" },
         { op: "replace", path: "/status", value: "preferred" },
-        { op: "replace", path: "/type", value: "" },
-        { op: "replace", path: "/gender", value: "" },
-        { op: "replace", path: "/note", value: "" },
-        { op: "replace", path: "/url", value: "" },
       ],
     ]);
   });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -42,6 +42,7 @@ import {
   type CrowdinDirectory,
   type CrowdinFile,
   type CrowdinGlossary,
+  type CrowdinGlossaryPatch,
   type CrowdinProject,
   type CrowdinShortUser,
   type CrowdinSourceString,
@@ -237,6 +238,56 @@ export type CrowdinGlossaryConceptTerm = CrowdinGlossaryTermInput & {
   updatedAt?: string;
 };
 
+function omitBlankCrowdinTermValue(value: string | null | undefined) {
+  return typeof value !== "string" || value.trim() === "" ? undefined : value;
+}
+
+type CrowdinGlossaryTermRequest = CrowdinGlossaryTermInput & {
+  conceptId?: number;
+};
+
+function toCrowdinGlossaryTermRequest(
+  term: CrowdinGlossaryTermInput,
+  conceptId?: number,
+): CrowdinGlossaryTermRequest {
+  return {
+    languageId: toCrowdinGlossaryLanguageId(term.languageId),
+    text: term.text,
+    description: omitBlankCrowdinTermValue(term.description),
+    partOfSpeech: omitBlankCrowdinTermValue(term.partOfSpeech),
+    status: omitBlankCrowdinTermValue(term.status),
+    type: omitBlankCrowdinTermValue(term.type),
+    gender: omitBlankCrowdinTermValue(term.gender),
+    note: omitBlankCrowdinTermValue(term.note),
+    url: omitBlankCrowdinTermValue(term.url),
+    lemma: omitBlankCrowdinTermValue(term.lemma),
+    conceptId,
+  };
+}
+
+function toCrowdinGlossaryTermUpdatePatches(
+  term: CrowdinGlossaryTermInput,
+): CrowdinGlossaryPatch[] {
+  const normalizedTerm = toCrowdinGlossaryTermRequest(term);
+  const patches: CrowdinGlossaryPatch[] = [
+    { op: "replace", path: "/text", value: normalizedTerm.text },
+  ];
+
+  for (const [path, value] of [
+    ["/description", normalizedTerm.description],
+    ["/partOfSpeech", normalizedTerm.partOfSpeech],
+    ["/status", normalizedTerm.status],
+    ["/type", normalizedTerm.type],
+    ["/gender", normalizedTerm.gender],
+    ["/note", normalizedTerm.note],
+    ["/url", normalizedTerm.url],
+  ] as const) {
+    if (value !== undefined) patches.push({ op: "replace", path, value });
+  }
+
+  return patches;
+}
+
 export type CrowdinGlossaryLanguageDetails = {
   languageId: string;
   userId: number | null;
@@ -286,6 +337,7 @@ export type CrowdinLiveGlossaryPage = {
     termCount: number;
     externalUrl: string | null;
     externalProjectIds: string[];
+    createdAt: string | null;
   }>;
   offset: number;
   limit: number;
@@ -721,6 +773,7 @@ export class CrowdinTmsProvider extends TmsProvider {
       termCount: glossary.terms,
       externalUrl: glossary.webUrl ?? null,
       externalProjectIds: [...glossary.projectIds, ...glossary.defaultProjectIds].map(String),
+      createdAt: glossary.createdAt ?? null,
     };
   }
 
@@ -961,17 +1014,13 @@ export class CrowdinTmsProvider extends TmsProvider {
       languageId: sourceLanguageId,
       text: input.primaryTerm,
     };
-    const createdSource = await client.addGlossaryTerm(glossaryId, {
-      languageId: toCrowdinGlossaryLanguageId(source.languageId),
-      text: source.text,
-      description: source.description ?? input.definition,
-      partOfSpeech: source.partOfSpeech ?? input.subject,
-      status: source.status ?? "preferred",
-      type: source.type,
-      gender: source.gender,
-      note: source.note ?? input.note,
-      url: source.url,
-    });
+    const createdSource = await client.addGlossaryTerm(
+      glossaryId,
+      toCrowdinGlossaryTermRequest({
+        ...source,
+        status: omitBlankCrowdinTermValue(source.status) ?? "preferred",
+      }),
+    );
 
     // Crowdin creates a concept implicitly when the first term omits
     // conceptId. Concept metadata must be written after that term exists.
@@ -990,18 +1039,7 @@ export class CrowdinTmsProvider extends TmsProvider {
       })),
     });
     for (const term of input.terms.filter((item) => item !== source)) {
-      await client.addGlossaryTerm(glossaryId, {
-        languageId: toCrowdinGlossaryLanguageId(term.languageId),
-        text: term.text,
-        description: term.description,
-        partOfSpeech: term.partOfSpeech,
-        status: term.status,
-        type: term.type,
-        gender: term.gender,
-        note: term.note,
-        url: term.url,
-        conceptId,
-      });
+      await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
     }
     return this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
   }
@@ -1031,44 +1069,17 @@ export class CrowdinTmsProvider extends TmsProvider {
           toCrowdinGlossaryLanguageId(term.languageId) !==
           toCrowdinGlossaryLanguageId(existingTerm.languageId)
         ) {
-          await client.addGlossaryTerm(glossaryId, {
-            languageId: toCrowdinGlossaryLanguageId(term.languageId),
-            text: term.text,
-            description: term.description,
-            partOfSpeech: term.partOfSpeech,
-            status: term.status,
-            type: term.type,
-            gender: term.gender,
-            note: term.note,
-            url: term.url,
-            conceptId,
-          });
+          await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
           await client.deleteGlossaryTerm(glossaryId, existingTerm.id);
           continue;
         }
-        await client.updateGlossaryTerm(glossaryId, existingTerm.id, [
-          { op: "replace", path: "/text", value: term.text },
-          { op: "replace", path: "/description", value: term.description ?? "" },
-          { op: "replace", path: "/partOfSpeech", value: term.partOfSpeech ?? "" },
-          { op: "replace", path: "/status", value: term.status ?? "draft" },
-          { op: "replace", path: "/type", value: term.type ?? "" },
-          { op: "replace", path: "/gender", value: term.gender ?? "" },
-          { op: "replace", path: "/note", value: term.note ?? "" },
-          { op: "replace", path: "/url", value: term.url ?? "" },
-        ]);
+        await client.updateGlossaryTerm(
+          glossaryId,
+          existingTerm.id,
+          toCrowdinGlossaryTermUpdatePatches(term),
+        );
       } else {
-        await client.addGlossaryTerm(glossaryId, {
-          languageId: toCrowdinGlossaryLanguageId(term.languageId),
-          text: term.text,
-          description: term.description,
-          partOfSpeech: term.partOfSpeech,
-          status: term.status,
-          type: term.type,
-          gender: term.gender,
-          note: term.note,
-          url: term.url,
-          conceptId,
-        });
+        await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
       }
     }
     return this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
@@ -1093,18 +1104,7 @@ export class CrowdinTmsProvider extends TmsProvider {
     input: CrowdinGlossaryTermInput,
   ) {
     const client = this.createClient(scope);
-    return client.addGlossaryTerm(glossaryId, {
-      languageId: toCrowdinGlossaryLanguageId(input.languageId),
-      text: input.text,
-      description: input.description,
-      partOfSpeech: input.partOfSpeech,
-      status: input.status,
-      type: input.type,
-      gender: input.gender,
-      note: input.note,
-      url: input.url,
-      conceptId,
-    });
+    return client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(input, conceptId));
   }
 
   async updateLiveGlossaryTerm(
@@ -1122,31 +1122,14 @@ export class CrowdinTmsProvider extends TmsProvider {
       toCrowdinGlossaryLanguageId(input.languageId) !==
       toCrowdinGlossaryLanguageId(existingTerm.languageId)
     ) {
-      const replacement = await client.addGlossaryTerm(glossaryId, {
-        languageId: toCrowdinGlossaryLanguageId(input.languageId),
-        text: input.text,
-        description: input.description,
-        partOfSpeech: input.partOfSpeech,
-        status: input.status,
-        type: input.type,
-        gender: input.gender,
-        note: input.note,
-        url: input.url,
-        conceptId,
-      });
+      const replacement = await client.addGlossaryTerm(
+        glossaryId,
+        toCrowdinGlossaryTermRequest(input, conceptId),
+      );
       await client.deleteGlossaryTerm(glossaryId, termId);
       return replacement;
     }
-    return client.updateGlossaryTerm(glossaryId, termId, [
-      { op: "replace", path: "/text", value: input.text },
-      { op: "replace", path: "/description", value: input.description ?? "" },
-      { op: "replace", path: "/partOfSpeech", value: input.partOfSpeech ?? "" },
-      { op: "replace", path: "/status", value: input.status ?? "draft" },
-      { op: "replace", path: "/type", value: input.type ?? "" },
-      { op: "replace", path: "/gender", value: input.gender ?? "" },
-      { op: "replace", path: "/note", value: input.note ?? "" },
-      { op: "replace", path: "/url", value: input.url ?? "" },
-    ]);
+    return client.updateGlossaryTerm(glossaryId, termId, toCrowdinGlossaryTermUpdatePatches(input));
   }
 
   async deleteLiveGlossaryTerm(

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -305,6 +305,7 @@ export type TmsProviderLiveGlossary = {
   externalUrl: string | null;
   externalProjectId: string;
   projectName: string | null;
+  createdAt: string | null;
 };
 
 export type TmsProviderLiveTranslationMemory = {
@@ -4085,6 +4086,7 @@ function mapLiveGlossary(input: {
     externalUrl: input.glossary.externalUrl ?? null,
     externalProjectId: input.externalProjectId,
     projectName: input.projectName,
+    createdAt: input.glossary.createdAt ?? null,
   };
 }
 
@@ -4107,6 +4109,7 @@ export function mapCrowdinLiveGlossaryPageItem(input: {
     termCount: number | null;
     externalUrl: string | null;
     externalProjectIds: string[];
+    createdAt?: string | null;
   };
   projectById: Map<string, { name: string }>;
   externalProjectId?: string;
@@ -4132,6 +4135,7 @@ export function mapCrowdinLiveGlossaryPageItem(input: {
       localeCoverage: input.glossary.localeCoverage,
       termCount: input.glossary.termCount,
       externalUrl: input.glossary.externalUrl,
+      createdAt: input.glossary.createdAt ?? null,
     },
     externalProjectId,
     projectName: project?.name ?? null,

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-types.ts
@@ -226,6 +226,7 @@ export type ExternalTmsGlossaryMetadata = {
   externalResourceType?: ExternalTmsTerminologyResourceType;
   localeCoverage?: string[];
   termCount?: number | null;
+  createdAt?: string | null;
   externalUrl?: string | null;
   termCapabilities?: Record<string, unknown>;
   metadata?: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Surface provider-aware glossary metadata across the API and glossary UI.
- Show live Crowdin glossaries with their creation date, term count, project details, locale coverage, and a Live API integration badge.
- Preserve provider project details for other live TMS glossaries while showing native glossary usage counts.
- Add batched native term-count and project-count queries for glossary list responses, plus detail/update response metadata.
- Thread Crowdin glossary `createdAt` through the API adapter and live-provider contracts.
- Normalize language fallbacks and simplify glossary list/detail metadata presentation for native and live-provider glossaries.

## Validation
- `vp test run src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.test.ts` — passed
- `vp check --fix` — completed with existing warnings
- Full `vp test` — has unrelated API isolation failures in existing tests

## Test plan
- Verify native glossary rows show term counts and project usage counts.
- Verify live Crowdin rows show creation date, term count, project details, locale coverage, and Live API status.
- Verify other live providers retain their provider project details.
- Verify glossary detail and update responses include the new metadata.