### PR TITLE
fix(crowdin): add omitempty to BundleAddRequest boolean pointers

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-31 - Add omitempty struct tags to BundleAddRequest optional boolean pointers
+
+**Learning:** In Crowdin API v2, `isMultilingual` and `includeProjectSourceLanguage` are optional boolean parameters when creating a bundle (`POST /api/v2/projects/{projectId}/bundles`). Unset pointer fields without `omitempty` in Go standard `json.Marshal` serialize as `null` rather than being omitted from the request payload, which can trigger API validation errors.
+
+**Action:** Added `json:"isMultilingual,omitempty"` and `json:"includeProjectSourceLanguage,omitempty"` to `BundleAddRequest` in `third_party/crowdin-api-client-go/crowdin/model/bundles.go`. Added unit test assertions in `third_party/crowdin-api-client-go/crowdin/model/bundles_test.go`.
+
 ## 2026-12-31 - Add Type query filter parity to TasksListOptions
 
 **Learning:** In Crowdin API v2, the List Tasks endpoint (`GET /api/v2/projects/{projectId}/tasks`) accepts filtering tasks by `type` (0 - translate, 1 - proofread, 2 - translate by vendor, 3 - proofread by vendor) in addition to `status`, `assigneeId`, `creatorId`, `workflowStepId`, `labelIds`, and `excludeLabelIds`. The SDK's `TasksListOptions` previously lacked `Type`, preventing callers from filtering tasks by task type.

--- a/third_party/crowdin-api-client-go/crowdin/model/bundles.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/bundles.go
@@ -49,10 +49,10 @@ type BundleAddRequest struct {
 	ExportPattern string `json:"exportPattern"`
 	// Export translations in multilingual file.
 	// Default: false.
-	IsMultilingual *bool `json:"isMultilingual"`
+	IsMultilingual *bool `json:"isMultilingual,omitempty"`
 	// Add project source language to bundle.
 	// Default: false.
-	IncludeProjectSourceLanguage *bool `json:"includeProjectSourceLanguage"`
+	IncludeProjectSourceLanguage *bool `json:"includeProjectSourceLanguage,omitempty"`
 	// Label Identifiers.
 	LabelIDs []int `json:"labelIds,omitempty"`
 	// Exclude Label Identifiers.

--- a/third_party/crowdin-api-client-go/crowdin/model/bundles_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/bundles_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,47 @@ func TestBundleAddRequestValidate(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tt.err)
 			}
+		})
+	}
+}
+
+func TestBundleAddRequestMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      *BundleAddRequest
+		expected string
+	}{
+		{
+			name: "omitted optional boolean pointers",
+			req: &BundleAddRequest{
+				Name:           "Resx bundle",
+				Format:         "crowdin-resx",
+				SourcePatterns: []string{"/master"},
+				ExportPattern:  "translations",
+			},
+			expected: `{"name":"Resx bundle","format":"crowdin-resx","sourcePatterns":["/master"],"ignorePatterns":null,"exportPattern":"translations"}`,
+		},
+		{
+			name: "specified optional boolean pointers",
+			req: &BundleAddRequest{
+				Name:                         "Resx bundle",
+				Format:                       "crowdin-resx",
+				SourcePatterns:               []string{"/master"},
+				ExportPattern:                "translations",
+				IsMultilingual:               toPtr(true),
+				IncludeProjectSourceLanguage: toPtr(false),
+				LabelIDs:                     []int{1, 2},
+				ExcludeLabelIDs:              []int{3},
+			},
+			expected: `{"name":"Resx bundle","format":"crowdin-resx","sourcePatterns":["/master"],"ignorePatterns":null,"exportPattern":"translations","isMultilingual":true,"includeProjectSourceLanguage":false,"labelIds":[1,2],"excludeLabelIds":[3]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(tt.req)
+			assert.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(b))
 		})
 	}
 }


### PR DESCRIPTION
This change adds `omitempty` struct tags to `IsMultilingual` and `IncludeProjectSourceLanguage` in `BundleAddRequest` (`third_party/crowdin-api-client-go/crowdin/model/bundles.go`), aligning bundle creation with Crowdin API v2 specifications by omitting uninitialized boolean pointers from JSON payloads instead of serializing them as `null`. Unit test coverage has been added to `third_party/crowdin-api-client-go/crowdin/model/bundles_test.go`.

---
*PR created automatically by Jules for task [6501483341319790714](https://jules.google.com/task/6501483341319790714) started by @cungminh2710*