### PR TITLE
fix(agent-runtime): block symlink roots in grep and glob

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -43,6 +43,17 @@ function createTestContext(files: Record<string, string> = {}): { bash: Bash } {
 
 const toolCallInfo = { toolCallId: "test-tool-call", messages: [], context: {} };
 
+function unwrapSearchCommand(command: string, args: string[]) {
+  if (command !== "bash" || args[0] !== "-c") {
+    return { command, args };
+  }
+
+  return {
+    command: args[4] ?? "",
+    args: args.slice(5),
+  };
+}
+
 describe("redact", () => {
   it("redacts env var lines", () => {
     const input = "OPENAI_API_KEY=sk-12345\nAI_GATEWAY_API_KEY=gw-12345\nPATH=/usr/bin";
@@ -185,7 +196,7 @@ describe("createGrepTool", () => {
     const t = createGrepTool({
       bash: {
         exec: async (command, options) => {
-          calls.push({ command, args: options?.args ?? [] });
+          calls.push(unwrapSearchCommand(command, options?.args ?? []));
           return {
             stdout: "src/app.tsx:2:10:  return <h1>Dashboard</h1>;\n",
             stderr: "",
@@ -228,9 +239,10 @@ describe("createGrepTool", () => {
     const calls: string[] = [];
     const t = createGrepTool({
       bash: {
-        exec: async (command) => {
-          calls.push(command);
-          if (command === "rg") {
+        exec: async (command, options) => {
+          const searchCommand = unwrapSearchCommand(command, options?.args ?? []).command;
+          calls.push(searchCommand);
+          if (searchCommand === "rg") {
             return { stdout: "", stderr: "rg: command not found", exitCode: 127, env: {} };
           }
           return {
@@ -256,7 +268,7 @@ describe("createGrepTool", () => {
     const t = createGrepTool({
       bash: {
         exec: async (command, options) => {
-          calls.push({ command, args: options?.args ?? [] });
+          calls.push(unwrapSearchCommand(command, options?.args ?? []));
           return {
             stdout: "src/user/routes/page.tsx:2:10:  return <h1>Dashboard</h1>;\n",
             stderr: "",
@@ -290,6 +302,25 @@ describe("createGrepTool", () => {
         content: "  return <h1>Dashboard</h1>;",
       },
     ]);
+  });
+
+  it("treats flag-like ripgrep patterns as patterns", async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const t = createGrepTool({
+      bash: {
+        exec: async (command, options) => {
+          calls.push(unwrapSearchCommand(command, options?.args ?? []));
+          return { stdout: "", stderr: "", exitCode: 1, env: {} };
+        },
+        readFile: async () => "",
+      },
+    });
+
+    const result = await t.execute!({ pattern: "--follow" }, toolCallInfo);
+
+    expect(result).toMatchObject({ success: true, matches: [] });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args.slice(-3)).toEqual(["--", "--follow", "."]);
   });
 
   it("finds matches", async () => {
@@ -424,8 +455,8 @@ describe("createGrepTool", () => {
   it("parses single-file grep output without a filename prefix", async () => {
     const t = createGrepTool({
       bash: {
-        exec: async (command) =>
-          command === "rg"
+        exec: async (command, options) =>
+          unwrapSearchCommand(command, options?.args ?? []).command === "rg"
             ? {
                 stdout: "",
                 stderr: "rg: command not found",
@@ -453,15 +484,16 @@ describe("createGrepTool", () => {
   it("keeps colons in single-file grep matches", async () => {
     const t = createGrepTool({
       bash: {
-        exec: async (command) =>
-          command === "rg"
+        exec: async (command, options) => {
+          const searchCommand = unwrapSearchCommand(command, options?.args ?? []).command;
+          return searchCommand === "rg"
             ? {
                 stdout: "",
                 stderr: "rg: command not found",
                 exitCode: 127,
                 env: {},
               }
-            : command === "find"
+            : searchCommand === "find"
               ? {
                   stdout: "src/app/api/[[...route]]/route.ts\n",
                   stderr: "",
@@ -473,7 +505,8 @@ describe("createGrepTool", () => {
                   stderr: "",
                   exitCode: 0,
                   env: {},
-                },
+                };
+        },
         readFile: async () => "",
       },
     });
@@ -496,8 +529,8 @@ describe("createGrepTool", () => {
   it("ignores unparsable grep output when at least one match line parses", async () => {
     const t = createGrepTool({
       bash: {
-        exec: async (command) =>
-          command === "rg"
+        exec: async (command, options) =>
+          unwrapSearchCommand(command, options?.args ?? []).command === "rg"
             ? {
                 stdout: "",
                 stderr: "rg: command not found",
@@ -525,8 +558,8 @@ describe("createGrepTool", () => {
   it("does not report zero matches when grep output is unparsable", async () => {
     const t = createGrepTool({
       bash: {
-        exec: async (command) =>
-          command === "rg"
+        exec: async (command, options) =>
+          unwrapSearchCommand(command, options?.args ?? []).command === "rg"
             ? {
                 stdout: "",
                 stderr: "rg: command not found",
@@ -561,6 +594,20 @@ describe("createGrepTool", () => {
     expect(result).toMatchObject({ success: true, matches: [] });
   });
 
+  it("rejects search paths outside the workspace", async () => {
+    const ctx = createTestContext({ "/home/user/project/a.go": "package main\n" });
+    const result = await createGrepTool(ctx).execute!(
+      { pattern: "package", path: "../outside" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Search path must stay within the workspace.",
+      matches: [],
+    });
+  });
+
   it("truncates at max results", async () => {
     const ctx = createTestContext({
       "/home/user/project/a.go": "func a() {}\n",
@@ -582,6 +629,70 @@ describe("createGrepTool", () => {
     expect(matches).toHaveLength(1);
     expect(matches[0].content).toBe("api_token: ***REDACTED***");
     expect(matches[0].content).not.toContain("abcdefghijklmnopqrstuvwxyz12345");
+  });
+
+  it("rejects an outside-workspace symlink search root before ripgrep runs", async () => {
+    const fs = new InMemoryFs({
+      "/home/user/project/README.md": "safe",
+      "/tmp/external/secret.md": "outside-search-secret",
+    });
+    await fs.symlink("/tmp/external", "/home/user/project/leak");
+    const invokedCommands: string[] = [];
+    const bash = new Bash({ fs, cwd: "/home/user/project" });
+    bash.registerCommand(
+      defineCommand("rg", async () => {
+        invokedCommands.push("rg");
+        return {
+          stdout: "leak/secret.md:1:1:outside-search-secret\n",
+          stderr: "",
+          exitCode: 0,
+        };
+      }),
+    );
+
+    const result = await createGrepTool({ bash }).execute!(
+      { pattern: "outside-search-secret", path: "leak" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Search path must not contain symbolic links.",
+      matches: [],
+    });
+    expect(invokedCommands).toEqual([]);
+  });
+
+  it("rejects a symlinked search-root parent even when its target stays in the workspace", async () => {
+    const fs = new InMemoryFs({
+      "/home/user/project/actual/nested/secret.md": "inside-search-secret",
+      "/home/user/project/routes/.keep": "",
+    });
+    await fs.symlink("../actual", "/home/user/project/routes/link");
+    const invokedCommands: string[] = [];
+    const bash = new Bash({ fs, cwd: "/home/user/project" });
+    bash.registerCommand(
+      defineCommand("rg", async () => {
+        invokedCommands.push("rg");
+        return {
+          stdout: "routes/link/nested/secret.md:1:1:inside-search-secret\n",
+          stderr: "",
+          exitCode: 0,
+        };
+      }),
+    );
+
+    const result = await createGrepTool({ bash }).execute!(
+      { pattern: "inside-search-secret", path: "routes/link/nested" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Search path must not contain symbolic links.",
+      matches: [],
+    });
+    expect(invokedCommands).toEqual([]);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/glob.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/glob.test.ts
@@ -18,13 +18,24 @@ import type { RepoToolContext } from "./types";
 
 const toolCallInfo = { toolCallId: "test-tool-call", messages: [], context: {} };
 
+function unwrapSearchCommand(command: string, args: string[]) {
+  if (command !== "bash" || args[0] !== "-c") {
+    return { command, args };
+  }
+
+  return {
+    command: args[4] ?? "",
+    args: args.slice(5),
+  };
+}
+
 describe("createGlobTool", () => {
   it("lists files via ripgrep", async () => {
     const calls: Array<{ command: string; args: string[] }> = [];
     const tool = createGlobTool({
       bash: {
         exec: async (command, options) => {
-          calls.push({ command, args: options?.args ?? [] });
+          calls.push(unwrapSearchCommand(command, options?.args ?? []));
           return {
             stdout: "locales/en.json\nlocales/fr.json\n",
             stderr: "",
@@ -41,7 +52,7 @@ describe("createGlobTool", () => {
     expect(calls).toEqual([
       {
         command: "rg",
-        args: expect.arrayContaining(["--files", "--glob", "locales/*.json"]),
+        args: expect.arrayContaining(["--files", "--no-follow", "--glob", "locales/*.json"]),
       },
     ]);
     expect(result).toMatchObject({ success: true, count: 2 });
@@ -75,5 +86,76 @@ describe("createGlobTool", () => {
     const result = await tool.execute!({ pattern: "locales/*.json" }, toolCallInfo);
     expect(result).toMatchObject({ success: true, count: 2 });
     expect((result as { files: Array<{ path: string }> }).files[0].path).toContain("en.json");
+  });
+
+  it("rejects search paths outside the workspace", async () => {
+    const tool = createGlobTool({
+      bash: new Bash({ fs: new InMemoryFs(), cwd: "/home/user/project" }),
+    });
+    const result = await tool.execute!({ pattern: "**/*.json", path: "../outside" }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Search path must stay within the workspace.",
+      files: [],
+    });
+  });
+
+  it("rejects an outside-workspace symlink search root before ripgrep runs", async () => {
+    const fs = new InMemoryFs({
+      "/home/user/project/README.md": "safe",
+      "/tmp/external/secret.json": "{}",
+    });
+    await fs.symlink("/tmp/external", "/home/user/project/leak");
+    const invokedCommands: string[] = [];
+    const bash = new Bash({ fs, cwd: "/home/user/project" });
+    bash.registerCommand(
+      defineCommand("rg", async () => {
+        invokedCommands.push("rg");
+        return { stdout: "leak/secret.json\n", stderr: "", exitCode: 0 };
+      }),
+    );
+
+    const result = await createGlobTool({ bash }).execute!(
+      { pattern: "**/*.json", path: "leak" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Search path must not contain symbolic links.",
+      files: [],
+    });
+    expect(JSON.stringify(result)).not.toContain("secret.json");
+    expect(invokedCommands).toEqual([]);
+  });
+
+  it("rejects a symlinked search-root parent even when its target stays in the workspace", async () => {
+    const fs = new InMemoryFs({
+      "/home/user/project/actual/nested/secret.json": "{}",
+      "/home/user/project/routes/.keep": "",
+    });
+    await fs.symlink("../actual", "/home/user/project/routes/link");
+    const invokedCommands: string[] = [];
+    const bash = new Bash({ fs, cwd: "/home/user/project" });
+    bash.registerCommand(
+      defineCommand("rg", async () => {
+        invokedCommands.push("rg");
+        return { stdout: "routes/link/nested/secret.json\n", stderr: "", exitCode: 0 };
+      }),
+    );
+
+    const result = await createGlobTool({ bash }).execute!(
+      { pattern: "**/*.json", path: "routes/link/nested" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Search path must not contain symbolic links.",
+      files: [],
+    });
+    expect(JSON.stringify(result)).not.toContain("secret.json");
+    expect(invokedCommands).toEqual([]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/glob.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/glob.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 
 import { normalizeWorkspacePath, toShellRelativePath } from "./path";
 import { DEFAULT_GLOB_LIMIT } from "./redact";
+import { execWorkspaceSearch } from "./search-root";
 import type { RepoToolContext } from "./types";
 
 const globInputSchema = z.object({
@@ -63,7 +64,15 @@ USAGE:
 - Results limited by limit (default ${DEFAULT_GLOB_LIMIT})`,
     inputSchema: globInputSchema,
     execute: async ({ pattern, path: basePathInput, limit = DEFAULT_GLOB_LIMIT }) => {
-      const basePath = normalizeWorkspacePath(basePathInput ?? ".") ?? ".";
+      const basePath = normalizeWorkspacePath(basePathInput ?? ".");
+      if (!basePath) {
+        return {
+          success: false as const,
+          error: "Search path must stay within the workspace.",
+          pattern,
+          files: [],
+        };
+      }
 
       const rgResult = await listWithRipgrep(ctx, {
         pattern,
@@ -101,6 +110,7 @@ async function listWithRipgrep(
 ) {
   const args = [
     "--files",
+    "--no-follow",
     "--glob",
     input.pattern,
     "--glob",
@@ -109,7 +119,20 @@ async function listWithRipgrep(
     "!.git/**",
     toShellRelativePath(input.basePath),
   ];
-  const result = await ctx.bash.exec("rg", { args });
+  const execution = await execWorkspaceSearch(ctx, {
+    command: "rg",
+    args,
+    searchRoot: input.basePath,
+  });
+  if (!execution.success) {
+    return {
+      success: false as const,
+      error: execution.error,
+      pattern: input.pattern,
+      files: [],
+    };
+  }
+  const { result } = execution;
   if (result.exitCode >= 2) {
     return null;
   }
@@ -168,7 +191,20 @@ async function listWithFind(
     namePattern,
   );
 
-  const result = await ctx.bash.exec("find", { args: findArgs });
+  const execution = await execWorkspaceSearch(ctx, {
+    command: "find",
+    args: findArgs,
+    searchRoot: searchDir,
+  });
+  if (!execution.success) {
+    return {
+      success: false as const,
+      error: execution.error,
+      pattern: input.pattern,
+      files: [],
+    };
+  }
+  const { result } = execution;
   if (result.exitCode !== 0 && !result.stdout.trim()) {
     return null;
   }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/grep.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/grep.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import { parseGrepLine } from "./parse-grep-line";
 import { normalizeWorkspacePath, toShellRelativePath } from "./path";
 import { MAX_GREP_LINE_CHARS, MAX_GREP_MATCHES, MAX_GREP_MATCHES_PER_FILE, redact } from "./redact";
+import { execWorkspaceSearch } from "./search-root";
 import type { RepoToolContext } from "./types";
 
 const TEXT_FILE_INCLUDES = [
@@ -114,7 +115,16 @@ IMPORTANT:
       regex = false,
       maxResults,
     }) => {
-      const searchPath = normalizeWorkspacePath(searchPathInput ?? ".") ?? ".";
+      const searchPath = normalizeWorkspacePath(searchPathInput ?? ".");
+      if (!searchPath) {
+        return {
+          success: false as const,
+          error: "Search path must stay within the workspace.",
+          pattern,
+          matches: [],
+          filesWithMatches: 0 as const,
+        };
+      }
       const limit = maxResults ?? MAX_GREP_MATCHES;
       const includePattern = include ?? glob;
       const includes = includePattern ? [includePattern] : TEXT_FILE_INCLUDES;
@@ -218,9 +228,27 @@ async function grepWithRipgrep({
   }
   args.push("--glob", "!node_modules/**", "--glob", "!.git/**");
 
-  args.push(pattern, hasPathGlobMetacharacter(searchPath) ? "." : toShellRelativePath(searchPath));
+  args.push(
+    "--",
+    pattern,
+    hasPathGlobMetacharacter(searchPath) ? "." : toShellRelativePath(searchPath),
+  );
 
-  const result = await ctx.bash.exec("rg", { args });
+  const execution = await execWorkspaceSearch(ctx, {
+    command: "rg",
+    args,
+    searchRoot: searchPath,
+  });
+  if (!execution.success) {
+    return {
+      success: false,
+      error: execution.error,
+      pattern,
+      matches: [],
+      filesWithMatches: 0,
+    };
+  }
+  const { result } = execution;
 
   if (result.exitCode >= 2) {
     return null;
@@ -332,7 +360,21 @@ async function grepExactDiscoveredFiles({
   regex: boolean;
   limit: number;
 }): Promise<GrepToolResult> {
-  const listResult = await ctx.bash.exec("find", { args: findArgs(searchPath, includes) });
+  const listExecution = await execWorkspaceSearch(ctx, {
+    command: "find",
+    args: findArgs(searchPath, includes),
+    searchRoot: searchPath,
+  });
+  if (!listExecution.success) {
+    return {
+      success: false,
+      error: listExecution.error,
+      pattern,
+      matches: [],
+      filesWithMatches: 0,
+    };
+  }
+  const listResult = listExecution.result;
   if (listResult.exitCode !== 0 && !listResult.stdout.trim()) {
     return {
       success: false,
@@ -367,9 +409,23 @@ async function grepExactDiscoveredFiles({
     if (!caseSensitive) {
       args.push("-i");
     }
-    args.push(regex ? "-E" : "-F", pattern, file);
+    args.push(regex ? "-E" : "-F", "--", pattern, file);
 
-    const result = await ctx.bash.exec("grep", { args });
+    const execution = await execWorkspaceSearch(ctx, {
+      command: "grep",
+      args,
+      searchRoot: file,
+    });
+    if (!execution.success) {
+      return {
+        success: false,
+        error: execution.error,
+        pattern,
+        matches: [],
+        filesWithMatches: 0,
+      };
+    }
+    const { result } = execution;
     if (result.exitCode >= 2) {
       return {
         success: false,
@@ -473,9 +529,23 @@ async function grepWithPosixGrep({
     args.push(`--include=${include}`);
   }
 
-  args.push(pattern, searchPath === "." ? "." : searchPath);
+  args.push("--", pattern, searchPath === "." ? "." : searchPath);
 
-  const result = await ctx.bash.exec("grep", { args });
+  const execution = await execWorkspaceSearch(ctx, {
+    command: "grep",
+    args,
+    searchRoot: searchPath,
+  });
+  if (!execution.success) {
+    return {
+      success: false,
+      error: execution.error,
+      pattern,
+      matches: [],
+      filesWithMatches: 0,
+    };
+  }
+  const { result } = execution;
 
   if (result.exitCode >= 2) {
     return {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/search-root.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/search-root.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { RepoToolContext } from "./types";
+
+const UNSAFE_SEARCH_ROOT_EXIT_CODE = 78;
+
+const SEARCH_ROOT_GUARD_SCRIPT = `set -fu
+search_root=$1
+shift
+current=.
+remaining=$search_root
+
+if [ "$search_root" != "." ]; then
+  while [ -n "$remaining" ]; do
+    case "$remaining" in
+      */*)
+        component=\${remaining%%/*}
+        remaining=\${remaining#*/}
+        ;;
+      *)
+        component=$remaining
+        remaining=
+        ;;
+    esac
+
+    [ -n "$component" ] || continue
+    if [ "$current" = "." ]; then
+      current=$component
+    else
+      current=$current/$component
+    fi
+
+    if [ -L "$current" ]; then
+      exit ${UNSAFE_SEARCH_ROOT_EXIT_CODE}
+    fi
+  done
+fi
+
+exec "$@"`;
+
+type BashExecResult = Awaited<ReturnType<RepoToolContext["bash"]["exec"]>>;
+
+export type WorkspaceSearchExecResult =
+  | { success: true; result: BashExecResult }
+  | { success: false; error: string };
+
+/** Check every search-root component immediately before executing the search. */
+export async function execWorkspaceSearch(
+  ctx: RepoToolContext,
+  input: { command: string; args: string[]; searchRoot: string },
+): Promise<WorkspaceSearchExecResult> {
+  const result = await ctx.bash.exec("bash", {
+    args: [
+      "-c",
+      SEARCH_ROOT_GUARD_SCRIPT,
+      "workspace-search",
+      input.searchRoot,
+      input.command,
+      ...input.args,
+    ],
+  });
+
+  if (result.exitCode === UNSAFE_SEARCH_ROOT_EXIT_CODE) {
+    return {
+      success: false,
+      error: "Search path must not contain symbolic links.",
+    };
+  }
+
+  return { success: true, result };
+}

--- a/docs/adr/2026-08-24-agent-search-root-symlink-guard-design.md
+++ b/docs/adr/2026-08-24-agent-search-root-symlink-guard-design.md
@@ -1,0 +1,42 @@
+# Agent search-root symlink guard
+
+## Summary
+
+The agent workspace `grep` and `glob` tools must reject any search path whose root or parent is a symbolic link. This rule applies even when the link resolves inside the workspace.
+
+Ripgrep's `--no-follow` option protects descendant traversal, but ripgrep still follows a symbolic link supplied as its command-line search root. The current tools also execute searches directly instead of passing each result through the guarded `readFile` path. A repository symlink can therefore expose files outside the repository.
+
+## Design
+
+Add one shared search executor for the `rg`, `grep`, and `find` calls used by `grep` and `glob`. The executor receives a normalized, workspace-relative search root and runs two operations in one shell process:
+
+1. Check each component of the search root with a non-following symbolic-link test.
+2. Execute the requested search command only when every component passes.
+
+Keeping the check and command in one shell invocation prevents the path from changing between validation and search. Command names and arguments remain separate positional parameters; user input never becomes shell source.
+
+For a path containing glob metacharacters, validate the literal directory prefix before the first globbed segment. Ripgrep searches from the workspace root in this case, and `--no-follow` prevents traversal through matching descendant links.
+
+Add `--no-follow` to glob's ripgrep file listing. Keep the fallback `find` search non-following and execute it through the same root guard.
+
+## Failure handling
+
+The shared executor returns a distinct unsafe-root result when it finds a symlink component. `grep` and `glob` map that result to a stable tool failure and return no matches or files. They must not fall back to another search command after a guard failure.
+
+Missing ordinary paths retain their current search semantics. Lexically invalid paths, including absolute paths and parent traversal, remain blocked by `normalizeWorkspacePath`.
+
+## Tests
+
+Add regression tests with real in-memory filesystem symlinks. Cover direct search-root symlinks and symlinked parent directories, with targets both inside and outside the workspace. Assert that:
+
+- `grep` returns no match bodies from the target;
+- `glob` returns no target filenames;
+- neither tool invokes an unguarded fallback after rejection;
+- normal, bracketed Next.js, and globbed paths still work; and
+- glob's ripgrep invocation includes `--no-follow`.
+
+Run the focused workspace tool tests, then the required `vp test` and `vp check --fix` commands from `apps/hyperlocalise-web`.
+
+## Alternatives considered
+
+A new workspace-runtime validation method would place the check behind a cleaner interface, but it would expand several runtime and test contracts for this narrow fix. Reading every discovered file through `readFile` would reuse its existing guard, but it would reimplement grep in application code and make repository searches much slower.

--- a/docs/adr/2026-08-24-agent-search-root-symlink-guard-design.md
+++ b/docs/adr/2026-08-24-agent-search-root-symlink-guard-design.md
@@ -13,7 +13,7 @@ Add one shared search executor for the `rg`, `grep`, and `find` calls used by `g
 1. Check each component of the search root with a non-following symbolic-link test.
 2. Execute the requested search command only when every component passes.
 
-Keeping the check and command in one shell invocation prevents the path from changing between validation and search. Command names and arguments remain separate positional parameters; user input never becomes shell source.
+Keeping the check and command in one shell invocation avoids returning to application code between validation and search. The read-only workspace policy prevents repository changes while the command runs. Command names and arguments remain separate positional parameters; user input never becomes shell source.
 
 For a path containing glob metacharacters, validate the literal directory prefix before the first globbed segment. Ripgrep searches from the workspace root in this case, and `--no-follow` prevents traversal through matching descendant links.
 


### PR DESCRIPTION
## What changed

- Add a shared guarded search executor that rejects symbolic-link search roots and parents before running `rg`, `grep`, or `find`.
- Reject workspace-escaping paths instead of silently searching the repository root.
- Add `--no-follow` to glob’s ripgrep invocation.
- Treat flag-like grep patterns as search text so values such as `--follow` cannot override safety flags.
- Add regression coverage for symlinks targeting locations both inside and outside the workspace.

## How to test

- `vp test src/lib/agent-runtime/tools/repo-read-tools.test.ts src/lib/agent-runtime/tools/workspace/glob.test.ts` — 93 tests passed.
- `vp check --fix` — passed with nine unrelated existing warnings.
- `vp test` — attempted, but database-backed coverage could not complete because the local Drizzle migration exited with code 1.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review