### PR TITLE
feat(go-svc): add Hunspell C API wrapper

### DIFF
--- a/apps/go-svc/internal/hunspell/BUILD.bazel
+++ b/apps/go-svc/internal/hunspell/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+# This package is not depended on by any Bazel target built in CI
+# (//:cli, //apps/cli/cmd:cmd_test). It requires the Hunspell C library to
+# be installed and discoverable by the linker; see the package doc comment
+# in hunspell.go for local setup instructions.
+go_library(
+    name = "hunspell",
+    srcs = ["hunspell.go"],
+    cgo = True,
+    clinkopts = ["-lhunspell"],
+    gotags = ["cgo_hunspell"],
+    importpath = "github.com/hyperlocalise/hyperlocalise/apps/go-svc/internal/hunspell",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "hunspell_test",
+    srcs = ["hunspell_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":hunspell"],
+    gotags = ["cgo_hunspell"],
+)

--- a/apps/go-svc/internal/hunspell/hunspell.go
+++ b/apps/go-svc/internal/hunspell/hunspell.go
@@ -1,0 +1,75 @@
+//go:build cgo_hunspell
+
+// Package hunspell provides a CGO wrapper around the Hunspell C API.
+package hunspell
+
+/*
+#cgo pkg-config: hunspell
+#include <hunspell.h>
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"unsafe"
+)
+
+var ErrClosed = errors.New("hunspell: dictionary is closed")
+
+// Dictionary wraps a loaded Hunspell dictionary.
+// It is not safe for concurrent use.
+type Dictionary struct {
+	handle *C.Hunhandle
+	closed bool
+}
+
+// New loads an affix and dictionary file.
+func New(affPath, dicPath string) (*Dictionary, error) {
+	if _, err := os.Stat(affPath); err != nil {
+		return nil, fmt.Errorf("hunspell: affix file: %w", err)
+	}
+	if _, err := os.Stat(dicPath); err != nil {
+		return nil, fmt.Errorf("hunspell: dictionary file: %w", err)
+	}
+
+	cAffPath := C.CString(affPath)
+	defer C.free(unsafe.Pointer(cAffPath))
+	cDicPath := C.CString(dicPath)
+	defer C.free(unsafe.Pointer(cDicPath))
+
+	handle := C.Hunspell_create(cAffPath, cDicPath)
+	if handle == nil {
+		return nil, fmt.Errorf("hunspell: failed to create dictionary from affix file %q and dictionary file %q", affPath, dicPath)
+	}
+
+	return &Dictionary{handle: handle}, nil
+}
+
+// Spell reports whether word is recognized by the loaded dictionary.
+func (d *Dictionary) Spell(word string) (bool, error) {
+	if d.closed {
+		return false, ErrClosed
+	}
+
+	cWord := C.CString(word)
+	defer C.free(unsafe.Pointer(cWord))
+
+	return C.Hunspell_spell(d.handle, cWord) != 0, nil
+}
+
+// Close releases the native Hunspell handle owned by the Dictionary.
+// Close is idempotent.
+func (d *Dictionary) Close() error {
+	if d.closed {
+		return nil
+	}
+
+	C.Hunspell_destroy(d.handle)
+	d.handle = nil
+	d.closed = true
+
+	return nil
+}

--- a/apps/go-svc/internal/hunspell/hunspell.go
+++ b/apps/go-svc/internal/hunspell/hunspell.go
@@ -11,13 +11,21 @@ package hunspell
 import "C"
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"unsafe"
 )
 
+// ErrClosed is returned by Dictionary methods once Close has been called.
 var ErrClosed = errors.New("hunspell: dictionary is closed")
+
+var (
+	errAffixEncodingUndeclared = errors.New("hunspell: affix file has no SET declaration")
+	errAffixEncodingNotUTF8    = errors.New("hunspell: affix file declares a non-UTF-8 encoding")
+)
 
 const maxSuggestions = 5
 
@@ -27,14 +35,25 @@ type Dictionary struct {
 	closed bool
 }
 
-// New loads an affix and dictionary file.
-// It returns errors for unreadable files, but Hunspell may accept malformed contents.
+// New loads a UTF-8 Hunspell affix and dictionary pair.
+// Affix files without SET default to ISO8859-1 and are rejected.
 func New(affPath, dicPath string) (*Dictionary, error) {
 	if _, err := os.Stat(affPath); err != nil {
 		return nil, fmt.Errorf("hunspell: affix file: %w", err)
 	}
 	if _, err := os.Stat(dicPath); err != nil {
 		return nil, fmt.Errorf("hunspell: dictionary file: %w", err)
+	}
+
+	encoding, declared, err := affEncoding(affPath)
+	if err != nil {
+		return nil, fmt.Errorf("hunspell: reading affix file encoding: %w", err)
+	}
+	if !declared {
+		return nil, fmt.Errorf("%w: %q (Hunspell defaults undeclared dictionaries to ISO8859-1, not UTF-8)", errAffixEncodingUndeclared, affPath)
+	}
+	if encoding != "UTF-8" {
+		return nil, fmt.Errorf("%w: %q declares %q, only UTF-8 dictionaries are supported", errAffixEncodingNotUTF8, affPath, encoding)
 	}
 
 	cAffPath := C.CString(affPath)
@@ -50,6 +69,26 @@ func New(affPath, dicPath string) (*Dictionary, error) {
 	return &Dictionary{handle: handle}, nil
 }
 
+func affEncoding(affPath string) (encoding string, declared bool, err error) {
+	f, err := os.Open(affPath)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) > 0 && fields[0] == "SET" {
+			if len(fields) > 1 {
+				return fields[1], true, nil
+			}
+			return "", true, nil
+		}
+	}
+	return "", false, scanner.Err()
+}
+
 // Spell reports whether word is recognized by the loaded dictionary.
 func (d *Dictionary) Spell(word string) (bool, error) {
 	if d.closed {
@@ -62,8 +101,7 @@ func (d *Dictionary) Spell(word string) (bool, error) {
 	return C.Hunspell_spell(d.handle, cWord) != 0, nil
 }
 
-// Suggest returns up to maxSuggestions spelling suggestions for word, or
-// an empty slice if Hunspell has none.
+// Suggest returns up to maxSuggestions spelling suggestions for word.
 func (d *Dictionary) Suggest(word string) ([]string, error) {
 	if d.closed {
 		return nil, ErrClosed

--- a/apps/go-svc/internal/hunspell/hunspell.go
+++ b/apps/go-svc/internal/hunspell/hunspell.go
@@ -19,8 +19,9 @@ import (
 
 var ErrClosed = errors.New("hunspell: dictionary is closed")
 
-// Dictionary wraps a loaded Hunspell dictionary.
-// It is not safe for concurrent use.
+const maxSuggestions = 5
+
+// Dictionary wraps a loaded Hunspell dictionary, it's not safe for concurrent use.
 type Dictionary struct {
 	handle *C.Hunhandle
 	closed bool
@@ -60,8 +61,37 @@ func (d *Dictionary) Spell(word string) (bool, error) {
 	return C.Hunspell_spell(d.handle, cWord) != 0, nil
 }
 
-// Close releases the native Hunspell handle owned by the Dictionary.
-// Close is idempotent.
+// Suggest returns up to five spelling suggestions for word.
+func (d *Dictionary) Suggest(word string) ([]string, error) {
+	if d.closed {
+		return nil, ErrClosed
+	}
+
+	cWord := C.CString(word)
+	defer C.free(unsafe.Pointer(cWord))
+
+	var cList **C.char
+	n := int(C.Hunspell_suggest(d.handle, &cList, cWord))
+	if n <= 0 {
+		return nil, nil
+	}
+	defer C.Hunspell_free_list(d.handle, &cList, C.int(n))
+
+	limit := n
+	if limit > maxSuggestions {
+		limit = maxSuggestions
+	}
+
+	raw := (*[1 << 28]*C.char)(unsafe.Pointer(cList))[:n:n]
+	suggestions := make([]string, limit)
+	for i := 0; i < limit; i++ {
+		suggestions[i] = C.GoString(raw[i])
+	}
+
+	return suggestions, nil
+}
+
+// Close releases the Hunspell handle. It is idempotent.
 func (d *Dictionary) Close() error {
 	if d.closed {
 		return nil

--- a/apps/go-svc/internal/hunspell/hunspell.go
+++ b/apps/go-svc/internal/hunspell/hunspell.go
@@ -28,6 +28,17 @@ type Dictionary struct {
 }
 
 // New loads an affix and dictionary file.
+//
+// New reliably returns an error for a missing or unopenable affPath or
+// dicPath. It does not reliably detect malformed-but-readable dictionary
+// data: empirically, the installed Hunspell C library tolerates a wide
+// range of invalid .aff/.dic content (bad or missing word-count headers,
+// binary garbage, empty files, unsupported SET encodings, unparseable
+// affix directives) by logging a warning to stderr and constructing a
+// handle with zero or partial entries, rather than returning NULL from
+// Hunspell_create. Callers that need to detect malformed dictionary
+// content must do so themselves (for example, by checking whether known
+// words round-trip through Spell).
 func New(affPath, dicPath string) (*Dictionary, error) {
 	if _, err := os.Stat(affPath); err != nil {
 		return nil, fmt.Errorf("hunspell: affix file: %w", err)

--- a/apps/go-svc/internal/hunspell/hunspell.go
+++ b/apps/go-svc/internal/hunspell/hunspell.go
@@ -28,17 +28,7 @@ type Dictionary struct {
 }
 
 // New loads an affix and dictionary file.
-//
-// New reliably returns an error for a missing or unopenable affPath or
-// dicPath. It does not reliably detect malformed-but-readable dictionary
-// data: empirically, the installed Hunspell C library tolerates a wide
-// range of invalid .aff/.dic content (bad or missing word-count headers,
-// binary garbage, empty files, unsupported SET encodings, unparseable
-// affix directives) by logging a warning to stderr and constructing a
-// handle with zero or partial entries, rather than returning NULL from
-// Hunspell_create. Callers that need to detect malformed dictionary
-// content must do so themselves (for example, by checking whether known
-// words round-trip through Spell).
+// It returns errors for unreadable files, but Hunspell may accept malformed contents.
 func New(affPath, dicPath string) (*Dictionary, error) {
 	if _, err := os.Stat(affPath); err != nil {
 		return nil, fmt.Errorf("hunspell: affix file: %w", err)
@@ -72,7 +62,8 @@ func (d *Dictionary) Spell(word string) (bool, error) {
 	return C.Hunspell_spell(d.handle, cWord) != 0, nil
 }
 
-// Suggest returns up to five spelling suggestions for word.
+// Suggest returns up to maxSuggestions spelling suggestions for word, or
+// an empty slice if Hunspell has none.
 func (d *Dictionary) Suggest(word string) ([]string, error) {
 	if d.closed {
 		return nil, ErrClosed

--- a/apps/go-svc/internal/hunspell/hunspell_test.go
+++ b/apps/go-svc/internal/hunspell/hunspell_test.go
@@ -16,6 +16,12 @@ var (
 
 	malformedAff = filepath.Join("testdata", "malformed", "test.aff")
 	malformedDic = filepath.Join("testdata", "malformed", "test.dic")
+
+	nonUTF8Aff = filepath.Join("testdata", "non_utf8", "test.aff")
+	nonUTF8Dic = filepath.Join("testdata", "non_utf8", "test.dic")
+
+	noSetAff = filepath.Join("testdata", "no_set", "test.aff")
+	noSetDic = filepath.Join("testdata", "no_set", "test.dic")
 )
 
 func TestNew(t *testing.T) {
@@ -54,16 +60,24 @@ func TestNew(t *testing.T) {
 	})
 }
 
-// TestNewToleratesMalformedDictionaryData documents an empirically-verified
-// limitation: New cannot detect malformed-but-readable dictionary data.
-// testdata/malformed/test.dic has a non-numeric word-count header, which
-// violates Hunspell's own .dic format. Against the installed Hunspell C
-// library, this (and every other malformed variant tried during
-// development: negative/overflowing/mismatched counts, binary garbage in
-// either file, an empty file, an unsupported SET encoding, and unparseable
-// affix directives) logs a warning to stderr but still returns a non-NULL
-// handle from Hunspell_create, backed by zero usable entries, rather than
-// failing construction. See the New doc comment.
+func TestNewRejectsNonUTF8Dictionaries(t *testing.T) {
+	t.Run("declared non-UTF-8 encoding", func(t *testing.T) {
+		_, err := New(nonUTF8Aff, nonUTF8Dic)
+		if !errors.Is(err, errAffixEncodingNotUTF8) {
+			t.Fatalf("New() error = %v, want error wrapping errAffixEncodingNotUTF8", err)
+		}
+	})
+
+	t.Run("missing SET declaration", func(t *testing.T) {
+		_, err := New(noSetAff, noSetDic)
+		if !errors.Is(err, errAffixEncodingUndeclared) {
+			t.Fatalf("New() error = %v, want error wrapping errAffixEncodingUndeclared", err)
+		}
+	})
+}
+
+// Hunspell_create empirically tolerates malformed-but-readable dictionaries,
+// returning a non-NULL handle with no usable entries rather than failing.
 func TestNewToleratesMalformedDictionaryData(t *testing.T) {
 	d, err := New(malformedAff, malformedDic)
 	if err != nil {

--- a/apps/go-svc/internal/hunspell/hunspell_test.go
+++ b/apps/go-svc/internal/hunspell/hunspell_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -82,6 +83,63 @@ func TestDictionarySpell(t *testing.T) {
 				t.Errorf("Spell(%q) = %v, want %v", tt.word, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDictionarySuggest(t *testing.T) {
+	d, err := New(validAff, validDic)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := d.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	t.Run("misspelling returns suggestions", func(t *testing.T) {
+		got, err := d.Suggest("helo")
+		if err != nil {
+			t.Fatalf("Suggest() error = %v, want nil", err)
+		}
+		want := []string{"hello"}
+		if !slices.Equal(got, want) {
+			t.Errorf("Suggest(%q) = %v, want %v", "helo", got, want)
+		}
+	})
+
+	t.Run("no suggestions for an unrelated word", func(t *testing.T) {
+		got, err := d.Suggest("xyzxyz")
+		if err != nil {
+			t.Fatalf("Suggest() error = %v, want nil", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("Suggest(%q) = %v, want empty", "xyzxyz", got)
+		}
+	})
+
+	t.Run("bounded by maxSuggestions", func(t *testing.T) {
+		got, err := d.Suggest("zat")
+		if err != nil {
+			t.Fatalf("Suggest() error = %v, want nil", err)
+		}
+		if len(got) != maxSuggestions {
+			t.Errorf("Suggest(%q) returned %d suggestions, want exactly the capped %d", "zat", len(got), maxSuggestions)
+		}
+	})
+}
+
+func TestDictionarySuggestAfterClose(t *testing.T) {
+	d, err := New(validAff, validDic)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+
+	if _, err := d.Suggest("helo"); !errors.Is(err, ErrClosed) {
+		t.Errorf("Suggest() after Close() error = %v, want ErrClosed", err)
 	}
 }
 

--- a/apps/go-svc/internal/hunspell/hunspell_test.go
+++ b/apps/go-svc/internal/hunspell/hunspell_test.go
@@ -13,6 +13,9 @@ import (
 var (
 	validAff = filepath.Join("testdata", "valid", "test.aff")
 	validDic = filepath.Join("testdata", "valid", "test.dic")
+
+	malformedAff = filepath.Join("testdata", "malformed", "test.aff")
+	malformedDic = filepath.Join("testdata", "malformed", "test.dic")
 )
 
 func TestNew(t *testing.T) {
@@ -49,6 +52,36 @@ func TestNew(t *testing.T) {
 			t.Errorf("New() error = %v, want wrapped os.ErrNotExist", err)
 		}
 	})
+}
+
+// TestNewToleratesMalformedDictionaryData documents an empirically-verified
+// limitation: New cannot detect malformed-but-readable dictionary data.
+// testdata/malformed/test.dic has a non-numeric word-count header, which
+// violates Hunspell's own .dic format. Against the installed Hunspell C
+// library, this (and every other malformed variant tried during
+// development: negative/overflowing/mismatched counts, binary garbage in
+// either file, an empty file, an unsupported SET encoding, and unparseable
+// affix directives) logs a warning to stderr but still returns a non-NULL
+// handle from Hunspell_create, backed by zero usable entries, rather than
+// failing construction. See the New doc comment.
+func TestNewToleratesMalformedDictionaryData(t *testing.T) {
+	d, err := New(malformedAff, malformedDic)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil (Hunspell tolerates this input instead of failing construction)", err)
+	}
+	t.Cleanup(func() {
+		if err := d.Close(); err != nil {
+			t.Errorf("Close() error = %v, want nil", err)
+		}
+	})
+
+	got, err := d.Spell("hello")
+	if err != nil {
+		t.Fatalf("Spell() error = %v, want nil", err)
+	}
+	if got {
+		t.Errorf(`Spell("hello") = true, want false: a dictionary loaded from malformed data should have no usable entries`)
+	}
 }
 
 func TestDictionarySpell(t *testing.T) {

--- a/apps/go-svc/internal/hunspell/hunspell_test.go
+++ b/apps/go-svc/internal/hunspell/hunspell_test.go
@@ -1,0 +1,114 @@
+//go:build cgo_hunspell
+
+package hunspell
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var (
+	validAff = filepath.Join("testdata", "valid", "test.aff")
+	validDic = filepath.Join("testdata", "valid", "test.dic")
+)
+
+func TestNew(t *testing.T) {
+	t.Run("valid dictionary", func(t *testing.T) {
+		d, err := New(validAff, validDic)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil", err)
+		}
+		if err := d.Close(); err != nil {
+			t.Errorf("Close() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("missing affix file", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing.aff")
+
+		_, err := New(missing, validDic)
+		if err == nil {
+			t.Fatal("New() error = nil, want error for missing affix file")
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("New() error = %v, want wrapped os.ErrNotExist", err)
+		}
+	})
+
+	t.Run("missing dictionary file", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing.dic")
+
+		_, err := New(validAff, missing)
+		if err == nil {
+			t.Fatal("New() error = nil, want error for missing dictionary file")
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("New() error = %v, want wrapped os.ErrNotExist", err)
+		}
+	})
+}
+
+func TestDictionarySpell(t *testing.T) {
+	d, err := New(validAff, validDic)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := d.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	tests := []struct {
+		name string
+		word string
+		want bool
+	}{
+		{name: "known word", word: "hello", want: true},
+		{name: "another known word", word: "apple", want: true},
+		{name: "misspelling of a known word", word: "helllo", want: false},
+		{name: "word absent from the dictionary", word: "zzzqqqxxx", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := d.Spell(tt.word)
+			if err != nil {
+				t.Fatalf("Spell(%q) error = %v, want nil", tt.word, err)
+			}
+			if got != tt.want {
+				t.Errorf("Spell(%q) = %v, want %v", tt.word, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDictionaryCloseIsIdempotent(t *testing.T) {
+	d, err := New(validAff, validDic)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("first Close() error = %v, want nil", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("second Close() error = %v, want nil (idempotent)", err)
+	}
+}
+
+func TestDictionarySpellAfterClose(t *testing.T) {
+	d, err := New(validAff, validDic)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+
+	if _, err := d.Spell("hello"); !errors.Is(err, ErrClosed) {
+		t.Errorf("Spell() after Close() error = %v, want ErrClosed", err)
+	}
+}

--- a/apps/go-svc/internal/hunspell/testdata/malformed/test.aff
+++ b/apps/go-svc/internal/hunspell/testdata/malformed/test.aff
@@ -1,0 +1,2 @@
+SET UTF-8
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'

--- a/apps/go-svc/internal/hunspell/testdata/malformed/test.dic
+++ b/apps/go-svc/internal/hunspell/testdata/malformed/test.dic
@@ -1,0 +1,2 @@
+notanumber
+hello

--- a/apps/go-svc/internal/hunspell/testdata/no_set/test.aff
+++ b/apps/go-svc/internal/hunspell/testdata/no_set/test.aff
@@ -1,0 +1,1 @@
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'

--- a/apps/go-svc/internal/hunspell/testdata/no_set/test.dic
+++ b/apps/go-svc/internal/hunspell/testdata/no_set/test.dic
@@ -1,0 +1,3 @@
+2
+hello
+world

--- a/apps/go-svc/internal/hunspell/testdata/non_utf8/test.aff
+++ b/apps/go-svc/internal/hunspell/testdata/non_utf8/test.aff
@@ -1,0 +1,2 @@
+SET ISO8859-1
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'

--- a/apps/go-svc/internal/hunspell/testdata/non_utf8/test.dic
+++ b/apps/go-svc/internal/hunspell/testdata/non_utf8/test.dic
@@ -1,0 +1,3 @@
+2
+hello
+world

--- a/apps/go-svc/internal/hunspell/testdata/valid/test.aff
+++ b/apps/go-svc/internal/hunspell/testdata/valid/test.aff
@@ -1,0 +1,2 @@
+SET UTF-8
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'

--- a/apps/go-svc/internal/hunspell/testdata/valid/test.dic
+++ b/apps/go-svc/internal/hunspell/testdata/valid/test.dic
@@ -1,6 +1,15 @@
-5
+14
 hello
 world
 cat
 dog
 apple
+bat
+hat
+mat
+rat
+sat
+fat
+pat
+vat
+oat

--- a/apps/go-svc/internal/hunspell/testdata/valid/test.dic
+++ b/apps/go-svc/internal/hunspell/testdata/valid/test.dic
@@ -1,0 +1,6 @@
+5
+hello
+world
+cat
+dog
+apple

--- a/internal/i18n/spellcheck/DICTIONARIES.md
+++ b/internal/i18n/spellcheck/DICTIONARIES.md
@@ -1,4 +1,4 @@
-# HL-596: Hunspell dictionary manifest
+# Hunspell dictionary manifest
 
 This is the reproducible source-of-truth mapping between the initial
 spell-check locale set and the exact Hunspell dictionary files backing each


### PR DESCRIPTION
## What changed

- Added a focused CGO wrapper around the Hunspell C API for dictionary loading, spell checks, suggestions, and cleanup.
- Added bounded suggestions and explicit native resource ownership.
- Added fixture-based tests for lifecycle, missing files, suggestions, and malformed dictionary behaviour.

## How to test

```bash
CGO_ENABLED=1 go test -tags cgo_hunspell -race ./apps/go-svc/internal/hunspell/...
golangci-lint run --build-tags cgo_hunspell ./apps/go-svc/internal/hunspell/...
make fmt
make lint
make test
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
