### PR TITLE
chore(cli): bump pinned hyperlocalise CLI to 1.9.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.9.0
+          version: 1.9.1
 
       - name: Dry-run sync push
         run: hl sync push --dry-run

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.9.0
+          version: 1.9.1
 
       - name: Extract source catalog
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.9.0
+          version: 1.9.1
 
       - name: Extract source catalog
         run: |

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -19,7 +19,7 @@ import { isReleaseSandboxVcrImageEnabled } from "@/lib/flags/release-flags";
 export const sandboxRipgrepReleaseVersion = "14.1.1";
 
 /** Pinned hyperlocalise CLI release installed into every sandbox. */
-export const sandboxHyperlocaliseReleaseVersion = "1.9.0";
+export const sandboxHyperlocaliseReleaseVersion = "1.9.1";
 
 /**
  * Pinned Playwright release used for Debian/Ubuntu `install-deps` fallback.

--- a/apps/sandbox-image/Dockerfile
+++ b/apps/sandbox-image/Dockerfile
@@ -22,7 +22,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Keep in sync with apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
 ARG NODE_MAJOR=24
-ARG HYPERLOCALISE_VERSION=1.9.0
+ARG HYPERLOCALISE_VERSION=1.9.1
 ARG PLAYWRIGHT_VERSION=1.61.1
 # Optional pin; omit / leave empty to install the latest Volta release.
 ARG VOLTA_VERSION=


### PR DESCRIPTION
## What changed

Bump the pinned Hyperlocalise CLI from 1.9.0 to 1.9.1 in CI, the web localize workflow, sandbox bootstrap, and the sandbox image.

## How to test

- [x] `vp test src/lib/vercel-sandbox-config.test.ts` in `apps/hyperlocalise-web`
- [x] `vp check --fix src/lib/vercel-sandbox-config.ts` in `apps/hyperlocalise-web`
- [ ] Confirm CI installs `hl` 1.9.1 on the sync self-test job
- [ ] Confirm a new sandbox image build pulls CLI 1.9.1

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)