### PR TITLE
fix(web): split Hono RPC clients per router group

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -27,59 +27,18 @@ import type {
 } from "@/lib/workflow/types";
 import { createApiTranslationJobQueue } from "./queues/api-translation-job-queue";
 import { handleUnexpectedError, notFoundHandler } from "./errors";
-import { createAgentEmailRoutes } from "./routes/agent-email/agent-email.route";
-import { createAgentSlackRoutes } from "./routes/agent-slack/agent-slack.route";
-import { createApiKeyRoutes } from "./routes/api-key/api-key.route";
-import { authRoutes } from "./routes/auth/auth.route";
-import { createNativeAuthRoutes } from "./routes/auth/native-auth.route";
-import { createConversationRoutes } from "./routes/conversation/conversation.route";
-import { createCanvaConnectionRoutes } from "./routes/canva-connection/canva-connection.route";
 import { createCanvaIntegrationRoutes } from "./routes/canva-integration/canva-integration.route";
 import { createCrowdinAppRoutes } from "./routes/crowdin-app/crowdin-app.route";
-import { createContentfulConnectionRoutes } from "./routes/contentful-connection/contentful-connection.route";
 import { createContentfulWebhookRoutes } from "./routes/contentful-webhook/contentful-webhook.route";
-import { createMcpServerConnectionRoutes } from "./routes/mcp-server-connection/mcp-server-connection.route";
-import { createLinkedDomainRoutes } from "./routes/linked-domain/linked-domain.route";
-import { createAhrefsConnectionRoutes } from "./routes/ahrefs-connection/ahrefs-connection.route";
-import { createSemrushConnectionRoutes } from "./routes/semrush-connection/semrush-connection.route";
-import { createIntercomConnectionRoutes } from "./routes/intercom-connection/intercom-connection.route";
-import { createGlossaryRoutes } from "./routes/glossary/glossary.route";
-import { createKnowledgeMemoryRoutes } from "./routes/knowledge-memory/knowledge-memory.route";
-import { createMemoryRoutes } from "./routes/memory/memory.route";
-import { createOrganizationIssueSheetRoutes } from "./routes/issues/organization-issue-sheet.route";
-import { createOrganizationIssuesRoutes } from "./routes/issues/issues.route";
-import { createMentionSuggestionsRoutes } from "./routes/mentions/mention-suggestions.route";
-import { createIssueNotificationsRoutes } from "./routes/notifications/notifications.route";
-import { createNotificationPreferencesRoutes } from "./routes/notification-preferences/notification-preferences.route";
-import { createGithubInstallationRoutes } from "./routes/github-installation/github-installation.route";
 import { createGithubWebhookRoutes } from "./routes/github-webhook/github-webhook.route";
 import { healthRoutes } from "./routes/health";
 import { createMcpRoutes } from "./routes/mcp/mcp.route";
-import { createWorkspaceJobRoutes } from "./routes/project/job.route";
-import { createProjectRoutes } from "./routes/project/project.route";
-import { createProviderCredentialRoutes } from "./routes/provider-credential/provider-credential.route";
-import { createPublicFileRoutes } from "./routes/public-files/public-files.route";
-import { createPublicImageRoutes } from "./routes/public-images/public-images.route";
-import { createPublicJobRoutes } from "./routes/public-jobs/public-jobs.route";
 import { createPublicMediaRoutes } from "./routes/public-media/public-media.route";
-import { createPublicTranslationRoutes } from "./routes/public-translations/public-translations.route";
 import { createResendWebhookRoutes } from "./routes/resend-webhook/resend-webhook.route";
-import { createSlackOAuthRoutes } from "./routes/slack-oauth/slack-oauth.route";
 import { createSlackWebhookRoutes } from "./routes/slack-webhook/slack-webhook.route";
-import { createFileRoutes } from "./routes/file/file.route";
-import { createWorkspaceFilesRoutes } from "./routes/workspace-files/workspace-files.route";
-import { createWorkspaceAutomationRoutes } from "./routes/workspace-automation/workspace-automation.route";
 import { createWebChatRoutes } from "./routes/web-chat/web-chat.route";
-import { createExternalTmsProviderCredentialRoutes } from "./routes/external-tms-provider-credential/external-tms-provider-credential.route";
-import { createTmsProviderRoutes } from "./routes/tms-provider/tms-provider.route";
-import { createTmsAgentAutomationRoutes } from "./routes/tms-agent-automation/tms-agent-automation.route";
-import { createTmsDashboardSummaryRoutes } from "./routes/tms-dashboard-summary/tms-dashboard-summary.route";
-import { createMemberRoutes } from "./routes/member/member.route";
-import { createTeamRoutes } from "./routes/team/team.route";
-import { createWorkspaceRoutes } from "./routes/workspace/workspace.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook/workos-webhook.route";
 import { createAutumnRoutes } from "./routes/autumn/autumn.route";
-import { createBillingRoutes } from "./routes/billing/billing.route";
 import { createBlogOgImageRoutes } from "./routes/blog-og-image/blog-og-image.route";
 import { createGithubRepositoryAutomationDispatchRoutes } from "./routes/cron/github-repository-automation-dispatch.route";
 import { createSandboxCleanupRoutes } from "./routes/cron/sandbox-cleanup.route";
@@ -94,6 +53,7 @@ import {
   createProviderAgentWritebackQueue,
 } from "@/workflows/adapters";
 import type { LocalisationAuditQueue } from "@/lib/workflow/types";
+import { createAuthRoutes, createOrgScopedAppRoutes, createPublicApiRoutes } from "./route-groups";
 
 type CreateAppOptions = {
   emailAgentTaskQueue?: EmailAgentTaskQueue;
@@ -161,6 +121,7 @@ export function createApp(options: CreateAppOptions = {}) {
 
 export const app = createApp();
 
+/** Inferred schema of the single runtime Hono app. Use with `testClient`, not `hc`. */
 export type AppType = typeof app;
 
 function createInternalRoutes() {
@@ -174,92 +135,6 @@ function createInternalRoutes() {
     .route("/cron/sandbox-cleanup", createSandboxCleanupRoutes())
     .route("/cron/snapshot-cleanup", createSnapshotCleanupRoutes())
     .route("/cron/issue-notification-digest", createIssueNotificationDigestRoutes());
-}
-
-function createAuthRoutes() {
-  return new Hono()
-    .route("/native", createNativeAuthRoutes())
-    .route("/", authRoutes)
-    .route("/slack", createSlackOAuthRoutes());
-}
-
-function createOrgScopedAppRoutes(
-  options: CreateAppOptions & {
-    jobQueue: JobQueue<TranslationJobEventData>;
-    providerAgentTranslationQueue: ProviderAgentTranslationQueue;
-    providerAgentQaQueue: ProviderAgentQaQueue;
-    providerAgentCommentQueue: ProviderAgentCommentQueue;
-    providerAgentWritebackQueue: ProviderAgentWritebackQueue;
-  },
-) {
-  return new Hono()
-    .route("/issues", createOrganizationIssuesRoutes())
-    .route("/issue-sheet", createOrganizationIssueSheetRoutes())
-    .route("/notifications", createIssueNotificationsRoutes())
-    .route("/notification-preferences", createNotificationPreferencesRoutes())
-    .route("/mentions", createMentionSuggestionsRoutes())
-    .route("/glossaries", createGlossaryRoutes())
-    .route("/knowledge-memory", createKnowledgeMemoryRoutes())
-    .route("/translation-memories", createMemoryRoutes())
-    .route("/projects", createProjectRoutes(options))
-    .route(
-      "/jobs",
-      createWorkspaceJobRoutes({
-        jobQueue: options.jobQueue,
-        providerAgentTranslationQueue: options.providerAgentTranslationQueue,
-        providerAgentQaQueue: options.providerAgentQaQueue,
-        providerAgentCommentQueue: options.providerAgentCommentQueue,
-        providerAgentWritebackQueue: options.providerAgentWritebackQueue,
-      }),
-    )
-    .route("/provider-credential", createProviderCredentialRoutes())
-    .route("/contentful-connections", createContentfulConnectionRoutes())
-    .route("/mcp-server-connections", createMcpServerConnectionRoutes())
-    .route("/linked-domains", createLinkedDomainRoutes())
-    .route("/semrush-connections", createSemrushConnectionRoutes())
-    .route("/ahrefs-connections", createAhrefsConnectionRoutes())
-    .route("/intercom-connections", createIntercomConnectionRoutes())
-    .route("/canva-connections", createCanvaConnectionRoutes())
-    .route("/external-tms-provider-credential", createExternalTmsProviderCredentialRoutes())
-    .route(
-      "/tms-provider",
-      createTmsProviderRoutes({
-        providerAgentTranslationQueue: options.providerAgentTranslationQueue,
-      }),
-    )
-    .route("/tms-agent-automation", createTmsAgentAutomationRoutes())
-    .route("/tms-dashboard-summary", createTmsDashboardSummaryRoutes())
-    .route("/agent-email", createAgentEmailRoutes())
-    .route("/agent-slack", createAgentSlackRoutes())
-    .route("/teams", createTeamRoutes())
-    .route("/files", createFileRoutes({ fileStorageAdapter: options.fileStorageAdapter }))
-    .route("/workspace-files", createWorkspaceFilesRoutes())
-    .route(
-      "/automations",
-      createWorkspaceAutomationRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
-    )
-    .route(
-      "/conversations",
-      createConversationRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
-    )
-    .route("/github-installation", createGithubInstallationRoutes())
-    .route("/api-keys", createApiKeyRoutes())
-    .route("/billing", createBillingRoutes())
-    .route("/members", createMemberRoutes())
-    .route("/workspace", createWorkspaceRoutes());
-}
-
-function createPublicApiRoutes(
-  options: CreateAppOptions & { jobQueue: JobQueue<TranslationJobEventData> },
-) {
-  return new Hono()
-    .route("/files", createPublicFileRoutes({ fileStorageAdapter: options.fileStorageAdapter }))
-    .route("/jobs", createPublicJobRoutes(options))
-    .route("/projects", createPublicTranslationRoutes())
-    .route(
-      "/projects",
-      createPublicImageRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
-    );
 }
 
 function createWebhookRoutes(options: CreateAppOptions) {

--- a/apps/hyperlocalise-web/src/api/route-groups.ts
+++ b/apps/hyperlocalise-web/src/api/route-groups.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Hono } from "hono";
+
+import type { FileStorageAdapter } from "@/lib/file-storage";
+import type {
+  JobQueue,
+  ProviderAgentCommentQueue,
+  ProviderAgentQaQueue,
+  ProviderAgentTranslationQueue,
+  ProviderAgentWritebackQueue,
+  TranslationFileImportQueue,
+  TranslationJobEventData,
+} from "@/lib/workflow/types";
+
+import { createAgentEmailRoutes } from "./routes/agent-email/agent-email.route";
+import { createAgentSlackRoutes } from "./routes/agent-slack/agent-slack.route";
+import { createApiKeyRoutes } from "./routes/api-key/api-key.route";
+import { authRoutes } from "./routes/auth/auth.route";
+import { createNativeAuthRoutes } from "./routes/auth/native-auth.route";
+import { createConversationRoutes } from "./routes/conversation/conversation.route";
+import { createCanvaConnectionRoutes } from "./routes/canva-connection/canva-connection.route";
+import { createContentfulConnectionRoutes } from "./routes/contentful-connection/contentful-connection.route";
+import { createMcpServerConnectionRoutes } from "./routes/mcp-server-connection/mcp-server-connection.route";
+import { createLinkedDomainRoutes } from "./routes/linked-domain/linked-domain.route";
+import { createAhrefsConnectionRoutes } from "./routes/ahrefs-connection/ahrefs-connection.route";
+import { createSemrushConnectionRoutes } from "./routes/semrush-connection/semrush-connection.route";
+import { createIntercomConnectionRoutes } from "./routes/intercom-connection/intercom-connection.route";
+import { createGlossaryRoutes } from "./routes/glossary/glossary.route";
+import { createKnowledgeMemoryRoutes } from "./routes/knowledge-memory/knowledge-memory.route";
+import { createMemoryRoutes } from "./routes/memory/memory.route";
+import { createOrganizationIssueSheetRoutes } from "./routes/issues/organization-issue-sheet.route";
+import { createOrganizationIssuesRoutes } from "./routes/issues/issues.route";
+import { createMentionSuggestionsRoutes } from "./routes/mentions/mention-suggestions.route";
+import { createIssueNotificationsRoutes } from "./routes/notifications/notifications.route";
+import { createNotificationPreferencesRoutes } from "./routes/notification-preferences/notification-preferences.route";
+import { createGithubInstallationRoutes } from "./routes/github-installation/github-installation.route";
+import { createWorkspaceJobRoutes } from "./routes/project/job.route";
+import { createProjectRoutes } from "./routes/project/project.route";
+import { createProviderCredentialRoutes } from "./routes/provider-credential/provider-credential.route";
+import { createPublicFileRoutes } from "./routes/public-files/public-files.route";
+import { createPublicImageRoutes } from "./routes/public-images/public-images.route";
+import { createPublicJobRoutes } from "./routes/public-jobs/public-jobs.route";
+import { createPublicTranslationRoutes } from "./routes/public-translations/public-translations.route";
+import { createSlackOAuthRoutes } from "./routes/slack-oauth/slack-oauth.route";
+import { createFileRoutes } from "./routes/file/file.route";
+import { createWorkspaceFilesRoutes } from "./routes/workspace-files/workspace-files.route";
+import { createWorkspaceAutomationRoutes } from "./routes/workspace-automation/workspace-automation.route";
+import { createExternalTmsProviderCredentialRoutes } from "./routes/external-tms-provider-credential/external-tms-provider-credential.route";
+import { createTmsProviderRoutes } from "./routes/tms-provider/tms-provider.route";
+import { createTmsAgentAutomationRoutes } from "./routes/tms-agent-automation/tms-agent-automation.route";
+import { createTmsDashboardSummaryRoutes } from "./routes/tms-dashboard-summary/tms-dashboard-summary.route";
+import { createMemberRoutes } from "./routes/member/member.route";
+import { createTeamRoutes } from "./routes/team/team.route";
+import { createWorkspaceRoutes } from "./routes/workspace/workspace.route";
+import { createBillingRoutes } from "./routes/billing/billing.route";
+
+export type OrgScopedRouteOptions = {
+  jobQueue: JobQueue<TranslationJobEventData>;
+  providerAgentTranslationQueue: ProviderAgentTranslationQueue;
+  providerAgentQaQueue: ProviderAgentQaQueue;
+  providerAgentCommentQueue: ProviderAgentCommentQueue;
+  providerAgentWritebackQueue: ProviderAgentWritebackQueue;
+  fileStorageAdapter?: FileStorageAdapter;
+  translationFileImportQueue?: TranslationFileImportQueue;
+};
+
+export type PublicApiRouteOptions = {
+  jobQueue: JobQueue<TranslationJobEventData>;
+  fileStorageAdapter?: FileStorageAdapter;
+};
+
+export function createAuthRoutes() {
+  return new Hono()
+    .route("/native", createNativeAuthRoutes())
+    .route("/", authRoutes)
+    .route("/slack", createSlackOAuthRoutes());
+}
+
+export function createPublicApiRoutes(options: PublicApiRouteOptions) {
+  return new Hono()
+    .route("/files", createPublicFileRoutes({ fileStorageAdapter: options.fileStorageAdapter }))
+    .route("/jobs", createPublicJobRoutes(options))
+    .route("/projects", createPublicTranslationRoutes())
+    .route(
+      "/projects",
+      createPublicImageRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
+    );
+}
+
+export function createOrgInboxRoutes(options: OrgScopedRouteOptions) {
+  return new Hono()
+    .route("/issues", createOrganizationIssuesRoutes())
+    .route("/issue-sheet", createOrganizationIssueSheetRoutes())
+    .route("/notifications", createIssueNotificationsRoutes())
+    .route("/notification-preferences", createNotificationPreferencesRoutes())
+    .route("/mentions", createMentionSuggestionsRoutes())
+    .route(
+      "/conversations",
+      createConversationRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
+    );
+}
+
+export function createOrgKnowledgeRoutes() {
+  return new Hono()
+    .route("/glossaries", createGlossaryRoutes())
+    .route("/knowledge-memory", createKnowledgeMemoryRoutes())
+    .route("/translation-memories", createMemoryRoutes());
+}
+
+export function createOrgProjectsRoutes(options: OrgScopedRouteOptions) {
+  return new Hono()
+    .route("/projects", createProjectRoutes(options))
+    .route(
+      "/jobs",
+      createWorkspaceJobRoutes({
+        jobQueue: options.jobQueue,
+        providerAgentTranslationQueue: options.providerAgentTranslationQueue,
+        providerAgentQaQueue: options.providerAgentQaQueue,
+        providerAgentCommentQueue: options.providerAgentCommentQueue,
+        providerAgentWritebackQueue: options.providerAgentWritebackQueue,
+      }),
+    )
+    .route("/files", createFileRoutes({ fileStorageAdapter: options.fileStorageAdapter }))
+    .route("/workspace-files", createWorkspaceFilesRoutes())
+    .route(
+      "/automations",
+      createWorkspaceAutomationRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
+    );
+}
+
+export function createOrgTmsRoutes(options: OrgScopedRouteOptions) {
+  return new Hono()
+    .route("/external-tms-provider-credential", createExternalTmsProviderCredentialRoutes())
+    .route(
+      "/tms-provider",
+      createTmsProviderRoutes({
+        providerAgentTranslationQueue: options.providerAgentTranslationQueue,
+      }),
+    )
+    .route("/tms-agent-automation", createTmsAgentAutomationRoutes())
+    .route("/tms-dashboard-summary", createTmsDashboardSummaryRoutes())
+    .route("/provider-credential", createProviderCredentialRoutes());
+}
+
+export function createOrgIntegrationsRoutes() {
+  return new Hono()
+    .route("/contentful-connections", createContentfulConnectionRoutes())
+    .route("/mcp-server-connections", createMcpServerConnectionRoutes())
+    .route("/linked-domains", createLinkedDomainRoutes())
+    .route("/semrush-connections", createSemrushConnectionRoutes())
+    .route("/ahrefs-connections", createAhrefsConnectionRoutes())
+    .route("/intercom-connections", createIntercomConnectionRoutes())
+    .route("/canva-connections", createCanvaConnectionRoutes());
+}
+
+export function createOrgAgentsRoutes() {
+  return new Hono()
+    .route("/agent-email", createAgentEmailRoutes())
+    .route("/agent-slack", createAgentSlackRoutes())
+    .route("/github-installation", createGithubInstallationRoutes());
+}
+
+export function createOrgWorkspaceRoutes() {
+  return new Hono()
+    .route("/teams", createTeamRoutes())
+    .route("/members", createMemberRoutes())
+    .route("/workspace", createWorkspaceRoutes())
+    .route("/billing", createBillingRoutes())
+    .route("/api-keys", createApiKeyRoutes());
+}
+
+export function createOrgScopedAppRoutes(options: OrgScopedRouteOptions) {
+  return new Hono()
+    .route("/", createOrgInboxRoutes(options))
+    .route("/", createOrgKnowledgeRoutes())
+    .route("/", createOrgProjectsRoutes(options))
+    .route("/", createOrgTmsRoutes(options))
+    .route("/", createOrgIntegrationsRoutes())
+    .route("/", createOrgAgentsRoutes())
+    .route("/", createOrgWorkspaceRoutes());
+}

--- a/apps/hyperlocalise-web/src/api/rpc-apps.ts
+++ b/apps/hyperlocalise-web/src/api/rpc-apps.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Hono } from "hono";
+
+import {
+  createAuthRoutes,
+  createOrgAgentsRoutes,
+  createOrgInboxRoutes,
+  createOrgIntegrationsRoutes,
+  createOrgKnowledgeRoutes,
+  createOrgProjectsRoutes,
+  createOrgTmsRoutes,
+  createOrgWorkspaceRoutes,
+  createPublicApiRoutes,
+  type OrgScopedRouteOptions,
+  type PublicApiRouteOptions,
+} from "./route-groups";
+
+/**
+ * Type-only Hono apps for `hc<>`. Each group stays small enough for TypeScript
+ * to instantiate. Runtime serving still uses the single app in `app.ts`.
+ *
+ * Browser code must `import type` these aliases. Do not value-import this
+ * module from client components — the factories pull in server route modules.
+ */
+const rpcOrgRouteOptions = {} as OrgScopedRouteOptions;
+const rpcPublicApiRouteOptions = {} as PublicApiRouteOptions;
+
+function createAuthRpcApp() {
+  return new Hono().basePath("/api").route("/auth", createAuthRoutes());
+}
+
+function createV1RpcApp() {
+  return new Hono().basePath("/api").route("/v1", createPublicApiRoutes(rpcPublicApiRouteOptions));
+}
+
+function createOrgInboxRpcApp() {
+  return new Hono()
+    .basePath("/api")
+    .route("/orgs/:organizationSlug", createOrgInboxRoutes(rpcOrgRouteOptions));
+}
+
+function createOrgKnowledgeRpcApp() {
+  return new Hono().basePath("/api").route("/orgs/:organizationSlug", createOrgKnowledgeRoutes());
+}
+
+function createOrgProjectsRpcApp() {
+  return new Hono()
+    .basePath("/api")
+    .route("/orgs/:organizationSlug", createOrgProjectsRoutes(rpcOrgRouteOptions));
+}
+
+function createOrgTmsRpcApp() {
+  return new Hono()
+    .basePath("/api")
+    .route("/orgs/:organizationSlug", createOrgTmsRoutes(rpcOrgRouteOptions));
+}
+
+function createOrgIntegrationsRpcApp() {
+  return new Hono()
+    .basePath("/api")
+    .route("/orgs/:organizationSlug", createOrgIntegrationsRoutes());
+}
+
+function createOrgAgentsRpcApp() {
+  return new Hono().basePath("/api").route("/orgs/:organizationSlug", createOrgAgentsRoutes());
+}
+
+function createOrgWorkspaceRpcApp() {
+  return new Hono().basePath("/api").route("/orgs/:organizationSlug", createOrgWorkspaceRoutes());
+}
+
+export type AuthRpcAppType = ReturnType<typeof createAuthRpcApp>;
+export type V1RpcAppType = ReturnType<typeof createV1RpcApp>;
+export type OrgInboxRpcAppType = ReturnType<typeof createOrgInboxRpcApp>;
+export type OrgKnowledgeRpcAppType = ReturnType<typeof createOrgKnowledgeRpcApp>;
+export type OrgProjectsRpcAppType = ReturnType<typeof createOrgProjectsRpcApp>;
+export type OrgTmsRpcAppType = ReturnType<typeof createOrgTmsRpcApp>;
+export type OrgIntegrationsRpcAppType = ReturnType<typeof createOrgIntegrationsRpcApp>;
+export type OrgAgentsRpcAppType = ReturnType<typeof createOrgAgentsRpcApp>;
+export type OrgWorkspaceRpcAppType = ReturnType<typeof createOrgWorkspaceRpcApp>;

--- a/apps/hyperlocalise-web/src/lib/api-client.test.ts
+++ b/apps/hyperlocalise-web/src/lib/api-client.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
+
+import { createApiClient } from "./api-client";
+
+describe("createApiClient", () => {
+  const client = createApiClient();
+  const org = client.api.orgs[":organizationSlug"];
+
+  it("exposes org, v1, and auth RPC paths as callable methods", () => {
+    expect(typeof org.issues.$get).toBe("function");
+    expect(typeof org["issue-sheet"].search.$get).toBe("function");
+    expect(typeof org.notifications.$get).toBe("function");
+    expect(typeof org["notification-preferences"].$get).toBe("function");
+    expect(typeof org.mentions.$get).toBe("function");
+    expect(typeof org.conversations.$get).toBe("function");
+    expect(typeof org.glossaries.$get).toBe("function");
+    expect(typeof org["knowledge-memory"].$get).toBe("function");
+    expect(typeof org["translation-memories"].$get).toBe("function");
+    expect(typeof org.projects.$get).toBe("function");
+    expect(typeof org.jobs.$get).toBe("function");
+    expect(typeof org.files.$post).toBe("function");
+    expect(typeof org["workspace-files"].$get).toBe("function");
+    expect(typeof org.automations.$get).toBe("function");
+    expect(typeof org["external-tms-provider-credential"].$get).toBe("function");
+    expect(typeof org["tms-provider"].connection.$get).toBe("function");
+    expect(typeof org["tms-agent-automation"].organization.$get).toBe("function");
+    expect(typeof org["tms-dashboard-summary"].$get).toBe("function");
+    expect(typeof org["provider-credential"].$get).toBe("function");
+    expect(typeof org["contentful-connections"].$get).toBe("function");
+    expect(typeof org["mcp-server-connections"].$get).toBe("function");
+    expect(typeof org["linked-domains"].$get).toBe("function");
+    expect(typeof org["semrush-connections"].$get).toBe("function");
+    expect(typeof org["ahrefs-connections"].$get).toBe("function");
+    expect(typeof org["intercom-connections"].$get).toBe("function");
+    expect(typeof org["canva-connections"].$get).toBe("function");
+    expect(typeof org["agent-email"].$get).toBe("function");
+    expect(typeof org["agent-slack"].$get).toBe("function");
+    expect(typeof org["github-installation"].$get).toBe("function");
+    expect(typeof org.teams.$get).toBe("function");
+    expect(typeof org.members.$get).toBe("function");
+    expect(typeof org.workspace.$get).toBe("function");
+    expect(typeof org.billing["resource-usage"].$get).toBe("function");
+    expect(typeof org["api-keys"].$get).toBe("function");
+    expect(typeof client.api.v1.files.$post).toBe("function");
+    expect(typeof client.api.v1.jobs.$post).toBe("function");
+    expect(typeof client.api.auth.context.$get).toBe("function");
+    expect(typeof client.api.auth.native.authorize.$get).toBe("function");
+    expect(typeof client.api.auth.slack.callback.$get).toBe("function");
+  });
+
+  it("keeps typed $get/$post helpers on composed org paths", () => {
+    expectTypeOf(org.projects.$get).toBeFunction();
+    expectTypeOf(org.issues.$get).toBeFunction();
+    expectTypeOf(org.glossaries.$get).toBeFunction();
+    expectTypeOf(org["tms-provider"].connection.$get).toBeFunction();
+    expectTypeOf(org["github-installation"].$get).toBeFunction();
+    expectTypeOf(org.teams.$get).toBeFunction();
+    expectTypeOf(org.files.$post).toBeFunction();
+    expectTypeOf(client.api.v1.files.$post).toBeFunction();
+    expectTypeOf(client.api.auth.context.$get).toBeFunction();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/api-client.ts
+++ b/apps/hyperlocalise-web/src/lib/api-client.ts
@@ -12,10 +12,90 @@
  */
 import { hc } from "hono/client";
 
-import type { AppType } from "@/api/app";
+import type {
+  AuthRpcAppType,
+  OrgAgentsRpcAppType,
+  OrgInboxRpcAppType,
+  OrgIntegrationsRpcAppType,
+  OrgKnowledgeRpcAppType,
+  OrgProjectsRpcAppType,
+  OrgTmsRpcAppType,
+  OrgWorkspaceRpcAppType,
+  V1RpcAppType,
+} from "@/api/rpc-apps";
+
+/**
+ * Copy named paths off a Hono RPC proxy. Spreading the proxy itself yields an
+ * empty object because the client is a `get`-trap Proxy, not an enumerable map.
+ */
+function pickClientPaths<T extends object, const K extends readonly (keyof T)[]>(
+  client: T,
+  keys: K,
+): Pick<T, K[number]> {
+  const result = {} as Pick<T, K[number]>;
+  for (const key of keys) {
+    result[key] = client[key];
+  }
+  return result;
+}
+
+function apiOrigin() {
+  return typeof window !== "undefined" ? window.location.origin : "";
+}
+
+function createOrgSlugClient(origin: string) {
+  const inbox = hc<OrgInboxRpcAppType>(origin).api.orgs[":organizationSlug"];
+  const knowledge = hc<OrgKnowledgeRpcAppType>(origin).api.orgs[":organizationSlug"];
+  const projects = hc<OrgProjectsRpcAppType>(origin).api.orgs[":organizationSlug"];
+  const tms = hc<OrgTmsRpcAppType>(origin).api.orgs[":organizationSlug"];
+  const integrations = hc<OrgIntegrationsRpcAppType>(origin).api.orgs[":organizationSlug"];
+  const agents = hc<OrgAgentsRpcAppType>(origin).api.orgs[":organizationSlug"];
+  const workspace = hc<OrgWorkspaceRpcAppType>(origin).api.orgs[":organizationSlug"];
+
+  return {
+    ...pickClientPaths(inbox, [
+      "issues",
+      "issue-sheet",
+      "notifications",
+      "notification-preferences",
+      "mentions",
+      "conversations",
+    ]),
+    ...pickClientPaths(knowledge, ["glossaries", "knowledge-memory", "translation-memories"]),
+    ...pickClientPaths(projects, ["projects", "jobs", "files", "workspace-files", "automations"]),
+    ...pickClientPaths(tms, [
+      "external-tms-provider-credential",
+      "tms-provider",
+      "tms-agent-automation",
+      "tms-dashboard-summary",
+      "provider-credential",
+    ]),
+    ...pickClientPaths(integrations, [
+      "contentful-connections",
+      "mcp-server-connections",
+      "linked-domains",
+      "semrush-connections",
+      "ahrefs-connections",
+      "intercom-connections",
+      "canva-connections",
+    ]),
+    ...pickClientPaths(agents, ["agent-email", "agent-slack", "github-installation"]),
+    ...pickClientPaths(workspace, ["teams", "members", "workspace", "billing", "api-keys"]),
+  };
+}
 
 export function createApiClient() {
-  return hc<AppType>(typeof window !== "undefined" ? window.location.origin : "");
+  const origin = apiOrigin();
+
+  return {
+    api: {
+      orgs: {
+        ":organizationSlug": createOrgSlugClient(origin),
+      },
+      v1: hc<V1RpcAppType>(origin).api.v1,
+      auth: hc<AuthRpcAppType>(origin).api.auth,
+    },
+  };
 }
 
 export type ApiClient = ReturnType<typeof createApiClient>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Next.js `tsc` can fail with `TS2589` ("Type instantiation is excessively deep and possibly infinite") when `hc` is typed against the full Hono app schema.

This change keeps a **single runtime Hono instance** in `createApp()`, and splits the browser RPC client into smaller typed apps:

- Org routes are grouped (inbox, knowledge, projects, TMS, integrations, agents, workspace) and copied onto `client.api.orgs[":organizationSlug"]`
- `client.api.v1` and `client.api.auth` come from their own `hc<>` apps
- `AppType` remains for `testClient` fixtures

Call sites keep `client.api.orgs[":organizationSlug"].…`.

## How to test

- `vp test src/lib/api-client.test.ts` in `apps/hyperlocalise-web`
- `vp test` and `vp check --fix` in `apps/hyperlocalise-web`
- `next typegen` then `tsc --noEmit --pretty false --incremental false`

Verified in this PR:

- `vp test`: 731 files, 4929 tests passed
- `vp check --fix`: 0 errors
- `next typegen` + `tsc --noEmit`: no diagnostics

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`, `tsc`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1df7c3c-df63-4ff0-94bd-ec1bc5a7116d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1df7c3c-df63-4ff0-94bd-ec1bc5a7116d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

