### PR TITLE
fix(crowdin): add tmIds to TMConcordanceSearchRequest

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -347,3 +347,9 @@
 **Learning:** In Crowdin API v2, `parentId` is an optional field when listing groups. Specifically, querying root-level groups requires setting `parentId=0`. However, the Go SDK typed `ParentID` as an `int` and had a condition `o.ParentID > 0` before appending it to query parameters, making root group filtering impossible.
 
 **Action:** Changed `ParentID` type to `*int` in `GroupsListOptions` and updated `Values()` serialization logic to append the parameter as long as `ParentID != nil`. Updated unit tests in both `model/groups_test.go` and `groups_test.go` to explicitly verify `parentId=0` query parameter construction.
+
+## 2026-08-24 - Improve TM Concordance Search Request parity for tmIds
+
+**Learning:** Crowdin API v2 supports filtering Concordance Search across specific Translation Memories by passing `tmIds` in `TMConcordanceSearchRequest`, but `tmIds` was missing from the Go SDK model.
+
+**Action:** Added `TMIDs []int json:"tmIds,omitempty"` to `TMConcordanceSearchRequest` in `crowdin/model/translation_memory.go`. Updated validation and contract tests in `crowdin/model/translation_memory_test.go` and `crowdin/translation_memory_test.go`.

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
@@ -231,6 +231,7 @@ type TMConcordanceSearchRequest struct {
 	AutoSubstitution *bool    `json:"autoSubstitution"`
 	MinRelevant      int      `json:"minRelevant"`
 	Expressions      []string `json:"expressions"`
+	TMIDs            []int    `json:"tmIds,omitempty"`
 }
 
 // Validate checks if the TMConcordanceSearchRequest is valid.

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_memory_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_memory_test.go
@@ -234,6 +234,15 @@ func TestTMConcordanceSearchRequestValidate(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			name: "valid request with tmIds",
+			req: &TMConcordanceSearchRequest{
+				SourceLanguageID: "en", TargetLanguageID: "de",
+				AutoSubstitution: toPtr(true), MinRelevant: 60, Expressions: []string{"expression"},
+				TMIDs: []int{4, 5},
+			},
+			valid: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/third_party/crowdin-api-client-go/crowdin/translation_memory_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translation_memory_test.go
@@ -585,7 +585,7 @@ func TestTranslationMemoryService_ConcordanceSearch(t *testing.T) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, path)
-		testBody(t, r, `{"sourceLanguageId":"en","targetLanguageId":"de","autoSubstitution":true,"minRelevant":60,"expressions":["Welcome!","Save as...","View","About..."]}`+"\n")
+		testBody(t, r, `{"sourceLanguageId":"en","targetLanguageId":"de","autoSubstitution":true,"minRelevant":60,"expressions":["Welcome!","Save as...","View","About..."],"tmIds":[4]}`+"\n")
 
 		fmt.Fprint(w, `{
 			"data": [
@@ -622,6 +622,7 @@ func TestTranslationMemoryService_ConcordanceSearch(t *testing.T) {
 			"View",
 			"About...",
 		},
+		TMIDs: []int{4},
 	}
 	tmList, resp, err := client.TranslationMemory.ConcordanceSearch(context.Background(), 1, req)
 	require.NoError(t, err)


### PR DESCRIPTION
Added TMIDs []int `json:"tmIds,omitempty"` to TMConcordanceSearchRequest to align with Crowdin API v2 Concordance Search specifications (`POST /api/v2/projects/{projectId}/tms/concordance`). Added unit and contract test coverage in model/translation_memory_test.go and translation_memory_test.go, and recorded learnings in .jules/crowdin-steward.md.

---
*PR created automatically by Jules for task [10767963057244265398](https://jules.google.com/task/10767963057244265398) started by @cungminh2710*