### PR TITLE
fix(glossary): surface Crowdin validation errors

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -91,7 +91,7 @@ function glossaryValidationErrorResponse(
   error: unknown,
 ) {
   if (!(error instanceof GlossaryValidationError)) return null;
-  return badRequestResponse(c, error.code, error.message);
+  return badRequestResponse(c, error.code, error.message, error.details);
 }
 
 function toCrowdinTermRecord(

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
@@ -215,8 +215,12 @@ export type GlossaryConceptInput = {
 
 export class GlossaryValidationError extends Error {
   constructor(
-    readonly code: "invalid_part_of_speech" | "stale_glossary_term_id",
+    readonly code:
+      | "invalid_part_of_speech"
+      | "stale_glossary_term_id"
+      | "crowdin_validation_failed",
     message: string,
+    readonly details?: unknown,
   ) {
     super(message);
     this.name = "GlossaryValidationError";

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -1838,6 +1838,23 @@ describe("extractCrowdinApiErrorSummary", () => {
     });
   });
 
+  it("extracts direct nested validation errors", () => {
+    expect(
+      extractCrowdinApiErrorSummary({
+        errors: [
+          {
+            error: {
+              key: "text",
+              errors: [{ code: "notUnique", message: "The term must be unique" }],
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      errors: [{ code: "notUnique", message: "The term must be unique" }],
+    });
+  });
+
   it("truncates long messages and ignores non-string codes", () => {
     const summary = extractCrowdinApiErrorSummary({
       error: { message: "x".repeat(500), code: null },

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -779,17 +779,16 @@ function readCrowdinErrorSummaryEntry(entry: unknown): {
   }
 
   const nestedErrors = entry.errors;
-  if (Array.isArray(nestedErrors)) {
-    const firstNested = nestedErrors.find(isRecord);
-    const error = firstNested?.error;
-    if (isRecord(error) && Array.isArray(error.errors)) {
-      const firstDetail = error.errors.find(isRecord);
-      if (firstDetail && typeof firstDetail.code === "string") {
-        summary.code = firstDetail.code;
-      }
-      if (firstDetail && typeof firstDetail.message === "string") {
-        summary.message = firstDetail.message.slice(0, MAX_CROWDIN_ERROR_SUMMARY_MESSAGE_LENGTH);
-      }
+  const nestedError = Array.isArray(nestedErrors)
+    ? nestedErrors.find(isRecord)?.error
+    : entry.error;
+  if (isRecord(nestedError) && Array.isArray(nestedError.errors)) {
+    const firstDetail = nestedError.errors.find(isRecord);
+    if (firstDetail && typeof firstDetail.code === "string") {
+      summary.code = firstDetail.code;
+    }
+    if (firstDetail && typeof firstDetail.message === "string") {
+      summary.message = firstDetail.message.slice(0, MAX_CROWDIN_ERROR_SUMMARY_MESSAGE_LENGTH);
     }
   }
 
@@ -798,7 +797,7 @@ function readCrowdinErrorSummaryEntry(entry: unknown): {
 
 /**
  * Extracts a small, provider-generated error summary from a Crowdin error
- * response body for logging. Never includes request or translation content.
+ * response body. Never includes request or translation content.
  */
 export function extractCrowdinApiErrorSummary(responseBody: unknown): {
   code?: string | number;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -453,10 +453,74 @@ describe("Crowdin live glossary concepts", () => {
           terms: [{ languageId: "en", text: "Checkout", status: "preferred" }],
         },
       ),
-    ).rejects.toMatchObject({ status: 400 });
+    ).rejects.toMatchObject({
+      name: "GlossaryValidationError",
+      code: "crowdin_validation_failed",
+      message: "invalid metadata",
+    });
 
     expect(termBodies).toEqual([expect.objectContaining({ languageId: "en", text: "Checkout" })]);
     expect(termBodies[0]).not.toHaveProperty("conceptId");
+  });
+
+  it("surfaces Crowdin glossary validation errors", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          errors: [
+            {
+              error: {
+                key: "text",
+                errors: [
+                  {
+                    code: "notUnique",
+                    message:
+                      "Invalid text or part of speech or type given. Text and part of speech and type must be unique",
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        { status: 400 },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(
+      crowdinTmsProvider.createLiveGlossaryTerm(
+        {
+          organizationId: "organization-1",
+          credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+          secretMaterial: "test-token",
+          projectId: "project-42",
+          externalProjectId: "42",
+          sourceLocale: "en-US",
+          fetchFn: fetchMock,
+        },
+        7,
+        8,
+        {
+          languageId: "en",
+          text: "Checkout",
+          status: "preferred",
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "GlossaryValidationError",
+      code: "crowdin_validation_failed",
+      message:
+        "Invalid text or part of speech or type given. Text and part of speech and type must be unique",
+      details: {
+        provider: "crowdin",
+        errors: [
+          {
+            code: "notUnique",
+            message:
+              "Invalid text or part of speech or type given. Text and part of speech and type must be unique",
+          },
+        ],
+      },
+    });
   });
 
   it("treats native locales and Crowdin IDs as the same language on term update", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -36,6 +36,7 @@ import {
   CrowdinApiClient,
   CrowdinApiError,
   escapeCrowdinCroqlString,
+  extractCrowdinApiErrorSummary,
   type CrowdinAiPrompt,
   type CrowdinBranch,
   type CrowdinCreateTaskRequest,
@@ -120,6 +121,30 @@ export {
 
 const implemented = { state: "implemented" } as const satisfies TmsProviderFeature;
 const logger = createLogger("crowdin-provider");
+
+function toCrowdinGlossaryValidationError(error: unknown): GlossaryValidationError | null {
+  if (!(error instanceof CrowdinApiError) || error.status !== 400) return null;
+
+  const summary = extractCrowdinApiErrorSummary(error.responseBody);
+  const message = summary?.errors?.find((entry) => entry.message)?.message ?? summary?.message;
+  if (!message) return null;
+
+  return new GlossaryValidationError("crowdin_validation_failed", message, {
+    provider: "crowdin",
+    ...(summary?.code !== undefined ? { code: summary.code } : {}),
+    ...(summary?.errors ? { errors: summary.errors } : {}),
+  });
+}
+
+async function withCrowdinGlossaryValidation<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    const validationError = toCrowdinGlossaryValidationError(error);
+    if (validationError) throw validationError;
+    throw error;
+  }
+}
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
@@ -1032,42 +1057,44 @@ export class CrowdinTmsProvider extends TmsProvider {
     glossaryId: number,
     input: CrowdinGlossaryConcept,
   ) {
-    const client = this.createClient(scope);
-    const sourceLanguageId = toCrowdinGlossaryLanguageId(input.sourceLocale);
-    const source = input.terms.find(
-      (term) => toCrowdinGlossaryLanguageId(term.languageId) === sourceLanguageId,
-    ) ?? {
-      languageId: sourceLanguageId,
-      text: input.primaryTerm,
-    };
-    const createdSource = await client.addGlossaryTerm(
-      glossaryId,
-      toCrowdinGlossaryTermRequest({
-        ...source,
-        status: omitBlankCrowdinTermValue(source.status) ?? "preferred",
-      }),
-    );
+    return withCrowdinGlossaryValidation(async () => {
+      const client = this.createClient(scope);
+      const sourceLanguageId = toCrowdinGlossaryLanguageId(input.sourceLocale);
+      const source = input.terms.find(
+        (term) => toCrowdinGlossaryLanguageId(term.languageId) === sourceLanguageId,
+      ) ?? {
+        languageId: sourceLanguageId,
+        text: input.primaryTerm,
+      };
+      const createdSource = await client.addGlossaryTerm(
+        glossaryId,
+        toCrowdinGlossaryTermRequest({
+          ...source,
+          status: omitBlankCrowdinTermValue(source.status) ?? "preferred",
+        }),
+      );
 
-    // Crowdin creates a concept implicitly when the first term omits
-    // conceptId. Concept metadata must be written after that term exists.
-    const conceptId = createdSource.conceptId;
-    await client.updateGlossaryConcept(glossaryId, conceptId, {
-      subject: input.subject,
-      definition: input.definition,
-      translatable: input.translatable,
-      note: input.note,
-      url: input.url ?? undefined,
-      figure: input.figure ?? undefined,
-      languagesDetails: input.languageDetails?.map((detail) => ({
-        languageId: toCrowdinGlossaryLanguageId(detail.languageId),
-        definition: detail.definition,
-        note: detail.note,
-      })),
+      // Crowdin creates a concept implicitly when the first term omits
+      // conceptId. Concept metadata must be written after that term exists.
+      const conceptId = createdSource.conceptId;
+      await client.updateGlossaryConcept(glossaryId, conceptId, {
+        subject: input.subject,
+        definition: input.definition,
+        translatable: input.translatable,
+        note: input.note,
+        url: input.url ?? undefined,
+        figure: input.figure ?? undefined,
+        languagesDetails: input.languageDetails?.map((detail) => ({
+          languageId: toCrowdinGlossaryLanguageId(detail.languageId),
+          definition: detail.definition,
+          note: detail.note,
+        })),
+      });
+      for (const term of input.terms.filter((item) => item !== source)) {
+        await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
+      }
+      return this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
     });
-    for (const term of input.terms.filter((item) => item !== source)) {
-      await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
-    }
-    return this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
   }
 
   async updateLiveGlossaryConcept(
@@ -1076,58 +1103,60 @@ export class CrowdinTmsProvider extends TmsProvider {
     conceptId: number,
     input: CrowdinGlossaryConcept,
   ) {
-    const client = this.createClient(scope);
-    const existing = await this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
-    if (!existing) return null;
-    const existingById = new Map(existing.terms.map((term) => [String(term.id), term]));
-    const hasUnknownTermId = input.terms.some(
-      (term) => term.id !== undefined && !existingById.has(String(term.id)),
-    );
-    if (hasUnknownTermId) {
-      throw new GlossaryValidationError(
-        "stale_glossary_term_id",
-        "The glossary update contains a term that is no longer part of this concept",
+    return withCrowdinGlossaryValidation(async () => {
+      const client = this.createClient(scope);
+      const existing = await this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
+      if (!existing) return null;
+      const existingById = new Map(existing.terms.map((term) => [String(term.id), term]));
+      const hasUnknownTermId = input.terms.some(
+        (term) => term.id !== undefined && !existingById.has(String(term.id)),
       );
-    }
-    await client.updateGlossaryConcept(glossaryId, conceptId, {
-      subject: input.subject ?? "",
-      definition: input.definition ?? "",
-      translatable: input.translatable ?? true,
-      note: input.note ?? "",
-      url: input.url ?? "",
-      figure: input.figure ?? "",
-    });
-    // Term ids that must not be deleted in the orphan pass (kept, updated, or already replaced).
-    const retainedIds = new Set<string>();
-
-    for (const term of input.terms) {
-      const existingTerm = term.id !== undefined ? existingById.get(String(term.id)) : undefined;
-      if (existingTerm && typeof existingTerm.id === "number") {
-        retainedIds.add(String(existingTerm.id));
-        if (
-          toCrowdinGlossaryLanguageId(term.languageId) !==
-          toCrowdinGlossaryLanguageId(existingTerm.languageId)
-        ) {
-          await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
-          await client.deleteGlossaryTerm(glossaryId, existingTerm.id);
-          continue;
-        }
-        if (crowdinGlossaryTermsEqual(existingTerm, term)) continue;
-        const patches = toCrowdinGlossaryTermUpdatePatches(term, existingTerm);
-        if (patches.length === 0) continue;
-        await client.updateGlossaryTerm(glossaryId, existingTerm.id, patches);
-      } else {
-        await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
+      if (hasUnknownTermId) {
+        throw new GlossaryValidationError(
+          "stale_glossary_term_id",
+          "The glossary update contains a term that is no longer part of this concept",
+        );
       }
-    }
+      await client.updateGlossaryConcept(glossaryId, conceptId, {
+        subject: input.subject ?? "",
+        definition: input.definition ?? "",
+        translatable: input.translatable ?? true,
+        note: input.note ?? "",
+        url: input.url ?? "",
+        figure: input.figure ?? "",
+      });
+      // Term ids that must not be deleted in the orphan pass (kept, updated, or already replaced).
+      const retainedIds = new Set<string>();
 
-    for (const existingTerm of existing.terms) {
-      if (typeof existingTerm.id !== "number") continue;
-      if (retainedIds.has(String(existingTerm.id))) continue;
-      await client.deleteGlossaryTerm(glossaryId, existingTerm.id);
-    }
+      for (const term of input.terms) {
+        const existingTerm = term.id !== undefined ? existingById.get(String(term.id)) : undefined;
+        if (existingTerm && typeof existingTerm.id === "number") {
+          retainedIds.add(String(existingTerm.id));
+          if (
+            toCrowdinGlossaryLanguageId(term.languageId) !==
+            toCrowdinGlossaryLanguageId(existingTerm.languageId)
+          ) {
+            await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
+            await client.deleteGlossaryTerm(glossaryId, existingTerm.id);
+            continue;
+          }
+          if (crowdinGlossaryTermsEqual(existingTerm, term)) continue;
+          const patches = toCrowdinGlossaryTermUpdatePatches(term, existingTerm);
+          if (patches.length === 0) continue;
+          await client.updateGlossaryTerm(glossaryId, existingTerm.id, patches);
+        } else {
+          await client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(term, conceptId));
+        }
+      }
 
-    return this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
+      for (const existingTerm of existing.terms) {
+        if (typeof existingTerm.id !== "number") continue;
+        if (retainedIds.has(String(existingTerm.id))) continue;
+        await client.deleteGlossaryTerm(glossaryId, existingTerm.id);
+      }
+
+      return this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
+    });
   }
 
   async deleteLiveGlossaryConcept(
@@ -1148,8 +1177,10 @@ export class CrowdinTmsProvider extends TmsProvider {
     conceptId: number,
     input: CrowdinGlossaryTermInput,
   ) {
-    const client = this.createClient(scope);
-    return client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(input, conceptId));
+    return withCrowdinGlossaryValidation(async () => {
+      const client = this.createClient(scope);
+      return client.addGlossaryTerm(glossaryId, toCrowdinGlossaryTermRequest(input, conceptId));
+    });
   }
 
   async updateLiveGlossaryTerm(
@@ -1159,25 +1190,27 @@ export class CrowdinTmsProvider extends TmsProvider {
     termId: number,
     input: CrowdinGlossaryTermInput,
   ) {
-    const client = this.createClient(scope);
-    const existing = await this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
-    const existingTerm = existing?.terms.find((term) => String(term.id) === String(termId));
-    if (!existingTerm) return null;
-    if (
-      toCrowdinGlossaryLanguageId(input.languageId) !==
-      toCrowdinGlossaryLanguageId(existingTerm.languageId)
-    ) {
-      const replacement = await client.addGlossaryTerm(
-        glossaryId,
-        toCrowdinGlossaryTermRequest(input, conceptId),
-      );
-      await client.deleteGlossaryTerm(glossaryId, termId);
-      return replacement;
-    }
-    if (crowdinGlossaryTermsEqual(existingTerm, input)) return existingTerm;
-    const patches = toCrowdinGlossaryTermUpdatePatches(input, existingTerm);
-    if (patches.length === 0) return existingTerm;
-    return client.updateGlossaryTerm(glossaryId, termId, patches);
+    return withCrowdinGlossaryValidation(async () => {
+      const client = this.createClient(scope);
+      const existing = await this.getLiveGlossaryConcept(scope, glossaryId, conceptId);
+      const existingTerm = existing?.terms.find((term) => String(term.id) === String(termId));
+      if (!existingTerm) return null;
+      if (
+        toCrowdinGlossaryLanguageId(input.languageId) !==
+        toCrowdinGlossaryLanguageId(existingTerm.languageId)
+      ) {
+        const replacement = await client.addGlossaryTerm(
+          glossaryId,
+          toCrowdinGlossaryTermRequest(input, conceptId),
+        );
+        await client.deleteGlossaryTerm(glossaryId, termId);
+        return replacement;
+      }
+      if (crowdinGlossaryTermsEqual(existingTerm, input)) return existingTerm;
+      const patches = toCrowdinGlossaryTermUpdatePatches(input, existingTerm);
+      if (patches.length === 0) return existingTerm;
+      return client.updateGlossaryTerm(glossaryId, termId, patches);
+    });
   }
 
   async deleteLiveGlossaryTerm(


### PR DESCRIPTION
## Summary

- Convert Crowdin HTTP 400 glossary validation responses into typed glossary validation errors.
- Preserve Crowdin validation messages and safe structured details in the standard API error envelope.
- Cover direct and wrapped Crowdin error payloads with regression tests.

## Validation

- vp check --fix: passed.
- Focused Crowdin tests: 74 passed.
- Full vp test: 4,886 passed; 45 unrelated environment failures (missing local migration tables, unavailable localhost:3000 service, and auth/public-route fixture failures).
- vp run db:migrate: blocked by the local database migration environment.