### PR TITLE
feat(cat): add glossary guidance panel

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -14,6 +14,7 @@
  */
 import type { CSSProperties, ReactNode } from "react";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
@@ -83,7 +84,9 @@ export function AppShellClient({
   user,
 }: AppShellClientProps) {
   const intl = useIntl();
+  const pathname = usePathname();
   const organizationSlug = activeOrganization.slug ?? "";
+  const showGlossaryGuidance = pathname.includes("/strings") || pathname.includes("/files/cat");
   const tmsUserConnectQuery = useTmsUserConnectCta(organizationSlug, {
     enabled: Boolean(organizationSlug),
     initialData: tmsUserConnectCta,
@@ -181,6 +184,7 @@ export function AppShellClient({
         <AppShellFooter
           organizationSlug={organizationSlug}
           showPlan={showBillingLink && autumnConfigured}
+          showGlossaryGuidance={showGlossaryGuidance}
           currentUser={
             organizationSlug
               ? {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -20,6 +20,22 @@ export const appShellFooterMessages = defineMessages({
     id: "ecG+jsddyC",
     description: "Accessible label for the support email button in the app shell footer",
   },
+  glossaryGuidanceAriaLabel: {
+    defaultMessage: "Open glossary guidance",
+    id: "WHrTXX3A2/",
+    description: "Accessible label for the glossary guidance button in the app shell footer",
+  },
+  glossaryGuidanceAvailableAriaLabel: {
+    defaultMessage: "Glossary guidance, concept matches available",
+    id: "Z4KBzMvHKO",
+    description:
+      "Accessible label for the glossary guidance button when concept matches are available",
+  },
+  glossaryGuidanceLabel: {
+    defaultMessage: "Glossary guidance",
+    id: "w7J+PHlma7",
+    description: "Label for the glossary guidance button in the app shell footer",
+  },
   supportLabel: {
     defaultMessage: "Support",
     id: "VvLbwcYPHK",

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -12,7 +12,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { CustomerSupportIcon } from "@hugeicons/core-free-icons";
+import { useSyncExternalStore } from "react";
+import {
+  BookOpenTextIcon,
+  CheckmarkCircle02Icon,
+  CustomerSupportIcon,
+  MinusSignCircleIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -24,6 +30,12 @@ import {
 } from "@/components/app-shell/chat-dock/chat-dock";
 import { ChatDockErrorBoundary } from "@/components/app-shell/chat-dock/chat-dock-error-boundary";
 import { PlanUsageFooterControl } from "@/components/billing/plan-usage-summary";
+import {
+  getCatGlossaryGuidanceServerSnapshot,
+  getCatGlossaryGuidanceStatus,
+  requestCatGlossaryGuidance,
+  subscribeCatGlossaryGuidance,
+} from "@/components/cat/intelligence/cat-glossary-guidance-event";
 import { Button } from "@/components/ui/button";
 import { SUPPORT_EMAIL } from "@/lib/support-contact";
 
@@ -32,14 +44,21 @@ import { appShellFooterMessages } from "./app-shell-footer.messages";
 export function AppShellFooter({
   organizationSlug,
   showPlan,
+  showGlossaryGuidance = false,
   currentUser,
 }: {
   organizationSlug: string;
   showPlan: boolean;
+  showGlossaryGuidance?: boolean;
   currentUser?: InboxCurrentUser;
 }) {
   const intl = useIntl();
   const showChatDock = Boolean(organizationSlug && currentUser);
+  const glossaryGuidanceStatus = useSyncExternalStore(
+    subscribeCatGlossaryGuidance,
+    getCatGlossaryGuidanceStatus,
+    getCatGlossaryGuidanceServerSnapshot,
+  );
 
   return (
     <footer className="fixed inset-x-0 bottom-0 z-40 flex flex-col border-t border-border bg-background">
@@ -54,6 +73,48 @@ export function AppShellFooter({
         <div className="flex h-10 w-full items-center gap-2">
           {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
           <div className="ms-auto flex min-w-0 items-center gap-2">
+            {showGlossaryGuidance ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="gap-1.5 px-2"
+                onClick={requestCatGlossaryGuidance}
+                aria-label={intl.formatMessage(
+                  glossaryGuidanceStatus.preferredCount > 0 ||
+                    glossaryGuidanceStatus.notRecommendedCount > 0
+                    ? appShellFooterMessages.glossaryGuidanceAvailableAriaLabel
+                    : appShellFooterMessages.glossaryGuidanceAriaLabel,
+                )}
+              >
+                <HugeiconsIcon icon={BookOpenTextIcon} strokeWidth={2} className="size-3.5" />
+                <FormattedMessage {...appShellFooterMessages.glossaryGuidanceLabel} />
+                {glossaryGuidanceStatus.preferredCount > 0 ? (
+                  <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-500">
+                    <HugeiconsIcon
+                      icon={CheckmarkCircle02Icon}
+                      strokeWidth={2}
+                      className="size-4"
+                      aria-hidden="true"
+                    />
+                    <span className="tabular-nums">{glossaryGuidanceStatus.preferredCount}</span>
+                  </span>
+                ) : null}
+                {glossaryGuidanceStatus.notRecommendedCount > 0 ? (
+                  <span className="inline-flex items-center gap-0.5 text-xs font-medium text-rose-500">
+                    <HugeiconsIcon
+                      icon={MinusSignCircleIcon}
+                      strokeWidth={2}
+                      className="size-4"
+                      aria-hidden="true"
+                    />
+                    <span className="tabular-nums">
+                      {glossaryGuidanceStatus.notRecommendedCount}
+                    </span>
+                  </span>
+                ) : null}
+              </Button>
+            ) : null}
             {showChatDock ? <ChatDockFooterControls organizationSlug={organizationSlug} /> : null}
             <Button
               variant="ghost"

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useState } from "react";
+import {
+  ArrowDown01Icon,
+  ArrowUp01Icon,
+  Copy01Icon,
+  ExternalLinkIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messages";
+import type { CatGlossaryConcept, CatGlossaryConceptTerm } from "@/components/cat/shared/types";
+
+function readableLabel(value: string | null | undefined) {
+  if (!value) return null;
+  return value.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+type CatGlossaryTermStatus = "preferred" | "admitted" | "draft" | "not_recommended" | "obsolete";
+
+function normalizedTermStatus(term: CatGlossaryConceptTerm): CatGlossaryTermStatus {
+  const normalized = term.status?.trim().toLowerCase().replaceAll(" ", "_");
+  if (term.forbidden || normalized === "forbidden" || normalized === "not_recommended") {
+    return "not_recommended";
+  }
+  if (term.preferred || normalized === "preferred") {
+    return "preferred";
+  }
+  if (normalized === "admitted" || normalized === "draft" || normalized === "obsolete") {
+    return normalized;
+  }
+  return "draft";
+}
+
+function termStatus(term: CatGlossaryConceptTerm, intl: ReturnType<typeof useIntl>) {
+  const status = normalizedTermStatus(term);
+  const labels = {
+    preferred: catIntelligencePanelMessages.glossaryPreferred,
+    admitted: catIntelligencePanelMessages.glossaryAdmitted,
+    draft: catIntelligencePanelMessages.glossaryDraft,
+    not_recommended: catIntelligencePanelMessages.glossaryNotRecommended,
+    obsolete: catIntelligencePanelMessages.glossaryObsolete,
+  } satisfies Record<
+    CatGlossaryTermStatus,
+    (typeof catIntelligencePanelMessages)[keyof typeof catIntelligencePanelMessages]
+  >;
+  const classNames = {
+    preferred: "border-emerald-500/30 text-emerald-300",
+    admitted: "border-sky-500/30 text-sky-300",
+    draft: "border-amber-500/30 text-amber-300",
+    not_recommended: "border-rose-500/30 text-rose-300",
+    obsolete: "border-slate-500/30 text-slate-300",
+  } satisfies Record<CatGlossaryTermStatus, string>;
+  return { status, label: intl.formatMessage(labels[status]), className: classNames[status] };
+}
+
+function TermStatusIcon({ status }: { status: CatGlossaryTermStatus }) {
+  if (status === "preferred") {
+    return (
+      <svg viewBox="0 0 16 16" fill="none" className="size-3.5 shrink-0" aria-hidden="true">
+        <circle cx="8" cy="8" r="7" className="fill-emerald-500" />
+        <path
+          d="m5 8.2 2 2 4-4"
+          stroke="white"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+  if (status === "admitted") {
+    return (
+      <svg viewBox="0 0 16 16" fill="none" className="size-3.5 shrink-0" aria-hidden="true">
+        <circle cx="8" cy="8" r="6" className="stroke-sky-500" strokeWidth="1.75" />
+        <circle cx="8" cy="8" r="2.25" className="fill-sky-500" />
+      </svg>
+    );
+  }
+  if (status === "draft") {
+    return (
+      <svg viewBox="0 0 16 16" fill="none" className="size-3.5 shrink-0" aria-hidden="true">
+        <circle cx="8" cy="8" r="6" className="stroke-amber-500" strokeWidth="1.75" />
+        <path d="M8 2a6 6 0 0 1 0 12Z" className="fill-amber-500" />
+      </svg>
+    );
+  }
+  if (status === "not_recommended") {
+    return (
+      <svg viewBox="0 0 16 16" fill="none" className="size-3.5 shrink-0" aria-hidden="true">
+        <circle cx="8" cy="8" r="6" className="stroke-rose-500" strokeWidth="1.75" />
+        <path d="M5.5 8h5" className="stroke-rose-500" strokeWidth="1.75" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 16 16" fill="none" className="size-3.5 shrink-0" aria-hidden="true">
+      <circle cx="8" cy="8" r="7" className="fill-slate-500" />
+      <path d="m5.5 5.5 5 5m0-5-5 5" stroke="white" strokeWidth="1.75" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ConceptTermRow({ term }: { term: CatGlossaryConceptTerm }) {
+  const intl = useIntl();
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const status = termStatus(term, intl);
+
+  async function copyTerm() {
+    if (!term.text.trim() || typeof navigator === "undefined" || !navigator.clipboard) {
+      setCopyState("error");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(term.text);
+      setCopyState("copied");
+      window.setTimeout(() => setCopyState("idle"), 1600);
+    } catch {
+      setCopyState("error");
+    }
+  }
+
+  const metadata = [term.termType, term.partOfSpeech, term.gender]
+    .map(readableLabel)
+    .filter((value): value is string => Boolean(value));
+
+  return (
+    <div className="flex min-h-9 items-center gap-2 rounded-lg bg-input/30 px-2.5 py-1.5">
+      <Badge
+        variant="outline"
+        className="h-5 shrink-0 rounded-md border-input bg-background/30 px-1.5 text-[10px] uppercase tracking-wide"
+      >
+        {term.locale}
+      </Badge>
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+        <p className="min-w-24 flex-1 break-words text-sm font-medium leading-tight text-foreground">
+          {term.text}
+        </p>
+        <div className="flex flex-wrap gap-1">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs font-medium",
+              status.className,
+            )}
+          >
+            <TermStatusIcon status={status.status} />
+            {status.label}
+          </span>
+          {metadata.map((value) => (
+            <span
+              key={value}
+              className="rounded-md bg-background/20 px-1.5 py-0.5 text-xs text-muted-foreground"
+            >
+              {value}
+            </span>
+          ))}
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="shrink-0"
+        onClick={() => void copyTerm()}
+      >
+        {copyState === "copied" ? (
+          <HugeiconsIcon icon={Tick02Icon} className="size-3" aria-hidden />
+        ) : (
+          <HugeiconsIcon icon={Copy01Icon} className="size-3" aria-hidden />
+        )}
+        <span className="sr-only">
+          {copyState === "copied"
+            ? intl.formatMessage(catIntelligencePanelMessages.glossaryTermCopied)
+            : copyState === "error"
+              ? intl.formatMessage(catIntelligencePanelMessages.glossaryTermCopyFailed)
+              : intl.formatMessage(catIntelligencePanelMessages.copyGlossaryTerm)}
+        </span>
+      </Button>
+    </div>
+  );
+}
+
+function CollapsedTargetTermRow({ term }: { term: CatGlossaryConceptTerm }) {
+  const intl = useIntl();
+  const status = termStatus(term, intl);
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-1.5">
+      <span className="min-w-0 truncate text-sm font-medium text-foreground">{term.text}</span>
+      <span
+        className={cn(
+          "inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs font-medium",
+          status.className,
+        )}
+      >
+        <TermStatusIcon status={status.status} />
+        {status.label}
+      </span>
+    </div>
+  );
+}
+
+export function CatGlossaryConceptCard({
+  concept,
+  expanded,
+  onToggle,
+}: {
+  concept: CatGlossaryConcept;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const intl = useIntl();
+  const contentId = `glossary-concept-${concept.id.replaceAll(/[^a-zA-Z0-9_-]/g, "-")}`;
+  const sourceTerms = concept.sourceTerms.length > 0 ? concept.sourceTerms : concept.targetTerms;
+  const targetTerms = concept.targetTerms.length > 0 ? concept.targetTerms : concept.sourceTerms;
+
+  return (
+    <article className="overflow-hidden rounded-xl bg-muted/40">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-background/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        aria-label={intl.formatMessage(
+          expanded
+            ? catIntelligencePanelMessages.glossaryConceptCollapse
+            : catIntelligencePanelMessages.glossaryConceptExpand,
+        )}
+        onClick={onToggle}
+      >
+        <span className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="truncate text-base font-semibold text-foreground">
+            {concept.primaryTerm}
+          </span>
+          <Badge
+            variant="secondary"
+            className="h-6 max-w-full truncate rounded-md px-2 text-xs font-normal"
+          >
+            {concept.glossaryName}
+          </Badge>
+        </span>
+        <HugeiconsIcon
+          icon={expanded ? ArrowUp01Icon : ArrowDown01Icon}
+          className="size-4 shrink-0 text-muted-foreground"
+          aria-hidden
+        />
+      </button>
+
+      {!expanded ? (
+        <div className="space-y-1 px-3 pb-2">
+          {targetTerms.map((term) => (
+            <CollapsedTargetTermRow key={term.id} term={term} />
+          ))}
+        </div>
+      ) : null}
+
+      <div id={contentId} className={cn("px-3 pb-2.5", !expanded && "hidden")}>
+        {concept.definition || concept.subject ? (
+          <div className="mb-2 rounded-lg bg-input/20 px-2.5 py-2">
+            {concept.definition ? (
+              <p className="text-sm leading-relaxed text-foreground">{concept.definition}</p>
+            ) : null}
+            {concept.subject ? (
+              <p className="mt-0.5 text-xs text-muted-foreground">{concept.subject}</p>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="space-y-2">
+          <div className="space-y-1">
+            {sourceTerms.map((term) => (
+              <ConceptTermRow key={term.id} term={term} />
+            ))}
+          </div>
+          <div className="space-y-1">
+            {targetTerms.map((term) => (
+              <ConceptTermRow key={term.id} term={term} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="px-3 pb-2 pt-1">
+        {concept.glossaryUrl ? (
+          <a
+            href={concept.glossaryUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <FormattedMessage {...catIntelligencePanelMessages.projectGlossary} />
+            <HugeiconsIcon icon={ExternalLinkIcon} className="size-3.5" aria-hidden />
+          </a>
+        ) : (
+          <span className="text-sm text-muted-foreground">
+            <FormattedMessage {...catIntelligencePanelMessages.projectGlossary} />
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-guidance-event.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-guidance-event.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+export const CAT_GLOSSARY_GUIDANCE_OPEN_EVENT = "cat-glossary-guidance:open";
+
+export const EMPTY_CAT_GLOSSARY_GUIDANCE_STATUS = {
+  preferredCount: 0,
+  notRecommendedCount: 0,
+} as const;
+
+export type CatGlossaryGuidanceStatus = {
+  preferredCount: number;
+  notRecommendedCount: number;
+};
+
+type CatGlossaryGuidanceListener = () => void;
+
+let glossaryGuidanceStatus: CatGlossaryGuidanceStatus = EMPTY_CAT_GLOSSARY_GUIDANCE_STATUS;
+const glossaryGuidanceListeners = new Set<CatGlossaryGuidanceListener>();
+
+export function requestCatGlossaryGuidance() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent(CAT_GLOSSARY_GUIDANCE_OPEN_EVENT));
+}
+
+export function setCatGlossaryGuidanceStatus(status: CatGlossaryGuidanceStatus) {
+  if (
+    glossaryGuidanceStatus.preferredCount === status.preferredCount &&
+    glossaryGuidanceStatus.notRecommendedCount === status.notRecommendedCount
+  ) {
+    return;
+  }
+
+  glossaryGuidanceStatus = status;
+  glossaryGuidanceListeners.forEach((listener) => listener());
+}
+
+export function subscribeCatGlossaryGuidance(listener: CatGlossaryGuidanceListener) {
+  glossaryGuidanceListeners.add(listener);
+  return () => glossaryGuidanceListeners.delete(listener);
+}
+
+export function getCatGlossaryGuidanceStatus() {
+  return glossaryGuidanceStatus;
+}
+
+export function getCatGlossaryGuidanceServerSnapshot() {
+  return EMPTY_CAT_GLOSSARY_GUIDANCE_STATUS;
+}

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, userEvent } from "storybook/test";
+
+import { catSegmentsFixture, catIntelligenceFixture } from "@/components/cat/shared/cat.fixture";
+import type { CatSegmentIntelligence } from "@/components/cat/shared/types";
+
+import { CatIntelligencePanel } from "./cat-intelligence-panel";
+import { requestCatGlossaryGuidance } from "./cat-glossary-guidance-event";
+
+const defaultTargetText = catSegmentsFixture[1]?.targetText ?? "";
+
+const conceptIntelligence: CatSegmentIntelligence = {
+  ...catIntelligenceFixture,
+  glossaryConcepts: [
+    {
+      id: "concept-reseller",
+      glossaryId: "glossary-project",
+      glossaryName: "Partner Program",
+      glossaryUrl: "https://example.com/project-glossary",
+      primaryTerm: "Reseller",
+      definition: "A company or individual authorized to resell our product.",
+      sourceTerms: [
+        {
+          id: "reseller-en",
+          locale: "en",
+          text: "Reseller",
+          status: "preferred",
+          preferred: true,
+          termType: "full form",
+          partOfSpeech: "noun",
+          gender: "neuter",
+        },
+      ],
+      targetTerms: [
+        {
+          id: "reseller-vi-preferred",
+          locale: "vi",
+          text: "Đại lý",
+          status: "preferred",
+          preferred: true,
+          termType: "full form",
+          partOfSpeech: "noun",
+          gender: "neuter",
+        },
+        {
+          id: "reseller-vi-alternate",
+          locale: "vi",
+          text: "Nhà bán lại",
+          status: "not_recommended",
+          forbidden: true,
+          termType: "full form",
+          partOfSpeech: "noun",
+          gender: "masculine",
+        },
+      ],
+    },
+    {
+      id: "concept-review",
+      glossaryId: "glossary-project",
+      glossaryName: "Partner Program",
+      primaryTerm: "Review",
+      sourceTerms: [{ id: "review-en", locale: "en", text: "Review", preferred: true }],
+      targetTerms: [{ id: "review-vi", locale: "vi", text: "Đánh giá", preferred: true }],
+    },
+  ],
+};
+
+const meta = {
+  title: "CAT/Translation Intelligence",
+  component: CatIntelligencePanel,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto h-[42rem] max-w-xl border-x border-border bg-background text-foreground">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    intelligence: conceptIntelligence,
+    targetText: defaultTargetText,
+    isLookingUpContext: false,
+    isConcordanceLoading: false,
+    isVisualContextLoading: false,
+    showAgentContext: false,
+    showVisualContext: false,
+    canEditTranslations: true,
+    canLookupFreshContext: true,
+  },
+} satisfies Meta<typeof CatIntelligencePanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Results: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("heading", { name: "Translation Intelligence" }),
+    ).toBeInTheDocument();
+    requestCatGlossaryGuidance();
+    await expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    await expect(canvas.getByText("Reseller")).toBeInTheDocument();
+    await expect(canvas.getByText("Partner Program")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("A company or individual authorized to resell our product."),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Đại lý")).toBeInTheDocument();
+    await expect(canvas.getByText("Nhà bán lại")).toBeInTheDocument();
+    await expect(canvas.getAllByText("Project Glossary")).toHaveLength(2);
+    await expect(canvas.getByText("Translation memory")).toBeInTheDocument();
+    await expect(canvas.getByText("Dashboard card", { exact: true })).toBeInTheDocument();
+    await expect(canvas.getAllByRole("button", { name: "Use" })).toHaveLength(3);
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isConcordanceLoading: true,
+  },
+  play: async ({ canvas }) => {
+    requestCatGlossaryGuidance();
+    await expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    await expect(canvas.getByText("Translation memory")).toBeInTheDocument();
+    await expect(canvas.queryByText("Dashboard card", { exact: true })).not.toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    intelligence: {
+      ...catIntelligenceFixture,
+      glossaryTerms: [],
+      glossaryConcepts: [],
+      translationMemoryMatches: [],
+    },
+  },
+  play: async ({ canvas }) => {
+    requestCatGlossaryGuidance();
+    await expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    await expect(canvas.getByText("No glossary matches")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("No project glossary concepts match this string."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    canEditTranslations: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Dashboard card", { exact: true })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Use" })).not.toBeInTheDocument();
+  },
+};
+
+export const LegacyFallback: Story = {
+  args: {
+    intelligence: {
+      ...catIntelligenceFixture,
+      glossaryConcepts: undefined,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Dashboard", { exact: true })).toBeInTheDocument();
+    await expect(canvas.getByText("Bảng điều khiển", { exact: true })).toBeInTheDocument();
+  },
+};
+
+export const LowMatchConfirmation: Story = {
+  args: {
+    intelligence: {
+      ...catIntelligenceFixture,
+      translationMemoryMatches: [
+        {
+          id: "tm-low-match",
+          sourceText: "Review the pending dashboard changes.",
+          targetText: "Xem các thay đổi đang chờ duyệt trên bảng điều khiển.",
+          matchPercent: 62,
+          contextLabel: "Review queue",
+        },
+      ],
+    },
+    onUseTmMatch: fn(),
+  },
+  play: async ({ canvas, args }) => {
+    await userEvent.click(canvas.getByRole("button", { name: "Use" }));
+    await expect(canvas.getByRole("dialog")).toBeInTheDocument();
+    await expect(canvas.getByText("Apply low-quality TM match?")).toBeInTheDocument();
+    await expect(canvas.getByText(/only 62% similar/)).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Apply anyway" }));
+    await expect(args.onUseTmMatch).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "tm-low-match", matchPercent: 62 }),
+    );
+  },
+};

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -12,15 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useState, type ReactNode } from "react";
-import {
-  AlertCircleIcon,
-  BulbIcon,
-  CheckmarkCircle02Icon,
-  Copy01Icon,
-  RefreshIcon,
-  Tick02Icon,
-} from "@hugeicons/core-free-icons";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { BookOpenTextIcon, BulbIcon, Cancel01Icon, RefreshIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -42,24 +35,24 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/primitives/cn";
 
-import { glossaryTermStatusClass } from "@/components/cat/segment/cat-tone";
-
 import {
   catEditorPanelMessages,
   catIntelligencePanelMessages,
 } from "@/components/cat/shared/cat.messages";
 import type {
-  CatGlossaryTerm,
+  CatGlossaryConcept,
   CatSegmentIntelligence,
   CatTmMatchKind,
   CatTranslationMemoryMatch,
 } from "@/components/cat/shared/types";
 
-import { containsGlossaryTerm } from "./cat-glossary-checks";
+import { CatGlossaryConceptCard } from "./cat-glossary-concept-card";
+import {
+  CAT_GLOSSARY_GUIDANCE_OPEN_EVENT,
+  setCatGlossaryGuidanceStatus,
+} from "./cat-glossary-guidance-event";
 import { requiresLowMatchConfirmation } from "./tm-match-quality";
 import { CatVisualContextPanel } from "./cat-visual-context-panel";
-
-const RIGHT_ARROW = "→";
 
 function PanelSection({
   title,
@@ -110,82 +103,31 @@ function AgentContextSkeleton() {
   );
 }
 
-function GlossaryTermRow({ term, targetText }: { term: CatGlossaryTerm; targetText: string }) {
-  const intl = useIntl();
-  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
-  const forbiddenInTarget = term.forbidden && containsGlossaryTerm(targetText, term.source);
-  const copyValue = term.target.trim();
-
-  async function handleCopy() {
-    if (!copyValue) {
-      return;
-    }
-
-    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
-      setCopyState("error");
-      window.setTimeout(() => setCopyState("idle"), 2000);
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(copyValue);
-      setCopyState("copied");
-      window.setTimeout(() => setCopyState("idle"), 2000);
-    } catch {
-      setCopyState("error");
-      window.setTimeout(() => setCopyState("idle"), 2000);
-    }
-  }
-
-  return (
-    <li className="px-3 py-2.5">
-      <div className="flex items-center gap-3">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="min-w-0 truncate text-sm text-foreground">{term.source}</span>
-          <span className="shrink-0 text-xs text-muted-foreground">{RIGHT_ARROW}</span>
-          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-            {term.target}
-          </span>
-        </div>
-        {forbiddenInTarget ? (
-          <HugeiconsIcon
-            icon={AlertCircleIcon}
-            className={cn("size-4 shrink-0", glossaryTermStatusClass(term, forbiddenInTarget))}
-            aria-label={intl.formatMessage(catIntelligencePanelMessages.forbiddenInTargetAria)}
-          />
-        ) : term.approved ? (
-          <HugeiconsIcon
-            icon={CheckmarkCircle02Icon}
-            className={cn("size-4 shrink-0", glossaryTermStatusClass(term, forbiddenInTarget))}
-            aria-label={intl.formatMessage(catIntelligencePanelMessages.approvedAria)}
-          />
-        ) : null}
-        {copyValue ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            className="shrink-0"
-            onClick={() => void handleCopy()}
-          >
-            {copyState === "copied" ? (
-              <>
-                <HugeiconsIcon icon={Tick02Icon} className="size-3" aria-hidden />
-                <FormattedMessage {...catIntelligencePanelMessages.glossaryTermCopied} />
-              </>
-            ) : copyState === "error" ? (
-              <FormattedMessage {...catIntelligencePanelMessages.glossaryTermCopyFailed} />
-            ) : (
-              <>
-                <HugeiconsIcon icon={Copy01Icon} className="size-3" aria-hidden />
-                <FormattedMessage {...catIntelligencePanelMessages.copyGlossaryTerm} />
-              </>
-            )}
-          </Button>
-        ) : null}
-      </div>
-    </li>
-  );
+function legacyGlossaryConcepts(intelligence: CatSegmentIntelligence): CatGlossaryConcept[] {
+  return intelligence.glossaryTerms.map((term) => ({
+    id: `legacy:${term.id}`,
+    glossaryId: "legacy",
+    glossaryName: "Project Glossary",
+    primaryTerm: term.source,
+    sourceTerms: [
+      {
+        id: `${term.id}:source`,
+        locale: "source",
+        text: term.source,
+        preferred: term.approved,
+        forbidden: term.forbidden,
+      },
+    ],
+    targetTerms: [
+      {
+        id: `${term.id}:target`,
+        locale: "target",
+        text: term.target,
+        preferred: term.approved,
+        forbidden: term.forbidden,
+      },
+    ],
+  }));
 }
 
 function tmMatchBadgeTone(matchKind: CatTmMatchKind | undefined) {
@@ -262,7 +204,6 @@ function TranslationMemoryRow({
 
 export function CatIntelligencePanel({
   intelligence,
-  targetText = "",
   isLookingUpContext = false,
   isConcordanceLoading = false,
   isVisualContextLoading = false,
@@ -287,6 +228,66 @@ export function CatIntelligencePanel({
 }) {
   const intl = useIntl();
   const [pendingLowMatch, setPendingLowMatch] = useState<CatTranslationMemoryMatch | null>(null);
+  const [isGlossaryPanelOpen, setIsGlossaryPanelOpen] = useState(false);
+  const glossaryConcepts = useMemo(
+    () => intelligence.glossaryConcepts ?? legacyGlossaryConcepts(intelligence),
+    [intelligence],
+  );
+  const glossaryConceptKey = glossaryConcepts.map((concept) => concept.id).join("\u0000");
+  const glossaryGuidanceStatus = useMemo(() => {
+    const terms = glossaryConcepts.flatMap((concept) => [
+      ...concept.sourceTerms,
+      ...concept.targetTerms,
+    ]);
+
+    return {
+      preferredCount: terms.filter((term) => {
+        const normalized = term.status?.trim().toLowerCase().replaceAll(" ", "_");
+        return !term.forbidden && (term.preferred || normalized === "preferred");
+      }).length,
+      notRecommendedCount: terms.filter((term) => {
+        const normalized = term.status?.trim().toLowerCase().replaceAll(" ", "_");
+        return term.forbidden || normalized === "forbidden" || normalized === "not_recommended";
+      }).length,
+    };
+  }, [glossaryConcepts]);
+  const [expandedGlossaryConceptIds, setExpandedGlossaryConceptIds] = useState<Set<string>>(
+    () => new Set(glossaryConcepts[0] ? [glossaryConcepts[0].id] : []),
+  );
+
+  useEffect(() => {
+    setExpandedGlossaryConceptIds(new Set(glossaryConcepts[0] ? [glossaryConcepts[0].id] : []));
+  }, [glossaryConceptKey, glossaryConcepts]);
+
+  useEffect(() => {
+    setCatGlossaryGuidanceStatus(
+      isConcordanceLoading ? { preferredCount: 0, notRecommendedCount: 0 } : glossaryGuidanceStatus,
+    );
+
+    return () => {
+      setCatGlossaryGuidanceStatus({ preferredCount: 0, notRecommendedCount: 0 });
+    };
+  }, [glossaryConceptKey, glossaryGuidanceStatus, isConcordanceLoading]);
+
+  useEffect(() => {
+    function handleOpenGlossaryGuidance() {
+      setIsGlossaryPanelOpen(true);
+    }
+
+    window.addEventListener(CAT_GLOSSARY_GUIDANCE_OPEN_EVENT, handleOpenGlossaryGuidance);
+    return () => {
+      window.removeEventListener(CAT_GLOSSARY_GUIDANCE_OPEN_EVENT, handleOpenGlossaryGuidance);
+    };
+  }, []);
+
+  function toggleGlossaryConcept(conceptId: string) {
+    setExpandedGlossaryConceptIds((current) => {
+      const next = new Set(current);
+      if (next.has(conceptId)) next.delete(conceptId);
+      else next.add(conceptId);
+      return next;
+    });
+  }
   const hasFileContext = Boolean(intelligence.productMeaning?.trim());
   const agentBadges = [
     intelligence.locationBreadcrumb,
@@ -433,28 +434,11 @@ export function CatIntelligencePanel({
           {isConcordanceLoading ? (
             <>
               <PanelSection
-                title={intl.formatMessage(catIntelligencePanelMessages.glossaryGuidance)}
-              >
-                <ConcordanceSkeleton />
-              </PanelSection>
-              <PanelSection
                 title={intl.formatMessage(catIntelligencePanelMessages.translationMemory)}
               >
                 <ConcordanceSkeleton />
               </PanelSection>
             </>
-          ) : null}
-
-          {!isConcordanceLoading && intelligence.glossaryTerms.length > 0 ? (
-            <PanelSection title={intl.formatMessage(catIntelligencePanelMessages.glossaryGuidance)}>
-              <div className="overflow-hidden rounded-2xl bg-muted">
-                <ul className="divide-y divide-border">
-                  {intelligence.glossaryTerms.map((term) => (
-                    <GlossaryTermRow key={term.id} term={term} targetText={targetText} />
-                  ))}
-                </ul>
-              </div>
-            </PanelSection>
           ) : null}
 
           {!isConcordanceLoading &&
@@ -478,6 +462,68 @@ export function CatIntelligencePanel({
           ) : null}
         </div>
       </ScrollArea>
+
+      {isGlossaryPanelOpen ? (
+        <section
+          className="fixed inset-x-2 bottom-[calc(var(--app-shell-plan-footer-height)+0.5rem)] z-50 flex h-[min(44rem,calc(100svh-var(--app-shell-plan-footer-height)-1rem))] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15 sm:inset-x-auto sm:right-3 sm:w-[38rem]"
+          aria-label={intl.formatMessage(catIntelligencePanelMessages.glossaryGuidance)}
+        >
+          <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
+            <div className="min-w-0 flex-1">
+              <h2 className="truncate text-base font-medium text-foreground">
+                <FormattedMessage {...catIntelligencePanelMessages.glossaryGuidance} />
+              </h2>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={intl.formatMessage(catIntelligencePanelMessages.glossaryGuidanceClose)}
+              onClick={() => setIsGlossaryPanelOpen(false)}
+            >
+              <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+            </Button>
+          </header>
+
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="space-y-3 p-4">
+              <p className="text-sm text-muted-foreground">
+                <FormattedMessage {...catIntelligencePanelMessages.glossaryGuidanceDescription} />
+              </p>
+              {isConcordanceLoading ? (
+                <ConcordanceSkeleton />
+              ) : glossaryConcepts.length === 0 ? (
+                <div className="flex min-h-56 flex-col items-center justify-center rounded-xl bg-muted/30 px-6 text-center">
+                  <HugeiconsIcon
+                    icon={BookOpenTextIcon}
+                    className="size-7 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <p className="mt-3 text-base font-medium text-foreground">
+                    <FormattedMessage
+                      {...catIntelligencePanelMessages.glossaryGuidanceEmptyTitle}
+                    />
+                  </p>
+                  <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                    <FormattedMessage
+                      {...catIntelligencePanelMessages.glossaryGuidanceEmptyDescription}
+                    />
+                  </p>
+                </div>
+              ) : (
+                glossaryConcepts.map((concept) => (
+                  <CatGlossaryConceptCard
+                    key={concept.id}
+                    concept={concept}
+                    expanded={expandedGlossaryConceptIds.has(concept.id)}
+                    onToggle={() => toggleGlossaryConcept(concept.id)}
+                  />
+                ))
+              )}
+            </div>
+          </ScrollArea>
+        </section>
+      ) : null}
 
       <AlertDialog
         open={pendingLowMatch !== null}

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -525,6 +525,26 @@ export const catIntelligencePanelMessages = defineMessages({
     id: "ee60kiAN7Z",
     description: "Section heading for glossary term guidance in the intelligence panel",
   },
+  glossaryGuidanceDescription: {
+    defaultMessage: "Matched concepts from the project glossary.",
+    id: "h6wm+58u19",
+    description: "Description for the glossary guidance dialog",
+  },
+  glossaryGuidanceClose: {
+    defaultMessage: "Close glossary guidance",
+    id: "pQttDyq4Mr",
+    description: "Accessible label for closing the glossary guidance panel",
+  },
+  glossaryGuidanceEmptyTitle: {
+    defaultMessage: "No glossary matches",
+    id: "fdAK5CKbNL",
+    description: "Empty state title for the glossary guidance panel",
+  },
+  glossaryGuidanceEmptyDescription: {
+    defaultMessage: "No project glossary concepts match this string.",
+    id: "4DQSOq1CB0",
+    description: "Empty state description for the glossary guidance panel",
+  },
   translationMemory: {
     defaultMessage: "Translation memory",
     id: "okYWXGLSBl",
@@ -579,6 +599,46 @@ export const catIntelligencePanelMessages = defineMessages({
     defaultMessage: "Copy failed",
     id: "Ya0t4KyDVG",
     description: "Button label when copying a glossary target term fails",
+  },
+  glossaryConceptExpand: {
+    defaultMessage: "Show glossary concept details",
+    id: "mK6wLZvKdg",
+    description: "Accessible label for expanding glossary concept details",
+  },
+  glossaryConceptCollapse: {
+    defaultMessage: "Hide glossary concept details",
+    id: "5//srj2rVM",
+    description: "Accessible label for collapsing glossary concept details",
+  },
+  glossaryPreferred: {
+    defaultMessage: "Preferred",
+    id: "h1gQeaJchd",
+    description: "Status badge for a preferred glossary term",
+  },
+  glossaryNotRecommended: {
+    defaultMessage: "Not recommended",
+    id: "Q/u6jDht8H",
+    description: "Status badge for a discouraged glossary term",
+  },
+  glossaryAdmitted: {
+    defaultMessage: "Admitted",
+    id: "T03AFW0QvU",
+    description: "Status badge for an admitted glossary term",
+  },
+  glossaryDraft: {
+    defaultMessage: "Draft",
+    id: "8bfW3Jqg2b",
+    description: "Status badge for a draft glossary term",
+  },
+  glossaryObsolete: {
+    defaultMessage: "Obsolete",
+    id: "+pwP0Po+Io",
+    description: "Status badge for an obsolete glossary term",
+  },
+  projectGlossary: {
+    defaultMessage: "Project Glossary",
+    id: "SLnLYAC4Ib",
+    description: "Link to the source glossary for a CAT concept",
   },
   lowMatchConfirmTitle: {
     defaultMessage: "Apply low-quality TM match?",

--- a/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
@@ -13,6 +13,7 @@
 import type { CatVisualContext } from "@/lib/translation/cat-visual-context";
 import type {
   CatFormatCheck,
+  CatGlossaryConcept,
   CatGlossaryTerm,
   CatSegment,
   CatSegmentCommentInput,
@@ -31,6 +32,7 @@ export interface CatAiRecommendationResult {
 
 export interface CatSegmentConcordanceResult {
   glossaryTerms: CatGlossaryTerm[];
+  glossaryConcepts?: CatGlossaryConcept[];
   translationMemoryMatches: CatTranslationMemoryMatch[];
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -139,6 +139,30 @@ export interface CatGlossaryTerm {
   forbidden: boolean;
 }
 
+export interface CatGlossaryConceptTerm {
+  id: string;
+  locale: string;
+  text: string;
+  status?: string | null;
+  forbidden?: boolean;
+  preferred?: boolean;
+  termType?: string | null;
+  partOfSpeech?: string | null;
+  gender?: string | null;
+}
+
+export interface CatGlossaryConcept {
+  id: string;
+  glossaryId: string;
+  glossaryName: string;
+  glossaryUrl?: string | null;
+  primaryTerm: string;
+  subject?: string | null;
+  definition?: string | null;
+  sourceTerms: CatGlossaryConceptTerm[];
+  targetTerms: CatGlossaryConceptTerm[];
+}
+
 export interface CatTranslationMemoryMatch {
   id: string;
   sourceText: string;
@@ -162,6 +186,7 @@ export interface CatSegmentIntelligence {
   reviewerPreference?: string;
   constraints?: string;
   glossaryTerms: CatGlossaryTerm[];
+  glossaryConcepts?: CatGlossaryConcept[];
   translationMemoryMatches?: CatTranslationMemoryMatch[];
   aiSuggestion?: string;
   aiReasoning?: string;

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
@@ -84,6 +84,7 @@ export class CatIntelligenceController {
         this.workspace.segmentIntelligence[segmentId] ?? this.workspace.intelligence;
       return {
         glossaryTerms: intelligence.glossaryTerms ?? [],
+        glossaryConcepts: intelligence.glossaryConcepts,
         translationMemoryMatches: intelligence.translationMemoryMatches ?? [],
       };
     }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-store-utils.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-store-utils.ts
@@ -116,9 +116,11 @@ export function mergeSegmentIntelligenceOnHydrate(input: {
 
   const hasCurrentConcordance =
     (currentConcordance?.glossaryTerms.length ?? 0) > 0 ||
+    (currentConcordance?.glossaryConcepts?.length ?? 0) > 0 ||
     (currentConcordance?.translationMemoryMatches?.length ?? 0) > 0;
   const hasNextConcordance =
     (nextConcordance?.glossaryTerms.length ?? 0) > 0 ||
+    (nextConcordance?.glossaryConcepts?.length ?? 0) > 0 ||
     (nextConcordance?.translationMemoryMatches?.length ?? 0) > 0;
 
   if (hasCurrentConcordance && !hasNextConcordance) {
@@ -126,6 +128,7 @@ export function mergeSegmentIntelligenceOnHydrate(input: {
       ...(merged ?? nextInitialState.intelligence),
       ...currentConcordance,
       glossaryTerms: currentConcordance?.glossaryTerms ?? [],
+      glossaryConcepts: currentConcordance?.glossaryConcepts,
       translationMemoryMatches: currentConcordance?.translationMemoryMatches,
     };
   }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -708,15 +708,26 @@ export interface CrowdinGlossaryConcordanceTerm {
   text: string;
   description?: string | null;
   status?: string | null;
+  partOfSpeech?: string | null;
+  type?: string | null;
+  gender?: string | null;
+  conceptId?: number | null;
 }
 
 export interface CrowdinGlossaryConcordanceSearchResult {
   glossary: {
     id: number;
     name: string;
+    webUrl?: string | null;
   };
   sourceTerms: CrowdinGlossaryConcordanceTerm[];
   targetTerms: CrowdinGlossaryConcordanceTerm[];
+  concept?: {
+    id: number;
+    subject?: string | null;
+    definition?: string | null;
+    url?: string | null;
+  } | null;
 }
 
 interface CrowdinListResponse<T> {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -74,7 +74,12 @@ import {
 } from "@/lib/providers/contracts/tms-provider";
 import type { ExternalTmsGlossaryMatcherInput } from "@/lib/providers/contracts/glossary-matcher";
 import { normalizeProviderGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
-import type { NormalizedGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
+import type {
+  NormalizedGlossaryConcept,
+  NormalizedGlossaryConceptTerm,
+  NormalizedGlossaryMatch,
+} from "@/lib/providers/contracts/glossary-match";
+import { normalizeProviderGlossaryTermFlags } from "@/lib/providers/contracts/glossary-term-status";
 import type { ExternalTmsTranslationMemoryMatcherInput } from "@/lib/providers/contracts/translation-memory-matcher";
 import { normalizeProviderTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
 import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
@@ -2775,6 +2780,9 @@ export class CrowdinTmsProvider extends TmsProvider {
       }
 
       const externalGlossaryId = String(result.glossary.id);
+      const glossaryUrl =
+        sanitizeExternalUrl(result.glossary.webUrl) ??
+        `https://crowdin.com/glossary/${encodeURIComponent(externalGlossaryId)}`;
       const status =
         this.pickTermStatus(result.targetTerms, targetLanguageId) ??
         this.pickTermStatus(result.sourceTerms, sourceLanguageId);
@@ -2783,6 +2791,32 @@ export class CrowdinTmsProvider extends TmsProvider {
         providerTermId != null
           ? String(providerTermId)
           : this.stableConcordanceTermId(externalGlossaryId, sourceTerm, input.targetLocale);
+
+      const toConceptTerm = (
+        term: (typeof result.sourceTerms)[number],
+      ): NormalizedGlossaryConceptTerm => {
+        const forbidden = normalizeProviderGlossaryTermFlags({ status: term.status }).forbidden;
+        return {
+          id: String(term.id),
+          locale: term.languageId,
+          text: term.text,
+          status: term.status,
+          forbidden,
+          preferred: !forbidden,
+          termType: term.type,
+          partOfSpeech: term.partOfSpeech,
+          gender: term.gender,
+        };
+      };
+      const concept: NormalizedGlossaryConcept = {
+        id: result.concept ? String(result.concept.id) : externalTermId,
+        primaryTerm: sourceTerm,
+        subject: result.concept?.subject,
+        definition: result.concept?.definition,
+        glossaryUrl,
+        sourceTerms: result.sourceTerms.map(toConceptTerm),
+        targetTerms: result.targetTerms.map(toConceptTerm),
+      };
 
       glossaryTerms.push(
         normalizeProviderGlossaryMatch({
@@ -2797,6 +2831,7 @@ export class CrowdinTmsProvider extends TmsProvider {
           glossaryName: result.glossary.name,
           rank: 1 - index * 0.01,
           status: { status },
+          concept,
         }),
       );
     }

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-match.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-match.ts
@@ -23,6 +23,28 @@ export type NormalizedGlossaryTermStatus = {
   preferred: boolean;
 };
 
+export type NormalizedGlossaryConceptTerm = {
+  id: string;
+  locale: string;
+  text: string;
+  status?: string | null;
+  forbidden?: boolean;
+  preferred?: boolean;
+  termType?: string | null;
+  partOfSpeech?: string | null;
+  gender?: string | null;
+};
+
+export type NormalizedGlossaryConcept = {
+  id: string;
+  primaryTerm: string;
+  subject?: string | null;
+  definition?: string | null;
+  glossaryUrl?: string | null;
+  sourceTerms: NormalizedGlossaryConceptTerm[];
+  targetTerms: NormalizedGlossaryConceptTerm[];
+};
+
 export type NormalizedGlossaryMatch = {
   id: string;
   glossaryId: string;
@@ -40,6 +62,7 @@ export type NormalizedGlossaryMatch = {
   externalResourceId: string | null;
   externalTermId: string | null;
   termStatus: NormalizedGlossaryTermStatus;
+  concept?: NormalizedGlossaryConcept;
 };
 
 export type ContextGlossaryMatch = {
@@ -87,6 +110,7 @@ export type ProviderGlossaryMatchInput = {
   glossaryName: string;
   rank?: number;
   status?: ProviderGlossaryTermStatusInput;
+  concept?: NormalizedGlossaryConcept;
 };
 
 export function normalizeGlossaryTermStatus(
@@ -124,6 +148,7 @@ export function normalizeProviderGlossaryMatch(
     externalResourceId,
     externalTermId,
     termStatus,
+    ...(input.concept ? { concept: input.concept } : {}),
   };
 }
 
@@ -142,6 +167,7 @@ export function normalizeSyncedDatabaseGlossaryMatch(input: {
   providerKind: ExternalTmsProviderKind | null;
   externalResourceId: string | null;
   externalTermId: string | null;
+  concept?: NormalizedGlossaryConcept;
 }): NormalizedGlossaryMatch {
   return {
     id: input.id,
@@ -163,6 +189,7 @@ export function normalizeSyncedDatabaseGlossaryMatch(input: {
       forbidden: input.forbidden,
       preferred: !input.forbidden,
     },
+    ...(input.concept ? { concept: input.concept } : {}),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-term-status.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-term-status.ts
@@ -30,7 +30,7 @@ export function normalizeProviderGlossaryTermFlags(input: ProviderGlossaryTermSt
     return { forbidden: false };
   }
 
-  const status = input.status?.trim().toLowerCase();
+  const status = input.status?.trim().toLowerCase().replaceAll("_", " ");
   if (!status) {
     return { forbidden: false };
   }

--- a/apps/hyperlocalise-web/src/lib/translation/cat.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/cat.ts
@@ -10,7 +10,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import type { CatGlossaryTerm, CatTranslationMemoryMatch } from "@/components/cat/shared/types";
+import type {
+  CatGlossaryConcept,
+  CatGlossaryConceptTerm,
+  CatGlossaryTerm,
+  CatTranslationMemoryMatch,
+} from "@/components/cat/shared/types";
 import { inferTmMatchKind } from "@/components/cat/intelligence/tm-match-quality";
 import { crowdinTmsProvider } from "@/lib/providers/adapters/crowdin/crowdin-provider";
 import { CrowdinApiClient } from "@/lib/providers/adapters/crowdin/crowdin-api";
@@ -29,7 +34,10 @@ import { TmsProviderLiveError } from "@/lib/providers/jobs/tms-provider-live-err
 import { tryLoadActiveTmsProviderContext } from "@/lib/providers/jobs/tms-provider-live";
 import { resolveExternalTmsSecretMaterialForActor } from "@/lib/providers/shared/tms-provider-content";
 import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
-import type { NormalizedGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
+import type {
+  NormalizedGlossaryConceptTerm,
+  NormalizedGlossaryMatch,
+} from "@/lib/providers/contracts/glossary-match";
 import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
 import {
   defaultGlossaryMatchResolution,
@@ -61,6 +69,7 @@ export { pixelRectToPercentMarkers } from "@/lib/translation/cat-visual-context"
 
 export type CatSegmentConcordance = {
   glossaryTerms: CatGlossaryTerm[];
+  glossaryConcepts?: CatGlossaryConcept[];
   translationMemoryMatches: CatTranslationMemoryMatch[];
 };
 
@@ -72,6 +81,71 @@ function toCatGlossaryTerm(match: NormalizedGlossaryMatch): CatGlossaryTerm {
     approved: match.termStatus.preferred,
     forbidden: match.termStatus.forbidden,
   };
+}
+
+function toCatGlossaryConceptTerm(term: NormalizedGlossaryConceptTerm): CatGlossaryConceptTerm {
+  return { ...term };
+}
+
+function toCatGlossaryConcept(match: NormalizedGlossaryMatch): CatGlossaryConcept {
+  const concept = match.concept;
+  if (concept) {
+    return {
+      id: `${match.glossaryId}:${concept.id}`,
+      glossaryId: match.glossaryId,
+      glossaryName: match.glossaryName,
+      glossaryUrl: concept.glossaryUrl,
+      primaryTerm: concept.primaryTerm || match.sourceTerm,
+      subject: concept.subject,
+      definition: concept.definition ?? match.description,
+      sourceTerms: concept.sourceTerms.map(toCatGlossaryConceptTerm),
+      targetTerms: concept.targetTerms.map(toCatGlossaryConceptTerm),
+    };
+  }
+
+  return {
+    id: `${match.glossaryId}:${match.sourceLocale}:${match.sourceTerm}`,
+    glossaryId: match.glossaryId,
+    glossaryName: match.glossaryName,
+    primaryTerm: match.sourceTerm,
+    definition: match.description,
+    sourceTerms: [
+      {
+        id: `${match.id}:source`,
+        locale: match.sourceLocale,
+        text: match.sourceTerm,
+        preferred: match.termStatus.preferred,
+        forbidden: match.termStatus.forbidden,
+      },
+    ],
+    targetTerms: [
+      {
+        id: `${match.id}:target`,
+        locale: match.targetLocale,
+        text: match.targetTerm,
+        preferred: match.termStatus.preferred,
+        forbidden: match.termStatus.forbidden,
+      },
+    ],
+  };
+}
+
+function toCatGlossaryConcepts(matches: NormalizedGlossaryMatch[]): CatGlossaryConcept[] {
+  const concepts = new Map<string, CatGlossaryConcept>();
+  for (const match of matches) {
+    const next = toCatGlossaryConcept(match);
+    const existing = concepts.get(next.id);
+    if (!existing) {
+      concepts.set(next.id, next);
+      continue;
+    }
+
+    const sourceIds = new Set(existing.sourceTerms.map((term) => term.id));
+    const targetIds = new Set(existing.targetTerms.map((term) => term.id));
+    existing.sourceTerms.push(...next.sourceTerms.filter((term) => !sourceIds.has(term.id)));
+    existing.targetTerms.push(...next.targetTerms.filter((term) => !targetIds.has(term.id)));
+  }
+  return [...concepts.values()];
 }
 
 function toCatTranslationMemoryMatch(
@@ -289,6 +363,7 @@ export class CatConcordanceService {
         if (liveMatches) {
           return {
             glossaryTerms: liveMatches.glossaryTerms.map(toCatGlossaryTerm),
+            glossaryConcepts: toCatGlossaryConcepts(liveMatches.glossaryTerms),
             translationMemoryMatches: liveMatches.translationMemoryMatches.map((match) =>
               toCatTranslationMemoryMatch(match, input.sourceText),
             ),
@@ -320,6 +395,7 @@ export class CatConcordanceService {
 
     return {
       glossaryTerms: glossaryMatches.map(toCatGlossaryTerm),
+      glossaryConcepts: toCatGlossaryConcepts(glossaryMatches),
       translationMemoryMatches: translationMemoryMatches.map((match) =>
         toCatTranslationMemoryMatch(match, input.sourceText),
       ),

--- a/apps/hyperlocalise-web/src/lib/translation/concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/concordance.ts
@@ -344,6 +344,23 @@ class GlossaryConcordancePipeline extends ConcordancePipeline<
           externalKey: sql<string | null>`null`,
           externalProviderKind: schema.glossaries.externalProviderKind,
           externalGlossaryId: schema.glossaries.externalGlossaryId,
+          externalGlossaryUrl: schema.glossaries.externalUrl,
+          conceptId: sql<string | null>`null`,
+          conceptPrimaryTerm: sql<string | null>`null`,
+          conceptSubject: sql<string | null>`null`,
+          conceptDefinition: sql<string | null>`null`,
+          conceptUrl: sql<string | null>`null`,
+          sourceTermId: sql<string | null>`null`,
+          targetTermId: sql<string | null>`null`,
+          sourcePartOfSpeech: sql<string | null>`null`,
+          targetPartOfSpeech: sql<string | null>`null`,
+          sourceTermType: sql<string | null>`null`,
+          targetTermType: sql<string | null>`null`,
+          sourceGender: sql<string | null>`null`,
+          targetGender: sql<string | null>`null`,
+          sourceStatus: sql<string | null>`null`,
+          targetStatus: sql<string | null>`null`,
+          targetForbidden: sql<boolean | null>`null`,
           rank: sql<number>`ts_rank(${schema.glossaryTerms.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
             "rank",
           ),
@@ -377,6 +394,23 @@ class GlossaryConcordancePipeline extends ConcordancePipeline<
           externalKey: sql<string | null>`null`,
           externalProviderKind: schema.glossaries.externalProviderKind,
           externalGlossaryId: schema.glossaries.externalGlossaryId,
+          externalGlossaryUrl: schema.glossaries.externalUrl,
+          conceptId: concordanceSourceTerms.conceptId,
+          conceptPrimaryTerm: schema.glossaryConcepts.primaryTerm,
+          conceptSubject: schema.glossaryConcepts.subject,
+          conceptDefinition: schema.glossaryConcepts.definition,
+          conceptUrl: schema.glossaryConcepts.url,
+          sourceTermId: concordanceSourceTerms.id,
+          targetTermId: concordanceTargetTerms.id,
+          sourcePartOfSpeech: concordanceSourceTerms.partOfSpeech,
+          targetPartOfSpeech: concordanceTargetTerms.partOfSpeech,
+          sourceTermType: concordanceSourceTerms.termType,
+          targetTermType: concordanceTargetTerms.termType,
+          sourceGender: concordanceSourceTerms.gender,
+          targetGender: concordanceTargetTerms.gender,
+          sourceStatus: concordanceSourceTerms.status,
+          targetStatus: concordanceTargetTerms.status,
+          targetForbidden: concordanceTargetTerms.forbidden,
           rank: sql<number>`ts_rank(${concordanceSourceTerms.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
             "rank",
           ),
@@ -390,6 +424,10 @@ class GlossaryConcordancePipeline extends ConcordancePipeline<
           ),
         )
         .innerJoin(schema.glossaries, eq(concordanceSourceTerms.glossaryId, schema.glossaries.id))
+        .leftJoin(
+          schema.glossaryConcepts,
+          eq(concordanceSourceTerms.conceptId, schema.glossaryConcepts.id),
+        )
         .where(
           and(
             inArray(concordanceSourceTerms.glossaryId, glossaryIds),
@@ -433,6 +471,41 @@ class GlossaryConcordancePipeline extends ConcordancePipeline<
           providerKind: entry.externalProviderKind,
           externalResourceId: entry.externalGlossaryId,
           externalTermId: entry.externalKey,
+          concept: entry.conceptId
+            ? {
+                id: entry.conceptId,
+                primaryTerm: entry.conceptPrimaryTerm ?? entry.sourceTerm,
+                subject: entry.conceptSubject,
+                definition: entry.conceptDefinition,
+                glossaryUrl: entry.externalGlossaryUrl ?? entry.conceptUrl,
+                sourceTerms: [
+                  {
+                    id: entry.sourceTermId ?? `${entry.id}:source`,
+                    locale: entry.sourceLocale,
+                    text: entry.sourceTerm,
+                    status: entry.sourceStatus,
+                    forbidden: entry.forbidden,
+                    preferred: !entry.forbidden,
+                    partOfSpeech: entry.sourcePartOfSpeech,
+                    termType: entry.sourceTermType,
+                    gender: entry.sourceGender,
+                  },
+                ],
+                targetTerms: [
+                  {
+                    id: entry.targetTermId ?? `${entry.id}:target`,
+                    locale: entry.targetLocale,
+                    text: entry.targetTerm,
+                    status: entry.targetStatus,
+                    forbidden: entry.targetForbidden ?? false,
+                    preferred: !(entry.targetForbidden ?? false),
+                    partOfSpeech: entry.targetPartOfSpeech,
+                    termType: entry.targetTermType,
+                    gender: entry.targetGender,
+                  },
+                ],
+              }
+            : undefined,
         }),
       );
   }


### PR DESCRIPTION
## Summary
- add concordance-backed glossary concept cards with term statuses, metadata, copy actions, and glossary links
- add a floating Glossary guidance panel opened from the CAT app-shell footer
- add preferred/not-recommended match signals and Storybook coverage for results, loading, and empty states

## Validation
- `vp check --fix` passes with 0 errors and 9 pre-existing warnings
- focused tests pass: 2 files, 15 tests
- `vp test` completed with 4,602 passing tests, but 415 failures caused by the local database schema being behind the current code (`projects.identifier` is missing), plus local `localhost:3000` connection refusals