### PR TITLE
feat(cat): add Storybook for image and video File view

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.fixture.ts
@@ -15,6 +15,7 @@ import {
   createCatWorkspaceState,
 } from "@/components/cat/shared/cat.fixture";
 import type {
+  CatFileContext,
   CatSegment,
   CatSegmentIntelligence,
   CatWorkspaceState,
@@ -105,11 +106,23 @@ export function createCatVideoFileSegment(overrides: Partial<CatSegment> = {}): 
   };
 }
 
+function createMediaFileContext(sourcePath: string, filename: string): CatFileContext {
+  return {
+    sourcePath,
+    filename,
+    sourceLocale: SOURCE_LOCALE,
+    targetLocale: TARGET_LOCALE,
+    providerKind: null,
+    canEditTranslations: true,
+    canAddComments: true,
+  };
+}
+
 function createMediaWorkspaceState(
   segments: CatSegment[],
   selectedSegmentId: string,
   intelligence: CatSegmentIntelligence,
-  fileContext: { sourcePath: string; filename: string },
+  fileContext: CatFileContext,
 ): CatWorkspaceState {
   return createCatWorkspaceState({
     segments,
@@ -134,10 +147,7 @@ export function createCatImageFileWorkspaceState(
     [segment],
     segment.id,
     catImageFileIntelligenceFixture,
-    {
-      sourcePath: segment.sourcePath ?? "marketing/hero.png",
-      filename: "hero.png",
-    },
+    createMediaFileContext(segment.sourcePath ?? "marketing/hero.png", "hero.png"),
   );
 }
 
@@ -149,10 +159,7 @@ export function createCatVideoFileWorkspaceState(
     [segment],
     segment.id,
     catVideoFileIntelligenceFixture,
-    {
-      sourcePath: segment.sourcePath ?? "onboarding/walkthrough.mp4",
-      filename: "walkthrough.mp4",
-    },
+    createMediaFileContext(segment.sourcePath ?? "onboarding/walkthrough.mp4", "walkthrough.mp4"),
   );
 }
 
@@ -172,10 +179,7 @@ export function createCatImageAndVideoWorkspaceState(): CatWorkspaceState {
       [imageSegment.id]: catImageFileIntelligenceFixture,
       [videoSegment.id]: catVideoFileIntelligenceFixture,
     },
-    fileContext: {
-      sourcePath: "All Files",
-      filename: "All Files",
-    },
+    fileContext: createMediaFileContext("All Files", "All Files"),
     breadcrumbs: ["Project", "HL-Test", "Files", "All Files"],
   });
 }

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.fixture.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  catIntelligenceFixture,
+  createCatWorkspaceState,
+} from "@/components/cat/shared/cat.fixture";
+import type {
+  CatSegment,
+  CatSegmentIntelligence,
+  CatWorkspaceState,
+} from "@/components/cat/shared/types";
+import { toQueueSegment } from "@/components/cat/workspace/store/cat-segment-view";
+
+const SOURCE_LOCALE = "en-US";
+const TARGET_LOCALE = "vi";
+
+export const CAT_STORY_IMAGE_SOURCE_URL =
+  "https://placehold.co/960x540/1e293b/f8fafc/png?text=Source+hero";
+export const CAT_STORY_IMAGE_TARGET_URL =
+  "https://placehold.co/960x540/0f766e/ecfdf5/png?text=Translated+hero";
+export const CAT_STORY_VIDEO_SOURCE_URL =
+  "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4";
+export const CAT_STORY_VIDEO_TARGET_URL =
+  "https://www.w3.org/WAI/content-images/wai-videos/perspective-video-form-controls.mp4";
+
+export const catImageFileIntelligenceFixture: CatSegmentIntelligence = {
+  ...catIntelligenceFixture,
+  reviewReason:
+    "The hero image still carries English CTA copy. Localize the visual, not only the surrounding strings.",
+  reviewRisk: "medium",
+  intent: "Marketing hero image on the dashboard landing page.",
+  locationBreadcrumb: "Marketing > Landing hero",
+  filePath: "marketing/hero.png",
+  componentName: "HeroBanner",
+  productMeaning: "Hero image that introduces pending review work on the dashboard.",
+  segmentType: "Image file",
+  constraints: "Keep the product UI readable. Do not crop the CTA.",
+  aiSuggestion: undefined,
+  aiReasoning: undefined,
+};
+
+export const catVideoFileIntelligenceFixture: CatSegmentIntelligence = {
+  ...catIntelligenceFixture,
+  reviewReason:
+    "On-screen captions and the spoken product name need a localized cut, not a subtitle overlay only.",
+  reviewRisk: "high",
+  intent: "Product walkthrough video for the onboarding flow.",
+  locationBreadcrumb: "Onboarding > Walkthrough",
+  filePath: "onboarding/walkthrough.mp4",
+  componentName: "WalkthroughPlayer",
+  productMeaning: "Short video that shows how reviewers approve translations.",
+  segmentType: "Video file",
+  constraints: "Keep the same runtime and safe-area captions.",
+  aiSuggestion: undefined,
+  aiReasoning: undefined,
+};
+
+export function createCatImageFileSegment(overrides: Partial<CatSegment> = {}): CatSegment {
+  return {
+    id: "seg-image-file",
+    index: 1,
+    key: "marketing/hero.png",
+    sourceText: "marketing/hero.png",
+    targetText: "",
+    sourcePath: "marketing/hero.png",
+    sourceLocale: SOURCE_LOCALE,
+    targetLocale: TARGET_LOCALE,
+    status: "needs_review",
+    contextLabel: "Hero image",
+    tags: ["image", "marketing"],
+    contentKind: "image_file",
+    sourceAssetUrl: CAT_STORY_IMAGE_SOURCE_URL,
+    targetAssetUrl: CAT_STORY_IMAGE_TARGET_URL,
+    ...overrides,
+  };
+}
+
+export function createCatVideoFileSegment(overrides: Partial<CatSegment> = {}): CatSegment {
+  return {
+    id: "seg-video-file",
+    index: 1,
+    key: "onboarding/walkthrough.mp4",
+    sourceText: "onboarding/walkthrough.mp4",
+    targetText: "",
+    sourcePath: "onboarding/walkthrough.mp4",
+    sourceLocale: SOURCE_LOCALE,
+    targetLocale: TARGET_LOCALE,
+    status: "needs_review",
+    contextLabel: "Walkthrough video",
+    tags: ["video", "onboarding"],
+    contentKind: "video_file",
+    sourceAssetUrl: CAT_STORY_VIDEO_SOURCE_URL,
+    targetAssetUrl: CAT_STORY_VIDEO_TARGET_URL,
+    ...overrides,
+  };
+}
+
+function createMediaWorkspaceState(
+  segments: CatSegment[],
+  selectedSegmentId: string,
+  intelligence: CatSegmentIntelligence,
+  fileContext: { sourcePath: string; filename: string },
+): CatWorkspaceState {
+  return createCatWorkspaceState({
+    segments,
+    queueSegments: segments.map(toQueueSegment),
+    selectedSegmentId,
+    formatChecks: [],
+    segmentFormatChecks: {},
+    intelligence,
+    segmentIntelligence: {
+      [selectedSegmentId]: intelligence,
+    },
+    fileContext,
+    breadcrumbs: ["Project", "HL-Test", "Files", fileContext.filename],
+  });
+}
+
+export function createCatImageFileWorkspaceState(
+  overrides: Partial<CatSegment> = {},
+): CatWorkspaceState {
+  const segment = createCatImageFileSegment(overrides);
+  return createMediaWorkspaceState(
+    [segment],
+    segment.id,
+    catImageFileIntelligenceFixture,
+    {
+      sourcePath: segment.sourcePath ?? "marketing/hero.png",
+      filename: "hero.png",
+    },
+  );
+}
+
+export function createCatVideoFileWorkspaceState(
+  overrides: Partial<CatSegment> = {},
+): CatWorkspaceState {
+  const segment = createCatVideoFileSegment(overrides);
+  return createMediaWorkspaceState(
+    [segment],
+    segment.id,
+    catVideoFileIntelligenceFixture,
+    {
+      sourcePath: segment.sourcePath ?? "onboarding/walkthrough.mp4",
+      filename: "walkthrough.mp4",
+    },
+  );
+}
+
+export function createCatImageAndVideoWorkspaceState(): CatWorkspaceState {
+  const imageSegment = createCatImageFileSegment({ index: 1 });
+  const videoSegment = createCatVideoFileSegment({ index: 2 });
+  const segments = [imageSegment, videoSegment];
+
+  return createCatWorkspaceState({
+    segments,
+    queueSegments: segments.map(toQueueSegment),
+    selectedSegmentId: imageSegment.id,
+    formatChecks: [],
+    segmentFormatChecks: {},
+    intelligence: catImageFileIntelligenceFixture,
+    segmentIntelligence: {
+      [imageSegment.id]: catImageFileIntelligenceFixture,
+      [videoSegment.id]: catVideoFileIntelligenceFixture,
+    },
+    fileContext: {
+      sourcePath: "All Files",
+      filename: "All Files",
+    },
+    breadcrumbs: ["Project", "HL-Test", "Files", "All Files"],
+  });
+}

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.stories.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+
+import type { CatWorkspaceState } from "@/components/cat/shared/types";
+import { CatWorkspaceContainer } from "@/components/cat/workspace/cat-workspace-container";
+import {
+  CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY,
+  writeCatWorkspaceViewMode,
+} from "@/components/cat/workspace/cat-workspace-view-mode";
+
+import {
+  CAT_STORY_IMAGE_SOURCE_URL,
+  CAT_STORY_IMAGE_TARGET_URL,
+  CAT_STORY_VIDEO_SOURCE_URL,
+  CAT_STORY_VIDEO_TARGET_URL,
+  createCatImageAndVideoWorkspaceState,
+  createCatImageFileWorkspaceState,
+  createCatVideoFileWorkspaceState,
+} from "./cat-file-view.fixture";
+
+const meta = {
+  title: "CAT/File view",
+  component: CatWorkspaceContainer,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => {
+      writeCatWorkspaceViewMode("file");
+      return (
+        <div className="h-svh bg-background text-foreground">
+          <Story />
+        </div>
+      );
+    },
+  ],
+} satisfies Meta<typeof CatWorkspaceContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mediaEditing = {
+  onTargetChange: fn(),
+  onUseAiSuggestion: fn(),
+  onRegenerateImage: fn(),
+  onUploadImage: fn(),
+};
+
+const mediaNavigation = {
+  onSelectSegment: fn(),
+  onPreviousSegment: fn(),
+  onNextSegment: fn(),
+  onReviewInSequence: fn(),
+};
+
+const mediaReview = {
+  onApprove: fn(),
+  onAskQuestion: fn(),
+};
+
+function fileViewArgs(initialState: CatWorkspaceState): Story["args"] {
+  return {
+    initialState,
+    initialViewMode: "file",
+    navigation: mediaNavigation,
+    editing: mediaEditing,
+    review: mediaReview,
+  };
+}
+
+async function expectFileViewChrome(canvas: ReturnType<typeof within>, filename: string) {
+  await expect(canvas.getByRole("button", { name: "CAT view mode" })).toBeInTheDocument();
+  await expect(canvas.getByText(filename)).toBeInTheDocument();
+  await expect(canvas.getByRole("heading", { name: /Translated \(vi\)/i })).toBeInTheDocument();
+  await expect(canvas.getByRole("heading", { name: /Source \(en-US\)/i })).toBeInTheDocument();
+  await expect(canvas.getByRole("button", { name: /Regenerate/i })).toBeInTheDocument();
+  await expect(canvas.getByText("Upload translated file")).toBeInTheDocument();
+}
+
+export const ImageFile: Story = {
+  args: fileViewArgs(createCatImageFileWorkspaceState()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectFileViewChrome(canvas, "marketing/hero.png");
+    await expect(canvas.getByAltText("Translated image")).toHaveAttribute(
+      "src",
+      CAT_STORY_IMAGE_TARGET_URL,
+    );
+    await expect(canvas.getByAltText("Source image")).toHaveAttribute(
+      "src",
+      CAT_STORY_IMAGE_SOURCE_URL,
+    );
+    await expect(canvas.getByRole("button", { name: /^Approve$/i })).toBeEnabled();
+  },
+};
+
+export const ImageFileEmptyTarget: Story = {
+  args: fileViewArgs(createCatImageFileWorkspaceState({ targetAssetUrl: null })),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectFileViewChrome(canvas, "marketing/hero.png");
+    await expect(canvas.getByText("No translated file yet")).toBeInTheDocument();
+    await expect(canvas.getByAltText("Source image")).toHaveAttribute(
+      "src",
+      CAT_STORY_IMAGE_SOURCE_URL,
+    );
+    await expect(canvas.getByRole("button", { name: /^Approve$/i })).toBeDisabled();
+  },
+};
+
+export const ImageFileComfortable: Story = {
+  args: fileViewArgs(createCatImageFileWorkspaceState()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectFileViewChrome(canvas, "marketing/hero.png");
+    await userEvent.click(canvas.getByRole("button", { name: "CAT view mode" }));
+    await userEvent.click(canvas.getByRole("menuitemradio", { name: /Comfortable/i }));
+
+    await waitFor(() => expect(canvas.getByText("Queue")).toBeInTheDocument());
+    await expect(canvas.getByAltText("Source image")).toHaveAttribute(
+      "src",
+      CAT_STORY_IMAGE_SOURCE_URL,
+    );
+    await expect(canvas.getByAltText("Target image")).toHaveAttribute(
+      "src",
+      CAT_STORY_IMAGE_TARGET_URL,
+    );
+    await expect(canvas.getAllByRole("button", { name: /Regenerate image/i }).length).toBeGreaterThan(
+      0,
+    );
+    await expect(canvas.getByText("Upload image")).toBeInTheDocument();
+  },
+};
+
+export const VideoFile: Story = {
+  args: fileViewArgs(createCatVideoFileWorkspaceState()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectFileViewChrome(canvas, "onboarding/walkthrough.mp4");
+    const videos = canvasElement.querySelectorAll("video");
+    await expect(videos).toHaveLength(2);
+    await expect(videos[0]).toHaveAttribute("src", CAT_STORY_VIDEO_TARGET_URL);
+    await expect(videos[1]).toHaveAttribute("src", CAT_STORY_VIDEO_SOURCE_URL);
+    await expect(canvas.getByRole("button", { name: /^Approve$/i })).toBeEnabled();
+  },
+};
+
+export const VideoFileEmptyTarget: Story = {
+  args: fileViewArgs(createCatVideoFileWorkspaceState({ targetAssetUrl: null })),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectFileViewChrome(canvas, "onboarding/walkthrough.mp4");
+    await expect(canvas.getByText("No translated file yet")).toBeInTheDocument();
+    const videos = canvasElement.querySelectorAll("video");
+    await expect(videos).toHaveLength(1);
+    await expect(videos[0]).toHaveAttribute("src", CAT_STORY_VIDEO_SOURCE_URL);
+    await expect(canvas.getByRole("button", { name: /^Approve$/i })).toBeDisabled();
+  },
+};
+
+export const VideoFileComfortable: Story = {
+  args: fileViewArgs(createCatVideoFileWorkspaceState()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectFileViewChrome(canvas, "onboarding/walkthrough.mp4");
+    await userEvent.click(canvas.getByRole("button", { name: "CAT view mode" }));
+    await userEvent.click(canvas.getByRole("menuitemradio", { name: /Comfortable/i }));
+
+    await waitFor(() => expect(canvas.getByText("Queue")).toBeInTheDocument());
+    const videos = canvasElement.querySelectorAll("video");
+    await expect(videos).toHaveLength(2);
+    await expect(videos[0]).toHaveAttribute("src", CAT_STORY_VIDEO_SOURCE_URL);
+    await expect(videos[1]).toHaveAttribute("src", CAT_STORY_VIDEO_TARGET_URL);
+    await expect(canvas.getAllByRole("button", { name: /Regenerate video/i }).length).toBeGreaterThan(
+      0,
+    );
+    await expect(canvas.getByText("Upload video")).toBeInTheDocument();
+  },
+};
+
+export const ImageAndVideoQueue: Story = {
+  args: fileViewArgs(createCatImageAndVideoWorkspaceState()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectFileViewChrome(canvas, "marketing/hero.png");
+    await expect(canvas.getByAltText("Source image")).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: /Next file/i }));
+    await waitFor(() => expect(canvas.getByText("onboarding/walkthrough.mp4")).toBeInTheDocument());
+    await expect(canvasElement.querySelectorAll("video").length).toBeGreaterThan(0);
+    await expect(canvas.queryByAltText("Source image")).not.toBeInTheDocument();
+
+    await expect(window.localStorage.getItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY)).toBe("file");
+  },
+};

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.stories.tsx
@@ -140,9 +140,9 @@ export const ImageFileComfortable: Story = {
       "src",
       CAT_STORY_IMAGE_TARGET_URL,
     );
-    await expect(canvas.getAllByRole("button", { name: /Regenerate image/i }).length).toBeGreaterThan(
-      0,
-    );
+    await expect(
+      canvas.getAllByRole("button", { name: /Regenerate image/i }).length,
+    ).toBeGreaterThan(0);
     await expect(canvas.getByText("Upload image")).toBeInTheDocument();
   },
 };
@@ -189,9 +189,9 @@ export const VideoFileComfortable: Story = {
     await expect(videos).toHaveLength(2);
     await expect(videos[0]).toHaveAttribute("src", CAT_STORY_VIDEO_SOURCE_URL);
     await expect(videos[1]).toHaveAttribute("src", CAT_STORY_VIDEO_TARGET_URL);
-    await expect(canvas.getAllByRole("button", { name: /Regenerate video/i }).length).toBeGreaterThan(
-      0,
-    );
+    await expect(
+      canvas.getAllByRole("button", { name: /Regenerate video/i }).length,
+    ).toBeGreaterThan(0);
     await expect(canvas.getByText("Upload video")).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.stories.tsx
@@ -80,13 +80,22 @@ function fileViewArgs(initialState: CatWorkspaceState): Story["args"] {
   };
 }
 
+function viewModeButtons(canvas: ReturnType<typeof within>) {
+  return canvas.getAllByRole("button", { name: "CAT view mode" });
+}
+
 async function expectFileViewChrome(canvas: ReturnType<typeof within>, filename: string) {
-  await expect(canvas.getByRole("button", { name: "CAT view mode" })).toBeInTheDocument();
+  await expect(viewModeButtons(canvas).length).toBeGreaterThan(0);
   await expect(canvas.getByText(filename)).toBeInTheDocument();
   await expect(canvas.getByRole("heading", { name: /Translated \(vi\)/i })).toBeInTheDocument();
   await expect(canvas.getByRole("heading", { name: /Source \(en-US\)/i })).toBeInTheDocument();
   await expect(canvas.getByRole("button", { name: /Regenerate/i })).toBeInTheDocument();
   await expect(canvas.getByText("Upload translated file")).toBeInTheDocument();
+}
+
+async function switchToComfortable(canvas: ReturnType<typeof within>) {
+  await userEvent.click(viewModeButtons(canvas)[0]);
+  await userEvent.click(canvas.getByRole("menuitemradio", { name: /Comfortable/i }));
 }
 
 export const ImageFile: Story = {
@@ -128,8 +137,7 @@ export const ImageFileComfortable: Story = {
     const canvas = within(canvasElement);
 
     await expectFileViewChrome(canvas, "marketing/hero.png");
-    await userEvent.click(canvas.getByRole("button", { name: "CAT view mode" }));
-    await userEvent.click(canvas.getByRole("menuitemradio", { name: /Comfortable/i }));
+    await switchToComfortable(canvas);
 
     await waitFor(() => expect(canvas.getByText("Queue")).toBeInTheDocument());
     await expect(canvas.getByAltText("Source image")).toHaveAttribute(
@@ -181,8 +189,7 @@ export const VideoFileComfortable: Story = {
     const canvas = within(canvasElement);
 
     await expectFileViewChrome(canvas, "onboarding/walkthrough.mp4");
-    await userEvent.click(canvas.getByRole("button", { name: "CAT view mode" }));
-    await userEvent.click(canvas.getByRole("menuitemradio", { name: /Comfortable/i }));
+    await switchToComfortable(canvas);
 
     await waitFor(() => expect(canvas.getByText("Queue")).toBeInTheDocument());
     const videos = canvasElement.querySelectorAll("video");

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.test.tsx
@@ -18,6 +18,10 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  createCatImageFileWorkspaceState,
+  createCatVideoFileWorkspaceState,
+} from "@/components/cat/file-view/cat-file-view.fixture";
+import {
   catSegmentsFixture,
   createCatWorkspaceState,
   mockValidateFormat,
@@ -205,5 +209,50 @@ describe("CatWorkspaceContainer UI", () => {
     } finally {
       window.matchMedia = originalMatchMedia;
     }
+  });
+
+  it("renders File view for an image file segment", async () => {
+    renderCatWorkspace(
+      <CatWorkspaceContainer
+        initialState={createCatImageFileWorkspaceState()}
+        initialViewMode="file"
+        editing={{
+          onRegenerateImage: vi.fn(),
+          onUploadImage: vi.fn(),
+        }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Translated \(vi\)/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("heading", { name: /Source \(en-US\)/i })).toBeInTheDocument();
+    expect(screen.getByText("marketing/hero.png")).toBeInTheDocument();
+    expect(screen.getByAltText("Translated image")).toBeInTheDocument();
+    expect(screen.getByAltText("Source image")).toBeInTheDocument();
+    expect(screen.getByText("Upload translated file")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Approve$/i })).toBeEnabled();
+  });
+
+  it("renders File view for a video file segment", async () => {
+    renderCatWorkspace(
+      <CatWorkspaceContainer
+        initialState={createCatVideoFileWorkspaceState()}
+        initialViewMode="file"
+        editing={{
+          onRegenerateImage: vi.fn(),
+          onUploadImage: vi.fn(),
+        }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Translated \(vi\)/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("heading", { name: /Source \(en-US\)/i })).toBeInTheDocument();
+    expect(screen.getByText("onboarding/walkthrough.mp4")).toBeInTheDocument();
+    expect(document.querySelectorAll("video")).toHaveLength(2);
+    expect(screen.getByText("Upload translated file")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Approve$/i })).toBeEnabled();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Add Storybook coverage for the CAT workspace when opening image and video files.

New `CAT/File view` stories cover:

- Image and video File view with source and translated previews
- Empty translated-file states
- Switching from File view to Comfortable for image and video editors
- Next-file navigation across a mixed image and video queue

Workspace container tests now assert File view mounts for `image_file` and `video_file` segments.

## How to test

- Open Storybook and browse `CAT/File view`
- Confirm image stories show source and translated images, upload, regenerate, and Approve
- Confirm video stories render both video players
- Confirm empty-target stories disable Approve and show “No translated file yet”
- Confirm Comfortable stories switch view and show the image or video editor sections
- Confirm `ImageAndVideoQueue` moves between the hero image and the walkthrough video

[Image File view story](https://cursor.com/agents/bc-01a02be6-f821-7641-889f-930db3aa6c95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcat_file_view_image.webp)
[Video File view story](https://cursor.com/agents/bc-01a02be6-f821-7641-889f-930db3aa6c95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcat_file_view_video.webp)
[Image File empty target story](https://cursor.com/agents/bc-01a02be6-f821-7641-889f-930db3aa6c95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcat_file_view_image_empty_target.webp)
[Image and video queue story](https://cursor.com/agents/bc-01a02be6-f821-7641-889f-930db3aa6c95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcat_file_view_image_and_video_queue.webp)
[cat_file_view_image_and_video_stories.mp4](https://cursor.com/agents/bc-01a02be6-f821-7641-889f-930db3aa6c95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcat_file_view_image_and_video_stories.mp4)

```
cd apps/hyperlocalise-web
vp test src/components/cat/file-view src/components/cat/workspace/cat-workspace-container.test.tsx
vp check --fix src/components/cat/file-view src/components/cat/workspace/cat-workspace-container.test.tsx
```

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02be6-f821-7641-889f-930db3aa6c95?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02be6-f821-7641-889f-930db3aa6c95&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

