### PR TITLE
Native CAT: add exact-source grouping (source_text_hash), resolver, API and schema updates

### DIFF
--- a/apps/hyperlocalise-web/drizzle/0096_outstanding_blink.sql
+++ b/apps/hyperlocalise-web/drizzle/0096_outstanding_blink.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "project_translation_keys" ADD COLUMN "source_text_hash" text GENERATED ALWAYS AS (encode(sha256(convert_to(source_text, 'UTF8')), 'hex')) STORED;--> statement-breakpoint
+CREATE INDEX "idx_project_translation_keys_project_source_hash" ON "project_translation_keys" USING btree ("organization_id","project_id","source_text_hash");

--- a/apps/hyperlocalise-web/drizzle/0096_outstanding_blink.sql
+++ b/apps/hyperlocalise-web/drizzle/0096_outstanding_blink.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "project_translation_keys" ADD COLUMN "source_text_hash" text GENERATED ALWAYS AS (encode(sha256(convert_to(source_text, 'UTF8')), 'hex')) STORED;--> statement-breakpoint
+ALTER TABLE "project_translation_keys" ADD COLUMN "source_text_hash" text GENERATED ALWAYS AS (encode(sha256(source_text::bytea), 'hex')) STORED;--> statement-breakpoint
 CREATE INDEX "idx_project_translation_keys_project_source_hash" ON "project_translation_keys" USING btree ("organization_id","project_id","source_text_hash");

--- a/apps/hyperlocalise-web/drizzle/meta/0096_snapshot.json
+++ b/apps/hyperlocalise-web/drizzle/meta/0096_snapshot.json
@@ -14778,7 +14778,7 @@
           "primaryKey": false,
           "notNull": false,
           "generated": {
-            "as": "encode(sha256(convert_to(source_text, 'UTF8')), 'hex')",
+            "as": "encode(sha256(source_text::bytea), 'hex')",
             "type": "stored"
           }
         },

--- a/apps/hyperlocalise-web/drizzle/meta/0096_snapshot.json
+++ b/apps/hyperlocalise-web/drizzle/meta/0096_snapshot.json
@@ -1,0 +1,20357 @@
+{
+  "id": "eaa3d11b-bffe-41b4-84d6-7d1eb22f1f3c",
+  "prevId": "f15d712f-5806-4e9e-903f-1f0546ffca82",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workos_membership_id": {
+          "name": "workos_membership_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_memberships_org_user_key": {
+          "name": "organization_memberships_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_workos_membership_id_key": {
+          "name": "organization_memberships_workos_membership_id_key",
+          "columns": [
+            {
+              "expression": "workos_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_memberships_user_id": {
+          "name": "idx_organization_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_organization_id": {
+          "name": "workos_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "organization_lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_workos_organization_id_key": {
+          "name": "organizations_workos_organization_id_key",
+          "columns": [
+            {
+              "expression": "workos_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_slug_key": {
+          "name": "organizations_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organizations_created_at": {
+          "name": "idx_organizations_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_memberships_team_user_key": {
+          "name": "team_memberships_team_user_key",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_memberships_user_id": {
+          "name": "idx_team_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_memberships_team_id_teams_id_fk": {
+          "name": "team_memberships_team_id_teams_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_org_slug_key": {
+          "name": "teams_org_slug_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_created_at": {
+          "name": "idx_teams_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_organization_id_organizations_id_fk": {
+          "name": "teams_organization_id_organizations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_user_id": {
+          "name": "workos_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workos_memberships_reconciled_at": {
+          "name": "workos_memberships_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_workos_user_id_key": {
+          "name": "users_workos_user_id_key",
+          "columns": [
+            {
+              "expression": "workos_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowdin_oauth_states": {
+      "name": "crowdin_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_encryption_algorithm": {
+          "name": "oauth_client_secret_encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_ciphertext": {
+          "name": "oauth_client_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_iv": {
+          "name": "oauth_client_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_auth_tag": {
+          "name": "oauth_client_secret_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_key_version": {
+          "name": "oauth_client_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowdin_oauth_states_nonce_key": {
+          "name": "crowdin_oauth_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_oauth_states_org_user": {
+          "name": "idx_crowdin_oauth_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_oauth_states_expires_at": {
+          "name": "idx_crowdin_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowdin_oauth_states_organization_id_organizations_id_fk": {
+          "name": "crowdin_oauth_states_organization_id_organizations_id_fk",
+          "tableFrom": "crowdin_oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_oauth_states_user_id_users_id_fk": {
+          "name": "crowdin_oauth_states_user_id_users_id_fk",
+          "tableFrom": "crowdin_oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowdin_user_connections": {
+      "name": "crowdin_user_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crowdin_user_id": {
+          "name": "crowdin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oauth'"
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowdin_user_connections_org_user_key": {
+          "name": "crowdin_user_connections_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crowdin_user_connections_org_crowdin_user_key": {
+          "name": "crowdin_user_connections_org_crowdin_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "crowdin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_user_connections_provider_credential": {
+          "name": "idx_crowdin_user_connections_provider_credential",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowdin_user_connections_organization_id_organizations_id_fk": {
+          "name": "crowdin_user_connections_organization_id_organizations_id_fk",
+          "tableFrom": "crowdin_user_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_user_connections_user_id_users_id_fk": {
+          "name": "crowdin_user_connections_user_id_users_id_fk",
+          "tableFrom": "crowdin_user_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "crowdin_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "crowdin_user_connections",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowdin_user_oauth_states": {
+      "name": "crowdin_user_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowdin_user_oauth_states_nonce_key": {
+          "name": "crowdin_user_oauth_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_user_oauth_states_org_user": {
+          "name": "idx_crowdin_user_oauth_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_user_oauth_states_expires_at": {
+          "name": "idx_crowdin_user_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowdin_user_oauth_states_organization_id_organizations_id_fk": {
+          "name": "crowdin_user_oauth_states_organization_id_organizations_id_fk",
+          "tableFrom": "crowdin_user_oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_user_oauth_states_user_id_users_id_fk": {
+          "name": "crowdin_user_oauth_states_user_id_users_id_fk",
+          "tableFrom": "crowdin_user_oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "crowdin_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "crowdin_user_oauth_states",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lokalise_user_connections": {
+      "name": "lokalise_user_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lokalise_user_id": {
+          "name": "lokalise_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lokalise_user_connections_org_user_key": {
+          "name": "lokalise_user_connections_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lokalise_user_connections_org_lokalise_user_key": {
+          "name": "lokalise_user_connections_org_lokalise_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lokalise_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lokalise_user_connections_provider_credential": {
+          "name": "idx_lokalise_user_connections_provider_credential",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lokalise_user_connections_organization_id_organizations_id_fk": {
+          "name": "lokalise_user_connections_organization_id_organizations_id_fk",
+          "tableFrom": "lokalise_user_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lokalise_user_connections_user_id_users_id_fk": {
+          "name": "lokalise_user_connections_user_id_users_id_fk",
+          "tableFrom": "lokalise_user_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lokalise_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "lokalise_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "lokalise_user_connections",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lokalise_user_oauth_states": {
+      "name": "lokalise_user_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lokalise_user_oauth_states_nonce_key": {
+          "name": "lokalise_user_oauth_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lokalise_user_oauth_states_org_user": {
+          "name": "idx_lokalise_user_oauth_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lokalise_user_oauth_states_expires_at": {
+          "name": "idx_lokalise_user_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lokalise_user_oauth_states_organization_id_organizations_id_fk": {
+          "name": "lokalise_user_oauth_states_organization_id_organizations_id_fk",
+          "tableFrom": "lokalise_user_oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lokalise_user_oauth_states_user_id_users_id_fk": {
+          "name": "lokalise_user_oauth_states_user_id_users_id_fk",
+          "tableFrom": "lokalise_user_oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lokalise_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "lokalise_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "lokalise_user_oauth_states",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_external_tms_provider_credentials": {
+      "name": "organization_external_tms_provider_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api_token'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_organization_id": {
+          "name": "external_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_secret_suffix": {
+          "name": "masked_secret_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_external_tms_provider_credentials_org_provider_kind_key": {
+          "name": "organization_external_tms_provider_credentials_org_provider_kind_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_external_tms_provider_credentials_updated_at": {
+          "name": "idx_organization_external_tms_provider_credentials_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_external_tms_provider_credentials_provider_ext_org_key": {
+          "name": "organization_external_tms_provider_credentials_provider_ext_org_key",
+          "columns": [
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_external_tms_provider_credentials\".\"external_organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_external_tms_provider_credentials_organization_id_organizations_id_fk": {
+          "name": "organization_external_tms_provider_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "organization_external_tms_provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_external_tms_provider_credentials_created_by_user_id_users_id_fk": {
+          "name": "organization_external_tms_provider_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "organization_external_tms_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_external_tms_provider_credentials_updated_by_user_id_users_id_fk": {
+          "name": "organization_external_tms_provider_credentials_updated_by_user_id_users_id_fk",
+          "tableFrom": "organization_external_tms_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_llm_provider_credentials": {
+      "name": "organization_llm_provider_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "llm_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masked_api_key_suffix": {
+          "name": "masked_api_key_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_llm_provider_credentials_org_provider_key": {
+          "name": "organization_llm_provider_credentials_org_provider_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_llm_provider_credentials_updated_at": {
+          "name": "idx_organization_llm_provider_credentials_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_llm_provider_credentials_organization_id_organizations_id_fk": {
+          "name": "organization_llm_provider_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_llm_provider_credentials_created_by_user_id_users_id_fk": {
+          "name": "organization_llm_provider_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_llm_provider_credentials_updated_by_user_id_users_id_fk": {
+          "name": "organization_llm_provider_credentials_updated_by_user_id_users_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phrase_user_connections": {
+      "name": "phrase_user_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_user_uid": {
+          "name": "phrase_user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrase_user_connections_org_user_key": {
+          "name": "phrase_user_connections_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrase_user_connections_org_phrase_user_key": {
+          "name": "phrase_user_connections_org_phrase_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phrase_user_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phrase_user_connections_provider_credential": {
+          "name": "idx_phrase_user_connections_provider_credential",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_user_connections_organization_id_organizations_id_fk": {
+          "name": "phrase_user_connections_organization_id_organizations_id_fk",
+          "tableFrom": "phrase_user_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_user_connections_user_id_users_id_fk": {
+          "name": "phrase_user_connections_user_id_users_id_fk",
+          "tableFrom": "phrase_user_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "phrase_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "phrase_user_connections",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phrase_user_oauth_states": {
+      "name": "phrase_user_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrase_user_oauth_states_nonce_key": {
+          "name": "phrase_user_oauth_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phrase_user_oauth_states_org_user": {
+          "name": "idx_phrase_user_oauth_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phrase_user_oauth_states_expires_at": {
+          "name": "idx_phrase_user_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_user_oauth_states_organization_id_organizations_id_fk": {
+          "name": "phrase_user_oauth_states_organization_id_organizations_id_fk",
+          "tableFrom": "phrase_user_oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_user_oauth_states_user_id_users_id_fk": {
+          "name": "phrase_user_oauth_states_user_id_users_id_fk",
+          "tableFrom": "phrase_user_oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "phrase_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "phrase_user_oauth_states",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_sync_intents": {
+      "name": "provider_sync_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_kind": {
+          "name": "sync_kind",
+          "type": "provider_sync_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_ids": {
+          "name": "resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cause": {
+          "name": "cause",
+          "type": "provider_sync_intent_cause",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_references": {
+          "name": "event_references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_sync_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lease_key": {
+          "name": "lease_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leased_until": {
+          "name": "leased_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leased_by": {
+          "name": "leased_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_sync_run_id": {
+          "name": "provider_sync_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_provider_sync_intents_org_created": {
+          "name": "idx_provider_sync_intents_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_intents_status_next_attempt": {
+          "name": "idx_provider_sync_intents_status_next_attempt",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_intents_lease_key": {
+          "name": "idx_provider_sync_intents_lease_key",
+          "columns": [
+            {
+              "expression": "lease_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_sync_intents_lease_key_active_key": {
+          "name": "provider_sync_intents_lease_key_active_key",
+          "columns": [
+            {
+              "expression": "lease_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_sync_intents\".\"status\" in ('pending', 'running', 'retryable')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_sync_intents_organization_id_organizations_id_fk": {
+          "name": "provider_sync_intents_organization_id_organizations_id_fk",
+          "tableFrom": "provider_sync_intents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_sync_intents_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "provider_sync_intents_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "provider_sync_intents",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_sync_intents_project_id_projects_id_fk": {
+          "name": "provider_sync_intents_project_id_projects_id_fk",
+          "tableFrom": "provider_sync_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_sync_intents_provider_sync_run_id_provider_sync_runs_id_fk": {
+          "name": "provider_sync_intents_provider_sync_run_id_provider_sync_runs_id_fk",
+          "tableFrom": "provider_sync_intents",
+          "tableTo": "provider_sync_runs",
+          "columnsFrom": [
+            "provider_sync_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_sync_runs": {
+      "name": "provider_sync_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "provider_sync_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_sync_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_resource_id": {
+          "name": "external_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "counts": {
+          "name": "counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_sync_runs_org_started": {
+          "name": "idx_provider_sync_runs_org_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_org_provider_started": {
+          "name": "idx_provider_sync_runs_org_provider_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_org_kind_started": {
+          "name": "idx_provider_sync_runs_org_kind_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_org_project_started": {
+          "name": "idx_provider_sync_runs_org_project_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_org_resource_started": {
+          "name": "idx_provider_sync_runs_org_resource_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_status": {
+          "name": "idx_provider_sync_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_sync_runs_organization_id_organizations_id_fk": {
+          "name": "provider_sync_runs_organization_id_organizations_id_fk",
+          "tableFrom": "provider_sync_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_sync_runs_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "provider_sync_runs_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "provider_sync_runs",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_sync_runs_project_id_projects_id_fk": {
+          "name": "provider_sync_runs_project_id_projects_id_fk",
+          "tableFrom": "provider_sync_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_webhook_events": {
+      "name": "provider_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_resource_id": {
+          "name": "external_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_payload": {
+          "name": "redacted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "provider_webhook_event_processing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_sync_intent_id": {
+          "name": "provider_sync_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_sync_run_id": {
+          "name": "provider_sync_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_webhook_events_subscription_provider_event_key": {
+          "name": "provider_webhook_events_subscription_provider_event_key",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_webhook_events_subscription_dedupe_key": {
+          "name": "provider_webhook_events_subscription_dedupe_key",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_events_org_received": {
+          "name": "idx_provider_webhook_events_org_received",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_events_subscription_received": {
+          "name": "idx_provider_webhook_events_subscription_received",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_events_pending_retry": {
+          "name": "idx_provider_webhook_events_pending_retry",
+          "columns": [
+            {
+              "expression": "processing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_events_sync_run": {
+          "name": "idx_provider_webhook_events_sync_run",
+          "columns": [
+            {
+              "expression": "provider_sync_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_webhook_events_organization_id_organizations_id_fk": {
+          "name": "provider_webhook_events_organization_id_organizations_id_fk",
+          "tableFrom": "provider_webhook_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_events_subscription_id_provider_webhook_subscriptions_id_fk": {
+          "name": "provider_webhook_events_subscription_id_provider_webhook_subscriptions_id_fk",
+          "tableFrom": "provider_webhook_events",
+          "tableTo": "provider_webhook_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_events_project_id_projects_id_fk": {
+          "name": "provider_webhook_events_project_id_projects_id_fk",
+          "tableFrom": "provider_webhook_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_events_provider_sync_run_id_provider_sync_runs_id_fk": {
+          "name": "provider_webhook_events_provider_sync_run_id_provider_sync_runs_id_fk",
+          "tableFrom": "provider_webhook_events",
+          "tableTo": "provider_sync_runs",
+          "columnsFrom": [
+            "provider_sync_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_webhook_subscriptions": {
+      "name": "provider_webhook_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_webhook_id": {
+          "name": "provider_webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_url": {
+          "name": "endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_metadata": {
+          "name": "secret_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "webhook_secret_ciphertext": {
+          "name": "webhook_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_iv": {
+          "name": "webhook_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_auth_tag": {
+          "name": "webhook_secret_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_key_version": {
+          "name": "webhook_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_events": {
+          "name": "subscribed_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_webhook_subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "manual_fallback": {
+          "name": "manual_fallback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_audited_at": {
+          "name": "last_audited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_webhook_subscriptions_credential_webhook_key": {
+          "name": "provider_webhook_subscriptions_credential_webhook_key",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_subscriptions_org": {
+          "name": "idx_provider_webhook_subscriptions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_subscriptions_credential": {
+          "name": "idx_provider_webhook_subscriptions_credential",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_subscriptions_credential_project": {
+          "name": "idx_provider_webhook_subscriptions_credential_project",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_webhook_subscriptions_credential_project_key": {
+          "name": "provider_webhook_subscriptions_credential_project_key",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_subscriptions_org_status": {
+          "name": "idx_provider_webhook_subscriptions_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_webhook_subscriptions_organization_id_organizations_id_fk": {
+          "name": "provider_webhook_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "provider_webhook_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_subscriptions_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "provider_webhook_subscriptions_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "provider_webhook_subscriptions",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_subscriptions_project_id_projects_id_fk": {
+          "name": "provider_webhook_subscriptions_project_id_projects_id_fk",
+          "tableFrom": "provider_webhook_subscriptions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tms_agent_automation_settings": {
+      "name": "tms_agent_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "tms_agent_automation_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tms_agent_automation_settings_org": {
+          "name": "idx_tms_agent_automation_settings_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tms_agent_automation_settings_organization_id_organizations_id_fk": {
+          "name": "tms_agent_automation_settings_organization_id_organizations_id_fk",
+          "tableFrom": "tms_agent_automation_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tms_agent_automation_settings_project_id_projects_id_fk": {
+          "name": "tms_agent_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "tms_agent_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tms_agent_automation_settings_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "tms_agent_automation_settings_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "tms_agent_automation_settings",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tms_agent_automation_settings_org_scope_key": {
+          "name": "tms_agent_automation_settings_org_scope_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "organization_id",
+            "scope",
+            "project_id",
+            "provider_credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tms_agent_automation_settings_scope_shape": {
+          "name": "tms_agent_automation_settings_scope_shape",
+          "value": "(\n        (\"tms_agent_automation_settings\".\"scope\" = 'organization' AND \"tms_agent_automation_settings\".\"project_id\" IS NULL AND \"tms_agent_automation_settings\".\"provider_credential_id\" IS NULL)\n        OR (\"tms_agent_automation_settings\".\"scope\" = 'project' AND \"tms_agent_automation_settings\".\"project_id\" IS NOT NULL AND \"tms_agent_automation_settings\".\"provider_credential_id\" IS NULL)\n        OR (\"tms_agent_automation_settings\".\"scope\" = 'provider' AND \"tms_agent_automation_settings\".\"project_id\" IS NULL AND \"tms_agent_automation_settings\".\"provider_credential_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'P' || upper(substr(replace(gen_random_uuid()::text, '-', ''), 1, 9))"
+        },
+        "issue_number_seq": {
+          "name": "issue_number_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "translation_context": {
+          "name": "translation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "project_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "external_provider_kind": {
+          "name": "external_provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_provider_credential_id": {
+          "name": "external_provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "external_project_url": {
+          "name": "external_project_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_at": {
+          "name": "last_sync_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_message": {
+          "name": "last_sync_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "issue_template_config": {
+          "name": "issue_template_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "automatically_group_identical_strings": {
+          "name": "automatically_group_identical_strings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cat_grouping_revision": {
+          "name": "cat_grouping_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_id_organization_id_key": {
+          "name": "projects_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_id_identifier_key": {
+          "name": "projects_organization_id_identifier_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_org_provider_external_project_key": {
+          "name": "projects_org_provider_external_project_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_org_created_at": {
+          "name": "idx_projects_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_team_id": {
+          "name": "idx_projects_team_id",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_created_by_user_id": {
+          "name": "idx_projects_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_team_id_teams_id_fk": {
+          "name": "projects_team_id_teams_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_users_id_fk": {
+          "name": "projects_created_by_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_updated_by_user_id_users_id_fk": {
+          "name": "projects_updated_by_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "projects_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "external_provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_identifier_format_check": {
+          "name": "projects_identifier_format_check",
+          "value": "\"projects\".\"identifier\" ~ '^[A-Z][A-Z0-9]{0,9}$'"
+        },
+        "projects_issue_number_seq_check": {
+          "name": "projects_issue_number_seq_check",
+          "value": "\"projects\".\"issue_number_seq\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.glossaries": {
+      "name": "glossaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "project_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "external_provider_kind": {
+          "name": "external_provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_provider_credential_id": {
+          "name": "external_provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_resource_type": {
+          "name": "external_resource_type",
+          "type": "external_tms_terminology_resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_glossary_id": {
+          "name": "external_glossary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_coverage": {
+          "name": "locale_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "term_count": {
+          "name": "term_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "glossary_sync_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_capabilities": {
+          "name": "term_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_at": {
+          "name": "last_sync_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_message": {
+          "name": "last_sync_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "glossaries_id_organization_id_key": {
+          "name": "glossaries_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "glossaries_org_provider_external_resource_key": {
+          "name": "glossaries_org_provider_external_resource_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_org_created_at": {
+          "name": "idx_glossaries_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_org_locale_pair": {
+          "name": "idx_glossaries_org_locale_pair",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_created_by_user_id": {
+          "name": "idx_glossaries_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_sync_state": {
+          "name": "idx_glossaries_sync_state",
+          "columns": [
+            {
+              "expression": "sync_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_external_provider": {
+          "name": "idx_glossaries_external_provider",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "glossaries_organization_id_organizations_id_fk": {
+          "name": "glossaries_organization_id_organizations_id_fk",
+          "tableFrom": "glossaries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "glossaries_created_by_user_id_users_id_fk": {
+          "name": "glossaries_created_by_user_id_users_id_fk",
+          "tableFrom": "glossaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "glossaries_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "glossaries_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "glossaries",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "external_provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_concepts": {
+      "name": "glossary_concepts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_term": {
+          "name": "primary_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "translatable": {
+          "name": "translatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "figure": {
+          "name": "figure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_details": {
+          "name": "language_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "external_created_at": {
+          "name": "external_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_updated_at": {
+          "name": "external_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "glossary_concepts_glossary_external_key": {
+          "name": "glossary_concepts_glossary_external_key",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_concepts_glossary_created_at": {
+          "name": "idx_glossary_concepts_glossary_created_at",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "glossary_concepts_glossary_id_glossaries_id_fk": {
+          "name": "glossary_concepts_glossary_id_glossaries_id_fk",
+          "tableFrom": "glossary_concepts",
+          "tableTo": "glossaries",
+          "columnsFrom": [
+            "glossary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_terms": {
+      "name": "glossary_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_term": {
+          "name": "source_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_term": {
+          "name": "target_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "part_of_speech": {
+          "name": "part_of_speech",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_type": {
+          "name": "term_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preferred'"
+        },
+        "case_sensitive": {
+          "name": "case_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forbidden": {
+          "name": "forbidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "glossary_term_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      setweight(to_tsvector('simple', coalesce(source_term, '')), 'A') ||\n      setweight(to_tsvector('simple', coalesce(target_term, '')), 'B') ||\n      setweight(to_tsvector('simple', coalesce(description, '')), 'C')\n    ",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_glossary_terms_glossary_source_term": {
+          "name": "idx_glossary_terms_glossary_source_term",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_term",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_glossary_source_term_ci": {
+          "name": "idx_glossary_terms_glossary_source_term_ci",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"source_term\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "glossary_terms_concept_locale_term_key": {
+          "name": "glossary_terms_concept_locale_term_key",
+          "columns": [
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "term",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"glossary_terms\".\"concept_id\" is not null and \"glossary_terms\".\"locale\" is not null and \"glossary_terms\".\"term\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_glossary_created_at": {
+          "name": "idx_glossary_terms_glossary_created_at",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_concept_id": {
+          "name": "idx_glossary_terms_concept_id",
+          "columns": [
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_concept_locale": {
+          "name": "idx_glossary_terms_concept_locale",
+          "columns": [
+            {
+              "expression": "concept_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_search_vector": {
+          "name": "idx_glossary_terms_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "glossary_terms_glossary_id_glossaries_id_fk": {
+          "name": "glossary_terms_glossary_id_glossaries_id_fk",
+          "tableFrom": "glossary_terms",
+          "tableTo": "glossaries",
+          "columnsFrom": [
+            "glossary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "glossary_terms_concept_id_glossary_concepts_id_fk": {
+          "name": "glossary_terms_concept_id_glossary_concepts_id_fk",
+          "tableFrom": "glossary_terms",
+          "tableTo": "glossary_concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "project_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "external_provider_kind": {
+          "name": "external_provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_provider_credential_id": {
+          "name": "external_provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_memory_id": {
+          "name": "external_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_coverage": {
+          "name": "locale_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "segment_count": {
+          "name": "segment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "glossary_sync_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_mode": {
+          "name": "capability_mode",
+          "type": "external_tms_memory_capability_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_capabilities": {
+          "name": "segment_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_at": {
+          "name": "last_sync_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_message": {
+          "name": "last_sync_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memories_id_organization_id_key": {
+          "name": "memories_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memories_org_provider_external_memory_key": {
+          "name": "memories_org_provider_external_memory_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_org_created_at": {
+          "name": "idx_memories_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_created_by_user_id": {
+          "name": "idx_memories_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_sync_state": {
+          "name": "idx_memories_sync_state",
+          "columns": [
+            {
+              "expression": "sync_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_external_provider": {
+          "name": "idx_memories_external_provider",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memories_organization_id_organizations_id_fk": {
+          "name": "memories_organization_id_organizations_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memories_created_by_user_id_users_id_fk": {
+          "name": "memories_created_by_user_id_users_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "memories_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "memories_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "external_provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_entries": {
+      "name": "memory_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_source_text": {
+          "name": "normalized_source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      setweight(to_tsvector('simple', coalesce(source_text, '')), 'A') ||\n      setweight(to_tsvector('simple', coalesce(target_text, '')), 'B')\n    ",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_entries_memory_locale_source_key": {
+          "name": "memory_entries_memory_locale_source_key",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_source_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_entries_memory_external_key": {
+          "name": "memory_entries_memory_external_key",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_memory_locale_pair": {
+          "name": "idx_memory_entries_memory_locale_pair",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_external_key": {
+          "name": "idx_memory_entries_external_key",
+          "columns": [
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_search_vector": {
+          "name": "idx_memory_entries_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_entries_memory_id_memories_id_fk": {
+          "name": "memory_entries_memory_id_memories_id_fk",
+          "tableFrom": "memory_entries",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_entries_match_score_check": {
+          "name": "memory_entries_match_score_check",
+          "value": "\"memory_entries\".\"match_score\" >= 0 AND \"memory_entries\".\"match_score\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_glossaries": {
+      "name": "project_glossaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_glossaries_project_glossary_key": {
+          "name": "project_glossaries_project_glossary_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_glossaries_org": {
+          "name": "idx_project_glossaries_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_glossaries_project_priority": {
+          "name": "idx_project_glossaries_project_priority",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_glossaries_organization_id_organizations_id_fk": {
+          "name": "project_glossaries_organization_id_organizations_id_fk",
+          "tableFrom": "project_glossaries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_glossaries_project_id_projects_id_fk": {
+          "name": "project_glossaries_project_id_projects_id_fk",
+          "tableFrom": "project_glossaries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_memories": {
+      "name": "project_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_memories_project_memory_key": {
+          "name": "project_memories_project_memory_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_memories_org": {
+          "name": "idx_project_memories_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_memories_project_priority": {
+          "name": "idx_project_memories_project_priority",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_memories_organization_id_organizations_id_fk": {
+          "name": "project_memories_organization_id_organizations_id_fk",
+          "tableFrom": "project_memories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_memories_project_id_projects_id_fk": {
+          "name": "project_memories_project_id_projects_id_fk",
+          "tableFrom": "project_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_agent_requests": {
+      "name": "github_agent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_kind": {
+          "name": "request_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claimed'"
+        },
+        "workflow_run_ids": {
+          "name": "workflow_run_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_agent_requests_idempotency_key": {
+          "name": "github_agent_requests_idempotency_key",
+          "columns": [
+            {
+              "expression": "request_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_agent_requests_installation_repo": {
+          "name": "idx_github_agent_requests_installation_repo",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_agent_requests_created_at": {
+          "name": "idx_github_agent_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_auto_review_repositories": {
+      "name": "github_auto_review_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_repository_id": {
+          "name": "github_installation_repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_auto_review_repositories_org_repo_key": {
+          "name": "github_auto_review_repositories_org_repo_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_installation_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_auto_review_repositories_org": {
+          "name": "idx_github_auto_review_repositories_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_auto_review_repositories_repo": {
+          "name": "idx_github_auto_review_repositories_repo",
+          "columns": [
+            {
+              "expression": "github_installation_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_auto_review_repositories_organization_id_organizations_id_fk": {
+          "name": "github_auto_review_repositories_organization_id_organizations_id_fk",
+          "tableFrom": "github_auto_review_repositories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_auto_review_repositories_github_installation_repository_id_github_installation_repositories_id_fk": {
+          "name": "github_auto_review_repositories_github_installation_repository_id_github_installation_repositories_id_fk",
+          "tableFrom": "github_auto_review_repositories",
+          "tableTo": "github_installation_repositories",
+          "columnsFrom": [
+            "github_installation_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_auto_review_settings": {
+      "name": "github_auto_review_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "additional_prompt": {
+          "name": "additional_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_auto_review_settings_organization_id_organizations_id_fk": {
+          "name": "github_auto_review_settings_organization_id_organizations_id_fk",
+          "tableFrom": "github_auto_review_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_i18n_setup_runs": {
+      "name": "github_i18n_setup_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_locale_count": {
+          "name": "detected_locale_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_i18n_setup_runs_org_repo": {
+          "name": "idx_github_i18n_setup_runs_org_repo",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_i18n_setup_runs_status": {
+          "name": "idx_github_i18n_setup_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_i18n_setup_runs_created_at": {
+          "name": "idx_github_i18n_setup_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_i18n_setup_runs_organization_id_organizations_id_fk": {
+          "name": "github_i18n_setup_runs_organization_id_organizations_id_fk",
+          "tableFrom": "github_i18n_setup_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_i18n_setup_runs_actor_user_id_users_id_fk": {
+          "name": "github_i18n_setup_runs_actor_user_id_users_id_fk",
+          "tableFrom": "github_i18n_setup_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installation_repositories": {
+      "name": "github_installation_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installation_repositories_github_repository_id_key": {
+          "name": "github_installation_repositories_github_repository_id_key",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_org": {
+          "name": "idx_github_installation_repositories_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_installation": {
+          "name": "idx_github_installation_repositories_installation",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_org_enabled": {
+          "name": "idx_github_installation_repositories_org_enabled",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installation_repositories_organization_id_organizations_id_fk": {
+          "name": "github_installation_repositories_organization_id_organizations_id_fk",
+          "tableFrom": "github_installation_repositories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installation_states": {
+      "name": "github_installation_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installation_states_nonce_key": {
+          "name": "github_installation_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_states_org_user": {
+          "name": "idx_github_installation_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_states_expires_at": {
+          "name": "idx_github_installation_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installation_states_organization_id_organizations_id_fk": {
+          "name": "github_installation_states_organization_id_organizations_id_fk",
+          "tableFrom": "github_installation_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installation_states_user_id_users_id_fk": {
+          "name": "github_installation_states_user_id_users_id_fk",
+          "tableFrom": "github_installation_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_app_id": {
+          "name": "github_app_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_organization_id_key": {
+          "name": "github_installations_organization_id_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_github_installation_id_key": {
+          "name": "github_installations_github_installation_id_key",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_created_at": {
+          "name": "idx_github_installations_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_organization_id_organizations_id_fk": {
+          "name": "github_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_automation_commit_results": {
+      "name": "github_repository_automation_commit_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_commit_sha": {
+          "name": "parent_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "github_repository_automation_commit_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_paths": {
+          "name": "changed_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "hl_check_report": {
+          "name": "hl_check_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_fixes": {
+          "name": "suggested_fixes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_url": {
+          "name": "log_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_automation_commit_results_job_commit": {
+          "name": "github_repository_automation_commit_results_job_commit",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_commit_results_job": {
+          "name": "idx_github_repository_automation_commit_results_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_automation_commit_results_job_id_github_repository_automation_jobs_id_fk": {
+          "name": "github_repository_automation_commit_results_job_id_github_repository_automation_jobs_id_fk",
+          "tableFrom": "github_repository_automation_commit_results",
+          "tableTo": "github_repository_automation_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_automation_jobs": {
+      "name": "github_repository_automation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_repository_id": {
+          "name": "github_installation_repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_mode": {
+          "name": "trigger_mode",
+          "type": "github_repository_automation_job_trigger_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_repository_automation_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_branch": {
+          "name": "trigger_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_before": {
+          "name": "commit_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_after": {
+          "name": "commit_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflows": {
+          "name": "workflows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pushSource\":false,\"pullTranslations\":false,\"validation\":false}'::jsonb"
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_delivery_id": {
+          "name": "github_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_run_at": {
+          "name": "scheduled_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_check_run_id": {
+          "name": "github_check_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repository_automation_jobs_idempotency_key": {
+          "name": "github_repository_automation_jobs_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_jobs_org_created": {
+          "name": "idx_github_repository_automation_jobs_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_jobs_repo_created": {
+          "name": "idx_github_repository_automation_jobs_repo_created",
+          "columns": [
+            {
+              "expression": "github_installation_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_jobs_status": {
+          "name": "idx_github_repository_automation_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_automation_jobs_organization_id_organizations_id_fk": {
+          "name": "github_repository_automation_jobs_organization_id_organizations_id_fk",
+          "tableFrom": "github_repository_automation_jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_automation_jobs_github_installation_repository_id_github_installation_repositories_id_fk": {
+          "name": "github_repository_automation_jobs_github_installation_repository_id_github_installation_repositories_id_fk",
+          "tableFrom": "github_repository_automation_jobs",
+          "tableTo": "github_installation_repositories",
+          "columnsFrom": [
+            "github_installation_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_automation_settings": {
+      "name": "github_repository_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_repository_id": {
+          "name": "github_installation_repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_automation_settings_repo_key": {
+          "name": "github_repository_automation_settings_repo_key",
+          "columns": [
+            {
+              "expression": "github_installation_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_settings_org": {
+          "name": "idx_github_repository_automation_settings_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_settings_next_run": {
+          "name": "idx_github_repository_automation_settings_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_automation_settings_organization_id_organizations_id_fk": {
+          "name": "github_repository_automation_settings_organization_id_organizations_id_fk",
+          "tableFrom": "github_repository_automation_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_automation_settings_github_installation_repository_id_github_installation_repositories_id_fk": {
+          "name": "github_repository_automation_settings_github_installation_repository_id_github_installation_repositories_id_fk",
+          "tableFrom": "github_repository_automation_settings",
+          "tableTo": "github_installation_repositories",
+          "columnsFrom": [
+            "github_installation_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installation_states": {
+      "name": "slack_installation_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installation_states_nonce_key": {
+          "name": "slack_installation_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_installation_states_org_user": {
+          "name": "idx_slack_installation_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_installation_states_expires_at": {
+          "name": "idx_slack_installation_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installation_states_organization_id_organizations_id_fk": {
+          "name": "slack_installation_states_organization_id_organizations_id_fk",
+          "tableFrom": "slack_installation_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installation_states_user_id_users_id_fk": {
+          "name": "slack_installation_states_user_id_users_id_fk",
+          "tableFrom": "slack_installation_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectors_org_kind_key": {
+          "name": "connectors_org_kind_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_slack_team_id": {
+          "name": "idx_connectors_slack_team_id",
+          "columns": [
+            {
+              "expression": "(config->>'teamId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connectors\".\"kind\" = 'slack'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connectors_organization_id_organizations_id_fk": {
+          "name": "connectors_organization_id_organizations_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"code\"]'::jsonb"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_clients_created_at": {
+          "name": "idx_mcp_oauth_clients_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workos_access_token_encrypted": {
+          "name": "workos_access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workos_refresh_token_encrypted": {
+          "name": "workos_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_sessions_access_token_hash_key": {
+          "name": "mcp_sessions_access_token_hash_key",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_sessions_refresh_token_hash_key": {
+          "name": "mcp_sessions_refresh_token_hash_key",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_sessions_user_id": {
+          "name": "idx_mcp_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_sessions_organization_id": {
+          "name": "idx_mcp_sessions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_sessions_expires_at": {
+          "name": "idx_mcp_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_sessions_user_id_users_id_fk": {
+          "name": "mcp_sessions_user_id_users_id_fk",
+          "tableFrom": "mcp_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_sessions_organization_id_organizations_id_fk": {
+          "name": "mcp_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"jobs:read\", \"jobs:write\", \"files:read\", \"files:write\"]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_api_keys_key_hash_key": {
+          "name": "organization_api_keys_key_hash_key",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_api_keys_org": {
+          "name": "idx_organization_api_keys_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_api_keys_created_at": {
+          "name": "idx_organization_api_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organizations_id_fk": {
+          "name": "organization_api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_user_id_users_id_fk": {
+          "name": "organization_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tms_links": {
+      "name": "tms_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tms_links_org": {
+          "name": "idx_tms_links_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tms_links_org_provider": {
+          "name": "idx_tms_links_org_provider",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tms_links_organization_id_organizations_id_fk": {
+          "name": "tms_links_organization_id_organizations_id_fk",
+          "tableFrom": "tms_links",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tms_links_project_id_projects_id_fk": {
+          "name": "tms_links_project_id_projects_id_fk",
+          "tableFrom": "tms_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.used_authorization_codes": {
+      "name": "used_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_used_authorization_codes_expires_at": {
+          "name": "idx_used_authorization_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_connections": {
+      "name": "contentful_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'master'"
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "content_type_ids": {
+          "name": "content_type_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "field_config": {
+          "name": "field_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_token_suffix": {
+          "name": "masked_token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentful_connections_org_space_env_key": {
+          "name": "contentful_connections_org_space_env_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_connections_org": {
+          "name": "idx_contentful_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_connections_project": {
+          "name": "idx_contentful_connections_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_connections_organization_id_organizations_id_fk": {
+          "name": "contentful_connections_organization_id_organizations_id_fk",
+          "tableFrom": "contentful_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_connections_project_id_projects_id_fk": {
+          "name": "contentful_connections_project_id_projects_id_fk",
+          "tableFrom": "contentful_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contentful_connections_created_by_user_id_users_id_fk": {
+          "name": "contentful_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "contentful_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contentful_connections_updated_by_user_id_users_id_fk": {
+          "name": "contentful_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "contentful_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_translation_run_items": {
+      "name": "contentful_translation_run_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_preview": {
+          "name": "source_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translation_preview": {
+          "name": "translation_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qa_findings": {
+          "name": "qa_findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_contentful_translation_run_items_run": {
+          "name": "idx_contentful_translation_run_items_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_run_items_status": {
+          "name": "idx_contentful_translation_run_items_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_translation_run_items_run_id_contentful_translation_runs_id_fk": {
+          "name": "contentful_translation_run_items_run_id_contentful_translation_runs_id_fk",
+          "tableFrom": "contentful_translation_run_items",
+          "tableTo": "contentful_translation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_translation_runs": {
+      "name": "contentful_translation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_automation_run_id": {
+          "name": "workspace_automation_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_event_id": {
+          "name": "webhook_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type_id": {
+          "name": "content_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "run_qa": {
+          "name": "run_qa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "write_drafts": {
+          "name": "write_drafts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "overwrite_draft_locales": {
+          "name": "overwrite_draft_locales",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "detected_fields": {
+          "name": "detected_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "qa_summary": {
+          "name": "qa_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "writeback_summary": {
+          "name": "writeback_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_contentful_translation_runs_org_created": {
+          "name": "idx_contentful_translation_runs_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_connection": {
+          "name": "idx_contentful_translation_runs_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_project": {
+          "name": "idx_contentful_translation_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_status": {
+          "name": "idx_contentful_translation_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_automation_run": {
+          "name": "idx_contentful_translation_runs_automation_run",
+          "columns": [
+            {
+              "expression": "workspace_automation_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_webhook_event_org": {
+          "name": "idx_contentful_translation_runs_webhook_event_org",
+          "columns": [
+            {
+              "expression": "webhook_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_translation_runs_organization_id_organizations_id_fk": {
+          "name": "contentful_translation_runs_organization_id_organizations_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_translation_runs_connection_id_contentful_connections_id_fk": {
+          "name": "contentful_translation_runs_connection_id_contentful_connections_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "contentful_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_translation_runs_project_id_projects_id_fk": {
+          "name": "contentful_translation_runs_project_id_projects_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_translation_runs_workspace_automation_run_id_workspace_automation_runs_id_fk": {
+          "name": "contentful_translation_runs_workspace_automation_run_id_workspace_automation_runs_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "workspace_automation_runs",
+          "columnsFrom": [
+            "workspace_automation_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contentful_translation_runs_webhook_event_id_contentful_webhook_events_id_fk": {
+          "name": "contentful_translation_runs_webhook_event_id_contentful_webhook_events_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "contentful_webhook_events",
+          "columnsFrom": [
+            "webhook_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_webhook_events": {
+      "name": "contentful_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type_id": {
+          "name": "content_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "redacted_payload": {
+          "name": "redacted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentful_webhook_events_dedupe_key": {
+          "name": "contentful_webhook_events_dedupe_key",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_webhook_events_org_created": {
+          "name": "idx_contentful_webhook_events_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_webhook_events_status": {
+          "name": "idx_contentful_webhook_events_status",
+          "columns": [
+            {
+              "expression": "processing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_webhook_events_organization_id_organizations_id_fk": {
+          "name": "contentful_webhook_events_organization_id_organizations_id_fk",
+          "tableFrom": "contentful_webhook_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_webhook_events_connection_id_contentful_connections_id_fk": {
+          "name": "contentful_webhook_events_connection_id_contentful_connections_id_fk",
+          "tableFrom": "contentful_webhook_events",
+          "tableTo": "contentful_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_webhook_events_subscription_id_contentful_webhook_subscriptions_id_fk": {
+          "name": "contentful_webhook_events_subscription_id_contentful_webhook_subscriptions_id_fk",
+          "tableFrom": "contentful_webhook_events",
+          "tableTo": "contentful_webhook_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_webhook_subscriptions": {
+      "name": "contentful_webhook_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_webhook_id": {
+          "name": "provider_webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_id": {
+          "name": "last_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentful_webhook_subscriptions_connection_key": {
+          "name": "contentful_webhook_subscriptions_connection_key",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_webhook_subscriptions_org": {
+          "name": "idx_contentful_webhook_subscriptions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_webhook_subscriptions_provider_webhook": {
+          "name": "idx_contentful_webhook_subscriptions_provider_webhook",
+          "columns": [
+            {
+              "expression": "provider_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_webhook_subscriptions_organization_id_organizations_id_fk": {
+          "name": "contentful_webhook_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "contentful_webhook_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_webhook_subscriptions_connection_id_contentful_connections_id_fk": {
+          "name": "contentful_webhook_subscriptions_connection_id_contentful_connections_id_fk",
+          "tableFrom": "contentful_webhook_subscriptions",
+          "tableTo": "contentful_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_connections": {
+      "name": "mcp_server_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "auth_kind": {
+          "name": "auth_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_token_suffix": {
+          "name": "masked_token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_server_connections_org_url_key": {
+          "name": "mcp_server_connections_org_url_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_server_connections_org": {
+          "name": "idx_mcp_server_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_connections_organization_id_organizations_id_fk": {
+          "name": "mcp_server_connections_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_server_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_connections_created_by_user_id_users_id_fk": {
+          "name": "mcp_server_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "mcp_server_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_server_connections_updated_by_user_id_users_id_fk": {
+          "name": "mcp_server_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "mcp_server_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.semrush_connections": {
+      "name": "semrush_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_api_key_suffix": {
+          "name": "masked_api_key_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_semrush_connections_org": {
+          "name": "idx_semrush_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "semrush_connections_organization_id_organizations_id_fk": {
+          "name": "semrush_connections_organization_id_organizations_id_fk",
+          "tableFrom": "semrush_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "semrush_connections_created_by_user_id_users_id_fk": {
+          "name": "semrush_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "semrush_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "semrush_connections_updated_by_user_id_users_id_fk": {
+          "name": "semrush_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "semrush_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ahrefs_connections": {
+      "name": "ahrefs_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_api_key_suffix": {
+          "name": "masked_api_key_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ahrefs_connections_org": {
+          "name": "idx_ahrefs_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ahrefs_connections_organization_id_organizations_id_fk": {
+          "name": "ahrefs_connections_organization_id_organizations_id_fk",
+          "tableFrom": "ahrefs_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ahrefs_connections_created_by_user_id_users_id_fk": {
+          "name": "ahrefs_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "ahrefs_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ahrefs_connections_updated_by_user_id_users_id_fk": {
+          "name": "ahrefs_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "ahrefs_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intercom_connections": {
+      "name": "intercom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rest_endpoint": {
+          "name": "rest_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_access_token_suffix": {
+          "name": "masked_access_token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_intercom_connections_org": {
+          "name": "idx_intercom_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intercom_connections_organization_id_organizations_id_fk": {
+          "name": "intercom_connections_organization_id_organizations_id_fk",
+          "tableFrom": "intercom_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intercom_connections_created_by_user_id_users_id_fk": {
+          "name": "intercom_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "intercom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "intercom_connections_updated_by_user_id_users_id_fk": {
+          "name": "intercom_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "intercom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canva_connections": {
+      "name": "canva_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"es\",\"fr\",\"de\"]'::jsonb"
+        },
+        "canva_brand_id": {
+          "name": "canva_brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_token_hash": {
+          "name": "connection_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_token_prefix": {
+          "name": "connection_token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "canva_connections_token_hash_key": {
+          "name": "canva_connections_token_hash_key",
+          "columns": [
+            {
+              "expression": "connection_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "canva_connections_org_brand_key": {
+          "name": "canva_connections_org_brand_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canva_brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"canva_connections\".\"canva_brand_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_canva_connections_org": {
+          "name": "idx_canva_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_canva_connections_api_key": {
+          "name": "idx_canva_connections_api_key",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_canva_connections_project": {
+          "name": "idx_canva_connections_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canva_connections_organization_id_organizations_id_fk": {
+          "name": "canva_connections_organization_id_organizations_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "canva_connections_api_key_id_organization_api_keys_id_fk": {
+          "name": "canva_connections_api_key_id_organization_api_keys_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "organization_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "canva_connections_project_id_projects_id_fk": {
+          "name": "canva_connections_project_id_projects_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "canva_connections_created_by_user_id_users_id_fk": {
+          "name": "canva_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "canva_connections_updated_by_user_id_users_id_fk": {
+          "name": "canva_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowdin_app_installations": {
+      "name": "crowdin_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "crowdin_organization_id": {
+          "name": "crowdin_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crowdin_domain": {
+          "name": "crowdin_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowdin_base_url": {
+          "name": "crowdin_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crowdin_user_id": {
+          "name": "crowdin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_encryption_algorithm": {
+          "name": "app_secret_encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_ciphertext": {
+          "name": "app_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_iv": {
+          "name": "app_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_auth_tag": {
+          "name": "app_secret_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_key_version": {
+          "name": "app_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowdin_app_installations_crowdin_org_key": {
+          "name": "crowdin_app_installations_crowdin_org_key",
+          "columns": [
+            {
+              "expression": "crowdin_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_app_installations_organization": {
+          "name": "idx_crowdin_app_installations_organization",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowdin_app_installations_organization_id_organizations_id_fk": {
+          "name": "crowdin_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "crowdin_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_management_job_details": {
+      "name": "asset_management_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_management_job_details_job_id_jobs_id_fk": {
+          "name": "asset_management_job_details_job_id_jobs_id_fk",
+          "tableFrom": "asset_management_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_job_details": {
+      "name": "external_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_task_id": {
+          "name": "external_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_status": {
+          "name": "external_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "assigned_users": {
+          "name": "assigned_users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provider_payload": {
+          "name": "provider_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "linked_job_id": {
+          "name": "linked_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_external_job_details_provider_kind": {
+          "name": "idx_external_job_details_provider_kind",
+          "columns": [
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_external_job_id": {
+          "name": "idx_external_job_details_external_job_id",
+          "columns": [
+            {
+              "expression": "external_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_external_task_id": {
+          "name": "idx_external_job_details_external_task_id",
+          "columns": [
+            {
+              "expression": "external_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_sync_state": {
+          "name": "idx_external_job_details_sync_state",
+          "columns": [
+            {
+              "expression": "sync_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_linked_job": {
+          "name": "idx_external_job_details_linked_job",
+          "columns": [
+            {
+              "expression": "linked_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_provider_job_unique": {
+          "name": "idx_external_job_details_provider_job_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_job_details_job_id_jobs_id_fk": {
+          "name": "external_job_details_job_id_jobs_id_fk",
+          "tableFrom": "external_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_job_details_organization_id_organizations_id_fk": {
+          "name": "external_job_details_organization_id_organizations_id_fk",
+          "tableFrom": "external_job_details",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_job_details_linked_job_id_jobs_id_fk": {
+          "name": "external_job_details_linked_job_id_jobs_id_fk",
+          "tableFrom": "external_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "linked_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "job_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_payload": {
+          "name": "outcome_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_org_created_at": {
+          "name": "idx_jobs_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_project_created_at": {
+          "name": "idx_jobs_project_created_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_created_by_user_id": {
+          "name": "idx_jobs_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_owner_user_id": {
+          "name": "idx_jobs_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_kind_status": {
+          "name": "idx_jobs_kind_status",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_workflow_run_id": {
+          "name": "idx_jobs_workflow_run_id",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_status": {
+          "name": "idx_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_interaction": {
+          "name": "idx_jobs_interaction",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_api_key_id": {
+          "name": "idx_jobs_api_key_id",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_organization_id_organizations_id_fk": {
+          "name": "jobs_organization_id_organizations_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "jobs_project_id_projects_id_fk": {
+          "name": "jobs_project_id_projects_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_created_by_user_id_users_id_fk": {
+          "name": "jobs_created_by_user_id_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_owner_user_id_users_id_fk": {
+          "name": "jobs_owner_user_id_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_api_key_id_organization_api_keys_id_fk": {
+          "name": "jobs_api_key_id_organization_api_keys_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "organization_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_interaction_id_interactions_id_fk": {
+          "name": "jobs_interaction_id_interactions_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_job_details": {
+      "name": "review_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_job_details_job_id_jobs_id_fk": {
+          "name": "review_job_details_job_id_jobs_id_fk",
+          "tableFrom": "review_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_job_details": {
+      "name": "sync_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connector_kind": {
+          "name": "connector_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identifiers": {
+          "name": "external_identifiers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_job_details_job_id_jobs_id_fk": {
+          "name": "sync_job_details_job_id_jobs_id_fk",
+          "tableFrom": "sync_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_job_details": {
+      "name": "translation_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "translation_job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_version_id": {
+          "name": "source_file_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_kind": {
+          "name": "outcome_kind",
+          "type": "translation_job_outcome_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_job_details_type": {
+          "name": "idx_translation_job_details_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_job_details_source_file_version": {
+          "name": "idx_translation_job_details_source_file_version",
+          "columns": [
+            {
+              "expression": "source_file_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_job_details_outcome_kind": {
+          "name": "idx_translation_job_details_outcome_kind",
+          "columns": [
+            {
+              "expression": "outcome_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_job_details_job_id_jobs_id_fk": {
+          "name": "translation_job_details_job_id_jobs_id_fk",
+          "tableFrom": "translation_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_job_details_source_file_version_id_repository_source_file_versions_id_fk": {
+          "name": "translation_job_details_source_file_version_id_repository_source_file_versions_id_fk",
+          "tableFrom": "translation_job_details",
+          "tableTo": "repository_source_file_versions",
+          "columnsFrom": [
+            "source_file_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_events": {
+      "name": "usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "usage_feature_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "usage_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autumn_tracked_at": {
+          "name": "autumn_tracked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autumn_track_error": {
+          "name": "autumn_track_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_events_operation_key_key": {
+          "name": "usage_events_operation_key_key",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_org_created_at": {
+          "name": "idx_usage_events_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_feature_status": {
+          "name": "idx_usage_events_feature_status",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_job_id": {
+          "name": "idx_usage_events_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_events_organization_id_organizations_id_fk": {
+          "name": "usage_events_organization_id_organizations_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_events_actor_user_id_users_id_fk": {
+          "name": "usage_events_actor_user_id_users_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_events_api_key_id_organization_api_keys_id_fk": {
+          "name": "usage_events_api_key_id_organization_api_keys_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "organization_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_events_job_id_jobs_id_fk": {
+          "name": "usage_events_job_id_jobs_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_events_interaction_id_interactions_id_fk": {
+          "name": "usage_events_interaction_id_interactions_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_task_id": {
+          "name": "external_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "agent_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_snapshot": {
+          "name": "input_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "changed_items": {
+          "name": "changed_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "hyperlocalise_job_id": {
+          "name": "hyperlocalise_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_org_created": {
+          "name": "idx_agent_runs_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_provider_job": {
+          "name": "idx_agent_runs_org_provider_job",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_provider_task": {
+          "name": "idx_agent_runs_org_provider_task",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status": {
+          "name": "idx_agent_runs_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_hyperlocalise_job": {
+          "name": "idx_agent_runs_hyperlocalise_job",
+          "columns": [
+            {
+              "expression": "hyperlocalise_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_actor": {
+          "name": "idx_agent_runs_org_actor",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_organization_id_organizations_id_fk": {
+          "name": "agent_runs_organization_id_organizations_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_actor_user_id_users_id_fk": {
+          "name": "agent_runs_actor_user_id_users_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_hyperlocalise_job_id_jobs_id_fk": {
+          "name": "agent_runs_hyperlocalise_job_id_jobs_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "hyperlocalise_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_items": {
+      "name": "inbox_items",
+      "schema": "",
+      "columns": {
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "inbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbox_items_org_status": {
+          "name": "idx_inbox_items_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_items_org_updated": {
+          "name": "idx_inbox_items_org_updated",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_items_interaction_id_interactions_id_fk": {
+          "name": "inbox_items_interaction_id_interactions_id_fk",
+          "tableFrom": "inbox_items",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_items_organization_id_organizations_id_fk": {
+          "name": "inbox_items_organization_id_organizations_id_fk",
+          "tableFrom": "inbox_items",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interaction_messages": {
+      "name": "interaction_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "message_sender_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_interaction_messages_interaction_created": {
+          "name": "idx_interaction_messages_interaction_created",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interaction_messages_interaction_id_interactions_id_fk": {
+          "name": "interaction_messages_interaction_id_interactions_id_fk",
+          "tableFrom": "interaction_messages",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interaction_repository_sessions": {
+      "name": "interaction_repository_sessions",
+      "schema": "",
+      "columns": {
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session": {
+          "name": "session",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_interaction_repository_sessions_org_expires": {
+          "name": "idx_interaction_repository_sessions_org_expires",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_interaction_repository_sessions_expires": {
+          "name": "idx_interaction_repository_sessions_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interaction_repository_sessions_interaction_id_interactions_id_fk": {
+          "name": "interaction_repository_sessions_interaction_id_interactions_id_fk",
+          "tableFrom": "interaction_repository_sessions",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interaction_repository_sessions_organization_id_organizations_id_fk": {
+          "name": "interaction_repository_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "interaction_repository_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interactions": {
+      "name": "interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "interaction_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interactions_id_organization_id_key": {
+          "name": "interactions_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_org_source_thread_id_key": {
+          "name": "interactions_org_source_thread_id_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"interactions\".\"source_thread_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_interactions_org_last_message": {
+          "name": "idx_interactions_org_last_message",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interactions_organization_id_organizations_id_fk": {
+          "name": "interactions_organization_id_organizations_id_fk",
+          "tableFrom": "interactions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_automation_runs": {
+      "name": "workspace_automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "workspace_automation_run_trigger_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workspace_automation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_snapshot": {
+          "name": "input_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_automation_job_id": {
+          "name": "github_repository_automation_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_automation_runs_automation_created": {
+          "name": "idx_workspace_automation_runs_automation_created",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automation_runs_org_status": {
+          "name": "idx_workspace_automation_runs_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automation_runs_idempotency_key": {
+          "name": "idx_workspace_automation_runs_idempotency_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_automation_runs\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automation_runs_github_job": {
+          "name": "idx_workspace_automation_runs_github_job",
+          "columns": [
+            {
+              "expression": "github_repository_automation_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_automation_runs\".\"github_repository_automation_job_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_automation_runs_automation_id_workspace_automations_id_fk": {
+          "name": "workspace_automation_runs_automation_id_workspace_automations_id_fk",
+          "tableFrom": "workspace_automation_runs",
+          "tableTo": "workspace_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automation_runs_organization_id_organizations_id_fk": {
+          "name": "workspace_automation_runs_organization_id_organizations_id_fk",
+          "tableFrom": "workspace_automation_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automation_runs_github_repository_automation_job_id_github_repository_automation_jobs_id_fk": {
+          "name": "workspace_automation_runs_github_repository_automation_job_id_github_repository_automation_jobs_id_fk",
+          "tableFrom": "workspace_automation_runs",
+          "tableTo": "github_repository_automation_jobs",
+          "columnsFrom": [
+            "github_repository_automation_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_automations": {
+      "name": "workspace_automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workspace_automation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-5.6-luna'"
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "github_installation_repository_id": {
+          "name": "github_installation_repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_target": {
+          "name": "repository_target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "tool_config": {
+          "name": "tool_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_automations_org_status": {
+          "name": "idx_workspace_automations_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automations_org_next_run": {
+          "name": "idx_workspace_automations_org_next_run",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automations_github_repo": {
+          "name": "idx_workspace_automations_github_repo",
+          "columns": [
+            {
+              "expression": "github_installation_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automations_org_project": {
+          "name": "idx_workspace_automations_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_automations_organization_id_organizations_id_fk": {
+          "name": "workspace_automations_organization_id_organizations_id_fk",
+          "tableFrom": "workspace_automations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automations_author_user_id_users_id_fk": {
+          "name": "workspace_automations_author_user_id_users_id_fk",
+          "tableFrom": "workspace_automations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_automations_github_installation_repository_id_github_installation_repositories_id_fk": {
+          "name": "workspace_automations_github_installation_repository_id_github_installation_repositories_id_fk",
+          "tableFrom": "workspace_automations",
+          "tableTo": "github_installation_repositories",
+          "columnsFrom": [
+            "github_installation_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_automations_project_id_projects_id_fk": {
+          "name": "workspace_automations_project_id_projects_id_fk",
+          "tableFrom": "workspace_automations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_tms_file_versions": {
+      "name": "external_tms_file_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_tms_file_id": {
+          "name": "external_tms_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_external_tms_file_versions_file_captured": {
+          "name": "idx_external_tms_file_versions_file_captured",
+          "columns": [
+            {
+              "expression": "external_tms_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_file_versions_org_project_path": {
+          "name": "idx_external_tms_file_versions_org_project_path",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_tms_file_versions_organization_id_organizations_id_fk": {
+          "name": "external_tms_file_versions_organization_id_organizations_id_fk",
+          "tableFrom": "external_tms_file_versions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_file_versions_project_id_projects_id_fk": {
+          "name": "external_tms_file_versions_project_id_projects_id_fk",
+          "tableFrom": "external_tms_file_versions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_file_versions_external_tms_file_id_external_tms_files_id_fk": {
+          "name": "external_tms_file_versions_external_tms_file_id_external_tms_files_id_fk",
+          "tableFrom": "external_tms_file_versions",
+          "tableTo": "external_tms_files",
+          "columnsFrom": [
+            "external_tms_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_file_versions_stored_file_id_stored_files_id_fk": {
+          "name": "external_tms_file_versions_stored_file_id_stored_files_id_fk",
+          "tableFrom": "external_tms_file_versions",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_tms_files": {
+      "name": "external_tms_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "external_tms_resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_resource_id": {
+          "name": "external_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "locale_readiness": {
+          "name": "locale_readiness",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "provider_payload": {
+          "name": "provider_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_tms_files_provider_resource_key": {
+          "name": "external_tms_files_provider_resource_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_files_org_project_path": {
+          "name": "idx_external_tms_files_org_project_path",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_files_provider_project": {
+          "name": "idx_external_tms_files_provider_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_files_stored_file": {
+          "name": "idx_external_tms_files_stored_file",
+          "columns": [
+            {
+              "expression": "stored_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_files_sync_state": {
+          "name": "idx_external_tms_files_sync_state",
+          "columns": [
+            {
+              "expression": "sync_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_tms_files_organization_id_organizations_id_fk": {
+          "name": "external_tms_files_organization_id_organizations_id_fk",
+          "tableFrom": "external_tms_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_files_project_id_projects_id_fk": {
+          "name": "external_tms_files_project_id_projects_id_fk",
+          "tableFrom": "external_tms_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_files_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "external_tms_files_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "external_tms_files",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "external_tms_files_stored_file_id_stored_files_id_fk": {
+          "name": "external_tms_files_stored_file_id_stored_files_id_fk",
+          "tableFrom": "external_tms_files",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_source_file_versions": {
+      "name": "repository_source_file_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_source_file_id": {
+          "name": "repository_source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_api_key_id": {
+          "name": "uploaded_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_surface": {
+          "name": "upload_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_state": {
+          "name": "ingest_state",
+          "type": "repository_source_file_ingest_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ingest_error": {
+          "name": "ingest_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_workflow_run_id": {
+          "name": "ingest_workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repository_source_file_versions_stored_file_key": {
+          "name": "repository_source_file_versions_stored_file_key",
+          "columns": [
+            {
+              "expression": "stored_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_file_created": {
+          "name": "idx_repository_source_file_versions_file_created",
+          "columns": [
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_project_path_created": {
+          "name": "idx_repository_source_file_versions_project_path_created",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_workflow_run": {
+          "name": "idx_repository_source_file_versions_workflow_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_api_key": {
+          "name": "idx_repository_source_file_versions_api_key",
+          "columns": [
+            {
+              "expression": "uploaded_by_api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_ingest_state": {
+          "name": "idx_repository_source_file_versions_ingest_state",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ingest_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_source_file_versions_repository_source_file_id_repository_source_files_id_fk": {
+          "name": "repository_source_file_versions_repository_source_file_id_repository_source_files_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "repository_source_files",
+          "columnsFrom": [
+            "repository_source_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_organization_id_organizations_id_fk": {
+          "name": "repository_source_file_versions_organization_id_organizations_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_project_id_projects_id_fk": {
+          "name": "repository_source_file_versions_project_id_projects_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_stored_file_id_stored_files_id_fk": {
+          "name": "repository_source_file_versions_stored_file_id_stored_files_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_uploaded_by_user_id_users_id_fk": {
+          "name": "repository_source_file_versions_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_uploaded_by_api_key_id_organization_api_keys_id_fk": {
+          "name": "repository_source_file_versions_uploaded_by_api_key_id_organization_api_keys_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "organization_api_keys",
+          "columnsFrom": [
+            "uploaded_by_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_source_files": {
+      "name": "repository_source_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repository_source_files_project_path_key": {
+          "name": "repository_source_files_project_path_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_files_org_project": {
+          "name": "idx_repository_source_files_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_source_files_organization_id_organizations_id_fk": {
+          "name": "repository_source_files_organization_id_organizations_id_fk",
+          "tableFrom": "repository_source_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_files_project_id_projects_id_fk": {
+          "name": "repository_source_files_project_id_projects_id_fk",
+          "tableFrom": "repository_source_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stored_files": {
+      "name": "stored_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "stored_file_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "stored_file_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_interaction_id": {
+          "name": "source_interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stored_files_storage_provider_key": {
+          "name": "stored_files_storage_provider_key",
+          "columns": [
+            {
+              "expression": "storage_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_org_created_at": {
+          "name": "idx_stored_files_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_project_created_at": {
+          "name": "idx_stored_files_project_created_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_created_by_user_id": {
+          "name": "idx_stored_files_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_source_interaction": {
+          "name": "idx_stored_files_source_interaction",
+          "columns": [
+            {
+              "expression": "source_interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_source_job": {
+          "name": "idx_stored_files_source_job",
+          "columns": [
+            {
+              "expression": "source_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_org_role": {
+          "name": "idx_stored_files_org_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stored_files_organization_id_organizations_id_fk": {
+          "name": "stored_files_organization_id_organizations_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stored_files_project_id_projects_id_fk": {
+          "name": "stored_files_project_id_projects_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_created_by_user_id_users_id_fk": {
+          "name": "stored_files_created_by_user_id_users_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_source_interaction_id_interactions_id_fk": {
+          "name": "stored_files_source_interaction_id_interactions_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "source_interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_source_job_id_jobs_id_fk": {
+          "name": "stored_files_source_job_id_jobs_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "source_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_automation_knowledge_files": {
+      "name": "workspace_automation_knowledge_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_automation_knowledge_files_stored_file_key": {
+          "name": "workspace_automation_knowledge_files_stored_file_key",
+          "columns": [
+            {
+              "expression": "stored_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automation_knowledge_files_automation": {
+          "name": "idx_workspace_automation_knowledge_files_automation",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_automation_knowledge_files_organization_id_organizations_id_fk": {
+          "name": "workspace_automation_knowledge_files_organization_id_organizations_id_fk",
+          "tableFrom": "workspace_automation_knowledge_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automation_knowledge_files_automation_id_workspace_automations_id_fk": {
+          "name": "workspace_automation_knowledge_files_automation_id_workspace_automations_id_fk",
+          "tableFrom": "workspace_automation_knowledge_files",
+          "tableTo": "workspace_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automation_knowledge_files_stored_file_id_stored_files_id_fk": {
+          "name": "workspace_automation_knowledge_files_stored_file_id_stored_files_id_fk",
+          "tableFrom": "workspace_automation_knowledge_files",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automation_knowledge_files_created_by_user_id_users_id_fk": {
+          "name": "workspace_automation_knowledge_files_created_by_user_id_users_id_fk",
+          "tableFrom": "workspace_automation_knowledge_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_translation_comments": {
+      "name": "project_translation_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_key_id": {
+          "name": "translation_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "project_translation_comment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_translation_comments_org_project": {
+          "name": "idx_project_translation_comments_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translation_comments_key_locale": {
+          "name": "idx_project_translation_comments_key_locale",
+          "columns": [
+            {
+              "expression": "translation_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_translation_comments_organization_id_organizations_id_fk": {
+          "name": "project_translation_comments_organization_id_organizations_id_fk",
+          "tableFrom": "project_translation_comments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_comments_project_id_projects_id_fk": {
+          "name": "project_translation_comments_project_id_projects_id_fk",
+          "tableFrom": "project_translation_comments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_comments_translation_key_id_project_translation_keys_id_fk": {
+          "name": "project_translation_comments_translation_key_id_project_translation_keys_id_fk",
+          "tableFrom": "project_translation_comments",
+          "tableTo": "project_translation_keys",
+          "columnsFrom": [
+            "translation_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_comments_author_user_id_users_id_fk": {
+          "name": "project_translation_comments_author_user_id_users_id_fk",
+          "tableFrom": "project_translation_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_translation_keys": {
+      "name": "project_translation_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_source_file_id": {
+          "name": "repository_source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text_hash": {
+          "name": "source_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "encode(sha256(convert_to(source_text, 'UTF8')), 'hex')",
+            "type": "stored"
+          }
+        },
+        "normalized_source_text": {
+          "name": "normalized_source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_length": {
+          "name": "max_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_file_version_id": {
+          "name": "source_file_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_translation_keys_project_file_key": {
+          "name": "project_translation_keys_project_file_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translation_keys_org_project": {
+          "name": "idx_project_translation_keys_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translation_keys_project_source_hash": {
+          "name": "idx_project_translation_keys_project_source_hash",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_text_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translation_keys_file": {
+          "name": "idx_project_translation_keys_file",
+          "columns": [
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_translation_keys_organization_id_organizations_id_fk": {
+          "name": "project_translation_keys_organization_id_organizations_id_fk",
+          "tableFrom": "project_translation_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_keys_project_id_projects_id_fk": {
+          "name": "project_translation_keys_project_id_projects_id_fk",
+          "tableFrom": "project_translation_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_keys_repository_source_file_id_repository_source_files_id_fk": {
+          "name": "project_translation_keys_repository_source_file_id_repository_source_files_id_fk",
+          "tableFrom": "project_translation_keys",
+          "tableTo": "repository_source_files",
+          "columnsFrom": [
+            "repository_source_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_keys_source_file_version_id_repository_source_file_versions_id_fk": {
+          "name": "project_translation_keys_source_file_version_id_repository_source_file_versions_id_fk",
+          "tableFrom": "project_translation_keys",
+          "tableTo": "repository_source_file_versions",
+          "columnsFrom": [
+            "source_file_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_translations": {
+      "name": "project_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_key_id": {
+          "name": "translation_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "project_translation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "project_translation_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_translations_key_locale": {
+          "name": "project_translations_key_locale",
+          "columns": [
+            {
+              "expression": "translation_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translations_org_project": {
+          "name": "idx_project_translations_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translations_status": {
+          "name": "idx_project_translations_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_translations_organization_id_organizations_id_fk": {
+          "name": "project_translations_organization_id_organizations_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translations_project_id_projects_id_fk": {
+          "name": "project_translations_project_id_projects_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translations_translation_key_id_project_translation_keys_id_fk": {
+          "name": "project_translations_translation_key_id_project_translation_keys_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "project_translation_keys",
+          "columnsFrom": [
+            "translation_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translations_source_job_id_jobs_id_fk": {
+          "name": "project_translations_source_job_id_jobs_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "source_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_translations_reviewed_by_user_id_users_id_fk": {
+          "name": "project_translations_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_image_variants": {
+      "name": "project_image_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_source_file_id": {
+          "name": "repository_source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_tms_file_id": {
+          "name": "external_tms_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_translation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "project_translation_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_image_variants_project_path_locale": {
+          "name": "project_image_variants_project_path_locale",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_image_variants_org_project": {
+          "name": "idx_project_image_variants_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_image_variants_repo_file": {
+          "name": "idx_project_image_variants_repo_file",
+          "columns": [
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_image_variants_external_file": {
+          "name": "idx_project_image_variants_external_file",
+          "columns": [
+            {
+              "expression": "external_tms_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_image_variants_status": {
+          "name": "idx_project_image_variants_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_image_variants_organization_id_organizations_id_fk": {
+          "name": "project_image_variants_organization_id_organizations_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_project_id_projects_id_fk": {
+          "name": "project_image_variants_project_id_projects_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_repository_source_file_id_repository_source_files_id_fk": {
+          "name": "project_image_variants_repository_source_file_id_repository_source_files_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "repository_source_files",
+          "columnsFrom": [
+            "repository_source_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_external_tms_file_id_external_tms_files_id_fk": {
+          "name": "project_image_variants_external_tms_file_id_external_tms_files_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "external_tms_files",
+          "columnsFrom": [
+            "external_tms_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_stored_file_id_stored_files_id_fk": {
+          "name": "project_image_variants_stored_file_id_stored_files_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_source_job_id_jobs_id_fk": {
+          "name": "project_image_variants_source_job_id_jobs_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "source_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_reviewed_by_user_id_users_id_fk": {
+          "name": "project_image_variants_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_video_variants": {
+      "name": "project_video_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_source_file_id": {
+          "name": "repository_source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_tms_file_id": {
+          "name": "external_tms_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_translation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "project_translation_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_video_variants_project_path_locale": {
+          "name": "project_video_variants_project_path_locale",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_video_variants_org_project": {
+          "name": "idx_project_video_variants_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_video_variants_repo_file": {
+          "name": "idx_project_video_variants_repo_file",
+          "columns": [
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_video_variants_external_file": {
+          "name": "idx_project_video_variants_external_file",
+          "columns": [
+            {
+              "expression": "external_tms_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_video_variants_status": {
+          "name": "idx_project_video_variants_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_video_variants_organization_id_organizations_id_fk": {
+          "name": "project_video_variants_organization_id_organizations_id_fk",
+          "tableFrom": "project_video_variants",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_video_variants_project_id_projects_id_fk": {
+          "name": "project_video_variants_project_id_projects_id_fk",
+          "tableFrom": "project_video_variants",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_video_variants_repository_source_file_id_repository_source_files_id_fk": {
+          "name": "project_video_variants_repository_source_file_id_repository_source_files_id_fk",
+          "tableFrom": "project_video_variants",
+          "tableTo": "repository_source_files",
+          "columnsFrom": [
+            "repository_source_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_video_variants_external_tms_file_id_external_tms_files_id_fk": {
+          "name": "project_video_variants_external_tms_file_id_external_tms_files_id_fk",
+          "tableFrom": "project_video_variants",
+          "tableTo": "external_tms_files",
+          "columnsFrom": [
+            "external_tms_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_video_variants_stored_file_id_stored_files_id_fk": {
+          "name": "project_video_variants_stored_file_id_stored_files_id_fk",
+          "tableFrom": "project_video_variants",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_video_variants_source_job_id_jobs_id_fk": {
+          "name": "project_video_variants_source_job_id_jobs_id_fk",
+          "tableFrom": "project_video_variants",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "source_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_video_variants_reviewed_by_user_id_users_id_fk": {
+          "name": "project_video_variants_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "project_video_variants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_notifications": {
+      "name": "issue_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailed_at": {
+          "name": "emailed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_notifications_recipient_dedupe_key": {
+          "name": "issue_notifications_recipient_dedupe_key",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_notifications_recipient_org_created": {
+          "name": "idx_issue_notifications_recipient_org_created",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_notifications_recipient_org_unread": {
+          "name": "idx_issue_notifications_recipient_org_unread",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_notifications_issue": {
+          "name": "idx_issue_notifications_issue",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_notifications_email_digest": {
+          "name": "idx_issue_notifications_email_digest",
+          "columns": [
+            {
+              "expression": "emailed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_notifications_organization_id_organizations_id_fk": {
+          "name": "issue_notifications_organization_id_organizations_id_fk",
+          "tableFrom": "issue_notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_notifications_project_id_projects_id_fk": {
+          "name": "issue_notifications_project_id_projects_id_fk",
+          "tableFrom": "issue_notifications",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_notifications_recipient_user_id_users_id_fk": {
+          "name": "issue_notifications_recipient_user_id_users_id_fk",
+          "tableFrom": "issue_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_notifications_actor_user_id_users_id_fk": {
+          "name": "issue_notifications_actor_user_id_users_id_fk",
+          "tableFrom": "issue_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_notifications_issue_id_issue_sheet_issues_id_fk": {
+          "name": "issue_notifications_issue_id_issue_sheet_issues_id_fk",
+          "tableFrom": "issue_notifications",
+          "tableTo": "issue_sheet_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_activities": {
+      "name": "issue_sheet_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_sheet_activities_issue_created": {
+          "name": "idx_issue_sheet_activities_issue_created",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_activities_org_project_issue": {
+          "name": "idx_issue_sheet_activities_org_project_issue",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_activities_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_activities_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_activities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_activities_project_id_projects_id_fk": {
+          "name": "issue_sheet_activities_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_activities",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_activities_issue_id_issue_sheet_issues_id_fk": {
+          "name": "issue_sheet_activities_issue_id_issue_sheet_issues_id_fk",
+          "tableFrom": "issue_sheet_activities",
+          "tableTo": "issue_sheet_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_activities_actor_user_id_users_id_fk": {
+          "name": "issue_sheet_activities_actor_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_activities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_columns": {
+      "name": "issue_sheet_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layer": {
+          "name": "layer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_sheet_columns_project_key": {
+          "name": "issue_sheet_columns_project_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_columns_org_project": {
+          "name": "idx_issue_sheet_columns_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_columns_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_columns_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_columns",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_columns_project_id_projects_id_fk": {
+          "name": "issue_sheet_columns_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_columns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_columns_created_by_user_id_users_id_fk": {
+          "name": "issue_sheet_columns_created_by_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_columns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_comments": {
+      "name": "issue_sheet_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_ids": {
+          "name": "mentioned_user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mentioned_issue_ids": {
+          "name": "mentioned_issue_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_sheet_comments_issue_path_key": {
+          "name": "issue_sheet_comments_issue_path_key",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_comments_issue_path": {
+          "name": "idx_issue_sheet_comments_issue_path",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_comments_issue_created": {
+          "name": "idx_issue_sheet_comments_issue_created",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_comments_org_project_issue": {
+          "name": "idx_issue_sheet_comments_org_project_issue",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_comments_parent": {
+          "name": "idx_issue_sheet_comments_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_comments_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_comments_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_comments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_comments_project_id_projects_id_fk": {
+          "name": "issue_sheet_comments_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_comments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_comments_issue_id_issue_sheet_issues_id_fk": {
+          "name": "issue_sheet_comments_issue_id_issue_sheet_issues_id_fk",
+          "tableFrom": "issue_sheet_comments",
+          "tableTo": "issue_sheet_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_comments_author_user_id_users_id_fk": {
+          "name": "issue_sheet_comments_author_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_comments_parent_id_issue_sheet_comments_id_fk": {
+          "name": "issue_sheet_comments_parent_id_issue_sheet_comments_id_fk",
+          "tableFrom": "issue_sheet_comments",
+          "tableTo": "issue_sheet_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_issues": {
+      "name": "issue_sheet_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(floor(random() * 2147483646) + 1)::integer"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'I' || upper(substr(replace(gen_random_uuid()::text, '-', ''), 1, 8)) || '-' || ((floor(random() * 2147483646) + 1)::integer)::text"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general_question'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translation_key_id": {
+          "name": "translation_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_comment_id": {
+          "name": "linked_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_agent_run_id": {
+          "name": "linked_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_kind": {
+          "name": "link_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reporter_user_id": {
+          "name": "reporter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_issue_sheet_issues_org_project_status": {
+          "name": "idx_issue_sheet_issues_org_project_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_issues_project_locale": {
+          "name": "idx_issue_sheet_issues_project_locale",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_issues_linked_comment": {
+          "name": "idx_issue_sheet_issues_linked_comment",
+          "columns": [
+            {
+              "expression": "linked_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_issues_translation_key": {
+          "name": "idx_issue_sheet_issues_translation_key",
+          "columns": [
+            {
+              "expression": "translation_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_issues_org_project_number": {
+          "name": "idx_issue_sheet_issues_org_project_number",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_sheet_issues_project_number_key": {
+          "name": "issue_sheet_issues_project_number_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_sheet_issues_project_identifier_key": {
+          "name": "issue_sheet_issues_project_identifier_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_sheet_issues_project_external_ref_key": {
+          "name": "issue_sheet_issues_project_external_ref_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_sheet_issues\".\"external_ref\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_issues_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_issues_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_project_id_projects_id_fk": {
+          "name": "issue_sheet_issues_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_translation_key_id_project_translation_keys_id_fk": {
+          "name": "issue_sheet_issues_translation_key_id_project_translation_keys_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "project_translation_keys",
+          "columnsFrom": [
+            "translation_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_linked_comment_id_project_translation_comments_id_fk": {
+          "name": "issue_sheet_issues_linked_comment_id_project_translation_comments_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "project_translation_comments",
+          "columnsFrom": [
+            "linked_comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_linked_agent_run_id_agent_runs_id_fk": {
+          "name": "issue_sheet_issues_linked_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "linked_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_reporter_user_id_users_id_fk": {
+          "name": "issue_sheet_issues_reporter_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_assignee_user_id_users_id_fk": {
+          "name": "issue_sheet_issues_assignee_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_sheet_issues_number_check": {
+          "name": "issue_sheet_issues_number_check",
+          "value": "\"issue_sheet_issues\".\"number\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_relationships": {
+      "name": "issue_sheet_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_issue_id": {
+          "name": "related_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_sheet_relationships_issue_kind": {
+          "name": "idx_issue_sheet_relationships_issue_kind",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_relationships_related_kind": {
+          "name": "idx_issue_sheet_relationships_related_kind",
+          "columns": [
+            {
+              "expression": "related_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_sheet_relationships_edge_key": {
+          "name": "issue_sheet_relationships_edge_key",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_sheet_relationships_one_canonical_key": {
+          "name": "issue_sheet_relationships_one_canonical_key",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_sheet_relationships\".\"kind\" = 'duplicate_of'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_relationships_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_relationships_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_relationships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_relationships_project_id_projects_id_fk": {
+          "name": "issue_sheet_relationships_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_relationships",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_relationships_issue_id_issue_sheet_issues_id_fk": {
+          "name": "issue_sheet_relationships_issue_id_issue_sheet_issues_id_fk",
+          "tableFrom": "issue_sheet_relationships",
+          "tableTo": "issue_sheet_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_relationships_related_issue_id_issue_sheet_issues_id_fk": {
+          "name": "issue_sheet_relationships_related_issue_id_issue_sheet_issues_id_fk",
+          "tableFrom": "issue_sheet_relationships",
+          "tableTo": "issue_sheet_issues",
+          "columnsFrom": [
+            "related_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_relationships_created_by_user_id_users_id_fk": {
+          "name": "issue_sheet_relationships_created_by_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_row_values": {
+      "name": "issue_sheet_row_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_by_agent_run_id": {
+          "name": "computed_by_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_sheet_row_values_issue_column": {
+          "name": "issue_sheet_row_values_issue_column",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_row_values_org_project": {
+          "name": "idx_issue_sheet_row_values_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_row_values_column": {
+          "name": "idx_issue_sheet_row_values_column",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_row_values_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_row_values_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_row_values_project_id_projects_id_fk": {
+          "name": "issue_sheet_row_values_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_row_values_issue_id_issue_sheet_issues_id_fk": {
+          "name": "issue_sheet_row_values_issue_id_issue_sheet_issues_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "issue_sheet_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_row_values_column_id_issue_sheet_columns_id_fk": {
+          "name": "issue_sheet_row_values_column_id_issue_sheet_columns_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "issue_sheet_columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_row_values_computed_by_agent_run_id_agent_runs_id_fk": {
+          "name": "issue_sheet_row_values_computed_by_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "computed_by_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_subscriptions": {
+      "name": "issue_sheet_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_sheet_subscriptions_issue_user_key": {
+          "name": "issue_sheet_subscriptions_issue_user_key",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_subscriptions_user_org": {
+          "name": "idx_issue_sheet_subscriptions_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_subscriptions_issue": {
+          "name": "idx_issue_sheet_subscriptions_issue",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_subscriptions_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_subscriptions_project_id_projects_id_fk": {
+          "name": "issue_sheet_subscriptions_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_subscriptions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_subscriptions_issue_id_issue_sheet_issues_id_fk": {
+          "name": "issue_sheet_subscriptions_issue_id_issue_sheet_issues_id_fk",
+          "tableFrom": "issue_sheet_subscriptions",
+          "tableTo": "issue_sheet_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_subscriptions_user_id_users_id_fk": {
+          "name": "issue_sheet_subscriptions_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_format": {
+          "name": "email_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'digest'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_tms_mutation_logs": {
+      "name": "repo_tms_mutation_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "repo_tms_mutation_log_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "repo_tms_mutation_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_repo_tms_mutation_logs_org": {
+          "name": "idx_repo_tms_mutation_logs_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repo_tms_mutation_logs_task": {
+          "name": "idx_repo_tms_mutation_logs_task",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repo_tms_mutation_logs_workflow_run": {
+          "name": "idx_repo_tms_mutation_logs_workflow_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repo_tms_mutation_logs_created_at": {
+          "name": "idx_repo_tms_mutation_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_tms_mutation_logs_organization_id_organizations_id_fk": {
+          "name": "repo_tms_mutation_logs_organization_id_organizations_id_fk",
+          "tableFrom": "repo_tms_mutation_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_tms_mutation_logs_project_id_projects_id_fk": {
+          "name": "repo_tms_mutation_logs_project_id_projects_id_fk",
+          "tableFrom": "repo_tms_mutation_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_memories": {
+      "name": "knowledge_memories",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Initial version'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_memories_revision_id_key": {
+          "name": "knowledge_memories_revision_id_key",
+          "columns": [
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_memories_organization_id_organizations_id_fk": {
+          "name": "knowledge_memories_organization_id_organizations_id_fk",
+          "tableFrom": "knowledge_memories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_memories_updated_by_user_id_users_id_fk": {
+          "name": "knowledge_memories_updated_by_user_id_users_id_fk",
+          "tableFrom": "knowledge_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_memories_content_length_check": {
+          "name": "knowledge_memories_content_length_check",
+          "value": "char_length(\"knowledge_memories\".\"content\") <= 50000"
+        },
+        "knowledge_memories_summary_length_check": {
+          "name": "knowledge_memories_summary_length_check",
+          "value": "char_length(\"knowledge_memories\".\"summary\") <= 160"
+        },
+        "knowledge_memories_version_check": {
+          "name": "knowledge_memories_version_check",
+          "value": "\"knowledge_memories\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.knowledge_memory_revisions": {
+      "name": "knowledge_memory_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "knowledge_memory_revisions_org_version_key": {
+          "name": "knowledge_memory_revisions_org_version_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_memory_revisions_organization_id_organizations_id_fk": {
+          "name": "knowledge_memory_revisions_organization_id_organizations_id_fk",
+          "tableFrom": "knowledge_memory_revisions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_memory_revisions_created_by_user_id_users_id_fk": {
+          "name": "knowledge_memory_revisions_created_by_user_id_users_id_fk",
+          "tableFrom": "knowledge_memory_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_memory_revisions_content_length_check": {
+          "name": "knowledge_memory_revisions_content_length_check",
+          "value": "char_length(\"knowledge_memory_revisions\".\"content\") <= 50000"
+        },
+        "knowledge_memory_revisions_summary_length_check": {
+          "name": "knowledge_memory_revisions_summary_length_check",
+          "value": "char_length(\"knowledge_memory_revisions\".\"summary\") <= 160"
+        },
+        "knowledge_memory_revisions_version_check": {
+          "name": "knowledge_memory_revisions_version_check",
+          "value": "\"knowledge_memory_revisions\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_knowledge_memories": {
+      "name": "project_knowledge_memories",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Initial version'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_knowledge_memories_revision_id_key": {
+          "name": "project_knowledge_memories_revision_id_key",
+          "columns": [
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_knowledge_memories_project_id_projects_id_fk": {
+          "name": "project_knowledge_memories_project_id_projects_id_fk",
+          "tableFrom": "project_knowledge_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_knowledge_memories_updated_by_user_id_users_id_fk": {
+          "name": "project_knowledge_memories_updated_by_user_id_users_id_fk",
+          "tableFrom": "project_knowledge_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_knowledge_memories_content_length_check": {
+          "name": "project_knowledge_memories_content_length_check",
+          "value": "char_length(\"project_knowledge_memories\".\"content\") <= 50000"
+        },
+        "project_knowledge_memories_summary_length_check": {
+          "name": "project_knowledge_memories_summary_length_check",
+          "value": "char_length(\"project_knowledge_memories\".\"summary\") <= 160"
+        },
+        "project_knowledge_memories_version_check": {
+          "name": "project_knowledge_memories_version_check",
+          "value": "\"project_knowledge_memories\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_knowledge_memory_revisions": {
+      "name": "project_knowledge_memory_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_knowledge_memory_revisions_project_version_key": {
+          "name": "project_knowledge_memory_revisions_project_version_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_knowledge_memory_revisions_project_id_projects_id_fk": {
+          "name": "project_knowledge_memory_revisions_project_id_projects_id_fk",
+          "tableFrom": "project_knowledge_memory_revisions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_knowledge_memory_revisions_created_by_user_id_users_id_fk": {
+          "name": "project_knowledge_memory_revisions_created_by_user_id_users_id_fk",
+          "tableFrom": "project_knowledge_memory_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_knowledge_memory_revisions_content_length_check": {
+          "name": "project_knowledge_memory_revisions_content_length_check",
+          "value": "char_length(\"project_knowledge_memory_revisions\".\"content\") <= 50000"
+        },
+        "project_knowledge_memory_revisions_summary_length_check": {
+          "name": "project_knowledge_memory_revisions_summary_length_check",
+          "value": "char_length(\"project_knowledge_memory_revisions\".\"summary\") <= 160"
+        },
+        "project_knowledge_memory_revisions_version_check": {
+          "name": "project_knowledge_memory_revisions_version_check",
+          "value": "\"project_knowledge_memory_revisions\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_file_string_repository_contexts": {
+      "name": "project_file_string_repository_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "string_key": {
+          "name": "string_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text_hash": {
+          "name": "source_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_file_string_repository_contexts_lookup": {
+          "name": "project_file_string_repository_contexts_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "string_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_file_string_repository_contexts_file": {
+          "name": "idx_project_file_string_repository_contexts_file",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_string_repository_contexts_organization_id_organizations_id_fk": {
+          "name": "project_file_string_repository_contexts_organization_id_organizations_id_fk",
+          "tableFrom": "project_file_string_repository_contexts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_file_string_repository_contexts_created_by_user_id_users_id_fk": {
+          "name": "project_file_string_repository_contexts_created_by_user_id_users_id_fk",
+          "tableFrom": "project_file_string_repository_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_file_string_repository_contexts_summary_length_check": {
+          "name": "project_file_string_repository_contexts_summary_length_check",
+          "value": "char_length(\"project_file_string_repository_contexts\".\"summary\") <= 16384"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_cat_string_overlays": {
+      "name": "project_cat_string_overlays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_resource_id": {
+          "name": "external_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_string_id": {
+          "name": "external_string_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_cat_string_overlays_lookup": {
+          "name": "project_cat_string_overlays_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_string_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_cat_string_overlays_file": {
+          "name": "idx_project_cat_string_overlays_file",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_cat_string_overlays_organization_id_organizations_id_fk": {
+          "name": "project_cat_string_overlays_organization_id_organizations_id_fk",
+          "tableFrom": "project_cat_string_overlays",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_cat_string_overlays_updated_by_user_id_users_id_fk": {
+          "name": "project_cat_string_overlays_updated_by_user_id_users_id_fk",
+          "tableFrom": "project_cat_string_overlays",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_cat_segment_locks": {
+      "name": "project_cat_segment_locks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_string_id": {
+          "name": "external_string_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by_user_id": {
+          "name": "locked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_cat_segment_locks_lookup": {
+          "name": "project_cat_segment_locks_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_string_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_cat_segment_locks_locale": {
+          "name": "idx_project_cat_segment_locks_locale",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_cat_segment_locks_organization_id_organizations_id_fk": {
+          "name": "project_cat_segment_locks_organization_id_organizations_id_fk",
+          "tableFrom": "project_cat_segment_locks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_cat_segment_locks_locked_by_user_id_users_id_fk": {
+          "name": "project_cat_segment_locks_locked_by_user_id_users_id_fk",
+          "tableFrom": "project_cat_segment_locks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "locked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_resource_usage_sync_states": {
+      "name": "workspace_resource_usage_sync_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_usage": {
+          "name": "synced_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_sequence": {
+          "name": "sync_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_resource_usage_sync_states_org_feature_key": {
+          "name": "workspace_resource_usage_sync_states_org_feature_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_resource_usage_sync_states_org": {
+          "name": "idx_workspace_resource_usage_sync_states_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_resource_usage_sync_states_organization_id_organizations_id_fk": {
+          "name": "workspace_resource_usage_sync_states_organization_id_organizations_id_fk",
+          "tableFrom": "workspace_resource_usage_sync_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.localisation_audit_leads": {
+      "name": "localisation_audit_leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_sent_at": {
+          "name": "email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_error": {
+          "name": "email_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_queued_at": {
+          "name": "last_email_queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_localisation_audit_leads_audit_email": {
+          "name": "uq_localisation_audit_leads_audit_email",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audit_leads_audit": {
+          "name": "idx_localisation_audit_leads_audit",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audit_leads_token_hash": {
+          "name": "idx_localisation_audit_leads_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audit_leads_delivery_status": {
+          "name": "idx_localisation_audit_leads_delivery_status",
+          "columns": [
+            {
+              "expression": "delivery_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "localisation_audit_leads_audit_id_localisation_audits_id_fk": {
+          "name": "localisation_audit_leads_audit_id_localisation_audits_id_fk",
+          "tableFrom": "localisation_audit_leads",
+          "tableTo": "localisation_audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.localisation_audits": {
+      "name": "localisation_audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_key": {
+          "name": "domain_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_slug": {
+          "name": "domain_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "progress_stage": {
+          "name": "progress_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_source": {
+          "name": "run_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_locales": {
+          "name": "focus_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teaser": {
+          "name": "teaser",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_domain_id": {
+          "name": "linked_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_localisation_audits_domain_key": {
+          "name": "uq_localisation_audits_domain_key",
+          "columns": [
+            {
+              "expression": "domain_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_localisation_audits_domain_slug": {
+          "name": "uq_localisation_audits_domain_slug",
+          "columns": [
+            {
+              "expression": "domain_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_status": {
+          "name": "idx_localisation_audits_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_completed_at": {
+          "name": "idx_localisation_audits_completed_at",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_status_updated_at": {
+          "name": "idx_localisation_audits_status_updated_at",
+          "columns": [
+            {
+              "expression": "status_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_score": {
+          "name": "idx_localisation_audits_score",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_organization_id": {
+          "name": "idx_localisation_audits_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_linked_domain_id": {
+          "name": "idx_localisation_audits_linked_domain_id",
+          "columns": [
+            {
+              "expression": "linked_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_run_source_last_attempt": {
+          "name": "idx_localisation_audits_run_source_last_attempt",
+          "columns": [
+            {
+              "expression": "run_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "localisation_audits_organization_id_organizations_id_fk": {
+          "name": "localisation_audits_organization_id_organizations_id_fk",
+          "tableFrom": "localisation_audits",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linked_domains": {
+      "name": "linked_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_key": {
+          "name": "domain_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_slug": {
+          "name": "domain_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_verification'"
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_method": {
+          "name": "preferred_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_method": {
+          "name": "verified_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "localisation_audit_id": {
+          "name": "localisation_audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_linked_domains_org_domain_key": {
+          "name": "uq_linked_domains_org_domain_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_linked_domains_verified_domain_key": {
+          "name": "uq_linked_domains_verified_domain_key",
+          "columns": [
+            {
+              "expression": "domain_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"linked_domains\".\"status\" = 'verified'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_linked_domains_org": {
+          "name": "idx_linked_domains_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_linked_domains_domain_slug": {
+          "name": "idx_linked_domains_domain_slug",
+          "columns": [
+            {
+              "expression": "domain_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_linked_domains_status": {
+          "name": "idx_linked_domains_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_linked_domains_localisation_audit_id": {
+          "name": "idx_linked_domains_localisation_audit_id",
+          "columns": [
+            {
+              "expression": "localisation_audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linked_domains_organization_id_organizations_id_fk": {
+          "name": "linked_domains_organization_id_organizations_id_fk",
+          "tableFrom": "linked_domains",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linked_domains_created_by_user_id_users_id_fk": {
+          "name": "linked_domains_created_by_user_id_users_id_fk",
+          "tableFrom": "linked_domains",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "linked_domains_localisation_audit_id_localisation_audits_id_fk": {
+          "name": "linked_domains_localisation_audit_id_localisation_audits_id_fk",
+          "tableFrom": "linked_domains",
+          "tableTo": "localisation_audits",
+          "columnsFrom": [
+            "localisation_audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "linked_domains_project_id_projects_id_fk": {
+          "name": "linked_domains_project_id_projects_id_fk",
+          "tableFrom": "linked_domains",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_run_kind": {
+      "name": "agent_run_kind",
+      "schema": "public",
+      "values": [
+        "translate",
+        "review",
+        "qa_fix",
+        "glossary_suggestion",
+        "comment_only"
+      ]
+    },
+    "public.agent_run_status": {
+      "name": "agent_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.external_tms_memory_capability_mode": {
+      "name": "external_tms_memory_capability_mode",
+      "schema": "public",
+      "values": [
+        "live_search",
+        "synced_import",
+        "reference_only"
+      ]
+    },
+    "public.external_tms_provider_kind": {
+      "name": "external_tms_provider_kind",
+      "schema": "public",
+      "values": [
+        "crowdin",
+        "smartling",
+        "phrase",
+        "lokalise"
+      ]
+    },
+    "public.external_tms_resource_type": {
+      "name": "external_tms_resource_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "key"
+      ]
+    },
+    "public.external_tms_terminology_resource_type": {
+      "name": "external_tms_terminology_resource_type",
+      "schema": "public",
+      "values": [
+        "glossary",
+        "term_base"
+      ]
+    },
+    "public.glossary_sync_state": {
+      "name": "glossary_sync_state",
+      "schema": "public",
+      "values": [
+        "synced",
+        "stale",
+        "syncing",
+        "error"
+      ]
+    },
+    "public.glossary_term_provenance": {
+      "name": "glossary_term_provenance",
+      "schema": "public",
+      "values": [
+        "manual",
+        "sync"
+      ]
+    },
+    "public.inbox_status": {
+      "name": "inbox_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.interaction_source": {
+      "name": "interaction_source",
+      "schema": "public",
+      "values": [
+        "chat_ui",
+        "email_agent",
+        "github_agent",
+        "slack_agent",
+        "web_chat"
+      ]
+    },
+    "public.job_kind": {
+      "name": "job_kind",
+      "schema": "public",
+      "values": [
+        "translation",
+        "research",
+        "review",
+        "proofread",
+        "sync",
+        "asset_management"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "waiting_for_review",
+        "cancelled"
+      ]
+    },
+    "public.llm_provider": {
+      "name": "llm_provider",
+      "schema": "public",
+      "values": [
+        "openai",
+        "anthropic",
+        "gemini",
+        "groq",
+        "mistral"
+      ]
+    },
+    "public.message_sender_type": {
+      "name": "message_sender_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.organization_lifecycle_status": {
+      "name": "organization_lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived",
+        "deprecated"
+      ]
+    },
+    "public.organization_membership_role": {
+      "name": "organization_membership_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "localization_manager",
+        "developer",
+        "reviewer",
+        "translator",
+        "member"
+      ]
+    },
+    "public.project_source": {
+      "name": "project_source",
+      "schema": "public",
+      "values": [
+        "native",
+        "external_tms"
+      ]
+    },
+    "public.project_translation_comment_type": {
+      "name": "project_translation_comment_type",
+      "schema": "public",
+      "values": [
+        "comment",
+        "issue"
+      ]
+    },
+    "public.project_translation_provenance": {
+      "name": "project_translation_provenance",
+      "schema": "public",
+      "values": [
+        "manual",
+        "translation_job",
+        "import",
+        "agent"
+      ]
+    },
+    "public.project_translation_status": {
+      "name": "project_translation_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "needs_review",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.provider_sync_intent_cause": {
+      "name": "provider_sync_intent_cause",
+      "schema": "public",
+      "values": [
+        "webhook",
+        "manual",
+        "scheduled"
+      ]
+    },
+    "public.provider_sync_intent_status": {
+      "name": "provider_sync_intent_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "retryable",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.provider_sync_run_kind": {
+      "name": "provider_sync_run_kind",
+      "schema": "public",
+      "values": [
+        "project_scan",
+        "file_key_scan",
+        "job_task_scan",
+        "context_scan",
+        "tm_scan",
+        "glossary_scan",
+        "pull_content",
+        "push_translations",
+        "webhook",
+        "health_check"
+      ]
+    },
+    "public.provider_sync_run_status": {
+      "name": "provider_sync_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.provider_webhook_event_processing_status": {
+      "name": "provider_webhook_event_processing_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "succeeded",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.provider_webhook_subscription_status": {
+      "name": "provider_webhook_subscription_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "permission_error",
+        "provider_error",
+        "disabled",
+        "manual_required"
+      ]
+    },
+    "public.repository_source_file_ingest_state": {
+      "name": "repository_source_file_ingest_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ingesting",
+        "ingested",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.stored_file_role": {
+      "name": "stored_file_role",
+      "schema": "public",
+      "values": [
+        "source",
+        "output",
+        "reference",
+        "asset"
+      ]
+    },
+    "public.stored_file_source_kind": {
+      "name": "stored_file_source_kind",
+      "schema": "public",
+      "values": [
+        "chat_upload",
+        "email_attachment",
+        "job_output",
+        "repository_file",
+        "tms_file",
+        "editor_upload",
+        "automation_knowledge"
+      ]
+    },
+    "public.team_membership_role": {
+      "name": "team_membership_role",
+      "schema": "public",
+      "values": [
+        "manager",
+        "member"
+      ]
+    },
+    "public.tms_agent_automation_scope": {
+      "name": "tms_agent_automation_scope",
+      "schema": "public",
+      "values": [
+        "organization",
+        "project",
+        "provider"
+      ]
+    },
+    "public.translation_job_outcome_kind": {
+      "name": "translation_job_outcome_kind",
+      "schema": "public",
+      "values": [
+        "string_result",
+        "file_result",
+        "error"
+      ]
+    },
+    "public.translation_job_type": {
+      "name": "translation_job_type",
+      "schema": "public",
+      "values": [
+        "string",
+        "file"
+      ]
+    },
+    "public.usage_event_status": {
+      "name": "usage_event_status",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "succeeded",
+        "rejected",
+        "tracking_pending",
+        "tracking_succeeded",
+        "tracking_failed"
+      ]
+    },
+    "public.usage_feature_id": {
+      "name": "usage_feature_id",
+      "schema": "public",
+      "values": [
+        "translation_jobs",
+        "translation_units",
+        "source_characters",
+        "ai_tokens",
+        "api_requests",
+        "agent_runs"
+      ]
+    },
+    "public.workspace_automation_run_status": {
+      "name": "workspace_automation_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "skipped"
+      ]
+    },
+    "public.workspace_automation_run_trigger_source": {
+      "name": "workspace_automation_run_trigger_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "github",
+        "contentful",
+        "source_upload",
+        "web_chat"
+      ]
+    },
+    "public.workspace_automation_status": {
+      "name": "workspace_automation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "archived"
+      ]
+    },
+    "public.github_repository_automation_commit_result_status": {
+      "name": "github_repository_automation_commit_result_status",
+      "schema": "public",
+      "values": [
+        "skipped",
+        "passed",
+        "warning",
+        "failed",
+        "error"
+      ]
+    },
+    "public.github_repository_automation_job_status": {
+      "name": "github_repository_automation_job_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.github_repository_automation_job_trigger_mode": {
+      "name": "github_repository_automation_job_trigger_mode",
+      "schema": "public",
+      "values": [
+        "push",
+        "scheduled"
+      ]
+    },
+    "public.repo_tms_mutation_log_action": {
+      "name": "repo_tms_mutation_log_action",
+      "schema": "public",
+      "values": [
+        "upload_sources",
+        "apply_fixes",
+        "commit_changes",
+        "push_to_branch",
+        "tms_mutate"
+      ]
+    },
+    "public.repo_tms_mutation_log_status": {
+      "name": "repo_tms_mutation_log_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hyperlocalise-web/drizzle/meta/_journal.json
+++ b/apps/hyperlocalise-web/drizzle/meta/_journal.json
@@ -673,6 +673,13 @@
       "when": 1787539372687,
       "tag": "0095_daffy_lyja",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "7",
+      "when": 1787562684930,
+      "tag": "0096_outstanding_blink",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -72,6 +72,7 @@ import {
 import { listOrganizationProjects } from "@/lib/projects/organization/organization-project-service";
 import {
   getNativeProjectCatFile,
+  getNativeProjectCatGroupOccurrences,
   getNativeProjectCatSegmentComments,
   fileBackedCatSegmentIds,
   getNativeProjectCatSegmentTarget,
@@ -153,6 +154,8 @@ import {
   maxProjectFileUploadBytes,
   projectFileCatSegmentParamsSchema,
   projectFileCatSegmentQuerySchema,
+  projectFileCatGroupParamsSchema,
+  projectFileCatGroupOccurrencesQuerySchema,
   projectFileCatQuerySchema,
   projectFileCatExportQuerySchema,
   projectFileCatConcordanceBodySchema,
@@ -558,6 +561,18 @@ const validateProjectFileCatSegmentQuery = validator("query", (value, c) => {
     return invalidProjectPayloadResponse(c);
   }
 
+  return parsed.data;
+});
+
+const validateProjectFileCatGroupParams = validator("param", (value, c) => {
+  const parsed = projectFileCatGroupParamsSchema.safeParse(value);
+  if (!parsed.success) return invalidProjectPayloadResponse(c);
+  return parsed.data;
+});
+
+const validateProjectFileCatGroupOccurrencesQuery = validator("query", (value, c) => {
+  const parsed = projectFileCatGroupOccurrencesQuerySchema.safeParse(value);
+  if (!parsed.success) return invalidProjectPayloadResponse(c);
   return parsed.data;
 });
 
@@ -1182,6 +1197,33 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         }
 
         return c.json({ catFile: result.catQueue }, 200);
+      },
+    )
+    .get(
+      "/:projectId/files/detail/cat/groups/:groupId/occurrences",
+      validateProjectFileCatGroupParams,
+      validateProjectFileCatGroupOccurrencesQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query = c.req.valid("query");
+        const project = await getOwnedProject(c.var.auth, params.projectId);
+        if (!project) return projectNotFoundResponse(c);
+        if (!project.automaticallyGroupIdenticalStrings) {
+          return notFoundResponse(c, "cat_group_not_found");
+        }
+
+        const occurrences = await getNativeProjectCatGroupOccurrences({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          targetLocale: query.targetLocale,
+          groupId: params.groupId,
+          sourceTextHash: query.sourceTextHash,
+        });
+        if (!occurrences) return notFoundResponse(c, "cat_group_not_found");
+
+        return c.json({
+          groupOccurrences: { groupId: params.groupId, occurrences },
+        });
       },
     )
     .get(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -1206,7 +1206,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       async (c) => {
         const params = c.req.valid("param");
         const query = c.req.valid("query");
-        const project = await getOwnedProject(c.var.auth, params.projectId);
+        const project = await getOwnedProjectRecord(c.var.auth, params.projectId);
         if (!project) return projectNotFoundResponse(c);
         if (!project.automaticallyGroupIdenticalStrings) {
           return notFoundResponse(c, "cat_group_not_found");

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -879,6 +879,10 @@ export type ProjectFileCatTranslation = z.infer<typeof projectFileCatTranslation
 export type ProjectFileCatSegment = z.infer<typeof projectFileCatSegmentSchema>;
 export type ProjectFileCatGroup = z.infer<typeof projectFileCatGroupSchema>;
 export type ProjectFileCatQueueSegment = ProjectFileCatSegment | ProjectFileCatGroup;
+export type ProjectFileCatGroupOccurrence = z.infer<typeof projectFileCatGroupOccurrenceSchema>;
+export type ProjectFileCatGroupOccurrencesResponse = z.infer<
+  typeof projectFileCatGroupOccurrencesResponseSchema
+>;
 export type ProjectFileCatSegmentParams = z.infer<typeof projectFileCatSegmentParamsSchema>;
 export type ProjectFileCatSegmentQuery = z.infer<typeof projectFileCatSegmentQuerySchema>;
 export type ProjectFileCatSegmentCommentsResponse = z.infer<

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -324,6 +324,8 @@ export const projectFileCatPaginationSchema = z.object({
   limit: z.number().int().min(1),
   returnedCount: z.number().int().min(0),
   totalCount: z.number().int().min(0),
+  /** Underlying source keys represented by the filtered logical rows. */
+  totalSourceOccurrences: z.number().int().min(0).optional(),
   hasMore: z.boolean(),
   nextPhraseScanPage: z.number().int().min(1).optional(),
   nextPhraseScanSkip: z.number().int().min(0).optional(),
@@ -703,6 +705,7 @@ export const projectFileCatTranslationSchema = z.object({
 });
 
 export const projectFileCatSegmentSchema = z.object({
+  kind: z.literal("segment").optional(),
   externalStringId: z.string(),
   key: z.string(),
   sourceText: z.string(),
@@ -727,6 +730,15 @@ export const projectFileCatSegmentSchema = z.object({
   resourceType: z.enum(["file", "key"]).optional(),
 });
 
+export const projectFileCatGroupSchema = projectFileCatSegmentSchema.extend({
+  kind: z.literal("group"),
+  groupId: z.string(),
+  sourceTextHash: z.string().length(64),
+  translationKeyId: z.null(),
+  projectOccurrenceCount: z.number().int().min(2),
+  fileOccurrenceCount: z.number().int().min(1),
+});
+
 export const projectFileCatSegmentParamsSchema = z.object({
   organizationSlug: z.string().trim().min(1).max(128),
   projectId: z.string().trim().min(1).max(128),
@@ -739,6 +751,33 @@ export const projectFileCatSegmentQuerySchema = z.object({
   externalResourceId: z.string().trim().min(1).max(128).optional(),
   resourceType: z.enum(["file", "key"]).optional(),
   repositoryFullName: z.string().trim().min(1).max(256).optional(),
+});
+
+export const projectFileCatGroupParamsSchema = projectIdParamsSchema.extend({
+  groupId: z.string().length(64),
+});
+
+export const projectFileCatGroupOccurrencesQuerySchema = z.object({
+  targetLocale: z.string().trim().min(1).max(32),
+  sourceTextHash: z.string().length(64),
+});
+
+export const projectFileCatGroupOccurrenceSchema = z.object({
+  translationKeyId: z.string(),
+  key: z.string(),
+  sourcePath: z.string(),
+  context: z.string().nullable(),
+  comments: z.array(projectFileCatCommentSchema),
+  isLocked: z.boolean(),
+  target: projectFileCatTranslationSchema.nullable(),
+  reviewState: z.enum(["draft", "needs_review", "approved", "rejected"]).nullable(),
+});
+
+export const projectFileCatGroupOccurrencesResponseSchema = z.object({
+  groupOccurrences: z.object({
+    groupId: z.string(),
+    occurrences: z.array(projectFileCatGroupOccurrenceSchema),
+  }),
 });
 
 export const projectFileCatSegmentCommentsResponseSchema = z.object({
@@ -763,7 +802,7 @@ export const projectFileCatResponseSchema = z.object({
 });
 
 export const projectFileCatQueueFileSchema = projectFileCatResponseSchema.shape.catFile.extend({
-  segments: z.array(projectFileCatSegmentSchema),
+  segments: z.array(z.union([projectFileCatSegmentSchema, projectFileCatGroupSchema])),
 });
 
 export const projectFileCatQueueResponseSchema = z.object({
@@ -838,7 +877,8 @@ export type ProjectFileCatCommentResolveResponse = z.infer<
 >;
 export type ProjectFileCatTranslation = z.infer<typeof projectFileCatTranslationSchema>;
 export type ProjectFileCatSegment = z.infer<typeof projectFileCatSegmentSchema>;
-export type ProjectFileCatQueueSegment = ProjectFileCatSegment;
+export type ProjectFileCatGroup = z.infer<typeof projectFileCatGroupSchema>;
+export type ProjectFileCatQueueSegment = ProjectFileCatSegment | ProjectFileCatGroup;
 export type ProjectFileCatSegmentParams = z.infer<typeof projectFileCatSegmentParamsSchema>;
 export type ProjectFileCatSegmentQuery = z.infer<typeof projectFileCatSegmentQuerySchema>;
 export type ProjectFileCatSegmentCommentsResponse = z.infer<

--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issue-translation-key.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issue-translation-key.test.ts
@@ -72,6 +72,17 @@ describe("resolveCatLinkedIssueTranslationKeyId", () => {
     ).toBeNull();
   });
 
+  it("returns null for synthetic exact-source groups", () => {
+    expect(
+      resolveCatLinkedIssueTranslationKeyId({
+        isNativeProject: true,
+        segmentId: "a".repeat(64),
+        contentKind: "text",
+        kind: "group",
+      }),
+    ).toBeNull();
+  });
+
   it("returns null when the segment id is empty", () => {
     expect(
       resolveCatLinkedIssueTranslationKeyId({

--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issue-translation-key.ts
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issue-translation-key.ts
@@ -33,8 +33,13 @@ export function resolveCatLinkedIssueTranslationKeyId(input: {
   isNativeProject: boolean;
   segmentId: string;
   contentKind: CatSegment["contentKind"];
+  kind?: "segment" | "group";
 }): string | null {
   if (!input.isNativeProject) {
+    return null;
+  }
+
+  if (input.kind === "group") {
     return null;
   }
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.messages.ts
@@ -32,7 +32,7 @@ export const projectFileCatApiMessages = defineMessages({
   },
   failedToLoadGroupOccurrences: {
     defaultMessage: "Failed to load grouped string occurrences",
-    id: "n3Q8kR2wLm",
+    id: "c/cACn/ksv",
     description: "Fallback error when loading native CAT group occurrences fails",
   },
   failedToExportQueue: {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.messages.ts
@@ -30,6 +30,11 @@ export const projectFileCatApiMessages = defineMessages({
     id: "4MUAkFDjce",
     description: "Fallback error when loading a CAT segment target translation fails",
   },
+  failedToLoadGroupOccurrences: {
+    defaultMessage: "Failed to load grouped string occurrences",
+    id: "n3Q8kR2wLm",
+    description: "Fallback error when loading native CAT group occurrences fails",
+  },
   failedToExportQueue: {
     defaultMessage: "Failed to download filtered view",
     id: "0tcV3U/r5g",

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
@@ -237,6 +237,7 @@ export function projectFileCatToWorkspaceState(
     index: segmentOffset + index + 1,
     key: segment.key,
     sourceText: segment.sourceText,
+    ...(segment.kind ? { kind: segment.kind } : {}),
     ...(segment.contentKind ? { contentKind: segment.contentKind } : {}),
     ...(segment.sourceAssetUrl !== undefined ? { sourceAssetUrl: segment.sourceAssetUrl } : {}),
     ...(segment.targetAssetUrl !== undefined ? { targetAssetUrl: segment.targetAssetUrl } : {}),

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -479,10 +479,12 @@ export function ProjectFileCatWorkspace({
         ? segmentIds.filter((segmentId) => {
             const segment = catFile.segments.find((item) => item.externalStringId === segmentId);
             return (
+              segment?.kind === "group" ||
               resolveCatLinkedIssueTranslationKeyId({
                 isNativeProject: true,
                 segmentId,
                 contentKind: segment?.contentKind,
+                kind: segment?.kind,
               }) != null
             );
           })
@@ -530,6 +532,7 @@ export function ProjectFileCatWorkspace({
         isNativeProject,
         segmentId,
         contentKind: segment.contentKind,
+        kind: segment.kind,
       });
       setLinkedIssuesSegment({
         segmentId,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-group-occurrences.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-group-occurrences.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ProjectFileCatGroupOccurrence } from "@/api/routes/project/project.schema";
+
+import {
+  flattenGroupOccurrenceComments,
+  representativeTargetFromOccurrences,
+} from "./use-cat-group-occurrences";
+
+function occurrence(
+  overrides: Partial<ProjectFileCatGroupOccurrence> = {},
+): ProjectFileCatGroupOccurrence {
+  return {
+    translationKeyId: "key-1",
+    key: "save",
+    sourcePath: "locales/en.json",
+    context: null,
+    comments: [],
+    isLocked: false,
+    target: null,
+    reviewState: null,
+    ...overrides,
+  };
+}
+
+describe("group occurrence helpers", () => {
+  it("uses the first persisted occurrence target as the group representative", () => {
+    expect(
+      representativeTargetFromOccurrences([
+        occurrence(),
+        occurrence({
+          translationKeyId: "key-2",
+          target: { text: "Enregistrer", externalTranslationId: "t1", isApproved: true },
+        }),
+      ]),
+    ).toEqual({ text: "Enregistrer", externalTranslationId: "t1", isApproved: true });
+  });
+
+  it("flattens comments from every occurrence", () => {
+    expect(
+      flattenGroupOccurrenceComments([
+        occurrence({
+          comments: [
+            {
+              externalCommentId: "c1",
+              type: "comment",
+              status: null,
+              text: "First",
+              createdAt: null,
+              locale: "fr",
+            },
+          ],
+        }),
+        occurrence({
+          translationKeyId: "key-2",
+          comments: [
+            {
+              externalCommentId: "c2",
+              type: "issue",
+              status: "unresolved",
+              text: "Second",
+              createdAt: null,
+              locale: "fr",
+            },
+          ],
+        }),
+      ]).map((comment) => comment.externalCommentId),
+    ).toEqual(["c1", "c2"]);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-group-occurrences.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-group-occurrences.ts
@@ -1,0 +1,198 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useMemo } from "react";
+import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
+
+import type {
+  ProjectFileCatComment,
+  ProjectFileCatGroupOccurrence,
+  ProjectFileCatGroupOccurrencesResponse,
+  ProjectFileCatTranslation,
+} from "@/api/routes/project/project.schema";
+import type { CatFormatMessageIntl } from "@/components/cat/message-format/cat-message-format-i18n";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+
+import { projectFileCatApiMessages } from "./project-file-cat-api.messages";
+
+export function projectFileCatGroupOccurrencesQueryKey(input: {
+  organizationSlug: string;
+  projectId: string;
+  targetLocale: string;
+  groupId: string;
+  sourceTextHash: string;
+}) {
+  return [
+    "project-file-cat-group-occurrences",
+    input.organizationSlug,
+    input.projectId,
+    input.targetLocale,
+    input.groupId,
+    input.sourceTextHash,
+  ] as const;
+}
+
+export async function fetchProjectFileCatGroupOccurrences(input: {
+  organizationSlug: string;
+  projectId: string;
+  targetLocale: string;
+  groupId: string;
+  sourceTextHash: string;
+  intl: CatFormatMessageIntl;
+}): Promise<ProjectFileCatGroupOccurrence[]> {
+  const response = await apiClient.api.orgs[":organizationSlug"].projects[
+    ":projectId"
+  ].files.detail.cat.groups[":groupId"].occurrences.$get({
+    param: {
+      organizationSlug: input.organizationSlug,
+      projectId: input.projectId,
+      groupId: input.groupId,
+    },
+    query: {
+      targetLocale: input.targetLocale,
+      sourceTextHash: input.sourceTextHash,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      await readApiError(
+        response,
+        input.intl.formatMessage(projectFileCatApiMessages.failedToLoadGroupOccurrences),
+      ),
+    );
+  }
+
+  const body = (await response.json()) as ProjectFileCatGroupOccurrencesResponse;
+  return body.groupOccurrences.occurrences;
+}
+
+export function representativeTargetFromOccurrences(
+  occurrences: readonly ProjectFileCatGroupOccurrence[],
+): ProjectFileCatTranslation | null {
+  return occurrences.find((occurrence) => occurrence.target)?.target ?? null;
+}
+
+export function flattenGroupOccurrenceComments(
+  occurrences: readonly ProjectFileCatGroupOccurrence[],
+): ProjectFileCatComment[] {
+  return occurrences.flatMap((occurrence) => occurrence.comments);
+}
+
+export function useCatGroupOccurrences(input: {
+  organizationSlug: string;
+  projectId: string;
+  targetLocale: string;
+  groupId: string | null;
+  sourceTextHash: string | null;
+  enabled?: boolean;
+}) {
+  const intl = useIntl();
+  const groupId = input.groupId ?? "";
+  const sourceTextHash = input.sourceTextHash ?? "";
+
+  return useQuery({
+    queryKey: projectFileCatGroupOccurrencesQueryKey({
+      organizationSlug: input.organizationSlug,
+      projectId: input.projectId,
+      targetLocale: input.targetLocale,
+      groupId,
+      sourceTextHash,
+    }),
+    enabled:
+      input.enabled !== false &&
+      Boolean(groupId) &&
+      Boolean(sourceTextHash) &&
+      Boolean(input.targetLocale),
+    staleTime: 30_000,
+    queryFn: () =>
+      fetchProjectFileCatGroupOccurrences({
+        organizationSlug: input.organizationSlug,
+        projectId: input.projectId,
+        targetLocale: input.targetLocale,
+        groupId,
+        sourceTextHash,
+        intl,
+      }),
+  });
+}
+
+export function useCatGroupOccurrencesList(input: {
+  organizationSlug: string;
+  projectId: string;
+  targetLocale: string;
+  groups: Array<{ groupId: string; sourceTextHash: string }>;
+  enabled?: boolean;
+}) {
+  const intl = useIntl();
+  const groups = useMemo(() => {
+    const seen = new Set<string>();
+    const unique: typeof input.groups = [];
+    for (const group of input.groups) {
+      const id = group.groupId.trim();
+      if (!id || seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+      unique.push(group);
+    }
+    return unique;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- callers memoize input.groups
+  }, [input.groups]);
+
+  return useQueries({
+    queries: groups.map((group) => ({
+      queryKey: projectFileCatGroupOccurrencesQueryKey({
+        organizationSlug: input.organizationSlug,
+        projectId: input.projectId,
+        targetLocale: input.targetLocale,
+        groupId: group.groupId,
+        sourceTextHash: group.sourceTextHash,
+      }),
+      enabled:
+        input.enabled !== false &&
+        Boolean(group.groupId) &&
+        Boolean(group.sourceTextHash) &&
+        Boolean(input.targetLocale),
+      staleTime: 30_000,
+      queryFn: () =>
+        fetchProjectFileCatGroupOccurrences({
+          organizationSlug: input.organizationSlug,
+          projectId: input.projectId,
+          targetLocale: input.targetLocale,
+          groupId: group.groupId,
+          sourceTextHash: group.sourceTextHash,
+          intl,
+        }),
+    })),
+  });
+}
+
+export function useInvalidateCatGroupOccurrences() {
+  const queryClient = useQueryClient();
+
+  return async (input: {
+    organizationSlug: string;
+    projectId: string;
+    targetLocale: string;
+    groupId: string;
+    sourceTextHash: string;
+  }) => {
+    await queryClient.invalidateQueries({
+      queryKey: projectFileCatGroupOccurrencesQueryKey(input),
+    });
+  };
+}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.test.tsx
@@ -172,7 +172,7 @@ describe("useCatMutations", () => {
     const translation = createCatTranslation({ isApproved: true });
     const groupId = "g".repeat(64);
     const sourceTextHash = "h".repeat(64);
-    catGroupOccurrencesGetMock.mockResolvedValue(
+    catGroupOccurrencesGetMock.mockImplementation(() =>
       jsonResponse({
         groupOccurrences: {
           groupId,
@@ -201,7 +201,7 @@ describe("useCatMutations", () => {
         },
       }),
     );
-    catTranslationsPostMock.mockResolvedValue(jsonResponse({ translation }));
+    catTranslationsPostMock.mockImplementation(() => jsonResponse({ translation }));
 
     const { result } = renderCatMutations({
       ...createCatFileResponse().catFile,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.test.tsx
@@ -15,6 +15,7 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
+import type { ProjectFileCatQueueFile } from "@/api/routes/project/project.schema";
 import {
   catApiTestContext,
   createCatComment,
@@ -33,6 +34,7 @@ const {
   catCommentResolvePatchMock,
   catStringsHiddenPostMock,
   catStringsLockedPostMock,
+  catGroupOccurrencesGetMock,
   invalidateSegmentTargetMock,
   syncSegmentTargetAfterSaveMock,
   invalidateSegmentCommentsMock,
@@ -42,6 +44,7 @@ const {
   catCommentResolvePatchMock: vi.fn(),
   catStringsHiddenPostMock: vi.fn(),
   catStringsLockedPostMock: vi.fn(),
+  catGroupOccurrencesGetMock: vi.fn(),
   invalidateSegmentTargetMock: vi.fn(),
   syncSegmentTargetAfterSaveMock: vi.fn(),
   invalidateSegmentCommentsMock: vi.fn(),
@@ -76,6 +79,13 @@ vi.mock("@/lib/api-client-instance", () => ({
                         },
                       },
                     },
+                    groups: {
+                      ":groupId": {
+                        occurrences: {
+                          $get: (...args: unknown[]) => catGroupOccurrencesGetMock(...args),
+                        },
+                      },
+                    },
                   },
                 },
               },
@@ -103,7 +113,7 @@ const onTranslationSaved = vi.fn();
 
 syncSegmentTargetAfterSaveMock.mockResolvedValue(undefined);
 
-function renderCatMutations(catFile = createCatFileResponse().catFile) {
+function renderCatMutations(catFile: ProjectFileCatQueueFile = createCatFileResponse().catFile) {
   return renderHook(
     () =>
       useCatMutations({
@@ -156,6 +166,91 @@ describe("useCatMutations", () => {
       }),
       translation,
     );
+  });
+
+  it("saves grouped rows to occurrence translation keys instead of the group id", async () => {
+    const translation = createCatTranslation({ isApproved: true });
+    const groupId = "g".repeat(64);
+    const sourceTextHash = "h".repeat(64);
+    catGroupOccurrencesGetMock.mockResolvedValue(
+      jsonResponse({
+        groupOccurrences: {
+          groupId,
+          occurrences: [
+            {
+              translationKeyId: "key-a",
+              key: "actions.save",
+              sourcePath: "locales/en.json",
+              context: null,
+              comments: [],
+              isLocked: false,
+              target: null,
+              reviewState: null,
+            },
+            {
+              translationKeyId: "key-b",
+              key: "common.save",
+              sourcePath: "shared/en.json",
+              context: null,
+              comments: [],
+              isLocked: false,
+              target: null,
+              reviewState: null,
+            },
+          ],
+        },
+      }),
+    );
+    catTranslationsPostMock.mockResolvedValue(jsonResponse({ translation }));
+
+    const { result } = renderCatMutations({
+      ...createCatFileResponse().catFile,
+      provider: null,
+      segments: [
+        {
+          kind: "group",
+          externalStringId: groupId,
+          groupId,
+          sourceTextHash,
+          translationKeyId: null,
+          projectOccurrenceCount: 2,
+          fileOccurrenceCount: 2,
+          key: "save",
+          sourceText: "Save",
+          context: null,
+          type: null,
+        },
+      ],
+    });
+
+    await act(async () => {
+      await result.current.saveTranslation({
+        externalStringId: groupId,
+        text: "Enregistrer",
+        approve: true,
+      });
+    });
+
+    expect(catTranslationsPostMock).toHaveBeenCalledTimes(2);
+    expect(catTranslationsPostMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          externalStringId: "key-a",
+          sourcePath: "locales/en.json",
+          text: "Enregistrer",
+        }),
+      }),
+    );
+    expect(catTranslationsPostMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          externalStringId: "key-b",
+          sourcePath: "shared/en.json",
+          text: "Enregistrer",
+        }),
+      }),
+    );
+    expect(onTranslationSaved).toHaveBeenCalledWith(groupId, "Enregistrer", true);
   });
 
   it("surfaces API errors when saving translations fails", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
@@ -19,22 +19,43 @@ import {
   maxCatLockedStringBatch,
   maxNativeCatHiddenStringBatch,
   type ProjectFileCatComment,
+  type ProjectFileCatGroup,
   type ProjectFileCatQueueFile,
   type ProjectFileCatTranslation,
 } from "@/api/routes/project/project.schema";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
+import { isCatQueueGroup } from "@/lib/projects/cat/cat-queue-row";
 
 import type { CatIssueType } from "@/components/cat/shared/types";
 
 import { requireProviderExternalResourceId } from "./project-file-cat-mapper";
 import { isCatAllFilesSourcePath } from "@/lib/projects/cat-all-files";
+import {
+  fetchProjectFileCatGroupOccurrences,
+  useInvalidateCatGroupOccurrences,
+} from "./use-cat-group-occurrences";
 import { useInvalidateCatSegmentComments } from "./use-cat-segment-comments";
 import {
   useInvalidateCatSegmentTarget,
   useSyncCatSegmentTargetAfterSave,
 } from "./use-cat-segment-target";
 import { useCatMutationsMessages } from "./use-cat-mutations.messages";
+
+type CatMutationTarget = {
+  externalStringId: string;
+  sourcePath: string;
+  externalResourceId?: string;
+  resourceType?: "file" | "key";
+  isLocked?: boolean;
+};
+
+function findCatQueueRow(
+  catFile: ProjectFileCatQueueFile | null | undefined,
+  externalStringId: string,
+) {
+  return catFile?.segments.find((entry) => entry.externalStringId === externalStringId);
+}
 
 function resolveCatMutationFileIdentity(
   input: {
@@ -44,9 +65,7 @@ function resolveCatMutationFileIdentity(
   externalStringId: string,
   intl: IntlShape,
 ) {
-  const segment = input.catFile?.segments.find(
-    (entry) => entry.externalStringId === externalStringId,
-  );
+  const segment = findCatQueueRow(input.catFile, externalStringId);
   const sourcePath =
     segment?.sourcePath?.trim() ||
     (isCatAllFilesSourcePath(input.sourcePath) ? "" : input.sourcePath);
@@ -63,6 +82,50 @@ function resolveCatMutationFileIdentity(
   const resourceType = segment?.resourceType ?? input.catFile?.provider?.resourceType;
 
   return { sourcePath, externalResourceId, resourceType };
+}
+
+async function resolveCatMutationTargets(
+  input: {
+    organizationSlug: string;
+    projectId: string;
+    sourcePath: string;
+    targetLocale: string;
+    catFile: ProjectFileCatQueueFile | null | undefined;
+  },
+  externalStringId: string,
+  intl: IntlShape,
+): Promise<{ queueGroup: ProjectFileCatGroup | null; targets: CatMutationTarget[] }> {
+  const segment = findCatQueueRow(input.catFile, externalStringId);
+  if (segment && isCatQueueGroup(segment)) {
+    const occurrences = await fetchProjectFileCatGroupOccurrences({
+      organizationSlug: input.organizationSlug,
+      projectId: input.projectId,
+      targetLocale: input.targetLocale,
+      groupId: segment.groupId,
+      sourceTextHash: segment.sourceTextHash,
+      intl,
+    });
+    return {
+      queueGroup: segment,
+      targets: occurrences.map((occurrence) => ({
+        externalStringId: occurrence.translationKeyId,
+        sourcePath: occurrence.sourcePath,
+        isLocked: occurrence.isLocked,
+      })),
+    };
+  }
+
+  const identity = resolveCatMutationFileIdentity(input, externalStringId, intl);
+  return {
+    queueGroup: null,
+    targets: [
+      {
+        externalStringId,
+        ...identity,
+        isLocked: segment?.isLocked,
+      },
+    ],
+  };
 }
 
 function chunkItems<T>(items: T[], size: number): T[][] {
@@ -86,6 +149,7 @@ export function useCatMutations(input: {
   const invalidateSegmentTarget = useInvalidateCatSegmentTarget();
   const syncSegmentTargetAfterSave = useSyncCatSegmentTargetAfterSave();
   const invalidateSegmentComments = useInvalidateCatSegmentComments();
+  const invalidateGroupOccurrences = useInvalidateCatGroupOccurrences();
 
   const saveMutation = useMutation({
     mutationFn: async (mutationInput: {
@@ -93,50 +157,47 @@ export function useCatMutations(input: {
       text: string;
       approve?: boolean;
     }) => {
-      const segment = input.catFile?.segments.find(
-        (entry) => entry.externalStringId === mutationInput.externalStringId,
-      );
-      // Hidden is informational (hidden-string ADRs). Only an explicit lock blocks saves.
-      if (segment?.isLocked) {
+      const { targets } = await resolveCatMutationTargets(input, mutationInput.externalStringId, intl);
+      const writableTargets = targets.filter((target) => !target.isLocked);
+      if (writableTargets.length === 0) {
         throw new Error(
           intl.formatMessage(useCatMutationsMessages.cannotEditLockedStringTranslation),
         );
       }
 
-      const { sourcePath, externalResourceId } = resolveCatMutationFileIdentity(
-        input,
-        mutationInput.externalStringId,
-        intl,
-      );
+      let translation: ProjectFileCatTranslation | null = null;
+      for (const target of writableTargets) {
+        const response = await apiClient.api.orgs[":organizationSlug"].projects[
+          ":projectId"
+        ].files.detail.cat.translations.$post({
+          param: {
+            organizationSlug: input.organizationSlug,
+            projectId: input.projectId,
+          },
+          json: {
+            sourcePath: target.sourcePath,
+            targetLocale: input.targetLocale,
+            externalStringId: target.externalStringId,
+            externalResourceId: target.externalResourceId,
+            text: mutationInput.text,
+            approve: mutationInput.approve,
+          },
+        });
 
-      const response = await apiClient.api.orgs[":organizationSlug"].projects[
-        ":projectId"
-      ].files.detail.cat.translations.$post({
-        param: {
-          organizationSlug: input.organizationSlug,
-          projectId: input.projectId,
-        },
-        json: {
-          sourcePath,
-          targetLocale: input.targetLocale,
-          externalStringId: mutationInput.externalStringId,
-          externalResourceId,
-          text: mutationInput.text,
-          approve: mutationInput.approve,
-        },
-      });
+        if (!response.ok) {
+          throw new Error(
+            await readApiError(
+              response,
+              intl.formatMessage(useCatMutationsMessages.failedToSaveTranslation),
+            ),
+          );
+        }
 
-      if (!response.ok) {
-        throw new Error(
-          await readApiError(
-            response,
-            intl.formatMessage(useCatMutationsMessages.failedToSaveTranslation),
-          ),
-        );
+        const body = (await response.json()) as { translation: ProjectFileCatTranslation };
+        translation = body.translation;
       }
 
-      const body = (await response.json()) as { translation: ProjectFileCatTranslation };
-      return body.translation;
+      return translation!;
     },
     onSuccess: async (translation, variables) => {
       input.onTranslationSaved?.(
@@ -144,25 +205,52 @@ export function useCatMutations(input: {
         variables.text,
         translation.isApproved,
       );
-      const { sourcePath, externalResourceId, resourceType } = resolveCatMutationFileIdentity(
+      const { queueGroup, targets } = await resolveCatMutationTargets(
         input,
         variables.externalStringId,
         intl,
       );
 
-      const segmentTargetInput = {
-        organizationSlug: input.organizationSlug,
-        projectId: input.projectId,
-        sourcePath,
-        externalResourceId,
-        resourceType,
-        targetLocale: input.targetLocale,
-        externalStringId: variables.externalStringId,
-      };
-
       await Promise.all([
         input.invalidateQueue(),
-        syncSegmentTargetAfterSave(segmentTargetInput, translation),
+        ...(queueGroup
+          ? [
+              invalidateGroupOccurrences({
+                organizationSlug: input.organizationSlug,
+                projectId: input.projectId,
+                targetLocale: input.targetLocale,
+                groupId: queueGroup.groupId,
+                sourceTextHash: queueGroup.sourceTextHash,
+              }),
+              ...targets.map((target) =>
+                syncSegmentTargetAfterSave(
+                  {
+                    organizationSlug: input.organizationSlug,
+                    projectId: input.projectId,
+                    sourcePath: target.sourcePath,
+                    externalResourceId: target.externalResourceId,
+                    resourceType: target.resourceType,
+                    targetLocale: input.targetLocale,
+                    externalStringId: target.externalStringId,
+                  },
+                  translation,
+                ),
+              ),
+            ]
+          : [
+              syncSegmentTargetAfterSave(
+                {
+                  organizationSlug: input.organizationSlug,
+                  projectId: input.projectId,
+                  sourcePath: targets[0]!.sourcePath,
+                  externalResourceId: targets[0]!.externalResourceId,
+                  resourceType: targets[0]!.resourceType,
+                  targetLocale: input.targetLocale,
+                  externalStringId: variables.externalStringId,
+                },
+                translation,
+              ),
+            ]),
       ]);
     },
   });
@@ -174,44 +262,48 @@ export function useCatMutations(input: {
       type?: "comment" | "issue";
       issueType?: CatIssueType;
     }) => {
-      const { sourcePath, externalResourceId } = resolveCatMutationFileIdentity(
-        input,
-        mutationInput.externalStringId,
-        intl,
-      );
-
-      const response = await apiClient.api.orgs[":organizationSlug"].projects[
-        ":projectId"
-      ].files.detail.cat.comments.$post({
-        param: {
-          organizationSlug: input.organizationSlug,
-          projectId: input.projectId,
-        },
-        json: {
-          sourcePath,
-          targetLocale: input.targetLocale,
-          externalStringId: mutationInput.externalStringId,
-          externalResourceId,
-          text: mutationInput.text,
-          type: mutationInput.type,
-          issueType: mutationInput.issueType,
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          await readApiError(
-            response,
-            intl.formatMessage(useCatMutationsMessages.failedToPostComment),
-          ),
-        );
+      const { targets } = await resolveCatMutationTargets(input, mutationInput.externalStringId, intl);
+      if (targets.length === 0) {
+        throw new Error(intl.formatMessage(useCatMutationsMessages.missingSegmentSourceFile));
       }
 
-      const body = (await response.json()) as { comment: ProjectFileCatComment };
-      return body.comment;
+      let comment: ProjectFileCatComment | null = null;
+      for (const target of targets) {
+        const response = await apiClient.api.orgs[":organizationSlug"].projects[
+          ":projectId"
+        ].files.detail.cat.comments.$post({
+          param: {
+            organizationSlug: input.organizationSlug,
+            projectId: input.projectId,
+          },
+          json: {
+            sourcePath: target.sourcePath,
+            targetLocale: input.targetLocale,
+            externalStringId: target.externalStringId,
+            externalResourceId: target.externalResourceId,
+            text: mutationInput.text,
+            type: mutationInput.type,
+            issueType: mutationInput.issueType,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            await readApiError(
+              response,
+              intl.formatMessage(useCatMutationsMessages.failedToPostComment),
+            ),
+          );
+        }
+
+        const body = (await response.json()) as { comment: ProjectFileCatComment };
+        comment = body.comment;
+      }
+
+      return comment!;
     },
     onSuccess: async (_data, variables) => {
-      const { sourcePath, externalResourceId, resourceType } = resolveCatMutationFileIdentity(
+      const { queueGroup, targets } = await resolveCatMutationTargets(
         input,
         variables.externalStringId,
         intl,
@@ -219,24 +311,37 @@ export function useCatMutations(input: {
 
       await Promise.all([
         input.invalidateQueue(),
-        invalidateSegmentTarget({
-          organizationSlug: input.organizationSlug,
-          projectId: input.projectId,
-          sourcePath,
-          externalResourceId,
-          resourceType,
-          targetLocale: input.targetLocale,
-          externalStringId: variables.externalStringId,
-        }),
-        invalidateSegmentComments({
-          organizationSlug: input.organizationSlug,
-          projectId: input.projectId,
-          sourcePath,
-          externalResourceId,
-          resourceType,
-          targetLocale: input.targetLocale,
-          externalStringId: variables.externalStringId,
-        }),
+        ...(queueGroup
+          ? [
+              invalidateGroupOccurrences({
+                organizationSlug: input.organizationSlug,
+                projectId: input.projectId,
+                targetLocale: input.targetLocale,
+                groupId: queueGroup.groupId,
+                sourceTextHash: queueGroup.sourceTextHash,
+              }),
+            ]
+          : []),
+        ...targets.flatMap((target) => [
+          invalidateSegmentTarget({
+            organizationSlug: input.organizationSlug,
+            projectId: input.projectId,
+            sourcePath: target.sourcePath,
+            externalResourceId: target.externalResourceId,
+            resourceType: target.resourceType,
+            targetLocale: input.targetLocale,
+            externalStringId: target.externalStringId,
+          }),
+          invalidateSegmentComments({
+            organizationSlug: input.organizationSlug,
+            projectId: input.projectId,
+            sourcePath: target.sourcePath,
+            externalResourceId: target.externalResourceId,
+            resourceType: target.resourceType,
+            targetLocale: input.targetLocale,
+            externalStringId: target.externalStringId,
+          }),
+        ]),
       ]);
     },
   });
@@ -500,7 +605,18 @@ export function useCatMutations(input: {
 
   const hiddenStringsMutation = useMutation({
     mutationFn: async (mutationInput: { externalStringIds: string[]; isHidden: boolean }) => {
-      const uniqueIds = [...new Set(mutationInput.externalStringIds)];
+      const uniqueIds = [
+        ...new Set(
+          (
+            await Promise.all(
+              mutationInput.externalStringIds.map(async (externalStringId) => {
+                const { targets } = await resolveCatMutationTargets(input, externalStringId, intl);
+                return targets.map((target) => target.externalStringId);
+              }),
+            )
+          ).flat(),
+        ),
+      ];
       const chunks = chunkItems(uniqueIds, maxNativeCatHiddenStringBatch);
       let updatedCount = 0;
 
@@ -541,7 +657,18 @@ export function useCatMutations(input: {
 
   const lockedStringsMutation = useMutation({
     mutationFn: async (mutationInput: { externalStringIds: string[]; isLocked: boolean }) => {
-      const uniqueIds = [...new Set(mutationInput.externalStringIds)];
+      const uniqueIds = [
+        ...new Set(
+          (
+            await Promise.all(
+              mutationInput.externalStringIds.map(async (externalStringId) => {
+                const { targets } = await resolveCatMutationTargets(input, externalStringId, intl);
+                return targets.map((target) => target.externalStringId);
+              }),
+            )
+          ).flat(),
+        ),
+      ];
       const chunks = chunkItems(uniqueIds, maxCatLockedStringBatch);
       let updatedCount = 0;
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
@@ -157,7 +157,11 @@ export function useCatMutations(input: {
       text: string;
       approve?: boolean;
     }) => {
-      const { targets } = await resolveCatMutationTargets(input, mutationInput.externalStringId, intl);
+      const { targets } = await resolveCatMutationTargets(
+        input,
+        mutationInput.externalStringId,
+        intl,
+      );
       const writableTargets = targets.filter((target) => !target.isLocked);
       if (writableTargets.length === 0) {
         throw new Error(
@@ -262,7 +266,11 @@ export function useCatMutations(input: {
       type?: "comment" | "issue";
       issueType?: CatIssueType;
     }) => {
-      const { targets } = await resolveCatMutationTargets(input, mutationInput.externalStringId, intl);
+      const { targets } = await resolveCatMutationTargets(
+        input,
+        mutationInput.externalStringId,
+        intl,
+      );
       if (targets.length === 0) {
         throw new Error(intl.formatMessage(useCatMutationsMessages.missingSegmentSourceFile));
       }

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat-api.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat-api.fixture.ts
@@ -44,8 +44,8 @@ export function createCatProviderMeta() {
 }
 
 export function createCatQueueSegment(
-  overrides: Partial<ProjectFileCatQueueResponse["catQueue"]["segments"][number]> = {},
-) {
+  overrides: Partial<ProjectFileCatSegment> = {},
+): ProjectFileCatSegment {
   return {
     externalStringId: "segment-1",
     key: "auth.signIn.title",

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -100,6 +100,7 @@ export interface CatSegment {
   index: number;
   key: string;
   sourceText: string;
+  kind?: "segment" | "group";
   targetText: string;
   /** Present when the queue spans multiple files. */
   sourcePath?: string;

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -66,6 +66,7 @@ export interface CatQueueSegment {
   index: number;
   key: string;
   sourceText: string;
+  kind?: "segment" | "group";
   contentKind?: CatContentKind;
   sourceAssetUrl?: string | null;
   targetAssetUrl?: string | null;

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -115,9 +115,15 @@ function useCatSegmentLazySync(input: {
       return;
     }
 
-    store.applySegmentTarget(segmentId, representativeTargetFromOccurrences(groupOccurrencesQuery.data));
+    store.applySegmentTarget(
+      segmentId,
+      representativeTargetFromOccurrences(groupOccurrencesQuery.data),
+    );
     if (input.syncComments) {
-      store.applySegmentComments(segmentId, flattenGroupOccurrenceComments(groupOccurrencesQuery.data));
+      store.applySegmentComments(
+        segmentId,
+        flattenGroupOccurrenceComments(groupOccurrencesQuery.data),
+      );
     }
   }, [groupOccurrencesQuery.data, input.syncComments, queueGroup, segmentId, store]);
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -18,11 +18,18 @@ import { observer } from "mobx-react-lite";
 import type { ProjectFileCatQueueFile } from "@/api/routes/project/project.schema";
 
 import { resolveCatFileIdentity } from "@/components/cat/project-file/project-file-cat-mapper";
+import {
+  flattenGroupOccurrenceComments,
+  representativeTargetFromOccurrences,
+  useCatGroupOccurrences,
+  useCatGroupOccurrencesList,
+} from "@/components/cat/project-file/use-cat-group-occurrences";
 import { useCatSegmentComments } from "@/components/cat/project-file/use-cat-segment-comments";
 import {
   useCatSegmentTarget,
   useCatSegmentTargets,
 } from "@/components/cat/project-file/use-cat-segment-target";
+import { isCatQueueGroup } from "@/lib/projects/cat/cat-queue-row";
 
 import { useCatWorkspace } from "./cat-workspace-context";
 
@@ -48,6 +55,7 @@ function useCatSegmentLazySync(input: {
   const queueSegment = segmentId
     ? input.catFile?.segments.find((segment) => segment.externalStringId === segmentId)
     : null;
+  const queueGroup = queueSegment && isCatQueueGroup(queueSegment) ? queueSegment : null;
 
   const { externalResourceId: resolvedExternalResourceId, resourceType: resolvedResourceType } =
     resolveCatFileIdentity({
@@ -57,6 +65,8 @@ function useCatSegmentLazySync(input: {
     });
 
   const resolvedSourcePath = queueSegment?.sourcePath?.trim() || input.sourcePath;
+  const segmentSyncEnabled =
+    input.enabled && Boolean(input.catFile && segmentId) && queueGroup == null;
 
   const segmentTargetQuery = useCatSegmentTarget({
     organizationSlug: input.organizationSlug,
@@ -66,7 +76,7 @@ function useCatSegmentLazySync(input: {
     resourceType: resolvedResourceType,
     targetLocale: input.targetLocale,
     externalStringId: segmentId,
-    enabled: input.enabled && Boolean(input.catFile && segmentId),
+    enabled: segmentSyncEnabled,
   });
 
   const segmentCommentsQuery = useCatSegmentComments({
@@ -77,33 +87,62 @@ function useCatSegmentLazySync(input: {
     resourceType: resolvedResourceType,
     targetLocale: input.targetLocale,
     externalStringId: segmentId,
-    enabled: input.enabled && input.syncComments && Boolean(input.catFile && segmentId),
+    enabled: segmentSyncEnabled && input.syncComments,
+  });
+
+  const groupOccurrencesQuery = useCatGroupOccurrences({
+    organizationSlug: input.organizationSlug,
+    projectId: input.projectId,
+    targetLocale: input.targetLocale,
+    groupId: queueGroup?.groupId ?? null,
+    sourceTextHash: queueGroup?.sourceTextHash ?? null,
+    enabled: input.enabled && Boolean(input.catFile && queueGroup),
   });
 
   useEffect(() => {
-    if (!segmentId || segmentTargetQuery.data === undefined) {
+    if (!segmentId || queueGroup) {
+      return;
+    }
+    if (segmentTargetQuery.data === undefined) {
       return;
     }
 
     store.applySegmentTarget(segmentId, segmentTargetQuery.data);
-  }, [segmentId, segmentTargetQuery.data, store]);
+  }, [queueGroup, segmentId, segmentTargetQuery.data, store]);
 
   useEffect(() => {
-    if (!segmentId || !segmentCommentsQuery.data || !input.syncComments) {
+    if (!segmentId || !queueGroup || groupOccurrencesQuery.data === undefined) {
+      return;
+    }
+
+    store.applySegmentTarget(segmentId, representativeTargetFromOccurrences(groupOccurrencesQuery.data));
+    if (input.syncComments) {
+      store.applySegmentComments(segmentId, flattenGroupOccurrenceComments(groupOccurrencesQuery.data));
+    }
+  }, [groupOccurrencesQuery.data, input.syncComments, queueGroup, segmentId, store]);
+
+  useEffect(() => {
+    if (!segmentId || !segmentCommentsQuery.data || !input.syncComments || queueGroup) {
       return;
     }
 
     store.applySegmentComments(segmentId, segmentCommentsQuery.data);
-  }, [input.syncComments, segmentCommentsQuery.data, segmentId, store]);
+  }, [input.syncComments, queueGroup, segmentCommentsQuery.data, segmentId, store]);
 
   useEffect(() => {
     if (!input.syncCommentsLoading || !segmentId) {
       return;
     }
 
-    store.setCommentsLoading(segmentCommentsQuery.isFetching && !segmentCommentsQuery.data);
+    const isFetching = queueGroup
+      ? groupOccurrencesQuery.isFetching && !groupOccurrencesQuery.data
+      : segmentCommentsQuery.isFetching && !segmentCommentsQuery.data;
+    store.setCommentsLoading(isFetching);
   }, [
+    groupOccurrencesQuery.data,
+    groupOccurrencesQuery.isFetching,
     input.syncCommentsLoading,
+    queueGroup,
     segmentCommentsQuery.data,
     segmentCommentsQuery.isFetching,
     segmentId,
@@ -115,28 +154,37 @@ function useCatSegmentLazySync(input: {
       return;
     }
 
+    const query = queueGroup ? groupOccurrencesQuery : segmentTargetQuery;
     const isLoading =
-      segmentTargetQuery.isFetching &&
-      segmentTargetQuery.data === undefined &&
+      query.isFetching &&
+      query.data === undefined &&
       !(segmentId && store.drafts.get(segmentId)?.targetText.trim());
 
     store.setSegmentTargetLoading(isLoading);
   }, [
+    groupOccurrencesQuery.data,
+    groupOccurrencesQuery.isFetching,
     input.syncTargetLoading,
+    queueGroup,
     segmentId,
     segmentTargetQuery.data,
     segmentTargetQuery.isFetching,
     store,
   ]);
 
+  const isTargetFetching = queueGroup
+    ? groupOccurrencesQuery.isFetching && groupOccurrencesQuery.data === undefined
+    : segmentTargetQuery.isFetching && segmentTargetQuery.data === undefined;
+
   return {
     segmentId,
     isTargetLoading:
       Boolean(segmentId) &&
-      segmentTargetQuery.isFetching &&
-      segmentTargetQuery.data === undefined &&
+      isTargetFetching &&
       !(segmentId && store.drafts.get(segmentId)?.targetText.trim()),
-    isCommentsFetching: segmentCommentsQuery.isFetching,
+    isCommentsFetching: queueGroup
+      ? groupOccurrencesQuery.isFetching
+      : segmentCommentsQuery.isFetching,
     comments: segmentId ? store.segmentComments.get(segmentId) : undefined,
   };
 }
@@ -176,16 +224,21 @@ function useCatLoadedQueueTargetsSync(input: {
 
   const targetSegments = useMemo(
     () =>
-      segmentIds.map((externalStringId) => {
+      segmentIds.flatMap((externalStringId) => {
         const queueSegment = input.catFile?.segments.find(
           (segment) => segment.externalStringId === externalStringId,
         );
-        return {
-          externalStringId,
-          sourcePath: queueSegment?.sourcePath?.trim() || input.sourcePath,
-          externalResourceId: queueSegment?.externalResourceId ?? resolvedExternalResourceId,
-          resourceType: queueSegment?.resourceType ?? resolvedResourceType,
-        };
+        if (queueSegment && isCatQueueGroup(queueSegment)) {
+          return [];
+        }
+        return [
+          {
+            externalStringId,
+            sourcePath: queueSegment?.sourcePath?.trim() || input.sourcePath,
+            externalResourceId: queueSegment?.externalResourceId ?? resolvedExternalResourceId,
+            resourceType: queueSegment?.resourceType ?? resolvedResourceType,
+          },
+        ];
       }),
     [
       input.catFile?.segments,
@@ -194,6 +247,18 @@ function useCatLoadedQueueTargetsSync(input: {
       resolvedResourceType,
       segmentIds,
     ],
+  );
+  const visibleGroups = useMemo(
+    () =>
+      segmentIds.flatMap((externalStringId) => {
+        const queueSegment = input.catFile?.segments.find(
+          (segment) => segment.externalStringId === externalStringId,
+        );
+        return queueSegment && isCatQueueGroup(queueSegment)
+          ? [{ groupId: queueSegment.groupId, sourceTextHash: queueSegment.sourceTextHash }]
+          : [];
+      }),
+    [input.catFile?.segments, segmentIds],
   );
 
   const targetQueries = useCatSegmentTargets({
@@ -206,28 +271,52 @@ function useCatLoadedQueueTargetsSync(input: {
     segments: targetSegments,
     enabled: targetsEnabled,
   });
+  const groupQueries = useCatGroupOccurrencesList({
+    organizationSlug: input.organizationSlug,
+    projectId: input.projectId,
+    targetLocale: input.targetLocale,
+    groups: visibleGroups,
+    enabled: targetsEnabled,
+  });
 
   // useQueries() returns a new array every render. Depend on result fingerprints
   // instead so applying targets / loading ids does not form a MobX update loop.
   const targetQueriesRef = useRef(targetQueries);
   targetQueriesRef.current = targetQueries;
+  const groupQueriesRef = useRef(groupQueries);
+  groupQueriesRef.current = groupQueries;
   const targetDataSyncKey = targetQueries
     .map((query) => `${query.dataUpdatedAt}:${query.status}`)
     .join("|");
-  const targetLoadingSyncKey = targetQueries
-    .map((query) => `${query.isFetching}:${query.data === undefined}`)
+  const groupDataSyncKey = groupQueries
+    .map((query) => `${query.dataUpdatedAt}:${query.status}`)
     .join("|");
+  const targetLoadingSyncKey = [
+    ...targetQueries.map((query) => `${query.isFetching}:${query.data === undefined}`),
+    ...groupQueries.map((query) => `${query.isFetching}:${query.data === undefined}`),
+  ].join("|");
 
   useEffect(() => {
     targetQueriesRef.current.forEach((query, index) => {
-      const segmentId = segmentIds[index];
+      const segmentId = targetSegments[index]?.externalStringId;
       if (!segmentId || query.data === undefined) {
         return;
       }
 
       store.applySegmentTarget(segmentId, query.data);
     });
-  }, [segmentIds, store, targetDataSyncKey]);
+  }, [store, targetDataSyncKey, targetSegments]);
+
+  useEffect(() => {
+    groupQueriesRef.current.forEach((query, index) => {
+      const group = visibleGroups[index];
+      if (!group || query.data === undefined) {
+        return;
+      }
+
+      store.applySegmentTarget(group.groupId, representativeTargetFromOccurrences(query.data));
+    });
+  }, [groupDataSyncKey, store, visibleGroups]);
 
   useEffect(() => {
     if (!targetsEnabled) {
@@ -238,13 +327,21 @@ function useCatLoadedQueueTargetsSync(input: {
     // Track fetch-in-flight only. Draft text is filtered in `loadingSegmentIds`
     // so typing during a fetch clears the skeleton without needing this effect
     // to re-run on draft changes.
-    const loadingIds = segmentIds.filter((_segmentId, index) => {
-      const query = targetQueriesRef.current[index];
-      return Boolean(query?.isFetching && query.data === undefined);
-    });
+    const loadingSegmentIds = targetSegments
+      .filter((_segment, index) => {
+        const query = targetQueriesRef.current[index];
+        return Boolean(query?.isFetching && query.data === undefined);
+      })
+      .map((segment) => segment.externalStringId);
+    const loadingGroupIds = visibleGroups
+      .filter((_group, index) => {
+        const query = groupQueriesRef.current[index];
+        return Boolean(query?.isFetching && query.data === undefined);
+      })
+      .map((group) => group.groupId);
 
-    store.setQueueTargetLoadingSegmentIds(loadingIds);
-  }, [segmentIds, store, targetLoadingSyncKey, targetsEnabled]);
+    store.setQueueTargetLoadingSegmentIds([...loadingSegmentIds, ...loadingGroupIds]);
+  }, [store, targetLoadingSyncKey, targetSegments, targetsEnabled, visibleGroups]);
 }
 
 export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySegmentSync({

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -247,16 +247,12 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
   const isNativeProject = shell.fileContext.providerKind === null;
   const showNativeIssues = nativeIssuesEnabled && isNativeProject;
   const issueTargetLocale = showNativeIssues ? shell.fileContext.targetLocale : null;
-  const editorQueueRow = queueSegments.find((segment) => segment.id === editorSegment.id);
-  const intelligenceQueueRow = intelligenceSegment
-    ? queueSegments.find((segment) => segment.id === intelligenceSegment.id)
-    : undefined;
   const editorTranslationKeyId = showNativeIssues
     ? resolveCatLinkedIssueTranslationKeyId({
         isNativeProject: true,
         segmentId: editorSegment.id,
         contentKind: editorSegment.contentKind,
-        kind: editorQueueRow?.kind,
+        kind: editorSegment.kind,
       })
     : null;
   const editorIssueStringLink =
@@ -275,7 +271,7 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           isNativeProject: true,
           segmentId: intelligenceSegment.id,
           contentKind: intelligenceSegment.contentKind,
-          kind: intelligenceQueueRow?.kind,
+          kind: intelligenceSegment.kind,
         })
       : null;
   const intelligenceIssueStringLink =

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -247,11 +247,16 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
   const isNativeProject = shell.fileContext.providerKind === null;
   const showNativeIssues = nativeIssuesEnabled && isNativeProject;
   const issueTargetLocale = showNativeIssues ? shell.fileContext.targetLocale : null;
+  const editorQueueRow = queueSegments.find((segment) => segment.id === editorSegment.id);
+  const intelligenceQueueRow = intelligenceSegment
+    ? queueSegments.find((segment) => segment.id === intelligenceSegment.id)
+    : undefined;
   const editorTranslationKeyId = showNativeIssues
     ? resolveCatLinkedIssueTranslationKeyId({
         isNativeProject: true,
         segmentId: editorSegment.id,
         contentKind: editorSegment.contentKind,
+        kind: editorQueueRow?.kind,
       })
     : null;
   const editorIssueStringLink =
@@ -270,6 +275,7 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           isNativeProject: true,
           segmentId: intelligenceSegment.id,
           contentKind: intelligenceSegment.contentKind,
+          kind: intelligenceQueueRow?.kind,
         })
       : null;
   const intelligenceIssueStringLink =

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.test.ts
@@ -44,6 +44,24 @@ describe("toQueueSegment", () => {
     });
   });
 
+  it("preserves group kind when present", () => {
+    expect(
+      toQueueSegment({
+        id: "g".repeat(64),
+        index: 1,
+        key: "save",
+        sourceText: "Save",
+        kind: "group",
+      }),
+    ).toEqual({
+      id: "g".repeat(64),
+      index: 1,
+      key: "save",
+      sourceText: "Save",
+      kind: "group",
+    });
+  });
+
   it("preserves sourcePath when present", () => {
     expect(
       toQueueSegment({

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.ts
@@ -85,6 +85,7 @@ export function toQueueSegment(
     | "index"
     | "key"
     | "sourceText"
+    | "kind"
     | "sourcePath"
     | "contentKind"
     | "sourceAssetUrl"
@@ -101,6 +102,7 @@ export function toQueueSegment(
     index: segment.index,
     key: segment.key,
     sourceText: segment.sourceText,
+    ...(segment.kind ? { kind: segment.kind } : {}),
     ...(segment.sourcePath ? { sourcePath: segment.sourcePath } : {}),
     ...(segment.contentKind ? { contentKind: segment.contentKind } : {}),
     ...(segment.sourceAssetUrl !== undefined ? { sourceAssetUrl: segment.sourceAssetUrl } : {}),

--- a/apps/hyperlocalise-web/src/lib/database/schema/project-strings.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema/project-strings.ts
@@ -52,8 +52,11 @@ export const projectTranslationKeys = pgTable(
     ),
     key: text("key").notNull(),
     sourceText: text("source_text").notNull(),
+    // `convert_to(..., 'UTF8')` is STABLE, so PostgreSQL rejects it in a
+    // generated column. `text::bytea` is IMMUTABLE and uses the database
+    // encoding, which this project keeps as UTF-8.
     sourceTextHash: text("source_text_hash").generatedAlwaysAs(
-      sql`encode(sha256(convert_to(source_text, 'UTF8')), 'hex')`,
+      sql`encode(sha256(source_text::bytea), 'hex')`,
     ),
     normalizedSourceText: text("normalized_source_text").notNull(),
     context: text("context"),

--- a/apps/hyperlocalise-web/src/lib/database/schema/project-strings.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema/project-strings.ts
@@ -52,6 +52,9 @@ export const projectTranslationKeys = pgTable(
     ),
     key: text("key").notNull(),
     sourceText: text("source_text").notNull(),
+    sourceTextHash: text("source_text_hash").generatedAlwaysAs(
+      sql`encode(sha256(convert_to(source_text, 'UTF8')), 'hex')`,
+    ),
     normalizedSourceText: text("normalized_source_text").notNull(),
     context: text("context"),
     type: text("type"),
@@ -82,6 +85,11 @@ export const projectTranslationKeys = pgTable(
       table.key,
     ),
     index("idx_project_translation_keys_org_project").on(table.organizationId, table.projectId),
+    index("idx_project_translation_keys_project_source_hash").on(
+      table.organizationId,
+      table.projectId,
+      table.sourceTextHash,
+    ),
     index("idx_project_translation_keys_file").on(table.repositorySourceFileId),
   ],
 );

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.test.ts
@@ -419,10 +419,7 @@ describe("collectCatFilteredExportRows", () => {
     const loadCatQueue = vi.fn<CatQueueLoader>().mockResolvedValue({
       kind: "ok",
       catQueue: queuePage({
-        segments: [
-          segment({ externalStringId: "k1", key: "hello", sourceText: "Hello" }),
-          group,
-        ],
+        segments: [segment({ externalStringId: "k1", key: "hello", sourceText: "Hello" }), group],
         hasMore: false,
       }),
     });
@@ -448,7 +445,9 @@ describe("collectCatFilteredExportRows", () => {
         reviewState: "draft",
       },
     ]);
-    getProjectTranslationsByKeyIdsMock.mockResolvedValue([{ translationKeyId: "k1", text: "Xin chào" }]);
+    getProjectTranslationsByKeyIdsMock.mockResolvedValue([
+      { translationKeyId: "k1", text: "Xin chào" },
+    ]);
 
     const result = await collectCatFilteredExportRows({
       auth,

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.test.ts
@@ -14,8 +14,10 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
 import type {
+  ProjectFileCatGroup,
   ProjectFileCatQuery,
   ProjectFileCatQueueFile,
+  ProjectFileCatQueueSegment,
   ProjectFileCatSegment,
 } from "@/api/routes/project/project.schema";
 
@@ -73,7 +75,7 @@ function segment(
 }
 
 function queuePage(input: {
-  segments: ProjectFileCatSegment[];
+  segments: ProjectFileCatQueueSegment[];
   hasMore: boolean;
   offset?: number;
   returnedCount?: number;
@@ -398,6 +400,108 @@ describe("collectCatFilteredExportRows", () => {
         resourceType: undefined,
       },
     );
+  });
+
+  it("expands native groups to occurrence rows instead of using the group id", async () => {
+    const group: ProjectFileCatGroup = {
+      kind: "group",
+      externalStringId: "g".repeat(64),
+      groupId: "g".repeat(64),
+      sourceTextHash: "h".repeat(64),
+      translationKeyId: null,
+      projectOccurrenceCount: 2,
+      fileOccurrenceCount: 2,
+      key: "save",
+      sourceText: "Save",
+      context: null,
+      type: null,
+    };
+    const loadCatQueue = vi.fn<CatQueueLoader>().mockResolvedValue({
+      kind: "ok",
+      catQueue: queuePage({
+        segments: [
+          segment({ externalStringId: "k1", key: "hello", sourceText: "Hello" }),
+          group,
+        ],
+        hasMore: false,
+      }),
+    });
+    const loadGroupOccurrences = vi.fn().mockResolvedValue([
+      {
+        translationKeyId: "key-a",
+        key: "actions.save",
+        sourcePath: "locales/en.json",
+        context: null,
+        comments: [],
+        isLocked: false,
+        target: { text: "Enregistrer", externalTranslationId: "t1", isApproved: true },
+        reviewState: "approved",
+      },
+      {
+        translationKeyId: "key-b",
+        key: "common.save",
+        sourcePath: "shared/en.json",
+        context: null,
+        comments: [],
+        isLocked: false,
+        target: { text: "Sauvegarder", externalTranslationId: "t2", isApproved: false },
+        reviewState: "draft",
+      },
+    ]);
+    getProjectTranslationsByKeyIdsMock.mockResolvedValue([{ translationKeyId: "k1", text: "Xin chào" }]);
+
+    const result = await collectCatFilteredExportRows({
+      auth,
+      projectId: "project_1",
+      query: baseQuery,
+      sourceLocale: "en",
+      loadCatQueue,
+      loadGroupOccurrences,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      truncated: false,
+      rows: [
+        {
+          key: "hello",
+          sourceText: "Hello",
+          targetText: "Xin chào",
+          sourceLocale: "en",
+          targetLocale: "vi",
+          sourcePath: "locales/en.json",
+        },
+        {
+          key: "actions.save",
+          sourceText: "Save",
+          targetText: "Enregistrer",
+          sourceLocale: "en",
+          targetLocale: "vi",
+          sourcePath: "locales/en.json",
+        },
+        {
+          key: "common.save",
+          sourceText: "Save",
+          targetText: "Sauvegarder",
+          sourceLocale: "en",
+          targetLocale: "vi",
+          sourcePath: "shared/en.json",
+        },
+      ],
+    });
+    expect(getProjectTranslationsByKeyIdsMock).toHaveBeenCalledWith({
+      organizationId: "org_1",
+      projectId: "project_1",
+      translationKeyIds: ["k1"],
+      targetLocale: "vi",
+    });
+    expect(loadGroupOccurrences).toHaveBeenCalledWith({
+      organizationId: "org_1",
+      projectId: "project_1",
+      targetLocale: "vi",
+      groupId: "g".repeat(64),
+      sourceTextHash: "h".repeat(64),
+    });
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
@@ -170,9 +170,8 @@ export async function collectCatFilteredExportRows(input: {
     const loadGroupOccurrences =
       input.loadGroupOccurrences ??
       (async (groupInput) => {
-        const { getNativeProjectCatGroupOccurrences } = await import(
-          "@/lib/projects/cat/native-cat-service"
-        );
+        const { getNativeProjectCatGroupOccurrences } =
+          await import("@/lib/projects/cat/native-cat-service");
         return getNativeProjectCatGroupOccurrences(groupInput);
       });
 

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
@@ -12,6 +12,7 @@
  */
 import type { AuthVariables } from "@/api/auth/workos";
 import type {
+  ProjectFileCatGroupOccurrence,
   ProjectFileCatQuery,
   ProjectFileCatQueueFile,
   ProjectFileCatSegment,
@@ -19,6 +20,8 @@ import type {
 import type { ProjectResourceTarget } from "@/api/routes/project/project.shared";
 import { maxProjectFileCatPageLimit } from "@/api/routes/project/project.schema";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
+import { isCatQueueGroup, isCatQueueSegmentRow } from "@/lib/projects/cat/cat-queue-row";
+import { getNativeProjectCatGroupOccurrences } from "@/lib/projects/cat/native-cat-service";
 import { getProjectTranslationsByKeyIds } from "@/lib/projects/translations/project-translation-service";
 import { getTmsProviderLiveCatSegmentTarget } from "@/lib/providers/jobs/tms-provider-live";
 
@@ -48,6 +51,14 @@ export type CatQueueLoader = (
 ) => Promise<CatQueueLoaderResult>;
 
 const PROVIDER_TARGET_CONCURRENCY = 8;
+
+export type CatGroupOccurrencesLoader = (input: {
+  organizationId: string;
+  projectId: string;
+  targetLocale: string;
+  groupId: string;
+  sourceTextHash: string;
+}) => Promise<ProjectFileCatGroupOccurrence[] | null>;
 
 async function loadNativeTargets(input: {
   organizationId: string;
@@ -104,6 +115,7 @@ export async function collectCatFilteredExportRows(input: {
   sourceLocale: string;
   loadCatQueue: CatQueueLoader;
   externalProjectId?: string | null;
+  loadGroupOccurrences?: CatGroupOccurrencesLoader;
 }): Promise<
   | { kind: "ok"; rows: CatFilteredExportRow[]; truncated: boolean }
   | { kind: "empty" }
@@ -140,6 +152,7 @@ export async function collectCatFilteredExportRows(input: {
       break;
     }
 
+    const singletonSegments = catQueue.segments.filter(isCatQueueSegmentRow);
     const targetById = isProvider
       ? await loadProviderTargets({
           organizationId: input.auth.organization.localOrganizationId,
@@ -147,16 +160,42 @@ export async function collectCatFilteredExportRows(input: {
           sourcePath: input.query.sourcePath,
           targetLocale: input.query.targetLocale,
           actorUserId: input.auth.user.localUserId,
-          segments: catQueue.segments,
+          segments: singletonSegments,
         })
       : await loadNativeTargets({
           organizationId: input.auth.organization.localOrganizationId,
           projectId: input.projectId,
           targetLocale: input.query.targetLocale,
-          segments: catQueue.segments,
+          segments: singletonSegments,
         });
+    const loadGroupOccurrences =
+      input.loadGroupOccurrences ?? getNativeProjectCatGroupOccurrences;
 
     for (const segment of catQueue.segments) {
+      if (isCatQueueGroup(segment)) {
+        const occurrences = await loadGroupOccurrences({
+          organizationId: input.auth.organization.localOrganizationId,
+          projectId: input.projectId,
+          targetLocale: input.query.targetLocale,
+          groupId: segment.groupId,
+          sourceTextHash: segment.sourceTextHash,
+        });
+        if (!occurrences) {
+          continue;
+        }
+        for (const occurrence of occurrences) {
+          rows.push({
+            key: occurrence.key,
+            sourceText: segment.sourceText,
+            targetText: occurrence.target?.text ?? "",
+            sourceLocale: input.sourceLocale,
+            targetLocale: input.query.targetLocale,
+            sourcePath: occurrence.sourcePath,
+          });
+        }
+        continue;
+      }
+
       rows.push({
         key: segment.key,
         sourceText: segment.sourceText,

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
@@ -21,7 +21,6 @@ import type { ProjectResourceTarget } from "@/api/routes/project/project.shared"
 import { maxProjectFileCatPageLimit } from "@/api/routes/project/project.schema";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import { isCatQueueGroup, isCatQueueSegmentRow } from "@/lib/projects/cat/cat-queue-row";
-import { getNativeProjectCatGroupOccurrences } from "@/lib/projects/cat/native-cat-service";
 import { getProjectTranslationsByKeyIds } from "@/lib/projects/translations/project-translation-service";
 import { getTmsProviderLiveCatSegmentTarget } from "@/lib/providers/jobs/tms-provider-live";
 
@@ -169,7 +168,13 @@ export async function collectCatFilteredExportRows(input: {
           segments: singletonSegments,
         });
     const loadGroupOccurrences =
-      input.loadGroupOccurrences ?? getNativeProjectCatGroupOccurrences;
+      input.loadGroupOccurrences ??
+      (async (groupInput) => {
+        const { getNativeProjectCatGroupOccurrences } = await import(
+          "@/lib/projects/cat/native-cat-service"
+        );
+        return getNativeProjectCatGroupOccurrences(groupInput);
+      });
 
     for (const segment of catQueue.segments) {
       if (isCatQueueGroup(segment)) {

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-queue-row.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-queue-row.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { isCatQueueGroup, isCatQueueSegmentRow } from "./cat-queue-row";
+
+describe("cat queue row guards", () => {
+  it("treats synthetic groups as distinct from persisted segments", () => {
+    const group = {
+      kind: "group" as const,
+      externalStringId: "g".repeat(64),
+      groupId: "g".repeat(64),
+      sourceTextHash: "h".repeat(64),
+      translationKeyId: null,
+      projectOccurrenceCount: 2,
+      fileOccurrenceCount: 1,
+      key: "save",
+      sourceText: "Save",
+      context: null,
+      type: null,
+    };
+    const segment = {
+      externalStringId: "key-1",
+      key: "save",
+      sourceText: "Save",
+      context: null,
+      type: null,
+    };
+
+    expect(isCatQueueGroup(group)).toBe(true);
+    expect(isCatQueueSegmentRow(group)).toBe(false);
+    expect(isCatQueueGroup(segment)).toBe(false);
+    expect(isCatQueueSegmentRow(segment)).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-queue-row.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-queue-row.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type {
+  ProjectFileCatGroup,
+  ProjectFileCatQueueSegment,
+  ProjectFileCatSegment,
+} from "@/api/routes/project/project.schema";
+
+export function isCatQueueGroup(
+  segment: ProjectFileCatQueueSegment,
+): segment is ProjectFileCatGroup {
+  return segment.kind === "group";
+}
+
+export function isCatQueueSegmentRow(
+  segment: ProjectFileCatQueueSegment,
+): segment is ProjectFileCatSegment {
+  return segment.kind !== "group";
+}

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { DatabaseClient } from "@/lib/database";
+
+import { nativeCatGroupId, resolveNativeCatLogicalRows } from "./native-cat-group-resolver";
+
+function groupedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    representativeId: "key-1",
+    representativeKey: "actions.save",
+    sourceText: "Save",
+    sourceTextHash: "a".repeat(64),
+    representativeContext: "Toolbar",
+    representativeType: null,
+    representativeMaxLength: null,
+    representativeMetadata: {},
+    representativeHidden: false,
+    representativeSourcePath: "locales/en.json",
+    projectOccurrenceCount: 2,
+    fileOccurrenceCount: 1,
+    totalLogicalRows: 3,
+    totalSourceOccurrences: 5,
+    ...overrides,
+  };
+}
+
+function input() {
+  return {
+    organizationId: "organization-1",
+    projectId: "project-1",
+    targetLocale: "fr-FR",
+    sourcePath: "locales/en.json",
+    limit: 50,
+    offset: 0,
+    queueFilter: "all" as const,
+    queueSort: "file_order" as const,
+  };
+}
+
+describe("nativeCatGroupId", () => {
+  it("is deterministic and scoped by project, locale, and exact source", () => {
+    const first = nativeCatGroupId({
+      projectId: "project-1",
+      targetLocale: "fr-FR",
+      sourceText: "Save",
+    });
+
+    expect(
+      nativeCatGroupId({ projectId: "project-1", targetLocale: "fr-FR", sourceText: "Save" }),
+    ).toBe(first);
+    expect(
+      nativeCatGroupId({ projectId: "project-1", targetLocale: "de-DE", sourceText: "Save" }),
+    ).not.toBe(first);
+    expect(
+      nativeCatGroupId({ projectId: "project-1", targetLocale: "fr-FR", sourceText: " save " }),
+    ).not.toBe(first);
+  });
+});
+
+describe("resolveNativeCatLogicalRows", () => {
+  it("returns group summaries without eagerly returning members", async () => {
+    const execute = vi.fn().mockResolvedValue([groupedRow()]);
+    const result = await resolveNativeCatLogicalRows(input(), {
+      database: { execute } as unknown as DatabaseClient,
+    });
+
+    expect(result).toMatchObject({ totalLogicalRows: 3, totalSourceOccurrences: 5 });
+    expect(result.rows).toEqual([
+      expect.objectContaining({
+        kind: "group",
+        translationKeyId: null,
+        sourceText: "Save",
+        projectOccurrenceCount: 2,
+        fileOccurrenceCount: 1,
+      }),
+    ]);
+    expect(result.rows[0]).not.toHaveProperty("members");
+  });
+
+  it("keeps a single occurrence as its persisted segment", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValue([groupedRow({ projectOccurrenceCount: 1, fileOccurrenceCount: 1 })]);
+    const resolveExceptionPredicate = vi.fn().mockResolvedValue(["key-1"]);
+    const result = await resolveNativeCatLogicalRows(input(), {
+      database: { execute } as unknown as DatabaseClient,
+      resolveExceptionPredicate,
+    });
+
+    expect(result.rows).toEqual([
+      expect.objectContaining({
+        kind: "segment",
+        externalStringId: "key-1",
+        translationKeyId: "key-1",
+      }),
+    ]);
+    expect(resolveExceptionPredicate).toHaveBeenCalledWith({
+      organizationId: "organization-1",
+      projectId: "project-1",
+      targetLocale: "fr-FR",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.test.ts
@@ -112,4 +112,16 @@ describe("resolveNativeCatLogicalRows", () => {
       targetLocale: "fr-FR",
     });
   });
+
+  it("treats missing occurrence statuses as unreviewed", async () => {
+    const execute = vi.fn().mockResolvedValue([]);
+    await resolveNativeCatLogicalRows(
+      { ...input(), queueFilter: "reviewed" },
+      { database: { execute } as unknown as DatabaseClient },
+    );
+
+    expect(String(execute.mock.calls[0]?.[0])).toContain(
+      "coalesce(target_status = 'approved', false)",
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.test.ts
@@ -120,7 +120,7 @@ describe("resolveNativeCatLogicalRows", () => {
       { database: { execute } as unknown as DatabaseClient },
     );
 
-    expect(String(execute.mock.calls[0]?.[0])).toContain(
+    expect(JSON.stringify(execute.mock.calls[0]?.[0])).toContain(
       "coalesce(target_status = 'approved', false)",
     );
   });

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createHash } from "node:crypto";
+import { sql, type SQL } from "drizzle-orm";
+
+import type {
+  ProjectFileCatQueueFilter,
+  ProjectFileCatQueueSort,
+} from "@/api/routes/project/project.schema";
+import { db, type DatabaseClient } from "@/lib/database";
+
+export type NativeCatGroupingExceptionResolver = (input: {
+  organizationId: string;
+  projectId: string;
+  targetLocale: string;
+}) => Promise<readonly string[]> | readonly string[];
+
+export type NativeCatLogicalRow = {
+  kind: "segment" | "group";
+  externalStringId: string;
+  translationKeyId: string | null;
+  groupId?: string;
+  sourceTextHash?: string;
+  key: string;
+  sourceText: string;
+  context: string | null;
+  type: string | null;
+  maxLength: number | null;
+  metadata: Record<string, unknown> | null;
+  isHidden: boolean;
+  sourcePath: string;
+  projectOccurrenceCount: number;
+  fileOccurrenceCount: number;
+};
+
+type GroupedRow = {
+  representativeId: string;
+  representativeKey: string;
+  sourceText: string;
+  sourceTextHash: string;
+  representativeContext: string | null;
+  representativeType: string | null;
+  representativeMaxLength: number | null;
+  representativeMetadata: Record<string, unknown> | null;
+  representativeHidden: boolean;
+  representativeSourcePath: string;
+  projectOccurrenceCount: number;
+  fileOccurrenceCount: number;
+  totalLogicalRows: number;
+  totalSourceOccurrences: number;
+};
+
+export function nativeCatGroupId(input: {
+  projectId: string;
+  targetLocale: string;
+  sourceText: string;
+}) {
+  return createHash("sha256")
+    .update(input.projectId, "utf8")
+    .update("\0")
+    .update(input.targetLocale, "utf8")
+    .update("\0")
+    .update(input.sourceText, "utf8")
+    .digest("hex");
+}
+
+function escapeLike(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+function groupFilter(filter: ProjectFileCatQueueFilter): SQL {
+  switch (filter) {
+    case "untranslated":
+      return sql`bool_or(coalesce(trim(target_text), '') = '')`;
+    case "reviewed":
+      return sql`bool_and(target_status = 'approved')`;
+    case "needs_review":
+      return sql`bool_or(coalesce(trim(target_text), '') != '' and target_status != 'approved')`;
+    case "has_issues":
+      return sql`bool_or(has_issues)`;
+    case "hidden":
+      return sql`bool_or(is_hidden)`;
+    case "all":
+      return sql`true`;
+    default:
+      return sql`true`;
+  }
+}
+
+/**
+ * Resolves native CAT logical rows in PostgreSQL. The exception resolver returns
+ * translation key IDs to subtract from automatic groups for HL-622.
+ */
+export async function resolveNativeCatLogicalRows(
+  input: {
+    organizationId: string;
+    projectId: string;
+    targetLocale: string;
+    sourcePath: string;
+    sourcePaths?: readonly string[] | null;
+    limit: number;
+    offset: number;
+    search?: string;
+    queueFilter: ProjectFileCatQueueFilter;
+    queueSort: ProjectFileCatQueueSort;
+  },
+  options: {
+    database?: DatabaseClient;
+    resolveExceptionPredicate?: NativeCatGroupingExceptionResolver;
+  } = {},
+) {
+  const database = options.database ?? db;
+  const excludedTranslationKeyIds =
+    (await options.resolveExceptionPredicate?.({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      targetLocale: input.targetLocale,
+    })) ?? [];
+  const groupingKey =
+    excludedTranslationKeyIds.length > 0
+      ? sql`case when k.id in (${sql.join(
+          excludedTranslationKeyIds.map((id) => sql`${id}`),
+          sql`, `,
+        )}) then k.id::text else k.source_text_hash end`
+      : sql`k.source_text_hash`;
+  const requestedPaths = input.sourcePath === "*" ? input.sourcePaths : [input.sourcePath];
+  const pathPredicate =
+    requestedPaths && requestedPaths.length > 0
+      ? sql`source_path in (${sql.join(
+          requestedPaths.map((path) => sql`${path}`),
+          sql`, `,
+        )})`
+      : sql`true`;
+  const search = input.search?.trim();
+  const searchPredicate = search
+    ? sql`bool_or(
+        key ilike ${`%${escapeLike(search)}%`} escape '\\'
+        or source_text ilike ${`%${escapeLike(search)}%`} escape '\\'
+        or context ilike ${`%${escapeLike(search)}%`} escape '\\'
+        or target_text ilike ${`%${escapeLike(search)}%`} escape '\\'
+      )`
+    : sql`true`;
+  const filterPredicate = groupFilter(input.queueFilter);
+  const order =
+    input.queueSort === "untranslated_first"
+      ? sql`untranslated_rank, representative_source_path, representative_key, representative_id`
+      : sql`representative_source_path, representative_key, representative_id`;
+
+  const rows = await database.execute<GroupedRow>(sql`
+    with scoped as (
+      select
+        k.id,
+        k.key,
+        k.source_text,
+        k.source_text_hash,
+        ${groupingKey} as grouping_key,
+        k.context,
+        k.type,
+        k.max_length,
+        k.metadata,
+        k.is_hidden,
+        f.source_path,
+        t.text as target_text,
+        t.status as target_status,
+        (
+          exists (
+            select 1 from issue_sheet_issues i
+            where i.translation_key_id = k.id
+              and i.organization_id = ${input.organizationId}
+              and i.project_id = ${input.projectId}
+              and i.target_locale = ${input.targetLocale}
+              and i.status in ('open', 'in_progress')
+          )
+          or exists (
+            select 1 from project_translation_comments c
+            where c.translation_key_id = k.id
+              and c.organization_id = ${input.organizationId}
+              and c.project_id = ${input.projectId}
+              and c.target_locale = ${input.targetLocale}
+              and c.type = 'issue'
+              and c.status = 'unresolved'
+          )
+        ) as has_issues
+      from project_translation_keys k
+      inner join repository_source_files f on f.id = k.repository_source_file_id
+      left join project_translations t
+        on t.translation_key_id = k.id
+        and t.target_locale = ${input.targetLocale}
+      where k.organization_id = ${input.organizationId}
+        and k.project_id = ${input.projectId}
+    ), grouped as (
+      select
+        (array_agg(id order by source_path, key, id))[1] as representative_id,
+        (array_agg(key order by source_path, key, id))[1] as representative_key,
+        source_text,
+        source_text_hash,
+        (array_agg(context order by source_path, key, id))[1] as representative_context,
+        (array_agg(type order by source_path, key, id))[1] as representative_type,
+        (array_agg(max_length order by source_path, key, id))[1] as representative_max_length,
+        (array_agg(metadata order by source_path, key, id))[1] as representative_metadata,
+        (array_agg(is_hidden order by source_path, key, id))[1] as representative_hidden,
+        (array_agg(source_path order by source_path, key, id))[1] as representative_source_path,
+        count(*)::int as project_occurrence_count,
+        count(*) filter (where ${pathPredicate})::int as file_occurrence_count,
+        case
+          when bool_or(coalesce(trim(target_text), '') = '') then 0
+          when bool_or(target_status != 'approved') then 1
+          else 2
+        end as untranslated_rank
+      from scoped
+      group by grouping_key, source_text_hash, source_text
+      having count(*) filter (where ${pathPredicate}) > 0
+        and ${searchPredicate}
+        and ${filterPredicate}
+    ), counted as (
+      select
+        *,
+        count(*) over ()::int as total_logical_rows,
+        sum(project_occurrence_count) over ()::int as total_source_occurrences
+      from grouped
+    )
+    select
+      representative_id as "representativeId",
+      representative_key as "representativeKey",
+      source_text as "sourceText",
+      source_text_hash as "sourceTextHash",
+      representative_context as "representativeContext",
+      representative_type as "representativeType",
+      representative_max_length as "representativeMaxLength",
+      representative_metadata as "representativeMetadata",
+      representative_hidden as "representativeHidden",
+      representative_source_path as "representativeSourcePath",
+      project_occurrence_count as "projectOccurrenceCount",
+      file_occurrence_count as "fileOccurrenceCount",
+      total_logical_rows as "totalLogicalRows",
+      total_source_occurrences as "totalSourceOccurrences"
+    from counted
+    order by ${order}
+    limit ${input.limit}
+    offset ${input.offset}
+  `);
+
+  const logicalRows: NativeCatLogicalRow[] = rows.map((row) => {
+    const projectOccurrenceCount = Number(row.projectOccurrenceCount);
+    if (projectOccurrenceCount === 1) {
+      return {
+        kind: "segment",
+        externalStringId: row.representativeId,
+        translationKeyId: row.representativeId,
+        key: row.representativeKey,
+        sourceText: row.sourceText,
+        context: row.representativeContext,
+        type: row.representativeType,
+        maxLength: row.representativeMaxLength,
+        metadata: row.representativeMetadata,
+        isHidden: row.representativeHidden,
+        sourcePath: row.representativeSourcePath,
+        projectOccurrenceCount,
+        fileOccurrenceCount: Number(row.fileOccurrenceCount),
+      };
+    }
+
+    const groupId = nativeCatGroupId({
+      projectId: input.projectId,
+      targetLocale: input.targetLocale,
+      sourceText: row.sourceText,
+    });
+    return {
+      kind: "group",
+      externalStringId: groupId,
+      translationKeyId: null,
+      groupId,
+      sourceTextHash: row.sourceTextHash,
+      key: row.representativeKey,
+      sourceText: row.sourceText,
+      context: row.representativeContext,
+      type: row.representativeType,
+      maxLength: row.representativeMaxLength,
+      metadata: row.representativeMetadata,
+      isHidden: row.representativeHidden,
+      sourcePath: row.representativeSourcePath,
+      projectOccurrenceCount,
+      fileOccurrenceCount: Number(row.fileOccurrenceCount),
+    };
+  });
+
+  return {
+    rows: logicalRows,
+    totalLogicalRows: Number(rows[0]?.totalLogicalRows ?? 0),
+    totalSourceOccurrences: Number(rows[0]?.totalSourceOccurrences ?? 0),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-group-resolver.ts
@@ -25,12 +25,8 @@ export type NativeCatGroupingExceptionResolver = (input: {
   targetLocale: string;
 }) => Promise<readonly string[]> | readonly string[];
 
-export type NativeCatLogicalRow = {
-  kind: "segment" | "group";
+type NativeCatLogicalRowBase = {
   externalStringId: string;
-  translationKeyId: string | null;
-  groupId?: string;
-  sourceTextHash?: string;
   key: string;
   sourceText: string;
   context: string | null;
@@ -42,6 +38,18 @@ export type NativeCatLogicalRow = {
   projectOccurrenceCount: number;
   fileOccurrenceCount: number;
 };
+
+export type NativeCatLogicalRow =
+  | (NativeCatLogicalRowBase & {
+      kind: "segment";
+      translationKeyId: string;
+    })
+  | (NativeCatLogicalRowBase & {
+      kind: "group";
+      translationKeyId: null;
+      groupId: string;
+      sourceTextHash: string;
+    });
 
 type GroupedRow = {
   representativeId: string;
@@ -74,6 +82,21 @@ export function nativeCatGroupId(input: {
     .digest("hex");
 }
 
+function executedRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) {
+    return result as T[];
+  }
+  if (
+    result &&
+    typeof result === "object" &&
+    "rows" in result &&
+    Array.isArray((result as { rows: unknown }).rows)
+  ) {
+    return (result as { rows: T[] }).rows;
+  }
+  return [];
+}
+
 function escapeLike(value: string) {
   return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
@@ -83,9 +106,12 @@ function groupFilter(filter: ProjectFileCatQueueFilter): SQL {
     case "untranslated":
       return sql`bool_or(coalesce(trim(target_text), '') = '')`;
     case "reviewed":
-      return sql`bool_and(target_status = 'approved')`;
+      return sql`bool_and(coalesce(target_status = 'approved', false))`;
     case "needs_review":
-      return sql`bool_or(coalesce(trim(target_text), '') != '' and target_status != 'approved')`;
+      return sql`bool_or(
+        coalesce(trim(target_text), '') != ''
+        and coalesce(target_status, 'draft') != 'approved'
+      )`;
     case "has_issues":
       return sql`bool_or(has_issues)`;
     case "hidden":
@@ -156,7 +182,7 @@ export async function resolveNativeCatLogicalRows(
       ? sql`untranslated_rank, representative_source_path, representative_key, representative_id`
       : sql`representative_source_path, representative_key, representative_id`;
 
-  const rows = await database.execute<GroupedRow>(sql`
+  const queryResult = await database.execute<GroupedRow>(sql`
     with scoped as (
       select
         k.id,
@@ -249,6 +275,7 @@ export async function resolveNativeCatLogicalRows(
     limit ${input.limit}
     offset ${input.offset}
   `);
+  const rows = executedRows<GroupedRow>(queryResult);
 
   const logicalRows: NativeCatLogicalRow[] = rows.map((row) => {
     const projectOccurrenceCount = Number(row.projectOccurrenceCount);

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -16,7 +16,6 @@ import type {
   ProjectFileCatComment,
   ProjectFileCatQueueFile,
   ProjectFileCatQueueSegment,
-  ProjectFileCatSegment,
   ProjectFileCatTranslation,
 } from "@/api/routes/project/project.schema";
 import { legacyNativeCatSegmentLimit } from "@/api/routes/project/project.schema";
@@ -388,7 +387,7 @@ export class NativeCatService extends ProjectServiceBase {
             sourcePath: row.sourcePath,
             kind: row.kind,
             groupId: row.kind === "group" ? row.groupId : undefined,
-            sourceTextHash: row.sourceTextHash,
+            sourceTextHash: row.kind === "group" ? row.sourceTextHash : undefined,
             projectOccurrenceCount: row.projectOccurrenceCount,
             fileOccurrenceCount: row.fileOccurrenceCount,
           },

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -110,7 +110,7 @@ function toCatTranslation(row: {
   };
 }
 
-function mapTextSegment(
+function mapTextSegmentSharedFields(
   key: {
     id: string;
     key: string;
@@ -121,15 +121,9 @@ function mapTextSegment(
     metadata: Record<string, unknown> | null;
     isHidden?: boolean;
     sourcePath?: string;
-    kind?: "segment" | "group";
-    translationKeyId?: string | null;
-    groupId?: string;
-    sourceTextHash?: string;
-    projectOccurrenceCount?: number;
-    fileOccurrenceCount?: number;
   },
   options?: { includeSourcePath?: boolean },
-): ProjectFileCatQueueSegment {
+) {
   const isVideoUrl = isVideoUrlContentKind(key.metadata);
   const isImageUrl = isImageUrlContentKind(key.metadata);
   const contentKind = isVideoUrl
@@ -141,7 +135,6 @@ function mapTextSegment(
   const looksLikeVideo = looksLikeVideoUrl(key.sourceText);
 
   return {
-    ...(key.kind ? { kind: key.kind } : {}),
     externalStringId: key.id,
     key: key.key,
     sourceText: key.sourceText,
@@ -156,15 +149,44 @@ function mapTextSegment(
     ...(looksLikeImage || isImageUrl ? { looksLikeImageUrl: looksLikeImage || isImageUrl } : {}),
     ...(looksLikeVideo || isVideoUrl ? { looksLikeVideoUrl: looksLikeVideo || isVideoUrl } : {}),
     ...(options?.includeSourcePath && key.sourcePath ? { sourcePath: key.sourcePath } : {}),
-    ...(key.kind === "group"
-      ? {
-          groupId: key.groupId!,
-          sourceTextHash: key.sourceTextHash!,
-          translationKeyId: null,
-          projectOccurrenceCount: key.projectOccurrenceCount!,
-          fileOccurrenceCount: key.fileOccurrenceCount!,
-        }
-      : {}),
+  };
+}
+
+function mapTextSegment(
+  key: {
+    id: string;
+    key: string;
+    sourceText: string;
+    context: string | null;
+    type: string | null;
+    maxLength: number | null;
+    metadata: Record<string, unknown> | null;
+    isHidden?: boolean;
+    sourcePath?: string;
+    kind?: "segment" | "group";
+    groupId?: string;
+    sourceTextHash?: string;
+    projectOccurrenceCount?: number;
+    fileOccurrenceCount?: number;
+  },
+  options?: { includeSourcePath?: boolean },
+): ProjectFileCatQueueSegment {
+  const shared = mapTextSegmentSharedFields(key, options);
+  if (key.kind === "group") {
+    return {
+      ...shared,
+      kind: "group",
+      groupId: key.groupId!,
+      sourceTextHash: key.sourceTextHash!,
+      translationKeyId: null,
+      projectOccurrenceCount: key.projectOccurrenceCount!,
+      fileOccurrenceCount: key.fileOccurrenceCount!,
+    };
+  }
+
+  return {
+    ...shared,
+    ...(key.kind ? { kind: "segment" as const } : {}),
   };
 }
 
@@ -365,8 +387,7 @@ export class NativeCatService extends ProjectServiceBase {
             isHidden: row.isHidden,
             sourcePath: row.sourcePath,
             kind: row.kind,
-            translationKeyId: row.translationKeyId,
-            groupId: row.groupId,
+            groupId: row.kind === "group" ? row.groupId : undefined,
             sourceTextHash: row.sourceTextHash,
             projectOccurrenceCount: row.projectOccurrenceCount,
             fileOccurrenceCount: row.fileOccurrenceCount,

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -10,11 +10,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import type {
   ProjectFileCatComment,
   ProjectFileCatQueueFile,
+  ProjectFileCatQueueSegment,
   ProjectFileCatSegment,
   ProjectFileCatTranslation,
 } from "@/api/routes/project/project.schema";
@@ -22,6 +23,10 @@ import { legacyNativeCatSegmentLimit } from "@/api/routes/project/project.schema
 import { db, schema } from "@/lib/database";
 import { getLatestRepositorySourceFileVersion } from "@/lib/file-storage/records";
 import { NativeCatCommentService } from "@/lib/projects/cat/native-cat-comment-service";
+import {
+  nativeCatGroupId,
+  resolveNativeCatLogicalRows,
+} from "@/lib/projects/cat/native-cat-group-resolver";
 import {
   CAT_ALL_FILES_FILENAME,
   CAT_ALL_FILES_SOURCE_PATH,
@@ -116,9 +121,15 @@ function mapTextSegment(
     metadata: Record<string, unknown> | null;
     isHidden?: boolean;
     sourcePath?: string;
+    kind?: "segment" | "group";
+    translationKeyId?: string | null;
+    groupId?: string;
+    sourceTextHash?: string;
+    projectOccurrenceCount?: number;
+    fileOccurrenceCount?: number;
   },
   options?: { includeSourcePath?: boolean },
-): ProjectFileCatSegment {
+): ProjectFileCatQueueSegment {
   const isVideoUrl = isVideoUrlContentKind(key.metadata);
   const isImageUrl = isImageUrlContentKind(key.metadata);
   const contentKind = isVideoUrl
@@ -130,6 +141,7 @@ function mapTextSegment(
   const looksLikeVideo = looksLikeVideoUrl(key.sourceText);
 
   return {
+    ...(key.kind ? { kind: key.kind } : {}),
     externalStringId: key.id,
     key: key.key,
     sourceText: key.sourceText,
@@ -144,6 +156,15 @@ function mapTextSegment(
     ...(looksLikeImage || isImageUrl ? { looksLikeImageUrl: looksLikeImage || isImageUrl } : {}),
     ...(looksLikeVideo || isVideoUrl ? { looksLikeVideoUrl: looksLikeVideo || isVideoUrl } : {}),
     ...(options?.includeSourcePath && key.sourcePath ? { sourcePath: key.sourcePath } : {}),
+    ...(key.kind === "group"
+      ? {
+          groupId: key.groupId!,
+          sourceTextHash: key.sourceTextHash!,
+          translationKeyId: null,
+          projectOccurrenceCount: key.projectOccurrenceCount!,
+          fileOccurrenceCount: key.fileOccurrenceCount!,
+        }
+      : {}),
   };
 }
 
@@ -171,7 +192,22 @@ export class NativeCatService extends ProjectServiceBase {
     pagination?: ProjectFileCatPaginationInput;
     sourcePaths?: readonly string[] | null;
   }): Promise<ProjectFileCatQueueFile | null> {
+    const paginationInput = input.pagination ?? {
+      offset: 0,
+      limit: legacyNativeCatSegmentLimit,
+      search: undefined,
+      queueFilter: "all" as const,
+      queueSort: "file_order" as const,
+      paginated: false,
+    };
+
     if (isCatAllFilesSourcePath(input.sourcePath)) {
+      const groupingEnabled = this.translations.isIdenticalStringGroupingEnabled
+        ? await this.translations.isIdenticalStringGroupingEnabled(input)
+        : false;
+      if (groupingEnabled) {
+        return this.getGroupedCatQueue(input, paginationInput);
+      }
       return this.getAllFilesCatQueue(input);
     }
 
@@ -206,14 +242,13 @@ export class NativeCatService extends ProjectServiceBase {
       });
     }
 
-    const paginationInput = input.pagination ?? {
-      offset: 0,
-      limit: legacyNativeCatSegmentLimit,
-      search: undefined,
-      queueFilter: "all",
-      queueSort: "file_order",
-      paginated: false,
-    };
+    const groupingEnabled = this.translations.isIdenticalStringGroupingEnabled
+      ? await this.translations.isIdenticalStringGroupingEnabled(input)
+      : false;
+
+    if (groupingEnabled) {
+      return this.getGroupedCatQueue(input, paginationInput);
+    }
 
     if (!paginationInput.paginated) {
       const keys = await this.translations.listKeysForFile({
@@ -269,6 +304,77 @@ export class NativeCatService extends ProjectServiceBase {
       truncated: pagination.hasMore,
       pagination,
     });
+  }
+
+  private async getGroupedCatQueue(
+    input: {
+      organizationId: string;
+      projectId: string;
+      sourcePath: string;
+      targetLocale: string;
+      canEditTranslations: boolean;
+      sourcePaths?: readonly string[] | null;
+    },
+    paginationInput: ProjectFileCatPaginationInput,
+  ): Promise<ProjectFileCatQueueFile> {
+    const result = await resolveNativeCatLogicalRows(
+      {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetLocale: input.targetLocale,
+        sourcePath: input.sourcePath,
+        sourcePaths: input.sourcePaths,
+        limit: paginationInput.limit,
+        offset: paginationInput.offset,
+        search: paginationInput.search,
+        queueFilter: paginationInput.queueFilter ?? "all",
+        queueSort: paginationInput.queueSort ?? "file_order",
+      },
+      { database: this.database },
+    );
+    const pagination = buildCatFilePagination({
+      offset: paginationInput.offset,
+      limit: paginationInput.limit,
+      returnedCount: result.rows.length,
+      totalCount: result.totalLogicalRows,
+    });
+
+    return {
+      sourcePath: input.sourcePath,
+      filename: isCatAllFilesSourcePath(input.sourcePath)
+        ? CAT_ALL_FILES_FILENAME
+        : filenameFromSourcePath(input.sourcePath),
+      provider: null,
+      targetLocale: input.targetLocale,
+      canEditTranslations: input.canEditTranslations,
+      truncated: pagination.hasMore,
+      pagination: {
+        ...pagination,
+        totalSourceOccurrences: result.totalSourceOccurrences,
+      },
+      segments: result.rows.map((row) =>
+        mapTextSegment(
+          {
+            id: row.externalStringId,
+            key: row.key,
+            sourceText: row.sourceText,
+            context: row.context,
+            type: row.type,
+            maxLength: row.maxLength,
+            metadata: row.metadata,
+            isHidden: row.isHidden,
+            sourcePath: row.sourcePath,
+            kind: row.kind,
+            translationKeyId: row.translationKeyId,
+            groupId: row.groupId,
+            sourceTextHash: row.sourceTextHash,
+            projectOccurrenceCount: row.projectOccurrenceCount,
+            fileOccurrenceCount: row.fileOccurrenceCount,
+          },
+          { includeSourcePath: isCatAllFilesSourcePath(input.sourcePath) },
+        ),
+      ),
+    };
   }
 
   private async buildImageCatFileResponse(input: {
@@ -967,6 +1073,92 @@ export class NativeCatService extends ProjectServiceBase {
 
     return commentsByKeyId.get(key.id) ?? [];
   }
+
+  async getGroupOccurrences(input: {
+    organizationId: string;
+    projectId: string;
+    targetLocale: string;
+    groupId: string;
+    sourceTextHash: string;
+  }) {
+    const candidates = await this.database
+      .select({
+        id: schema.projectTranslationKeys.id,
+        key: schema.projectTranslationKeys.key,
+        sourceText: schema.projectTranslationKeys.sourceText,
+        context: schema.projectTranslationKeys.context,
+        sourcePath: schema.repositorySourceFiles.sourcePath,
+      })
+      .from(schema.projectTranslationKeys)
+      .innerJoin(
+        schema.repositorySourceFiles,
+        eq(schema.projectTranslationKeys.repositorySourceFileId, schema.repositorySourceFiles.id),
+      )
+      .where(
+        and(
+          eq(schema.projectTranslationKeys.organizationId, input.organizationId),
+          eq(schema.projectTranslationKeys.projectId, input.projectId),
+          eq(schema.projectTranslationKeys.sourceTextHash, input.sourceTextHash),
+        ),
+      );
+    const members = candidates.filter(
+      (candidate) =>
+        nativeCatGroupId({
+          projectId: input.projectId,
+          targetLocale: input.targetLocale,
+          sourceText: candidate.sourceText,
+        }) === input.groupId,
+    );
+    if (members.length < 2) return null;
+
+    const memberIds = members.map((member) => member.id);
+    const [translations, commentsByKeyId] = await Promise.all([
+      this.translations.getTranslationsByKeyIds({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        translationKeyIds: memberIds,
+        targetLocale: input.targetLocale,
+      }),
+      this.comments.listByKeyIds({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        translationKeyIds: memberIds,
+        targetLocale: input.targetLocale,
+      }),
+    ]);
+    const lockedIds = new Set(
+      (
+        await this.database
+          .select({ externalStringId: schema.projectCatSegmentLocks.externalStringId })
+          .from(schema.projectCatSegmentLocks)
+          .where(
+            and(
+              eq(schema.projectCatSegmentLocks.organizationId, input.organizationId),
+              eq(schema.projectCatSegmentLocks.projectId, input.projectId),
+              eq(schema.projectCatSegmentLocks.targetLocale, input.targetLocale),
+              inArray(schema.projectCatSegmentLocks.externalStringId, memberIds),
+            ),
+          )
+      ).map((row) => row.externalStringId),
+    );
+    const translationByKeyId = new Map(
+      translations.map((translation) => [translation.translationKeyId, translation]),
+    );
+
+    return members.map((member) => {
+      const translation = translationByKeyId.get(member.id);
+      return {
+        translationKeyId: member.id,
+        key: member.key,
+        sourcePath: member.sourcePath,
+        context: member.context,
+        comments: commentsByKeyId.get(member.id) ?? [],
+        isLocked: lockedIds.has(member.id),
+        target: translation ? toCatTranslation(translation) : null,
+        reviewState: translation?.status ?? null,
+      };
+    });
+  }
 }
 
 export const nativeCatService = new NativeCatService();
@@ -981,6 +1173,10 @@ export const getNativeProjectCatSegmentTarget = (
 export const getNativeProjectCatSegmentComments = (
   input: Parameters<NativeCatService["getSegmentComments"]>[0],
 ) => nativeCatService.getSegmentComments(input);
+
+export const getNativeProjectCatGroupOccurrences = (
+  input: Parameters<NativeCatService["getGroupOccurrences"]>[0],
+) => nativeCatService.getGroupOccurrences(input);
 
 export const saveNativeProjectCatTranslation = (
   input: Parameters<NativeCatService["saveTranslation"]>[0],

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -191,6 +191,20 @@ export class ProjectTranslationService extends ProjectServiceBase {
     super(database, "projects.translations");
   }
 
+  async isIdenticalStringGroupingEnabled(input: { organizationId: string; projectId: string }) {
+    const [project] = await this.database
+      .select({ enabled: schema.projects.automaticallyGroupIdenticalStrings })
+      .from(schema.projects)
+      .where(
+        and(
+          eq(schema.projects.organizationId, input.organizationId),
+          eq(schema.projects.id, input.projectId),
+        ),
+      )
+      .limit(1);
+    return project?.enabled ?? false;
+  }
+
   async getRepositorySourceFileByPath(input: {
     organizationId: string;
     projectId: string;

--- a/docs/adr/2026-08-24-native-cat-exact-source-group-resolution-design.md
+++ b/docs/adr/2026-08-24-native-cat-exact-source-group-resolution-design.md
@@ -1,0 +1,23 @@
+# Native CAT exact-source group resolution
+
+## Context
+
+Native CAT queue pages cannot determine duplicate membership because matching source keys may live on another page or in another repository file. The backend must derive groups from the native project scope while keeping translation keys and translations as the persistence boundary.
+
+## Design
+
+Each imported native translation key stores a SHA-256 hash of its exact UTF-8 source text. Source synchronization recomputes the hash whenever it upserts a key. A composite project-and-hash index supports candidate grouping and member lookup without indexing arbitrarily long source text.
+
+The hash accelerates database access; it does not define equality. Group queries also compare the raw `sourceText`, so normalization and hash collisions cannot merge different sources. A group ID is derived from the project ID, target locale, source hash, and exact source text. No synthetic key, group, or membership record is stored.
+
+When `automaticallyGroupIdenticalStrings` is disabled, native CAT keeps its existing segment query. When enabled, PostgreSQL resolves logical rows before queue filtering, ordering, counting, and pagination. A logical row is either an individual segment or a group summary. Group summaries report occurrence counts for the selected file and the project. The resolver accepts an exception predicate seam for HL-622.
+
+The queue does not include complete group membership. A native group-occurrences endpoint resolves the group again by project, locale, hash, and exact source text, then returns the current translation keys with their file, context, comments, lock, target, and review state. Imports and synchronization therefore cannot leave stale members in a group.
+
+## Performance
+
+Import computes one SHA-256 digest per source key. Queue and occurrence queries use the composite project-and-hash index and keep grouping, filtering, ordering, counting, and pagination in PostgreSQL. The application receives only the requested logical summaries or one opened group's members.
+
+## Tests
+
+Focused tests cover exact versus normalized source equality, cross-file membership, deterministic IDs, setting-disabled behavior, logical filters and ordering, logical-row and occurrence totals, pagination across groups, lazy occurrence loading, exception subtraction, and source changes after synchronization.


### PR DESCRIPTION
### Motivation

- Enable efficient identification and lazy resolution of identical exact source strings across a project by hashing long source text and grouping logical rows for CAT queues. 
- Avoid storing synthetic group membership; compute groups on demand and keep translation keys/translations as the persistence boundary. 
- Provide an endpoint to fetch full occurrences for a selected group on demand while preserving pagination and counts.

### Description

- Database: add generated SHA-256 column `source_text_hash` to `project_translation_keys` and create index `idx_project_translation_keys_project_source_hash` via migration `drizzle/0096_outstanding_blink.sql`, and update drizzle metadata/journal snapshots. 
- Schema & types: introduce `projectFileCatGroup*` schemas and types, add `totalSourceOccurrences` to pagination schema, and allow CAT queue segments to be either `segment` or `group`. 
- API & routing: add validators and new route `GET /:projectId/files/detail/cat/groups/:groupId/occurrences` to fetch occurrences for a group, and wire new query validators into the project routes. 
- Backend logic: implement `native-cat-group-resolver` to derive deterministic group IDs, resolve logical rows (groups vs segments) in PostgreSQL using the new hash/index, and expose `getGroupOccurrences` in `native-cat-service`; integrate grouping into `getCatFile` flow and return grouping-aware pagination and segments. 
- Translation service: add `isIdenticalStringGroupingEnabled` check on the project to toggle behavior via `automaticallyGroupIdenticalStrings`. 
- Tests & docs: add unit tests `native-cat-group-resolver.test.ts` and an ADR documenting design and performance considerations.

### Testing

- Added unit tests in `src/lib/projects/cat/native-cat-group-resolver.test.ts` and ran them with the project's test runner; tests passed. 
- Ran the backend test suite (unit tests) after integrating the changes; all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8bf6b83ad4832c8cc68805c803e559)