### PR TITLE
Use PostgreSQL `clock_timestamp()` for issue activity `created_at` to fix feed ordering

### DIFF
--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-relationship-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-relationship-service.ts
@@ -165,6 +165,7 @@ export class IssueRelationshipService extends ProjectServiceBase {
       actorUserId: input.actorUserId,
       type: input.type,
       payload: { relatedIssueId: input.relatedIssueId, kind: input.relationshipKind },
+      createdAt: sql`clock_timestamp()`,
     });
   }
 

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import-runner.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import-runner.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import type { IssueSheetImportBody } from "@/api/routes/project/issue-sheet.schema";
 import { db, schema } from "@/lib/database";
@@ -445,8 +445,6 @@ export async function runIssueSheetCsvImport(
         throw new Error("issue_sheet_import_insert_failed");
       }
 
-      const activityCreatedAt = new Date();
-
       await tx.insert(schema.issueSheetActivities).values({
         organizationId: input.organizationId,
         projectId: input.projectId,
@@ -454,7 +452,7 @@ export async function runIssueSheetCsvImport(
         actorUserId: input.actorUserId,
         type: ISSUE_SHEET_ACTIVITY_ISSUE_CREATED,
         payload: {},
-        createdAt: activityCreatedAt,
+        createdAt: sql`clock_timestamp()`,
       });
 
       if (row.assigneeUserId) {
@@ -468,7 +466,7 @@ export async function runIssueSheetCsvImport(
             previousAssigneeUserId: null,
             nextAssigneeUserId: row.assigneeUserId,
           },
-          createdAt: new Date(activityCreatedAt.getTime() + 1),
+          createdAt: sql`clock_timestamp()`,
         });
       }
 

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-feed-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-feed-service.test.ts
@@ -124,6 +124,22 @@ describe("IssueSheetService.listFeed", () => {
       kind: "activity",
       activity: { type: "status_changed", previousStatus: "open", nextStatus: "resolved" },
     });
+    const creation = feed.items[0];
+    const commentThread = feed.items[1];
+    const statusChange = feed.items[2];
+    if (
+      creation?.kind !== "activity" ||
+      commentThread?.kind !== "comment_thread" ||
+      statusChange?.kind !== "activity"
+    ) {
+      throw new Error("expected activity, comment thread, and activity feed ordering");
+    }
+    expect(new Date(creation.activity.createdAt).getTime()).toBeLessThan(
+      new Date(commentThread.root.createdAt).getTime(),
+    );
+    expect(new Date(commentThread.root.createdAt).getTime()).toBeLessThan(
+      new Date(statusChange.activity.createdAt).getTime(),
+    );
 
     const firstPage = await issueSheetService.listFeed({
       organizationId: organization.id,

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -1312,15 +1312,12 @@ export class IssueSheetService {
         return null;
       }
 
-      const activityCreatedAt = new Date();
-
       await this.insertIssueCreatedActivity({
         database: tx,
         organizationId: input.organizationId,
         projectId: input.projectId,
         issueId: issue.id,
         actorUserId: input.actorUserId,
-        createdAt: activityCreatedAt,
       });
 
       if (assigneeUserId) {
@@ -1332,7 +1329,6 @@ export class IssueSheetService {
           actorUserId: input.actorUserId,
           previousAssigneeUserId: null,
           nextAssigneeUserId: assigneeUserId,
-          createdAt: new Date(activityCreatedAt.getTime() + 1),
         });
       }
 
@@ -1743,7 +1739,6 @@ export class IssueSheetService {
     actorUserId: string;
     previousAssigneeUserId: string | null;
     nextAssigneeUserId: string | null;
-    createdAt?: Date;
   }) {
     await input.database.insert(schema.issueSheetActivities).values({
       organizationId: input.organizationId,
@@ -1755,7 +1750,7 @@ export class IssueSheetService {
         previousAssigneeUserId: input.previousAssigneeUserId,
         nextAssigneeUserId: input.nextAssigneeUserId,
       },
-      ...(input.createdAt ? { createdAt: input.createdAt } : {}),
+      createdAt: sql`clock_timestamp()`,
     });
   }
 
@@ -1765,7 +1760,6 @@ export class IssueSheetService {
     projectId: string;
     issueId: string;
     actorUserId: string;
-    createdAt?: Date;
   }) {
     await input.database.insert(schema.issueSheetActivities).values({
       organizationId: input.organizationId,
@@ -1774,7 +1768,7 @@ export class IssueSheetService {
       actorUserId: input.actorUserId,
       type: ISSUE_SHEET_ACTIVITY_ISSUE_CREATED,
       payload: {},
-      ...(input.createdAt ? { createdAt: input.createdAt } : {}),
+      createdAt: sql`clock_timestamp()`,
     });
   }
 
@@ -1797,6 +1791,7 @@ export class IssueSheetService {
         previousStatus: input.previousStatus,
         nextStatus: input.nextStatus,
       },
+      createdAt: sql`clock_timestamp()`,
     });
   }
 
@@ -1819,6 +1814,7 @@ export class IssueSheetService {
         previousIssueType: input.previousIssueType,
         nextIssueType: input.nextIssueType,
       },
+      createdAt: sql`clock_timestamp()`,
     });
   }
 
@@ -1841,6 +1837,7 @@ export class IssueSheetService {
         previousPriority: input.previousPriority,
         nextPriority: input.nextPriority,
       },
+      createdAt: sql`clock_timestamp()`,
     });
   }
 

--- a/docs/adr/2026-08-23-issue-feed-activity-timestamps-design.md
+++ b/docs/adr/2026-08-23-issue-feed-activity-timestamps-design.md
@@ -1,0 +1,27 @@
+# Issue feed activity timestamps
+
+## Context
+
+The issue feed orders activities and comments by `created_at`. Activities created with a Node.js
+timestamp can sort after a logically later comment whose timestamp comes from PostgreSQL. The two
+processes do not necessarily have identical clocks. PostgreSQL's `now()` is not a suitable direct
+replacement because it remains fixed for the duration of a transaction, causing sequential activity
+inserts to tie.
+
+## Decision
+
+Every issue activity insert supplies PostgreSQL's `clock_timestamp()` as `created_at`. This keeps
+activity and comment timestamps on the database clock while allowing sequential statements in one
+transaction to receive advancing values. Issue creation and assignment no longer compute timestamps
+in Node or add a synthetic millisecond to enforce their order.
+
+This is implemented at each activity insert rather than by changing the column default. Explicit
+values make the behavior apply immediately without a schema migration and prevent callers from
+silently depending on the existing `now()` default.
+
+## Testing
+
+The existing feed service and route integration tests create an issue, add a comment, add a later
+activity, and assert the unified SQL feed order. Creation-with-assignee coverage also verifies that
+the two activities retain their statement order. The full web test and static-check suites protect
+all activity-producing paths.


### PR DESCRIPTION
### Motivation

- Feed ordering could be incorrect because activity rows used Node.js timestamps while comments used the database clock, and separate clocks can be inconsistent.
- Using `now()` is unsuitable because it is fixed for the duration of a transaction and can cause sequential inserts to tie.
- The goal is to ensure all activity timestamps come from the database clock and can advance within a transaction so statement order is preserved.

### Description

- Replaced Node-generated `new Date()` timestamps and synthetic millisecond offsets with `sql`clock_timestamp()` for all issue activity inserts in `issue-sheet-service.ts`, `issue-relationship-service.ts`, and the CSV import runner `issue-sheet-csv-import-runner.ts`.
- Added `sql` import where needed and removed optional `createdAt` parameters that were previously used to pass Node timestamps.
- Added an ADR document `docs/adr/2026-08-23-issue-feed-activity-timestamps-design.md` describing the decision and rationale.
- Updated feed test `issue-sheet-feed-service.test.ts` to explicitly assert the chronological ordering of activity/comment timestamps.

### Testing

- Ran the updated unit/integration test covering the unified feed ordering (`issue-sheet-feed-service.test.ts`), and the test passed.
- Ran the full web test and static-check suites to ensure no regressions in activity-producing paths, and they passed.
- Existing feed and route integration tests that exercise issue creation-with-assignee and sequential activity ordering continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8af9a07eac832c85ff33ecf64e4d4d)