### PR TITLE
fix(projects): name-based avatars and settings save fixes

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.test.tsx
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { IntlProvider } from "react-intl";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { AppShellHeaderActions } from "@/components/app-shell/store/app-shell-header-actions";
+import { AppShellStoreProvider } from "@/components/app-shell/store/app-shell-store-context";
+
+import type { ProjectListRow } from "../../../_components/project-list";
+
+const { useProjectPageQueryMock, patchMock, toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  useProjectPageQueryMock: vi.fn(),
+  patchMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/en/org/acme/projects/project_1/settings",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+vi.mock("../../_components/project-page-shell", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../_components/project-page-shell")>();
+  return {
+    ...actual,
+    useProjectPageQuery: (...args: unknown[]) => useProjectPageQueryMock(...args),
+  };
+});
+
+vi.mock("@/lib/api-client-instance", () => ({
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          projects: {
+            ":projectId": {
+              $patch: (...args: unknown[]) => patchMock(...args),
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("./project-issue-templates-panel", () => ({
+  ProjectIssueTemplatesPanel: () => null,
+}));
+
+vi.mock("./project-native-connect-cli-panel", () => ({
+  ProjectNativeConnectCliPanel: () => null,
+}));
+
+vi.mock("./project-cat-behavior-settings", () => ({
+  ProjectCatBehaviorSettings: () => null,
+}));
+
+vi.mock("./project-issue-columns-settings", () => ({
+  ProjectIssueColumnsSettings: () => null,
+}));
+
+import { ProjectSettingsPageContent } from "./project-settings-page-content";
+
+function createProject(overrides: Partial<ProjectListRow> = {}): ProjectListRow {
+  return {
+    id: "project_1",
+    name: "Tourmatic",
+    key: "TM",
+    identifier: "TM",
+    description: "No description",
+    descriptionValue: "",
+    translationContext: "No translation context",
+    translationContextValue: "",
+    created: "Apr 29, 2026",
+    updated: "Apr 30, 2026",
+    source: "native",
+    externalProviderKind: null,
+    externalProjectId: null,
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR", "de-DE"],
+    externalProjectUrl: null,
+    isActive: true,
+    logoUrl: null,
+    lastActivityAt: null,
+    lastSyncedAt: null,
+    lastSyncErrorAt: null,
+    lastSyncErrorMessage: null,
+    openJobCount: 0,
+    ...overrides,
+  };
+}
+
+function mockProjectQuery(project: ProjectListRow | undefined, options?: { isLoading?: boolean }) {
+  useProjectPageQueryMock.mockReturnValue({
+    isLoading: options?.isLoading ?? false,
+    isError: false,
+    isSuccess: Boolean(project),
+    data: project,
+    error: null,
+  });
+}
+
+function renderSettings(project: ProjectListRow = createProject()) {
+  mockProjectQuery(project);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en" messages={{}}>
+          <AppShellStoreProvider defaultNavigationGroups={[]}>
+            <div data-testid="header-actions">
+              <AppShellHeaderActions />
+            </div>
+            {children}
+          </AppShellStoreProvider>
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  return render(
+    <ProjectSettingsPageContent
+      organizationSlug="acme"
+      projectId={project.id}
+      canManageCatBehavior
+    />,
+    { wrapper: Wrapper },
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  patchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ project: createProject({ identifier: "NEW" }) }),
+  });
+});
+
+describe("ProjectSettingsPageContent", () => {
+  it("saves an updated identifier via the header Save settings action", async () => {
+    const user = userEvent.setup();
+    renderSettings();
+
+    const identifier = await screen.findByLabelText("Identifier");
+    await user.clear(identifier);
+    await user.type(identifier, "new");
+
+    await user.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() => expect(patchMock).toHaveBeenCalled());
+    expect(patchMock.mock.calls[0]?.[0]).toMatchObject({
+      param: { organizationSlug: "acme", projectId: "project_1" },
+      json: expect.objectContaining({ identifier: "NEW" }),
+    });
+    await waitFor(() => expect(toastSuccessMock).toHaveBeenCalledWith("Project settings saved"));
+  });
+
+  it("shows a toast and skips PATCH when the identifier is invalid", async () => {
+    const user = userEvent.setup();
+    renderSettings();
+
+    const identifier = await screen.findByLabelText("Identifier");
+    await user.clear(identifier);
+    await user.type(identifier, "123");
+
+    await user.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() =>
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Use 1–10 letters or numbers, starting with a letter (e.g. HL).",
+      ),
+    );
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Use 1–10 letters or numbers, starting with a letter (e.g. HL)."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not wipe in-progress identifier edits when the same project data is refetched", async () => {
+    const user = userEvent.setup();
+    const project = createProject();
+    const view = renderSettings(project);
+
+    const identifier = await screen.findByLabelText("Identifier");
+    await user.clear(identifier);
+    await user.type(identifier, "edit");
+    expect(identifier).toHaveValue("EDIT");
+
+    mockProjectQuery({ ...project });
+    view.rerender(
+      <ProjectSettingsPageContent
+        organizationSlug="acme"
+        projectId={project.id}
+        canManageCatBehavior
+      />,
+    );
+
+    expect(await screen.findByLabelText("Identifier")).toHaveValue("EDIT");
+  });
+
+  it("hides Save settings while the project is still loading", () => {
+    mockProjectQuery(undefined, { isLoading: true });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en" messages={{}}>
+          <AppShellStoreProvider defaultNavigationGroups={[]}>
+            <AppShellHeaderActions />
+            <ProjectSettingsPageContent
+              organizationSlug="acme"
+              projectId="project_1"
+              canManageCatBehavior
+            />
+          </AppShellStoreProvider>
+        </IntlProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Save settings" })).not.toBeInTheDocument();
+    expect(screen.getByText("Loading project settings...")).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { HugeiconsIcon } from "@hugeicons/react";
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { SaveIcon, Settings01Icon } from "@hugeicons/core-free-icons";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -87,6 +87,68 @@ async function readProjectError(response: Response, fallback: string) {
   return fallback;
 }
 
+const PROJECT_FORM_FIELD_ORDER: (keyof ProjectFormValues)[] = [
+  "name",
+  "identifier",
+  "description",
+  "translationContext",
+  "sourceLocale",
+  "targetLocales",
+];
+
+const PROJECT_FORM_FIELD_FOCUS_IDS: Partial<Record<keyof ProjectFormValues, string>> = {
+  name: "project-name",
+  identifier: "project-identifier",
+  description: "project-description",
+  translationContext: "translation-context",
+};
+
+/** Stable fingerprint of server-backed form fields so refetches do not wipe edits. */
+function projectFormFingerprint(project: ProjectListRow) {
+  return [
+    project.id,
+    project.updated,
+    project.name,
+    project.identifier,
+    project.descriptionValue,
+    project.translationContextValue,
+    project.sourceLocale ?? "",
+    project.targetLocales.join(","),
+  ].join("\0");
+}
+
+function firstProjectFormErrorMessage(errors: ProjectFormErrors) {
+  for (const key of PROJECT_FORM_FIELD_ORDER) {
+    const message = errors[key];
+    if (message) {
+      return message;
+    }
+  }
+  return undefined;
+}
+
+function focusFirstProjectFormError(errors: ProjectFormErrors) {
+  for (const key of PROJECT_FORM_FIELD_ORDER) {
+    if (!errors[key]) {
+      continue;
+    }
+
+    const fieldId = PROJECT_FORM_FIELD_FOCUS_IDS[key];
+    if (fieldId) {
+      const element = document.getElementById(fieldId);
+      if (element) {
+        element.focus({ preventScroll: true });
+        element.scrollIntoView({ behavior: "smooth", block: "center" });
+        return;
+      }
+    }
+
+    const alert = document.querySelector<HTMLElement>("[data-slot=field-error]");
+    alert?.scrollIntoView({ behavior: "smooth", block: "center" });
+    return;
+  }
+}
+
 function DetailRow({ label, value }: { label: string; value: string | null }) {
   const intl = useIntl();
 
@@ -153,18 +215,29 @@ export function ProjectSettingsPageContent({
   projectId: string;
   canManageCatBehavior: boolean;
 }) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const projectQuery = useProjectPageQuery(organizationSlug, projectId);
   const project = projectQuery.data;
+  const formRef = useRef<HTMLFormElement>(null);
   const [values, setValues] = useState<ProjectFormValues | null>(null);
   const [errors, setErrors] = useState<ProjectFormErrors>({});
+  const [syncedFingerprint, setSyncedFingerprint] = useState<string | null>(null);
 
   useEffect(() => {
-    if (project) {
-      setValues(createProjectFormFromRow(project));
-      setErrors({});
+    if (!project) {
+      return;
     }
-  }, [project]);
+
+    const fingerprint = projectFormFingerprint(project);
+    if (fingerprint === syncedFingerprint) {
+      return;
+    }
+
+    setValues(createProjectFormFromRow(project));
+    setErrors({});
+    setSyncedFingerprint(fingerprint);
+  }, [project, syncedFingerprint]);
 
   const updateProject = useMutation({
     mutationFn: async (nextValues: ProjectFormValues) => {
@@ -203,11 +276,18 @@ export function ProjectSettingsPageContent({
 
   const isSaving = updateProject.isPending;
   const metadataEditable = project?.source === "native";
+  const formReady = Boolean(project && values && !projectQuery.isLoading);
   useAppShellHeaderAction({
     id: "project-settings-save",
-    visible: true,
+    visible: formReady,
     render: () => (
-      <Button type="submit" form="project-settings-form" disabled={isSaving}>
+      <Button
+        type="button"
+        disabled={isSaving}
+        onClick={() => {
+          formRef.current?.requestSubmit();
+        }}
+      >
         {isSaving ? (
           <Spinner />
         ) : (
@@ -229,10 +309,16 @@ export function ProjectSettingsPageContent({
     const nextErrors = validateProjectForm(values, {
       requireLocales: projectFormRequiresLocales("edit", project.source),
       requireIdentifier: true,
+      intl,
     });
     setErrors(nextErrors);
 
     if (projectFormHasErrors(nextErrors)) {
+      const message = firstProjectFormErrorMessage(nextErrors);
+      if (message) {
+        toast.error(message);
+      }
+      focusFirstProjectFormError(nextErrors);
       return;
     }
 
@@ -273,7 +359,7 @@ export function ProjectSettingsPageContent({
         }
       />
 
-      <form id="project-settings-form" onSubmit={handleSubmit} className="grid gap-5">
+      <form id="project-settings-form" ref={formRef} onSubmit={handleSubmit} className="grid gap-5">
         <section className="grid gap-4 rounded-lg border border-border bg-muted p-4">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+
+import { PROJECT_AVATAR_KEY_MAX_LENGTH, ProjectAvatar } from "./project-avatar";
+
+describe("ProjectAvatar", () => {
+  it("truncates long project keys to three characters in the fallback", () => {
+    render(
+      <ProjectAvatar
+        project={{
+          name: "Tourmatic",
+          key: "P1FF26E5FA",
+          logoUrl: null,
+          externalProviderKind: null,
+          source: "native",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("P1F")).toBeInTheDocument();
+    expect(screen.queryByText("P1FF26E5FA")).not.toBeInTheDocument();
+    expect(screen.getByTitle("P1FF26E5FA")).toBeInTheDocument();
+    expect(PROJECT_AVATAR_KEY_MAX_LENGTH).toBe(3);
+  });
+
+  it("keeps short keys unchanged", () => {
+    render(
+      <ProjectAvatar
+        project={{
+          name: "Docs",
+          key: "HL",
+          logoUrl: null,
+          externalProviderKind: null,
+          source: "native",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("HL")).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx
@@ -15,15 +15,34 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vite-plus/test";
 
-import { PROJECT_AVATAR_KEY_MAX_LENGTH, ProjectAvatar } from "./project-avatar";
+import {
+  PROJECT_AVATAR_KEY_MAX_LENGTH,
+  ProjectAvatar,
+  projectAvatarLabelFromName,
+} from "./project-avatar";
+
+describe("projectAvatarLabelFromName", () => {
+  it("uses word initials for multi-word names", () => {
+    expect(projectAvatarLabelFromName("Website Launch")).toBe("WL");
+    expect(projectAvatarLabelFromName("Hyper Local App")).toBe("HLA");
+  });
+
+  it("uses leading letters for single-word names", () => {
+    expect(projectAvatarLabelFromName("Tourmatic")).toBe("TOU");
+  });
+
+  it("falls back when the name is empty", () => {
+    expect(projectAvatarLabelFromName("")).toBe("PRJ");
+    expect(projectAvatarLabelFromName("   ")).toBe("PRJ");
+  });
+});
 
 describe("ProjectAvatar", () => {
-  it("truncates long project keys to three characters in the fallback", () => {
+  it("derives the fallback from the project name instead of the identifier", () => {
     render(
       <ProjectAvatar
         project={{
           name: "Tourmatic",
-          key: "P1FF26E5FA",
           logoUrl: null,
           externalProviderKind: null,
           source: "native",
@@ -31,18 +50,17 @@ describe("ProjectAvatar", () => {
       />,
     );
 
-    expect(screen.getByText("P1F")).toBeInTheDocument();
-    expect(screen.queryByText("P1FF26E5FA")).not.toBeInTheDocument();
-    expect(screen.getByTitle("P1FF26E5FA")).toBeInTheDocument();
+    expect(screen.getByText("TOU")).toBeInTheDocument();
+    expect(screen.queryByText("P1F")).not.toBeInTheDocument();
+    expect(screen.getByTitle("Tourmatic")).toBeInTheDocument();
     expect(PROJECT_AVATAR_KEY_MAX_LENGTH).toBe(3);
   });
 
-  it("keeps short keys unchanged", () => {
+  it("keeps short name labels unchanged", () => {
     render(
       <ProjectAvatar
         project={{
           name: "Docs",
-          key: "HL",
           logoUrl: null,
           externalProviderKind: null,
           source: "native",
@@ -50,6 +68,6 @@ describe("ProjectAvatar", () => {
       />,
     );
 
-    expect(screen.getByText("HL")).toBeInTheDocument();
+    expect(screen.getByText("DOC")).toBeInTheDocument();
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
@@ -18,6 +18,9 @@ import { TmsProviderBrandMark } from "@/lib/providers/shared/tms-provider-brand-
 
 import type { ProjectListRow } from "./project-list";
 
+/** Max chars shown in the avatar fallback so long identifiers do not overflow. */
+export const PROJECT_AVATAR_KEY_MAX_LENGTH = 3;
+
 export function ProjectAvatar({
   project,
   className,
@@ -28,15 +31,16 @@ export function ProjectAvatar({
   compact?: boolean;
 }) {
   const sizeClass = compact ? "size-9 rounded-lg" : "size-10 rounded-lg";
+  const avatarKey = project.key.slice(0, PROJECT_AVATAR_KEY_MAX_LENGTH);
 
   return (
     <span className={cn("relative shrink-0", className)}>
-      <Avatar className={cn(sizeClass, "after:rounded-lg")}>
+      <Avatar className={cn(sizeClass, "after:rounded-lg")} title={project.key}>
         {project.logoUrl ? (
           <AvatarImage src={project.logoUrl} alt="" className="rounded-lg object-cover" />
         ) : null}
-        <AvatarFallback className="rounded-lg bg-background text-xs font-medium text-foreground">
-          {project.key}
+        <AvatarFallback className="overflow-hidden rounded-lg bg-background text-xs font-medium text-foreground">
+          {avatarKey}
         </AvatarFallback>
       </Avatar>
       {project.source === "external_tms" && project.externalProviderKind ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
@@ -18,29 +18,57 @@ import { TmsProviderBrandMark } from "@/lib/providers/shared/tms-provider-brand-
 
 import type { ProjectListRow } from "./project-list";
 
-/** Max chars shown in the avatar fallback so long identifiers do not overflow. */
+/** Max chars shown in the avatar fallback so long names do not overflow. */
 export const PROJECT_AVATAR_KEY_MAX_LENGTH = 3;
+
+const PROJECT_AVATAR_FALLBACK = "PRJ";
+
+/** Derive a short avatar label from the project display name. */
+export function projectAvatarLabelFromName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return PROJECT_AVATAR_FALLBACK;
+  }
+
+  const initials = trimmed
+    .split(/[\s/_-]+/)
+    .map((part) => part.replace(/[^A-Za-z0-9]/g, "")[0])
+    .filter(Boolean)
+    .join("")
+    .toUpperCase();
+
+  if (initials.length >= 2) {
+    return initials.slice(0, PROJECT_AVATAR_KEY_MAX_LENGTH);
+  }
+
+  const letters = trimmed
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .slice(0, PROJECT_AVATAR_KEY_MAX_LENGTH);
+
+  return letters || PROJECT_AVATAR_FALLBACK;
+}
 
 export function ProjectAvatar({
   project,
   className,
   compact = false,
 }: {
-  project: Pick<ProjectListRow, "name" | "key" | "logoUrl" | "externalProviderKind" | "source">;
+  project: Pick<ProjectListRow, "name" | "logoUrl" | "externalProviderKind" | "source">;
   className?: string;
   compact?: boolean;
 }) {
   const sizeClass = compact ? "size-9 rounded-lg" : "size-10 rounded-lg";
-  const avatarKey = project.key.slice(0, PROJECT_AVATAR_KEY_MAX_LENGTH);
+  const avatarLabel = projectAvatarLabelFromName(project.name);
 
   return (
     <span className={cn("relative shrink-0", className)}>
-      <Avatar className={cn(sizeClass, "after:rounded-lg")} title={project.key}>
+      <Avatar className={cn(sizeClass, "after:rounded-lg")} title={project.name}>
         {project.logoUrl ? (
           <AvatarImage src={project.logoUrl} alt="" className="rounded-lg object-cover" />
         ) : null}
         <AvatarFallback className="overflow-hidden rounded-lg bg-background text-xs font-medium text-foreground">
-          {avatarKey}
+          {avatarLabel}
         </AvatarFallback>
       </Avatar>
       {project.source === "external_tms" && project.externalProviderKind ? (


### PR DESCRIPTION
## Summary
- Derive project avatar fallback labels from the **project name** (word initials or leading letters, max 3 chars) instead of the issue identifier or project id, so avatars stay readable and recognizable (e.g. "Tourmatic" → `TOU`, not `P1F`)
- Fix native project settings Save for Identifier: use `requestSubmit`, show validation toast + scroll to first error, avoid wiping edits on refetch, and hide Save while loading
- Add unit tests for avatar label derivation and settings save / validation / refetch behavior

## Test plan
- [ ] Projects list: avatars without a logo show name-based labels (e.g. "Tourmatic" → `TOU`, "Website Launch" → `WL`) and do not overlap project titles
- [ ] Project settings: change Identifier → Save settings → success toast and value persists after reload
- [ ] Project settings: enter invalid Identifier (e.g. `123`) → error toast, no network PATCH
- [ ] Project settings: edit Identifier, switch browser tab away/back → edit is preserved until save