### PR TITLE
fix(crowdin): allow optional individualRates in report schemas and settings templates

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-31 - Allow optional IndividualRates in report schemas and settings templates
+
+**Learning:** In Crowdin API v2, `individualRates` is an optional array of custom rates per language or user in report generation schemas and report settings templates. The SDK previously enforced `r.IndividualRates != nil` in `GroupTransactionCostsPostEditingSchema` and `len(r.Config.IndividualRates) > 0` in `ReportSettingsTemplateAddRequest.Validate()`, causing client-side validation to reject valid requests when no custom individual rates were specified.
+
+**Action:** Updated `GroupTransactionCostsPostEditingSchema.ValidateGroupSchema()` and `ReportSettingsTemplateAddRequest.Validate()` in `third_party/crowdin-api-client-go/crowdin/model/reports.go` to omit mandatory checks for `IndividualRates`. Updated unit and contract tests in `crowdin/model/reports_test.go` and `crowdin/reports_test.go` to assert successful validation when `IndividualRates` is omitted.
+
 ## 2026-12-31 - Add TargetLanguageID parity to StringCommentsListOptions
 
 **Learning:** In Crowdin API v2, the List String Comments endpoint (`GET /api/v2/projects/{projectId}/comments`) accepts an optional `targetLanguageId` query parameter to filter comments and issues for a specific target language. The SDK's `StringCommentsListOptions` previously lacked `TargetLanguageID`, preventing callers from filtering comments by target language.

--- a/third_party/crowdin-api-client-go/crowdin/model/reports.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/reports.go
@@ -793,9 +793,6 @@ func (r *GroupTransactionCostsPostEditingSchema) ValidateGroupSchema() error {
 	if r.BaseRates == nil {
 		return errors.New("baseRates is required")
 	}
-	if r.IndividualRates == nil {
-		return errors.New("individualRates is required")
-	}
 	if r.NetRateSchemes == nil {
 		return errors.New("netRateSchemes is required")
 	}
@@ -938,7 +935,7 @@ func (r *ReportSettingsTemplateAddRequest) Validate() error {
 	if r.Config == nil {
 		return errors.New("config is required")
 	}
-	if r.Config.BaseRates == nil || len(r.Config.IndividualRates) == 0 || r.Config.NetRateSchemes == nil {
+	if r.Config.BaseRates == nil || r.Config.NetRateSchemes == nil {
 		return errors.New("config fields are required")
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/model/reports_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/reports_test.go
@@ -219,25 +219,27 @@ func TestGroupReportGenerateRequestValidate(t *testing.T) {
 			err: "baseRates is required",
 		},
 		{
-			name: "required schema.individualRates",
+			name: "required schema.netRateSchemes",
 			req: &GroupReportGenerateRequest{
 				Name: ReportGroupTranslationCostsPostEditing,
 				Schema: &GroupTransactionCostsPostEditingSchema{
 					BaseRates: &ReportBaseRates{},
 				},
 			},
-			err: "individualRates is required",
+			err: "netRateSchemes is required",
 		},
 		{
-			name: "required schema.netRateSchemes",
+			name: "valid request without individualRates (GroupTransactionCostsPostEditingSchema)",
 			req: &GroupReportGenerateRequest{
 				Name: ReportGroupTranslationCostsPostEditing,
 				Schema: &GroupTransactionCostsPostEditingSchema{
-					BaseRates:       &ReportBaseRates{},
-					IndividualRates: []*ReportIndividualRates{},
+					BaseRates: &ReportBaseRates{FullTranslation: 0.1, Proofread: 0.2},
+					NetRateSchemes: &ReportNetRateSchemes{
+						TMMatch: []ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.1}},
+					},
 				},
 			},
-			err: "netRateSchemes is required",
+			valid: true,
 		},
 		{
 			name: "valid request (GroupTransactionCostsPostEditingSchema)",
@@ -392,6 +394,19 @@ func TestReportSettingsTemplateAddRequestValidate(t *testing.T) {
 						TMMatch:         []ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.1}},
 						MTMatch:         []ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.2}},
 						SuggestionMatch: []ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.3}},
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "valid request without individualRates",
+			req: &ReportSettingsTemplateAddRequest{
+				Name: "Default template", Currency: "USD", Unit: ReportUnitWords,
+				Config: &ReportSettingsTemplateConfig{
+					BaseRates: &ReportBaseRates{FullTranslation: 0.1, Proofread: 0.2},
+					NetRateSchemes: &ReportNetRateSchemes{
+						TMMatch: []ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.1}},
 					},
 				},
 			},

--- a/third_party/crowdin-api-client-go/crowdin/reports_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/reports_test.go
@@ -798,6 +798,59 @@ func TestReportsService_AddSettingsTemplate(t *testing.T) {
 		_, _, err = client.Reports.AddSettingsTemplate(context.Background(), 0, req)
 		require.NoError(t, err)
 	})
+
+	t.Run("omitted individualRates", func(t *testing.T) {
+		const path = "/api/v2/projects/2/reports/settings-templates"
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "POST")
+			testURL(t, r, path)
+			testJSONBody(t, r, `{
+				"name":"No Individual Rates Template",
+				"currency":"USD",
+				"unit":"words",
+				"config":{
+					"baseRates":{
+						"fullTranslation":0.1,
+						"proofread":0.12
+					},
+					"netRateSchemes":{
+						"tmMatch":[
+							{
+								"matchType":"perfect",
+								"price":0.1
+							}
+						]
+					}
+				}
+			}`)
+
+			fmt.Fprint(w, `{
+				"data": {
+					"id": 2,
+					"name": "No Individual Rates Template"
+				}
+			}`)
+		})
+
+		reqNoIndiv := &model.ReportSettingsTemplateAddRequest{
+			Name:     "No Individual Rates Template",
+			Currency: "USD",
+			Unit:     model.ReportUnitWords,
+			Config: &model.ReportSettingsTemplateConfig{
+				BaseRates: &model.ReportBaseRates{
+					FullTranslation: 0.1,
+					Proofread:       0.12,
+				},
+				NetRateSchemes: &model.ReportNetRateSchemes{
+					TMMatch: []model.ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.1}},
+				},
+			},
+		}
+		template, resp, err := client.Reports.AddSettingsTemplate(context.Background(), 2, reqNoIndiv)
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, &model.ReportSettingsTemplate{ID: 2, Name: "No Individual Rates Template"}, template)
+	})
 }
 
 func TestReportsService_EditSettingsTemplate(t *testing.T) {


### PR DESCRIPTION
- What: Updated GroupTransactionCostsPostEditingSchema.ValidateGroupSchema() and ReportSettingsTemplateAddRequest.Validate() in third_party/crowdin-api-client-go/crowdin/model/reports.go to allow optional individualRates.
- Why: Crowdin API v2 specifies individualRates as an optional parameter in report generation schemas and report settings templates. Mandatory validation caused valid requests without custom individual rates to fail client-side validation.
- Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.reports.post and https://developer.crowdin.com/api/v2/#operation/api.projects.reports.settings-templates.post
- Scope: third_party/crowdin-api-client-go/crowdin/model/reports.go, crowdin/model/reports_test.go, crowdin/reports_test.go, .jules/crowdin-steward.md
- Tests: cd third_party/crowdin-api-client-go && go test -count=1 ./...
- Confidence: Prevents client-side validation failures when generating reports or adding report settings templates without individual rates.

---
*PR created automatically by Jules for task [16541995681702345252](https://jules.google.com/task/16541995681702345252) started by @cungminh2710*