### PR TITLE
fix(web): skip localStorage when it is unavailable

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.test.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   readIssueDetailSidebarOpen,
@@ -30,6 +30,10 @@ function createStorageMock() {
 }
 
 describe("issue-detail-sidebar-state", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("returns the fallback when no value is stored for an issue", () => {
     const { getItem, setItem } = createStorageMock();
     vi.stubGlobal("window", {
@@ -84,5 +88,14 @@ describe("issue-detail-sidebar-state", () => {
 
     expect(listener).toHaveBeenCalledTimes(1);
     unsubscribe();
+  });
+
+  it("returns fallbacks and skips writes when storage is unavailable", () => {
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("window", {});
+
+    expect(readIssueDetailSidebarOpen("issue-detail", "issue_1", true)).toBe(true);
+    expect(() => writeIssueDetailSidebarOpen("issue-detail", "issue_1", false)).not.toThrow();
+    expect(readIssueDetailSidebarOpen("issue-detail", "issue_1", true)).toBe(true);
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.ts
@@ -10,6 +10,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  readBrowserLocalStorageItem,
+  writeBrowserLocalStorageItem,
+} from "@/lib/primitives/browser-local-storage/browser-local-storage";
+
 export type IssueDetailSidebarScope = "issue-detail" | "inbox";
 
 const STORAGE_KEYS: Record<IssueDetailSidebarScope, string> = {
@@ -46,27 +51,11 @@ function parseStoredSidebarState(value: string | null): IssueDetailSidebarState 
 }
 
 function readStoredSidebarState(scope: IssueDetailSidebarScope): IssueDetailSidebarState {
-  if (typeof window === "undefined") {
-    return {};
-  }
-
-  try {
-    return parseStoredSidebarState(window.localStorage.getItem(STORAGE_KEYS[scope])) ?? {};
-  } catch {
-    return {};
-  }
+  return parseStoredSidebarState(readBrowserLocalStorageItem(STORAGE_KEYS[scope])) ?? {};
 }
 
 function writeStoredSidebarState(scope: IssueDetailSidebarScope, state: IssueDetailSidebarState) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem(STORAGE_KEYS[scope], JSON.stringify(state));
-  } catch {
-    // Ignore storage failures in private browsing or restricted environments.
-  }
+  writeBrowserLocalStorageItem(STORAGE_KEYS[scope], JSON.stringify(state));
 }
 
 function notifyIssueDetailSidebarStateListeners() {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
@@ -161,4 +161,10 @@ describe("jobs-view-helpers", () => {
       });
     }
   });
+
+  it("defaults to kanban and skips writes when storage is unavailable", () => {
+    expect(readJobsViewMode()).toBe("kanban");
+    expect(() => writeJobsViewMode("row")).not.toThrow();
+    expect(readJobsViewMode()).toBe("kanban");
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.ts
@@ -10,6 +10,10 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  readBrowserLocalStorageItem,
+  writeBrowserLocalStorageItem,
+} from "@/lib/primitives/browser-local-storage/browser-local-storage";
 import { buildJobCatHref, canOpenJobCat, type JobCatTarget } from "@/lib/projects/job-cat-routing";
 import { resolveJobProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
@@ -35,32 +39,16 @@ export function isKanbanStatus(status: string): status is KanbanStatus {
 export { buildJobCatHref, canOpenJobCat, type JobCatTarget };
 
 export function readJobsViewMode(): JobsViewMode {
-  if (typeof window === "undefined") {
-    return "kanban";
-  }
-
-  try {
-    const stored = window.localStorage.getItem(JOBS_VIEW_MODE_STORAGE_KEY);
-    if (stored === "row" || stored === "kanban") {
-      return stored;
-    }
-  } catch {
-    return "kanban";
+  const stored = readBrowserLocalStorageItem(JOBS_VIEW_MODE_STORAGE_KEY);
+  if (stored === "row" || stored === "kanban") {
+    return stored;
   }
 
   return "kanban";
 }
 
 export function writeJobsViewMode(mode: JobsViewMode) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem(JOBS_VIEW_MODE_STORAGE_KEY, mode);
-  } catch {
-    // Ignore storage failures in private browsing or restricted environments.
-  }
+  writeBrowserLocalStorageItem(JOBS_VIEW_MODE_STORAGE_KEY, mode);
 }
 
 export function buildJobDetailHref(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-repository-preference.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-repository-preference.test.ts
@@ -53,4 +53,14 @@ describe("job-cat-repository-preference", () => {
     writeCatFileRepositoryPreference(storageKey, "acme/web");
     expect(readCatFileRepositoryPreference(storageKey)).toBe("acme/web");
   });
+
+  it("skips persistence when storage is unavailable", () => {
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("window", {});
+
+    const storageKey = catFileRepositoryPreferenceKey("acme", "project-1", "en-US.json");
+    expect(readCatFileRepositoryPreference(storageKey)).toBeNull();
+    expect(() => writeCatFileRepositoryPreference(storageKey, "acme/web")).not.toThrow();
+    expect(readCatFileRepositoryPreference(storageKey)).toBeNull();
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-repository-preference.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-repository-preference.ts
@@ -10,6 +10,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  readBrowserLocalStorageItem,
+  writeBrowserLocalStorageItem,
+} from "@/lib/primitives/browser-local-storage/browser-local-storage";
+
 const STORAGE_PREFIX = "job-cat-repository";
 
 export function catFileRepositoryPreferenceKey(
@@ -21,26 +26,10 @@ export function catFileRepositoryPreferenceKey(
 }
 
 export function readCatFileRepositoryPreference(storageKey: string): string | null {
-  try {
-    if (typeof localStorage === "undefined") {
-      return null;
-    }
-
-    const value = localStorage.getItem(storageKey);
-    return value?.trim() ? value.trim() : null;
-  } catch {
-    return null;
-  }
+  const value = readBrowserLocalStorageItem(storageKey)?.trim();
+  return value ? value : null;
 }
 
 export function writeCatFileRepositoryPreference(storageKey: string, repositoryFullName: string) {
-  try {
-    if (typeof localStorage === "undefined") {
-      return;
-    }
-
-    localStorage.setItem(storageKey, repositoryFullName);
-  } catch {
-    // Storage may be unavailable in private browsing or when quota is exceeded.
-  }
+  writeBrowserLocalStorageItem(storageKey, repositoryFullName);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts
@@ -88,4 +88,10 @@ describe("recent-projects", () => {
       }),
     ).toEqual([{ id: "project_a", name: "Alpha" }]);
   });
+
+  it("skips persistence when browser storage is unavailable", () => {
+    expect(readRecentProjectVisits("acme")).toEqual([]);
+    expect(() => recordRecentProjectVisit("acme", "project_a")).not.toThrow();
+    expect(readRecentProjectVisits("acme")).toEqual([]);
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.ts
@@ -10,6 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { getBrowserLocalStorage } from "@/lib/primitives/browser-local-storage/browser-local-storage";
+
 const RECENT_PROJECTS_STORAGE_VERSION = 1;
 const RECENT_PROJECTS_LIMIT = 20;
 
@@ -22,14 +24,6 @@ type RecentProjectsStorage = Pick<Storage, "getItem" | "setItem">;
 
 function recentProjectsStorageKey(organizationSlug: string) {
   return `hyperlocalise:recent-projects:v${RECENT_PROJECTS_STORAGE_VERSION}:${organizationSlug}`;
-}
-
-function getBrowserStorage() {
-  try {
-    return typeof window === "undefined" ? undefined : window.localStorage;
-  } catch {
-    return undefined;
-  }
 }
 
 function isRecentProjectVisit(value: unknown): value is RecentProjectVisit {
@@ -48,7 +42,7 @@ function isRecentProjectVisit(value: unknown): value is RecentProjectVisit {
 
 export function readRecentProjectVisits(
   organizationSlug: string,
-  storage: RecentProjectsStorage | undefined = getBrowserStorage(),
+  storage: RecentProjectsStorage | undefined = getBrowserLocalStorage(),
 ): RecentProjectVisit[] {
   if (!storage) {
     return [];
@@ -82,7 +76,7 @@ export function recordRecentProjectVisit(
     visitedAt?: number;
   },
 ) {
-  const storage = options?.storage ?? getBrowserStorage();
+  const storage = options?.storage ?? getBrowserLocalStorage();
   if (!storage || !projectId) {
     return;
   }

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.test.ts
@@ -97,4 +97,10 @@ describe("chat-dock-persistence", () => {
     clearChatDockState("acme", storage);
     expect(storage.getItem(chatDockStorageKey("acme"))).toBeNull();
   });
+
+  it("returns empty state when browser storage is unavailable", () => {
+    expect(readChatDockState("acme")).toEqual(createEmptyChatDockState("acme"));
+    expect(() => writeChatDockState(createEmptyChatDockState("acme"))).not.toThrow();
+    expect(() => clearChatDockState("acme")).not.toThrow();
+  });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.ts
@@ -10,6 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { getBrowserLocalStorage } from "@/lib/primitives/browser-local-storage/browser-local-storage";
+
 const CHAT_DOCK_STORAGE_VERSION = 1;
 export const CHAT_DOCK_MAX_CONCURRENT_STREAMS = 3;
 
@@ -48,14 +50,6 @@ export type ChatDockStorage = Pick<Storage, "getItem" | "setItem" | "removeItem"
 
 export function chatDockStorageKey(organizationSlug: string) {
   return `chat-dock:v${CHAT_DOCK_STORAGE_VERSION}:${organizationSlug}`;
-}
-
-function getBrowserStorage(): ChatDockStorage | undefined {
-  try {
-    return typeof window === "undefined" ? undefined : window.localStorage;
-  } catch {
-    return undefined;
-  }
 }
 
 function isPersistedStreamSnapshot(value: unknown): value is PersistedChatDockStreamSnapshot {
@@ -108,7 +102,7 @@ export function createEmptyChatDockState(organizationSlug: string): PersistedCha
 
 export function readChatDockState(
   organizationSlug: string,
-  storage: ChatDockStorage | undefined = getBrowserStorage(),
+  storage: ChatDockStorage | undefined = getBrowserLocalStorage(),
 ): PersistedChatDockState {
   if (!storage || !organizationSlug) {
     return createEmptyChatDockState(organizationSlug);
@@ -150,7 +144,7 @@ export function readChatDockState(
 
 export function writeChatDockState(
   state: PersistedChatDockState,
-  storage: ChatDockStorage | undefined = getBrowserStorage(),
+  storage: ChatDockStorage | undefined = getBrowserLocalStorage(),
 ) {
   if (!storage || !state.organizationSlug) {
     return;
@@ -165,7 +159,7 @@ export function writeChatDockState(
 
 export function clearChatDockState(
   organizationSlug: string,
-  storage: ChatDockStorage | undefined = getBrowserStorage(),
+  storage: ChatDockStorage | undefined = getBrowserLocalStorage(),
 ) {
   if (!storage || !organizationSlug) {
     return;

--- a/apps/hyperlocalise-web/src/components/cat/queue/use-cat-queue-selection-mode.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/queue/use-cat-queue-selection-mode.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  readCatQueueSelectionModePreference,
+  writeCatQueueSelectionModePreference,
+} from "./use-cat-queue-selection-mode";
+
+describe("cat queue selection mode preference", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to off and skips writes when storage is unavailable", () => {
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("window", {});
+
+    expect(readCatQueueSelectionModePreference()).toBe(false);
+    expect(() => writeCatQueueSelectionModePreference(true)).not.toThrow();
+    expect(readCatQueueSelectionModePreference()).toBe(false);
+  });
+
+  it("persists selection mode when storage is available", () => {
+    const values = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+      },
+      removeItem: (key: string) => {
+        values.delete(key);
+      },
+    });
+
+    expect(readCatQueueSelectionModePreference()).toBe(false);
+    writeCatQueueSelectionModePreference(true);
+    expect(readCatQueueSelectionModePreference()).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/queue/use-cat-queue-selection-mode.ts
+++ b/apps/hyperlocalise-web/src/components/cat/queue/use-cat-queue-selection-mode.ts
@@ -11,24 +11,17 @@
  * Version 2.0 or later.
  */
 
+import {
+  readBrowserLocalStorageItem,
+  writeBrowserLocalStorageItem,
+} from "@/lib/primitives/browser-local-storage/browser-local-storage";
+
 const STORAGE_KEY = "cat-queue:selection-mode:v1";
 
 export function readCatQueueSelectionModePreference() {
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  try {
-    return localStorage.getItem(STORAGE_KEY) === "true";
-  } catch {
-    return false;
-  }
+  return readBrowserLocalStorageItem(STORAGE_KEY) === "true";
 }
 
 export function writeCatQueueSelectionModePreference(value: boolean) {
-  try {
-    localStorage.setItem(STORAGE_KEY, String(value));
-  } catch {
-    // Ignore storage failures in private browsing or restricted contexts.
-  }
+  writeBrowserLocalStorageItem(STORAGE_KEY, String(value));
 }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.test.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY,
@@ -21,6 +21,10 @@ import {
 } from "./cat-workspace-view-mode";
 
 describe("cat-workspace-view-mode", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("defaults to comfortable when storage is empty", () => {
     const getItem = vi.fn().mockReturnValue(null);
     vi.stubGlobal("window", {
@@ -57,6 +61,15 @@ describe("cat-workspace-view-mode", () => {
     writeCatWorkspaceViewMode("side-by-side");
 
     expect(setItem).toHaveBeenCalledWith(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY, "side-by-side");
+  });
+
+  it("defaults to comfortable and skips writes when storage is unavailable", () => {
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("window", {});
+
+    expect(readCatWorkspaceViewMode()).toBe("comfortable");
+    expect(() => writeCatWorkspaceViewMode("file")).not.toThrow();
+    expect(readCatWorkspaceViewMode()).toBe("comfortable");
   });
 
   it("maps view mode to page limits", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.ts
@@ -10,6 +10,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  readBrowserLocalStorageItem,
+  writeBrowserLocalStorageItem,
+} from "@/lib/primitives/browser-local-storage/browser-local-storage";
+
 export type CatWorkspaceViewMode = "comfortable" | "side-by-side" | "file";
 
 export const CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY = "cat-workspace-view-mode:v1";
@@ -27,32 +32,16 @@ export function isCatWorkspaceViewMode(
 }
 
 export function readCatWorkspaceViewMode(): CatWorkspaceViewMode {
-  if (typeof window === "undefined") {
-    return "comfortable";
-  }
-
-  try {
-    const stored = window.localStorage.getItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY);
-    if (isCatWorkspaceViewMode(stored)) {
-      return stored;
-    }
-  } catch {
-    return "comfortable";
+  const stored = readBrowserLocalStorageItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY);
+  if (isCatWorkspaceViewMode(stored)) {
+    return stored;
   }
 
   return "comfortable";
 }
 
 export function writeCatWorkspaceViewMode(mode: CatWorkspaceViewMode) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY, mode);
-  } catch {
-    // Ignore storage failures in private browsing or restricted environments.
-  }
+  writeBrowserLocalStorageItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY, mode);
 }
 
 export function catPageLimitForViewMode(mode: CatWorkspaceViewMode) {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -26,6 +26,19 @@ const queueSegments = [
 ] as const;
 
 describe("CatQueueStore", () => {
+  it("constructs without throwing when storage is unavailable", () => {
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("window", {});
+
+    try {
+      const queue = new CatQueueStore();
+      expect(queue.selectionMode).toBe(false);
+      expect(() => queue.setSelectionMode(true)).not.toThrow();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("sorts segments by index", () => {
     const queue = new CatQueueStore();
     queue.replace([

--- a/apps/hyperlocalise-web/src/lib/primitives/browser-local-storage/browser-local-storage.test.ts
+++ b/apps/hyperlocalise-web/src/lib/primitives/browser-local-storage/browser-local-storage.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  getBrowserLocalStorage,
+  readBrowserLocalStorageItem,
+  removeBrowserLocalStorageItem,
+  writeBrowserLocalStorageItem,
+} from "./browser-local-storage";
+
+function createMemoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+    values,
+  };
+}
+
+describe("browser-local-storage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns undefined when no storage API is available", () => {
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("window", undefined);
+
+    expect(getBrowserLocalStorage()).toBeUndefined();
+    expect(readBrowserLocalStorageItem("theme")).toBeNull();
+    expect(() => writeBrowserLocalStorageItem("theme", "dark")).not.toThrow();
+    expect(() => removeBrowserLocalStorageItem("theme")).not.toThrow();
+  });
+
+  it("reads and writes through the global storage object", () => {
+    const storage = createMemoryStorage();
+    vi.stubGlobal("localStorage", storage);
+
+    writeBrowserLocalStorageItem("theme", "dark");
+    expect(readBrowserLocalStorageItem("theme")).toBe("dark");
+    removeBrowserLocalStorageItem("theme");
+    expect(readBrowserLocalStorageItem("theme")).toBeNull();
+    expect(storage.setItem).toHaveBeenCalledWith("theme", "dark");
+    expect(storage.removeItem).toHaveBeenCalledWith("theme");
+  });
+
+  it("falls back to window.localStorage when the global identifier is missing", () => {
+    const storage = createMemoryStorage();
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("window", { localStorage: storage });
+
+    writeBrowserLocalStorageItem("theme", "light");
+    expect(readBrowserLocalStorageItem("theme")).toBe("light");
+  });
+
+  it("skips storage when the Storage getter throws", () => {
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("window", {
+      get localStorage(): Storage {
+        throw new Error("Access is denied for this document");
+      },
+    });
+
+    expect(getBrowserLocalStorage()).toBeUndefined();
+    expect(readBrowserLocalStorageItem("theme")).toBeNull();
+    expect(() => writeBrowserLocalStorageItem("theme", "dark")).not.toThrow();
+  });
+
+  it("skips storage when getItem or setItem throw", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+      removeItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+    });
+
+    expect(readBrowserLocalStorageItem("theme")).toBeNull();
+    expect(() => writeBrowserLocalStorageItem("theme", "dark")).not.toThrow();
+    expect(() => removeBrowserLocalStorageItem("theme")).not.toThrow();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/primitives/browser-local-storage/browser-local-storage.ts
+++ b/apps/hyperlocalise-web/src/lib/primitives/browser-local-storage/browser-local-storage.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export type BrowserLocalStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/**
+ * Best-effort access to `localStorage`.
+ *
+ * Returns `undefined` during SSR, when the Storage API is missing, and when
+ * private browsing / quota / disabled-cookie policies throw on access.
+ * Callers should skip persistence rather than treating storage as required.
+ */
+export function getBrowserLocalStorage(): BrowserLocalStorage | undefined {
+  try {
+    const fromGlobal = globalThis.localStorage;
+    if (fromGlobal) {
+      return fromGlobal;
+    }
+  } catch {
+    return undefined;
+  }
+
+  try {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    return window.localStorage || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readBrowserLocalStorageItem(key: string): string | null {
+  try {
+    return getBrowserLocalStorage()?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeBrowserLocalStorageItem(key: string, value: string) {
+  try {
+    getBrowserLocalStorage()?.setItem(key, value);
+  } catch {
+    // Ignore private browsing, quota, and disabled-storage failures.
+  }
+}
+
+export function removeBrowserLocalStorageItem(key: string) {
+  try {
+    getBrowserLocalStorage()?.removeItem(key);
+  } catch {
+    // Ignore private browsing, quota, and disabled-storage failures.
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

UI preferences no longer read or write `localStorage` directly. They go through a shared helper that returns `undefined` when storage is missing or throws (SSR, incognito/private browsing, quota, disabled cookies). The app keeps working with in-memory defaults instead of crashing with `ReferenceError: localStorage is not defined`.

Covered call sites: CAT view/selection mode, jobs view mode, repository preference, issue sidebar, chat dock, and recent projects.

## How to test

- `cd apps/hyperlocalise-web && vp test`
- `cd apps/hyperlocalise-web && vp check --fix`
- Open the web app in a private/incognito window and confirm pages load. View-mode and similar preferences simply will not persist.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48b774e1-18dd-40d7-8666-b26ec1b669df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48b774e1-18dd-40d7-8666-b26ec1b669df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

