### PR TITLE
fix(web): guard marketing SSR and add SEO metadata

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/layout.tsx
@@ -10,11 +10,22 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import type { Metadata } from "next";
+
+import { JsonLd } from "@/components/seo/json-ld";
+import { organizationJsonLd } from "@/components/seo/organization-json-ld";
+import { INDEXABLE_ROBOTS } from "@/lib/seo/robots-metadata";
+
 import Navbar from "./_components/navbar";
+
+export const metadata: Metadata = {
+  robots: INDEXABLE_ROBOTS,
+};
 
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
+      <JsonLd data={organizationJsonLd} />
       <Navbar />
       <main>{children}</main>
     </>

--- a/apps/hyperlocalise-web/src/app/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/layout.tsx
@@ -26,6 +26,7 @@ import { SITE_URL } from "@/lib/seo/site-url";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { GA_MEASUREMENT_ID } from "@/lib/analytics/google-analytics";
 import { cn } from "@/lib/primitives/cn";
+import { PRIVATE_ROBOTS } from "@/lib/seo/robots-metadata";
 import "./globals.css";
 
 const inter = Inter({
@@ -73,6 +74,7 @@ export const metadata: Metadata = {
   title: "Hyperlocalise | The Best Agentic Localisation Platform",
   description:
     "Hyperlocalise is an AI workforce that helps teams launch globally in days — with market nuance, translation, and first-class human review.",
+  robots: PRIVATE_ROBOTS,
 };
 
 async function getInitialAuth(): Promise<

--- a/apps/hyperlocalise-web/src/components/marketing/hero-frame-mesh-stage.test.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-frame-mesh-stage.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const dynamicOptions = vi.hoisted(() => ({ ssr: undefined as boolean | undefined }));
+
+vi.mock("next/dynamic", () => ({
+  default: (_loader: unknown, options: { loading?: () => React.ReactNode; ssr?: boolean }) => {
+    dynamicOptions.ssr = options.ssr;
+    return options.loading ?? (() => null);
+  },
+}));
+
+import { HeroFrameLoadingShell } from "./hero-frame-mesh-stage";
+
+describe("HeroFrameMeshStage", () => {
+  it("keeps the browser-dependent CAT workspace out of server rendering", () => {
+    expect(dynamicOptions.ssr).toBe(false);
+  });
+
+  it("reserves the CAT workspace height while the client bundle loads", () => {
+    const markup = renderToStaticMarkup(<HeroFrameLoadingShell />);
+
+    expect(markup).toContain("h-[min(42rem,78svh)]");
+    expect(markup).toContain("min-h-136");
+    expect(markup).toContain('aria-hidden="true"');
+  });
+});

--- a/apps/hyperlocalise-web/src/components/marketing/hero-frame-mesh-stage.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-frame-mesh-stage.tsx
@@ -15,11 +15,29 @@
 import type { ReactNode } from "react";
 
 import { motion, useReducedMotion } from "motion/react";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 
 import { cn } from "@/lib/primitives/cn";
 
-import { HeroFrame } from "./hero-frame";
+export function HeroFrameLoadingShell() {
+  return (
+    <div
+      aria-hidden
+      className="overflow-hidden rounded-2xl border border-border bg-background shadow-2xl"
+    >
+      <div className="flex h-[min(42rem,78svh)] min-h-136 flex-col bg-muted/20" />
+    </div>
+  );
+}
+
+const ClientOnlyHeroFrame = dynamic(
+  () => import("./hero-frame").then((module) => module.HeroFrame),
+  {
+    loading: HeroFrameLoadingShell,
+    ssr: false,
+  },
+);
 
 export const SEAFOAM_MESH_GRADIENT_SRC = "/images/mesh/mesh-gradient-1784864145512.jpg";
 export const LAVENDER_MESH_GRADIENT_SRC = "/images/mesh/mesh-gradient-1784864042890.jpg";
@@ -91,7 +109,7 @@ type HeroFrameMeshStageProps = {
 export function HeroFrameMeshStage({ className, priority = false }: HeroFrameMeshStageProps) {
   return (
     <MeshStage layout="breakout" className={className} priority={priority}>
-      <HeroFrame layout="contained" className="shadow-[0_24px_64px_rgba(0,0,0,0.28)]" />
+      <ClientOnlyHeroFrame layout="contained" className="shadow-[0_24px_64px_rgba(0,0,0,0.28)]" />
     </MeshStage>
   );
 }

--- a/apps/hyperlocalise-web/src/components/seo/organization-json-ld.test.ts
+++ b/apps/hyperlocalise-web/src/components/seo/organization-json-ld.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { organizationJsonLd } from "./organization-json-ld";
+
+describe("organizationJsonLd", () => {
+  it("describes Hyperlocalise and its public company profiles", () => {
+    expect(organizationJsonLd).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "@id": "https://www.hyperlocalise.com/#organization",
+      name: "Hyperlocalise",
+      url: "https://www.hyperlocalise.com",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://www.hyperlocalise.com/images/logo.png",
+      },
+      description:
+        "Agentic localisation platform that connects product change signals, AI translation, human review, and release workflows.",
+      foundingDate: "2026",
+      founders: [
+        {
+          "@type": "Person",
+          name: "Minh Cung",
+          sameAs: "https://www.linkedin.com/in/minhcung/",
+        },
+        {
+          "@type": "Person",
+          name: "Hans Bui",
+          sameAs: "https://www.linkedin.com/in/hansbui/",
+        },
+      ],
+      sameAs: ["https://www.linkedin.com/company/hyperlocalise/"],
+      contactPoint: {
+        "@type": "ContactPoint",
+        contactType: "sales",
+        email: "minh@hyperlocalise.com",
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/components/seo/organization-json-ld.ts
+++ b/apps/hyperlocalise-web/src/components/seo/organization-json-ld.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Organization, WithContext } from "schema-dts";
+
+export const organizationJsonLd: WithContext<Organization> = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://www.hyperlocalise.com/#organization",
+  name: "Hyperlocalise",
+  url: "https://www.hyperlocalise.com",
+  logo: {
+    "@type": "ImageObject",
+    url: "https://www.hyperlocalise.com/images/logo.png",
+  },
+  description:
+    "Agentic localisation platform that connects product change signals, AI translation, human review, and release workflows.",
+  foundingDate: "2026",
+  founders: [
+    {
+      "@type": "Person",
+      name: "Minh Cung",
+      sameAs: "https://www.linkedin.com/in/minhcung/",
+    },
+    {
+      "@type": "Person",
+      name: "Hans Bui",
+      sameAs: "https://www.linkedin.com/in/hansbui/",
+    },
+  ],
+  sameAs: ["https://www.linkedin.com/company/hyperlocalise/"],
+  contactPoint: {
+    "@type": "ContactPoint",
+    contactType: "sales",
+    email: "minh@hyperlocalise.com",
+  },
+};

--- a/apps/hyperlocalise-web/src/lib/seo/robots-metadata.test.ts
+++ b/apps/hyperlocalise-web/src/lib/seo/robots-metadata.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { INDEXABLE_ROBOTS, PRIVATE_ROBOTS } from "./robots-metadata";
+
+describe("robots metadata", () => {
+  it("indexes public marketing routes", () => {
+    expect(INDEXABLE_ROBOTS).toEqual({ index: true, follow: true });
+  });
+
+  it("keeps non-marketing routes out of search indexes by default", () => {
+    expect(PRIVATE_ROBOTS).toEqual({ index: false, follow: false });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/seo/robots-metadata.ts
+++ b/apps/hyperlocalise-web/src/lib/seo/robots-metadata.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Metadata } from "next";
+
+export const INDEXABLE_ROBOTS: NonNullable<Metadata["robots"]> = {
+  index: true,
+  follow: true,
+};
+
+export const PRIVATE_ROBOTS: NonNullable<Metadata["robots"]> = {
+  index: false,
+  follow: false,
+};

--- a/docs/adr/2026-08-25-marketing-cat-demo-ssr-and-organization-json-ld-design.md
+++ b/docs/adr/2026-08-25-marketing-cat-demo-ssr-and-organization-json-ld-design.md
@@ -1,0 +1,22 @@
+# Marketing CAT Demo SSR and Organization JSON-LD Design
+
+## Context
+
+The marketing homepage and `/en/product/next-gen-cat-tool` both render the interactive CAT demo. During server rendering, that client component tree can evaluate browser-only code and raise `ReferenceError: localStorage is not defined`.
+
+The marketing site also needs a single Organization structured-data entity that describes Hyperlocalise and its founders. Robots metadata is currently absent from most routes, so public pages do not emit an explicit `index, follow` directive and private routes lack a consistent `noindex` default.
+
+## Design
+
+Keep the mesh stage and its image server-rendered, but load the interactive `HeroFrame` with `next/dynamic` and `ssr: false`. A structural loading shell will reserve the demo's height while its client bundle loads. This boundary is deliberately narrow: it excludes the browser-dependent CAT workspace from server rendering without turning the surrounding showcase into client-only content.
+
+Render a typed Organization JSON-LD object from the marketing layout through the existing `JsonLd` component. Placing it in the marketing layout emits one entity on every public marketing page while excluding authenticated and utility routes. The existing serializer escapes angle brackets before placing JSON in the script element.
+
+Set `noindex, nofollow` in the root metadata as the safe default for authenticated, auth, and utility routes. Override that policy with `index, follow` in the marketing layout. Existing route-specific restrictions remain in place.
+
+## Verification
+
+- Add coverage for the client-only CAT demo boundary and loading shell.
+- Add coverage for the Organization JSON-LD fields rendered by the marketing layout.
+- Add coverage for the public and private robots policies.
+- Run the web test and check commands required by the repository.


### PR DESCRIPTION
## Summary
- render the browser-dependent CAT demo client-side to prevent localStorage access during SSR
- add Organization JSON-LD across public marketing pages
- emit index/follow robots metadata for marketing routes and noindex/nofollow elsewhere by default

## Verification
- vp test src/components/marketing/hero-frame-mesh-stage.test.tsx src/components/seo/organization-json-ld.test.ts src/lib/seo/robots-metadata.test.ts
- vp check --fix (0 errors; 9 pre-existing unrelated warnings)

## Environment note
- the full vp test suite was attempted, but this checkout has no .env or DATABASE_URL; database-backed tests could not initialize and localhost connections are sandbox-restricted