### PR TITLE
fix(glossary): defer term deletion until save

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content-msw-handlers.ts
@@ -24,14 +24,19 @@ export function createGlossaryDetailMswHandlers({
   attachedProjects = [],
   projects = [],
   conceptsLoading = false,
+  onConceptUpdate,
+  onTermDelete,
 }: {
   glossary: GlossaryRecord;
   concepts: GlossaryConceptRecord[];
   attachedProjects?: GlossaryProjectRecord[];
   projects?: Array<{ id: string; name: string; sourceLocale: string }>;
   conceptsLoading?: boolean;
+  onConceptUpdate?: (termIds: string[]) => void;
+  onTermDelete?: (termId: string) => void;
 }) {
   let currentGlossary = glossary;
+  let currentConcepts = concepts;
 
   return [
     http.get("/api/orgs/:organizationSlug/glossaries/:glossaryId", () =>
@@ -46,8 +51,45 @@ export function createGlossaryDetailMswHandlers({
     }),
     http.get("/api/orgs/:organizationSlug/glossaries/:glossaryId/concepts", async () => {
       if (conceptsLoading) await delay("infinite");
-      return HttpResponse.json({ concepts, total: concepts.length });
+      return HttpResponse.json({
+        concepts: currentConcepts,
+        total: currentConcepts.length,
+      });
     }),
+    http.patch(
+      "/api/orgs/:organizationSlug/glossaries/:glossaryId/concepts/:conceptId",
+      async ({ params, request }) => {
+        const body = (await request.json()) as {
+          primaryTerm?: string;
+          terms?: Array<{ id?: string }>;
+        };
+        const conceptId = String(params.conceptId);
+        const currentConcept = currentConcepts.find((concept) => concept.id === conceptId);
+        if (!currentConcept) return HttpResponse.json({ error: "not_found" }, { status: 404 });
+
+        const termIds = new Set((body.terms ?? []).flatMap((term) => (term.id ? [term.id] : [])));
+        currentConcepts = currentConcepts.map((concept) =>
+          concept.id === conceptId
+            ? {
+                ...concept,
+                primaryTerm: body.primaryTerm ?? concept.primaryTerm,
+                terms: concept.terms.filter((term) => termIds.has(term.id)),
+              }
+            : concept,
+        );
+        onConceptUpdate?.(body.terms?.flatMap((term) => (term.id ? [term.id] : [])) ?? []);
+        return HttpResponse.json({
+          concept: currentConcepts.find((concept) => concept.id === conceptId),
+        });
+      },
+    ),
+    http.delete(
+      "/api/orgs/:organizationSlug/glossaries/:glossaryId/concepts/:conceptId/terms/:termId",
+      ({ params }) => {
+        onTermDelete?.(String(params.termId));
+        return new HttpResponse(null, { status: 204 });
+      },
+    ),
     http.get("/api/orgs/:organizationSlug/glossaries/:glossaryId/projects", () =>
       HttpResponse.json({ projects: attachedProjects }),
     ),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
@@ -60,11 +60,6 @@ export const glossaryDetailPageContentMessages = defineMessages({
     id: "iCizofrwwK",
     description: "Fallback error when saving a glossary term fails",
   },
-  deleteTermFailed: {
-    defaultMessage: "Unable to delete term",
-    id: "gN0y8UhzTR",
-    description: "Fallback error when deleting a glossary term fails",
-  },
   importTermsFailed: {
     defaultMessage: "Unable to import terms",
     id: "ujii3FwBE5",
@@ -486,8 +481,8 @@ export const glossaryDetailPageContentMessages = defineMessages({
     description: "Title of the term deletion confirmation dialog",
   },
   confirmDeleteTermDescription: {
-    defaultMessage: "This term will be removed from the concept and cannot be restored.",
-    id: "tQnEG79lWB",
+    defaultMessage: "This term will be removed from the concept when you save.",
+    id: "WhmV5YamvS",
     description: "Description of the term deletion confirmation dialog",
   },
   noConcepts: {
@@ -524,10 +519,5 @@ export const glossaryDetailPageContentMessages = defineMessages({
     defaultMessage: "Term saved",
     id: "TmON06MWzq",
     description: "Toast after a concept term is saved",
-  },
-  termDeletedFromConcept: {
-    defaultMessage: "Term deleted",
-    id: "ECdzHS9iJQ",
-    description: "Toast after a concept term is deleted",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
@@ -11,7 +11,7 @@
  * Version 2.0 or later.
  */
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect, userEvent, waitFor } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import type { GlossaryConceptRecord, GlossaryRecord } from "@/api/routes/glossary/glossary.schema";
 
@@ -110,6 +110,8 @@ const conceptFixture: GlossaryConceptRecord = {
 };
 
 const conceptsFixture = [conceptFixture];
+const onConceptUpdate = fn();
+const onTermDelete = fn();
 
 const meta = {
   title: "App/Glossaries/Detail",
@@ -130,6 +132,8 @@ type Story = StoryObj<typeof meta>;
 const detailHandlers = createGlossaryDetailMswHandlers({
   glossary: glossaryFixture,
   concepts: conceptsFixture,
+  onConceptUpdate,
+  onTermDelete,
 });
 
 export const ConceptList: Story = {
@@ -209,6 +213,23 @@ export const ConceptDetail: Story = {
     await expect(canvas.getByRole("button", { name: "Save" })).toBeEnabled();
     await waitFor(() => {
       void expect(termRow?.querySelector(".bg-emerald-500")).toBeTruthy();
+    });
+
+    const expandTermButton = termRow?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Expand term details"]',
+    );
+    if (!expandTermButton) throw new Error("Term details button not found");
+    await userEvent.click(expandTermButton);
+    await userEvent.click(canvas.getByRole("button", { name: "Delete term" }));
+    const deleteDialog = canvas.getByRole("dialog", { name: "Delete this term?" });
+    await userEvent.click(within(deleteDialog).getByRole("button", { name: "Delete term" }));
+    await expect(canvas.queryByDisplayValue("Đại lý updated")).not.toBeInTheDocument();
+    await expect(onTermDelete).not.toHaveBeenCalled();
+    await expect(canvas.getByRole("button", { name: "Save" })).toBeEnabled();
+    await expect(onConceptUpdate).not.toHaveBeenCalled();
+    await userEvent.click(canvas.getByRole("button", { name: "Save" }));
+    await waitFor(() => {
+      void expect(onConceptUpdate).toHaveBeenCalledWith(["term-en-1"]);
     });
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -842,6 +842,7 @@ export function GlossaryDetailPageContent({
   const [newTermDraft, setNewTermDraft] = useState<TermDraft>(emptyTermDraft);
   const [creatingTermDrafts, setCreatingTermDrafts] = useState<CreatingTermDraft[]>([]);
   const [termDrafts, setTermDrafts] = useState<Record<string, TermDraft>>({});
+  const [deletedTermIds, setDeletedTermIds] = useState<Set<string>>(new Set());
   const [expandedTermIds, setExpandedTermIds] = useState<Set<string>>(new Set());
   const [expandedCreatingTermIds, setExpandedCreatingTermIds] = useState<Set<string>>(new Set());
   const [termToDeleteId, setTermToDeleteId] = useState<string | null>(null);
@@ -947,6 +948,7 @@ export function GlossaryDetailPageContent({
     if (conceptId === "new") {
       setConceptDraft(emptyConceptDraft);
       setTermDrafts({});
+      setDeletedTermIds(new Set());
       setCreatingTermDrafts(
         sourceLanguage.locale
           ? [createCreatingTermDraft(sourceLanguage.locale, `new-source-${sourceLanguage.locale}`)]
@@ -967,6 +969,7 @@ export function GlossaryDetailPageContent({
           selectedConcept.terms.map((term) => [term.id, termDraftFromRecord(term)]),
         ),
       );
+      setDeletedTermIds(new Set());
       setNewTermLocale(null);
       setNewTermDraft(emptyTermDraft);
       setCreatingTermDrafts([]);
@@ -979,15 +982,17 @@ export function GlossaryDetailPageContent({
   const conceptTermCandidates = isCreatingConcept
     ? creatingTermDrafts
     : [
-        ...(selectedConcept?.terms ?? []).map((term) => {
-          const draft = termDrafts[term.id] ?? termDraftFromRecord(term);
-          return {
-            id: term.id,
-            locale: term.locale,
-            term: draft.term,
-            status: draft.status,
-          };
-        }),
+        ...(selectedConcept?.terms ?? [])
+          .filter((term) => !deletedTermIds.has(term.id))
+          .map((term) => {
+            const draft = termDrafts[term.id] ?? termDraftFromRecord(term);
+            return {
+              id: term.id,
+              locale: term.locale,
+              term: draft.term,
+              status: draft.status,
+            };
+          }),
         ...(newTermLocale
           ? [
               {
@@ -1013,6 +1018,20 @@ export function GlossaryDetailPageContent({
       const draft = current[termId];
       return draft ? { ...current, [termId]: { ...draft, ...patch } } : current;
     });
+  };
+
+  const markTermForDeletion = (termId: string) => {
+    setDeletedTermIds((current) => {
+      const next = new Set(current);
+      next.add(termId);
+      return next;
+    });
+    setExpandedTermIds((current) => {
+      const next = new Set(current);
+      next.delete(termId);
+      return next;
+    });
+    setTermToDeleteId(null);
   };
 
   const invalidateConcepts = () =>
@@ -1069,23 +1088,25 @@ export function GlossaryDetailPageContent({
       } else {
         if (!selectedConceptId) throw new Error(intl.formatMessage(messages.saveConceptFailed));
         const terms: UpsertGlossaryConceptTermBody[] = selectedConcept
-          ? selectedConcept.terms.map((term) => {
-              const termDraft = termDrafts[term.id] ?? termDraftFromRecord(term);
-              return {
-                id: term.id,
-                locale: term.locale,
-                term: termDraft.term,
-                partOfSpeech: normalizePartOfSpeech(termDraft.partOfSpeech),
-                gender: termDraft.gender as UpsertGlossaryConceptTermBody["gender"],
-                termType: termDraft.termType as UpsertGlossaryConceptTermBody["termType"],
-                status: termDraft.status,
-                description: termDraft.description,
-                note: termDraft.note,
-                url: termDraft.url,
-                caseSensitive: term.caseSensitive,
-                forbidden: term.forbidden,
-              };
-            })
+          ? selectedConcept.terms
+              .filter((term) => !deletedTermIds.has(term.id))
+              .map((term) => {
+                const termDraft = termDrafts[term.id] ?? termDraftFromRecord(term);
+                return {
+                  id: term.id,
+                  locale: term.locale,
+                  term: termDraft.term,
+                  partOfSpeech: normalizePartOfSpeech(termDraft.partOfSpeech),
+                  gender: termDraft.gender as UpsertGlossaryConceptTermBody["gender"],
+                  termType: termDraft.termType as UpsertGlossaryConceptTermBody["termType"],
+                  status: termDraft.status,
+                  description: termDraft.description,
+                  note: termDraft.note,
+                  url: termDraft.url,
+                  caseSensitive: term.caseSensitive,
+                  forbidden: term.forbidden,
+                };
+              })
           : [];
         if (newTermLocale && newTermDraft.term.trim()) {
           terms.push({
@@ -1157,26 +1178,6 @@ export function GlossaryDetailPageContent({
       if (conceptPageMode) router.push(glossaryHref);
       else setSelectedConceptId(null);
       toast.success(intl.formatMessage(messages.conceptDeleted));
-    },
-    onError: (error) => toast.error(error.message),
-  });
-  const deleteTerm = useMutation({
-    mutationFn: async (termId: string) => {
-      if (!selectedConceptId) return;
-      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
-        ":glossaryId"
-      ].concepts[":conceptId"].terms[":termId"].$delete({
-        param: { organizationSlug, glossaryId, conceptId: selectedConceptId, termId },
-      });
-      if (!response.ok)
-        throw new Error(
-          await readApiError(response, intl.formatMessage(messages.deleteTermFailed)),
-        );
-    },
-    onSuccess: async () => {
-      await invalidateConcepts();
-      setTermToDeleteId(null);
-      toast.success(intl.formatMessage(messages.termDeletedFromConcept));
     },
     onError: (error) => toast.error(error.message),
   });
@@ -1313,6 +1314,7 @@ export function GlossaryDetailPageContent({
   const normalizedLanguageFilter = languageFilter.trim().toLowerCase();
   const availableTermLocales = availableConceptTermLocales();
   const termGroups = (selected?.terms ?? [])
+    .filter((term) => !deletedTermIds.has(term.id))
     .filter(
       (term) =>
         !normalizedLanguageFilter ||
@@ -1352,12 +1354,14 @@ export function GlossaryDetailPageContent({
     : selectedConcept
       ? !areConceptDraftsEqual(conceptDraft, conceptDraftFromRecord(selectedConcept))
       : false;
-  const termsAreDirty = Boolean(
-    selectedConcept?.terms.some((term) => {
-      const draft = termDrafts[term.id];
-      return draft && !areTermDraftsEqual(draft, termDraftFromRecord(term));
-    }),
-  );
+  const termsAreDirty =
+    deletedTermIds.size > 0 ||
+    Boolean(
+      selectedConcept?.terms.some((term) => {
+        const draft = termDrafts[term.id];
+        return draft && !areTermDraftsEqual(draft, termDraftFromRecord(term));
+      }),
+    );
   const newTermIsDirty = Boolean(newTermLocale && newTermDraft.term.trim());
   const isDirty =
     conceptIsDirty || termsAreDirty || newTermIsDirty || creatingTermDrafts.length > 0;
@@ -2842,9 +2846,8 @@ export function GlossaryDetailPageContent({
             </AlertDialogCancel>
             <AlertDialogAction
               variant="destructive"
-              disabled={deleteTerm.isPending}
               onClick={() => {
-                if (termToDeleteId) deleteTerm.mutate(termToDeleteId);
+                if (termToDeleteId) markTermForDeletion(termToDeleteId);
               }}
             >
               <FormattedMessage {...messages.deleteTerm} />


### PR DESCRIPTION
## Summary

- Defer persisted glossary term deletion until the concept Save action.
- Remove deleted terms locally and include the remaining terms in the concept update payload.
- Update confirmation copy and add Storybook/MSW coverage.

## Validation

- vp check --fix passes with existing unrelated warnings.
- vp test is blocked by unavailable Postgres and localhost:3000 dependencies.
- Storybook build is blocked by unavailable Google Fonts DNS resolution.