### PR TITLE
feat(web): add feature teaser pages for gated workspace features

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
@@ -13,9 +13,10 @@
 import { Suspense } from "react";
 
 import { hasCapability } from "@/api/auth/policy";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import {
   evaluateWorkspaceFeatureFlags,
-  requireWorkspaceFeatureFlag,
+  getWorkspaceFeatureFlagEnabled,
   workspaceAutomationsFlag,
 } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
@@ -29,7 +30,12 @@ export default async function AutomationDetailPage({
 }) {
   const { organizationSlug, automationId } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const automationsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceAutomationsFlag, auth);
+
+  if (!automationsEnabled) {
+    return <FeatureTeaserPage feature="automations" scope="workspace" />;
+  }
+
   const flags = await evaluateWorkspaceFeatureFlags(auth);
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
@@ -13,6 +13,7 @@
 import { Suspense } from "react";
 
 import { hasCapability } from "@/api/auth/policy";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import {
   createDefaultWorkspaceAutomationFormState,
   createWorkspaceAutomationFormStateFromTemplate,
@@ -20,7 +21,7 @@ import {
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
 import {
   evaluateWorkspaceFeatureFlags,
-  requireWorkspaceFeatureFlag,
+  getWorkspaceFeatureFlagEnabled,
   workspaceAutomationsFlag,
 } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
@@ -37,7 +38,12 @@ export default async function NewAutomationPage({
   const { organizationSlug } = await params;
   const { template } = await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const automationsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceAutomationsFlag, auth);
+
+  if (!automationsEnabled) {
+    return <FeatureTeaserPage feature="automations" scope="workspace" />;
+  }
+
   const flags = await evaluateWorkspaceFeatureFlags(auth);
   const templates = getMergedWorkspaceAutomationTemplates();
   const initialForm = template

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/page.tsx
@@ -12,8 +12,12 @@
  */
 import { Suspense } from "react";
 
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
-import { requireWorkspaceFeatureFlag, workspaceAutomationsFlag } from "@/lib/flags/workspace-flags";
+import {
+  getWorkspaceFeatureFlagEnabled,
+  workspaceAutomationsFlag,
+} from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationsPageContent } from "./_components/automations-page-content";
@@ -25,7 +29,12 @@ export default async function AutomationsPage({
 }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const automationsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceAutomationsFlag, auth);
+
+  if (!automationsEnabled) {
+    return <FeatureTeaserPage feature="automations" scope="workspace" />;
+  }
+
   const templates = getMergedWorkspaceAutomationTemplates();
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/page.tsx
@@ -10,7 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { requireWorkspaceFeatureFlag, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
+import { getWorkspaceFeatureFlagEnabled, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { DomainDetailPageContent } from "./_components/domain-detail-page-content";
@@ -22,7 +23,11 @@ export default async function DomainDetailPage({
 }) {
   const { organizationSlug, linkedDomainId } = await params;
   const auth = await requireAppCapability("projects:read", { organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceDomainsFlag, auth);
+  const domainsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceDomainsFlag, auth);
+
+  if (!domainsEnabled) {
+    return <FeatureTeaserPage feature="domains" scope="workspace" />;
+  }
 
   return (
     <DomainDetailPageContent organizationSlug={organizationSlug} linkedDomainId={linkedDomainId} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/page.tsx
@@ -10,7 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { requireWorkspaceFeatureFlag, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
+import { getWorkspaceFeatureFlagEnabled, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { DomainsPageContent } from "./_components/domains-page-content";
@@ -22,7 +23,11 @@ export default async function DomainsPage({
 }) {
   const { organizationSlug } = await params;
   const auth = await requireAppCapability("projects:read", { organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceDomainsFlag, auth);
+  const domainsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceDomainsFlag, auth);
+
+  if (!domainsEnabled) {
+    return <FeatureTeaserPage feature="domains" scope="workspace" />;
+  }
 
   return <DomainsPageContent organizationSlug={organizationSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/page.tsx
@@ -11,7 +11,11 @@
  * Version 2.0 or later.
  */
 import { hasCapability } from "@/api/auth/policy";
-import { requireWorkspaceFeatureFlag, workspaceKnowledgeFlag } from "@/lib/flags/workspace-flags";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
+import {
+  getWorkspaceFeatureFlagEnabled,
+  workspaceKnowledgeFlag,
+} from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { KnowledgePageContent } from "./_components/knowledge-page-content";
@@ -23,7 +27,11 @@ export default async function KnowledgePage({
 }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceKnowledgeFlag, auth);
+  const knowledgeEnabled = await getWorkspaceFeatureFlagEnabled(workspaceKnowledgeFlag, auth);
+
+  if (!knowledgeEnabled) {
+    return <FeatureTeaserPage feature="guideline" scope="workspace" />;
+  }
 
   return (
     <KnowledgePageContent

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/link-domain/[domainSlug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/link-domain/[domainSlug]/page.tsx
@@ -10,7 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { requireWorkspaceFeatureFlag, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
+import { getWorkspaceFeatureFlagEnabled, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { LinkDomainPageContent } from "./_components/link-domain-page-content";
@@ -22,7 +23,11 @@ export default async function LinkDomainPage({
 }) {
   const { organizationSlug, domainSlug } = await params;
   const auth = await requireAppCapability("projects:create", { organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceDomainsFlag, auth);
+  const domainsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceDomainsFlag, auth);
+
+  if (!domainsEnabled) {
+    return <FeatureTeaserPage feature="domains" scope="workspace" />;
+  }
 
   return <LinkDomainPageContent organizationSlug={organizationSlug} domainSlug={domainSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/[automationId]/page.tsx
@@ -13,9 +13,10 @@
 import { Suspense } from "react";
 
 import { hasCapability } from "@/api/auth/policy";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import {
   evaluateWorkspaceFeatureFlags,
-  requireWorkspaceFeatureFlag,
+  getWorkspaceFeatureFlagEnabled,
   workspaceAutomationsFlag,
 } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
@@ -29,7 +30,12 @@ export default async function ProjectAutomationDetailPage({
 }) {
   const { organizationSlug, projectId, automationId } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const automationsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceAutomationsFlag, auth);
+
+  if (!automationsEnabled) {
+    return <FeatureTeaserPage feature="automations" scope="project" />;
+  }
+
   const flags = await evaluateWorkspaceFeatureFlags(auth);
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/new/page.tsx
@@ -13,6 +13,7 @@
 import { Suspense } from "react";
 
 import { hasCapability } from "@/api/auth/policy";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import {
   createDefaultWorkspaceAutomationFormState,
   createWorkspaceAutomationFormStateFromTemplate,
@@ -20,7 +21,7 @@ import {
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
 import {
   evaluateWorkspaceFeatureFlags,
-  requireWorkspaceFeatureFlag,
+  getWorkspaceFeatureFlagEnabled,
   workspaceAutomationsFlag,
 } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
@@ -37,7 +38,12 @@ export default async function ProjectNewAutomationPage({
   const { organizationSlug, projectId } = await params;
   const { template } = await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const automationsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceAutomationsFlag, auth);
+
+  if (!automationsEnabled) {
+    return <FeatureTeaserPage feature="automations" scope="project" />;
+  }
+
   const flags = await evaluateWorkspaceFeatureFlags(auth);
   const templates = getMergedWorkspaceAutomationTemplates();
   const templateForm = template

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/page.tsx
@@ -12,8 +12,12 @@
  */
 import { Suspense } from "react";
 
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
-import { requireWorkspaceFeatureFlag, workspaceAutomationsFlag } from "@/lib/flags/workspace-flags";
+import {
+  getWorkspaceFeatureFlagEnabled,
+  workspaceAutomationsFlag,
+} from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationsPageContent } from "../../../automations/_components/automations-page-content";
@@ -25,7 +29,12 @@ export default async function ProjectAutomationsPage({
 }) {
   const { organizationSlug, projectId } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const automationsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceAutomationsFlag, auth);
+
+  if (!automationsEnabled) {
+    return <FeatureTeaserPage feature="automations" scope="project" />;
+  }
+
   const templates = getMergedWorkspaceAutomationTemplates();
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/knowledge/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/knowledge/page.tsx
@@ -12,7 +12,11 @@
  */
 import { hasCapability } from "@/api/auth/policy";
 import { KnowledgePageContent } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-page-content";
-import { requireWorkspaceFeatureFlag, workspaceKnowledgeFlag } from "@/lib/flags/workspace-flags";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
+import {
+  getWorkspaceFeatureFlagEnabled,
+  workspaceKnowledgeFlag,
+} from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 export default async function ProjectKnowledgePage({
@@ -22,7 +26,11 @@ export default async function ProjectKnowledgePage({
 }) {
   const { organizationSlug, projectId } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceKnowledgeFlag, auth);
+  const knowledgeEnabled = await getWorkspaceFeatureFlagEnabled(workspaceKnowledgeFlag, auth);
+
+  if (!knowledgeEnabled) {
+    return <FeatureTeaserPage feature="guideline" scope="project" />;
+  }
 
   return (
     <KnowledgePageContent

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
@@ -60,8 +60,8 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
   const intl = getIntlShape(locale);
 
   const title = intl.formatMessage({
-    defaultMessage: "Hyperlocalise | The Best Agentic Localisation Platform",
-    id: "9EV17CGa2+",
+    defaultMessage: "Hyperlocalise | Infrastructure for multilingual content operations",
+    id: "fYpd91LP4S",
     description: "Page title for the marketing homepage",
   });
   const description = intl.formatMessage({
@@ -71,8 +71,8 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
     description: "Meta description for the marketing homepage",
   });
   const openGraphDescription = intl.formatMessage({
-    defaultMessage: "The best agentic localisation platform to launch globally in days.",
-    id: "cdezPwXx10",
+    defaultMessage: "Infrastructure for multilingual content operations.",
+    id: "qJ16Joucwo",
     description:
       "Open Graph meta description for the marketing homepage (shorter than the main description)",
   });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.messages.ts
@@ -35,4 +35,9 @@ export const appShellNavigationMessages = defineMessages({
     id: "90L8I4Y/Gl",
     description: "Sidebar tooltip combining a navigation item label and its badge",
   },
+  previewBadge: {
+    defaultMessage: "Preview",
+    id: "qiPX0q5vvf",
+    description: "Sidebar badge for gated features that link to teaser pages",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -39,7 +39,7 @@ import {
 } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-notifications-api";
 
 import { appShellNavigationMessages } from "./app-shell-navigation.messages";
-import { filterNavigationItemsByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
+import { annotateNavigationItemsWithWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
 import { formatInboxUnreadBadgeLabel, inboxUnreadBadgeClassName } from "./inbox-unread-badge";
 
 import {
@@ -186,7 +186,7 @@ function ProjectNavigation({
   });
 
   const store = useAppShellStore();
-  const resolvedItems = filterNavigationItemsByWorkspaceFlags(
+  const resolvedItems = annotateNavigationItemsWithWorkspaceFlags(
     items ?? buildProjectNavigationItems(organizationSlug, projectId, intl),
     store.workspaceFeatureFlags,
   );
@@ -274,8 +274,11 @@ function NavigationGroupItems({
             organizationSlug,
           });
           const isInboxItem = item.href === inboxHref;
+          const previewBadgeLabel = item.preview
+            ? intl.formatMessage(appShellNavigationMessages.previewBadge)
+            : null;
           const dynamicBadge = isInboxItem ? unreadBadgeLabel : null;
-          const badge = dynamicBadge ?? item.badge;
+          const badge = dynamicBadge ?? previewBadgeLabel ?? item.badge;
           const tooltip = badge
             ? intl.formatMessage(appShellNavigationMessages.badgeSeparator, {
                 label: item.label,
@@ -293,9 +296,9 @@ function NavigationGroupItems({
               >
                 <HugeiconsIcon icon={item.icon} strokeWidth={2} className="size-4" />
                 <span className="min-w-0 flex-1 truncate">{item.label}</span>
-                {item.badge && !dynamicBadge ? (
+                {badge && !dynamicBadge ? (
                   <span className="ms-auto inline-flex shrink-0 items-center rounded-full border border-sidebar-border bg-sidebar px-1.5 py-0.5 text-[0.625rem] leading-none font-medium tracking-normal text-muted-foreground group-data-[collapsible=icon]:hidden">
-                    {item.badge}
+                    {badge}
                   </span>
                 ) : null}
               </SidebarMenuButton>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -17,7 +17,7 @@ import { AppShellClient } from "@/components/app-shell/app-shell-client";
 import { buildGlobalNavigationGroups } from "@/components/app-shell/navigation-config";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 import { getAppLocale } from "@/lib/app-i18n/server-locale";
-import { filterNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
+import { annotateNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
 import { evaluateWorkspaceFeatureFlags } from "@/lib/flags/workspace-flags";
 import { getTmsProviderConnection } from "@/lib/providers/jobs/tms-provider-live";
 import {
@@ -49,7 +49,7 @@ export async function AppShell({
     [auth.sessionUser.firstName, auth.sessionUser.lastName].filter(Boolean).join(" ") ||
     auth.sessionUser.email;
   const workspaceFeatureFlags = await evaluateWorkspaceFeatureFlags(auth);
-  const navigationGroups = filterNavigationByWorkspaceFlags(
+  const navigationGroups = annotateNavigationByWorkspaceFlags(
     buildGlobalNavigationGroups(activeOrganizationSlug, intl),
     workspaceFeatureFlags,
   );

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -58,6 +58,8 @@ export type NavigationItem = {
     | typeof WORKSPACE_KNOWLEDGE_FLAG
     | typeof WORKSPACE_DOMAINS_FLAG
     | typeof RELEASE_CAT_ALL_FILES_FLAG;
+  /** When true, the feature flag is off and the nav item links to a teaser page. */
+  preview?: boolean;
 };
 
 export type NavigationGroup = {

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-benefits.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-benefits.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { MessageDescriptor } from "react-intl";
+import { FormattedMessage } from "react-intl";
+
+export function FeatureTeaserBenefits({ benefits }: { benefits: readonly MessageDescriptor[] }) {
+  return (
+    <ul className="space-y-2">
+      {benefits.map((benefit) => (
+        <li
+          key={benefit.id}
+          className="flex items-start gap-2 text-sm leading-6 text-muted-foreground"
+        >
+          <HugeiconsIcon
+            icon={Tick02Icon}
+            strokeWidth={2}
+            className="mt-0.5 size-4 shrink-0 text-primary"
+          />
+          <FormattedMessage {...benefit} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-cta-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-cta-panel.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { MessageDescriptor } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { TypographyH2, TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+import { SUPPORT_EMAIL } from "@/lib/support-contact";
+
+import { FeatureTeaserBenefits } from "./feature-teaser-benefits";
+import { featureTeaserMessages } from "./feature-teaser-registry";
+
+export function FeatureTeaserCtaPanel({
+  title,
+  description,
+  benefits,
+  contactSubject,
+  className,
+}: {
+  title: MessageDescriptor;
+  description: MessageDescriptor;
+  benefits: readonly MessageDescriptor[];
+  contactSubject: MessageDescriptor;
+  className?: string;
+}) {
+  const intl = useIntl();
+  const mailtoHref = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+    intl.formatMessage(contactSubject),
+  )}`;
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)}>
+      <div className="space-y-3">
+        <TypographyH2 className="text-xl font-medium text-foreground md:text-2xl">
+          <FormattedMessage {...title} />
+        </TypographyH2>
+        <TypographyP className="text-sm leading-6 text-muted-foreground sm:text-base">
+          <FormattedMessage {...description} />
+        </TypographyP>
+      </div>
+
+      <FeatureTeaserBenefits benefits={benefits} />
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          nativeButton={false}
+          render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+        >
+          <FormattedMessage {...featureTeaserMessages.requestDemo} />
+          <HugeiconsIcon icon={ArrowRight01Icon} data-icon="inline-end" className="size-4" />
+        </Button>
+        <Button variant="outline" nativeButton={false} render={<a href={mailtoHref} />}>
+          <FormattedMessage {...featureTeaserMessages.contactSupport} />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.stories.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ComponentProps } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { FeatureTeaserPage } from "./feature-teaser-page";
+
+function FeatureTeaserShowcase(props: ComponentProps<typeof FeatureTeaserPage>) {
+  return (
+    <div className="bg-background px-6 py-8 text-foreground">
+      <FeatureTeaserPage {...props} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "App/FeatureTeaser",
+  component: FeatureTeaserShowcase,
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/automations",
+      },
+    },
+  },
+} satisfies Meta<typeof FeatureTeaserShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Automations: Story = {
+  args: {
+    feature: "automations",
+    scope: "workspace",
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    await expect(canvas.getAllByText("Preview").length).toBeGreaterThan(0);
+    await expect(
+      canvas.getByText("Ship to more markets without growing the team"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Request a demo" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Contact us" })).toBeInTheDocument();
+    await expect(canvas.getByText("GitHub pull request opened")).toBeInTheDocument();
+  },
+};
+
+export const Guideline: Story = {
+  args: {
+    feature: "guideline",
+    scope: "workspace",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/knowledge",
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Guideline" })).toBeInTheDocument();
+    await expect(
+      canvas.getByText("One playbook for global growth in every market"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Market: Germany")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Request a demo" })).toHaveAttribute(
+      "href",
+      "https://calendar.app.google/gEiRwNvAZ1ERXvT26",
+    );
+  },
+};
+
+export const Domains: Story = {
+  args: {
+    feature: "domains",
+    scope: "workspace",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/domains",
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Domains" })).toBeInTheDocument();
+    await expect(
+      canvas.getByText("See what is hurting search and AI answers in every locale"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Website audit · acme.com")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Find hreflang errors, missing locales, and content gaps"),
+    ).toBeInTheDocument();
+  },
+};
+
+export const ProjectAutomations: Story = {
+  args: {
+    feature: "automations",
+    scope: "project",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/projects/proj_1/automations",
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Project")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Keep this project releasing on time without chasing manual handoffs."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const ProjectGuideline: Story = {
+  args: {
+    feature: "guideline",
+    scope: "project",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/projects/proj_1/knowledge",
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Project")).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        "Give this project the GTM context it needs to launch and grow in new markets.",
+      ),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.stories.tsx
@@ -53,7 +53,7 @@ export const Automations: Story = {
     ).toBeInTheDocument();
     await expect(canvas.getByRole("link", { name: "Request a demo" })).toBeInTheDocument();
     await expect(canvas.getByRole("link", { name: "Contact us" })).toBeInTheDocument();
-    await expect(canvas.getByText("GitHub pull request opened")).toBeInTheDocument();
+    await expect(canvas.getByText("GTM brief approved · Q2 launch")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { useIntl } from "react-intl";
+
+import {
+  PageHeader,
+  WorkspacePageShell,
+} from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-resource-shared";
+import { AutomationsMockUI } from "@/components/marketing/product/automations-mock-ui";
+import { DomainsMockUI } from "@/components/marketing/product/domains-mock-ui";
+import { GuidelineMockUI } from "@/components/marketing/product/guideline-mock-ui";
+import type { MarketingMockMeshPosition } from "@/components/marketing/product/marketing-mock-shell";
+
+import { FeatureTeaserCtaPanel } from "./feature-teaser-cta-panel";
+import {
+  featureTeaserContactSubjects,
+  featureTeaserMessages,
+  featureTeaserRegistry,
+  type FeatureTeaserId,
+  type FeatureTeaserScope,
+} from "./feature-teaser-registry";
+
+const teaserMockProps = {
+  variant: "embedded" as const,
+  pauseAutoplay: false,
+  renderCta: () => null,
+  meshPosition: "left" as const satisfies MarketingMockMeshPosition,
+};
+
+function FeatureTeaserShowcase({ feature, aside }: { feature: FeatureTeaserId; aside: ReactNode }) {
+  switch (feature) {
+    case "automations":
+      return <AutomationsMockUI {...teaserMockProps} aside={aside} />;
+    case "guideline":
+      return <GuidelineMockUI {...teaserMockProps} aside={aside} />;
+    case "domains":
+      return <DomainsMockUI {...teaserMockProps} aside={aside} />;
+  }
+}
+
+export function FeatureTeaserPage({
+  feature,
+  scope = "workspace",
+}: {
+  feature: FeatureTeaserId;
+  scope?: FeatureTeaserScope;
+}) {
+  const intl = useIntl();
+  const config = featureTeaserRegistry[feature];
+  const isProjectScope = scope === "project";
+
+  const ctaPanel = (
+    <FeatureTeaserCtaPanel
+      title={config.earlyAccessTitle}
+      description={config.earlyAccessDescription}
+      benefits={config.benefits}
+      contactSubject={featureTeaserContactSubjects[feature]}
+    />
+  );
+
+  return (
+    <WorkspacePageShell>
+      <PageHeader
+        icon={config.icon}
+        label={intl.formatMessage(isProjectScope ? config.pageLabelProject : config.pageLabel)}
+        title={intl.formatMessage(config.pageTitle)}
+        description={intl.formatMessage(
+          isProjectScope ? config.pageDescriptionProject : config.pageDescription,
+        )}
+        statusLabel={intl.formatMessage(featureTeaserMessages.previewBadge)}
+      />
+
+      <section aria-label={intl.formatMessage(config.pageTitle)}>
+        <FeatureTeaserShowcase feature={feature} aside={ctaPanel} />
+      </section>
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-registry.ts
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-registry.ts
@@ -1,0 +1,281 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages, type MessageDescriptor } from "react-intl";
+import { AiBrain01Icon, Globe02Icon, Task01Icon } from "@hugeicons/core-free-icons";
+
+import type { NavigationIcon } from "@/components/app-shell/navigation-config";
+
+export type FeatureTeaserId = "automations" | "guideline" | "domains";
+
+export type FeatureTeaserScope = "workspace" | "project";
+
+export type FeatureTeaserConfig = {
+  icon: NavigationIcon;
+  pageLabel: MessageDescriptor;
+  pageLabelProject: MessageDescriptor;
+  pageTitle: MessageDescriptor;
+  pageDescription: MessageDescriptor;
+  pageDescriptionProject: MessageDescriptor;
+  earlyAccessTitle: MessageDescriptor;
+  earlyAccessDescription: MessageDescriptor;
+  benefits: readonly MessageDescriptor[];
+};
+
+export const featureTeaserMessages = defineMessages({
+  previewBadge: {
+    defaultMessage: "Preview",
+    id: "slYILV02yb",
+    description: "Badge shown on feature teaser pages and gated navigation items",
+  },
+  requestDemo: {
+    defaultMessage: "Request a demo",
+    id: "oKauJvNSsW",
+    description: "Primary call to action on feature teaser pages",
+  },
+  contactSupport: {
+    defaultMessage: "Contact us",
+    id: "RcUVixjzZV",
+    description: "Secondary call to action on feature teaser pages",
+  },
+  contactSubjectAutomations: {
+    defaultMessage: "Demo request: Automations",
+    id: "++6KcoXi6F",
+    description: "Email subject for automations feature teaser contact link",
+  },
+  contactSubjectGuideline: {
+    defaultMessage: "Demo request: Guideline",
+    id: "BHmWNCONbs",
+    description: "Email subject for guideline feature teaser contact link",
+  },
+  contactSubjectDomains: {
+    defaultMessage: "Demo request: Domains",
+    id: "XztnKIGYn5",
+    description: "Email subject for domains feature teaser contact link",
+  },
+
+  automationsPageLabel: {
+    defaultMessage: "Workspace",
+    id: "SQywnBh/uh",
+    description: "Feature teaser page label for workspace automations",
+  },
+  automationsPageLabelProject: {
+    defaultMessage: "Project",
+    id: "ioiYh1dY+T",
+    description: "Feature teaser page label for project automations",
+  },
+  automationsTitle: {
+    defaultMessage: "Automations",
+    id: "uQuuO1WuxO",
+    description: "Feature teaser page title for automations",
+  },
+  automationsDescription: {
+    defaultMessage:
+      "Put repetitive global content work on autopilot so your team ships to more markets, faster.",
+    id: "D3q/aG4RpR",
+    description: "Feature teaser page description for workspace automations",
+  },
+  automationsDescriptionProject: {
+    defaultMessage: "Keep this project releasing on time without chasing manual handoffs.",
+    id: "99UKjV7Fo4",
+    description: "Feature teaser page description for project automations",
+  },
+  automationsEarlyAccessTitle: {
+    defaultMessage: "Ship to more markets without growing the team",
+    id: "PG2jivJB3X",
+    description: "Feature teaser early access title for automations",
+  },
+  automationsEarlyAccessDescription: {
+    defaultMessage:
+      "Automations handles repetitive steps between content, review, and release so your team can focus on quality. Available in early access. Book a demo to see it on your stack.",
+    id: "j0WZLPTpqA",
+    description: "Feature teaser early access description for automations",
+  },
+  automationsBenefit0: {
+    defaultMessage: "Cut hours lost to manual review and delivery handoffs",
+    id: "+je2CrABfF",
+    description: "Feature teaser benefit for automations",
+  },
+  automationsBenefit1: {
+    defaultMessage: "Release on schedule, even as locale count grows",
+    id: "8JgsbTFb9B",
+    description: "Feature teaser benefit for automations",
+  },
+  automationsBenefit2: {
+    defaultMessage: "Scale output without scaling headcount",
+    id: "7DcMnrFZgv",
+    description: "Feature teaser benefit for automations",
+  },
+
+  guidelinePageLabel: {
+    defaultMessage: "Workspace",
+    id: "Ez0AubJEsT",
+    description: "Feature teaser page label for workspace guideline",
+  },
+  guidelinePageLabelProject: {
+    defaultMessage: "Project",
+    id: "s0SZ6JCFMT",
+    description: "Feature teaser page label for project guideline",
+  },
+  guidelineTitle: {
+    defaultMessage: "Guideline",
+    id: "UQT1fdMFbW",
+    description: "Feature teaser page title for guideline",
+  },
+  guidelineDescription: {
+    defaultMessage:
+      "Capture style, market, and compliance guidance so teams scale into new markets with confidence.",
+    id: "4y4y0oNFFl",
+    description: "Feature teaser page description for workspace guideline",
+  },
+  guidelineDescriptionProject: {
+    defaultMessage: "Give this project the GTM context it needs to launch and grow in new markets.",
+    id: "FcomHiDTaX",
+    description: "Feature teaser page description for project guideline",
+  },
+  guidelineEarlyAccessTitle: {
+    defaultMessage: "One playbook for global growth in every market",
+    id: "ESsYtK4MNy",
+    description: "Feature teaser early access title for guideline",
+  },
+  guidelineEarlyAccessDescription: {
+    defaultMessage:
+      "Guideline stores style, market, and compliance rules in one place for teams and AI. Available in early access. Book a demo to see it in action.",
+    id: "nY6L1mpX2I",
+    description: "Feature teaser early access description for guideline",
+  },
+  guidelineBenefit0: {
+    defaultMessage: "Launch campaigns that fit each market from day one",
+    id: "yHuJniMEb/",
+    description: "Feature teaser benefit for guideline",
+  },
+  guidelineBenefit1: {
+    defaultMessage: "New regions ramp up faster with shared GTM playbooks",
+    id: "66l3idHXx9",
+    description: "Feature teaser benefit for guideline",
+  },
+  guidelineBenefit2: {
+    defaultMessage: "Decisions compound as teams learn what works in each market",
+    id: "plDoLEcfb7",
+    description: "Feature teaser benefit for guideline",
+  },
+
+  domainsPageLabel: {
+    defaultMessage: "Workspace",
+    id: "e39hEFri57",
+    description: "Feature teaser page label for domains",
+  },
+  domainsPageLabelProject: {
+    defaultMessage: "Workspace",
+    id: "0IVc9Jxawk",
+    description: "Feature teaser page label for domains (project scope unused)",
+  },
+  domainsTitle: {
+    defaultMessage: "Domains",
+    id: "hSuFqgtras",
+    description: "Feature teaser page title for domains",
+  },
+  domainsDescription: {
+    defaultMessage:
+      "Audit your websites for localisation, SEO, and AEO. See what is blocking discoverability in every market.",
+    id: "2icICV/DAq",
+    description: "Feature teaser page description for domains",
+  },
+  domainsDescriptionProject: {
+    defaultMessage:
+      "Audit your websites for localisation, SEO, and AEO. See what is blocking discoverability in every market.",
+    id: "PyZoyjoXDF",
+    description: "Feature teaser page description for domains (project scope unused)",
+  },
+  domainsEarlyAccessTitle: {
+    defaultMessage: "See what is hurting search and AI answers in every locale",
+    id: "SWDbxCkEGV",
+    description: "Feature teaser early access title for domains",
+  },
+  domainsEarlyAccessDescription: {
+    defaultMessage:
+      "Domains crawls your sites and scores localisation, SEO, and AEO readiness. Fix the highest-impact issues first. Available in early access. Book a demo to run an audit.",
+    id: "AZAD/rhnHJ",
+    description: "Feature teaser early access description for domains",
+  },
+  domainsBenefit0: {
+    defaultMessage: "Find hreflang errors, missing locales, and content gaps",
+    id: "iMzelu42WD",
+    description: "Feature teaser benefit for domains",
+  },
+  domainsBenefit1: {
+    defaultMessage: "Improve SEO and AEO discoverability across markets",
+    id: "J7hBoTRR5O",
+    description: "Feature teaser benefit for domains",
+  },
+  domainsBenefit2: {
+    defaultMessage: "Track audit scores and open issues as you expand",
+    id: "4Y5ejA62oY",
+    description: "Feature teaser benefit for domains",
+  },
+});
+
+export const featureTeaserRegistry: Record<FeatureTeaserId, FeatureTeaserConfig> = {
+  automations: {
+    icon: Task01Icon,
+    pageLabel: featureTeaserMessages.automationsPageLabel,
+    pageLabelProject: featureTeaserMessages.automationsPageLabelProject,
+    pageTitle: featureTeaserMessages.automationsTitle,
+    pageDescription: featureTeaserMessages.automationsDescription,
+    pageDescriptionProject: featureTeaserMessages.automationsDescriptionProject,
+    earlyAccessTitle: featureTeaserMessages.automationsEarlyAccessTitle,
+    earlyAccessDescription: featureTeaserMessages.automationsEarlyAccessDescription,
+    benefits: [
+      featureTeaserMessages.automationsBenefit0,
+      featureTeaserMessages.automationsBenefit1,
+      featureTeaserMessages.automationsBenefit2,
+    ],
+  },
+  guideline: {
+    icon: AiBrain01Icon,
+    pageLabel: featureTeaserMessages.guidelinePageLabel,
+    pageLabelProject: featureTeaserMessages.guidelinePageLabelProject,
+    pageTitle: featureTeaserMessages.guidelineTitle,
+    pageDescription: featureTeaserMessages.guidelineDescription,
+    pageDescriptionProject: featureTeaserMessages.guidelineDescriptionProject,
+    earlyAccessTitle: featureTeaserMessages.guidelineEarlyAccessTitle,
+    earlyAccessDescription: featureTeaserMessages.guidelineEarlyAccessDescription,
+    benefits: [
+      featureTeaserMessages.guidelineBenefit0,
+      featureTeaserMessages.guidelineBenefit1,
+      featureTeaserMessages.guidelineBenefit2,
+    ],
+  },
+  domains: {
+    icon: Globe02Icon,
+    pageLabel: featureTeaserMessages.domainsPageLabel,
+    pageLabelProject: featureTeaserMessages.domainsPageLabelProject,
+    pageTitle: featureTeaserMessages.domainsTitle,
+    pageDescription: featureTeaserMessages.domainsDescription,
+    pageDescriptionProject: featureTeaserMessages.domainsDescriptionProject,
+    earlyAccessTitle: featureTeaserMessages.domainsEarlyAccessTitle,
+    earlyAccessDescription: featureTeaserMessages.domainsEarlyAccessDescription,
+    benefits: [
+      featureTeaserMessages.domainsBenefit0,
+      featureTeaserMessages.domainsBenefit1,
+      featureTeaserMessages.domainsBenefit2,
+    ],
+  },
+};
+
+export const featureTeaserContactSubjects: Record<FeatureTeaserId, MessageDescriptor> = {
+  automations: featureTeaserMessages.contactSubjectAutomations,
+  guideline: featureTeaserMessages.contactSubjectGuideline,
+  domains: featureTeaserMessages.contactSubjectDomains,
+};

--- a/apps/hyperlocalise-web/src/components/marketing/hero-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-section.messages.ts
@@ -16,14 +16,14 @@ import { defineMessages } from "react-intl";
 
 export const heroSectionMessages = defineMessages({
   headline: {
-    defaultMessage: "The best agentic localisation platform to launch globally in days",
-    id: "31nY7d5ehk",
+    defaultMessage: "Infrastructure for multilingual content operations",
+    id: "A2kYJXCOdt",
     description: "Marketing homepage hero headline",
   },
   body: {
     defaultMessage:
-      "An AI workforce that acts like your team of local experts.<desktopOnly><lineBreak></lineBreak>It understands market nuance, then translates and transcreates.</desktopOnly>",
-    id: "3i6/WZOWss",
+      "Enter new markets, generate 10x more multilingual content with the same headcount, and keep quality as you scale.",
+    id: "Gx82rosgM3",
     description: "Marketing homepage hero supporting copy below the headline",
   },
   joinWaitlist: {

--- a/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.messages.ts
@@ -19,13 +19,13 @@ export const automationsMockMessages = defineMessages({
     description: "Automations mock UI eyebrow label",
   },
   headline: {
-    defaultMessage: "Review localisation before it merges",
-    id: "fIjUMyYSYz",
+    defaultMessage: "Automate GTM, review, and research workflows",
+    id: "EaT7nmsjT2",
     description: "Automations mock UI section heading",
   },
   botLabel: {
-    defaultMessage: "Hyperlocalise · Bot",
-    id: "eHZIquSdN0",
+    defaultMessage: "Use Hyperlocalise Agent",
+    id: "6CovsOk2Kn",
     description: "Automations mock UI terminal title bar label",
   },
   requestDemo: {
@@ -34,61 +34,66 @@ export const automationsMockMessages = defineMessages({
     description: "Automations mock UI call-to-action button",
   },
 
+  useCaseGtmPublishingTitle: {
+    defaultMessage: "GTM content publishing",
+    id: "22+D8zh5+I",
+    description: "Automations mock UI GTM content publishing use case title",
+  },
+  useCaseGtmPublishingDescription: {
+    defaultMessage: "Publish localized campaigns and landing pages across markets",
+    id: "LCZuQN14MY",
+    description: "Automations mock UI GTM content publishing use case description",
+  },
   useCaseAutoReviewTitle: {
-    defaultMessage: "Auto-review",
-    id: "9kDc2CzQHo",
-    description: "Automations mock UI Auto-review use case title",
+    defaultMessage: "Localisation review",
+    id: "cRykdemD86",
+    description: "Automations mock UI localisation review use case title",
   },
   useCaseAutoReviewDescription: {
-    defaultMessage: "Review pull requests and post one sticky comment",
-    id: "b4zb6//QSL",
-    description: "Automations mock UI Auto-review use case description",
+    defaultMessage: "Review pull requests on GitHub and post one sticky comment",
+    id: "BzZ7RfYZdI",
+    description: "Automations mock UI localisation review use case description",
   },
-  useCaseAutoTranslationTitle: {
-    defaultMessage: "Auto Translation",
-    id: "c83abCYnIc",
-    description: "Automations mock UI auto translation use case title",
+  useCaseKeywordResearchTitle: {
+    defaultMessage: "Multilingual keyword research",
+    id: "Wy1vE+UJqV",
+    description: "Automations mock UI multilingual keyword research use case title",
   },
-  useCaseAutoTranslationDescription: {
-    defaultMessage: "Detect string changes and translate automatically",
-    id: "xLIQFiGFVJ",
-    description: "Automations mock UI auto translation use case description",
-  },
-  useCaseLocalisationAuditTitle: {
-    defaultMessage: "Localisation Audit",
-    id: "to5Onmz+Xc",
-    description: "Automations mock UI use case 3 title",
-  },
-  useCaseLocalisationAuditDescription: {
-    defaultMessage: "Check hreflang, RTL support, terminology and compliance",
-    id: "gNb7LVmFTm",
-    description: "Automations mock UI use case 3 description",
+  useCaseKeywordResearchDescription: {
+    defaultMessage: "Compare search demand and content gaps across locales",
+    id: "MszSNYsOAF",
+    description: "Automations mock UI multilingual keyword research use case description",
   },
 
-  triggerSourceUpload: {
-    defaultMessage: "Source upload",
-    id: "SZbykgpUeM",
-    description: "Automations mock UI trigger label for source upload",
+  triggerGtmBriefApproved: {
+    defaultMessage: "GTM brief approved · Q2 launch",
+    id: "fq5dqebQ+i",
+    description: "Automations mock UI trigger label for GTM content publishing",
   },
   triggerGithubPullRequest: {
     defaultMessage: "GitHub pull request opened",
     id: "/6wXYQGzwZ",
     description: "Automations mock UI trigger label for a GitHub pull request opening",
   },
-  triggerGithubRelease: {
-    defaultMessage: "GitHub push · release/*",
-    id: "QgJDE+xhbx",
-    description: "Automations mock UI trigger label for GitHub push to release",
+  triggerKeywordResearchSchedule: {
+    defaultMessage: "Scheduled run · 1st of month",
+    id: "gh3szaohtI",
+    description: "Automations mock UI trigger label for keyword research schedule",
   },
 
-  toolCreateJob: {
-    defaultMessage: "Create job",
-    id: "01u9U8ASiI",
+  toolCms: {
+    defaultMessage: "CMS",
+    id: "Zxvw5o8hCN",
     description: "Automations mock UI tool label",
   },
-  toolTranslateWithAgent: {
-    defaultMessage: "Translate with agent",
-    id: "qMPafsI8mp",
+  toolSlack: {
+    defaultMessage: "Slack",
+    id: "SWV7AxBTg5",
+    description: "Automations mock UI tool label",
+  },
+  toolTranslate: {
+    defaultMessage: "Translate",
+    id: "JZdvnbrCrK",
     description: "Automations mock UI tool label",
   },
   toolGitHub: {
@@ -96,98 +101,83 @@ export const automationsMockMessages = defineMessages({
     id: "lsxAaZycti",
     description: "Automations mock UI tool label",
   },
-  toolValidation: {
-    defaultMessage: "Validation",
-    id: "qfZTKSfQgm",
-    description: "Automations mock UI tool label",
-  },
   toolMentionReview: {
     defaultMessage: "@hyperlocalise review",
     id: "mNhu5W2AEy",
     description: "Automations mock UI tool label for the mention review command",
   },
-  toolSlack: {
-    defaultMessage: "Slack",
-    id: "SWV7AxBTg5",
+  toolSearch: {
+    defaultMessage: "Search",
+    id: "Bzgz2WD+0h",
+    description: "Automations mock UI tool label",
+  },
+  toolExport: {
+    defaultMessage: "Export brief",
+    id: "9he5ArvC5a",
     description: "Automations mock UI tool label",
   },
 
-  step1Auto1: {
-    defaultMessage: "Reading uploaded source file...",
-    id: "Tpf2GEAF9w",
-    description: "Automations mock UI auto translation step 1",
+  stepGtm1: {
+    defaultMessage: "Brief received · 4 markets, 12 assets",
+    id: "O5AUx21Cqs",
+    description: "Automations mock UI GTM publishing step 1",
   },
-  step1Auto2: {
-    defaultMessage: "Source file detected · 24 strings",
-    id: "o1YK/dYPDZ",
-    description: "Automations mock UI auto translation step 2",
+  stepGtm2: {
+    defaultMessage: "Generating localized landing page drafts...",
+    id: "vRzaf+T+4c",
+    description: "Automations mock UI GTM publishing step 2",
   },
-  step1Auto3: {
-    defaultMessage: "Creating translation job for FR, DE, JA...",
-    id: "6Z1HHKVZs9",
-    description: "Automations mock UI auto translation step 3",
+  stepGtm3: {
+    defaultMessage: "FR and DE routed for review",
+    id: "CjBhJGtOu7",
+    description: "Automations mock UI GTM publishing step 3",
   },
-  step1Auto4: {
-    defaultMessage: "Translation job created",
-    id: "wsDlv0gzm0",
-    description: "Automations mock UI auto translation step 4",
-  },
-  step1Auto5: {
-    defaultMessage: "Agent assigned · translating now",
-    id: "T+F7HlwHlj",
-    description: "Automations mock UI auto translation step 5",
+  stepGtm4: {
+    defaultMessage: "Published to staging · notified #gtm",
+    id: "Rkonjwj/NH",
+    description: "Automations mock UI GTM publishing step 4",
   },
 
   stepAutoReview1: {
     defaultMessage: "Pull request opened on checkout-fr",
-    id: "3ewdsyHYyw",
-    description: "Automations mock UI Auto-review step 1",
+    id: "ILNKwHSRC9",
+    description: "Automations mock UI localisation review step 1",
   },
   stepAutoReview2: {
     defaultMessage: "Reading localisation diff...",
-    id: "31b9kvfP1i",
-    description: "Automations mock UI Auto-review step 2",
+    id: "q2LrsHfEDQ",
+    description: "Automations mock UI localisation review step 2",
   },
   stepAutoReview3: {
     defaultMessage: "Checked missing translations and placeholders",
-    id: "YBk75aHrs3",
-    description: "Automations mock UI Auto-review step 3",
+    id: "a9xpifQQ4Q",
+    description: "Automations mock UI localisation review step 3",
   },
   stepAutoReview4: {
     defaultMessage: "Posted sticky review comment",
-    id: "aGgOWl6hrF",
-    description: "Automations mock UI Auto-review step 4",
+    id: "gmpcqBlz7J",
+    description: "Automations mock UI localisation review step 4",
   },
 
-  step3Audit1: {
-    defaultMessage: "Checking locale coverage expectations...",
-    id: "y8Gkw54qZc",
-    description: "Automations mock UI localisation audit step 1",
+  stepKeyword1: {
+    defaultMessage: "Pulling search volume for core product terms",
+    id: "Ve+0mAQW0d",
+    description: "Automations mock UI keyword research step 1",
   },
-  step3Audit2: {
-    defaultMessage: "FR 100% · DE 98% · JA 87% coverage",
-    id: "/u4S4pwmIn",
-    description: "Automations mock UI localisation audit step 2",
+  stepKeyword2: {
+    defaultMessage: "EN · FR · DE · JA demand compared",
+    id: "OSUbc/2Yxx",
+    description: "Automations mock UI keyword research step 2",
   },
-  step3Audit3: {
-    defaultMessage: "Arabic (ar) RTL layout not detected",
-    id: "/CA59wrwPr",
-    description: "Automations mock UI localisation audit step 3 — warning state",
+  stepKeyword3: {
+    defaultMessage: "12 high-intent gaps found in DE",
+    id: "dpJb4JeW+k",
+    description: "Automations mock UI keyword research step 3 — highlight",
   },
-  step3Audit4: {
-    defaultMessage: "Verifying ICU syntax & placeholders...",
-    id: "JaqIVrRaDX",
-    description: "Automations mock UI localisation audit step 4",
-  },
-  step3Audit5: {
-    defaultMessage: "No placeholder regressions found",
-    id: "N3wHJrm6Ss",
-    description: "Automations mock UI localisation audit step 5",
-  },
-  step3Audit6: {
-    defaultMessage: "Audit report sent to Slack",
-    id: "GoCK8c5u+Q",
-    description: "Automations mock UI localisation audit step 6",
+  stepKeyword4: {
+    defaultMessage: "Keyword brief exported to content team",
+    id: "WM/mPEZR5D",
+    description: "Automations mock UI keyword research step 4",
   },
 });
 

--- a/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.stories.tsx
@@ -36,14 +36,30 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   play: async ({ canvas }) => {
-    await expect(canvas.getByRole("button", { name: /Auto-review/ })).toBeInTheDocument();
     await expect(
-      canvas.getByText("Review pull requests and post one sticky comment"),
+      canvas.getByRole("button", { name: /GTM content publishing/ }),
     ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /Localisation review/ })).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Review pull requests on GitHub and post one sticky comment"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Use Hyperlocalise Agent")).toBeInTheDocument();
     await expect(canvas.getByText("GitHub pull request opened")).toBeInTheDocument();
-    await expect(canvas.getByText("@hyperlocalise review")).toBeInTheDocument();
     await expect(
-      canvas.getByRole("heading", { name: "Review localisation before it merges" }),
+      canvas.getByRole("heading", { name: "Automate GTM, review, and research workflows" }),
     ).toBeInTheDocument();
+  },
+};
+
+export const Embedded: Story = {
+  render: () => (
+    <div className="mx-auto max-w-6xl p-6">
+      <AutomationsMockUI variant="embedded" />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Use Hyperlocalise Agent")).toBeInTheDocument();
+    await expect(canvas.getByText("GTM brief approved · Q2 launch")).toBeInTheDocument();
+    await expect(canvas.queryByRole("link", { name: "Request a Demo" })).not.toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.stories.tsx
@@ -44,7 +44,7 @@ export const Default: Story = {
       canvas.getByText("Review pull requests on GitHub and post one sticky comment"),
     ).toBeInTheDocument();
     await expect(canvas.getByText("Use Hyperlocalise Agent")).toBeInTheDocument();
-    await expect(canvas.getByText("GitHub pull request opened")).toBeInTheDocument();
+    await expect(canvas.getByText("GTM brief approved · Q2 launch")).toBeInTheDocument();
     await expect(
       canvas.getByRole("heading", { name: "Automate GTM, review, and research workflows" }),
     ).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.tsx
@@ -14,7 +14,7 @@
  */
 import { useEffect, useState, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { Clock01Icon, GitPullRequestIcon, Upload01Icon } from "@hugeicons/core-free-icons";
+import { Clock01Icon, GitPullRequestIcon, Rocket01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Image from "next/image";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -25,6 +25,12 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/primitives/cn";
 
 import { automationsMockMessages } from "./automations-mock-ui.messages";
+import {
+  MarketingMockShell,
+  type MarketingMockMeshPosition,
+  type MarketingMockVariant,
+} from "./marketing-mock-shell";
+import { MarketingMockUseCaseSelector } from "./marketing-mock-use-case-selector";
 
 type StepStatus = "pending" | "running" | "done" | "warning";
 
@@ -149,57 +155,14 @@ function UseCaseSelector({
   cta: ReactNode;
 }) {
   return (
-    <div className="flex h-full flex-col justify-between px-6 py-5">
-      <div>
-        <p className="mb-2 text-xs font-semibold tracking-[0.18em] text-primary uppercase">
-          <FormattedMessage {...automationsMockMessages.eyebrow} />
-        </p>
-        <h3 className="mb-6 font-heading text-xl font-semibold leading-snug tracking-normal text-foreground sm:text-2xl">
-          <FormattedMessage {...automationsMockMessages.headline} />
-        </h3>
-        <div className="flex flex-col gap-2">
-          {useCases.map((uc) => (
-            <button
-              key={uc.id}
-              onClick={() => onSelect(uc.id)}
-              className={cn(
-                "flex cursor-pointer items-start gap-3 rounded-sm border px-4 py-3.5 text-left transition-all duration-200",
-                uc.id === active
-                  ? "border-primary/30 bg-primary/6"
-                  : "border-transparent hover:border-border/60 hover:bg-muted/30",
-              )}
-            >
-              <div
-                className={cn(
-                  "mt-1 w-0.5 self-stretch rounded-full transition-all duration-200",
-                  uc.id === active ? "bg-primary" : "bg-transparent",
-                )}
-              />
-              <div className="min-w-0">
-                <p
-                  className={cn(
-                    "text-sm font-semibold leading-snug transition-colors",
-                    uc.id === active ? "text-foreground" : "text-muted-foreground",
-                  )}
-                >
-                  {uc.title}
-                </p>
-                <p
-                  className={cn(
-                    "mt-0.5 text-xs leading-relaxed transition-colors",
-                    uc.id === active ? "text-muted-foreground" : "text-muted-foreground/50",
-                  )}
-                >
-                  {uc.description}
-                </p>
-              </div>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="mt-4 flex items-center">{cta}</div>
-    </div>
+    <MarketingMockUseCaseSelector
+      eyebrow={automationsMockMessages.eyebrow}
+      headline={automationsMockMessages.headline}
+      useCases={useCases}
+      activeId={active}
+      onSelect={onSelect}
+      cta={cta}
+    />
   );
 }
 
@@ -207,15 +170,39 @@ export function AutomationsMockUI({
   priority = false,
   pauseAutoplay = false,
   renderCta,
+  variant = "full",
+  aside,
+  meshPosition = "left",
 }: {
   priority?: boolean;
   pauseAutoplay?: boolean;
   renderCta?: (useCaseId: string) => ReactNode;
+  variant?: MarketingMockVariant;
+  aside?: ReactNode;
+  meshPosition?: MarketingMockMeshPosition;
 }) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion();
 
   const useCases: UseCase[] = [
+    {
+      id: "gtm-publishing",
+      title: intl.formatMessage(automationsMockMessages.useCaseGtmPublishingTitle),
+      description: intl.formatMessage(automationsMockMessages.useCaseGtmPublishingDescription),
+      triggerIcon: <HugeiconsIcon icon={Rocket01Icon} strokeWidth={1.8} className="size-3" />,
+      triggerLabel: intl.formatMessage(automationsMockMessages.triggerGtmBriefApproved),
+      tools: [
+        intl.formatMessage(automationsMockMessages.toolCms),
+        intl.formatMessage(automationsMockMessages.toolTranslate),
+        intl.formatMessage(automationsMockMessages.toolSlack),
+      ],
+      steps: [
+        { label: intl.formatMessage(automationsMockMessages.stepGtm1) },
+        { label: intl.formatMessage(automationsMockMessages.stepGtm2) },
+        { label: intl.formatMessage(automationsMockMessages.stepGtm3) },
+        { label: intl.formatMessage(automationsMockMessages.stepGtm4) },
+      ],
+    },
     {
       id: AUTOMATIONS_MOCK_AUTO_REVIEW_ID,
       title: intl.formatMessage(automationsMockMessages.useCaseAutoReviewTitle),
@@ -234,46 +221,26 @@ export function AutomationsMockUI({
       ],
     },
     {
-      id: "auto-translation",
-      title: intl.formatMessage(automationsMockMessages.useCaseAutoTranslationTitle),
-      description: intl.formatMessage(automationsMockMessages.useCaseAutoTranslationDescription),
-      triggerIcon: <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-3" />,
-      triggerLabel: intl.formatMessage(automationsMockMessages.triggerSourceUpload),
-      tools: [
-        intl.formatMessage(automationsMockMessages.toolCreateJob),
-        intl.formatMessage(automationsMockMessages.toolTranslateWithAgent),
-      ],
-      steps: [
-        { label: intl.formatMessage(automationsMockMessages.step1Auto1) },
-        { label: intl.formatMessage(automationsMockMessages.step1Auto2) },
-        { label: intl.formatMessage(automationsMockMessages.step1Auto3) },
-        { label: intl.formatMessage(automationsMockMessages.step1Auto4) },
-        { label: intl.formatMessage(automationsMockMessages.step1Auto5) },
-      ],
-    },
-    {
-      id: "localisation-audit",
-      title: intl.formatMessage(automationsMockMessages.useCaseLocalisationAuditTitle),
-      description: intl.formatMessage(automationsMockMessages.useCaseLocalisationAuditDescription),
+      id: "keyword-research",
+      title: intl.formatMessage(automationsMockMessages.useCaseKeywordResearchTitle),
+      description: intl.formatMessage(automationsMockMessages.useCaseKeywordResearchDescription),
       triggerIcon: <HugeiconsIcon icon={Clock01Icon} strokeWidth={1.8} className="size-3" />,
-      triggerLabel: intl.formatMessage(automationsMockMessages.triggerGithubRelease),
+      triggerLabel: intl.formatMessage(automationsMockMessages.triggerKeywordResearchSchedule),
       tools: [
-        intl.formatMessage(automationsMockMessages.toolGitHub),
-        intl.formatMessage(automationsMockMessages.toolValidation),
+        intl.formatMessage(automationsMockMessages.toolSearch),
+        intl.formatMessage(automationsMockMessages.toolExport),
         intl.formatMessage(automationsMockMessages.toolSlack),
       ],
       steps: [
-        { label: intl.formatMessage(automationsMockMessages.step3Audit1) },
-        { label: intl.formatMessage(automationsMockMessages.step3Audit2) },
-        { label: intl.formatMessage(automationsMockMessages.step3Audit3) },
-        { label: intl.formatMessage(automationsMockMessages.step3Audit4) },
-        { label: intl.formatMessage(automationsMockMessages.step3Audit5) },
-        { label: intl.formatMessage(automationsMockMessages.step3Audit6) },
+        { label: intl.formatMessage(automationsMockMessages.stepKeyword1) },
+        { label: intl.formatMessage(automationsMockMessages.stepKeyword2) },
+        { label: intl.formatMessage(automationsMockMessages.stepKeyword3) },
+        { label: intl.formatMessage(automationsMockMessages.stepKeyword4) },
       ],
     },
   ];
 
-  const warningSteps = new Set([intl.formatMessage(automationsMockMessages.step3Audit3)]);
+  const highlightSteps = new Set([intl.formatMessage(automationsMockMessages.stepKeyword3)]);
 
   const [activeIndex, setActiveIndex] = useState(0);
   const [visibleStepCount, setVisibleStepCount] = useState(1);
@@ -283,13 +250,13 @@ export function AutomationsMockUI({
 
   const visibleSteps: Step[] = activeUseCase.steps.slice(0, visibleStepCount).map((step, i) => {
     const isLast = i === visibleStepCount - 1;
-    const isWarning = warningSteps.has(step.label);
+    const isHighlight = highlightSteps.has(step.label);
     return {
       ...step,
       status:
         isLast && visibleStepCount < activeUseCase.steps.length
           ? "running"
-          : isWarning
+          : isHighlight
             ? "warning"
             : "done",
     } satisfies Step;
@@ -331,38 +298,23 @@ export function AutomationsMockUI({
   }
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-gray-alpha-100">
-      <div className="grid min-h-[22rem] md:grid-cols-[1fr_1.4fr]">
-        <div className="relative min-h-[20rem] overflow-hidden border-b border-border md:min-h-0 md:border-b-0">
-          <Image
-            src={LAVENDER_MESH_GRADIENT_SRC}
-            alt=""
-            aria-hidden
-            fill
-            priority={priority}
-            sizes="(min-width: 768px) 28rem, 100vw"
-            className="pointer-events-none object-cover object-center"
-          />
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-r from-transparent to-background md:w-24"
-          />
-          <div className="relative flex h-full items-center p-5 sm:p-7 lg:p-8">
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={activeUseCase.id}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.25 }}
-                className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm"
-              >
-                <TerminalPanel useCase={activeUseCase} visibleSteps={visibleSteps} />
-              </motion.div>
-            </AnimatePresence>
-          </div>
-        </div>
-        <div className="relative bg-background">
+    <MarketingMockShell
+      visual={
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={activeUseCase.id}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+            className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm"
+          >
+            <TerminalPanel useCase={activeUseCase} visibleSteps={visibleSteps} />
+          </motion.div>
+        </AnimatePresence>
+      }
+      sidebar={
+        variant === "full" ? (
           <UseCaseSelector
             useCases={useCases}
             active={activeUseCase.id}
@@ -383,8 +335,13 @@ export function AutomationsMockUI({
               )
             }
           />
-        </div>
-      </div>
-    </div>
+        ) : undefined
+      }
+      aside={aside}
+      meshSrc={LAVENDER_MESH_GRADIENT_SRC}
+      priority={priority}
+      variant={variant}
+      meshPosition={meshPosition}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/product/domains-mock-ui.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/domains-mock-ui.messages.ts
@@ -1,0 +1,120 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainsMockMessages = defineMessages({
+  eyebrow: {
+    defaultMessage: "Domains",
+    id: "nIU9FaUviZ",
+    description: "Domains mock UI eyebrow label",
+  },
+  headline: {
+    defaultMessage: "Website audits for localisation, SEO, and AEO",
+    id: "uaV1QEic0r",
+    description: "Domains mock UI section heading",
+  },
+  requestDemo: {
+    defaultMessage: "Request a Demo",
+    id: "oOV8fKHSG2",
+    description: "Domains mock UI call-to-action button",
+  },
+
+  useCaseLocalisationTitle: {
+    defaultMessage: "Localisation audit",
+    id: "z0PDxHZG+8",
+    description: "Domains mock UI localisation audit use case title",
+  },
+  useCaseLocalisationDescription: {
+    defaultMessage: "Hreflang, locale coverage, and multilingual content quality",
+    id: "e55K7kZph5",
+    description: "Domains mock UI localisation audit use case description",
+  },
+  useCaseSeoTitle: {
+    defaultMessage: "SEO audit",
+    id: "RijTrFBl7F",
+    description: "Domains mock UI SEO audit use case title",
+  },
+  useCaseSeoDescription: {
+    defaultMessage: "Meta tags, indexability, and discoverability across markets",
+    id: "vVscXxYSjv",
+    description: "Domains mock UI SEO audit use case description",
+  },
+  useCaseAeoTitle: {
+    defaultMessage: "AEO audit",
+    id: "Gndxudt/H7",
+    description: "Domains mock UI AEO audit use case title",
+  },
+  useCaseAeoDescription: {
+    defaultMessage: "Structured answers, FAQ coverage, and AI-search readiness",
+    id: "qAnWJy2K6s",
+    description: "Domains mock UI AEO audit use case description",
+  },
+
+  auditPanelTitle: {
+    defaultMessage: "Website audit · acme.com",
+    id: "tQU5xwuRdf",
+    description: "Domains mock UI audit panel title",
+  },
+  overallScore: {
+    defaultMessage: "Overall score",
+    id: "Vz9hpPn3p2",
+    description: "Domains mock UI overall score label",
+  },
+  scoreDelta: {
+    defaultMessage: "+4 vs last run",
+    id: "71wFkHX0+3",
+    description: "Domains mock UI score delta label",
+  },
+  dimensionLocalisation: {
+    defaultMessage: "Localisation",
+    id: "1d8EA4SWUv",
+    description: "Domains mock UI audit dimension label",
+  },
+  dimensionSeo: {
+    defaultMessage: "SEO",
+    id: "qUpTrGtrVw",
+    description: "Domains mock UI audit dimension label",
+  },
+  dimensionAeo: {
+    defaultMessage: "AEO",
+    id: "tS5s/SaJpX",
+    description: "Domains mock UI audit dimension label",
+  },
+  issuesTitle: {
+    defaultMessage: "Open issues",
+    id: "9zg4WqioX3",
+    description: "Domains mock UI issues section title",
+  },
+  issueHreflang: {
+    defaultMessage: "Hreflang mismatch on /pricing (DE)",
+    id: "7Az9Ev1DYa",
+    description: "Domains mock UI sample audit issue",
+  },
+  issueMeta: {
+    defaultMessage: "Missing meta description on /features (FR)",
+    id: "MF241rY4nN",
+    description: "Domains mock UI sample audit issue",
+  },
+  issueAeo: {
+    defaultMessage: "No FAQ schema for AI answers on /help (EN)",
+    id: "QW/TjWXEZ7",
+    description: "Domains mock UI sample audit issue",
+  },
+  lastRunLabel: {
+    defaultMessage: "Last run · 2 days ago · 842 pages crawled",
+    id: "fwRsrXyIL0",
+    description: "Domains mock UI last run metadata",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/domains-mock-ui.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/domains-mock-ui.stories.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { DomainsMockUI } from "./domains-mock-ui";
+
+function DomainsMockShowcase({ variant = "full" }: { variant?: "full" | "embedded" }) {
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <DomainsMockUI variant={variant} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Marketing/Product/DomainsMock",
+  component: DomainsMockShowcase,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof DomainsMockShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("heading", { name: "Website audits for localisation, SEO, and AEO" }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Localisation audit" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "SEO audit" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "AEO audit" })).toBeInTheDocument();
+    await expect(canvas.getByText("Website audit · acme.com")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Request a Demo" })).toBeInTheDocument();
+  },
+};
+
+export const Embedded: Story = {
+  render: () => <DomainsMockShowcase variant="embedded" />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Website audit · acme.com")).toBeInTheDocument();
+    await expect(canvas.getByText("Open issues")).toBeInTheDocument();
+    await expect(canvas.queryByRole("link", { name: "Request a Demo" })).not.toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/marketing/product/domains-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/domains-mock-ui.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useMemo, useState, type ReactNode } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { SEAFOAM_MESH_GRADIENT_SRC } from "@/components/marketing/hero-frame-mesh-stage";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { domainsMockMessages } from "./domains-mock-ui.messages";
+import {
+  MarketingMockShell,
+  type MarketingMockMeshPosition,
+  type MarketingMockVariant,
+} from "./marketing-mock-shell";
+import { MarketingMockUseCaseSelector } from "./marketing-mock-use-case-selector";
+
+type AuditFocus = "localisation" | "seo" | "aeo";
+
+function DomainsAuditDashboard({ focus }: { focus: AuditFocus }) {
+  const intl = useIntl();
+
+  const dimensions = useMemo(
+    () => [
+      {
+        id: "localisation" as const,
+        label: intl.formatMessage(domainsMockMessages.dimensionLocalisation),
+        value: 64,
+        tone: "watch" as const,
+      },
+      {
+        id: "seo" as const,
+        label: intl.formatMessage(domainsMockMessages.dimensionSeo),
+        value: 78,
+        tone: "info" as const,
+      },
+      {
+        id: "aeo" as const,
+        label: intl.formatMessage(domainsMockMessages.dimensionAeo),
+        value: 71,
+        tone: "info" as const,
+      },
+    ],
+    [intl],
+  );
+
+  const issues = useMemo(
+    () => [
+      {
+        id: "localisation" as const,
+        message: intl.formatMessage(domainsMockMessages.issueHreflang),
+      },
+      {
+        id: "seo" as const,
+        message: intl.formatMessage(domainsMockMessages.issueMeta),
+      },
+      {
+        id: "aeo" as const,
+        message: intl.formatMessage(domainsMockMessages.issueAeo),
+      },
+    ],
+    [intl],
+  );
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <div>
+          <div className="text-sm font-semibold text-foreground">
+            <FormattedMessage {...domainsMockMessages.auditPanelTitle} />
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            <FormattedMessage {...domainsMockMessages.lastRunLabel} />
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[10px] font-medium tracking-wide uppercase text-muted-foreground">
+            <FormattedMessage {...domainsMockMessages.overallScore} />
+          </div>
+          <div className="font-heading text-3xl font-medium text-foreground">82</div>
+          <div className="text-xs text-muted-foreground">
+            <FormattedMessage {...domainsMockMessages.scoreDelta} />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-4 px-4 py-4">
+        <div className="space-y-3">
+          {dimensions.map((dimension) => {
+            const isFocused = dimension.id === focus;
+            return (
+              <div
+                key={dimension.id}
+                className={cn(
+                  "space-y-1.5 rounded-lg border px-3 py-2.5 transition-colors",
+                  isFocused ? "border-primary/35 bg-primary/5" : "border-transparent",
+                )}
+              >
+                <div className="flex items-center justify-between gap-3 text-xs">
+                  <span
+                    className={cn(
+                      isFocused ? "font-medium text-foreground" : "text-muted-foreground",
+                    )}
+                  >
+                    {dimension.label}
+                  </span>
+                  <span className="font-medium text-foreground">{dimension.value}</span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-border/50">
+                  <div
+                    className={cn(
+                      "h-full rounded-full transition-all duration-500",
+                      dimension.tone === "watch" && "bg-bud-500",
+                      dimension.tone === "info" && "bg-dew-500",
+                    )}
+                    style={{ width: `${dimension.value}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="border-t border-border/50 pt-3">
+          <div className="mb-2 text-xs font-semibold text-foreground">
+            <FormattedMessage {...domainsMockMessages.issuesTitle} />
+          </div>
+          <ul className="space-y-2 text-xs leading-relaxed">
+            {issues.map((issue) => (
+              <li
+                key={issue.id}
+                className={cn(
+                  "rounded-md px-2 py-1.5",
+                  issue.id === focus
+                    ? "border border-destructive/25 bg-destructive/10 text-destructive dark:border-destructive/30 dark:bg-destructive/20 dark:text-destructive"
+                    : "text-muted-foreground",
+                )}
+              >
+                {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function DomainsMockUI({
+  priority = false,
+  pauseAutoplay: _pauseAutoplay = false,
+  renderCta,
+  variant = "full",
+  aside,
+  meshPosition = "left",
+}: {
+  priority?: boolean;
+  pauseAutoplay?: boolean;
+  renderCta?: () => ReactNode;
+  variant?: MarketingMockVariant;
+  aside?: ReactNode;
+  meshPosition?: MarketingMockMeshPosition;
+}) {
+  const intl = useIntl();
+
+  const useCases = useMemo(
+    () => [
+      {
+        id: "localisation",
+        title: intl.formatMessage(domainsMockMessages.useCaseLocalisationTitle),
+        description: intl.formatMessage(domainsMockMessages.useCaseLocalisationDescription),
+      },
+      {
+        id: "seo",
+        title: intl.formatMessage(domainsMockMessages.useCaseSeoTitle),
+        description: intl.formatMessage(domainsMockMessages.useCaseSeoDescription),
+      },
+      {
+        id: "aeo",
+        title: intl.formatMessage(domainsMockMessages.useCaseAeoTitle),
+        description: intl.formatMessage(domainsMockMessages.useCaseAeoDescription),
+      },
+    ],
+    [intl],
+  );
+
+  const focusByUseCase: Record<string, AuditFocus> = {
+    localisation: "localisation",
+    seo: "seo",
+    aeo: "aeo",
+  };
+
+  const [activeId, setActiveId] = useState(useCases[0]?.id ?? "localisation");
+  const focus = focusByUseCase[activeId] ?? "localisation";
+
+  const sidebar =
+    variant === "full" ? (
+      <MarketingMockUseCaseSelector
+        eyebrow={domainsMockMessages.eyebrow}
+        headline={domainsMockMessages.headline}
+        useCases={useCases}
+        activeId={activeId}
+        onSelect={setActiveId}
+        cta={
+          renderCta === undefined ? (
+            <Button
+              variant="outline"
+              size="lg"
+              nativeButton={false}
+              render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+              className="cursor-pointer rounded-sm"
+            >
+              <FormattedMessage {...domainsMockMessages.requestDemo} />
+            </Button>
+          ) : (
+            renderCta()
+          )
+        }
+      />
+    ) : undefined;
+
+  return (
+    <MarketingMockShell
+      visual={<DomainsAuditDashboard focus={focus} />}
+      sidebar={sidebar}
+      aside={aside}
+      meshSrc={SEAFOAM_MESH_GRADIENT_SRC}
+      priority={priority}
+      variant={variant}
+      meshPosition={meshPosition}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.messages.ts
@@ -1,0 +1,252 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const guidelineMockMessages = defineMessages({
+  eyebrow: {
+    defaultMessage: "Guideline",
+    id: "9tHXDXgSnV",
+    description: "Guideline mock UI eyebrow label",
+  },
+  headline: {
+    defaultMessage: "Guidance that powers global growth in every market",
+    id: "yELbhJ7Fvl",
+    description: "Guideline mock UI section heading",
+  },
+  requestDemo: {
+    defaultMessage: "Request a Demo",
+    id: "gmm85srlvL",
+    description: "Guideline mock UI call-to-action button",
+  },
+
+  useCaseStyleGuidesTitle: {
+    defaultMessage: "Style guides",
+    id: "UEha+JRVmS",
+    description: "Guideline mock UI style guides use case title",
+  },
+  useCaseStyleGuidesDescription: {
+    defaultMessage: "Brand voice, tone, and formatting rules applied consistently",
+    id: "6T7zkHULvo",
+    description: "Guideline mock UI style guides use case description",
+  },
+  useCaseMarketKnowledgeTitle: {
+    defaultMessage: "Market knowledge",
+    id: "U2neU5uHvN",
+    description: "Guideline mock UI market knowledge use case title",
+  },
+  useCaseMarketKnowledgeDescription: {
+    defaultMessage: "Cultural context and GTM nuance for each market you enter",
+    id: "DX2PXd39k/",
+    description: "Guideline mock UI market knowledge use case description",
+  },
+  useCaseComplianceTitle: {
+    defaultMessage: "Compliance & regulatory",
+    id: "cm1Sl6tAVk",
+    description: "Guideline mock UI compliance use case title",
+  },
+  useCaseComplianceDescription: {
+    defaultMessage: "Claims, disclosures, and market-specific legal guardrails",
+    id: "PynZYcq/3Y",
+    description: "Guideline mock UI compliance use case description",
+  },
+
+  styleGuidePanelTitle: {
+    defaultMessage: "Brand voice · Style guide",
+    id: "5C0es8ldjV",
+    description: "Guideline mock UI style guide panel title",
+  },
+  styleGuidePanelSubtitle: {
+    defaultMessage: "Applied while drafting Q2 global launch campaign",
+    id: "B17gDUeMj6",
+    description: "Guideline mock UI style guide panel subtitle",
+  },
+  styleRuleTone: {
+    defaultMessage: "Tone: friendly, direct, no jargon",
+    id: "uWYTH2Am0l",
+    description: "Guideline mock UI style rule",
+  },
+  styleRuleCta: {
+    defaultMessage: "CTAs: verb-first, max 3 words",
+    id: "rO1dVLIBD9",
+    description: "Guideline mock UI style rule",
+  },
+  styleRuleTerms: {
+    defaultMessage: "Positioning: lead with outcomes, not features",
+    id: "qLRe/0Zdoa",
+    description: "Guideline mock UI style rule",
+  },
+  styleBeforeLabel: {
+    defaultMessage: "Before",
+    id: "jznR5bfb88",
+    description: "Guideline mock UI before label",
+  },
+  styleAfterLabel: {
+    defaultMessage: "After guideline",
+    id: "u2RclKmNRW",
+    description: "Guideline mock UI after label",
+  },
+  styleBeforeCopy: {
+    defaultMessage: "Sign up now for our amazing platform!",
+    id: "jqkxh1mejA",
+    description: "Guideline mock UI before copy example",
+  },
+  styleAfterCopy: {
+    defaultMessage: "Start your team in minutes. No credit card required.",
+    id: "cqUF7piMT2",
+    description: "Guideline mock UI after copy example",
+  },
+  styleBeforeCopyCta: {
+    defaultMessage: "Click here to get started with our solution today",
+    id: "LvdKgn2PqS",
+    description: "Guideline mock UI before copy for CTA rule",
+  },
+  styleAfterCopyCta: {
+    defaultMessage: "Start free trial",
+    id: "deAxZHDk25",
+    description: "Guideline mock UI after copy for CTA rule",
+  },
+  styleBeforeCopyTerms: {
+    defaultMessage: "Our platform has advanced AI-powered content tools",
+    id: "Sh8RAqFAQE",
+    description: "Guideline mock UI before copy for terms rule",
+  },
+  styleAfterCopyTerms: {
+    defaultMessage: "Go global faster with one system for content and GTM",
+    id: "UZScHD9hML",
+    description: "Guideline mock UI after copy for terms rule",
+  },
+  styleDraftPreviewLabel: {
+    defaultMessage: "Draft preview",
+    id: "FJh620HSgn",
+    description: "Guideline mock UI draft preview section label",
+  },
+  styleAppliedBadge: {
+    defaultMessage: "Guideline applied",
+    id: "ZKnAXeyV+T",
+    description: "Guideline mock UI applied badge on after copy",
+  },
+
+  marketPanelTitle: {
+    defaultMessage: "Market knowledge",
+    id: "c33GKyYAi6",
+    description: "Guideline mock UI market knowledge panel title",
+  },
+  marketPanelSubtitle: {
+    defaultMessage: "GTM context recalled for JP product launch",
+    id: "FqCBwFx5md",
+    description: "Guideline mock UI market knowledge panel subtitle",
+  },
+  marketDoLabel: {
+    defaultMessage: "Do",
+    id: "nolrv5QFV2",
+    description: "Guideline mock UI market knowledge do label",
+  },
+  marketDontLabel: {
+    defaultMessage: "Don't",
+    id: "MgrnAEA2q2",
+    description: "Guideline mock UI market knowledge don't label",
+  },
+  marketActiveLabel: {
+    defaultMessage: "Market: {market}",
+    id: "8IDMB90y6m",
+    description: "Guideline mock UI active market heading",
+  },
+  marketDeTitle: {
+    defaultMessage: "Germany",
+    id: "f3OeDvFw9c",
+    description: "Guideline mock UI market card title",
+  },
+  marketDeDo: {
+    defaultMessage: "Lead with formal Sie and detailed security proof points",
+    id: "t6HkPpZGu2",
+    description: "Guideline mock UI Germany market do guidance",
+  },
+  marketDeDont: {
+    defaultMessage: "Use casual du or hype-heavy superlatives",
+    id: "Q0vW+9N0lG",
+    description: "Guideline mock UI Germany market don't guidance",
+  },
+  marketJpTitle: {
+    defaultMessage: "Japan",
+    id: "AilK04z1F7",
+    description: "Guideline mock UI market card title",
+  },
+  marketJpDo: {
+    defaultMessage: "Lead with trust signals and social proof",
+    id: "elG2nM/iT3",
+    description: "Guideline mock UI Japan market do guidance",
+  },
+  marketJpDont: {
+    defaultMessage: "Use aggressive discount language or urgency tactics",
+    id: "XdFUMStcvy",
+    description: "Guideline mock UI Japan market don't guidance",
+  },
+  marketBrTitle: {
+    defaultMessage: "Brazil",
+    id: "40ZOWpo+3r",
+    description: "Guideline mock UI market card title",
+  },
+  marketBrDo: {
+    defaultMessage: "Highlight local payment methods and regional customer logos",
+    id: "ApClKhi42J",
+    description: "Guideline mock UI Brazil market do guidance",
+  },
+  marketBrDont: {
+    defaultMessage: "Reuse the US homepage hero without local proof points",
+    id: "pDmu9CvY1J",
+    description: "Guideline mock UI Brazil market don't guidance",
+  },
+
+  complianceProgressLabel: {
+    defaultMessage: "Pre-publish checks",
+    id: "IFi2sEaC0J",
+    description: "Guideline mock UI compliance progress label",
+  },
+  compliancePanelTitle: {
+    defaultMessage: "Compliance & regulatory",
+    id: "RAs/HG4kYE",
+    description: "Guideline mock UI compliance panel title",
+  },
+  compliancePanelSubtitle: {
+    defaultMessage: "Checked before global campaign goes live",
+    id: "rLDtsiqRXk",
+    description: "Guideline mock UI compliance panel subtitle",
+  },
+  complianceItemGdpr: {
+    defaultMessage: "GDPR marketing claims reviewed",
+    id: "xJ1r4T0Bx9",
+    description: "Guideline mock UI compliance checklist item",
+  },
+  complianceItemAi: {
+    defaultMessage: "EU AI Act disclosure present on AI features page",
+    id: "tQqO272GR5",
+    description: "Guideline mock UI compliance checklist item",
+  },
+  complianceItemHealth: {
+    defaultMessage: "Health claims match approved regulatory wording",
+    id: "xDMwfqrOb5",
+    description: "Guideline mock UI compliance checklist item",
+  },
+  complianceBlockedLabel: {
+    defaultMessage: "Blocked until resolved",
+    id: "MyG7pe2tfV",
+    description: "Guideline mock UI compliance blocked label",
+  },
+  complianceReadyLabel: {
+    defaultMessage: "Ready to publish",
+    id: "nmng5/nBX4",
+    description: "Guideline mock UI compliance ready label",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.stories.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { GuidelineMockUI } from "./guideline-mock-ui";
+
+function GuidelineMockShowcase({ variant = "full" }: { variant?: "full" | "embedded" }) {
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <GuidelineMockUI variant={variant} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Marketing/Product/GuidelineMock",
+  component: GuidelineMockShowcase,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof GuidelineMockShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("heading", { name: "Guidance that powers global growth in every market" }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Market knowledge" })).toBeInTheDocument();
+    await expect(canvas.getByText("Market: Germany")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Request a Demo" })).toBeInTheDocument();
+    await expect(canvas.getByText("Do")).toBeInTheDocument();
+    await expect(canvas.getByText("Don't")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Lead with formal Sie and detailed security proof points"),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Embedded: Story = {
+  render: () => <GuidelineMockShowcase variant="embedded" />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Market knowledge")).toBeInTheDocument();
+    await expect(canvas.getByText("Market: Germany")).toBeInTheDocument();
+    await expect(canvas.queryByRole("link", { name: "Request a Demo" })).not.toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.tsx
@@ -1,0 +1,513 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { SAGE_MESH_GRADIENT_SRC } from "@/components/marketing/hero-frame-mesh-stage";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { guidelineMockMessages } from "./guideline-mock-ui.messages";
+import {
+  MarketingMockShell,
+  type MarketingMockMeshPosition,
+  type MarketingMockVariant,
+} from "./marketing-mock-shell";
+import { MarketingMockUseCaseSelector } from "./marketing-mock-use-case-selector";
+
+const RULE_CYCLE_MS = 2200;
+const MARKET_CYCLE_MS = 2600;
+const SCENE_HOLD_MS = 3200;
+
+type SceneId = "style-guides" | "market-knowledge" | "compliance";
+
+function StyleGuidePanel({ activeRuleIndex }: { activeRuleIndex: number }) {
+  const intl = useIntl();
+  const rules = useMemo(
+    () => [
+      {
+        label: intl.formatMessage(guidelineMockMessages.styleRuleTone),
+        before: intl.formatMessage(guidelineMockMessages.styleBeforeCopy),
+        after: intl.formatMessage(guidelineMockMessages.styleAfterCopy),
+      },
+      {
+        label: intl.formatMessage(guidelineMockMessages.styleRuleCta),
+        before: intl.formatMessage(guidelineMockMessages.styleBeforeCopyCta),
+        after: intl.formatMessage(guidelineMockMessages.styleAfterCopyCta),
+      },
+      {
+        label: intl.formatMessage(guidelineMockMessages.styleRuleTerms),
+        before: intl.formatMessage(guidelineMockMessages.styleBeforeCopyTerms),
+        after: intl.formatMessage(guidelineMockMessages.styleAfterCopyTerms),
+      },
+    ],
+    [intl],
+  );
+
+  const activeRule = rules[activeRuleIndex] ?? rules[0]!;
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="border-b border-border/50 px-4 py-3">
+        <div className="text-sm font-semibold text-foreground">
+          <FormattedMessage {...guidelineMockMessages.styleGuidePanelTitle} />
+        </div>
+        <div className="text-xs text-muted-foreground">
+          <FormattedMessage {...guidelineMockMessages.styleGuidePanelSubtitle} />
+        </div>
+      </div>
+
+      <div className="space-y-4 p-4">
+        <div className="flex flex-wrap gap-2">
+          {rules.map((rule, index) => (
+            <motion.span
+              key={rule.label}
+              layout
+              animate={{
+                scale: index === activeRuleIndex ? 1 : 0.98,
+                opacity: index === activeRuleIndex ? 1 : 0.55,
+              }}
+              transition={{ type: "spring", stiffness: 320, damping: 28 }}
+              className={cn(
+                "rounded-full border px-3 py-1 text-[11px] leading-relaxed",
+                index === activeRuleIndex
+                  ? "border-primary/40 bg-primary/10 font-medium text-foreground"
+                  : "border-border/70 bg-background text-muted-foreground",
+              )}
+            >
+              {rule.label}
+            </motion.span>
+          ))}
+        </div>
+
+        <div className="rounded-xl border border-border/60 bg-muted/20 p-4">
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <span className="text-[10px] font-semibold tracking-wide uppercase text-muted-foreground">
+              <FormattedMessage {...guidelineMockMessages.styleDraftPreviewLabel} />
+            </span>
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+              <FormattedMessage {...guidelineMockMessages.styleAppliedBadge} />
+            </span>
+          </div>
+
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={activeRuleIndex}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              transition={{ duration: 0.24 }}
+              className="space-y-3"
+            >
+              <div className="rounded-lg border border-border/50 bg-background/70 px-3 py-2.5">
+                <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <FormattedMessage {...guidelineMockMessages.styleBeforeLabel} />
+                </div>
+                <p className="text-sm leading-relaxed text-muted-foreground">{activeRule.before}</p>
+              </div>
+
+              <div className="flex justify-center">
+                <span className="text-muted-foreground/60" aria-hidden>
+                  ↓
+                </span>
+              </div>
+
+              <div className="rounded-lg border border-primary/25 bg-primary/5 px-3 py-2.5">
+                <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-primary/80">
+                  <FormattedMessage {...guidelineMockMessages.styleAfterLabel} />
+                </div>
+                <p className="text-sm font-medium leading-relaxed text-foreground">
+                  {activeRule.after}
+                </p>
+              </div>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MarketKnowledgePanel({ activeMarketIndex }: { activeMarketIndex: number }) {
+  const intl = useIntl();
+  const markets = useMemo(
+    () => [
+      {
+        title: intl.formatMessage(guidelineMockMessages.marketDeTitle),
+        do: intl.formatMessage(guidelineMockMessages.marketDeDo),
+        dont: intl.formatMessage(guidelineMockMessages.marketDeDont),
+        flag: "DE",
+      },
+      {
+        title: intl.formatMessage(guidelineMockMessages.marketJpTitle),
+        do: intl.formatMessage(guidelineMockMessages.marketJpDo),
+        dont: intl.formatMessage(guidelineMockMessages.marketJpDont),
+        flag: "JP",
+      },
+      {
+        title: intl.formatMessage(guidelineMockMessages.marketBrTitle),
+        do: intl.formatMessage(guidelineMockMessages.marketBrDo),
+        dont: intl.formatMessage(guidelineMockMessages.marketBrDont),
+        flag: "BR",
+      },
+    ],
+    [intl],
+  );
+
+  const activeMarket = markets[activeMarketIndex] ?? markets[0]!;
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="border-b border-border/50 px-4 py-3">
+        <div className="text-sm font-semibold text-foreground">
+          <FormattedMessage {...guidelineMockMessages.marketPanelTitle} />
+        </div>
+        <div className="text-xs text-muted-foreground">
+          <FormattedMessage {...guidelineMockMessages.marketPanelSubtitle} />
+        </div>
+      </div>
+
+      <div className="space-y-4 p-4">
+        <div className="flex gap-2">
+          {markets.map((market, index) => (
+            <div
+              key={market.flag}
+              className={cn(
+                "flex-1 rounded-lg border px-3 py-2 text-center transition-colors",
+                index === activeMarketIndex
+                  ? "border-primary/40 bg-primary/10"
+                  : "border-border/60 bg-background/80 opacity-60",
+              )}
+            >
+              <div className="text-xs font-medium text-foreground">{market.flag}</div>
+              <div className="mt-0.5 truncate text-[10px] text-muted-foreground">
+                {market.title}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={activeMarket.flag}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.28 }}
+            className="space-y-3"
+          >
+            <div className="text-sm font-semibold text-foreground">
+              <FormattedMessage
+                {...guidelineMockMessages.marketActiveLabel}
+                values={{ market: activeMarket.title }}
+              />
+            </div>
+
+            <div className="rounded-lg border border-grove-500/35 bg-grove-100 px-3 py-2.5 dark:border-grove-300/20 dark:bg-grove-300/10">
+              <div className="mb-1 text-[10px] font-semibold tracking-wide uppercase text-grove-900 dark:text-grove-300">
+                <FormattedMessage {...guidelineMockMessages.marketDoLabel} />
+              </div>
+              <p className="text-sm leading-relaxed text-grove-900 dark:text-grove-300">
+                {activeMarket.do}
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2.5 dark:border-destructive/30 dark:bg-destructive/20">
+              <div className="mb-1 text-[10px] font-semibold tracking-wide uppercase text-destructive">
+                <FormattedMessage {...guidelineMockMessages.marketDontLabel} />
+              </div>
+              <p className="text-sm leading-relaxed text-destructive">{activeMarket.dont}</p>
+            </div>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+function CompliancePanel({ checkedCount }: { checkedCount: number }) {
+  const intl = useIntl();
+  const items = useMemo(
+    () => [
+      intl.formatMessage(guidelineMockMessages.complianceItemGdpr),
+      intl.formatMessage(guidelineMockMessages.complianceItemAi),
+      intl.formatMessage(guidelineMockMessages.complianceItemHealth),
+    ],
+    [intl],
+  );
+
+  const progress = checkedCount / items.length;
+  const isReady = checkedCount >= items.length;
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="flex items-start justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <div>
+          <div className="text-sm font-semibold text-foreground">
+            <FormattedMessage {...guidelineMockMessages.compliancePanelTitle} />
+          </div>
+          <div className="text-xs text-muted-foreground">
+            <FormattedMessage {...guidelineMockMessages.compliancePanelSubtitle} />
+          </div>
+        </div>
+        {isReady ? (
+          <span className="rounded-full bg-grove-100 px-2.5 py-1 text-[10px] font-medium text-grove-900">
+            <FormattedMessage {...guidelineMockMessages.complianceReadyLabel} />
+          </span>
+        ) : (
+          <span className="rounded-full border border-destructive/25 bg-destructive/10 px-2.5 py-1 text-[10px] font-medium text-destructive dark:border-destructive/30 dark:bg-destructive/20">
+            <FormattedMessage {...guidelineMockMessages.complianceBlockedLabel} />
+          </span>
+        )}
+      </div>
+
+      <div className="space-y-4 px-4 py-4">
+        <div>
+          <div className="mb-2 flex items-center justify-between text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            <span>
+              <FormattedMessage {...guidelineMockMessages.complianceProgressLabel} />
+            </span>
+            <span>
+              {checkedCount}/{items.length}
+            </span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-border/50">
+            <motion.div
+              className="h-full rounded-full bg-primary/70"
+              initial={false}
+              animate={{ width: `${progress * 100}%` }}
+              transition={{ duration: 0.35, ease: "easeOut" }}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {items.map((item, index) => {
+            const isChecked = index < checkedCount;
+            const isPending = index === checkedCount;
+            return (
+              <motion.div
+                key={item}
+                initial={false}
+                animate={{ opacity: isChecked || isPending ? 1 : 0.45 }}
+                className={cn(
+                  "flex items-start gap-3 rounded-lg border px-3 py-2.5",
+                  isPending
+                    ? "border-primary/30 bg-primary/5"
+                    : isChecked
+                      ? "border-border/40 bg-background"
+                      : "border-transparent bg-muted/20",
+                )}
+              >
+                <span
+                  className={cn(
+                    "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full text-[10px]",
+                    isChecked
+                      ? "bg-grove-300 text-grove-900"
+                      : isPending
+                        ? "border border-primary/50 text-primary"
+                        : "border border-border/60",
+                  )}
+                >
+                  {isChecked ? "✓" : isPending ? "…" : ""}
+                </span>
+                <span
+                  className={cn(
+                    "text-xs leading-relaxed",
+                    isChecked || isPending ? "text-foreground/90" : "text-muted-foreground",
+                  )}
+                >
+                  {item}
+                </span>
+              </motion.div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function GuidelineMockUI({
+  priority = false,
+  pauseAutoplay = false,
+  renderCta,
+  variant = "full",
+  aside,
+  meshPosition = "left",
+}: {
+  priority?: boolean;
+  pauseAutoplay?: boolean;
+  renderCta?: () => ReactNode;
+  variant?: MarketingMockVariant;
+  aside?: ReactNode;
+  meshPosition?: MarketingMockMeshPosition;
+}) {
+  const intl = useIntl();
+  const shouldReduceMotion = useReducedMotion();
+
+  const useCases = useMemo(
+    () => [
+      {
+        id: "market-knowledge",
+        title: intl.formatMessage(guidelineMockMessages.useCaseMarketKnowledgeTitle),
+        description: intl.formatMessage(guidelineMockMessages.useCaseMarketKnowledgeDescription),
+      },
+      {
+        id: "style-guides",
+        title: intl.formatMessage(guidelineMockMessages.useCaseStyleGuidesTitle),
+        description: intl.formatMessage(guidelineMockMessages.useCaseStyleGuidesDescription),
+      },
+      {
+        id: "compliance-regulatory",
+        title: intl.formatMessage(guidelineMockMessages.useCaseComplianceTitle),
+        description: intl.formatMessage(guidelineMockMessages.useCaseComplianceDescription),
+      },
+    ],
+    [intl],
+  );
+
+  const sceneByUseCase: Record<string, SceneId> = {
+    "market-knowledge": "market-knowledge",
+    "style-guides": "style-guides",
+    "compliance-regulatory": "compliance",
+  };
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeRuleIndex, setActiveRuleIndex] = useState(0);
+  const [activeMarketIndex, setActiveMarketIndex] = useState(0);
+  const [checkedCount, setCheckedCount] = useState(1);
+  const [isPaused, setIsPaused] = useState(false);
+
+  const activeUseCase = useCases[activeIndex]!;
+  const activeScene = sceneByUseCase[activeUseCase.id] ?? "market-knowledge";
+
+  useEffect(() => {
+    if (isPaused || pauseAutoplay || shouldReduceMotion) {
+      return;
+    }
+
+    if (activeScene === "style-guides") {
+      const timer = setTimeout(() => setActiveRuleIndex((value) => (value + 1) % 3), RULE_CYCLE_MS);
+      return () => clearTimeout(timer);
+    }
+
+    if (activeScene === "market-knowledge") {
+      const timer = setTimeout(
+        () => setActiveMarketIndex((value) => (value + 1) % 3),
+        MARKET_CYCLE_MS,
+      );
+      return () => clearTimeout(timer);
+    }
+
+    if (activeScene === "compliance" && checkedCount < 3) {
+      const timer = setTimeout(() => setCheckedCount((value) => value + 1), RULE_CYCLE_MS);
+      return () => clearTimeout(timer);
+    }
+
+    const timer = setTimeout(() => {
+      setActiveIndex((index) => (index + 1) % useCases.length);
+      setActiveRuleIndex(0);
+      setActiveMarketIndex(0);
+      setCheckedCount(1);
+    }, SCENE_HOLD_MS);
+
+    return () => clearTimeout(timer);
+  }, [
+    activeScene,
+    activeRuleIndex,
+    activeMarketIndex,
+    checkedCount,
+    isPaused,
+    pauseAutoplay,
+    shouldReduceMotion,
+    useCases.length,
+  ]);
+
+  function handleSelect(id: string) {
+    const index = useCases.findIndex((useCase) => useCase.id === id);
+    if (index === -1) {
+      return;
+    }
+
+    setIsPaused(true);
+    setActiveIndex(index);
+    setActiveRuleIndex(0);
+    setActiveMarketIndex(0);
+    setCheckedCount(1);
+    setTimeout(() => setIsPaused(false), 500);
+  }
+
+  const visual = (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={activeUseCase.id}
+        initial={{ opacity: 0, x: -12 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: 12 }}
+        transition={{ duration: 0.32, ease: [0.19, 1, 0.22, 1] }}
+        className="w-full"
+      >
+        {activeScene === "style-guides" ? (
+          <StyleGuidePanel activeRuleIndex={activeRuleIndex} />
+        ) : null}
+        {activeScene === "market-knowledge" ? (
+          <MarketKnowledgePanel activeMarketIndex={activeMarketIndex} />
+        ) : null}
+        {activeScene === "compliance" ? <CompliancePanel checkedCount={checkedCount} /> : null}
+      </motion.div>
+    </AnimatePresence>
+  );
+
+  const sidebar =
+    variant === "full" ? (
+      <MarketingMockUseCaseSelector
+        eyebrow={guidelineMockMessages.eyebrow}
+        headline={guidelineMockMessages.headline}
+        useCases={useCases}
+        activeId={activeUseCase.id}
+        onSelect={handleSelect}
+        cta={
+          renderCta === undefined ? (
+            <Button
+              variant="outline"
+              size="lg"
+              nativeButton={false}
+              render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+              className="cursor-pointer rounded-sm"
+            >
+              <FormattedMessage {...guidelineMockMessages.requestDemo} />
+            </Button>
+          ) : (
+            renderCta()
+          )
+        }
+      />
+    ) : undefined;
+
+  return (
+    <MarketingMockShell
+      visual={visual}
+      sidebar={sidebar}
+      aside={aside}
+      meshSrc={SAGE_MESH_GRADIENT_SRC}
+      priority={priority}
+      variant={variant}
+      meshPosition={meshPosition}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.tsx
@@ -32,6 +32,9 @@ import { MarketingMockUseCaseSelector } from "./marketing-mock-use-case-selector
 const RULE_CYCLE_MS = 2200;
 const MARKET_CYCLE_MS = 2600;
 const SCENE_HOLD_MS = 3200;
+const STYLE_RULE_COUNT = 3;
+const MARKET_COUNT = 3;
+const COMPLIANCE_ITEM_COUNT = 3;
 
 type SceneId = "style-guides" | "market-knowledge" | "compliance";
 
@@ -401,20 +404,17 @@ export function GuidelineMockUI({
       return;
     }
 
-    if (activeScene === "style-guides") {
-      const timer = setTimeout(() => setActiveRuleIndex((value) => (value + 1) % 3), RULE_CYCLE_MS);
+    if (activeScene === "style-guides" && activeRuleIndex < STYLE_RULE_COUNT - 1) {
+      const timer = setTimeout(() => setActiveRuleIndex((value) => value + 1), RULE_CYCLE_MS);
       return () => clearTimeout(timer);
     }
 
-    if (activeScene === "market-knowledge") {
-      const timer = setTimeout(
-        () => setActiveMarketIndex((value) => (value + 1) % 3),
-        MARKET_CYCLE_MS,
-      );
+    if (activeScene === "market-knowledge" && activeMarketIndex < MARKET_COUNT - 1) {
+      const timer = setTimeout(() => setActiveMarketIndex((value) => value + 1), MARKET_CYCLE_MS);
       return () => clearTimeout(timer);
     }
 
-    if (activeScene === "compliance" && checkedCount < 3) {
+    if (activeScene === "compliance" && checkedCount < COMPLIANCE_ITEM_COUNT) {
       const timer = setTimeout(() => setCheckedCount((value) => value + 1), RULE_CYCLE_MS);
       return () => clearTimeout(timer);
     }

--- a/apps/hyperlocalise-web/src/components/marketing/product/marketing-mock-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/marketing-mock-shell.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import Image from "next/image";
+
+import { cn } from "@/lib/primitives/cn";
+
+export type MarketingMockVariant = "full" | "embedded";
+export type MarketingMockMeshPosition = "left" | "right";
+
+export function MarketingMockShell({
+  visual,
+  sidebar,
+  aside,
+  meshSrc,
+  priority = false,
+  variant = "full",
+  meshPosition = "left",
+  className,
+}: {
+  visual: ReactNode;
+  sidebar?: ReactNode;
+  aside?: ReactNode;
+  meshSrc: string;
+  priority?: boolean;
+  variant?: MarketingMockVariant;
+  meshPosition?: MarketingMockMeshPosition;
+  className?: string;
+}) {
+  const showSidebar = variant === "full" && sidebar && !aside;
+  const showAside = Boolean(aside);
+  const isSplit = showSidebar || showAside;
+  const meshOnRight = meshPosition === "right";
+
+  const meshPanel = (
+    <div
+      className={cn(
+        "relative min-h-[20rem] overflow-hidden",
+        isSplit ? "border-b border-border md:min-h-[24rem] md:border-b-0" : "min-h-[22rem]",
+        meshOnRight && isSplit && "md:border-l md:border-border",
+      )}
+    >
+      <Image
+        src={meshSrc}
+        alt=""
+        aria-hidden
+        fill
+        priority={priority}
+        sizes={isSplit ? "(min-width: 768px) 36rem, 100vw" : "100vw"}
+        className="pointer-events-none object-cover object-center"
+      />
+      {isSplit ? (
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-y-0 bg-gradient-to-r from-transparent to-background",
+            meshOnRight ? "left-0 w-16 md:w-24" : "right-0 w-16 md:w-24",
+          )}
+        />
+      ) : null}
+      <div className="relative flex h-full items-center p-5 sm:p-7 lg:p-8">{visual}</div>
+    </div>
+  );
+
+  const secondaryPanel = showAside ? (
+    <div className="relative flex flex-col justify-center bg-background p-6 sm:p-8 lg:p-10">
+      {aside}
+    </div>
+  ) : showSidebar ? (
+    <div className="relative bg-background">{sidebar}</div>
+  ) : null;
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-gray-alpha-100",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "grid min-h-[22rem]",
+          isSplit
+            ? showAside
+              ? "md:grid-cols-[0.95fr_1.35fr]"
+              : "md:grid-cols-[1fr_1.4fr]"
+            : "grid-cols-1",
+        )}
+      >
+        {meshOnRight ? (
+          <>
+            {secondaryPanel}
+            {meshPanel}
+          </>
+        ) : (
+          <>
+            {meshPanel}
+            {secondaryPanel}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/marketing-mock-use-case-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/marketing-mock-use-case-selector.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { FormattedMessage, type MessageDescriptor } from "react-intl";
+
+import { cn } from "@/lib/primitives/cn";
+
+export type MarketingMockUseCase = {
+  id: string;
+  title: string;
+  description: string;
+};
+
+export function MarketingMockUseCaseSelector({
+  eyebrow,
+  headline,
+  useCases,
+  activeId,
+  onSelect,
+  cta,
+}: {
+  eyebrow: MessageDescriptor;
+  headline: MessageDescriptor;
+  useCases: readonly MarketingMockUseCase[];
+  activeId: string;
+  onSelect: (id: string) => void;
+  cta?: ReactNode;
+}) {
+  return (
+    <div className="flex h-full flex-col justify-between px-6 py-5">
+      <div>
+        <p className="mb-2 text-xs font-semibold tracking-[0.18em] text-primary uppercase">
+          <FormattedMessage {...eyebrow} />
+        </p>
+        <h3 className="mb-6 font-heading text-xl leading-snug font-semibold tracking-normal text-foreground sm:text-2xl">
+          <FormattedMessage {...headline} />
+        </h3>
+        <div className="flex flex-col gap-2">
+          {useCases.map((useCase) => (
+            <button
+              key={useCase.id}
+              type="button"
+              onClick={() => onSelect(useCase.id)}
+              className={cn(
+                "flex cursor-pointer items-start gap-3 rounded-sm border px-4 py-3.5 text-left transition-all duration-200",
+                useCase.id === activeId
+                  ? "border-primary/30 bg-primary/6"
+                  : "border-transparent hover:border-border/60 hover:bg-muted/30",
+              )}
+            >
+              <div
+                className={cn(
+                  "mt-1 w-0.5 self-stretch rounded-full transition-all duration-200",
+                  useCase.id === activeId ? "bg-primary" : "bg-transparent",
+                )}
+              />
+              <div className="min-w-0">
+                <p
+                  className={cn(
+                    "text-sm leading-snug font-semibold transition-colors",
+                    useCase.id === activeId ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  {useCase.title}
+                </p>
+                <p
+                  className={cn(
+                    "mt-0.5 text-xs leading-relaxed transition-colors",
+                    useCase.id === activeId ? "text-muted-foreground" : "text-muted-foreground/50",
+                  )}
+                >
+                  {useCase.description}
+                </p>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {cta ? <div className="mt-4 flex items-center">{cta}</div> : null}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
@@ -22,12 +22,12 @@ import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/primitives/cn";
 import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
 import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
 
 import type { ProductPageContent } from "./product-page-content";
 import { AutomationsMockUI } from "./automations-mock-ui";
+import { GuidelineMockUI } from "./guideline-mock-ui";
 import { productPageMessages, type ProductMessageKey } from "./product-page-content.messages";
 import { AutomationEditorMock } from "./automation-editor-mock";
 import { IntegrationStripSection } from "./integration-strip-section";
@@ -87,66 +87,6 @@ function ProductHero({ content }: ProductPageProps) {
   );
 }
 
-function KnowledgePrimaryVisual() {
-  const nodes: ProductMessageKey[] = [
-    "visualKnowledgeNodeProductDocs",
-    "visualKnowledgeNodeGlossary",
-    "visualKnowledgeNodeTranslations",
-    "visualKnowledgeNodeReviewers",
-    "visualKnowledgeNodeMarkets",
-    "visualKnowledgeNodeAgents",
-  ];
-
-  return (
-    <div className="h-full rounded-lg border border-border bg-card p-5 shadow-2xl shadow-gray-alpha-100">
-      <div className="mb-6 flex items-center justify-between border-b border-border pb-4">
-        <div>
-          <div className="text-sm font-semibold">
-            <ProductMessage messageKey="visualKnowledgeMemoryLayerTitle" />
-          </div>
-          <div className="text-xs text-muted-foreground">
-            <ProductMessage messageKey="visualKnowledgeSignalsCaptured" />
-          </div>
-        </div>
-        <div className="rounded-full bg-secondary/25 px-3 py-1 text-xs font-medium">
-          <ProductMessage messageKey="visualKnowledgeStatusLearning" />
-        </div>
-      </div>
-      <div className="grid min-h-[20rem] gap-3 sm:grid-cols-3">
-        {nodes.map((nodeKey, index) => (
-          <div
-            key={nodeKey}
-            className={cn(
-              "rounded-lg border p-4",
-              index === 2 ? "border-primary/35 bg-primary/10" : "border-border bg-background",
-            )}
-          >
-            <div className="mb-8 size-2 rounded-full bg-primary" />
-            <div className="text-sm font-semibold">
-              <ProductMessage messageKey={nodeKey} />
-            </div>
-            <div className="mt-1 text-xs text-muted-foreground">
-              {index === 2 ? (
-                <ProductMessage messageKey="visualKnowledgeApprovedSourceOfTruth" />
-              ) : (
-                <ProductMessage messageKey="visualKnowledgeContextSignal" />
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-      <div className="mt-4 rounded-lg border border-border bg-muted/25 p-4">
-        <div className="text-xs font-semibold text-muted-foreground uppercase">
-          <ProductMessage messageKey="visualKnowledgeLatestDecision" />
-        </div>
-        <div className="mt-2 text-sm">
-          <ProductMessage messageKey="visualKnowledgeLatestDecisionBody" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function ProductShowcase({ content }: ProductPageProps) {
   if (content.visualKind === "cat") {
     return <HeroFrameMeshStage priority />;
@@ -161,16 +101,8 @@ function ProductShowcase({ content }: ProductPageProps) {
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-10">
-      <div className="relative">
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-x-[8%] -top-8 -bottom-10 rounded-lg bg-[radial-gradient(circle_at_top,rgba(96,116,9,0.16),transparent_58%),radial-gradient(circle_at_bottom_right,rgba(9,108,229,0.1),transparent_46%)] blur-3xl"
-        />
-        <div className="relative grid overflow-hidden rounded-lg border border-border bg-background p-2 shadow-2xl shadow-gray-alpha-100 sm:p-3">
-          <KnowledgePrimaryVisual />
-        </div>
-      </div>
+    <div className="mx-auto max-w-6xl">
+      <GuidelineMockUI priority />
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -19,7 +19,10 @@ import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
-import { filterNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
+import {
+  filterNavigationByWorkspaceFlags,
+  annotateNavigationByWorkspaceFlags,
+} from "@/lib/flags/workspace-flag-navigation";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 
 const isEnabled = vi.fn();
@@ -149,6 +152,50 @@ describe("workosAdapter", () => {
 });
 
 const intl = getIntlShape("en") as IntlShape;
+
+describe("annotateNavigationByWorkspaceFlags", () => {
+  it("marks Automations, Guideline, and Domains as preview when workspace flags are disabled", () => {
+    const groups = buildGlobalNavigationGroups("acme", intl);
+    const annotated = annotateNavigationByWorkspaceFlags(groups, {
+      automations: false,
+      knowledge: false,
+      visualMock: false,
+      domains: false,
+      glossarySearch: false,
+    });
+
+    const automationsItem = annotated
+      .flatMap((group) => group.items)
+      .find((item) => item.label === "Automations");
+    const guidelineItem = annotated
+      .flatMap((group) => group.items)
+      .find((item) => item.label === "Guideline");
+    const domainsItem = annotated
+      .flatMap((group) => group.items)
+      .find((item) => item.label === "Domains");
+
+    expect(automationsItem?.preview).toBe(true);
+    expect(guidelineItem?.preview).toBe(true);
+    expect(domainsItem?.preview).toBe(true);
+  });
+
+  it("clears preview badges when workspace flags are enabled", () => {
+    const groups = buildGlobalNavigationGroups("acme", intl);
+    const annotated = annotateNavigationByWorkspaceFlags(groups, {
+      automations: true,
+      knowledge: true,
+      visualMock: true,
+      domains: true,
+      glossarySearch: true,
+    });
+
+    const flaggedItems = annotated
+      .flatMap((group) => group.items)
+      .filter((item) => item.featureFlagKey);
+
+    expect(flaggedItems.every((item) => item.preview !== true)).toBe(true);
+  });
+});
 
 describe("filterNavigationByWorkspaceFlags", () => {
   it("removes Automations, Guideline, and Domains when workspace flags are disabled", () => {

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
@@ -31,29 +31,62 @@ function workspaceFlagEnabledByKey(flags: WorkspaceFeatureFlagState): Record<str
   };
 }
 
-function isNavigationItemEnabledByWorkspaceFlags(
-  item: Pick<NavigationItem, "featureFlagKey">,
+function annotateNavigationItemWithWorkspaceFlags(
+  item: NavigationItem,
   enabledByKey: Record<string, boolean>,
-) {
-  if (!item.featureFlagKey) {
-    return true;
+): NavigationItem {
+  if (!item.featureFlagKey || !(item.featureFlagKey in enabledByKey)) {
+    return item;
   }
 
-  if (!(item.featureFlagKey in enabledByKey)) {
-    return true;
+  const enabled = enabledByKey[item.featureFlagKey] ?? false;
+  if (enabled) {
+    return { ...item, preview: false };
   }
 
-  return enabledByKey[item.featureFlagKey] ?? false;
+  return { ...item, preview: true };
 }
 
+export function annotateNavigationItemsWithWorkspaceFlags(
+  items: readonly NavigationItem[],
+  flags: WorkspaceFeatureFlagState,
+): readonly NavigationItem[] {
+  const enabledByKey = workspaceFlagEnabledByKey(flags);
+  return items.map((item) => annotateNavigationItemWithWorkspaceFlags(item, enabledByKey));
+}
+
+export function annotateNavigationByWorkspaceFlags(
+  groups: readonly NavigationGroup[],
+  flags: WorkspaceFeatureFlagState,
+): readonly NavigationGroup[] {
+  const enabledByKey = workspaceFlagEnabledByKey(flags);
+
+  return groups.map((group) => ({
+    ...group,
+    items: group.items.map((item) => annotateNavigationItemWithWorkspaceFlags(item, enabledByKey)),
+  }));
+}
+
+/** @deprecated Use annotateNavigationItemsWithWorkspaceFlags — kept for tests during migration. */
 export function filterNavigationItemsByWorkspaceFlags(
   items: readonly NavigationItem[],
   flags: WorkspaceFeatureFlagState,
 ): readonly NavigationItem[] {
   const enabledByKey = workspaceFlagEnabledByKey(flags);
-  return items.filter((item) => isNavigationItemEnabledByWorkspaceFlags(item, enabledByKey));
+  return items.filter((item) => {
+    if (!item.featureFlagKey) {
+      return true;
+    }
+
+    if (!(item.featureFlagKey in enabledByKey)) {
+      return true;
+    }
+
+    return enabledByKey[item.featureFlagKey] ?? false;
+  });
 }
 
+/** @deprecated Use annotateNavigationByWorkspaceFlags — kept for tests during migration. */
 export function filterNavigationByWorkspaceFlags(
   groups: readonly NavigationGroup[],
   flags: WorkspaceFeatureFlagState,
@@ -63,9 +96,17 @@ export function filterNavigationByWorkspaceFlags(
   return groups
     .map((group) => ({
       ...group,
-      items: group.items.filter((item) =>
-        isNavigationItemEnabledByWorkspaceFlags(item, enabledByKey),
-      ),
+      items: group.items.filter((item) => {
+        if (!item.featureFlagKey) {
+          return true;
+        }
+
+        if (!(item.featureFlagKey in enabledByKey)) {
+          return true;
+        }
+
+        return enabledByKey[item.featureFlagKey] ?? false;
+      }),
     }))
     .filter((group) => group.items.length > 0);
 }

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -31,6 +31,8 @@ import {
 } from "./workos-flag-entities";
 
 export {
+  annotateNavigationByWorkspaceFlags,
+  annotateNavigationItemsWithWorkspaceFlags,
   filterNavigationByWorkspaceFlags,
   filterNavigationItemsByWorkspaceFlags,
 } from "./workspace-flag-navigation";
@@ -170,6 +172,17 @@ export async function resolveWorkspaceKnowledgeFlag(input: {
         identify: () => ({ organization: { id: organization.workosOrganizationId } }),
       })) === true
     );
+  } catch {
+    return false;
+  }
+}
+
+export async function getWorkspaceFeatureFlagEnabled(
+  workspaceFlag: Flag<boolean, WorkosFlagEntities>,
+  auth: Pick<AppAuthContext, "activeOrganization" | "user">,
+): Promise<boolean> {
+  try {
+    return (await workspaceFlag.run({ identify: () => createWorkosIdentify(auth) })) === true;
   } catch {
     return false;
   }


### PR DESCRIPTION
## What changed

When WorkOS feature flags are off, Automations, Guideline, and Domains routes now render marketing teaser pages instead of blocking access. Each teaser uses a split layout with an animated mock UI and a CTA panel for demo booking.

- Added `FeatureTeaserPage` and registry with outcome-focused copy for all three features
- Added Guideline and Domains marketing mocks; refreshed Automations mock with GTM use cases
- Guideline animation leads with market knowledge and GTM campaign copy (not translation examples)
- Domains mock is a static website audit dashboard (Localisation, SEO, AEO)
- Nav shows gated items with a Preview badge; workspace flag navigation updated
- Homepage hero body copy broadened to global growth framing

## How to test

- [ ] With Automations/Guideline/Domains flags off, visit org and project routes for each feature and confirm teaser pages render
- [ ] Confirm nav shows Preview badge on gated items and links still work
- [ ] Review Guideline mock animation in Storybook (`GuidelineMockUI`) — Market knowledge should cycle first
- [ ] Review feature teaser stories in Storybook
- [ ] Run `vp check --fix` and `vp test` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review