### PR TITLE
🧪 Scout: add storage adapter registry edge case unit tests

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -203,3 +203,7 @@
 ## 2026-11-23 - [CLI UI Progress Renderer Priority & Truncation Boundaries]
 **Learning:** In CLI Bubble Tea progress renderers (`progressui`), file status prioritization ranks `processing` (priority 0) ahead of `failed` (priority 1) and `done` (priority 2), maintaining recency order within the same state. Furthermore, finishing tasks for unstarted target paths must safely handle zero `processing` counts without integer underflow, and file status lists exceeding `maxVisible` must correctly compute and display the `... N more files` suffix line.
 **Action:** When testing CLI terminal rendering or state-machine UI models, verify both priority sorting boundaries and zero/underflow safety on event handlers alongside list truncation text rendering.
+
+## 2026-11-24 - [Storage Adapter Registry Normalization and Error Wrapping]
+**Learning:** The storage adapter registry (`storageregistry`) normalizes adapter names by converting to lowercase and stripping whitespace. When testing adapter registration and instantiation, lookups with mixed casing or leading/trailing whitespace (e.g. `"  CROWDIN-V2  "`) resolve to the same normalized key. Additionally, factory errors inside `New` are wrapped using Go `%w`, which preserves `errors.Is` error unwrapping while appending contextual adapter error prefixes.
+**Action:** When testing adapter registries or plugin factories, verify name normalization across registration, lookup, and list output, and assert both sentinel error unwrapping (`errors.Is`) and contextual message formatting.

--- a/apps/cli/internal/i18n/storageregistry/registry_scout_test.go
+++ b/apps/cli/internal/i18n/storageregistry/registry_scout_test.go
@@ -1,0 +1,184 @@
+package storageregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
+)
+
+func TestRegistry_RegisterValidationEdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		adapterName string
+		factory     Factory
+		errContains string
+	}{
+		{
+			name:        "empty adapter name",
+			adapterName: "",
+			factory:     func(_ json.RawMessage) (storage.StorageAdapter, error) { return stubAdapter{}, nil },
+			errContains: "name must not be empty",
+		},
+		{
+			name:        "whitespace-only adapter name",
+			adapterName: "   \t\n  ",
+			factory:     func(_ json.RawMessage) (storage.StorageAdapter, error) { return stubAdapter{}, nil },
+			errContains: "name must not be empty",
+		},
+		{
+			name:        "nil factory function",
+			adapterName: "valid-name",
+			factory:     nil,
+			errContains: "factory must not be nil",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New()
+			err := reg.Register(tc.adapterName, tc.factory)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.errContains)
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Fatalf("expected error containing %q, got %q", tc.errContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestRegistry_NameNormalizationAndCaseInsensitivity(t *testing.T) {
+	reg := New()
+	factory := func(_ json.RawMessage) (storage.StorageAdapter, error) {
+		return stubAdapter{}, nil
+	}
+
+	// Register with mixed case and surrounding whitespace
+	if err := reg.Register("  Crowdin-V2  ", factory); err != nil {
+		t.Fatalf("register with mixed case and spaces failed: %v", err)
+	}
+
+	// Lookup via uppercase, lowercase, and whitespace variations
+	lookups := []string{"CROWDIN-V2", "crowdin-v2", "  crowdin-v2\t", " CrOwDiN-v2 "}
+	for _, lookup := range lookups {
+		adapter, err := reg.New(lookup, nil)
+		if err != nil {
+			t.Fatalf("New(%q) failed: %v", lookup, err)
+		}
+		if adapter == nil {
+			t.Fatalf("New(%q) returned nil adapter", lookup)
+		}
+	}
+
+	// List should return the normalized lowercase trimmed name
+	list := reg.List()
+	if want := []string{"crowdin-v2"}; !reflect.DeepEqual(list, want) {
+		t.Fatalf("List() = %v, want %v", list, want)
+	}
+}
+
+func TestRegistry_NewValidationAndFactoryErrorWrapping(t *testing.T) {
+	reg := New()
+
+	// New with empty name
+	if _, err := reg.New("", nil); err == nil || !strings.Contains(err.Error(), "name must not be empty") {
+		t.Fatalf("expected empty name error, got %v", err)
+	}
+
+	// New with whitespace name
+	if _, err := reg.New("   ", nil); err == nil || !strings.Contains(err.Error(), "name must not be empty") {
+		t.Fatalf("expected empty name error for whitespace, got %v", err)
+	}
+
+	// New with unknown adapter
+	if _, err := reg.New("non-existent", nil); err == nil || !strings.Contains(err.Error(), "unknown adapter") {
+		t.Fatalf("expected unknown adapter error, got %v", err)
+	}
+
+	// Factory returns error -> New wraps it
+	errSentinel := errors.New("invalid JSON payload")
+	failingFactory := func(_ json.RawMessage) (storage.StorageAdapter, error) {
+		return nil, errSentinel
+	}
+	if err := reg.Register("failing", failingFactory); err != nil {
+		t.Fatalf("register failing factory: %v", err)
+	}
+
+	_, err := reg.New("failing", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatalf("expected error from failing factory, got nil")
+	}
+	if !errors.Is(err, errSentinel) {
+		t.Fatalf("expected wrapped sentinel error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "new storage adapter \"failing\":") {
+		t.Fatalf("expected contextual error message, got %q", err.Error())
+	}
+}
+
+func TestRegistry_MustRegisterPanics(t *testing.T) {
+	tests := []struct {
+		name        string
+		adapterName string
+		factory     Factory
+		panicMsg    string
+	}{
+		{
+			name:        "empty name",
+			adapterName: "",
+			factory:     func(_ json.RawMessage) (storage.StorageAdapter, error) { return stubAdapter{}, nil },
+			panicMsg:    "name must not be empty",
+		},
+		{
+			name:        "nil factory",
+			adapterName: "stub",
+			factory:     nil,
+			panicMsg:    "factory must not be nil",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New()
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("expected panic, got nil")
+				}
+				if msg := fmt.Sprint(r); !strings.Contains(msg, tc.panicMsg) {
+					t.Fatalf("expected panic containing %q, got %q", tc.panicMsg, msg)
+				}
+			}()
+
+			reg.MustRegister(tc.adapterName, tc.factory)
+		})
+	}
+}
+
+func TestRegistry_ListEmptyAndOrder(t *testing.T) {
+	reg := New()
+
+	// Empty registry returns empty slice (len 0)
+	emptyList := reg.List()
+	if len(emptyList) != 0 {
+		t.Fatalf("expected empty list, got %v", emptyList)
+	}
+
+	factory := func(_ json.RawMessage) (storage.StorageAdapter, error) { return stubAdapter{}, nil }
+
+	// Register multiple adapters out of alphabetical order
+	_ = reg.Register("smartling", factory)
+	_ = reg.Register("lokalise", factory)
+	_ = reg.Register("crowdin", factory)
+	_ = reg.Register("phrase", factory)
+
+	want := []string{"crowdin", "lokalise", "phrase", "smartling"}
+	if got := reg.List(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("List() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
💡 What: Added comprehensive behavior-driven unit tests for `Registry` in `apps/cli/internal/i18n/storageregistry/registry_scout_test.go` and documented learnings in `.jules/scout.md`.
🎯 Why: Protect storage adapter registration and instantiation against invalid inputs (empty/whitespace names, nil factory functions), verify casing and whitespace normalization across `Register`, `New`, and `List`, ensure factory error wrapping (`errors.Is`), and verify panic handling in `MustRegister`.
🧩 Scope: `apps/cli/internal/i18n/storageregistry/registry_scout_test.go`, `.jules/scout.md`
✅ Verification: `go test -v ./apps/cli/internal/i18n/storageregistry/...`, `go test ./...`
🛡️ Confidence: Ensures robust contract enforcement and error wrapping for storage adapter registration without changing production code.

---
*PR created automatically by Jules for task [11669283800470940567](https://jules.google.com/task/11669283800470940567) started by @cungminh2710*