### PR TITLE
fix(glossary): mirror primary term from source term

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/concept-detail-source-term.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/concept-detail-source-term.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { selectConceptDetailSourceTermText } from "./concept-detail-source-term";
+
+describe("selectConceptDetailSourceTermText", () => {
+  it("selects the preferred source-locale term", () => {
+    expect(
+      selectConceptDetailSourceTermText(
+        [
+          { id: "2", locale: "en-US", term: "Checkout", status: "admitted" },
+          { id: "1", locale: "en-US", term: "Payment", status: "preferred" },
+          { id: "3", locale: "fr-FR", term: "Paiement", status: "preferred" },
+        ],
+        "en-US",
+      ),
+    ).toBe("Payment");
+  });
+
+  it("uses the glossary fallback for source-locale terms without a preferred term", () => {
+    expect(
+      selectConceptDetailSourceTermText(
+        [
+          { id: "2", locale: "en-US", term: "Checkout", status: "admitted" },
+          { id: "1", locale: "en-US", term: "Payment", status: "draft" },
+          { id: "3", locale: "fr-FR", term: "Paiement", status: "preferred" },
+        ],
+        "en-US",
+      ),
+    ).toBe("Payment");
+  });
+
+  it("returns an empty string when no source-locale term exists", () => {
+    expect(
+      selectConceptDetailSourceTermText(
+        [{ id: "1", locale: "fr-FR", term: "Paiement", status: "preferred" }],
+        "en-US",
+      ),
+    ).toBe("");
+  });
+
+  it("keeps a blank unsaved term from displacing a persisted source term", () => {
+    expect(
+      selectConceptDetailSourceTermText(
+        [
+          { id: "1", locale: "en-US", term: "Payment", status: "draft" },
+          { locale: "en-US", term: "", status: "draft" },
+        ],
+        "en-US",
+      ),
+    ).toBe("Payment");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/concept-detail-source-term.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/concept-detail-source-term.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { selectGlossaryPrimaryTerm } from "@/lib/glossary/glossary";
+
+export type ConceptDetailSourceTermCandidate = {
+  id?: string | number;
+  locale: string;
+  term: string;
+  status?: string | null;
+};
+
+export function selectConceptDetailSourceTermText(
+  terms: readonly ConceptDetailSourceTermCandidate[],
+  sourceLocale: string,
+) {
+  const sourceTerms = terms.filter(
+    (term) =>
+      term.locale === sourceLocale && (term.id !== undefined || term.term.trim().length > 0),
+  );
+  const preferredSourceTerm = sourceTerms.find(
+    (term) => term.status?.trim().toLowerCase().replaceAll(" ", "_") === "preferred",
+  );
+  if (preferredSourceTerm) return preferredSourceTerm.term;
+
+  const persistedSourceTerms = sourceTerms.filter((term) => term.id !== undefined);
+  return (
+    selectGlossaryPrimaryTerm(
+      persistedSourceTerms.map((term) => ({
+        id: term.id,
+        locale: term.locale,
+        text: term.term,
+        status: term.status,
+      })),
+      sourceLocale,
+    )?.text ??
+    sourceTerms[0]?.term ??
+    ""
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
@@ -176,7 +176,16 @@ export const ConceptDetail: Story = {
     },
   },
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getAllByDisplayValue("Agency").length).toBeGreaterThan(1);
+    const primaryTermInput = canvas.getByRole("textbox", { name: "Primary term" });
+    await expect(primaryTermInput).toHaveValue("Agency");
+    await expect(primaryTermInput).toHaveAttribute("readonly");
+    const sourceTermInput = canvas
+      .getAllByDisplayValue("Agency")
+      .find((element) => element !== primaryTermInput);
+    if (!sourceTermInput) throw new Error("Source term input not found");
+    await userEvent.clear(sourceTermInput);
+    await userEvent.type(sourceTermInput, "Agency updated");
+    await expect(primaryTermInput).toHaveValue("Agency updated");
     await expect(await canvas.findByDisplayValue("Đại lý")).toBeInTheDocument();
     await expect(canvas.getByText("vi-VN")).toBeInTheDocument();
     await expect(canvas.getByText("SOURCE")).toBeInTheDocument();
@@ -219,6 +228,10 @@ export const ConceptCreationWithTerms: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Add concept" })).toBeInTheDocument();
+    const primaryTermInput = canvas.getByRole("textbox", { name: "Primary term" });
+    const sourceTermInput = canvas.getAllByPlaceholderText("Term")[0]!;
+    await userEvent.type(sourceTermInput, "Checkout");
+    await expect(primaryTermInput).toHaveValue("Checkout");
     const addTermButton = canvas.getByRole("button", { name: "Add term" });
     await expect(addTermButton).toBeEnabled();
     await userEvent.click(addTermButton);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -95,6 +95,7 @@ import {
 } from "@/lib/glossary/glossary";
 
 import { availableConceptTermLocales } from "./available-concept-term-locales";
+import { selectConceptDetailSourceTermText } from "./concept-detail-source-term";
 import { glossaryDetailPageContentMessages as messages } from "./glossary-detail-page-content.messages";
 
 type ConceptDraft = {
@@ -191,7 +192,6 @@ function areTermDraftsEqual(left: TermDraft, right: TermDraft) {
 
 function areConceptDraftsEqual(left: ConceptDraft, right: ConceptDraft) {
   return (
-    left.primaryTerm === right.primaryTerm &&
     left.subject === right.subject &&
     left.definition === right.definition &&
     left.translatable === right.translatable &&
@@ -976,10 +976,32 @@ export function GlossaryDetailPageContent({
     }
   }, [selectedConcept]);
 
-  const sourceTermDraft = isCreatingConcept
-    ? creatingTermDrafts.find((term) => term.locale === sourceLanguage.locale)
-    : undefined;
-  const sourceTermText = sourceTermDraft?.term ?? "";
+  const conceptTermCandidates = isCreatingConcept
+    ? creatingTermDrafts
+    : [
+        ...(selectedConcept?.terms ?? []).map((term) => {
+          const draft = termDrafts[term.id] ?? termDraftFromRecord(term);
+          return {
+            id: term.id,
+            locale: term.locale,
+            term: draft.term,
+            status: draft.status,
+          };
+        }),
+        ...(newTermLocale
+          ? [
+              {
+                locale: newTermLocale,
+                term: newTermDraft.term,
+                status: newTermDraft.status,
+              },
+            ]
+          : []),
+      ];
+  const sourceTermText = selectConceptDetailSourceTermText(
+    conceptTermCandidates,
+    sourceLanguage.locale,
+  );
 
   const goBack = () => {
     if (conceptPageMode) router.push(glossaryHref);
@@ -1006,9 +1028,9 @@ export function GlossaryDetailPageContent({
     mutationFn: async (draft: ConceptDraft) => {
       let concept: GlossaryConceptRecord;
       let created = false;
+      const primaryTerm = sourceTermText.trim();
+      if (!primaryTerm) throw new Error(intl.formatMessage(messages.saveConceptFailed));
       if (isCreatingConcept) {
-        const primaryTerm = sourceTermText.trim();
-        if (!primaryTerm) throw new Error(intl.formatMessage(messages.saveConceptFailed));
         const terms: NonNullable<CreateGlossaryConceptBody["terms"]> = creatingTermDrafts
           .filter(({ term }) => term.trim())
           .map(({ id: _id, ...term }) => ({
@@ -1086,6 +1108,7 @@ export function GlossaryDetailPageContent({
           param: { organizationSlug, glossaryId, conceptId: selectedConceptId },
           json: {
             ...draft,
+            primaryTerm,
             url: draft.url || undefined,
             terms: terms.map((term) => ({
               ...term,
@@ -1617,7 +1640,7 @@ export function GlossaryDetailPageContent({
                     {isCreatingConcept ? (
                       <FormattedMessage {...messages.addConcept} />
                     ) : (
-                      (selected?.primaryTerm ?? selectedConceptId)
+                      sourceTermText || selectedConceptId
                     )}
                   </TypographyH1>
                   <TypographyP className="text-sm text-muted-foreground">
@@ -1647,19 +1670,7 @@ export function GlossaryDetailPageContent({
                     <FieldLabel>
                       <FormattedMessage {...messages.primaryTermLabel} />
                     </FieldLabel>
-                    <Input
-                      value={isCreatingConcept ? sourceTermText : conceptDraft.primaryTerm}
-                      onChange={(event) => {
-                        if (!isCreatingConcept) {
-                          setConceptDraft((draft) => ({
-                            ...draft,
-                            primaryTerm: event.target.value,
-                          }));
-                        }
-                      }}
-                      disabled={!canEdit || isCreatingConcept}
-                      readOnly={isCreatingConcept}
-                    />
+                    <Input value={sourceTermText} disabled={!canEdit} readOnly />
                   </Field>
                   <Field className="gap-1.5">
                     <FieldLabel>
@@ -2704,11 +2715,7 @@ export function GlossaryDetailPageContent({
                     <Button
                       type="button"
                       aria-busy={saveConcept.isPending}
-                      disabled={
-                        (isCreatingConcept && !sourceTermText.trim()) ||
-                        !isDirty ||
-                        saveConcept.isPending
-                      }
+                      disabled={!sourceTermText.trim() || !isDirty || saveConcept.isPending}
                       onClick={() => saveConcept.mutate(conceptDraft)}
                     >
                       {saveConcept.isPending ? <Spinner className="size-4" /> : null}


### PR DESCRIPTION
## Summary
- derive the concept Primary term from the canonical source-locale term
- keep Primary term read-only and synchronize create/edit save payloads
- add helper coverage and update concept detail stories

## Validation
- `vp test run src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/concept-detail-source-term.test.ts` — 4 passed
- `vp check --fix` — 0 errors; 9 pre-existing warnings in unrelated files
- `vp test` — 718 passed, 45 failed due to unrelated environment/database issues, including missing `project_knowledge_memories` and baseline auth/status mismatches