### PR TITLE
feat(web): refresh homepage marketing copy and Tourfinder case study

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/feature-mesh-cards-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/feature-mesh-cards-section.messages.ts
@@ -17,7 +17,7 @@ import { defineMessages } from "react-intl";
 export const featureMeshCardsSectionMessages = defineMessages({
   headline: {
     defaultMessage: "Built for teams shipping multilingual content at scale",
-    id: "vaf540aoc8",
+    id: "9WZD3ligqI",
     description: "Marketing homepage feature mesh cards section headline",
   },
   intakeTitle: {

--- a/apps/hyperlocalise-web/src/components/marketing/feature-mesh-cards-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/feature-mesh-cards-section.messages.ts
@@ -16,7 +16,7 @@ import { defineMessages } from "react-intl";
 
 export const featureMeshCardsSectionMessages = defineMessages({
   headline: {
-    defaultMessage: "Purpose-built for localisation teams",
+    defaultMessage: "Built for teams shipping multilingual content at scale",
     id: "vaf540aoc8",
     description: "Marketing homepage feature mesh cards section headline",
   },

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
@@ -17,7 +17,7 @@ import { defineMessages } from "react-intl";
 export const principlesSectionMessages = defineMessages({
   headline: {
     defaultMessage:
-      "A localisation operating system for the AI era. <muted>Built for modern teams with translation, review, sync, and quality control in one workflow.</muted>",
+      "Multilingual content operations, unified. <muted>From GTM brief to market release — generate more multilingual content without adding headcount.</muted>",
     id: "0Ne4Lpi9ew",
     description:
       "Marketing homepage principles section headline; muted wraps the supporting sentence",

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
@@ -18,7 +18,7 @@ export const principlesSectionMessages = defineMessages({
   headline: {
     defaultMessage:
       "Multilingual content operations, unified. <muted>From GTM brief to market release — generate more multilingual content without adding headcount.</muted>",
-    id: "0Ne4Lpi9ew",
+    id: "3DgHaZOLH3",
     description:
       "Marketing homepage principles section headline; muted wraps the supporting sentence",
   },

--- a/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.messages.ts
@@ -16,19 +16,46 @@ import { defineMessages } from "react-intl";
 
 export const tourfinderTestimonialSectionMessages = defineMessages({
   eyebrow: {
-    defaultMessage: "Customer story",
+    defaultMessage: "Case Study",
     id: "WAOAGxwy+L",
     description: "Eyebrow label above the Tourfinder case study section",
+  },
+  industryLabel: {
+    defaultMessage: "Industry",
+    id: "TfCsIndLbl01",
+    description: "Label for the Tourfinder case study industry metadata field",
+  },
+  industryValue: {
+    defaultMessage: "Tourism",
+    id: "TfCsIndVal01",
+    description: "Tourfinder case study industry value",
+  },
+  locationLabel: {
+    defaultMessage: "Location",
+    id: "TfCsLocLbl01",
+    description: "Label for the Tourfinder case study location metadata field",
+  },
+  locationValue: {
+    defaultMessage: "Sydney, Australia",
+    id: "TfCsLocVal01",
+    description: "Tourfinder case study location value",
   },
   headline: {
     defaultMessage: "Ship apps that speak every market from day one",
     id: "a8cGGx+QlX",
     description: "Marketing homepage Tourfinder case study section headline",
   },
-  result: {
-    defaultMessage: "Tourfinder launched Vietnamese and Japanese marketing in days, not months.",
+  quote: {
+    defaultMessage:
+      "We experienced a <bold>21x increase in traffic</bold> and <bold>5x AI Assistant-originated sessions</bold> since introducing additional multilingual powered by Hyperlocalise.",
     id: "ZK/6pkQPQt",
-    description: "Marketing homepage Tourfinder case study result statement",
+    description:
+      "Tourfinder customer quote; bold wraps the outcome metrics",
+  },
+  authorName: {
+    defaultMessage: "Vi Nguyen",
+    id: "TfCsAuthNm01",
+    description: "Name of the Tourfinder customer quoted in the case study",
   },
   visitSite: {
     defaultMessage: "Visit tourfinder.vn",

--- a/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.messages.ts
@@ -17,27 +17,27 @@ import { defineMessages } from "react-intl";
 export const tourfinderTestimonialSectionMessages = defineMessages({
   eyebrow: {
     defaultMessage: "Case Study",
-    id: "WAOAGxwy+L",
+    id: "6JQLX0bSZ4",
     description: "Eyebrow label above the Tourfinder case study section",
   },
   industryLabel: {
     defaultMessage: "Industry",
-    id: "TfCsIndLbl01",
+    id: "pt0tAxl2FT",
     description: "Label for the Tourfinder case study industry metadata field",
   },
   industryValue: {
     defaultMessage: "Tourism",
-    id: "TfCsIndVal01",
+    id: "En0QEC1++B",
     description: "Tourfinder case study industry value",
   },
   locationLabel: {
     defaultMessage: "Location",
-    id: "TfCsLocLbl01",
+    id: "0LbxmzSNhE",
     description: "Label for the Tourfinder case study location metadata field",
   },
   locationValue: {
     defaultMessage: "Sydney, Australia",
-    id: "TfCsLocVal01",
+    id: "pWQfZXsgvn",
     description: "Tourfinder case study location value",
   },
   headline: {
@@ -48,13 +48,12 @@ export const tourfinderTestimonialSectionMessages = defineMessages({
   quote: {
     defaultMessage:
       "We experienced a <bold>21x increase in traffic</bold> and <bold>5x AI Assistant-originated sessions</bold> since introducing additional multilingual powered by Hyperlocalise.",
-    id: "ZK/6pkQPQt",
-    description:
-      "Tourfinder customer quote; bold wraps the outcome metrics",
+    id: "5EhEUiPeEZ",
+    description: "Tourfinder customer quote; bold wraps the outcome metrics",
   },
   authorName: {
     defaultMessage: "Vi Nguyen",
-    id: "TfCsAuthNm01",
+    id: "j1pOSgEa8H",
     description: "Name of the Tourfinder customer quoted in the case study",
   },
   visitSite: {

--- a/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.tsx
@@ -12,12 +12,19 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import type { ReactNode } from "react";
 import Image from "next/image";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { TypographyH2, TypographyP } from "@/components/ui/typography";
 
 import { tourfinderTestimonialSectionMessages } from "./tourfinder-testimonial-section.messages";
+
+const quoteRichTextValues = {
+  bold: (chunks: ReactNode) => (
+    <strong className="font-semibold text-foreground">{chunks}</strong>
+  ),
+};
 
 export function TourfinderTestimonialSection() {
   const intl = useIntl();
@@ -31,16 +38,45 @@ export function TourfinderTestimonialSection() {
               <FormattedMessage {...tourfinderTestimonialSectionMessages.eyebrow} />
             </p>
 
+            <dl className="mt-5 flex flex-wrap gap-x-10 gap-y-4 sm:mt-6">
+              <div>
+                <dt className="text-[0.72rem] font-medium tracking-[0.12em] text-muted-foreground uppercase">
+                  <FormattedMessage {...tourfinderTestimonialSectionMessages.industryLabel} />
+                </dt>
+                <dd className="mt-1 text-[0.95rem] font-medium text-foreground">
+                  <FormattedMessage {...tourfinderTestimonialSectionMessages.industryValue} />
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[0.72rem] font-medium tracking-[0.12em] text-muted-foreground uppercase">
+                  <FormattedMessage {...tourfinderTestimonialSectionMessages.locationLabel} />
+                </dt>
+                <dd className="mt-1 text-[0.95rem] font-medium text-foreground">
+                  <FormattedMessage {...tourfinderTestimonialSectionMessages.locationValue} />
+                </dd>
+              </div>
+            </dl>
+
             <TypographyH2
               id="tourfinder-testimonial-heading"
-              className="mt-5 pb-0 text-left text-[2.25rem] leading-[1.04] font-semibold tracking-[-0.045em] text-foreground normal-case sm:mt-6 sm:text-5xl md:text-[3.5rem] md:leading-[1.02]"
+              className="mt-8 pb-0 text-left text-[2.25rem] leading-[1.04] font-semibold tracking-[-0.045em] text-foreground normal-case sm:mt-10 sm:text-5xl md:text-[3.5rem] md:leading-[1.02]"
             >
               <FormattedMessage {...tourfinderTestimonialSectionMessages.headline} />
             </TypographyH2>
 
-            <TypographyP className="mt-6 max-w-2xl pb-0 text-pretty text-[1.15rem] leading-relaxed text-muted-foreground sm:mt-8 sm:text-[1.35rem] sm:leading-[1.4]">
-              <FormattedMessage {...tourfinderTestimonialSectionMessages.result} />
-            </TypographyP>
+            <blockquote className="mt-6 max-w-2xl border-l-2 border-border pl-6 sm:mt-8">
+              <TypographyP className="pb-0 text-pretty text-[1.15rem] leading-relaxed text-muted-foreground sm:text-[1.35rem] sm:leading-[1.4]">
+                <FormattedMessage
+                  {...tourfinderTestimonialSectionMessages.quote}
+                  values={quoteRichTextValues}
+                />
+              </TypographyP>
+              <footer className="mt-4 text-[0.95rem] font-medium text-foreground">
+                <cite className="not-italic">
+                  <FormattedMessage {...tourfinderTestimonialSectionMessages.authorName} />
+                </cite>
+              </footer>
+            </blockquote>
 
             <a
               href="https://tourfinder.vn"

--- a/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.tsx
@@ -21,9 +21,7 @@ import { TypographyH2, TypographyP } from "@/components/ui/typography";
 import { tourfinderTestimonialSectionMessages } from "./tourfinder-testimonial-section.messages";
 
 const quoteRichTextValues = {
-  bold: (chunks: ReactNode) => (
-    <strong className="font-semibold text-foreground">{chunks}</strong>
-  ),
+  bold: (chunks: ReactNode) => <strong className="font-semibold text-foreground">{chunks}</strong>,
 };
 
 export function TourfinderTestimonialSection() {


### PR DESCRIPTION
## What changed
- Updated homepage principles and feature section copy to reflect multilingual content operations positioning instead of localisation-only framing
- Reworked the Tourfinder section into a case study with industry/location metadata, a customer quote from Vi Nguyen, and bold emphasis on outcome metrics
## How to test
- [ ] Open the marketing homepage and verify the principles headline reads: "Multilingual content operations, unified."
- [ ] Confirm the feature mesh cards headline reads: "Built for teams shipping multilingual content at scale"
- [ ] Confirm the Tourfinder section shows Case Study metadata (Industry: Tourism, Location: Sydney, Australia), the customer quote with bold metrics, and Vi Nguyen attribution
## Checklist
- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review