### PR TITLE
Fix project settings identifier save and project avatar text overflow

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -388,9 +388,22 @@ const projectStore: ProjectStore = {
     return project ?? null;
   },
   async update(auth, projectId, payload): Promise<ProjectUpdateResult> {
-    const existing = await this.getById(auth, projectId);
+    let existing = await this.getById(auth, projectId);
     if (!existing) {
-      return ok(null);
+      const ensured = await ensureOrganizationProjectRecord({
+        organizationId: auth.organization.localOrganizationId,
+        projectId,
+        userId: auth.user.localUserId,
+      });
+
+      if (isErr(ensured)) {
+        return ok(null);
+      }
+
+      existing = await this.getById(auth, ensured.value);
+      if (!existing) {
+        return ok(null);
+      }
     }
 
     const { teamId, sourceLocale, targetLocales, identifier, ...updates } = payload;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -207,7 +207,18 @@ export function ProjectSettingsPageContent({
     id: "project-settings-save",
     visible: true,
     render: () => (
-      <Button type="submit" form="project-settings-form" disabled={isSaving}>
+      <Button
+        type="submit"
+        form="project-settings-form"
+        disabled={isSaving}
+        onClick={(e) => {
+          const form = document.getElementById("project-settings-form") as HTMLFormElement | null;
+          if (form) {
+            e.preventDefault();
+            form.requestSubmit();
+          }
+        }}
+      >
         {isSaving ? (
           <Spinner />
         ) : (
@@ -229,6 +240,7 @@ export function ProjectSettingsPageContent({
     const nextErrors = validateProjectForm(values, {
       requireLocales: projectFormRequiresLocales("edit", project.source),
       requireIdentifier: true,
+      requireMetadata: project.source === "native",
     });
     setErrors(nextErrors);
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
@@ -35,7 +35,7 @@ export function ProjectAvatar({
         {project.logoUrl ? (
           <AvatarImage src={project.logoUrl} alt="" className="rounded-lg object-cover" />
         ) : null}
-        <AvatarFallback className="rounded-lg bg-background text-xs font-medium text-foreground">
+        <AvatarFallback className="truncate rounded-lg bg-background px-0.5 text-center text-xs font-medium text-foreground select-none overflow-hidden">
           {project.key}
         </AvatarFallback>
       </Avatar>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-form.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-form.ts
@@ -76,18 +76,26 @@ export function createProjectFormFromRow(project: ProjectListRow): ProjectFormVa
 
 export function validateProjectForm(
   values: ProjectFormValues,
-  options?: { requireLocales?: boolean; requireIdentifier?: boolean; intl?: ProjectFormIntl },
+  options?: {
+    requireLocales?: boolean;
+    requireIdentifier?: boolean;
+    requireMetadata?: boolean;
+    intl?: ProjectFormIntl;
+  },
 ): ProjectFormErrors {
   const errors: ProjectFormErrors = {};
   const name = values.name.trim();
   const requireLocales = options?.requireLocales ?? true;
   const requireIdentifier = options?.requireIdentifier ?? false;
+  const requireMetadata = options?.requireMetadata ?? true;
   const intl = options?.intl;
 
-  if (!name) {
-    errors.name = resolveMessage(intl, projectFormMessages.nameRequired);
-  } else if (name.length > 200) {
-    errors.name = resolveMessage(intl, projectFormMessages.nameTooLong);
+  if (requireMetadata) {
+    if (!name) {
+      errors.name = resolveMessage(intl, projectFormMessages.nameRequired);
+    } else if (name.length > 200) {
+      errors.name = resolveMessage(intl, projectFormMessages.nameTooLong);
+    }
   }
 
   if (values.description.trim().length > 10_000) {


### PR DESCRIPTION
Fixed an issue where saving settings on an external TMS project (e.g. when changing the Identifier) did nothing by ensuring project record materialization and bypassing read-only metadata validation. Also fixed a UI text overflow issue in ProjectAvatar fallbacks for long project keys.

---
*PR created automatically by Jules for task [13094585257425148657](https://jules.google.com/task/13094585257425148657) started by @nguyenkhavi*