### PR TITLE
feat(glossary): keep Crowdin glossary navigation in-app

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.stories.tsx
@@ -102,7 +102,7 @@ export const LiveProviderGlossary: Story = {
         externalProviderKind: "crowdin",
         externalProjectId: "crowdin-project-1",
         externalGlossaryId: "99",
-        externalUrl: "https://crowdin.com/project/crowdin-project-1",
+        externalUrl: null,
         projectLinkId: "crowdin-project-link-1",
         isLiveApi: true,
         providerLogoSrc: "/images/tms/crowdin.png",
@@ -125,10 +125,7 @@ export const LiveProviderGlossary: Story = {
       "href",
       "/org/acme/glossaries/crowdin:glossary:99",
     );
-    await expect(canvas.getByRole("link", { name: "Open in provider" })).toHaveAttribute(
-      "href",
-      "https://crowdin.com/project/crowdin-project-1",
-    );
+    await expect(canvas.queryByRole("link", { name: "Open in provider" })).not.toBeInTheDocument();
     await expect(canvas.getByText("TMS project")).toBeInTheDocument();
     await expect(canvas.getByText("Sort")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "More glossary actions" })).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.test.ts
@@ -135,6 +135,41 @@ describe("glossary-list", () => {
     expect(row.externalProjectName).toBe("Acme");
     expect(row.providerLogoSrc).toBe("/images/tms/crowdin.png");
     expect(row.detailId).toBe("crowdin:glossary:gl-99");
+    expect(row.externalUrl).toBeNull();
+  });
+
+  it("clears Crowdin glossary external URLs from synced glossary rows", () => {
+    const row = mapGlossaryToListRow(
+      {
+        id: "glossary-crowdin",
+        organizationId: "org-1",
+        createdByUserId: null,
+        name: "Crowdin Glossary",
+        description: "",
+        sourceLocale: "en",
+        targetLocale: "de",
+        status: "active",
+        source: "external_tms",
+        externalProviderKind: "crowdin",
+        externalProjectId: "crowdin-project-1",
+        externalResourceType: "glossary",
+        externalGlossaryId: "gl-99",
+        localeCoverage: ["en", "de"],
+        languages: [],
+        termCount: 85,
+        syncState: "synced",
+        termCapabilities: {},
+        externalUrl: "https://crowdin.com/glossary/gl-99",
+        lastSyncedAt: null,
+        lastSyncErrorAt: null,
+        lastSyncErrorMessage: null,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      },
+      new Map(),
+    );
+
+    expect(row.externalUrl).toBeNull();
   });
 
   it("falls back when an external provider has no known logo", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.ts
@@ -250,7 +250,7 @@ export function mapGlossaryToListRow(
       formatRelativeTimestamp(glossary.createdAt) ??
       resolveMessage(intl, glossaryListMessages.unavailableTimestamp),
     syncState: glossary.syncState,
-    externalUrl: glossary.externalUrl,
+    externalUrl: glossary.externalProviderKind === "crowdin" ? null : glossary.externalUrl,
     lastSyncedAt: formatRelativeTimestamp(glossary.lastSyncedAt),
     lastSyncErrorAt: formatRelativeTimestamp(glossary.lastSyncErrorAt),
     lastSyncErrorMessage: glossary.lastSyncErrorMessage,
@@ -326,7 +326,7 @@ export function mapLiveTmsProviderGlossaryToListRow(
       formatRelativeTimestamp(glossary.createdAt) ??
       resolveMessage(intl, glossaryListMessages.unavailableTimestamp),
     syncState: null,
-    externalUrl: glossary.externalUrl,
+    externalUrl: isCrowdin ? null : glossary.externalUrl,
     lastSyncedAt: null,
     lastSyncErrorAt: null,
     lastSyncErrorMessage: null,

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
@@ -13,13 +13,7 @@
  * Version 2.0 or later.
  */
 import { useState } from "react";
-import {
-  ArrowDown01Icon,
-  ArrowUp01Icon,
-  Copy01Icon,
-  ExternalLinkIcon,
-  Tick02Icon,
-} from "@hugeicons/core-free-icons";
+import { ArrowDown01Icon, ArrowUp01Icon, Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -221,8 +215,6 @@ export function CatGlossaryConceptCard({
   const contentId = `glossary-concept-${concept.id.replaceAll(/[^a-zA-Z0-9_-]/g, "-")}`;
   const sourceTerms = concept.sourceTerms.length > 0 ? concept.sourceTerms : concept.targetTerms;
   const targetTerms = concept.targetTerms.length > 0 ? concept.targetTerms : concept.sourceTerms;
-  const glossaryUrl = concept.glossaryUrl;
-  const isInternalGlossaryUrl = glossaryUrl?.startsWith("/org/") ?? false;
 
   return (
     <article className="overflow-hidden rounded-xl bg-muted/40">
@@ -290,31 +282,23 @@ export function CatGlossaryConceptCard({
         </div>
       </div>
 
-      <div className="px-3 pb-2 pt-1">
-        {glossaryUrl ? (
-          isInternalGlossaryUrl ? (
-            <Link
-              href={glossaryUrl}
-              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <FormattedMessage {...catIntelligencePanelMessages.projectGlossary} />
-            </Link>
-          ) : (
-            <a
-              href={glossaryUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <FormattedMessage {...catIntelligencePanelMessages.projectGlossary} />
-              <HugeiconsIcon icon={ExternalLinkIcon} className="size-3.5" aria-hidden />
-            </a>
-          )
-        ) : (
-          <span className="text-sm text-muted-foreground">
-            <FormattedMessage {...catIntelligencePanelMessages.projectGlossary} />
-          </span>
-        )}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 pb-2 pt-1">
+        {concept.glossaryUrl?.startsWith("/org/") ? (
+          <Link
+            href={concept.glossaryUrl}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <FormattedMessage {...catIntelligencePanelMessages.openGlossary} />
+          </Link>
+        ) : null}
+        {concept.conceptUrl?.startsWith("/org/") ? (
+          <Link
+            href={concept.conceptUrl}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <FormattedMessage {...catIntelligencePanelMessages.openConcept} />
+          </Link>
+        ) : null}
       </div>
     </article>
   );

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
@@ -124,15 +124,22 @@ export const Results: Story = {
     ).toBeInTheDocument();
     await expect(canvas.getByText("Đại lý")).toBeInTheDocument();
     await expect(canvas.getByText("Nhà bán lại")).toBeInTheDocument();
-    await expect(canvas.getAllByRole("link", { name: "Open glossary" })).toHaveLength(2);
-    await expect(canvas.getAllByRole("link", { name: "Open concept" })).toHaveLength(2);
-    await expect(canvas.getByRole("link", { name: "Open glossary" })).toHaveAttribute(
-      "href",
-      "/org/acme/glossaries/glossary-partner",
+    const openGlossaryLinks = canvas.getAllByRole("link", { name: "Open glossary" });
+    await expect(openGlossaryLinks).toHaveLength(2);
+    await expect(openGlossaryLinks.map((link) => link.getAttribute("href"))).toEqual(
+      expect.arrayContaining([
+        "/org/acme/glossaries/glossary-partner",
+        "/org/acme/glossaries/glossary-product",
+      ]),
     );
-    await expect(canvas.getByRole("link", { name: "Open concept" })).toHaveAttribute(
-      "href",
-      "/org/acme/glossaries/glossary-partner/concepts/concept-reseller",
+
+    const openConceptLinks = canvas.getAllByRole("link", { name: "Open concept" });
+    await expect(openConceptLinks).toHaveLength(2);
+    await expect(openConceptLinks.map((link) => link.getAttribute("href"))).toEqual(
+      expect.arrayContaining([
+        "/org/acme/glossaries/glossary-partner/concepts/concept-reseller",
+        "/org/acme/glossaries/glossary-product/concepts/concept-review",
+      ]),
     );
     await expect(canvas.getByText("Translation memory")).toBeInTheDocument();
     await expect(canvas.getByText("Dashboard card", { exact: true })).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
@@ -26,9 +26,10 @@ const conceptIntelligence: CatSegmentIntelligence = {
   glossaryConcepts: [
     {
       id: "concept-reseller",
-      glossaryId: "glossary-project",
+      glossaryId: "glossary-partner",
       glossaryName: "Partner Program",
-      glossaryUrl: "https://example.com/project-glossary",
+      glossaryUrl: "/org/acme/glossaries/glossary-partner",
+      conceptUrl: "/org/acme/glossaries/glossary-partner/concepts/concept-reseller",
       primaryTerm: "Reseller",
       definition: "A company or individual authorized to resell our product.",
       sourceTerms: [
@@ -68,8 +69,10 @@ const conceptIntelligence: CatSegmentIntelligence = {
     },
     {
       id: "concept-review",
-      glossaryId: "glossary-project",
-      glossaryName: "Partner Program",
+      glossaryId: "glossary-product",
+      glossaryName: "Product UI",
+      glossaryUrl: "/org/acme/glossaries/glossary-product",
+      conceptUrl: "/org/acme/glossaries/glossary-product/concepts/concept-review",
       primaryTerm: "Review",
       sourceTerms: [{ id: "review-en", locale: "en", text: "Review", preferred: true }],
       targetTerms: [{ id: "review-vi", locale: "vi", text: "Đánh giá", preferred: true }],
@@ -115,12 +118,22 @@ export const Results: Story = {
     await expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
     await expect(canvas.getByText("Reseller")).toBeInTheDocument();
     await expect(canvas.getByText("Partner Program")).toBeInTheDocument();
+    await expect(canvas.getByText("Product UI")).toBeInTheDocument();
     await expect(
       canvas.getByText("A company or individual authorized to resell our product."),
     ).toBeInTheDocument();
     await expect(canvas.getByText("Đại lý")).toBeInTheDocument();
     await expect(canvas.getByText("Nhà bán lại")).toBeInTheDocument();
-    await expect(canvas.getAllByText("Project Glossary")).toHaveLength(2);
+    await expect(canvas.getAllByRole("link", { name: "Open glossary" })).toHaveLength(2);
+    await expect(canvas.getAllByRole("link", { name: "Open concept" })).toHaveLength(2);
+    await expect(canvas.getByRole("link", { name: "Open glossary" })).toHaveAttribute(
+      "href",
+      "/org/acme/glossaries/glossary-partner",
+    );
+    await expect(canvas.getByRole("link", { name: "Open concept" })).toHaveAttribute(
+      "href",
+      "/org/acme/glossaries/glossary-partner/concepts/concept-reseller",
+    );
     await expect(canvas.getByText("Translation memory")).toBeInTheDocument();
     await expect(canvas.getByText("Dashboard card", { exact: true })).toBeInTheDocument();
     await expect(canvas.getAllByRole("button", { name: "Use" })).toHaveLength(3);

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -680,6 +680,16 @@ export const catIntelligencePanelMessages = defineMessages({
     id: "SLnLYAC4Ib",
     description: "Link to the source glossary for a CAT concept",
   },
+  openGlossary: {
+    defaultMessage: "Open glossary",
+    id: "oa7ed0lrAe",
+    description: "Link to the in-app glossary detail page from glossary guidance",
+  },
+  openConcept: {
+    defaultMessage: "Open concept",
+    id: "6Lm9EGksM9",
+    description: "Link to the in-app glossary concept detail page from glossary guidance",
+  },
   lowMatchConfirmTitle: {
     defaultMessage: "Apply low-quality TM match?",
     id: "nojhrDNSfO",

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -156,6 +156,7 @@ export interface CatGlossaryConcept {
   glossaryId: string;
   glossaryName: string;
   glossaryUrl?: string | null;
+  conceptUrl?: string | null;
   primaryTerm: string;
   subject?: string | null;
   definition?: string | null;

--- a/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
@@ -282,7 +282,7 @@ function toNativeGlossary(
     localeCoverage,
     termCount: glossary.terms,
     externalGlossaryId: String(glossary.id),
-    externalUrl: glossary.webUrl,
+    externalUrl: null,
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary-detail-id.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary-detail-id.test.ts
@@ -12,9 +12,73 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveGlossaryDetailId } from "./glossary-detail-id";
+import {
+  buildCrowdinGlossaryConcordanceUrl,
+  buildGlossaryConceptDetailUrl,
+  buildGlossaryDetailUrl,
+  resolveGlossaryDetailId,
+} from "./glossary-detail-id";
 
-import { buildCrowdinGlossaryConcordanceUrl } from "./glossary-detail-id";
+describe("buildGlossaryDetailUrl", () => {
+  it("builds in-app glossary detail urls for live Crowdin glossary ids", () => {
+    expect(
+      buildGlossaryDetailUrl({
+        organizationSlug: "test-glossary",
+        glossaryId: "crowdin:glossary:718785",
+        providerKind: "crowdin",
+        externalResourceId: "718785",
+      }),
+    ).toBe("/org/test-glossary/glossaries/crowdin:glossary:718785");
+  });
+
+  it("maps numeric Crowdin glossary ids to live detail urls", () => {
+    expect(
+      buildGlossaryDetailUrl({
+        organizationSlug: "test-glossary",
+        glossaryId: "718785",
+        providerKind: "crowdin",
+        externalResourceId: "718785",
+      }),
+    ).toBe("/org/test-glossary/glossaries/crowdin:glossary:718785");
+  });
+
+  it("builds in-app glossary detail urls for native glossaries", () => {
+    const nativeId = "22222222-2222-4222-8222-222222222222";
+    expect(
+      buildGlossaryDetailUrl({
+        organizationSlug: "acme",
+        glossaryId: nativeId,
+        providerKind: null,
+      }),
+    ).toBe(`/org/acme/glossaries/${nativeId}`);
+  });
+});
+
+describe("buildGlossaryConceptDetailUrl", () => {
+  it("builds in-app concept detail urls for Crowdin glossaries", () => {
+    expect(
+      buildGlossaryConceptDetailUrl({
+        organizationSlug: "test-glossary",
+        glossaryId: "7",
+        conceptId: "42",
+        providerKind: "crowdin",
+        externalResourceId: "7",
+      }),
+    ).toBe("/org/test-glossary/glossaries/crowdin:glossary:7/concepts/42");
+  });
+
+  it("builds in-app concept detail urls for native glossaries", () => {
+    const nativeId = "22222222-2222-4222-8222-222222222222";
+    expect(
+      buildGlossaryConceptDetailUrl({
+        organizationSlug: "acme",
+        glossaryId: nativeId,
+        conceptId: "concept-1",
+        providerKind: null,
+      }),
+    ).toBe(`/org/acme/glossaries/${nativeId}/concepts/concept-1`);
+  });
+});
 
 describe("buildCrowdinGlossaryConcordanceUrl", () => {
   it("builds in-app glossary detail urls for live Crowdin glossary ids", () => {

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary-detail-id.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary-detail-id.ts
@@ -31,15 +31,40 @@ export function resolveGlossaryDetailId(input: {
   return input.glossaryId;
 }
 
+export function buildGlossaryDetailUrl(input: {
+  organizationSlug: string;
+  glossaryId: string;
+  providerKind?: ExternalTmsProviderKind | null;
+  externalResourceId?: string | null;
+}): string {
+  const detailId = resolveGlossaryDetailId({
+    glossaryId: input.glossaryId,
+    providerKind: input.providerKind,
+    externalResourceId: input.externalResourceId,
+  });
+  return `/org/${input.organizationSlug}/glossaries/${detailId}`;
+}
+
+export function buildGlossaryConceptDetailUrl(input: {
+  organizationSlug: string;
+  glossaryId: string;
+  conceptId: string;
+  providerKind?: ExternalTmsProviderKind | null;
+  externalResourceId?: string | null;
+}): string {
+  return `${buildGlossaryDetailUrl(input)}/concepts/${encodeURIComponent(input.conceptId)}`;
+}
+
+/** @deprecated Use {@link buildGlossaryDetailUrl} with providerKind crowdin. */
 export function buildCrowdinGlossaryConcordanceUrl(input: {
   organizationSlug: string;
   glossaryId: string;
   externalResourceId?: string | null;
 }): string {
-  const detailId = resolveGlossaryDetailId({
+  return buildGlossaryDetailUrl({
+    organizationSlug: input.organizationSlug,
     glossaryId: input.glossaryId,
     providerKind: "crowdin",
     externalResourceId: input.externalResourceId,
   });
-  return `/org/${input.organizationSlug}/glossaries/${detailId}`;
 }

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -127,7 +127,7 @@ function buildNormalizedConcept(input: {
     primaryTerm: input.concept.primaryTerm,
     subject: input.concept.subject,
     definition: input.concept.definition,
-    glossaryUrl: input.glossaryUrl ?? input.concept.url,
+    glossaryUrl: input.glossaryUrl ?? null,
     sourceTerms: conceptTerms.filter((term) => term.locale === input.sourceLocale),
     targetTerms: filterConcordanceTargetTerms(conceptTerms, input.targetLocales),
   };
@@ -1044,7 +1044,7 @@ export class NativeGlossary extends Glossary {
         terms: conceptTerms,
         sourceLocale,
         targetLocales: query.targetLocales,
-        glossaryUrl: hit.externalGlossaryUrl,
+        glossaryUrl: null,
       });
 
       for (const targetLocale of query.targetLocales) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
@@ -159,6 +159,46 @@ describe("searchCrowdinCatConcordance", () => {
       primaryTerm: "dashboard",
       glossaryUrl: null,
     });
+    expect(result.glossaryTerms[0]?.externalConceptId).toBeUndefined();
+  });
+
+  it("uses term conceptId when Crowdin omits concept metadata", async () => {
+    const client = {
+      glossaryConcordanceSearch: vi.fn().mockResolvedValue([
+        {
+          glossary: { id: 9, name: "Product terms" },
+          concept: null,
+          sourceTerms: [
+            { id: 21, conceptId: 55, languageId: "en", text: "dashboard", status: "preferred" },
+          ],
+          targetTerms: [
+            {
+              id: 22,
+              conceptId: 55,
+              languageId: "fr",
+              text: "tableau de bord",
+              status: "preferred",
+            },
+          ],
+        },
+      ]),
+      concordanceSearch: vi.fn().mockResolvedValue([]),
+    } as unknown as CrowdinApiClient;
+
+    const result = await crowdinTmsProvider.searchCatConcordance({
+      client,
+      externalProjectId: "42",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "dashboard",
+    });
+
+    expect(result.glossaryTerms[0]?.concept).toMatchObject({
+      id: "55",
+      primaryTerm: "dashboard",
+      glossaryUrl: null,
+    });
+    expect(result.glossaryTerms[0]?.externalConceptId).toBe("55");
   });
 
   it("does not expose Crowdin glossary webUrl on concept matches", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
@@ -113,7 +113,7 @@ describe("searchCrowdinCatConcordance", () => {
     expect(result.glossaryTerms[0]?.concept).toMatchObject({
       id: "1",
       primaryTerm: "workspace",
-      glossaryUrl: "https://crowdin.com/glossary/7",
+      glossaryUrl: null,
       sourceTerms: [
         expect.objectContaining({
           id: "11",
@@ -157,11 +157,11 @@ describe("searchCrowdinCatConcordance", () => {
     expect(result.glossaryTerms[0]?.concept).toMatchObject({
       id: "21",
       primaryTerm: "dashboard",
-      glossaryUrl: "https://crowdin.com/glossary/9",
+      glossaryUrl: null,
     });
   });
 
-  it("uses Crowdin glossary webUrl when it is a safe https URL", async () => {
+  it("does not expose Crowdin glossary webUrl on concept matches", async () => {
     const client = {
       glossaryConcordanceSearch: vi.fn().mockResolvedValue([
         {
@@ -200,7 +200,8 @@ describe("searchCrowdinCatConcordance", () => {
       id: "3",
       subject: "UI",
       definition: "Product workspace",
-      glossaryUrl: "https://acme.crowdin.com/u/projects/1/glossary/7",
+      glossaryUrl: null,
     });
+    expect(result.glossaryTerms[0]?.externalConceptId).toBe("3");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-concordance.ts
@@ -54,6 +54,20 @@ export function pickCrowdinConcordanceTermStatus(
   return match?.status ?? null;
 }
 
+export function resolveCrowdinConcordanceExternalConceptId(
+  result: CrowdinGlossaryConcordanceSearchResult,
+): string | null {
+  if (result.concept) {
+    return String(result.concept.id);
+  }
+
+  const termConceptId =
+    result.sourceTerms.find((term) => term.conceptId != null)?.conceptId ??
+    result.targetTerms.find((term) => term.conceptId != null)?.conceptId;
+
+  return termConceptId != null ? String(termConceptId) : null;
+}
+
 export function toCrowdinConcordanceConceptTerm(
   term: CrowdinGlossaryConcordanceTerm,
   preferredLocales: string[],
@@ -100,9 +114,11 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
       ? String(providerTermId)
       : stableCrowdinConcordanceTermId(stableTermIdGlossaryKey, sourceTerm, input.targetLocale);
 
+  const externalConceptId = resolveCrowdinConcordanceExternalConceptId(input.result);
+
   const preferredLocales = [input.sourceLocale, input.targetLocale];
   const concept: NormalizedGlossaryConcept = {
-    id: input.result.concept ? String(input.result.concept.id) : externalTermId,
+    id: externalConceptId ?? externalTermId,
     primaryTerm: sourceTerm,
     subject: input.result.concept?.subject,
     definition: input.result.concept?.definition,
@@ -124,7 +140,7 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
     resourceId: input.resourceId,
     externalResourceId: externalGlossaryId,
     externalTermId,
-    externalConceptId: input.result.concept ? String(input.result.concept.id) : null,
+    externalConceptId,
     glossaryName: input.glossaryName,
     rank: 1 - input.index * 0.01,
     status: { status },

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-concordance.ts
@@ -27,7 +27,6 @@ import {
   type NormalizedGlossaryMatch,
 } from "@/lib/providers/contracts/glossary-match";
 import { normalizedGlossaryTermStatusFromStatus } from "@/lib/providers/contracts/glossary-term-status";
-import { sanitizeExternalUrl } from "@/lib/security/safe-external-url";
 
 export function stableCrowdinConcordanceTermId(
   glossaryId: string,
@@ -91,9 +90,6 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
   }
 
   const externalGlossaryId = String(input.result.glossary.id);
-  const glossaryUrl =
-    sanitizeExternalUrl(input.result.glossary.webUrl) ??
-    `https://crowdin.com/glossary/${encodeURIComponent(externalGlossaryId)}`;
   const status =
     pickCrowdinConcordanceTermStatus(input.result.targetTerms, targetLanguageId) ??
     pickCrowdinConcordanceTermStatus(input.result.sourceTerms, sourceLanguageId);
@@ -110,7 +106,7 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
     primaryTerm: sourceTerm,
     subject: input.result.concept?.subject,
     definition: input.result.concept?.definition,
-    glossaryUrl,
+    glossaryUrl: null,
     sourceTerms: input.result.sourceTerms.map((term) =>
       toCrowdinConcordanceConceptTerm(term, preferredLocales),
     ),
@@ -128,6 +124,7 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
     resourceId: input.resourceId,
     externalResourceId: externalGlossaryId,
     externalTermId,
+    externalConceptId: input.result.concept ? String(input.result.concept.id) : null,
     glossaryName: input.glossaryName,
     rank: 1 - input.index * 0.01,
     status: { status },

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -749,7 +749,7 @@ export class CrowdinTmsProvider extends TmsProvider {
             targetLocale,
             localeCoverage: this.uniqueLocales([sourceLocale, ...languageIds]),
             termCount: glossary.terms,
-            externalUrl: glossary.webUrl,
+            externalUrl: null,
             metadata: {
               crowdinGlossaryId: glossary.id,
               crowdinProjectId,
@@ -787,7 +787,7 @@ export class CrowdinTmsProvider extends TmsProvider {
                 ),
               ]),
               termCount: glossary.terms,
-              externalUrl: glossary.webUrl,
+              externalUrl: null,
               syncErrorMessage:
                 error instanceof Error ? error.message : "glossary_term_fetch_failed",
               metadata: {
@@ -823,7 +823,7 @@ export class CrowdinTmsProvider extends TmsProvider {
       targetLocale,
       localeCoverage,
       termCount: glossary.terms,
-      externalUrl: glossary.webUrl ?? null,
+      externalUrl: null,
       externalProjectIds: [...glossary.projectIds, ...glossary.defaultProjectIds].map(String),
       createdAt: glossary.createdAt ?? null,
     };

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-match.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-match.ts
@@ -62,6 +62,7 @@ export type NormalizedGlossaryMatch = {
   resourceId: string;
   externalResourceId: string | null;
   externalTermId: string | null;
+  externalConceptId?: string | null;
   termStatus: NormalizedGlossaryTermStatus;
   concept?: NormalizedGlossaryConcept;
 };
@@ -108,6 +109,7 @@ export type ProviderGlossaryMatchInput = {
   resourceId: string;
   externalResourceId?: string | null;
   externalTermId?: string | null;
+  externalConceptId?: string | null;
   glossaryName: string;
   rank?: number;
   status?: ProviderGlossaryTermStatusInput;
@@ -133,6 +135,7 @@ export function normalizeProviderGlossaryMatch(
 ): NormalizedGlossaryMatch {
   const externalResourceId = input.externalResourceId ?? null;
   const externalTermId = input.externalTermId ?? null;
+  const externalConceptId = input.externalConceptId ?? null;
   const rank = input.rank ?? 1;
   const termStatus = normalizeGlossaryTermStatus(input.status ?? {});
 
@@ -152,6 +155,7 @@ export function normalizeProviderGlossaryMatch(
     resourceId: input.resourceId,
     externalResourceId,
     externalTermId,
+    ...(externalConceptId ? { externalConceptId } : {}),
     termStatus,
     ...(input.concept ? { concept: input.concept } : {}),
   };

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-glossaries-page.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-glossaries-page.test.ts
@@ -148,7 +148,7 @@ describe("listTmsProviderLiveGlossariesPage", () => {
             targetLocale: "fr",
             localeCoverage: ["en", "fr"],
             termCount: 12,
-            externalUrl: "https://crowdin.example/g/42",
+            externalUrl: null,
             externalProjectIds: ["200", "100"],
             createdAt: "2026-03-01T12:00:00.000Z",
           },
@@ -310,7 +310,7 @@ describe("getTmsProviderLiveGlossary", () => {
       targetLocale: "fr",
       localeCoverage: ["en", "fr"],
       termCount: 3,
-      externalUrl: "https://crowdin.example/g/42",
+      externalUrl: null,
       externalProjectIds: ["100"],
       createdAt: "2026-04-01T00:00:00.000Z",
     });

--- a/apps/hyperlocalise-web/src/lib/translation/cat.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/cat.ts
@@ -43,7 +43,10 @@ import {
   defaultGlossaryMatchResolution,
   defaultTranslationMemoryMatchResolution,
 } from "@/lib/providers/capabilities/match-resolution";
-import { buildCrowdinGlossaryConcordanceUrl } from "@/lib/glossary/glossary-detail-id";
+import {
+  buildGlossaryConceptDetailUrl,
+  buildGlossaryDetailUrl,
+} from "@/lib/glossary/glossary-detail-id";
 import { normalizedGlossaryTermStatusFromStatus } from "@/lib/providers/contracts/glossary-term-status";
 import {
   GlossaryConcordanceService,
@@ -98,33 +101,57 @@ function toCatGlossaryConceptTerm(term: NormalizedGlossaryConceptTerm): CatGloss
   return { ...term };
 }
 
-function resolveCatGlossaryUrl(
+function resolveCatGlossaryNavigationUrls(
   match: NormalizedGlossaryMatch,
-  conceptGlossaryUrl: string | null | undefined,
   organizationSlug?: string,
-): string | null | undefined {
-  if (match.providerKind === "crowdin" && organizationSlug) {
-    return buildCrowdinGlossaryConcordanceUrl({
-      organizationSlug,
-      glossaryId: match.glossaryId,
-      externalResourceId: match.externalResourceId,
-    });
+): { glossaryUrl?: string; conceptUrl?: string } {
+  if (!organizationSlug) {
+    return {};
   }
 
-  return conceptGlossaryUrl ?? undefined;
+  const usesInAppGlossaryNavigation =
+    match.providerKind === "crowdin" || match.providerKind === null;
+  if (!usesInAppGlossaryNavigation) {
+    return {
+      glossaryUrl: match.concept?.glossaryUrl ?? undefined,
+    };
+  }
+
+  const glossaryUrl = buildGlossaryDetailUrl({
+    organizationSlug,
+    glossaryId: match.glossaryId,
+    providerKind: match.providerKind,
+    externalResourceId: match.externalResourceId,
+  });
+
+  const conceptId = match.providerKind === "crowdin" ? match.externalConceptId : match.concept?.id;
+  const conceptUrl =
+    conceptId != null
+      ? buildGlossaryConceptDetailUrl({
+          organizationSlug,
+          glossaryId: match.glossaryId,
+          conceptId,
+          providerKind: match.providerKind,
+          externalResourceId: match.externalResourceId,
+        })
+      : undefined;
+
+  return { glossaryUrl, conceptUrl };
 }
 
 function toCatGlossaryConcept(
   match: NormalizedGlossaryMatch,
   organizationSlug?: string,
 ): CatGlossaryConcept {
+  const navigationUrls = resolveCatGlossaryNavigationUrls(match, organizationSlug);
   const concept = match.concept;
   if (concept) {
     return {
       id: `${match.glossaryId}:${concept.id}`,
       glossaryId: match.glossaryId,
       glossaryName: match.glossaryName,
-      glossaryUrl: resolveCatGlossaryUrl(match, concept.glossaryUrl, organizationSlug),
+      glossaryUrl: navigationUrls.glossaryUrl,
+      conceptUrl: navigationUrls.conceptUrl,
       primaryTerm: concept.primaryTerm || match.sourceTerm,
       subject: concept.subject,
       definition: concept.definition ?? match.description,
@@ -137,7 +164,8 @@ function toCatGlossaryConcept(
     id: `${match.glossaryId}:${match.sourceLocale}:${match.sourceTerm}`,
     glossaryId: match.glossaryId,
     glossaryName: match.glossaryName,
-    glossaryUrl: resolveCatGlossaryUrl(match, null, organizationSlug),
+    glossaryUrl: navigationUrls.glossaryUrl,
+    conceptUrl: navigationUrls.conceptUrl,
     primaryTerm: match.sourceTerm,
     definition: match.description,
     sourceTerms: [
@@ -175,6 +203,7 @@ function toCatGlossaryConcepts(
     }
 
     existing.glossaryUrl ??= next.glossaryUrl;
+    existing.conceptUrl ??= next.conceptUrl;
     const sourceIds = new Set(existing.sourceTerms.map((term) => term.id));
     const targetIds = new Set(existing.targetTerms.map((term) => term.id));
     existing.sourceTerms.push(...next.sourceTerms.filter((term) => !sourceIds.has(term.id)));

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.test.ts
@@ -320,13 +320,14 @@ describe("loadCatSegmentConcordance", () => {
           resourceId: "7",
           externalResourceId: "7",
           externalTermId: "11",
+          externalConceptId: "c1",
           termStatus: { forbidden: false, preferred: true },
           concept: {
             id: "c1",
             primaryTerm: "workspace",
             subject: "UI",
             definition: "Product workspace",
-            glossaryUrl: "https://crowdin.com/glossary/7",
+            glossaryUrl: null,
             sourceTerms: [
               {
                 id: "11",
@@ -368,6 +369,7 @@ describe("loadCatSegmentConcordance", () => {
         glossaryId: "7",
         glossaryName: "Product terms",
         glossaryUrl: "/org/test-glossary/glossaries/crowdin:glossary:7",
+        conceptUrl: "/org/test-glossary/glossaries/crowdin:glossary:7/concepts/c1",
         primaryTerm: "workspace",
         subject: "UI",
         definition: "Product workspace",
@@ -508,6 +510,105 @@ describe("loadCatSegmentConcordance", () => {
             forbidden: true,
           }),
         ],
+      }),
+    ]);
+    expect(result.glossaryConcepts?.[0]?.conceptUrl).toBeUndefined();
+  });
+
+  it("assigns separate in-app glossary and concept urls per glossary match", async () => {
+    searchCrowdinCatConcordanceMock.mockResolvedValue({
+      glossaryTerms: [
+        {
+          id: "match-a",
+          glossaryId: "7",
+          glossaryName: "Product terms",
+          sourceTerm: "workspace",
+          targetTerm: "espace de travail",
+          sourceLocale: "en",
+          targetLocale: "fr",
+          description: null,
+          caseSensitive: false,
+          rank: 1,
+          matchSource: "live_provider",
+          providerKind: "crowdin",
+          resourceId: "7",
+          externalResourceId: "7",
+          externalTermId: "11",
+          externalConceptId: "42",
+          termStatus: { forbidden: false, preferred: true },
+          concept: {
+            id: "42",
+            primaryTerm: "workspace",
+            glossaryUrl: null,
+            sourceTerms: [
+              { id: "11", locale: "en", text: "workspace", preferred: true, forbidden: false },
+            ],
+            targetTerms: [
+              {
+                id: "12",
+                locale: "fr",
+                text: "espace de travail",
+                preferred: true,
+                forbidden: false,
+              },
+            ],
+          },
+        },
+        {
+          id: "match-b",
+          glossaryId: "9",
+          glossaryName: "Marketing terms",
+          sourceTerm: "workspace",
+          targetTerm: "espace",
+          sourceLocale: "en",
+          targetLocale: "fr",
+          description: null,
+          caseSensitive: false,
+          rank: 1,
+          matchSource: "live_provider",
+          providerKind: "crowdin",
+          resourceId: "9",
+          externalResourceId: "9",
+          externalTermId: "21",
+          externalConceptId: "88",
+          termStatus: { forbidden: false, preferred: true },
+          concept: {
+            id: "88",
+            primaryTerm: "workspace",
+            glossaryUrl: null,
+            sourceTerms: [
+              { id: "21", locale: "en", text: "workspace", preferred: true, forbidden: false },
+            ],
+            targetTerms: [
+              { id: "22", locale: "fr", text: "espace", preferred: true, forbidden: false },
+            ],
+          },
+        },
+      ],
+      translationMemoryMatches: [],
+    });
+
+    const result = await loadCatSegmentConcordance({
+      organizationId: "org_1",
+      organizationSlug: "test-glossary",
+      projectId: "ext:crowdin:42",
+      providerKind: "crowdin",
+      actorUserId: "user_1",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "workspace",
+    });
+
+    expect(result.glossaryConcepts).toEqual([
+      expect.objectContaining({
+        glossaryId: "7",
+        glossaryUrl: "/org/test-glossary/glossaries/crowdin:glossary:7",
+        conceptUrl: "/org/test-glossary/glossaries/crowdin:glossary:7/concepts/42",
+      }),
+      expect.objectContaining({
+        glossaryId: "9",
+        glossaryUrl: "/org/test-glossary/glossaries/crowdin:glossary:9",
+        conceptUrl: "/org/test-glossary/glossaries/crowdin:glossary:9/concepts/88",
       }),
     ]);
   });


### PR DESCRIPTION
## Summary

- Stop emitting Crowdin.com glossary and concept URLs from concordance mappers, live glossary adapters, and the glossaries list (Phrase/Lokalise **Open in provider** unchanged).
- Build in-app glossary and concept detail URLs for Crowdin and native CAT matches when `organizationSlug` is present.
- Replace the single **Project Glossary** footer link with **Open glossary** and **Open concept** in-app links on each glossary guidance concept card.

## Test plan

- [ ] Open CAT glossary guidance for a Crowdin project with matches from multiple glossaries; each card shows **Open glossary** and **Open concept** pointing at `/org/{slug}/glossaries/...` routes.
- [ ] Confirm synthesized matches (no concept payload) show **Open glossary** only.
- [ ] Open glossaries list with live Crowdin glossaries; verify no **Open in provider** link for Crowdin rows, while Phrase/Lokalise rows still have it.
- [ ] Open native glossary concordance in CAT; verify in-app glossary and concept links use native UUID paths.
- [ ] `vp test` and `vp check --fix` pass for touched web files.


Made with [Cursor](https://cursor.com)