### PR TITLE
fix(web): preserve locale in marketing navigation links

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/legal-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/legal-page.tsx
@@ -18,6 +18,7 @@ import type { AppLocale } from "@/lib/app-i18n/locales";
 import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
 
 type LegalPageProps = {
+  locale: AppLocale;
   eyebrow: string;
   title: string;
   description: string;
@@ -42,7 +43,7 @@ export function createLegalMetadata({
   };
 }
 
-export function LegalPage({ eyebrow, title, description, children }: LegalPageProps) {
+export function LegalPage({ locale, eyebrow, title, description, children }: LegalPageProps) {
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="relative isolate overflow-hidden">
@@ -50,7 +51,7 @@ export function LegalPage({ eyebrow, title, description, children }: LegalPagePr
         <div className="mx-auto flex w-full max-w-4xl flex-col px-6 py-14 sm:px-8 lg:px-12 lg:py-18">
           <div className="flex flex-col gap-6">
             <Link
-              href="/"
+              href={`/${locale}`}
               className="w-fit text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-foreground"
             >
               Back to home

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-auth-actions.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-auth-actions.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { IntlProvider } from "react-intl";
+
+import { NavbarDesktopAuthActions } from "./navbar-auth-actions";
+
+function renderActions(isAuthenticated: boolean) {
+  return render(
+    <IntlProvider locale="de-DE" messages={{}} onError={() => undefined}>
+      <NavbarDesktopAuthActions auth={{ loading: false, isAuthenticated }} locale="de-DE" />
+    </IntlProvider>,
+  );
+}
+
+describe("NavbarDesktopAuthActions", () => {
+  it("links authenticated visitors directly to the localized dashboard", () => {
+    renderActions(true);
+
+    expect(screen.getByRole("button", { name: "Dashboard" }).getAttribute("href")).toBe(
+      "/de-DE/dashboard",
+    );
+  });
+
+  it("keeps the sign-in route outside the locale prefix", () => {
+    renderActions(false);
+
+    expect(screen.getByRole("button", { name: "Sign in" }).getAttribute("href")).toBe(
+      "/auth/sign-in",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-auth-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-auth-actions.tsx
@@ -19,6 +19,8 @@ import Link from "next/link";
 import { FormattedMessage } from "react-intl";
 
 import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
 
 import { navbarMessages } from "./navbar.messages";
 
@@ -30,7 +32,13 @@ export type NavbarAuthState = {
   isAuthenticated: boolean;
 };
 
-export function NavbarDesktopAuthActions({ auth }: { auth: NavbarAuthState }) {
+export function NavbarDesktopAuthActions({
+  auth,
+  locale,
+}: {
+  auth: NavbarAuthState;
+  locale: AppLocale;
+}) {
   if (auth.loading) {
     return (
       <div className="flex items-center gap-2" aria-hidden="true">
@@ -42,7 +50,10 @@ export function NavbarDesktopAuthActions({ auth }: { auth: NavbarAuthState }) {
 
   if (auth.isAuthenticated) {
     return (
-      <Button nativeButton={false} render={<Link href={dashboardHref} />}>
+      <Button
+        nativeButton={false}
+        render={<Link href={rewriteAppLocalePath(dashboardHref, locale)} />}
+      >
         <FormattedMessage {...navbarMessages.dashboard} />
       </Button>
     );
@@ -67,14 +78,24 @@ export function NavbarDesktopAuthActions({ auth }: { auth: NavbarAuthState }) {
   );
 }
 
-export function NavbarMobileAuthCta({ auth }: { auth: NavbarAuthState }) {
+export function NavbarMobileAuthCta({
+  auth,
+  locale,
+}: {
+  auth: NavbarAuthState;
+  locale: AppLocale;
+}) {
   if (auth.loading) {
     return <Skeleton className="h-9 w-24 rounded-md" aria-hidden="true" />;
   }
 
   if (auth.isAuthenticated) {
     return (
-      <Button className="px-3.5" nativeButton={false} render={<Link href={dashboardHref} />}>
+      <Button
+        className="px-3.5"
+        nativeButton={false}
+        render={<Link href={rewriteAppLocalePath(dashboardHref, locale)} />}
+      >
         <FormattedMessage {...navbarMessages.dashboard} />
       </Button>
     );
@@ -91,7 +112,13 @@ export function NavbarMobileAuthCta({ auth }: { auth: NavbarAuthState }) {
   );
 }
 
-export function NavbarMobileAuthFooter({ auth }: { auth: NavbarAuthState }) {
+export function NavbarMobileAuthFooter({
+  auth,
+  locale,
+}: {
+  auth: NavbarAuthState;
+  locale: AppLocale;
+}) {
   if (auth.loading) {
     return (
       <div className="flex w-full flex-col gap-2" aria-hidden="true">
@@ -103,7 +130,10 @@ export function NavbarMobileAuthFooter({ auth }: { auth: NavbarAuthState }) {
 
   if (auth.isAuthenticated) {
     return (
-      <SheetClose render={<Link href={dashboardHref} />} className="w-full">
+      <SheetClose
+        render={<Link href={rewriteAppLocalePath(dashboardHref, locale)} />}
+        className="w-full"
+      >
         <Button size="lg" className="w-full" nativeButton={false} render={<span />}>
           <FormattedMessage {...navbarMessages.dashboard} />
         </Button>

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-view.tsx
@@ -55,6 +55,9 @@ import { FormattedMessage, useIntl } from "react-intl";
 import LocaleToggle from "@/components/locale-toggle/locale-toggle";
 import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 import { themeToggleMessages } from "@/components/theme-toggle/theme-toggle.messages";
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
+import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
 
 import {
   NavbarDesktopAuthActions,
@@ -136,6 +139,10 @@ const megaMenuLinkClassName =
 const megaMenuHeadingClassName =
   "px-3 pb-2 text-[11px] font-medium tracking-[0.16em] text-muted-foreground uppercase";
 
+function getNavLinkHref(link: NavLink, locale: AppLocale) {
+  return link.href.startsWith("/") ? rewriteAppLocalePath(link.href, locale) : link.href;
+}
+
 function NavLinkLabel({ link }: { link: NavLink }) {
   if (link.kind === "product") {
     return <FormattedMessage {...productPageMessages[link.labelKey]} />;
@@ -168,7 +175,7 @@ function ExternalLinkIcon() {
   );
 }
 
-function MegaMenuLink({ link }: { link: NavLink }) {
+function MegaMenuLink({ link, locale }: { link: NavLink; locale: AppLocale }) {
   const intl = useIntl();
 
   if (link.external) {
@@ -189,13 +196,21 @@ function MegaMenuLink({ link }: { link: NavLink }) {
   }
 
   return (
-    <NavigationMenuLink href={link.href} className={megaMenuLinkClassName}>
+    <NavigationMenuLink href={getNavLinkHref(link, locale)} className={megaMenuLinkClassName}>
       <NavLinkLabel link={link} />
     </NavigationMenuLink>
   );
 }
 
-function MegaMenuColumn({ headingKey, links }: { headingKey: NavbarMessageKey; links: NavLink[] }) {
+function MegaMenuColumn({
+  headingKey,
+  links,
+  locale,
+}: {
+  headingKey: NavbarMessageKey;
+  links: NavLink[];
+  locale: AppLocale;
+}) {
   return (
     <div className="min-w-[11.5rem]">
       <div className={megaMenuHeadingClassName}>
@@ -204,7 +219,7 @@ function MegaMenuColumn({ headingKey, links }: { headingKey: NavbarMessageKey; l
       <ul className="grid gap-0.5">
         {links.map((link) => (
           <li key={`${link.kind}-${link.href}`}>
-            <MegaMenuLink link={link} />
+            <MegaMenuLink link={link} locale={locale} />
           </li>
         ))}
       </ul>
@@ -212,11 +227,11 @@ function MegaMenuColumn({ headingKey, links }: { headingKey: NavbarMessageKey; l
   );
 }
 
-function Logo({ onHero = false }: { onHero?: boolean }) {
+function Logo({ locale, onHero = false }: { locale: AppLocale; onHero?: boolean }) {
   const intl = useIntl();
 
   return (
-    <Link href="/" className="flex items-center gap-2.5">
+    <Link href={rewriteAppLocalePath("/", locale)} className="flex items-center gap-2.5">
       <Image
         src="/images/logo.png"
         className="size-8"
@@ -269,9 +284,11 @@ function useHomeHeroNavTone() {
 function MobileNavSection({
   headingKey,
   links,
+  locale,
 }: {
   headingKey: NavbarMessageKey;
   links: NavLink[];
+  locale: AppLocale;
 }) {
   const intl = useIntl();
 
@@ -310,7 +327,7 @@ function MobileNavSection({
         return (
           <SheetClose
             key={`${link.kind}-${link.href}`}
-            render={<a href={link.href} />}
+            render={<a href={getNavLinkHref(link, locale)} />}
             className={mobileNavLinkClassName}
           >
             {content}
@@ -321,7 +338,7 @@ function MobileNavSection({
   );
 }
 
-function MobileNavigation({ auth }: { auth: NavbarAuthState }) {
+function MobileNavigation({ auth, locale }: { auth: NavbarAuthState; locale: AppLocale }) {
   const intl = useIntl();
 
   return (
@@ -368,7 +385,7 @@ function MobileNavigation({ auth }: { auth: NavbarAuthState }) {
             <FormattedMessage {...navbarMessages.navigationHeading} />
           </div>
           <div className="pr-10">
-            <Logo />
+            <Logo locale={locale} />
           </div>
         </SheetHeader>
         <div className="flex flex-1 flex-col overflow-y-auto px-3 py-2">
@@ -376,16 +393,31 @@ function MobileNavigation({ auth }: { auth: NavbarAuthState }) {
             aria-label={intl.formatMessage(navbarMessages.mobileNavAriaLabel)}
             className="flex flex-col gap-2 pb-4"
           >
-            <MobileNavSection headingKey="navPlatformHeading" links={productLinks} />
-            <MobileNavSection headingKey="navUseCasesHeading" links={useCaseLinks} />
-            <MobileNavSection headingKey="navResourcesHeading" links={resourceLinks} />
-            <MobileNavSection headingKey="navLegalHeading" links={legalLinks} />
+            <MobileNavSection
+              headingKey="navPlatformHeading"
+              links={productLinks}
+              locale={locale}
+            />
+            <MobileNavSection
+              headingKey="navUseCasesHeading"
+              links={useCaseLinks}
+              locale={locale}
+            />
+            <MobileNavSection
+              headingKey="navResourcesHeading"
+              links={resourceLinks}
+              locale={locale}
+            />
+            <MobileNavSection headingKey="navLegalHeading" links={legalLinks} locale={locale} />
             <div className="space-y-1.5">
-              <SheetClose render={<a href={pricingLink.href} />} className={mobileNavLinkClassName}>
+              <SheetClose
+                render={<a href={rewriteAppLocalePath(pricingLink.href, locale)} />}
+                className={mobileNavLinkClassName}
+              >
                 <NavLinkLabel link={pricingLink} />
               </SheetClose>
               <SheetClose
-                render={<a href={companyPageLink.href} />}
+                render={<a href={rewriteAppLocalePath(companyPageLink.href, locale)} />}
                 className={mobileNavLinkClassName}
               >
                 <NavLinkLabel link={companyPageLink} />
@@ -400,14 +432,14 @@ function MobileNavigation({ auth }: { auth: NavbarAuthState }) {
             </span>
             <ThemeToggle />
           </div>
-          <NavbarMobileAuthFooter auth={auth} />
+          <NavbarMobileAuthFooter auth={auth} locale={locale} />
         </SheetFooter>
       </SheetContent>
     </Sheet>
   );
 }
 
-function DesktopNavigation() {
+function DesktopNavigation({ locale }: { locale: AppLocale }) {
   return (
     <NavigationMenu className="mx-auto hidden max-w-none md:flex">
       <NavigationMenuList className="gap-1">
@@ -417,8 +449,16 @@ function DesktopNavigation() {
           </NavigationMenuTrigger>
           <NavigationMenuContent>
             <div className="grid w-max grid-cols-2 gap-6 p-3 pe-4">
-              <MegaMenuColumn headingKey="navPlatformHeading" links={productLinks} />
-              <MegaMenuColumn headingKey="navUseCasesHeading" links={useCaseLinks} />
+              <MegaMenuColumn
+                headingKey="navPlatformHeading"
+                links={productLinks}
+                locale={locale}
+              />
+              <MegaMenuColumn
+                headingKey="navUseCasesHeading"
+                links={useCaseLinks}
+                locale={locale}
+              />
             </div>
           </NavigationMenuContent>
         </NavigationMenuItem>
@@ -428,14 +468,18 @@ function DesktopNavigation() {
           </NavigationMenuTrigger>
           <NavigationMenuContent>
             <div className="grid w-max grid-cols-2 gap-6 p-3 pe-4">
-              <MegaMenuColumn headingKey="navResourcesHeading" links={resourceLinks} />
-              <MegaMenuColumn headingKey="navLegalHeading" links={legalLinks} />
+              <MegaMenuColumn
+                headingKey="navResourcesHeading"
+                links={resourceLinks}
+                locale={locale}
+              />
+              <MegaMenuColumn headingKey="navLegalHeading" links={legalLinks} locale={locale} />
             </div>
           </NavigationMenuContent>
         </NavigationMenuItem>
         <NavigationMenuItem>
           <NavigationMenuLink
-            href={pricingLink.href}
+            href={rewriteAppLocalePath(pricingLink.href, locale)}
             className={cn(
               navigationMenuTriggerStyle(),
               "px-3 py-2 font-medium text-muted-foreground hover:text-foreground",
@@ -446,7 +490,7 @@ function DesktopNavigation() {
         </NavigationMenuItem>
         <NavigationMenuItem>
           <NavigationMenuLink
-            href={companyPageLink.href}
+            href={rewriteAppLocalePath(companyPageLink.href, locale)}
             className={cn(
               navigationMenuTriggerStyle(),
               "px-3 py-2 font-medium text-muted-foreground hover:text-foreground",
@@ -462,6 +506,7 @@ function DesktopNavigation() {
 
 export function NavbarView({ auth }: { auth: NavbarAuthState }) {
   const onHero = useHomeHeroNavTone();
+  const locale = useAppLocale();
 
   return (
     <header
@@ -474,7 +519,7 @@ export function NavbarView({ auth }: { auth: NavbarAuthState }) {
     >
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-3 px-4 sm:px-6">
         <div className="flex min-w-0 items-center gap-3 lg:gap-8">
-          <Logo onHero={onHero} />
+          <Logo locale={locale} onHero={onHero} />
           <div
             className={cn(
               onHero &&
@@ -484,7 +529,7 @@ export function NavbarView({ auth }: { auth: NavbarAuthState }) {
                 ].join(" "),
             )}
           >
-            <DesktopNavigation />
+            <DesktopNavigation locale={locale} />
           </div>
         </div>
 
@@ -495,7 +540,7 @@ export function NavbarView({ auth }: { auth: NavbarAuthState }) {
               "[&_button]:text-white [&_button[data-variant=ghost]]:hover:bg-white/10 [&_button[data-variant=ghost]]:hover:text-white [&_a]:text-white",
           )}
         >
-          <NavbarDesktopAuthActions auth={auth} />
+          <NavbarDesktopAuthActions auth={auth} locale={locale} />
           <LocaleToggle />
           <ThemeToggle />
         </div>
@@ -506,8 +551,8 @@ export function NavbarView({ auth }: { auth: NavbarAuthState }) {
             onHero && "[&_button]:border-white/30 [&_button]:text-white",
           )}
         >
-          <NavbarMobileAuthCta auth={auth} />
-          <MobileNavigation auth={auth} />
+          <NavbarMobileAuthCta auth={auth} locale={locale} />
+          <MobileNavigation auth={auth} locale={locale} />
           <LocaleToggle />
         </div>
       </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/privacy/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/privacy/page.tsx
@@ -33,9 +33,13 @@ export async function generateMetadata({ params }: PrivacyPageProps): Promise<Me
   });
 }
 
-export default function PrivacyPage() {
+export default async function PrivacyPage({ params }: PrivacyPageProps) {
+  const { lang } = await params;
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+
   return (
     <LegalPage
+      locale={locale}
       eyebrow="Legal"
       title="Privacy policy"
       description="How Hyperlocalise handles account, usage, and provider-related data."

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/terms/cloud-service-agreement.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/terms/cloud-service-agreement.tsx
@@ -13,6 +13,8 @@
 import Link from "next/link";
 
 import { TypographyP } from "@/components/ui/typography";
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
 import { SUPPORT_EMAIL } from "@/lib/support-contact";
 
 import { LegalList, LegalSection } from "../_components/legal-page";
@@ -26,7 +28,7 @@ const COMMON_PAPER_LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/";
  * Version 2.1 for Hyperlocalise Pty Ltd clickwrap / self-serve use.
  * Attribution: Common Paper CSA v2.1, CC BY 4.0.
  */
-export function CloudServiceAgreement() {
+export function CloudServiceAgreement({ locale }: { locale: AppLocale }) {
   return (
     <>
       <TypographyP>
@@ -257,7 +259,10 @@ export function CloudServiceAgreement() {
         <TypographyP>
           <strong>3.1 Personal Data.</strong> Provider’s handling of personal information is
           described in the{" "}
-          <Link href={PRIVACY_HREF} className="underline underline-offset-4 hover:text-foreground">
+          <Link
+            href={rewriteAppLocalePath(PRIVACY_HREF, locale)}
+            className="underline underline-offset-4 hover:text-foreground"
+          >
             Privacy Policy
           </Link>
           . Before submitting Personal Data governed by GDPR (or UK GDPR) to the Product, Customer

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/terms/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/terms/page.tsx
@@ -34,14 +34,18 @@ export async function generateMetadata({ params }: TermsPageProps): Promise<Meta
   });
 }
 
-export default function TermsPage() {
+export default async function TermsPage({ params }: TermsPageProps) {
+  const { lang } = await params;
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+
   return (
     <LegalPage
+      locale={locale}
       eyebrow="Legal"
       title="Terms of service"
       description="Cloud Service Agreement terms for Hyperlocalise Pty Ltd, adapted from Common Paper CSA Version 2.1."
     >
-      <CloudServiceAgreement />
+      <CloudServiceAgreement locale={locale} />
     </LegalPage>
   );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/hero-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-section.tsx
@@ -24,6 +24,8 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
+import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
 
 const dashboardHref = "/dashboard";
 const HERO_IMAGE_SRC = "/images/vimal-s-GBg3jyGS-Ug-unsplash.jpg";
@@ -63,6 +65,7 @@ export function HeroSection() {
   const { user, loading } = useAuth();
   const isAuthenticated = Boolean(user);
   const intl = useIntl();
+  const locale = useAppLocale();
 
   const headlineTransition = shouldReduceMotion
     ? { duration: 0 }
@@ -152,7 +155,7 @@ export function HeroSection() {
                   size="lg"
                   className="bg-white text-neutral-950 hover:bg-white/90"
                   nativeButton={false}
-                  render={<Link href={dashboardHref} />}
+                  render={<Link href={rewriteAppLocalePath(dashboardHref, locale)} />}
                 >
                   <FormattedMessage {...heroSectionMessages.goToDashboard} />
                 </Button>

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
@@ -52,6 +52,8 @@ import type {
   LocalisationAuditTeaser,
 } from "@/lib/localisation-audit/types";
 import { cn } from "@/lib/primitives/cn";
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
 
 import {
   getLocalisationAuditGuideHref,
@@ -629,6 +631,8 @@ export function LocalisationAuditResult({
   variant = "public",
 }: LocalisationAuditResultProps) {
   const copy = getLocalisationAuditResultCopy(locale);
+  const appLocale = normalizeAppLocale(locale) ?? DEFAULT_APP_LOCALE;
+  const claimDomainHref = rewriteAppLocalePath(`/claim-domain/${domainSlug}`, appLocale);
   const { user, loading: authLoading, featureFlags } = useAuth();
   const showSignInCtas = isLocalisationAuditSignInCtaEnabled({
     loading: authLoading,
@@ -853,7 +857,7 @@ export function LocalisationAuditResult({
         {error ? <p className="mt-4 text-sm text-red-200">{error}</p> : null}
         <Button
           nativeButton={false}
-          render={<Link href={`/${locale}/localisation-audit`} />}
+          render={<Link href={rewriteAppLocalePath("/localisation-audit", appLocale)} />}
           className="mt-8 bg-white text-black hover:bg-white/90"
         >
           {copy.startNewAudit}
@@ -1181,10 +1185,7 @@ export function LocalisationAuditResult({
                 <Button
                   nativeButton={false}
                   render={
-                    <Link
-                      href={`/claim-domain/${domainSlug}`}
-                      onClick={() => trackCta("open_claimed_domain")}
-                    />
+                    <Link href={claimDomainHref} onClick={() => trackCta("open_claimed_domain")} />
                   }
                 >
                   {copy.openInWorkspace}
@@ -1194,7 +1195,7 @@ export function LocalisationAuditResult({
                   nativeButton={false}
                   render={
                     <Link
-                      href={`/auth/sign-in?returnTo=${encodeURIComponent(`/claim-domain/${domainSlug}`)}`}
+                      href={`/auth/sign-in?returnTo=${encodeURIComponent(claimDomainHref)}`}
                       onClick={() => trackCta("claim_domain")}
                     />
                   }

--- a/apps/hyperlocalise-web/src/components/marketing/marketing-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/marketing-footer.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { IntlProvider } from "react-intl";
+
+import { MarketingFooter } from "./marketing-footer";
+
+describe("MarketingFooter", () => {
+  it("prefixes internal links with the active locale", () => {
+    render(
+      <IntlProvider locale="fr-FR" messages={{}} onError={() => undefined}>
+        <MarketingFooter
+          columns={[
+            {
+              title: "Links",
+              links: [
+                { label: "Pricing", href: "/pricing" },
+                { label: "Documentation", href: "https://hyperlocalise.dev" },
+                { label: "Contact", href: "mailto:minh@hyperlocalise.com" },
+              ],
+            },
+          ]}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByRole("link", { name: "Pricing" }).getAttribute("href")).toBe(
+      "/fr-FR/pricing",
+    );
+    expect(screen.getByRole("link", { name: "Documentation" }).getAttribute("href")).toBe(
+      "https://hyperlocalise.dev",
+    );
+    expect(screen.getByRole("link", { name: "Contact" }).getAttribute("href")).toBe(
+      "mailto:minh@hyperlocalise.com",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/marketing/marketing-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/marketing-footer.tsx
@@ -27,6 +27,9 @@ import { productPageMessages } from "./product/product-page-content.messages";
 import type { ProductMessageKey } from "./product/product-page-content.messages";
 import { useCasePageMessages } from "./use-case/use-case-page-content.messages";
 import type { UseCaseMessageKey } from "./use-case/use-case-page-content.messages";
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
+import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
 
 const FOOTER_IMAGE_SRC = "/images/nasa-yZygONrUBe8-unsplash.jpg";
 
@@ -63,9 +66,11 @@ function FooterLinkLabel({
 function FooterLinkList({
   links,
   isExternalHref,
+  locale,
 }: {
   links: MarketingFooterLink[];
   isExternalHref: (href: string) => boolean;
+  locale: AppLocale;
 }) {
   return (
     <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
@@ -91,7 +96,7 @@ function FooterLinkList({
             </a>
           ) : (
             <Link
-              href={link.href}
+              href={rewriteAppLocalePath(link.href, locale)}
               className="inline-flex rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             >
               <FooterLinkLabel
@@ -110,6 +115,7 @@ function FooterLinkList({
 
 export function MarketingFooter({ columns }: MarketingFooterProps) {
   const intl = useIntl();
+  const locale = useAppLocale();
   const year = new Date().getFullYear();
   const isExternalHref = (href: string) =>
     href.startsWith("http://") || href.startsWith("https://") || href.startsWith("mailto:");
@@ -140,11 +146,19 @@ export function MarketingFooter({ columns }: MarketingFooterProps) {
                   column.title
                 )}
               </div>
-              <FooterLinkList links={column.links} isExternalHref={isExternalHref} />
+              <FooterLinkList
+                links={column.links}
+                isExternalHref={isExternalHref}
+                locale={locale}
+              />
               {column.nested ? (
                 <div className="mt-10">
                   <div className="text-sm font-medium text-foreground">{column.nested.title}</div>
-                  <FooterLinkList links={column.nested.links} isExternalHref={isExternalHref} />
+                  <FooterLinkList
+                    links={column.nested.links}
+                    isExternalHref={isExternalHref}
+                    locale={locale}
+                  />
                 </div>
               ) : null}
             </div>

--- a/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.ts
@@ -81,7 +81,7 @@ export const footerColumns: MarketingFooterColumn[] = [
       { labelKey: "footerStartups", href: "/startups" },
       { labelKey: "footerCompany", href: "/company" },
       { labelKey: "footerLocalisationAudit", href: "/localisation-audit" },
-      { label: "Blog", href: "/en/blog" },
+      { label: "Blog", href: "/blog" },
       { labelKey: "footerGitHubAction", href: githubActionUrl },
       { labelKey: "footerContact", href: contactUrl },
       { labelKey: "footerStatus", href: statusUrl },
@@ -90,8 +90,8 @@ export const footerColumns: MarketingFooterColumn[] = [
   {
     title: "Legal",
     links: [
-      { label: "Terms", href: "/en/terms" },
-      { label: "Privacy", href: "/en/privacy" },
+      { label: "Terms", href: "/terms" },
+      { label: "Privacy", href: "/privacy" },
       { label: "Trust Center", href: trustCenterUrl },
     ],
     nested: {

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
@@ -23,6 +23,8 @@ import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/primitives/cn";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
+import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
 
 import type { ProductPageContent } from "./product-page-content";
 import { AutomationsMockUI } from "./automations-mock-ui";
@@ -174,6 +176,8 @@ function ProductShowcase({ content }: ProductPageProps) {
 }
 
 function ProductDetailsSection({ content }: ProductPageProps) {
+  const locale = useAppLocale();
+
   return (
     <div className="grid gap-12 lg:grid-cols-[0.82fr_1.18fr] lg:items-start">
       <div className="max-w-xl lg:sticky lg:top-24">
@@ -215,7 +219,7 @@ function ProductDetailsSection({ content }: ProductPageProps) {
                 size="sm"
                 className="rounded-full"
                 nativeButton={false}
-                render={<Link href={link.href} />}
+                render={<Link href={rewriteAppLocalePath(link.href, locale)} />}
               >
                 <ProductMessage messageKey={link.labelKey} />
                 <HugeiconsIcon

--- a/apps/hyperlocalise-web/src/components/marketing/startups/startups-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/startups/startups-page.tsx
@@ -20,6 +20,8 @@ import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 import { Button } from "@/components/ui/button";
 import { TypographyH1, TypographyH2, TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
 
 import {
   getStartupsFaqItems,
@@ -43,7 +45,7 @@ const benefitMeshById = {
 } as const;
 
 type StartupsPageProps = {
-  locale: string;
+  locale: AppLocale;
 };
 
 export function StartupsPage({ locale }: StartupsPageProps) {
@@ -88,7 +90,7 @@ export function StartupsPage({ locale }: StartupsPageProps) {
               variant="outline"
               className="border-white/40 bg-transparent text-white hover:bg-white/10 hover:text-white"
               nativeButton={false}
-              render={<Link href="/pricing" />}
+              render={<Link href={rewriteAppLocalePath("/pricing", locale)} />}
             >
               {copy.seePricingCta}
             </Button>

--- a/apps/hyperlocalise-web/src/lib/app-i18n/use-app-locale.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/use-app-locale.ts
@@ -1,0 +1,23 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useIntl } from "react-intl";
+
+import { DEFAULT_APP_LOCALE, normalizeAppLocale, type AppLocale } from "./locales";
+
+export function useAppLocale(): AppLocale {
+  const intl = useIntl();
+
+  return normalizeAppLocale(intl.locale) ?? DEFAULT_APP_LOCALE;
+}

--- a/docs/adr/2026-08-25-locale-preserving-marketing-links-design.md
+++ b/docs/adr/2026-08-25-locale-preserving-marketing-links-design.md
@@ -1,0 +1,20 @@
+# Locale-preserving marketing links
+
+## Goal
+
+Prevent redirect chains when visitors follow internal links from localized marketing pages. A visitor on `/en`, `/fr-FR`, or another supported locale should navigate directly to the corresponding locale-prefixed route.
+
+## Design
+
+Keep shared marketing link definitions locale-neutral, such as `/pricing` and `/product/agents-automation`. At each marketing link-rendering boundary, rewrite localized internal paths with the active page locale by using the existing `rewriteAppLocalePath` helper.
+
+Apply this rule to the desktop and mobile navbar, footer, legal-page home link, startups pricing call to action, product and use-case cross-links, and localized audit routes. Preserve external URLs, `mailto:` links, hash links, assets, and non-localized `/auth/*` routes.
+
+Derive the active locale from the localized route or pass it from the route page when a Server Component already owns validated `params.lang`. Avoid hard-coded `/en` paths so language switching continues to work across every supported locale.
+
+## Verification
+
+- Add focused tests for locale rewriting and shared marketing navigation.
+- Cover English and a non-English locale, the locale homepage, nested paths, and query or hash preservation.
+- Confirm external and non-localized links remain unchanged.
+- Run `vp test` and `vp check --fix` from `apps/hyperlocalise-web`.


### PR DESCRIPTION
## What changed

- Prefix marketing navbar, mobile menu, footer, and page links with the active locale.
- Preserve locale-aware dashboard, claim-domain, legal, product, and pricing destinations.
- Keep external URLs, email links, and non-localized authentication routes unchanged.
- Add focused coverage for localized navigation and document the routing design.

## How to test

- `vp check --fix` — completed with 0 errors and 9 unrelated existing warnings.
- `vp test 'src/components/marketing/marketing-footer.test.tsx' 'src/app/[lang]/(marketing)/_components/navbar-auth-actions.test.tsx' 'src/lib/app-i18n/rewrite-app-locale-path.test.ts'` — 12 tests passed.
- `vp test` — attempted, but database-backed suites fail because the local PostgreSQL schema lacks current migration objects such as `project_cat_segment_locks`. The focused non-database tests above pass.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
