### PR TITLE
fix(crowdin): add Type query filter parity to TasksListOptions

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-31 - Add Type query filter parity to TasksListOptions
+
+**Learning:** In Crowdin API v2, the List Tasks endpoint (`GET /api/v2/projects/{projectId}/tasks`) accepts filtering tasks by `type` (0 - translate, 1 - proofread, 2 - translate by vendor, 3 - proofread by vendor) in addition to `status`, `assigneeId`, `creatorId`, `workflowStepId`, `labelIds`, and `excludeLabelIds`. The SDK's `TasksListOptions` previously lacked `Type`, preventing callers from filtering tasks by task type.
+
+**Action:** Added `Type []TaskType json:"type,omitempty"` to `TasksListOptions` in `third_party/crowdin-api-client-go/crowdin/model/tasks.go` and updated its `Values()` method to encode `type` query parameter using `JoinSlice(o.Type)`. Added test assertions in `model/tasks_test.go` and `tasks_test.go`.
+
 ## 2026-12-31 - Allow optional IndividualRates in report schemas and settings templates
 
 **Learning:** In Crowdin API v2, `individualRates` is an optional array of custom rates per language or user in report generation schemas and report settings templates. The SDK previously enforced `r.IndividualRates != nil` in `GroupTransactionCostsPostEditingSchema` and `len(r.Config.IndividualRates) > 0` in `ReportSettingsTemplateAddRequest.Validate()`, causing client-side validation to reject valid requests when no custom individual rates were specified.

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks.go
@@ -109,6 +109,10 @@ type TasksListOptions struct {
 	// or a list of status values.
 	// Enum: todo, in_progress, done, closed.
 	Status []TaskStatus `json:"status,omitempty"`
+	// List tasks with specified types. It can be one type
+	// or a list of type values.
+	// Enum: 0 - translate, 1 - proofread, 2 - translate by vendor, 3 - proofread by vendor.
+	Type []TaskType `json:"type,omitempty"`
 	// List tasks for specified assignee.
 	AssigneeID int `json:"assigneeId,omitempty"`
 	// List tasks for specified creator.
@@ -137,6 +141,9 @@ func (o *TasksListOptions) Values() (url.Values, bool) {
 	}
 	if len(o.Status) > 0 {
 		v.Add("status", JoinSlice(o.Status))
+	}
+	if len(o.Type) > 0 {
+		v.Add("type", JoinSlice(o.Type))
 	}
 	if o.AssigneeID > 0 {
 		v.Add("assigneeId", strconv.Itoa(o.AssigneeID))

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks_test.go
@@ -24,10 +24,11 @@ func TestTasksListOptionsValues(t *testing.T) {
 			name: "all options",
 			opts: &TasksListOptions{
 				OrderBy: "createdAt desc,name", Status: []TaskStatus{TaskStatusTodo, TaskStatusDone},
+				Type:       []TaskType{TaskTypeTranslate, TaskTypeProofread},
 				AssigneeID: 1, CreatorID: 2, ListOptions: ListOptions{Limit: 10, Offset: 5},
 				LabelIDs: []int{1, 2}, ExcludeLabelIDs: []int{3, 4},
 			},
-			out: "assigneeId=1&creatorId=2&excludeLabelIds=3%2C4&labelIds=1%2C2&limit=10&offset=5&orderBy=createdAt+desc%2Cname&status=todo%2Cdone",
+			out: "assigneeId=1&creatorId=2&excludeLabelIds=3%2C4&labelIds=1%2C2&limit=10&offset=5&orderBy=createdAt+desc%2Cname&status=todo%2Cdone&type=0%2C1",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/tasks_test.go
@@ -266,6 +266,13 @@ func TestTasksService_List(t *testing.T) {
 			},
 			want: "?workflowStepId=10",
 		},
+		{
+			name: "with type",
+			options: &model.TasksListOptions{
+				Type: []model.TaskType{model.TaskTypeTranslate, model.TaskTypeProofread},
+			},
+			want: "?type=0%2C1",
+		},
 	}
 
 	client, mux, teardown := setupClient()


### PR DESCRIPTION
What: Added `Type []TaskType json:"type,omitempty"` to `TasksListOptions` in `third_party/crowdin-api-client-go/crowdin/model/tasks.go` and updated `TasksListOptions.Values()` to serialize the `"type"` query parameter using `JoinSlice`.

Why: In Crowdin API v2, the List Tasks endpoint (`GET /api/v2/projects/{projectId}/tasks`) accepts filtering tasks by `type` (0 - translate, 1 - proofread, 2 - translate by vendor, 3 - proofread by vendor) in addition to `status`, `assigneeId`, `creatorId`, `workflowStepId`, `labelIds`, and `excludeLabelIds`. Omission of this parameter from `TasksListOptions` prevented callers from filtering project tasks by task type.

Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.getMany

Scope:
- `third_party/crowdin-api-client-go/crowdin/model/tasks.go`
- `third_party/crowdin-api-client-go/crowdin/model/tasks_test.go`
- `third_party/crowdin-api-client-go/crowdin/tasks_test.go`
- `.jules/crowdin-steward.md`

Tests: Ran `go test ./...` across the entire repo and `cd third_party/crowdin-api-client-go && go test ./...`. All tests pass.

Confidence: Prevents query parameter omission for task type filtering when listing project tasks in Crowdin workflows.

---
*PR created automatically by Jules for task [16488832555207825436](https://jules.google.com/task/16488832555207825436) started by @cungminh2710*