### PR TITLE
feat(cat): add native max length editing and source-file import

### DIFF
--- a/apps/cli/cmd/entries.go
+++ b/apps/cli/cmd/entries.go
@@ -62,7 +62,7 @@ func newEntriesCmd() *cobra.Command {
 	return cmd
 }
 
-func readEntriesCommandOutput(path string, content []byte, sourcePath, locale string) (map[string]string, error) {
+func readEntriesCommandOutput(path string, content []byte, sourcePath, locale string) (map[string]translationfileparser.EntriesCommandOutputValue, error) {
 	if sourcePath != "" {
 		ext := strings.ToLower(filepath.Ext(path))
 		if ext == ".md" || ext == ".mdx" {
@@ -74,13 +74,17 @@ func readEntriesCommandOutput(path string, content []byte, sourcePath, locale st
 			if err != nil {
 				return nil, fmt.Errorf("read entries source %q: %w", sourcePath, err)
 			}
-			return translationfileparser.AlignMarkdownTargetToSource(sourceContent, content, ext == ".mdx"), nil
+			aligned := translationfileparser.AlignMarkdownTargetToSource(sourceContent, content, ext == ".mdx")
+			return translationfileparser.EncodeEntriesCommandOutput(
+				translationfileparser.IngestEntriesFromStringMap(aligned),
+			), nil
 		}
 	}
 
 	strategy := translationfileparser.NewDefaultStrategy()
-	if locale != "" {
-		return strategy.ParseWithLocale(path, content, locale)
+	entries, err := strategy.ParseIngestEntries(path, content, locale)
+	if err != nil {
+		return nil, err
 	}
-	return strategy.Parse(path, content)
+	return translationfileparser.EncodeEntriesCommandOutput(entries), nil
 }

--- a/apps/cli/cmd/entries_test.go
+++ b/apps/cli/cmd/entries_test.go
@@ -11,6 +11,47 @@ import (
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
 )
 
+func TestEntriesCommandExtractsMaxLengthFromAppleStrings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Localizable.strings")
+	content := []byte(`/* Max length: 24 */
+"cta" = "Continue";
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := newRootCmd("test")
+	out := bytes.NewBuffer(nil)
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"entries", path})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute entries: %v", err)
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+
+	var plain string
+	if err := json.Unmarshal(payload["cta"], &plain); err == nil {
+		t.Fatalf("expected enriched cta payload, got plain string %q", plain)
+	}
+
+	var enriched struct {
+		Text      string `json:"text"`
+		MaxLength int    `json:"maxLength"`
+	}
+	if err := json.Unmarshal(payload["cta"], &enriched); err != nil {
+		t.Fatalf("decode enriched cta: %v", err)
+	}
+	if enriched.Text != "Continue" || enriched.MaxLength != 24 {
+		t.Fatalf("unexpected enriched payload: %+v", enriched)
+	}
+}
+
 func TestEntriesCommandOutputsParsedEntries(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "en.json")

--- a/apps/hyperlocalise-web/.storybook/main.ts
+++ b/apps/hyperlocalise-web/.storybook/main.ts
@@ -33,10 +33,13 @@ const config: StorybookConfig = {
         },
       ];
     } else {
-      viteConfig.resolve.alias = {
-        ...(existingAlias && !Array.isArray(existingAlias) ? existingAlias : {}),
-        "@workos-inc/authkit-nextjs/components": authkitComponentsMock,
-      };
+      viteConfig.resolve.alias = Object.assign(
+        {},
+        existingAlias && !Array.isArray(existingAlias) ? existingAlias : {},
+        {
+          "@workos-inc/authkit-nextjs/components": authkitComponentsMock,
+        },
+      );
     }
 
     return viteConfig;

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -79,6 +79,7 @@ import {
   saveNativeProjectCatComment,
   saveNativeProjectCatTranslation,
   setNativeProjectCatStringsHidden,
+  setNativeProjectCatKeyMaxLength,
   updateNativeProjectTranslationStatus,
 } from "@/lib/projects/cat/native-cat-service";
 import {
@@ -160,6 +161,7 @@ import {
   projectFileCatCommentResolveBodySchema,
   projectFileCatHiddenStringsBodySchema,
   projectFileCatLockedStringsBodySchema,
+  projectFileCatMaxLengthBodySchema,
   projectFileCatImageRegenerateBodySchema,
   projectFileCatImageStatusBodySchema,
   projectFileCatRecommendationBodySchema,
@@ -663,6 +665,16 @@ const validateProjectFileCatHiddenStringsBody = validator("json", (value, c) => 
 
 const validateProjectFileCatLockedStringsBody = validator("json", (value, c) => {
   const parsed = projectFileCatLockedStringsBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFileCatMaxLengthBody = validator("json", (value, c) => {
+  const parsed = projectFileCatMaxLengthBodySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidProjectPayloadResponse(c);
@@ -1872,6 +1884,65 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         });
 
         return c.json({ catSegmentLock: result }, 200);
+      },
+    )
+    .post(
+      "/:projectId/files/detail/cat/segments/:externalStringId/max-length",
+      validateProjectParams,
+      validateProjectFileCatSegmentParams,
+      validateProjectFileCatMaxLengthBody,
+      async (c) => {
+        if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
+          return projectForbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const body = c.req.valid("json");
+        if (params.externalStringId !== body.externalStringId) {
+          return invalidProjectPayloadResponse(c);
+        }
+
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind === "provider") {
+          return badRequestResponse(
+            c,
+            "provider_cat_unsupported",
+            "Max length can only be updated for native CAT.",
+          );
+        }
+
+        const project = await getOwnedProject(c.var.auth, params.projectId);
+        if (!project) {
+          return projectNotFoundResponse(c);
+        }
+
+        const result = await setNativeProjectCatKeyMaxLength({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          translationKeyId: body.externalStringId,
+          maxLength: body.maxLength,
+          sourcePath: body.sourcePath,
+        });
+
+        if (!result.updated) {
+          return notFoundResponse(c, "translation_key_not_found");
+        }
+
+        return c.json(
+          {
+            segment: {
+              externalStringId: body.externalStringId,
+              ...(result.maxLength != null && result.maxLength > 0
+                ? { maxLength: result.maxLength }
+                : {}),
+            },
+          },
+          200,
+        );
       },
     )
     .post(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -388,6 +388,19 @@ export const projectFileCatLockedStringsResponseSchema = successEnvelopeSchema(
   projectFileCatLockedStringsResultSchema,
 );
 
+export const projectFileCatMaxLengthBodySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  externalStringId: z.string().trim().min(1).max(128),
+  maxLength: z.union([z.number().int().positive().max(100_000), z.null()]),
+});
+
+export const projectFileCatMaxLengthResponseSchema = z.object({
+  segment: z.object({
+    externalStringId: z.string(),
+    maxLength: z.number().int().positive().optional(),
+  }),
+});
+
 export const projectFileCatImageRegenerateBodySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
   targetLocale: z.string().trim().min(1).max(32),
@@ -436,6 +449,7 @@ export const projectSourceStringEntrySchema = z.object({
   text: z.string(),
   context: z.string().nullable(),
   type: z.string().optional(),
+  maxLength: z.number().int().positive().max(100_000).optional(),
   id: z.number().optional(),
 });
 
@@ -798,6 +812,8 @@ export type ProjectFileCatLockedStringsBody = z.infer<typeof projectFileCatLocke
 export type ProjectFileCatLockedStringsResponse = z.infer<
   typeof projectFileCatLockedStringsResponseSchema
 >;
+export type ProjectFileCatMaxLengthBody = z.infer<typeof projectFileCatMaxLengthBodySchema>;
+export type ProjectFileCatMaxLengthResponse = z.infer<typeof projectFileCatMaxLengthResponseSchema>;
 export type ProjectFileCatImageRegenerateBody = z.infer<
   typeof projectFileCatImageRegenerateBodySchema
 >;

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -53,6 +53,7 @@ import {
 } from "./cat-glossary-guidance-event";
 import { requiresLowMatchConfirmation } from "./tm-match-quality";
 import { CatVisualContextPanel } from "./cat-visual-context-panel";
+import { CatSegmentMaxLengthEditor } from "@/components/cat/segment/cat-segment-max-length-editor";
 
 function PanelSection({
   title,
@@ -209,10 +210,13 @@ export function CatIntelligencePanel({
   isVisualContextLoading = false,
   showAgentContext = false,
   showVisualContext = false,
+  showMaxLengthEditor = false,
+  isMaxLengthSaving = false,
   canEditTranslations = true,
   canLookupFreshContext = true,
   onRefreshContext,
   onUseTmMatch,
+  onSetMaxLength,
 }: {
   intelligence: CatSegmentIntelligence;
   targetText?: string;
@@ -221,10 +225,13 @@ export function CatIntelligencePanel({
   isVisualContextLoading?: boolean;
   showAgentContext?: boolean;
   showVisualContext?: boolean;
+  showMaxLengthEditor?: boolean;
+  isMaxLengthSaving?: boolean;
   canEditTranslations?: boolean;
   canLookupFreshContext?: boolean;
   onRefreshContext?: () => void;
   onUseTmMatch?: (match: CatTranslationMemoryMatch) => void;
+  onSetMaxLength?: (maxLength: number | null) => void | Promise<void>;
 }) {
   const intl = useIntl();
   const [pendingLowMatch, setPendingLowMatch] = useState<CatTranslationMemoryMatch | null>(null);
@@ -341,6 +348,19 @@ export function CatIntelligencePanel({
             isLoading={isVisualContextLoading}
             showPanel={showVisualContext}
           />
+
+          {showMaxLengthEditor ? (
+            <PanelSection title={intl.formatMessage(catIntelligencePanelMessages.maxLengthTitle)}>
+              <div className={intelligenceMutedPanelClassName}>
+                <CatSegmentMaxLengthEditor
+                  maxLength={intelligence.maxLength}
+                  canEdit={canEditTranslations && Boolean(onSetMaxLength)}
+                  isSaving={isMaxLengthSaving}
+                  onSave={onSetMaxLength ?? (async () => undefined)}
+                />
+              </div>
+            </PanelSection>
+          ) : null}
 
           <PanelSection title={intl.formatMessage(catIntelligencePanelMessages.fileContextTitle)}>
             <div className={intelligenceMutedPanelClassName}>

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -297,6 +297,8 @@ export function ProjectFileCatWorkspace({
     treatAsVideo,
     setStringsHidden,
     setStringsLocked,
+    setMaxLength,
+    isSavingMaxLength,
     isImageBusy,
   } = useCatMutations({
     organizationSlug,
@@ -517,6 +519,22 @@ export function ProjectFileCatWorkspace({
       });
     },
     [catFile?.canEditTranslations, intl, setStringsLocked],
+  );
+
+  const handleSetMaxLength = useCallback(
+    async (segmentId: string, maxLength: number | null) => {
+      if (!catFile?.canEditTranslations || !isNativeProject) {
+        throw new Error(
+          intl.formatMessage(projectFileCatWorkspaceMessages.cannotWriteTranslations),
+        );
+      }
+
+      await setMaxLength({
+        externalStringId: segmentId,
+        maxLength,
+      });
+    },
+    [catFile?.canEditTranslations, intl, isNativeProject, setMaxLength],
   );
 
   const handleAddToIssueSheet = useCallback(
@@ -830,6 +848,7 @@ export function ProjectFileCatWorkspace({
                 onRegenerateImage: async (segmentId: string) => {
                   await regenerateImage({ externalStringId: segmentId });
                 },
+                onSetMaxLength: handleSetMaxLength,
               }
             : {}),
           onUploadImage: async (segmentId, file) => {
@@ -877,6 +896,7 @@ export function ProjectFileCatWorkspace({
         isQueueFetchingPage={isFetchingNextPage}
         isQueueLoading={isQueueLoading}
         isImageBusy={isImageBusy}
+        isMaxLengthSaving={isSavingMaxLength}
         queuePagination={pagination}
         onLoadMoreQueue={loadNextPage}
         hasMoreQueue={pagination?.hasMore ?? false}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.messages.ts
@@ -76,4 +76,9 @@ export const useCatMutationsMessages = defineMessages({
     id: "dKnvI39kVF",
     description: "Fallback error when locking or unlocking CAT segments fails",
   },
+  failedToUpdateMaxLength: {
+    defaultMessage: "Failed to update character limit",
+    id: "ElyQMTBOLz",
+    description: "Fallback error when updating a native segment max length fails",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
@@ -583,6 +583,45 @@ export function useCatMutations(input: {
     },
   });
 
+  const maxLengthMutation = useMutation({
+    mutationFn: async (mutationInput: { externalStringId: string; maxLength: number | null }) => {
+      const { sourcePath } = resolveCatMutationFileIdentity(
+        input,
+        mutationInput.externalStringId,
+        intl,
+      );
+
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.segments[":externalStringId"]["max-length"].$post({
+        param: {
+          organizationSlug: input.organizationSlug,
+          projectId: input.projectId,
+          externalStringId: mutationInput.externalStringId,
+        },
+        json: {
+          sourcePath,
+          externalStringId: mutationInput.externalStringId,
+          maxLength: mutationInput.maxLength,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          await readApiError(
+            response,
+            intl.formatMessage(useCatMutationsMessages.failedToUpdateMaxLength),
+          ),
+        );
+      }
+
+      return response.json();
+    },
+    onSuccess: async () => {
+      await input.invalidateQueue();
+    },
+  });
+
   return {
     saveMutation,
     saveTranslation: saveMutation.mutateAsync,
@@ -600,6 +639,8 @@ export function useCatMutations(input: {
     treatAsVideo: treatAsVideoMutation.mutateAsync,
     setStringsHidden: hiddenStringsMutation.mutateAsync,
     setStringsLocked: lockedStringsMutation.mutateAsync,
+    setMaxLength: maxLengthMutation.mutateAsync,
+    isSavingMaxLength: maxLengthMutation.isPending,
     isSaving: saveMutation.isPending,
     isPostingComment: commentMutation.isPending,
     isResolvingComment: resolveCommentMutation.isPending,

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-max-length-editor.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-max-length-editor.test.tsx
@@ -12,11 +12,11 @@
  */
 // @vitest-environment happy-dom
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { IntlProvider } from "react-intl";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { CatSegmentMaxLengthEditor } from "./cat-segment-max-length-editor";
+import { CatSegmentMaxLengthEditor, parseMaxLengthDraft } from "./cat-segment-max-length-editor";
 
 function renderEditor(overrides: Partial<Parameters<typeof CatSegmentMaxLengthEditor>[0]> = {}) {
   const onSave = vi.fn().mockResolvedValue(undefined);
@@ -29,6 +29,20 @@ function renderEditor(overrides: Partial<Parameters<typeof CatSegmentMaxLengthEd
 
   return { onSave };
 }
+
+describe("parseMaxLengthDraft", () => {
+  it("accepts whole numbers within the supported range", () => {
+    expect(parseMaxLengthDraft("32")).toBe(32);
+    expect(parseMaxLengthDraft("100000")).toBe(100_000);
+  });
+
+  it("rejects partial numeric prefixes and out-of-range values", () => {
+    expect(parseMaxLengthDraft("12.5")).toBeNull();
+    expect(parseMaxLengthDraft("1e2")).toBeNull();
+    expect(parseMaxLengthDraft("100001")).toBeNull();
+    expect(parseMaxLengthDraft("0")).toBeNull();
+  });
+});
 
 describe("CatSegmentMaxLengthEditor", () => {
   it("shows the current limit in read-only mode", () => {
@@ -43,7 +57,36 @@ describe("CatSegmentMaxLengthEditor", () => {
     fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "32" } });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
-    expect(onSave).toHaveBeenCalledWith(32);
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(32);
+    });
+  });
+
+  it("rejects decimal and scientific-notation drafts", async () => {
+    const { onSave } = renderEditor({ maxLength: 80 });
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "12.5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText("Enter a whole number from 1 to 100,000.")).toBeTruthy();
+  });
+
+  it("surfaces save failures while keeping the draft", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("Network request failed"));
+    render(
+      <IntlProvider locale="en">
+        <CatSegmentMaxLengthEditor maxLength={80} canEdit onSave={onSave} />
+      </IntlProvider>,
+    );
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "32" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network request failed")).toBeTruthy();
+    });
+    expect(screen.getByRole("spinbutton")).toHaveValue(32);
   });
 
   it("clears the max length", async () => {
@@ -51,6 +94,8 @@ describe("CatSegmentMaxLengthEditor", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Clear" }));
 
-    expect(onSave).toHaveBeenCalledWith(null);
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(null);
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-max-length-editor.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-max-length-editor.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { CatSegmentMaxLengthEditor } from "./cat-segment-max-length-editor";
+
+function renderEditor(overrides: Partial<Parameters<typeof CatSegmentMaxLengthEditor>[0]> = {}) {
+  const onSave = vi.fn().mockResolvedValue(undefined);
+
+  render(
+    <IntlProvider locale="en">
+      <CatSegmentMaxLengthEditor maxLength={80} canEdit onSave={onSave} {...overrides} />
+    </IntlProvider>,
+  );
+
+  return { onSave };
+}
+
+describe("CatSegmentMaxLengthEditor", () => {
+  it("shows the current limit in read-only mode", () => {
+    renderEditor({ canEdit: false, maxLength: 24 });
+
+    expect(screen.getByText("Limit: 24 characters")).toBeTruthy();
+  });
+
+  it("saves a new max length", async () => {
+    const { onSave } = renderEditor({ maxLength: 80 });
+
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "32" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith(32);
+  });
+
+  it("clears the max length", async () => {
+    const { onSave } = renderEditor({ maxLength: 80 });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(onSave).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-max-length-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-max-length-editor.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+
+import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messages";
+
+function parseMaxLengthDraft(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function CatSegmentMaxLengthEditor({
+  maxLength,
+  canEdit,
+  isSaving = false,
+  onSave,
+}: {
+  maxLength?: number;
+  canEdit: boolean;
+  isSaving?: boolean;
+  onSave: (maxLength: number | null) => void | Promise<void>;
+}) {
+  const intl = useIntl();
+  const [draft, setDraft] = useState(maxLength != null ? String(maxLength) : "");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDraft(maxLength != null ? String(maxLength) : "");
+    setError(null);
+  }, [maxLength]);
+
+  async function handleSave() {
+    const trimmed = draft.trim();
+    if (trimmed.length > 0 && parseMaxLengthDraft(trimmed) == null) {
+      setError(intl.formatMessage(catIntelligencePanelMessages.maxLengthInvalid));
+      return;
+    }
+
+    setError(null);
+    await onSave(parseMaxLengthDraft(trimmed));
+  }
+
+  async function handleClear() {
+    setDraft("");
+    setError(null);
+    await onSave(null);
+  }
+
+  const parsedDraft = parseMaxLengthDraft(draft);
+  const hasChanges = (maxLength ?? null) !== (draft.trim().length === 0 ? null : parsedDraft);
+
+  if (!canEdit) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {maxLength != null && maxLength > 0 ? (
+          <FormattedMessage
+            {...catIntelligencePanelMessages.maxLengthCurrent}
+            values={{ maxLength }}
+          />
+        ) : (
+          <FormattedMessage {...catIntelligencePanelMessages.maxLengthPlaceholder} />
+        )}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        <FormattedMessage {...catIntelligencePanelMessages.maxLengthDescription} />
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          type="number"
+          min={1}
+          max={100_000}
+          inputMode="numeric"
+          value={draft}
+          placeholder={intl.formatMessage(catIntelligencePanelMessages.maxLengthPlaceholder)}
+          aria-label={intl.formatMessage(catIntelligencePanelMessages.maxLengthTitle)}
+          className="h-8 w-28 tabular-nums"
+          disabled={isSaving}
+          onChange={(event) => {
+            setDraft(event.currentTarget.value);
+            setError(null);
+          }}
+        />
+        <Button
+          type="button"
+          size="sm"
+          className="h-8"
+          disabled={isSaving || !hasChanges}
+          onClick={() => void handleSave()}
+        >
+          {isSaving ? <Spinner className="size-3.5" /> : null}
+          <FormattedMessage {...catIntelligencePanelMessages.maxLengthSave} />
+        </Button>
+        {maxLength != null && maxLength > 0 ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8"
+            disabled={isSaving}
+            onClick={() => void handleClear()}
+          >
+            <FormattedMessage {...catIntelligencePanelMessages.maxLengthClear} />
+          </Button>
+        ) : null}
+      </div>
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-max-length-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-max-length-editor.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
@@ -21,14 +21,20 @@ import { Spinner } from "@/components/ui/spinner";
 
 import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messages";
 
-function parseMaxLengthDraft(value: string): number | null {
+const MAX_SEGMENT_LENGTH = 100_000;
+
+export function parseMaxLengthDraft(value: string): number | null {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
     return null;
   }
 
-  const parsed = Number.parseInt(trimmed, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_SEGMENT_LENGTH) {
     return null;
   }
 
@@ -47,6 +53,7 @@ export function CatSegmentMaxLengthEditor({
   onSave: (maxLength: number | null) => void | Promise<void>;
 }) {
   const intl = useIntl();
+  const inputRef = useRef<HTMLInputElement>(null);
   const [draft, setDraft] = useState(maxLength != null ? String(maxLength) : "");
   const [error, setError] = useState<string | null>(null);
 
@@ -55,21 +62,57 @@ export function CatSegmentMaxLengthEditor({
     setError(null);
   }, [maxLength]);
 
-  async function handleSave() {
+  function validateDraft(): number | null | undefined {
     const trimmed = draft.trim();
-    if (trimmed.length > 0 && parseMaxLengthDraft(trimmed) == null) {
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    const input = inputRef.current;
+    if (input && !input.checkValidity()) {
       setError(intl.formatMessage(catIntelligencePanelMessages.maxLengthInvalid));
+      return undefined;
+    }
+
+    const parsed = parseMaxLengthDraft(trimmed);
+    if (parsed == null) {
+      setError(intl.formatMessage(catIntelligencePanelMessages.maxLengthInvalid));
+      return undefined;
+    }
+
+    return parsed;
+  }
+
+  async function handleSave() {
+    const parsed = validateDraft();
+    if (parsed === undefined) {
       return;
     }
 
     setError(null);
-    await onSave(parseMaxLengthDraft(trimmed));
+    try {
+      await onSave(parsed);
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : intl.formatMessage(catIntelligencePanelMessages.maxLengthSaveFailed),
+      );
+    }
   }
 
   async function handleClear() {
     setDraft("");
     setError(null);
-    await onSave(null);
+    try {
+      await onSave(null);
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : intl.formatMessage(catIntelligencePanelMessages.maxLengthSaveFailed),
+      );
+    }
   }
 
   const parsedDraft = parseMaxLengthDraft(draft);
@@ -97,9 +140,10 @@ export function CatSegmentMaxLengthEditor({
       </p>
       <div className="flex flex-wrap items-center gap-2">
         <Input
+          ref={inputRef}
           type="number"
           min={1}
-          max={100_000}
+          max={MAX_SEGMENT_LENGTH}
           inputMode="numeric"
           value={draft}
           placeholder={intl.formatMessage(catIntelligencePanelMessages.maxLengthPlaceholder)}

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -511,9 +511,14 @@ export const catIntelligencePanelMessages = defineMessages({
     description: "Button label to clear a native segment max length",
   },
   maxLengthInvalid: {
-    defaultMessage: "Enter a positive whole number.",
-    id: "lTD082Dlt5",
+    defaultMessage: "Enter a whole number from 1 to 100,000.",
+    id: "AWCVIFfr/k",
     description: "Validation error when the max length input is not a positive integer",
+  },
+  maxLengthSaveFailed: {
+    defaultMessage: "Could not save the character limit. Try again.",
+    id: "mvgKs5lzcT",
+    description: "Error shown when saving a native segment max length fails",
   },
   maxLengthCurrent: {
     defaultMessage: "Limit: {maxLength} characters",

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -485,6 +485,41 @@ export const catIntelligencePanelMessages = defineMessages({
     id: "bzdmXkD3a+",
     description: "Supporting copy below the CAT translation intelligence panel heading",
   },
+  maxLengthTitle: {
+    defaultMessage: "Character limit",
+    id: "RS4pbTA1Mq",
+    description: "Section heading for the native segment max length constraint",
+  },
+  maxLengthDescription: {
+    defaultMessage: "Set the maximum number of characters allowed in the translation.",
+    id: "+tsNE73Ud/",
+    description: "Helper text for the native segment max length editor",
+  },
+  maxLengthPlaceholder: {
+    defaultMessage: "No limit",
+    id: "hZ7gIyvYMF",
+    description: "Placeholder when a native segment has no max length set",
+  },
+  maxLengthSave: {
+    defaultMessage: "Save",
+    id: "+qqz/QE1GR",
+    description: "Button label to save a native segment max length",
+  },
+  maxLengthClear: {
+    defaultMessage: "Clear",
+    id: "DbdjwrPI01",
+    description: "Button label to clear a native segment max length",
+  },
+  maxLengthInvalid: {
+    defaultMessage: "Enter a positive whole number.",
+    id: "lTD082Dlt5",
+    description: "Validation error when the max length input is not a positive integer",
+  },
+  maxLengthCurrent: {
+    defaultMessage: "Limit: {maxLength} characters",
+    id: "k5etBkEqlB",
+    description: "Read-only summary of the current native segment max length",
+  },
   fileContextTitle: {
     defaultMessage: "Context attached in the file",
     id: "HZtAltEBuQ",

--- a/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
@@ -51,6 +51,7 @@ export interface CatWorkspaceEditing {
   onUseTmMatch: (segmentId: string, match: CatTranslationMemoryMatch) => void;
   onTreatAsImage?: (segmentId: string, treatAsImage: boolean) => void | Promise<void>;
   onTreatAsVideo?: (segmentId: string, treatAsVideo: boolean) => void | Promise<void>;
+  onSetMaxLength?: (segmentId: string, maxLength: number | null) => void | Promise<void>;
   onRegenerateImage?: (segmentId: string) => void | Promise<void>;
   onUploadImage?: (segmentId: string, file: File) => void | Promise<void>;
 }
@@ -155,6 +156,7 @@ export interface CatWorkspaceViewProps {
   isCommentsLoading?: boolean;
   isSegmentTargetLoading?: boolean;
   isImageBusy?: boolean;
+  isMaxLengthSaving?: boolean;
   queueFilter?: CatQueueFilter;
   checkedSegmentIds?: ReadonlySet<string>;
   onToggleSegmentChecked?: (segmentId: string, checked: boolean) => void;

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
@@ -72,6 +72,9 @@ export function CatSideBySideIntelligencePanel({
   issueTargetLocale = null,
   issueStringLink = null,
   onNativeOpenIssueCountChange,
+  showMaxLengthEditor = false,
+  isMaxLengthSaving = false,
+  onSetMaxLength,
   placement = "bottom",
   className,
 }: {
@@ -108,6 +111,9 @@ export function CatSideBySideIntelligencePanel({
   issueTargetLocale?: string | null;
   issueStringLink?: IssueSheetCreateStringLink | null;
   onNativeOpenIssueCountChange?: (openIssueCount: number) => void;
+  showMaxLengthEditor?: boolean;
+  isMaxLengthSaving?: boolean;
+  onSetMaxLength?: (maxLength: number | null) => void | Promise<void>;
   placement?: "bottom" | "right";
   className?: string;
 }) {
@@ -161,10 +167,13 @@ export function CatSideBySideIntelligencePanel({
       isVisualContextLoading={isVisualContextLoading}
       showAgentContext={showAgentContext}
       showVisualContext={showVisualContext}
+      showMaxLengthEditor={showMaxLengthEditor}
+      isMaxLengthSaving={isMaxLengthSaving}
       canEditTranslations={canEditTranslations}
       canLookupFreshContext={canLookupFreshContext}
       onRefreshContext={onRefreshContext}
       onUseTmMatch={onUseTmMatch}
+      onSetMaxLength={onSetMaxLength}
     />
   );
   const commentsPanel = (

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
@@ -169,11 +169,11 @@ export function CatSideBySideIntelligencePanel({
       showVisualContext={showVisualContext}
       showMaxLengthEditor={showMaxLengthEditor}
       isMaxLengthSaving={isMaxLengthSaving}
-      canEditTranslations={canEditTranslations}
+      canEditTranslations={canEditTranslations && !segment.isLocked}
       canLookupFreshContext={canLookupFreshContext}
       onRefreshContext={onRefreshContext}
       onUseTmMatch={onUseTmMatch}
-      onSetMaxLength={onSetMaxLength}
+      onSetMaxLength={segment.isLocked ? undefined : onSetMaxLength}
     />
   );
   const commentsPanel = (

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -103,6 +103,9 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   issueTargetLocale = null,
   issueStringLink = null,
   onNativeOpenIssueCountChange,
+  showMaxLengthEditor = false,
+  isMaxLengthSaving = false,
+  onSetMaxLength,
   primaryActionLabel,
   segmentShareUrl = null,
   className,
@@ -177,6 +180,9 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
     linkLabel?: string;
   } | null;
   onNativeOpenIssueCountChange?: (openIssueCount: number) => void;
+  showMaxLengthEditor?: boolean;
+  isMaxLengthSaving?: boolean;
+  onSetMaxLength?: (maxLength: number | null) => void | Promise<void>;
   primaryActionLabel?: string;
   segmentShareUrl?: string | null;
   className?: string;
@@ -355,6 +361,9 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
               ? () => onAddToIssueSheet(intelligenceSegmentId)
               : undefined
           }
+          showMaxLengthEditor={showMaxLengthEditor}
+          isMaxLengthSaving={isMaxLengthSaving}
+          onSetMaxLength={onSetMaxLength}
           organizationSlug={organizationSlug}
           projectId={projectId}
           nativeIssuesEnabled={nativeIssuesEnabled}

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -83,6 +83,7 @@ export interface CatWorkspaceContainerProps {
   isQueueFetchingPage?: boolean;
   isQueueLoading?: boolean;
   isImageBusy?: boolean;
+  isMaxLengthSaving?: boolean;
   queuePagination?: CatWorkspaceViewProps["queuePagination"];
   hasMoreQueue?: boolean;
   onLoadMoreQueue?: () => void;
@@ -119,6 +120,7 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
   isQueueFetchingPage,
   isQueueLoading,
   isImageBusy,
+  isMaxLengthSaving,
   queuePagination,
   hasMoreQueue,
   onLoadMoreQueue,
@@ -296,6 +298,7 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
           isCommentsLoading={store.isCommentsLoading}
           isSegmentTargetLoading={store.isSegmentTargetLoading}
           isImageBusy={isImageBusy}
+          isMaxLengthSaving={isMaxLengthSaving}
           queuePagination={queuePagination}
           hasMoreQueue={hasMoreQueue}
           onLoadMoreQueue={onLoadMoreQueue}

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -89,6 +89,7 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
   isCommentsLoading = false,
   isSegmentTargetLoading = false,
   isImageBusy = false,
+  isMaxLengthSaving = false,
   queuePagination = null,
   hasMoreQueue = false,
   onLoadMoreQueue,
@@ -417,6 +418,13 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
                 }
               : undefined
           }
+          showMaxLengthEditor={isNativeProject}
+          isMaxLengthSaving={isMaxLengthSaving}
+          onSetMaxLength={
+            editing.onSetMaxLength
+              ? (maxLength) => editing.onSetMaxLength!(intelligenceSegmentId, maxLength)
+              : undefined
+          }
           primaryActionLabel={shell.primaryActionLabel}
           segmentShareUrl={segmentShareUrl}
         />
@@ -616,12 +624,19 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           isVisualContextLoading={isVisualContextLoading}
           showAgentContext={showAgentContext}
           showVisualContext={showVisualContext}
+          showMaxLengthEditor={isNativeProject}
+          isMaxLengthSaving={isMaxLengthSaving}
           canEditTranslations={
             shell.fileContext.canEditTranslations !== false && !editorSegment.isLocked
           }
           canLookupFreshContext={canLookupContext}
           onRefreshContext={() => review.onAskQuestion(editorSegment.id, { forceRefresh: true })}
           onUseTmMatch={(match) => editing.onUseTmMatch(editorSegment.id, match)}
+          onSetMaxLength={
+            editing.onSetMaxLength
+              ? (maxLength) => editing.onSetMaxLength!(editorSegment.id, maxLength)
+              : undefined
+          }
         />
       </CatPanelErrorBoundary>
     );

--- a/apps/hyperlocalise-web/src/components/marketing/product/automation-editor-mock.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/automation-editor-mock.tsx
@@ -106,13 +106,11 @@ function Pill({ children }: { children: ReactNode }) {
 
 function MockEditorPreview({
   highlight,
-  isDone,
+  isDone: _isDone,
 }: {
   highlight: Step["highlightSection"];
   isDone: boolean;
 }) {
-  const intl = useIntl();
-
   return (
     <div className="flex flex-col">
       <div

--- a/apps/hyperlocalise-web/src/components/ui/globe.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/globe.tsx
@@ -123,6 +123,9 @@ export function Globe({ className }: { className?: string }) {
     canvas.addEventListener("pointerup", onPointerUp);
     canvas.addEventListener("pointerout", onPointerUp);
     canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("touchstart", onTouchStart, { passive: true });
+    canvas.addEventListener("touchend", onTouchEnd, { passive: true });
+    canvas.addEventListener("touchmove", onTouchMove, { passive: true });
 
     return () => {
       cancelAnimationFrame(animationFrame);
@@ -131,6 +134,9 @@ export function Globe({ className }: { className?: string }) {
       canvas.removeEventListener("pointerup", onPointerUp);
       canvas.removeEventListener("pointerout", onPointerUp);
       canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("touchstart", onTouchStart);
+      canvas.removeEventListener("touchend", onTouchEnd);
+      canvas.removeEventListener("touchmove", onTouchMove);
     };
   }, [isDark]);
 

--- a/apps/hyperlocalise-web/src/emails/issue-inbox-notifications-email.stories.tsx
+++ b/apps/hyperlocalise-web/src/emails/issue-inbox-notifications-email.stories.tsx
@@ -78,10 +78,10 @@ function EmailHtmlPreview({ html }: { html: string }) {
 
 async function emailCanvas(canvasElement: HTMLElement) {
   const iframe = canvasElement.querySelector("iframe");
-  expect(iframe).toBeTruthy();
-  await waitFor(() => {
-    expect(iframe!.contentDocument?.body).toBeTruthy();
-    expect(iframe!.contentDocument!.body.innerHTML.length).toBeGreaterThan(0);
+  await expect(iframe).toBeTruthy();
+  await waitFor(async () => {
+    await expect(iframe!.contentDocument?.body).toBeTruthy();
+    await expect(iframe!.contentDocument!.body.innerHTML.length).toBeGreaterThan(0);
   });
   return within(iframe!.contentDocument!.body);
 }

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
@@ -63,6 +63,7 @@ describe("NativeCatService.getCatFile", () => {
   const countKeysForFile = vi.fn();
   const getTranslationsByKeyIds = vi.fn();
   const setKeysHidden = vi.fn();
+  const setKeyMaxLength = vi.fn();
   let service: NativeCatService;
 
   beforeEach(() => {
@@ -94,6 +95,7 @@ describe("NativeCatService.getCatFile", () => {
       countKeysForFile,
       getTranslationsByKeyIds,
       setKeysHidden,
+      setKeyMaxLength,
     } as unknown as ProjectTranslationService;
 
     service = new NativeCatService(undefined as never, translations, {} as NativeCatCommentService);
@@ -486,5 +488,58 @@ describe("NativeCatService.getCatFile", () => {
     ).resolves.toEqual({ updatedCount: 0 });
 
     expect(setKeysHidden).not.toHaveBeenCalled();
+  });
+});
+
+describe("NativeCatService.setKeyMaxLength", () => {
+  const getRepositorySourceFileByPath = vi.fn();
+  const setKeyMaxLength = vi.fn();
+  let service: NativeCatService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRepositorySourceFileByPath.mockResolvedValue({ id: "file_1" });
+    setKeyMaxLength.mockResolvedValue({ updated: true, maxLength: 42 });
+
+    const translations = {
+      getRepositorySourceFileByPath,
+      setKeyMaxLength,
+    } as unknown as ProjectTranslationService;
+
+    service = new NativeCatService(undefined as never, translations, {} as NativeCatCommentService);
+  });
+
+  it("scopes max length updates to the source file when sourcePath is provided", async () => {
+    await service.setKeyMaxLength({
+      organizationId: "org_1",
+      projectId: "project_1",
+      translationKeyId: "key_1",
+      maxLength: 42,
+      sourcePath: "locales/en.json",
+    });
+
+    expect(setKeyMaxLength).toHaveBeenCalledWith({
+      organizationId: "org_1",
+      projectId: "project_1",
+      translationKeyId: "key_1",
+      maxLength: 42,
+      repositorySourceFileId: "file_1",
+    });
+  });
+
+  it("does not update max length when the source file is missing", async () => {
+    getRepositorySourceFileByPath.mockResolvedValueOnce(null);
+
+    await expect(
+      service.setKeyMaxLength({
+        organizationId: "org_1",
+        projectId: "project_1",
+        translationKeyId: "key_1",
+        maxLength: 42,
+        sourcePath: "locales/missing.json",
+      }),
+    ).resolves.toEqual({ updated: false, maxLength: null });
+
+    expect(setKeyMaxLength).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -597,6 +597,35 @@ export class NativeCatService extends ProjectServiceBase {
     });
   }
 
+  async setKeyMaxLength(input: {
+    organizationId: string;
+    projectId: string;
+    translationKeyId: string;
+    maxLength: number | null;
+    sourcePath?: string;
+  }) {
+    let repositorySourceFileId: string | undefined;
+    if (input.sourcePath && !isCatAllFilesSourcePath(input.sourcePath)) {
+      const sourceFile = await this.translations.getRepositorySourceFileByPath({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourcePath: input.sourcePath,
+      });
+      if (!sourceFile) {
+        return { updated: false, maxLength: null };
+      }
+      repositorySourceFileId = sourceFile.id;
+    }
+
+    return this.translations.setKeyMaxLength({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      translationKeyId: input.translationKeyId,
+      maxLength: input.maxLength,
+      repositorySourceFileId,
+    });
+  }
+
   async saveComment(input: Parameters<NativeCatCommentService["save"]>[0]) {
     return this.comments.save(input);
   }
@@ -1001,3 +1030,7 @@ export const updateNativeProjectTranslationStatus = (
 export const setNativeProjectCatStringsHidden = (
   input: Parameters<NativeCatService["setKeysHidden"]>[0],
 ) => nativeCatService.setKeysHidden(input);
+
+export const setNativeProjectCatKeyMaxLength = (
+  input: Parameters<NativeCatService["setKeyMaxLength"]>[0],
+) => nativeCatService.setKeyMaxLength(input);

--- a/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.test.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { entriesFromHlOutput } from "./hl-entries";
 

--- a/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.test.ts
@@ -40,8 +40,8 @@ describe("entriesFromHlOutput", () => {
   it("maps enriched hl entries output with maxLength metadata", () => {
     expect(
       entriesFromHlOutput({
-        "cta": { text: "Continue", maxLength: 24 },
-        "plain": "No limit",
+        cta: { text: "Continue", maxLength: 24 },
+        plain: "No limit",
       }),
     ).toEqual([
       {

--- a/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vitest";
+
+import { entriesFromHlOutput } from "./hl-entries";
+
+describe("entriesFromHlOutput", () => {
+  it("maps plain hl entries output into project source string entries", () => {
+    expect(
+      entriesFromHlOutput({
+        "greeting.title": "Hello",
+        "greeting.subtitle": "Welcome",
+      }),
+    ).toEqual([
+      {
+        key: "greeting.title",
+        text: "Hello",
+        context: null,
+        type: "string",
+      },
+      {
+        key: "greeting.subtitle",
+        text: "Welcome",
+        context: null,
+        type: "string",
+      },
+    ]);
+  });
+
+  it("maps enriched hl entries output with maxLength metadata", () => {
+    expect(
+      entriesFromHlOutput({
+        "cta": { text: "Continue", maxLength: 24 },
+        "plain": "No limit",
+      }),
+    ).toEqual([
+      {
+        key: "cta",
+        text: "Continue",
+        context: null,
+        type: "string",
+        maxLength: 24,
+      },
+      {
+        key: "plain",
+        text: "No limit",
+        context: null,
+        type: "string",
+      },
+    ]);
+  });
+
+  it("drops blank keys, empty values, and non-positive maxLength values", () => {
+    expect(
+      entriesFromHlOutput({
+        "": "ignored",
+        "valid.key": "   ",
+        "kept.key": "Value",
+        "limited.key": { text: "Short", maxLength: 0 },
+      }),
+    ).toEqual([
+      {
+        key: "kept.key",
+        text: "Value",
+        context: null,
+        type: "string",
+      },
+      {
+        key: "limited.key",
+        text: "Short",
+        context: null,
+        type: "string",
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ProjectSourceStringEntry } from "@/api/routes/project/project.schema";
+
+export type HlEntryRecord = {
+  text: string;
+  maxLength?: number;
+  context?: string | null;
+};
+
+export type HlEntriesPayload = Record<string, string | HlEntryRecord>;
+
+function isHlEntryRecord(value: unknown): value is HlEntryRecord {
+  if (!value || typeof value !== "object" || !("text" in value)) {
+    return false;
+  }
+  const record = value as HlEntryRecord;
+  return typeof record.text === "string";
+}
+
+export function hlEntriesPayloadToStringMap(payload: HlEntriesPayload): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    out[key] = typeof value === "string" ? value : value.text;
+  }
+  return out;
+}
+
+export function entriesFromHlOutput(payload: HlEntriesPayload): ProjectSourceStringEntry[] {
+  return Object.entries(payload)
+    .map(([key, value]) => {
+      const text = typeof value === "string" ? value : value.text;
+      const maxLength =
+        typeof value === "string"
+          ? undefined
+          : value.maxLength != null && value.maxLength > 0
+            ? Math.trunc(value.maxLength)
+            : undefined;
+
+      return {
+        key: key.trim(),
+        text,
+        context: typeof value === "string" ? null : (value.context ?? null),
+        type: "string" as const,
+        ...(maxLength !== undefined ? { maxLength } : {}),
+      };
+    })
+    .filter((entry) => entry.key.length > 0 && entry.text.trim().length > 0);
+}
+
+export function parseHlEntriesJson(raw: unknown): HlEntriesPayload {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("hl entries output must be a JSON object");
+  }
+
+  const payload: HlEntriesPayload = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === "string") {
+      payload[key] = value;
+      continue;
+    }
+    if (isHlEntryRecord(value)) {
+      payload[key] = value;
+      continue;
+    }
+    throw new Error(`hl entries output for key ${JSON.stringify(key)} must be a string or object`);
+  }
+  return payload;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/files/source-file-ingest.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/source-file-ingest.ts
@@ -12,7 +12,6 @@
  */
 import { and, desc, eq, inArray, or } from "drizzle-orm";
 
-import type { ProjectSourceStringEntry } from "@/api/routes/project/project.schema";
 import { dispatchWorkspaceAutomationsForSourceUpload } from "@/lib/agents/workspace-automation-dispatcher";
 import { db, schema } from "@/lib/database";
 import { createLogger } from "@/lib/log";
@@ -25,16 +24,7 @@ export type { SourceFileIngestEventData };
 export type SourceFileIngestState =
   (typeof schema.repositorySourceFileVersions.$inferSelect)["ingestState"];
 
-export function entriesFromHlOutput(entries: Record<string, string>): ProjectSourceStringEntry[] {
-  return Object.entries(entries)
-    .map(([key, text]) => ({
-      key: key.trim(),
-      text,
-      context: null,
-      type: "string",
-    }))
-    .filter((entry) => entry.key.length > 0 && entry.text.trim().length > 0);
-}
+export { entriesFromHlOutput } from "./hl-entries";
 
 export async function hasIngestedSourceHashForPath(input: {
   organizationId: string;

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -227,6 +227,8 @@ export class ProjectTranslationService extends ProjectServiceBase {
         sourceText: entry.text,
         context: entry.context?.trim() || null,
         type: entry.type?.trim() || null,
+        maxLength:
+          entry.maxLength != null && entry.maxLength > 0 ? Math.trunc(entry.maxLength) : null,
         normalizedSourceText: normalizeTranslationMemorySourceText(entry.text),
       }))
       .filter((entry) => entry.key.length > 0 && entry.sourceText.trim().length > 0)
@@ -273,6 +275,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
           normalizedSourceText: entry.normalizedSourceText,
           context: entry.context,
           type: entry.type,
+          maxLength: entry.maxLength,
           sourceFileVersionId: input.sourceFileVersionId ?? null,
         })),
       )
@@ -287,6 +290,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
           normalizedSourceText: sql`excluded.normalized_source_text`,
           context: sql`excluded.context`,
           type: sql`excluded.type`,
+          maxLength: sql`coalesce(excluded.max_length, ${schema.projectTranslationKeys.maxLength})`,
           sourceFileVersionId: sql`excluded.source_file_version_id`,
           updatedAt: sql`now()`,
         },
@@ -305,6 +309,40 @@ export class ProjectTranslationService extends ProjectServiceBase {
     );
 
     return { imported, updated };
+  }
+
+  async setKeyMaxLength(input: {
+    organizationId: string;
+    projectId: string;
+    translationKeyId: string;
+    maxLength: number | null;
+    repositorySourceFileId?: string;
+  }): Promise<{ updated: boolean; maxLength: number | null }> {
+    const normalizedMaxLength =
+      input.maxLength != null && input.maxLength > 0 ? Math.trunc(input.maxLength) : null;
+
+    const updated = await this.database
+      .update(schema.projectTranslationKeys)
+      .set({
+        maxLength: normalizedMaxLength,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(schema.projectTranslationKeys.organizationId, input.organizationId),
+          eq(schema.projectTranslationKeys.projectId, input.projectId),
+          eq(schema.projectTranslationKeys.id, input.translationKeyId),
+          input.repositorySourceFileId
+            ? eq(schema.projectTranslationKeys.repositorySourceFileId, input.repositorySourceFileId)
+            : undefined,
+        ),
+      )
+      .returning({ maxLength: schema.projectTranslationKeys.maxLength });
+
+    return {
+      updated: updated.length > 0,
+      maxLength: updated[0]?.maxLength ?? null,
+    };
   }
 
   async setKeysHidden(input: {
@@ -1185,6 +1223,10 @@ export const upsertProjectTranslationKeysFromEntries = (
 export const setProjectTranslationKeysHidden = (
   input: Parameters<ProjectTranslationService["setKeysHidden"]>[0],
 ) => projectTranslationService.setKeysHidden(input);
+
+export const setProjectTranslationKeyMaxLength = (
+  input: Parameters<ProjectTranslationService["setKeyMaxLength"]>[0],
+) => projectTranslationService.setKeyMaxLength(input);
 
 export const isProjectTranslationKeyHidden = (
   input: Parameters<ProjectTranslationService["isKeyHidden"]>[0],

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
@@ -107,29 +107,34 @@ vi.mock("@/lib/translation/sandbox-byok", () => ({
   loadSandboxByokCredentialForJob: vi.fn(async () => null),
 }));
 
-vi.mock("@/lib/translation/sandbox", () => ({
-  createTranslationSandbox: (...args: unknown[]) => createTranslationSandboxMock(...args),
-  prepareSandbox: (...args: unknown[]) => prepareSandboxMock(...args),
-  stopTranslationSandbox: (...args: unknown[]) => stopTranslationSandboxMock(...args),
-  downloadAttachment: (...args: unknown[]) => downloadAttachmentMock(...args),
-  downloadCrowdinSourceInSandbox: (...args: unknown[]) =>
-    downloadCrowdinSourceInSandboxMock(...args),
-  downloadCrowdinTranslationsInSandbox: (...args: unknown[]) =>
-    downloadCrowdinTranslationsInSandboxMock(...args),
-  extractSandboxEntries: (...args: unknown[]) => extractSandboxEntriesMock(...args),
-  readTranslatedFile: (...args: unknown[]) => readTranslatedFileMock(...args),
-  buildMultiFileMultiLocaleTempConfig: (...args: unknown[]) =>
-    buildMultiFileMultiLocaleTempConfigMock(...args),
-  buildCrowdinMultiFileSandboxConfig: (...args: unknown[]) =>
-    buildCrowdinMultiFileSandboxConfigMock(...args),
-  writeTempConfig: (...args: unknown[]) => writeTempConfigMock(...args),
-  writeFileToSandbox: (...args: unknown[]) => writeFileToSandboxMock(...args),
-  runSandboxCommand: (...args: unknown[]) => runSandboxCommandMock(...args),
-  getSandboxTranslationEnv: (...args: unknown[]) => getSandboxTranslationEnvMock(...args),
-  getOutputFilename: (...args: unknown[]) => getOutputFilenameMock(...args),
-  getOutputFilenamePattern: (...args: unknown[]) => getOutputFilenamePatternMock(...args),
-  sandboxI18nConfigPath: ".hl-sandbox-i18n.yml",
-}));
+vi.mock("@/lib/translation/sandbox", async () => {
+  const { hlEntriesPayloadToStringMap } = await import("@/lib/projects/files/hl-entries");
+
+  return {
+    createTranslationSandbox: (...args: unknown[]) => createTranslationSandboxMock(...args),
+    prepareSandbox: (...args: unknown[]) => prepareSandboxMock(...args),
+    stopTranslationSandbox: (...args: unknown[]) => stopTranslationSandboxMock(...args),
+    downloadAttachment: (...args: unknown[]) => downloadAttachmentMock(...args),
+    downloadCrowdinSourceInSandbox: (...args: unknown[]) =>
+      downloadCrowdinSourceInSandboxMock(...args),
+    downloadCrowdinTranslationsInSandbox: (...args: unknown[]) =>
+      downloadCrowdinTranslationsInSandboxMock(...args),
+    extractSandboxEntries: (...args: unknown[]) => extractSandboxEntriesMock(...args),
+    readTranslatedFile: (...args: unknown[]) => readTranslatedFileMock(...args),
+    buildMultiFileMultiLocaleTempConfig: (...args: unknown[]) =>
+      buildMultiFileMultiLocaleTempConfigMock(...args),
+    buildCrowdinMultiFileSandboxConfig: (...args: unknown[]) =>
+      buildCrowdinMultiFileSandboxConfigMock(...args),
+    writeTempConfig: (...args: unknown[]) => writeTempConfigMock(...args),
+    writeFileToSandbox: (...args: unknown[]) => writeFileToSandboxMock(...args),
+    runSandboxCommand: (...args: unknown[]) => runSandboxCommandMock(...args),
+    getSandboxTranslationEnv: (...args: unknown[]) => getSandboxTranslationEnvMock(...args),
+    getOutputFilename: (...args: unknown[]) => getOutputFilenameMock(...args),
+    getOutputFilenamePattern: (...args: unknown[]) => getOutputFilenamePatternMock(...args),
+    hlEntriesPayloadToStringMap,
+    sandboxI18nConfigPath: ".hl-sandbox-i18n.yml",
+  };
+});
 
 import {
   isProviderFileFullyTranslated,

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -552,6 +552,7 @@ export async function translateProviderJobFiles(input: {
       extractSandboxEntries,
       getOutputFilename,
       getOutputFilenamePattern,
+      hlEntriesPayloadToStringMap,
       prepareSandbox,
       readTranslatedFile,
       stopTranslationSandbox,
@@ -615,7 +616,7 @@ export async function translateProviderJobFiles(input: {
           try {
             const extracted = await extractSandboxEntries(sandboxId, workFilename);
             if (extracted.ok) {
-              sourceEntries = extracted.entries;
+              sourceEntries = hlEntriesPayloadToStringMap(extracted.entries);
             } else {
               warnings.push(
                 `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: exitCode=${extracted.exitCode}`,
@@ -756,7 +757,7 @@ export async function translateProviderJobFiles(input: {
               }
               // Existing/TM prefill wins over Crowdin prefill for the same key.
               filePrefills[index]![targetLocale] = {
-                ...crowdinEntries.entries,
+                ...hlEntriesPayloadToStringMap(crowdinEntries.entries),
                 ...filePrefills[index]![targetLocale],
               };
             }
@@ -823,7 +824,9 @@ export async function translateProviderJobFiles(input: {
                   );
                   continue;
                 }
-                const translatedEntries = translatedEntriesResult.entries;
+                const translatedEntries = hlEntriesPayloadToStringMap(
+                  translatedEntriesResult.entries,
+                );
 
                 const glossaryFailures = validateGlossaryTermsInTranslation({
                   sourceText: prepared.sourceText,

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -28,6 +28,11 @@ import {
 } from "@/lib/translation/file-formats";
 import { translationPromptPolicy } from "@/lib/translation/generation";
 import type { SandboxTranslationContext } from "@/lib/translation/domain";
+import {
+  hlEntriesPayloadToStringMap,
+  parseHlEntriesJson,
+  type HlEntriesPayload,
+} from "@/lib/projects/files/hl-entries";
 
 export const sandboxTimeoutMs = 10 * 60 * 1000;
 export const crowdinSandboxConfigPath = "/tmp/crowdin.yml";
@@ -39,8 +44,10 @@ export const sandboxFileBucketName = "file";
 export type { SandboxTranslationContext };
 
 export type ExtractSandboxEntriesResult =
-  | { ok: true; entries: Record<string, string> }
+  | { ok: true; entries: HlEntriesPayload }
   | { ok: false; exitCode: number; output: string };
+
+export { hlEntriesPayloadToStringMap };
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
@@ -812,7 +819,7 @@ export class HyperlocaliseCliRunner {
         const content = await this.lifecycle.readFile(sandboxId, outputPath);
         return {
           ok: true,
-          entries: JSON.parse(content.toString("utf8")) as Record<string, string>,
+          entries: parseHlEntriesJson(JSON.parse(content.toString("utf8"))),
         };
       } catch (error) {
         return {

--- a/apps/hyperlocalise-web/src/types/third-party-modules.d.ts
+++ b/apps/hyperlocalise-web/src/types/third-party-modules.d.ts
@@ -1,0 +1,36 @@
+declare module "cobe" {
+  type Marker = { location: [number, number]; size: number };
+
+  type GlobeOptions = {
+    devicePixelRatio?: number;
+    width: number;
+    height: number;
+    phi?: number;
+    theta?: number;
+    dark?: number;
+    diffuse?: number;
+    mapSamples?: number;
+    mapBrightness?: number;
+    baseColor?: [number, number, number];
+    markerColor?: [number, number, number];
+    glowColor?: [number, number, number];
+    markers?: Marker[];
+  };
+
+  type GlobeInstance = {
+    update: (options: Partial<GlobeOptions> & { phi?: number }) => void;
+    destroy: () => void;
+  };
+
+  export default function createGlobe(
+    canvas: HTMLCanvasElement,
+    options: GlobeOptions,
+  ): GlobeInstance;
+}
+
+declare module "unpdf" {
+  export function extractText(
+    data: Uint8Array,
+    options?: { mergePages?: boolean },
+  ): Promise<{ text: string }>;
+}

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -17,6 +17,7 @@ import {
   validateGlossaryTermsInTranslation,
 } from "@/lib/glossary/validate-glossary-terms-in-translation";
 import { mergeTranslationPrefills } from "@/lib/projects/translations/should-retry-same-as-source-prefill";
+import { hlEntriesPayloadToStringMap } from "@/lib/projects/files/hl-entries";
 import {
   inferSupportedFileTranslationFileFormat,
   isImageTranslationFileFormat,
@@ -419,7 +420,7 @@ async function extractEntriesStep(
       `failed to extract entries: exitCode=${result.exitCode} kind=${classifyCliFailureKind(result.output)}`,
     );
   }
-  return result.entries;
+  return hlEntriesPayloadToStringMap(result.entries);
 }
 async function readOutputStep(sandboxId: string, outputFile: string, _attempt: 1 | 2) {
   "use step";

--- a/apps/hyperlocalise-web/src/workflows/steps/source-file-ingest.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/source-file-ingest.ts
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import type { ProjectSourceStringEntry } from "@/api/routes/project/project.schema";
+import type { HlEntriesPayload } from "@/lib/projects/files/hl-entries";
 
 export async function claimSourceFileIngestStep(input: {
   sourceFileVersionId: string;
@@ -78,7 +79,7 @@ export async function extractSourceIngestEntriesStep(sandboxId: string, filePath
 }
 
 export async function parseHlEntriesStep(
-  extractedEntries: Record<string, string>,
+  extractedEntries: HlEntriesPayload,
 ): Promise<ProjectSourceStringEntry[]> {
   "use step";
   const { entriesFromHlOutput } = await import("@/lib/projects/files/source-file-ingest");

--- a/apps/hyperlocalise-web/src/workflows/translation-file-import.ts
+++ b/apps/hyperlocalise-web/src/workflows/translation-file-import.ts
@@ -53,18 +53,19 @@ export async function translationFileImportWorkflow(event: TranslationFileImport
     await prepareSourceIngestSandboxStep(sandboxId);
     await writeSourceIngestFileStep(sandboxId, inputFilename, content);
 
-    const entries = await extractTranslationImportEntriesStep({
+    const extractedEntries = await extractTranslationImportEntriesStep({
       sandboxId,
       filePath: inputFilename,
       targetLocale: event.targetLocale,
     });
+    const { hlEntriesPayloadToStringMap } = await import("@/lib/projects/files/hl-entries");
 
     const result = await importTranslationsFromEntriesStep({
       organizationId: event.organizationId,
       projectId: event.projectId,
       sourcePath: event.sourcePath,
       targetLocale: event.targetLocale,
-      entries,
+      entries: hlEntriesPayloadToStringMap(extractedEntries),
       actorUserId: event.actorUserId ?? null,
     });
 

--- a/internal/i18n/translationfileparser/README.md
+++ b/internal/i18n/translationfileparser/README.md
@@ -119,6 +119,7 @@
 - Ignores line comments (`// ...`) and block comments (`/* ... */`).
 - Decodes escaped sequences (`\n`, `\r`, `\t`, `\"`, `\\`) and unicode escapes (`\u`, `\Uhhhh`, surrogate pairs).
 - Supports multiline quoted value content.
+- Extracts optional max-length limits from leading entry comments using `hl:max-length=`, `max.length:`, `max length:`, or `character limit:` conventions.
 - `MarshalAppleStrings(template, values)` preserves template layout/comments/spacing and replaces only value literals.
 
 ### Apple Stringsdict (`.stringsdict`)
@@ -159,6 +160,7 @@
 - Falls back to the catalog key for simple source-only entries without a source localization.
 - Flattens variation and substitution leaves using stable `::` paths.
   - Examples: `item_count::plural.one`, `search_label::device.mac`, `count_label::substitution.total::plural.other`.
+- Extracts optional max-length limits from entry-level `maxLength` / `characterLimit` JSON fields or from the entry `comment` using the same comment conventions as `.strings`.
 - Preserves comments, extraction state, string-unit state, substitutions metadata, and unrelated JSON fields on marshal.
 - `MarshalXCStrings(template, sourceTemplate, values, sourceLocale, targetLocale)` writes translated values under `localizations[targetLocale]` and emits deterministic, pretty-printed JSON.
 - Original whitespace and object ordering are normalized during writeback.

--- a/internal/i18n/translationfileparser/entries_command_output.go
+++ b/internal/i18n/translationfileparser/entries_command_output.go
@@ -1,0 +1,55 @@
+package translationfileparser
+
+import "encoding/json"
+
+// EntriesCommandOutputValue is the JSON shape emitted by `hl entries` for one key.
+// Keys without metadata stay plain strings for backward compatibility.
+type EntriesCommandOutputValue any
+
+// EncodeEntriesCommandOutput renders ingest entries for `hl entries` JSON output.
+func EncodeEntriesCommandOutput(entries map[string]IngestEntry) map[string]EntriesCommandOutputValue {
+	if len(entries) == 0 {
+		return map[string]EntriesCommandOutputValue{}
+	}
+
+	out := make(map[string]EntriesCommandOutputValue, len(entries))
+	for key, entry := range entries {
+		if entry.MaxLength > 0 {
+			out[key] = map[string]any{
+				"text":      entry.Text,
+				"maxLength": entry.MaxLength,
+			}
+			continue
+		}
+		out[key] = entry.Text
+	}
+	return out
+}
+
+func decodeEntriesCommandOutput(raw map[string]json.RawMessage) (map[string]IngestEntry, error) {
+	if len(raw) == 0 {
+		return map[string]IngestEntry{}, nil
+	}
+
+	out := make(map[string]IngestEntry, len(raw))
+	for key, value := range raw {
+		var text string
+		if err := json.Unmarshal(value, &text); err == nil {
+			out[key] = IngestEntry{Text: text}
+			continue
+		}
+
+		var enriched struct {
+			Text      string `json:"text"`
+			MaxLength int    `json:"maxLength"`
+		}
+		if err := json.Unmarshal(value, &enriched); err != nil {
+			return nil, err
+		}
+		out[key] = IngestEntry{
+			Text:      enriched.Text,
+			MaxLength: enriched.MaxLength,
+		}
+	}
+	return out, nil
+}

--- a/internal/i18n/translationfileparser/entries_command_output.go
+++ b/internal/i18n/translationfileparser/entries_command_output.go
@@ -1,7 +1,5 @@
 package translationfileparser
 
-import "encoding/json"
-
 // EntriesCommandOutputValue is the JSON shape emitted by `hl entries` for one key.
 // Keys without metadata stay plain strings for backward compatibility.
 type EntriesCommandOutputValue any
@@ -24,32 +22,4 @@ func EncodeEntriesCommandOutput(entries map[string]IngestEntry) map[string]Entri
 		out[key] = entry.Text
 	}
 	return out
-}
-
-func decodeEntriesCommandOutput(raw map[string]json.RawMessage) (map[string]IngestEntry, error) {
-	if len(raw) == 0 {
-		return map[string]IngestEntry{}, nil
-	}
-
-	out := make(map[string]IngestEntry, len(raw))
-	for key, value := range raw {
-		var text string
-		if err := json.Unmarshal(value, &text); err == nil {
-			out[key] = IngestEntry{Text: text}
-			continue
-		}
-
-		var enriched struct {
-			Text      string `json:"text"`
-			MaxLength int    `json:"maxLength"`
-		}
-		if err := json.Unmarshal(value, &enriched); err != nil {
-			return nil, err
-		}
-		out[key] = IngestEntry{
-			Text:      enriched.Text,
-			MaxLength: enriched.MaxLength,
-		}
-	}
-	return out, nil
 }

--- a/internal/i18n/translationfileparser/entry_metadata.go
+++ b/internal/i18n/translationfileparser/entry_metadata.go
@@ -1,0 +1,108 @@
+package translationfileparser
+
+import (
+	"encoding/json"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const maxIngestEntryLength = 100_000
+
+// IngestEntry is a parsed translation entry with optional import metadata.
+type IngestEntry struct {
+	Text      string
+	MaxLength int
+}
+
+var maxLengthCommentPattern = regexp.MustCompile(`(?i)(?:max[\s._-]?length|character[\s._-]?limit|hl:max-length)\s*[:=]\s*(\d+)`)
+
+// ParseMaxLengthFromComment extracts a positive max-length limit from translator comments.
+func ParseMaxLengthFromComment(comment string) (int, bool) {
+	comment = strings.TrimSpace(comment)
+	if comment == "" {
+		return 0, false
+	}
+
+	match := maxLengthCommentPattern.FindStringSubmatch(comment)
+	if len(match) < 2 {
+		return 0, false
+	}
+
+	value, err := strconv.Atoi(match[1])
+	if err != nil || value <= 0 || value > maxIngestEntryLength {
+		return 0, false
+	}
+
+	return value, true
+}
+
+func positiveIntFromJSONValue(raw any) (int, bool) {
+	switch typed := raw.(type) {
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil || parsed <= 0 || parsed > maxIngestEntryLength {
+			return 0, false
+		}
+		return int(parsed), true
+	case float64:
+		if typed <= 0 || typed > maxIngestEntryLength || math.Trunc(typed) != typed {
+			return 0, false
+		}
+		return int(typed), true
+	case int:
+		if typed <= 0 || typed > maxIngestEntryLength {
+			return 0, false
+		}
+		return typed, true
+	case int64:
+		if typed <= 0 || typed > maxIngestEntryLength {
+			return 0, false
+		}
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
+func maxLengthFromObjectFields(obj map[string]any) (int, bool) {
+	for _, field := range []string{"maxLength", "characterLimit"} {
+		raw, ok := obj[field]
+		if !ok || raw == nil {
+			continue
+		}
+		if value, ok := positiveIntFromJSONValue(raw); ok {
+			return value, true
+		}
+	}
+	return 0, false
+}
+
+// IngestEntriesFromStringMap wraps plain key/value parser output as ingest entries.
+func IngestEntriesFromStringMap(values map[string]string) map[string]IngestEntry {
+	if len(values) == 0 {
+		return nil
+	}
+
+	out := make(map[string]IngestEntry, len(values))
+	for key, text := range values {
+		out[key] = IngestEntry{Text: text}
+	}
+	return out
+}
+
+func applyMaxLengthByKey(entries map[string]IngestEntry, maxLengthByKey map[string]int) map[string]IngestEntry {
+	if len(maxLengthByKey) == 0 {
+		return entries
+	}
+
+	out := make(map[string]IngestEntry, len(entries))
+	for key, entry := range entries {
+		if maxLength, ok := maxLengthByKey[key]; ok && maxLength > 0 {
+			entry.MaxLength = maxLength
+		}
+		out[key] = entry
+	}
+	return out
+}

--- a/internal/i18n/translationfileparser/entry_metadata_test.go
+++ b/internal/i18n/translationfileparser/entry_metadata_test.go
@@ -1,0 +1,32 @@
+package translationfileparser
+
+import "testing"
+
+func TestParseMaxLengthFromComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    int
+		ok      bool
+	}{
+		{name: "hl directive", comment: "hl:max-length=24", want: 24, ok: true},
+		{name: "max length words", comment: "Max length: 40", want: 40, ok: true},
+		{name: "max.length crowdin style", comment: "max.length: 35", want: 35, ok: true},
+		{name: "character limit", comment: "Character limit = 12", want: 12, ok: true},
+		{name: "embedded in sentence", comment: "Button label. Max length: 18 chars.", want: 18, ok: true},
+		{name: "zero rejected", comment: "max length: 0", ok: false},
+		{name: "missing", comment: "Shown on the welcome screen", ok: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseMaxLengthFromComment(tc.comment)
+			if ok != tc.ok {
+				t.Fatalf("ParseMaxLengthFromComment(%q) ok = %v, want %v", tc.comment, ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("ParseMaxLengthFromComment(%q) = %d, want %d", tc.comment, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/translationfileparser/strategy.go
+++ b/internal/i18n/translationfileparser/strategy.go
@@ -152,6 +152,44 @@ func (s *Strategy) ParseWithContext(path string, content []byte) (map[string]str
 	return s.parseWithContext(path, content)
 }
 
+// ParseIngestEntries resolves a parser from the file path extension and returns entries
+// enriched with optional import metadata such as max-length limits.
+func (s *Strategy) ParseIngestEntries(path string, content []byte, locale string) (map[string]IngestEntry, error) {
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(path)))
+	if ext == "" {
+		return nil, fmt.Errorf("translation file parser: file %q has no extension", path)
+	}
+
+	switch ext {
+	case ".strings":
+		parser, ok := s.parsersByExt[ext].(AppleStringsParser)
+		if !ok {
+			return nil, fmt.Errorf("translation file parser: unsupported file extension %q", ext)
+		}
+		entries, err := parser.ParseIngestEntries(content)
+		if err != nil {
+			return nil, fmt.Errorf("translation file parser: parse %q: %w", path, err)
+		}
+		return entries, nil
+	case ".xcstrings":
+		parser, ok := s.parsersByExt[ext].(XCStringsParser)
+		if !ok {
+			return nil, fmt.Errorf("translation file parser: unsupported file extension %q", ext)
+		}
+		entries, err := parser.ParseIngestEntries(content, locale)
+		if err != nil {
+			return nil, fmt.Errorf("translation file parser: parse %q: %w", path, err)
+		}
+		return entries, nil
+	}
+
+	values, err := s.ParseWithLocale(path, content, locale)
+	if err != nil {
+		return nil, err
+	}
+	return IngestEntriesFromStringMap(values), nil
+}
+
 func (s *Strategy) parseWithContext(path string, content []byte) (map[string]string, map[string]string, error) {
 	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(path)))
 	if ext == "" {

--- a/internal/i18n/translationfileparser/strings_parser.go
+++ b/internal/i18n/translationfileparser/strings_parser.go
@@ -20,11 +20,12 @@ var appleStringsEscaper = strings.NewReplacer(
 )
 
 type stringsEntry struct {
-	key          string
-	sourceValue  string
-	valueLiteral string
-	valueStart   int
-	valueEnd     int
+	key             string
+	sourceValue     string
+	valueLiteral    string
+	valueStart      int
+	valueEnd        int
+	leadingComments string
 }
 
 type stringsDocument struct {
@@ -33,13 +34,31 @@ type stringsDocument struct {
 }
 
 func (p AppleStringsParser) Parse(content []byte) (map[string]string, error) {
-	doc, err := parseStringsDocument(content)
+	entries, err := p.ParseIngestEntries(content)
 	if err != nil {
 		return nil, err
 	}
 	out := map[string]string{}
+	for key, entry := range entries {
+		out[key] = entry.Text
+	}
+	return out, nil
+}
+
+// ParseIngestEntries parses Apple .strings files and extracts optional max-length metadata
+// from leading entry comments.
+func (p AppleStringsParser) ParseIngestEntries(content []byte) (map[string]IngestEntry, error) {
+	doc, err := parseStringsDocument(content)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]IngestEntry, len(doc.entries))
 	for _, entry := range doc.entries {
-		out[entry.key] = entry.sourceValue
+		ingestEntry := IngestEntry{Text: entry.sourceValue}
+		if maxLength, ok := ParseMaxLengthFromComment(entry.leadingComments); ok {
+			ingestEntry.MaxLength = maxLength
+		}
+		out[entry.key] = ingestEntry
 	}
 	return out, nil
 }
@@ -97,7 +116,8 @@ func parseStringsDocument(content []byte) (stringsDocument, error) {
 	i := 0
 	for i < len(text) {
 		var lines int
-		next, lines, err := skipStringsTrivia(text, i)
+		var leadingComments string
+		next, lines, leadingComments, err := skipStringsLeadingComments(text, i)
 		if err != nil {
 			return stringsDocument{}, err
 		}
@@ -143,11 +163,12 @@ func parseStringsDocument(content []byte) (stringsDocument, error) {
 		i++
 
 		doc.entries = append(doc.entries, stringsEntry{
-			key:          keyToken.decoded,
-			sourceValue:  valueToken.decoded,
-			valueLiteral: valueToken.raw,
-			valueStart:   valueToken.start,
-			valueEnd:     valueToken.end,
+			key:             keyToken.decoded,
+			sourceValue:     valueToken.decoded,
+			valueLiteral:    valueToken.raw,
+			valueStart:      valueToken.start,
+			valueEnd:        valueToken.end,
+			leadingComments: leadingComments,
 		})
 	}
 
@@ -269,16 +290,19 @@ func decodeAppleStringsQuoted(raw string) (string, error) {
 	return b.String(), nil
 }
 
-func skipStringsTrivia(text string, start int) (int, int, error) {
+func skipStringsLeadingComments(text string, start int) (int, int, string, error) {
 	lines := 0
+	var comments []string
 	i, l := skipStringsWhitespace(text, start)
 	lines += l
 	for i < len(text) {
 		if i+1 < len(text) && text[i] == '/' && text[i+1] == '/' {
+			lineStart := i + 2
 			i += 2
 			for i < len(text) && text[i] != '\n' {
 				i++
 			}
+			comments = append(comments, strings.TrimSpace(text[lineStart:i]))
 			i, l = skipStringsWhitespace(text, i)
 			lines += l
 			continue
@@ -286,10 +310,14 @@ func skipStringsTrivia(text string, start int) (int, int, error) {
 		if i+1 < len(text) && text[i] == '/' && text[i+1] == '*' {
 			end := strings.Index(text[i+2:], "*/")
 			if end < 0 {
-				return start, lines, fmt.Errorf("line %d: unterminated block comment", lineNumberAt(text, i))
+				return start, lines, "", fmt.Errorf("line %d: unterminated block comment", lineNumberAt(text, i))
 			}
 			comment := text[i : i+2+end+2]
 			lines += strings.Count(comment, "\n")
+			inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(comment, "/*"), "*/"))
+			if inner != "" {
+				comments = append(comments, inner)
+			}
 			i = i + 2 + end + 2
 			i, l = skipStringsWhitespace(text, i)
 			lines += l
@@ -297,7 +325,12 @@ func skipStringsTrivia(text string, start int) (int, int, error) {
 		}
 		break
 	}
-	return i, lines, nil
+	return i, lines, strings.Join(comments, "\n"), nil
+}
+
+func skipStringsTrivia(text string, start int) (int, int, error) {
+	next, lines, _, err := skipStringsLeadingComments(text, start)
+	return next, lines, err
 }
 
 func skipStringsWhitespace(text string, start int) (int, int) {

--- a/internal/i18n/translationfileparser/strings_parser.go
+++ b/internal/i18n/translationfileparser/strings_parser.go
@@ -328,11 +328,6 @@ func skipStringsLeadingComments(text string, start int) (int, int, string, error
 	return i, lines, strings.Join(comments, "\n"), nil
 }
 
-func skipStringsTrivia(text string, start int) (int, int, error) {
-	next, lines, _, err := skipStringsLeadingComments(text, start)
-	return next, lines, err
-}
-
 func skipStringsWhitespace(text string, start int) (int, int) {
 	lines := 0
 	i := start

--- a/internal/i18n/translationfileparser/strings_parser_test.go
+++ b/internal/i18n/translationfileparser/strings_parser_test.go
@@ -52,6 +52,32 @@ func TestAppleStringsParserParsesMultilineAndUnicode(t *testing.T) {
 	}
 }
 
+func TestAppleStringsParserExtractsMaxLengthFromLeadingComments(t *testing.T) {
+	content := []byte(`/* Max length: 24 */
+"cta" = "Continue";
+
+// Character limit = 12
+"title" = "Welcome";
+
+"plain" = "No limit";
+`)
+
+	entries, err := (AppleStringsParser{}).ParseIngestEntries(content)
+	if err != nil {
+		t.Fatalf("parse strings ingest entries: %v", err)
+	}
+
+	if entries["cta"].MaxLength != 24 {
+		t.Fatalf("expected cta max length 24, got %+v", entries["cta"])
+	}
+	if entries["title"].MaxLength != 12 {
+		t.Fatalf("expected title max length 12, got %+v", entries["title"])
+	}
+	if entries["plain"].MaxLength != 0 {
+		t.Fatalf("expected plain entry without max length, got %+v", entries["plain"])
+	}
+}
+
 func TestMarshalAppleStringsPreservesTemplateFormatting(t *testing.T) {
 	template := []byte(`/* App title */
 "title"   =   "Welcome";

--- a/internal/i18n/translationfileparser/xcstrings_parser.go
+++ b/internal/i18n/translationfileparser/xcstrings_parser.go
@@ -26,29 +26,39 @@ type xcstringsLeafRef struct {
 }
 
 func (p XCStringsParser) Parse(content []byte) (map[string]string, error) {
-	values, _, err := parseXCStringsCatalog(content, "")
+	values, _, _, err := parseXCStringsCatalog(content, "")
 	return values, err
 }
 
 func (p XCStringsParser) ParseWithContext(content []byte) (map[string]string, map[string]string, error) {
-	return parseXCStringsCatalog(content, "")
+	values, contextByKey, _, err := parseXCStringsCatalog(content, "")
+	return values, contextByKey, err
+}
+
+// ParseIngestEntries parses Apple .xcstrings catalogs and extracts optional max-length metadata.
+func (p XCStringsParser) ParseIngestEntries(content []byte, locale string) (map[string]IngestEntry, error) {
+	values, _, maxLengthByKey, err := parseXCStringsCatalog(content, strings.TrimSpace(locale))
+	if err != nil {
+		return nil, err
+	}
+	return applyMaxLengthByKey(IngestEntriesFromStringMap(values), maxLengthByKey), nil
 }
 
 // ParseXCStringsLocale parses values for one localization inside a string catalog.
 // It is used by local target-file checks because .xcstrings can hold more than one locale.
 func ParseXCStringsLocale(content []byte, locale string) (map[string]string, error) {
-	values, _, err := parseXCStringsCatalog(content, strings.TrimSpace(locale))
+	values, _, _, err := parseXCStringsCatalog(content, strings.TrimSpace(locale))
 	return values, err
 }
 
-func parseXCStringsCatalog(content []byte, locale string) (map[string]string, map[string]string, error) {
+func parseXCStringsCatalog(content []byte, locale string) (map[string]string, map[string]string, map[string]int, error) {
 	root, err := decodeXCStringsObject(content)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	stringsNode, err := xcstringsObjectField(root, "strings")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	sourceLanguage, _ := root["sourceLanguage"].(string)
@@ -58,6 +68,7 @@ func parseXCStringsCatalog(content []byte, locale string) (map[string]string, ma
 
 	out := map[string]string{}
 	contextByKey := map[string]string{}
+	maxLengthByKey := map[string]int{}
 
 	// BOLT OPTIMIZATION: Avoid redundant O(N log N) sorting of all keys as map[string]string
 	// is unordered and sorting adds unnecessary allocations and CPU overhead.
@@ -65,24 +76,28 @@ func parseXCStringsCatalog(content []byte, locale string) (map[string]string, ma
 		// BOLT OPTIMIZATION: Use string concatenation instead of fmt.Sprintf
 		entry, err := xcstringsObjectValue(value, "strings."+key)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
+		entryMaxLength := xcstringsEntryMaxLength(entry)
 		baseContext := xcstringsEntryContext(entry, sourceLanguage)
 		if sourceMode {
 			refs, err := xcstringsSourceLeafRefs(key, entry, sourceLanguage)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			for _, ref := range refs {
 				translatedValue, ok, err := xcstringsValueForRef(entry, sourceLanguage, ref)
 				if err != nil {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 				if !ok {
 					translatedValue = key
 				}
 				out[ref.key] = translatedValue
+				if entryMaxLength > 0 {
+					maxLengthByKey[ref.key] = entryMaxLength
+				}
 				if ctx := xcstringsLeafContext(baseContext, ref.steps); ctx != "" {
 					contextByKey[ref.key] = ctx
 				}
@@ -92,7 +107,7 @@ func parseXCStringsCatalog(content []byte, locale string) (map[string]string, ma
 
 		locs, ok, err := xcstringsOptionalObjectField(entry, "localizations")
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if !ok {
 			continue
@@ -105,14 +120,29 @@ func parseXCStringsCatalog(content []byte, locale string) (map[string]string, ma
 		// BOLT OPTIMIZATION: Use string concatenation instead of fmt.Sprintf
 		loc, err := xcstringsObjectValue(locRaw, "strings."+key+".localizations."+entryTargetLocale)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
+		}
+		keysBefore := make(map[string]struct{}, len(out))
+		for leafKey := range out {
+			keysBefore[leafKey] = struct{}{}
 		}
 		if _, err := collectXCStringsLeaves(key, loc, out, contextByKey, baseContext, nil); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
+		}
+		if entryMaxLength > 0 {
+			for leafKey := range out {
+				if _, existed := keysBefore[leafKey]; !existed {
+					maxLengthByKey[leafKey] = entryMaxLength
+				}
+			}
 		}
 	}
 
-	return out, contextByKey, nil
+	if len(maxLengthByKey) == 0 {
+		maxLengthByKey = nil
+	}
+
+	return out, contextByKey, maxLengthByKey, nil
 }
 
 func decodeXCStringsObject(content []byte) (map[string]any, error) {
@@ -559,6 +589,18 @@ func escapeXCStringsBaseKey(key string) string {
 		return key
 	}
 	return xcstringsEscapedBaseKeyPrefix + base64.RawURLEncoding.EncodeToString([]byte(key))
+}
+
+func xcstringsEntryMaxLength(entry map[string]any) int {
+	if maxLength, ok := maxLengthFromObjectFields(entry); ok {
+		return maxLength
+	}
+	if comment, ok := entry["comment"].(string); ok {
+		if maxLength, ok := ParseMaxLengthFromComment(comment); ok {
+			return maxLength
+		}
+	}
+	return 0
 }
 
 func xcstringsEntryContext(entry map[string]any, sourceLanguage string) string {

--- a/internal/i18n/translationfileparser/xcstrings_parser_test.go
+++ b/internal/i18n/translationfileparser/xcstrings_parser_test.go
@@ -115,6 +115,79 @@ func TestXCStringsParserParsesSourceStringsVariantsAndContext(t *testing.T) {
 	}
 }
 
+func TestXCStringsParserExtractsMaxLengthFromEntryMetadata(t *testing.T) {
+	content := []byte(`{
+  "sourceLanguage": "en",
+  "strings": {
+    "cta": {
+      "maxLength": 24,
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        }
+      }
+    },
+    "title": {
+      "comment": "Screen title. Max length: 18",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome"
+          }
+        }
+      }
+    },
+    "item_count": {
+      "characterLimit": 30,
+      "comment": "Cart item count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld item"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld items"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}`)
+
+	entries, err := (XCStringsParser{}).ParseIngestEntries(content, "")
+	if err != nil {
+		t.Fatalf("parse xcstrings ingest entries: %v", err)
+	}
+
+	if entries["cta"].MaxLength != 24 {
+		t.Fatalf("expected cta max length 24, got %+v", entries["cta"])
+	}
+	if entries["title"].MaxLength != 18 {
+		t.Fatalf("expected title max length 18, got %+v", entries["title"])
+	}
+	if entries["item_count::plural.one"].MaxLength != 30 {
+		t.Fatalf("expected plural.one max length 30, got %+v", entries["item_count::plural.one"])
+	}
+	if entries["item_count::plural.other"].MaxLength != 30 {
+		t.Fatalf("expected plural.other max length 30, got %+v", entries["item_count::plural.other"])
+	}
+}
+
 func TestParseXCStringsLocaleReadsRequestedTargetLocale(t *testing.T) {
 	content := []byte(`{
   "sourceLanguage": "en",


### PR DESCRIPTION
## What changed

Adds native-only character limit support for CAT segments end-to-end.

**Manual editing**
- New API route: `POST /:projectId/files/detail/cat/segments/:externalStringId/max-length`
- Service layer updates `max_length` on native keys via `setKeyMaxLength()` and `upsertKeysFromEntries()`
- Intelligence panel editor (`cat-segment-max-length-editor.tsx`) wired through CAT workspace and side-by-side views

**Source file import**
- Go parsers extract max length from `.strings` comments and `.xcstrings` metadata (`maxLength`, `characterLimit`, or comment conventions)
- `hl entries` emits enriched JSON (`{ text, maxLength }` when present)
- Web ingest (`hl-entries.ts`, `source-file-ingest.ts`, sandbox/workflow steps) passes limits through to upsert

**Upsert policy**
- Re-import overwrites when the source provides a limit
- Preserves existing manual values when the entry has none (`COALESCE`)

Supported comment conventions: `hl:max-length=`, `max.length:`, `max length:`, `character limit:`.

## How to test

- Go: `go test ./internal/i18n/translationfileparser/... ./apps/cli/cmd/... -run 'MaxLength|EntriesCommandExtracts'`
- Web: `vp test src/lib/projects/files/hl-entries.test.ts src/components/cat/segment/cat-segment-max-length-editor.test.tsx src/lib/projects/cat/native-cat-service.test.ts`
- Manual: upload or re-ingest a `.strings` or `.xcstrings` file with max-length metadata; confirm limits appear in the CAT intelligence panel and character counter

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review