### PR TITLE
feat(mcp): support client ID metadata documents

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/mcp-client-metadata.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/mcp-client-metadata.test.ts
@@ -243,13 +243,6 @@ describe("resolveMcpClientMetadata", () => {
 
   it.each([
     [
-      "missing client_name",
-      {
-        client_id: "https://client.example/oauth/metadata.json",
-        redirect_uris: ["http://localhost:3000/callback"],
-      },
-    ],
-    [
       "empty redirect_uris",
       {
         client_id: "https://client.example/oauth/metadata.json",
@@ -305,6 +298,33 @@ describe("resolveMcpClientMetadata", () => {
       ok: false,
       error: {
         code: "metadata_fetch_failed",
+      },
+    });
+  });
+
+  it("accepts metadata without a client name", async () => {
+    const clientId = "https://client.example/oauth/metadata.json";
+    const redirectUri = "http://localhost:3000/callback";
+
+    const result = await resolveMcpClientMetadata(
+      {
+        clientId,
+        redirectUri,
+      },
+      {
+        fetchDocument: vi.fn().mockResolvedValue({
+          client_id: clientId,
+          redirect_uris: [redirectUri],
+        }),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        clientId,
+        clientName: undefined,
+        redirectUris: [redirectUri],
       },
     });
   });

--- a/apps/hyperlocalise-web/src/api/auth/mcp-client-metadata.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/mcp-client-metadata.test.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { withPublicHttpFetchMock } = vi.hoisted(() => ({
+  withPublicHttpFetchMock: vi.fn(),
+}));
+
+vi.mock("@/lib/security/public-http-fetch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/security/public-http-fetch")>();
+
+  return {
+    ...actual,
+    withPublicHttpFetch: withPublicHttpFetchMock,
+  };
+});
+
+import { fetchMcpClientMetadataDocument, resolveMcpClientMetadata } from "./mcp-client-metadata";
+
+describe("fetchMcpClientMetadataDocument", () => {
+  beforeEach(() => {
+    withPublicHttpFetchMock.mockReset();
+  });
+
+  it("fetches a JSON document through the public HTTP guard", async () => {
+    const clientId = "https://client.example/oauth/metadata.json";
+    const document = {
+      client_id: clientId,
+      client_name: "Example MCP Client",
+      redirect_uris: ["http://localhost:3000/callback"],
+    };
+
+    withPublicHttpFetchMock.mockImplementation(async (_url, _init, handler) =>
+      handler(
+        new Response(JSON.stringify(document), {
+          status: 200,
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+        }),
+      ),
+    );
+
+    await expect(fetchMcpClientMetadataDocument(clientId)).resolves.toEqual(document);
+
+    expect(withPublicHttpFetchMock).toHaveBeenCalledWith(
+      clientId,
+      expect.objectContaining({
+        method: "GET",
+        redirect: "error",
+      }),
+      expect.any(Function),
+      {
+        maxResponseSize: 5 * 1024,
+      },
+    );
+  });
+
+  it("rejects non-JSON responses", async () => {
+    withPublicHttpFetchMock.mockImplementation(async (_url, _init, handler) =>
+      handler(
+        new Response("not JSON", {
+          status: 200,
+          headers: {
+            "content-type": "text/plain",
+          },
+        }),
+      ),
+    );
+
+    await expect(
+      fetchMcpClientMetadataDocument("https://client.example/oauth/metadata.json"),
+    ).rejects.toThrow("must be JSON");
+  });
+
+  it("rejects metadata documents larger than 5 KiB", async () => {
+    withPublicHttpFetchMock.mockImplementation(async (_url, _init, handler) =>
+      handler(
+        new Response("x".repeat(5 * 1024 + 1), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        }),
+      ),
+    );
+
+    await expect(
+      fetchMcpClientMetadataDocument("https://client.example/oauth/metadata.json"),
+    ).rejects.toThrow("Response too large");
+  });
+});
+
+describe("resolveMcpClientMetadata", () => {
+  it("resolves a valid HTTPS Client ID Metadata Document", async () => {
+    const clientId = "https://client.example/oauth/metadata.json";
+    const redirectUri = "http://localhost:3000/callback";
+    const fetchDocument = vi.fn().mockResolvedValue({
+      client_id: clientId,
+      client_name: "Example MCP Client",
+      redirect_uris: [redirectUri],
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    });
+
+    const result = await resolveMcpClientMetadata(
+      {
+        clientId,
+        redirectUri,
+      },
+      {
+        fetchDocument,
+      },
+    );
+
+    expect(fetchDocument).toHaveBeenCalledWith(clientId);
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        clientId,
+        clientName: "Example MCP Client",
+        redirectUris: [redirectUri],
+      },
+    });
+  });
+
+  it("rejects metadata whose client_id does not match the document URL", async () => {
+    const clientId = "https://client.example/oauth/metadata.json";
+    const redirectUri = "http://localhost:3000/callback";
+    const fetchDocument = vi.fn().mockResolvedValue({
+      client_id: "https://attacker.example/oauth/metadata.json",
+      client_name: "Example MCP Client",
+      redirect_uris: [redirectUri],
+    });
+
+    const result = await resolveMcpClientMetadata(
+      {
+        clientId,
+        redirectUri,
+      },
+      {
+        fetchDocument,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "client_id_mismatch",
+      },
+    });
+  });
+
+  it("rejects redirect URIs that are not an exact metadata match", async () => {
+    const clientId = "https://client.example/oauth/metadata.json";
+    const registeredRedirectUri = "http://localhost:3000/callback";
+    const requestedRedirectUri = "http://localhost:3000/callback/attacker";
+
+    const fetchDocument = vi.fn().mockResolvedValue({
+      client_id: clientId,
+      client_name: "Example MCP Client",
+      redirect_uris: [registeredRedirectUri],
+    });
+
+    const result = await resolveMcpClientMetadata(
+      {
+        clientId,
+        redirectUri: requestedRedirectUri,
+      },
+      {
+        fetchDocument,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "redirect_uri_mismatch",
+      },
+    });
+  });
+
+  it("rejects non-HTTPS client IDs without fetching metadata", async () => {
+    const clientId = "http://client.example/oauth/metadata.json";
+    const redirectUri = "http://localhost:3000/callback";
+    const fetchDocument = vi.fn();
+
+    const result = await resolveMcpClientMetadata(
+      {
+        clientId,
+        redirectUri,
+      },
+      {
+        fetchDocument,
+      },
+    );
+
+    expect(fetchDocument).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "invalid_client_id",
+      },
+    });
+  });
+
+  it.each([
+    ["missing path", "https://client.example"],
+    ["containing credentials", "https://user:password@client.example/oauth/metadata.json"],
+    ["containing a fragment", "https://client.example/oauth/metadata.json#fragment"],
+  ])("rejects client IDs %s without fetching metadata", async (_case, clientId) => {
+    const fetchDocument = vi.fn();
+
+    const result = await resolveMcpClientMetadata(
+      {
+        clientId,
+        redirectUri: "http://localhost:3000/callback",
+      },
+      {
+        fetchDocument,
+      },
+    );
+
+    expect(fetchDocument).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "invalid_client_id",
+      },
+    });
+  });
+
+  it.each([
+    [
+      "missing client_name",
+      {
+        client_id: "https://client.example/oauth/metadata.json",
+        redirect_uris: ["http://localhost:3000/callback"],
+      },
+    ],
+    [
+      "empty redirect_uris",
+      {
+        client_id: "https://client.example/oauth/metadata.json",
+        client_name: "Example MCP Client",
+        redirect_uris: [],
+      },
+    ],
+    [
+      "an invalid redirect URI",
+      {
+        client_id: "https://client.example/oauth/metadata.json",
+        client_name: "Example MCP Client",
+        redirect_uris: ["not-a-url"],
+      },
+    ],
+  ])("rejects metadata with %s", async (_case, document) => {
+    const clientId = "https://client.example/oauth/metadata.json";
+    const fetchDocument = vi.fn().mockResolvedValue(document);
+
+    const result = await resolveMcpClientMetadata(
+      {
+        clientId,
+        redirectUri: "http://localhost:3000/callback",
+      },
+      {
+        fetchDocument,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "invalid_client_metadata",
+      },
+    });
+  });
+
+  it("returns a controlled error when metadata fetching fails", async () => {
+    const clientId = "https://client.example/oauth/metadata.json";
+    const fetchDocument = vi.fn().mockRejectedValue(new Error("network failure"));
+
+    const result = await resolveMcpClientMetadata(
+      {
+        clientId,
+        redirectUri: "http://localhost:3000/callback",
+      },
+      {
+        fetchDocument,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "metadata_fetch_failed",
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/auth/mcp-client-metadata.ts
+++ b/apps/hyperlocalise-web/src/api/auth/mcp-client-metadata.ts
@@ -17,7 +17,7 @@ import { readBoundedResponseBody, withPublicHttpFetch } from "@/lib/security/pub
 
 const mcpClientMetadataDocumentSchema = z.object({
   client_id: z.url().max(2048),
-  client_name: z.string().trim().min(1).max(128),
+  client_name: z.string().trim().min(1).max(128).optional(),
   client_uri: z.url().max(2048).optional(),
   logo_uri: z.url().max(2048).optional(),
   redirect_uris: z.array(z.url().max(2048)).min(1).max(10),
@@ -28,7 +28,7 @@ const mcpClientMetadataDocumentSchema = z.object({
 
 export type ResolvedMcpClientMetadata = {
   clientId: string;
-  clientName: string;
+  clientName?: string;
   redirectUris: string[];
 };
 

--- a/apps/hyperlocalise-web/src/api/auth/mcp-client-metadata.ts
+++ b/apps/hyperlocalise-web/src/api/auth/mcp-client-metadata.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import { readBoundedResponseBody, withPublicHttpFetch } from "@/lib/security/public-http-fetch";
+
+const mcpClientMetadataDocumentSchema = z.object({
+  client_id: z.url().max(2048),
+  client_name: z.string().trim().min(1).max(128),
+  client_uri: z.url().max(2048).optional(),
+  logo_uri: z.url().max(2048).optional(),
+  redirect_uris: z.array(z.url().max(2048)).min(1).max(10),
+  grant_types: z.array(z.string().max(32)).optional(),
+  response_types: z.array(z.string().max(32)).optional(),
+  token_endpoint_auth_method: z.string().max(64).optional(),
+});
+
+export type ResolvedMcpClientMetadata = {
+  clientId: string;
+  clientName: string;
+  redirectUris: string[];
+};
+
+export type McpClientMetadataError =
+  | { code: "invalid_client_metadata" }
+  | { code: "client_id_mismatch" }
+  | { code: "redirect_uri_mismatch" }
+  | { code: "invalid_client_id" }
+  | { code: "metadata_fetch_failed" };
+
+type ResolveMcpClientMetadataDependencies = {
+  fetchDocument: (url: string) => Promise<unknown>;
+};
+
+function isHttpsClientId(clientId: string): boolean {
+  try {
+    const url = new URL(clientId);
+
+    return (
+      url.protocol === "https:" &&
+      url.pathname !== "/" &&
+      !url.username &&
+      !url.password &&
+      !url.hash
+    );
+  } catch {
+    return false;
+  }
+}
+
+const MAX_CLIENT_METADATA_BYTES = 5 * 1024;
+const CLIENT_METADATA_FETCH_TIMEOUT_MS = 5_000;
+
+function isJsonContentType(contentType: string | null): boolean {
+  const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+
+  return (
+    mediaType === "application/json" ||
+    (mediaType?.startsWith("application/") === true && mediaType.endsWith("+json"))
+  );
+}
+
+export async function fetchMcpClientMetadataDocument(clientId: string): Promise<unknown> {
+  return withPublicHttpFetch(
+    clientId,
+    {
+      method: "GET",
+      redirect: "error",
+      headers: {
+        Accept: "application/json, application/*+json",
+      },
+      signal: AbortSignal.timeout(CLIENT_METADATA_FETCH_TIMEOUT_MS),
+    },
+    async (response) => {
+      if (!response.ok) {
+        throw new Error("Client metadata request failed");
+      }
+
+      if (!isJsonContentType(response.headers.get("content-type"))) {
+        throw new Error("Client metadata response must be JSON");
+      }
+
+      const body = await readBoundedResponseBody(response, MAX_CLIENT_METADATA_BYTES);
+
+      return JSON.parse(new TextDecoder().decode(body)) as unknown;
+    },
+    {
+      maxResponseSize: MAX_CLIENT_METADATA_BYTES,
+    },
+  );
+}
+
+export async function resolveMcpClientMetadata(
+  input: {
+    clientId: string;
+    redirectUri: string;
+  },
+  dependencies: ResolveMcpClientMetadataDependencies = {
+    fetchDocument: fetchMcpClientMetadataDocument,
+  },
+): Promise<Result<ResolvedMcpClientMetadata, McpClientMetadataError>> {
+  if (!isHttpsClientId(input.clientId)) {
+    return err({ code: "invalid_client_id" });
+  }
+  const documentResult = await fromThrowableAsync(dependencies.fetchDocument(input.clientId));
+
+  if (isErr(documentResult)) {
+    return err({ code: "metadata_fetch_failed" });
+  }
+
+  const parsed = mcpClientMetadataDocumentSchema.safeParse(documentResult.value);
+
+  if (!parsed.success) {
+    return err({ code: "invalid_client_metadata" });
+  }
+
+  if (parsed.data.client_id !== input.clientId) {
+    return err({ code: "client_id_mismatch" });
+  }
+
+  if (!parsed.data.redirect_uris.includes(input.redirectUri)) {
+    return err({ code: "redirect_uri_mismatch" });
+  }
+
+  return ok({
+    clientId: parsed.data.client_id,
+    clientName: parsed.data.client_name,
+    redirectUris: parsed.data.redirect_uris,
+  });
+}

--- a/apps/hyperlocalise-web/src/api/auth/mcp.ts
+++ b/apps/hyperlocalise-web/src/api/auth/mcp.ts
@@ -132,6 +132,7 @@ export function createAuthorizationCode(
 
 export type McpAuthorizationRequestPayload = {
   clientId: string;
+  clientName?: string;
   redirectUri: string;
   codeChallenge: string;
   codeChallengeMethod: "S256";

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -52,10 +52,31 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   };
 });
 
+const { resolveMcpClientMetadataMock } = vi.hoisted(() => ({
+  resolveMcpClientMetadataMock: vi.fn(),
+}));
+
+vi.mock("@/api/auth/mcp-client-metadata", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/mcp-client-metadata")>();
+
+  return {
+    ...actual,
+    resolveMcpClientMetadata: resolveMcpClientMetadataMock,
+  };
+});
+
 const app = createMcpTestApp();
 const apiApp = createApp();
 const fixture = createProjectTestFixture();
 const originalMcpAuthEnabled = env.MCP_AUTH_ENABLED;
+const originalMcpAllowDynamicRegistration = env.MCP_ALLOW_DYNAMIC_REGISTRATION;
+
+function setMcpAllowDynamicRegistration(value: boolean) {
+  Object.defineProperty(env, "MCP_ALLOW_DYNAMIC_REGISTRATION", {
+    configurable: true,
+    value,
+  });
+}
 
 function pkceChallenge(verifier: string) {
   return createHash("sha256").update(verifier).digest("base64url");
@@ -108,7 +129,9 @@ describe("mcpRoutes", () => {
   });
 
   afterEach(async () => {
+    resolveMcpClientMetadataMock.mockReset();
     setMcpAuthEnabled(originalMcpAuthEnabled);
+    setMcpAllowDynamicRegistration(originalMcpAllowDynamicRegistration);
     await fixture.cleanup();
     await db.delete(schema.usedAuthorizationCodes);
     await db.delete(schema.mcpOAuthClients);
@@ -123,6 +146,26 @@ describe("mcpRoutes", () => {
       authorization_endpoint: "http://localhost/mcp/authorize",
       token_endpoint: "http://localhost/mcp/token",
       code_challenge_methods_supported: ["S256"],
+      client_id_metadata_document_supported: true,
+    });
+  });
+
+  it("does not advertise dynamic registration when disabled", async () => {
+    setMcpAllowDynamicRegistration(false);
+
+    const response = await app.request("http://localhost/.well-known/oauth-authorization-server");
+    const metadata = await response.json();
+
+    expect(metadata).not.toHaveProperty("registration_endpoint");
+  });
+
+  it("advertises dynamic registration when enabled", async () => {
+    setMcpAllowDynamicRegistration(true);
+
+    const response = await app.request("http://localhost/.well-known/oauth-authorization-server");
+
+    await expect(response.json()).resolves.toMatchObject({
+      registration_endpoint: "http://localhost/mcp/register",
     });
   });
 
@@ -541,5 +584,78 @@ describe("mcpRoutes", () => {
 
     expect(refreshResponse.status).toBe(200);
     await expect(refreshResponse.json()).resolves.toMatchObject({ scope });
+  });
+  it("accepts a client identified by a Client ID Metadata Document", async () => {
+    const clientId = "https://client.example/oauth/metadata.json";
+    const redirectUri = "http://localhost:3000/callback";
+
+    resolveMcpClientMetadataMock.mockResolvedValue({
+      ok: true,
+      value: {
+        clientId,
+        clientName: "Example MCP Client",
+        redirectUris: [redirectUri],
+      },
+    });
+
+    const authorizeUrl = new URL("http://localhost/mcp/authorize");
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+    authorizeUrl.searchParams.set("code_challenge", pkceChallenge("a".repeat(64)));
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+
+    const response = await app.request(authorizeUrl);
+
+    expect(resolveMcpClientMetadataMock).toHaveBeenCalledWith({
+      clientId,
+      redirectUri,
+    });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain("/auth/sign-in");
+  });
+
+  it("shows the CIMD client name on the consent page", async () => {
+    const identity = fixture.createWorkosIdentity();
+    const headers = await fixture.authHeadersFor(identity);
+
+    const clientId = "https://client.example/oauth/metadata.json";
+    const redirectUri = "http://localhost:3000/callback";
+    const challenge = pkceChallenge("a".repeat(64));
+
+    resolveMcpClientMetadataMock.mockResolvedValue({
+      ok: true,
+      value: {
+        clientId,
+        clientName: "Example MCP Client",
+        redirectUris: [redirectUri],
+      },
+    });
+
+    const authRequest = createMcpAuthorizationRequest({
+      clientId,
+      clientName: "Example MCP Client",
+      redirectUri,
+      codeChallenge: challenge,
+      codeChallengeMethod: "S256",
+      scope: "mcp",
+    });
+
+    const consentUrl = new URL("http://localhost/mcp/consent");
+    consentUrl.searchParams.set("response_type", "code");
+    consentUrl.searchParams.set("client_id", clientId);
+    consentUrl.searchParams.set("redirect_uri", redirectUri);
+    consentUrl.searchParams.set("code_challenge", challenge);
+    consentUrl.searchParams.set("code_challenge_method", "S256");
+
+    const response = await app.request(consentUrl, {
+      headers: {
+        ...headers,
+        cookie: `${MCP_AUTH_REQUEST_COOKIE}=${authRequest}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Example MCP Client");
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -658,4 +658,33 @@ describe("mcpRoutes", () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toContain("Example MCP Client");
   });
+
+  it("rejects authorization requests whose signed cookie would exceed browser limits", async () => {
+    const clientId = `https://client.example/${"a".repeat(2_000)}`;
+    const redirectUri = `https://client.example/callback?state=${"b".repeat(1_900)}`;
+
+    resolveMcpClientMetadataMock.mockResolvedValue({
+      ok: true,
+      value: {
+        clientId,
+        clientName: "Example MCP Client",
+        redirectUris: [redirectUri],
+      },
+    });
+
+    const authorizeUrl = new URL("http://localhost/mcp/authorize");
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+    authorizeUrl.searchParams.set("code_challenge", pkceChallenge("a".repeat(64)));
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+
+    const response = await app.request(authorizeUrl);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+    });
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -143,8 +143,16 @@ function secureCookieOptions(maxAgeSeconds: number) {
   };
 }
 
-function storeMcpAuthRequestCookie(c: Parameters<typeof setCookie>[0], token: string) {
+const MAX_MCP_AUTH_REQUEST_COOKIE_VALUE_LENGTH = 3_500;
+
+function storeMcpAuthRequestCookie(c: Parameters<typeof setCookie>[0], token: string): boolean {
+  if (token.length > MAX_MCP_AUTH_REQUEST_COOKIE_VALUE_LENGTH) {
+    return false;
+  }
+
   setCookie(c, MCP_AUTH_REQUEST_COOKIE, token, secureCookieOptions(15 * 60));
+
+  return true;
 }
 
 function storeMcpConsentCookie(c: Parameters<typeof setCookie>[0], token: string) {
@@ -589,7 +597,9 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
         organizationSlug: query.organizationSlug,
       });
 
-      storeMcpAuthRequestCookie(c, authRequest);
+      if (!storeMcpAuthRequestCookie(c, authRequest)) {
+        return c.json({ error: "invalid_request" }, 400);
+      }
 
       const callbackUrl = buildCallbackUrl(apiBasePath, endpointOrigin(c), query);
       const signInUrl = new URL("/auth/sign-in", endpointOrigin(c));

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -51,10 +51,12 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
+import { resolveMcpClientMetadata } from "@/api/auth/mcp-client-metadata";
+import { isErr } from "@/lib/primitives/result/results";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
-  client_id: z.string().min(1).max(128),
+  client_id: z.string().min(1).max(2048),
   redirect_uri: z.url().max(2048),
   code_challenge: z.string().min(32).max(128),
   code_challenge_method: z.literal("S256"),
@@ -68,13 +70,13 @@ const tokenRequestSchema = z.discriminatedUnion("grant_type", [
     grant_type: z.literal("authorization_code"),
     code: z.string().min(1).max(8192),
     redirect_uri: z.url().max(2048),
-    client_id: z.string().min(1).max(128),
+    client_id: z.string().min(1).max(2048),
     code_verifier: z.string().min(43).max(128),
   }),
   z.object({
     grant_type: z.literal("refresh_token"),
     refresh_token: z.string().min(1).max(8192),
-    client_id: z.string().min(1).max(128).optional(),
+    client_id: z.string().min(1).max(2048).optional(),
   }),
 ]);
 
@@ -96,21 +98,35 @@ function isAllowedRedirectUri(redirectUri: string): boolean {
   return url.protocol === "http:" && (url.hostname === "localhost" || url.hostname === "127.0.0.1");
 }
 
-async function findRegisteredMcpClient(clientId: string, redirectUri: string) {
-  const [client] = await db
+async function findMcpClient(clientId: string, redirectUri: string) {
+  const [registeredClient] = await db
     .select({
       clientId: schema.mcpOAuthClients.clientId,
+      clientName: schema.mcpOAuthClients.clientName,
       redirectUris: schema.mcpOAuthClients.redirectUris,
     })
     .from(schema.mcpOAuthClients)
     .where(eq(schema.mcpOAuthClients.clientId, clientId))
     .limit(1);
 
-  if (!client?.redirectUris.includes(redirectUri)) {
+  if (registeredClient?.redirectUris.includes(redirectUri)) {
+    return registeredClient;
+  }
+
+  if (!clientId.startsWith("https://")) {
     return null;
   }
 
-  return client;
+  const metadataResult = await resolveMcpClientMetadata({
+    clientId,
+    redirectUri,
+  });
+
+  if (isErr(metadataResult)) {
+    return null;
+  }
+
+  return metadataResult.value;
 }
 
 function endpointOrigin(c: { req: { url: string } }) {
@@ -229,7 +245,9 @@ export function getMcpAuthorizationServerMetadata(origin: string, apiBasePath = 
     issuer: origin,
     authorization_endpoint: `${origin}${mcpBasePath}/authorize`,
     token_endpoint: `${origin}${mcpBasePath}/token`,
-    registration_endpoint: `${origin}${mcpBasePath}/register`,
+    ...(env.MCP_ALLOW_DYNAMIC_REGISTRATION
+      ? { registration_endpoint: `${origin}${mcpBasePath}/register` }
+      : {}),
     scopes_supported: ["mcp"],
     response_types_supported: ["code"],
     response_modes_supported: ["query"],
@@ -237,6 +255,7 @@ export function getMcpAuthorizationServerMetadata(origin: string, apiBasePath = 
     token_endpoint_auth_methods_supported: ["none"],
     code_challenge_methods_supported: ["S256"],
     service_documentation: "https://hyperlocalise.com",
+    client_id_metadata_document_supported: true,
   };
 }
 
@@ -553,13 +572,15 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
         return c.json({ error: "invalid_redirect_uri" }, 400);
       }
 
-      const client = await findRegisteredMcpClient(query.client_id, query.redirect_uri);
+      const client = await findMcpClient(query.client_id, query.redirect_uri);
+
       if (!client) {
         return c.json({ error: "invalid_client" }, 400);
       }
 
       const authRequest = createMcpAuthorizationRequest({
         clientId: query.client_id,
+        clientName: client.clientName ?? undefined,
         redirectUri: query.redirect_uri,
         codeChallenge: query.code_challenge,
         codeChallengeMethod: query.code_challenge_method,
@@ -567,6 +588,7 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
         state: query.state,
         organizationSlug: query.organizationSlug,
       });
+
       storeMcpAuthRequestCookie(c, authRequest);
 
       const callbackUrl = buildCallbackUrl(apiBasePath, endpointOrigin(c), query);
@@ -589,11 +611,6 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
         return c.json({ error: "invalid_request" }, 400);
       }
 
-      const client = await findRegisteredMcpClient(query.client_id, query.redirect_uri);
-      if (!client) {
-        return c.json({ error: "invalid_client" }, 400);
-      }
-
       const auth = await resolveApiAuthContextFromSession({
         organizationSlug: query.organizationSlug ?? authRequest.organizationSlug,
       });
@@ -605,12 +622,6 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
         return c.redirect(signInUrl.toString(), 302);
       }
 
-      const [registeredClient] = await db
-        .select({ clientName: schema.mcpOAuthClients.clientName })
-        .from(schema.mcpOAuthClients)
-        .where(eq(schema.mcpOAuthClients.clientId, query.client_id))
-        .limit(1);
-
       const consentUrl = new URL(`${apiBasePath}/mcp/consent`, endpointOrigin(c));
       for (const [key, value] of Object.entries(query)) {
         if (value !== undefined) {
@@ -620,7 +631,7 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
 
       return c.html(
         renderMcpConsentPage({
-          clientName: registeredClient?.clientName ?? null,
+          clientName: authRequest.clientName ?? null,
           redirectUri: query.redirect_uri,
           organizationName: auth.organization.name,
           scope: query.scope,
@@ -643,11 +654,6 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
         return c.json({ error: "invalid_request" }, 400);
       }
 
-      const client = await findRegisteredMcpClient(query.client_id, query.redirect_uri);
-      if (!client) {
-        return c.json({ error: "invalid_client" }, 400);
-      }
-
       const auth = await resolveApiAuthContextFromSession({
         organizationSlug: query.organizationSlug ?? authRequest.organizationSlug,
       });
@@ -668,15 +674,13 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
     })
     .get("/mcp/callback", validateAuthorizationQuery, async (c) => {
       const query = c.req.valid("query");
-      const client = await findRegisteredMcpClient(query.client_id, query.redirect_uri);
 
-      if (!client) {
-        return c.json({ error: "invalid_client" }, 400);
+      if (!isAllowedRedirectUri(query.redirect_uri)) {
+        return c.json({ error: "invalid_redirect_uri" }, 400);
       }
 
       const authRequestToken = getCookie(c, MCP_AUTH_REQUEST_COOKIE);
       const authRequest = authRequestToken ? parseMcpAuthorizationRequest(authRequestToken) : null;
-
       if (
         !authRequest ||
         authRequest.clientId !== query.client_id ||


### PR DESCRIPTION
## What changed

- Added Client ID Metadata Document support for MCP OAuth clients.
- Validated HTTPS client IDs, metadata structure, exact client ID matching, and exact redirect URI matching.
- Added SSRF-protected metadata fetching with JSON validation, timeout, and a 5 KiB response limit.
- Advertised CIMD support in authorization-server metadata.
- Advertised dynamic registration only when `MCP_ALLOW_DYNAMIC_REGISTRATION` is enabled.
- Preserved support for existing database-registered clients.
- Stored resolved client information in the signed authorization request to avoid fetching metadata repeatedly during consent and callback.

## How to test

- `vp test src/api/auth/mcp-client-metadata.test.ts`
- `vp test src/api/auth/mcp.test.ts src/api/auth/mcp-client-metadata.test.ts src/api/routes/mcp/mcp.route.test.ts`
- `vp check`
- `vp run build`
- `git diff --check`

## Checklist

- [x] I ran relevant checks locally (`vp check`, `vp test`, `vp run build`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review