### PR TITLE
fix(translation): scale sandbox timeouts by pending keys

### DIFF
--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -17,6 +17,7 @@ const { envMock, sandboxMocks } = vi.hoisted(() => {
   const output = vi.fn();
   const runCommand = vi.fn();
   const get = vi.fn();
+  const update = vi.fn();
 
   return {
     envMock: {
@@ -26,7 +27,7 @@ const { envMock, sandboxMocks } = vi.hoisted(() => {
       FILE_STORAGE_PROVIDER: "vercel_blob",
       FILE_STORAGE_ACCESS: "private",
     },
-    sandboxMocks: { create, get, output, runCommand },
+    sandboxMocks: { create, get, output, runCommand, update },
   };
 });
 
@@ -67,6 +68,7 @@ import {
   runSandboxCommand,
   sandboxFileBucketName,
   sandboxI18nConfigPath,
+  updateTranslationSandboxTimeout,
   userFacingFailureReason,
 } from "@/lib/translation/sandbox";
 import { StreamError } from "@vercel/sandbox";
@@ -105,6 +107,16 @@ describe("sandbox command runner", () => {
       args: ["-c", expect.stringContaining("install_hyperlocalise_from_github_release")],
       sudo: true,
     });
+  });
+
+  it("updates the running sandbox timeout", async () => {
+    sandboxMocks.get.mockResolvedValueOnce({ update: sandboxMocks.update });
+    sandboxMocks.update.mockResolvedValueOnce(undefined);
+
+    await updateTranslationSandboxTimeout("sandbox_123", 1_320_000);
+
+    expect(sandboxMocks.get).toHaveBeenCalledWith({ name: "sandbox_123" });
+    expect(sandboxMocks.update).toHaveBeenCalledWith({ timeout: 1_320_000 });
   });
 
   it("captures combined output by default", async () => {
@@ -211,6 +223,34 @@ describe("sandbox command runner", () => {
     });
     expect(wait).toHaveBeenCalledTimes(1);
     expect(sandboxMocks.output).toHaveBeenCalledWith("both");
+  });
+
+  it("kills and classifies commands that exceed their deadline", async () => {
+    const wait = vi.fn().mockResolvedValue({
+      exitCode: 137,
+      output: sandboxMocks.output,
+    });
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      cmdId: "cmd_timeout",
+      wait,
+    });
+    sandboxMocks.get.mockResolvedValueOnce({
+      runCommand: sandboxMocks.runCommand,
+    });
+
+    await expect(
+      runSandboxCommand("sandbox_123", "bash", ["-lc", "hl run"], { timeoutMs: 270_000 }),
+    ).rejects.toThrow("sandbox_timeout: bash exceeded 270000ms");
+
+    expect(sandboxMocks.runCommand).toHaveBeenCalledWith({
+      cmd: "bash",
+      args: ["-lc", "hl run"],
+      env: undefined,
+      detached: true,
+      signal: expect.any(AbortSignal),
+      timeoutMs: 270_000,
+    });
+    expect(wait).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
   });
 
   it("retries wait when the wait connection drops with TypeError terminated", async () => {
@@ -627,6 +667,12 @@ describe("crowdin sandbox file config", () => {
 });
 
 describe("sandbox translation failure reasons", () => {
+  it("maps command deadlines to a resumable timeout message", () => {
+    expect(userFacingFailureReason(new Error("sandbox_timeout: bash exceeded 270000ms"))).toBe(
+      "the translation took too long to finish. Progress was saved, so try the job again to continue.",
+    );
+  });
+
   it("preserves glossary validation diagnostics for persisted job failures", () => {
     const diagnostics = {
       targetLocale: "fr-FR",

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -669,7 +669,7 @@ describe("crowdin sandbox file config", () => {
 describe("sandbox translation failure reasons", () => {
   it("maps command deadlines to a resumable timeout message", () => {
     expect(userFacingFailureReason(new Error("sandbox_timeout: bash exceeded 270000ms"))).toBe(
-      "the translation took too long to finish. Progress was saved, so try the job again to continue.",
+      "the translation took too long to finish. Try the job again.",
     );
   });
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -220,7 +220,7 @@ export class SandboxErrorMapper {
     }
 
     if (message.includes("sandbox_timeout")) {
-      return "the translation took too long to finish. Progress was saved, so try the job again to continue.";
+      return "the translation took too long to finish. Try the job again.";
     }
 
     return "the translation failed before it could finish. This is usually temporary.";

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -12,7 +12,7 @@
  */
 import { randomUUID } from "node:crypto";
 
-import { Sandbox, StreamError } from "@vercel/sandbox";
+import { Sandbox, StreamError, type Command } from "@vercel/sandbox";
 
 import { env } from "@/lib/env";
 import {
@@ -35,6 +35,7 @@ import {
 } from "@/lib/projects/files/hl-entries";
 
 export const sandboxTimeoutMs = 10 * 60 * 1000;
+export const sandboxTranslationCommandTimeoutMs = 4 * 60 * 1000 + 30 * 1000;
 export const crowdinSandboxConfigPath = "/tmp/crowdin.yml";
 /** Colocated with sandbox source/output files so CLI pathguard root matches.
  *  Reserved name so a user source named i18n.yml is not overwritten. */
@@ -42,6 +43,15 @@ export const sandboxI18nConfigPath = ".hl-sandbox-i18n.yml";
 export const sandboxFileBucketName = "file";
 
 export type { SandboxTranslationContext };
+
+export class SandboxCommandTimeoutError extends Error {
+  readonly code = "sandbox_timeout";
+
+  constructor(command: string, timeoutMs: number) {
+    super(`sandbox_timeout: ${command} exceeded ${timeoutMs}ms`);
+    this.name = "SandboxCommandTimeoutError";
+  }
+}
 
 export type ExtractSandboxEntriesResult =
   | { ok: true; entries: HlEntriesPayload }
@@ -209,14 +219,23 @@ export class SandboxErrorMapper {
       return "the translation environment disconnected mid-run. This is usually temporary — try again.";
     }
 
+    if (message.includes("sandbox_timeout")) {
+      return "the translation took too long to finish. Progress was saved, so try the job again to continue.";
+    }
+
     return "the translation failed before it could finish. This is usually temporary.";
   }
 }
 
 export class SandboxLifecycle {
-  async create(): Promise<{ sandboxId: string }> {
-    const sandbox = await createConfiguredVercelSandbox({ timeout: sandboxTimeoutMs });
+  async create(timeoutMs = sandboxTimeoutMs): Promise<{ sandboxId: string }> {
+    const sandbox = await createConfiguredVercelSandbox({ timeout: timeoutMs });
     return { sandboxId: sandbox.name };
+  }
+
+  async updateTimeout(sandboxId: string, timeoutMs: number): Promise<void> {
+    const sandbox = await Sandbox.get({ name: sandboxId });
+    await sandbox.update({ timeout: timeoutMs });
   }
 
   async stop(sandboxId: string): Promise<void> {
@@ -276,9 +295,32 @@ export class SandboxLifecycle {
     sandboxId: string,
     command: string,
     args: string[],
-    options?: { env?: Record<string, string>; output?: "stdout" | "stderr" | "both" },
+    options?: {
+      env?: Record<string, string>;
+      output?: "stdout" | "stderr" | "both";
+      timeoutMs?: number;
+    },
   ): Promise<{ exitCode: number; output: string }> {
     const outputMode = options?.output ?? "both";
+    const timeoutController = new AbortController();
+    const timeout = options?.timeoutMs
+      ? setTimeout(() => timeoutController.abort(), options.timeoutMs)
+      : null;
+
+    const throwTimeout = () => {
+      throw new SandboxCommandTimeoutError(command, options?.timeoutMs ?? 0);
+    };
+
+    const throwIfTimedOut = () => {
+      if (timeoutController.signal.aborted) {
+        throwTimeout();
+      }
+    };
+
+    const waitForCommand = (sandboxCommand: Command) =>
+      options?.timeoutMs
+        ? sandboxCommand.wait({ signal: timeoutController.signal })
+        : sandboxCommand.wait();
 
     const startDetachedCommand = async () => {
       const sandbox = await Sandbox.get({ name: sandboxId });
@@ -289,6 +331,9 @@ export class SandboxLifecycle {
         args,
         env: options?.env,
         detached: true,
+        ...(options?.timeoutMs
+          ? { signal: timeoutController.signal, timeoutMs: options.timeoutMs }
+          : {}),
       });
     };
 
@@ -296,8 +341,9 @@ export class SandboxLifecycle {
       started: Awaited<ReturnType<typeof startDetachedCommand>>,
     ) => {
       try {
-        return await started.wait();
+        return await waitForCommand(started);
       } catch (error) {
+        throwIfTimedOut();
         if (!isSandboxDisconnectError(error)) {
           throw error;
         }
@@ -317,8 +363,10 @@ export class SandboxLifecycle {
           // files from a just-finished run.
           try {
             const sandbox = await Sandbox.get({ name: sandboxId });
-            const command = await sandbox.getCommand(started.cmdId);
-            return await command.wait();
+            const command = options?.timeoutMs
+              ? await sandbox.getCommand(started.cmdId, { signal: timeoutController.signal })
+              : await sandbox.getCommand(started.cmdId);
+            return await waitForCommand(command);
           } catch (reconnectError) {
             console.warn("[sandbox] reconnect wait failed; recovering session", {
               sandboxId,
@@ -338,45 +386,57 @@ export class SandboxLifecycle {
           }
 
           const sandbox = await Sandbox.get({ name: sandboxId });
-          const command = await sandbox.getCommand(started.cmdId);
-          return command.wait();
+          const command = options?.timeoutMs
+            ? await sandbox.getCommand(started.cmdId, { signal: timeoutController.signal })
+            : await sandbox.getCommand(started.cmdId);
+          return waitForCommand(command);
         }
 
-        return started.wait();
+        return waitForCommand(started);
       }
     };
 
-    let started;
     try {
-      started = await startDetachedCommand();
-    } catch (error) {
-      if (!isSandboxDisconnectError(error)) {
-        throw error;
-      }
-
-      console.warn("[sandbox] disconnect during sandbox IO; recovering session", {
-        sandboxId,
-        streamClosed: isSandboxStreamClosedError(error),
-        transientNetwork: isSandboxTransientNetworkError(error),
-        error: error instanceof Error ? error.message : "unknown",
-      });
+      let started;
       try {
-        await this.recoverSession(sandboxId);
-      } catch (recoverError) {
-        console.warn("[sandbox] session recovery failed", {
-          sandboxId,
-          error: recoverError instanceof Error ? recoverError.message : "unknown",
-        });
-        throw error;
-      }
-      started = await startDetachedCommand();
-    }
+        started = await startDetachedCommand();
+      } catch (error) {
+        throwIfTimedOut();
+        if (!isSandboxDisconnectError(error)) {
+          throw error;
+        }
 
-    const finished = await waitForDetachedCommand(started);
-    return {
-      exitCode: finished.exitCode,
-      output: await finished.output(outputMode),
-    };
+        console.warn("[sandbox] disconnect during sandbox IO; recovering session", {
+          sandboxId,
+          streamClosed: isSandboxStreamClosedError(error),
+          transientNetwork: isSandboxTransientNetworkError(error),
+          error: error instanceof Error ? error.message : "unknown",
+        });
+        try {
+          await this.recoverSession(sandboxId);
+        } catch (recoverError) {
+          console.warn("[sandbox] session recovery failed", {
+            sandboxId,
+            error: recoverError instanceof Error ? recoverError.message : "unknown",
+          });
+          throw error;
+        }
+        started = await startDetachedCommand();
+      }
+
+      const finished = await waitForDetachedCommand(started);
+      if (options?.timeoutMs && finished.exitCode === 137) {
+        throwTimeout();
+      }
+      return {
+        exitCode: finished.exitCode,
+        output: await finished.output(outputMode),
+      };
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   }
 
   async writeFiles(
@@ -880,8 +940,12 @@ export function getSandboxOutputFilename(attachmentFilename: string, targetLocal
   return getOutputFilename(sanitizeFilename(attachmentFilename), targetLocale);
 }
 
-export async function createTranslationSandbox() {
-  return defaultLifecycle.create();
+export async function createTranslationSandbox(timeoutMs?: number) {
+  return defaultLifecycle.create(timeoutMs);
+}
+
+export async function updateTranslationSandboxTimeout(sandboxId: string, timeoutMs: number) {
+  return defaultLifecycle.updateTimeout(sandboxId, timeoutMs);
 }
 
 export async function stopTranslationSandbox(sandboxId: string) {
@@ -896,7 +960,11 @@ export async function runSandboxCommand(
   sandboxId: string,
   command: string,
   args: string[],
-  options?: { env?: Record<string, string>; output?: "stdout" | "stderr" | "both" },
+  options?: {
+    env?: Record<string, string>;
+    output?: "stdout" | "stderr" | "both";
+    timeoutMs?: number;
+  },
 ) {
   return defaultLifecycle.runCommand(sandboxId, command, args, options);
 }

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job-pagination.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job-pagination.test.ts
@@ -15,6 +15,8 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   FILE_TRANSLATION_MAX_SANDBOX_TIMEOUT_MS,
   FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
+  FILE_TRANSLATION_MIN_PAGES,
+  calculateFileTranslationMaxPages,
   calculateFileTranslationSandboxTimeoutMs,
   countPendingFileTranslations,
   parseDeferredByLimit,
@@ -23,6 +25,15 @@ import {
 describe("file translation pagination", () => {
   it("checkpoints after 100 translations", () => {
     expect(FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION).toBe(100);
+  });
+
+  it("preserves capacity for 500,000 translations after shrinking pages", () => {
+    expect(FILE_TRANSLATION_MIN_PAGES).toBe(5_000);
+    expect(calculateFileTranslationMaxPages(500_000)).toBe(5_000);
+  });
+
+  it("expands the page ceiling for larger known workloads", () => {
+    expect(calculateFileTranslationMaxPages(500_001)).toBe(5_001);
   });
 
   it("keeps the ten-minute minimum for small workloads", () => {

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job-pagination.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job-pagination.test.ts
@@ -12,7 +12,42 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { parseDeferredByLimit } from "./file-translation-pagination";
+import {
+  FILE_TRANSLATION_MAX_SANDBOX_TIMEOUT_MS,
+  FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
+  calculateFileTranslationSandboxTimeoutMs,
+  countPendingFileTranslations,
+  parseDeferredByLimit,
+} from "./file-translation-pagination";
+
+describe("file translation pagination", () => {
+  it("checkpoints after 100 translations", () => {
+    expect(FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION).toBe(100);
+  });
+
+  it("keeps the ten-minute minimum for small workloads", () => {
+    expect(calculateFileTranslationSandboxTimeoutMs(10)).toBe(10 * 60 * 1_000);
+  });
+
+  it("counts untranslated key-locale pairs after merged prefills", () => {
+    expect(
+      countPendingFileTranslations({ one: "One", two: "Two", three: "Three" }, ["fr", "de"], {
+        fr: { one: "Un" },
+        de: { one: "Eins", two: "Zwei" },
+      }),
+    ).toBe(3);
+  });
+
+  it("budgets three seconds per pending key-locale translation plus overhead", () => {
+    expect(calculateFileTranslationSandboxTimeoutMs(800)).toBe(42 * 60 * 1_000);
+  });
+
+  it("caps the timeout at the sandbox platform maximum", () => {
+    expect(calculateFileTranslationSandboxTimeoutMs(1_000_000)).toBe(
+      FILE_TRANSLATION_MAX_SANDBOX_TIMEOUT_MS,
+    );
+  });
+});
 
 describe("parseDeferredByLimit", () => {
   it("reads deferred_by_limit from hl run stdout", () => {

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -47,6 +47,8 @@ import {
 import {
   FILE_TRANSLATION_MAX_PAGES,
   FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
+  calculateFileTranslationSandboxTimeoutMs,
+  countPendingFileTranslations,
   parseDeferredByLimit,
 } from "./file-translation-pagination";
 
@@ -263,6 +265,10 @@ function userFacingFailureReason(
     return "the translation finished, but the output file couldn't be read back. This is usually temporary.";
   }
 
+  if (message.includes("sandbox_timeout")) {
+    return "the translation took too long to finish. Progress was saved, so try the job again to continue.";
+  }
+
   return "the translation failed before it could finish. This is usually temporary.";
 }
 
@@ -270,6 +276,12 @@ async function createSandboxStep() {
   "use step";
   const { createTranslationSandbox } = await import("@/lib/translation/sandbox");
   return createTranslationSandbox();
+}
+
+async function updateSandboxTimeoutStep(sandboxId: string, timeoutMs: number) {
+  "use step";
+  const { updateTranslationSandboxTimeout } = await import("@/lib/translation/sandbox");
+  return updateTranslationSandboxTimeout(sandboxId, timeoutMs);
 }
 
 async function prepareSandboxStep(sandboxId: string) {
@@ -288,6 +300,7 @@ async function recreateSandboxWithSourceStep(input: {
   previousSandboxId: string | null;
   filename: string;
   content: Buffer;
+  timeoutMs: number;
 }) {
   "use step";
   const { createTranslationSandbox, prepareSandbox, stopTranslationSandbox, writeFileToSandbox } =
@@ -301,7 +314,7 @@ async function recreateSandboxWithSourceStep(input: {
     }
   }
 
-  const { sandboxId } = await createTranslationSandbox();
+  const { sandboxId } = await createTranslationSandbox(input.timeoutMs);
   await prepareSandbox(sandboxId);
   await writeFileToSandbox(sandboxId, input.filename, input.content);
   return { sandboxId };
@@ -327,6 +340,7 @@ async function runTranslationStep(
     recoverTranslationSandboxSession,
     runSandboxCommand,
     sandboxI18nConfigPath,
+    sandboxTranslationCommandTimeoutMs,
     writeFileToSandbox,
     writeTempConfig,
   } = await import("@/lib/translation/sandbox");
@@ -384,6 +398,7 @@ async function runTranslationStep(
       ],
       {
         env: getSandboxTranslationEnv(byok),
+        timeoutMs: sandboxTranslationCommandTimeoutMs,
       },
     );
   } catch (error) {
@@ -402,6 +417,7 @@ async function runTranslationStep(
     throw error;
   }
 }
+runTranslationStep.maxRetries = 0;
 
 async function extractEntriesStep(
   sandboxId: string,
@@ -790,6 +806,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
     const outputFiles: Array<{ fileId: string; locale: string; filename: string }> = [];
     let sourceEntries: Record<string, string> | null = null;
+    let translationSandboxTimeoutMs = calculateFileTranslationSandboxTimeoutMs(0);
 
     try {
       sourceEntries = await extractEntriesStep(sandboxId, inputFilename);
@@ -885,6 +902,26 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       if (Object.keys(merged).length > 0) {
         prefilledByLocale[targetLocale] = merged;
       }
+    }
+
+    if (sourceEntries) {
+      const pendingTranslationCount = countPendingFileTranslations(
+        sourceEntries,
+        parsedInput.targetLocales,
+        prefilledByLocale,
+      );
+      translationSandboxTimeoutMs =
+        calculateFileTranslationSandboxTimeoutMs(pendingTranslationCount);
+      await updateSandboxTimeoutStep(sandboxId, translationSandboxTimeoutMs);
+      console.info("[file-translation-workflow] sandbox timeout updated", {
+        jobId: claim.job.id,
+        projectId: claim.job.projectId,
+        sourceEntryCount: Object.keys(sourceEntries).length,
+        targetLocaleCount: parsedInput.targetLocales.length,
+        pendingTranslationCount,
+        translationSandboxTimeoutMs,
+        sandboxId,
+      });
     }
 
     const prefilledLocaleCount = Object.keys(prefilledByLocale).length;
@@ -1037,6 +1074,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             previousSandboxId: sandboxId,
             filename: inputFilename,
             content: sourceContent,
+            timeoutMs: translationSandboxTimeoutMs,
           });
           sandboxId = recreated.sandboxId;
           // Fresh sandbox has no lockfile — force is irrelevant; keep caller's intent.

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -45,8 +45,8 @@ import {
   storeOutputFileStep,
 } from "./steps/translation-job";
 import {
-  FILE_TRANSLATION_MAX_PAGES,
   FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
+  calculateFileTranslationMaxPages,
   calculateFileTranslationSandboxTimeoutMs,
   countPendingFileTranslations,
   parseDeferredByLimit,
@@ -266,7 +266,7 @@ function userFacingFailureReason(
   }
 
   if (message.includes("sandbox_timeout")) {
-    return "the translation took too long to finish. Progress was saved, so try the job again to continue.";
+    return "the translation took too long to finish. Try the job again.";
   }
 
   return "the translation failed before it could finish. This is usually temporary.";
@@ -807,6 +807,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     const outputFiles: Array<{ fileId: string; locale: string; filename: string }> = [];
     let sourceEntries: Record<string, string> | null = null;
     let translationSandboxTimeoutMs = calculateFileTranslationSandboxTimeoutMs(0);
+    let translationMaxPages = calculateFileTranslationMaxPages(0);
 
     try {
       sourceEntries = await extractEntriesStep(sandboxId, inputFilename);
@@ -912,6 +913,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       );
       translationSandboxTimeoutMs =
         calculateFileTranslationSandboxTimeoutMs(pendingTranslationCount);
+      translationMaxPages = calculateFileTranslationMaxPages(pendingTranslationCount);
       await updateSandboxTimeoutStep(sandboxId, translationSandboxTimeoutMs);
       console.info("[file-translation-workflow] sandbox timeout updated", {
         jobId: claim.job.id,
@@ -919,6 +921,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         sourceEntryCount: Object.keys(sourceEntries).length,
         targetLocaleCount: parsedInput.targetLocales.length,
         pendingTranslationCount,
+        translationMaxPages,
         translationSandboxTimeoutMs,
         sandboxId,
       });
@@ -1148,7 +1151,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     let localesNeedingWork = [...parsedInput.targetLocales];
     let batchFailed = false;
 
-    while (page < FILE_TRANSLATION_MAX_PAGES) {
+    while (page < translationMaxPages) {
       // Page 0 may use --force for a clean slate. Later pages omit it so the
       // lockfile skips completed tasks and advances through deferred work.
       const batchResult = await runHlForLocales(parsedInput.targetLocales, 1, {
@@ -1206,7 +1209,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
     if (!batchFailed && deferredByLimit > 0) {
       throw new Error(
-        `translation pagination exceeded ${FILE_TRANSLATION_MAX_PAGES} pages with deferred_by_limit=${deferredByLimit}`,
+        `translation pagination exceeded ${translationMaxPages} pages with deferred_by_limit=${deferredByLimit}`,
       );
     }
 
@@ -1216,7 +1219,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       const stillMissing: string[] = [];
       for (const targetLocale of localesNeedingWork) {
         let localeFailed = false;
-        for (let localePage = 0; localePage < FILE_TRANSLATION_MAX_PAGES; localePage += 1) {
+        for (let localePage = 0; localePage < translationMaxPages; localePage += 1) {
           const localeResult = await runHlForLocales([targetLocale], 1, {
             force: localePage === 0,
             maxTranslations: FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
@@ -1255,7 +1258,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           if (localeResult.deferredByLimit <= 0) {
             break;
           }
-          if (localePage === FILE_TRANSLATION_MAX_PAGES - 1) {
+          if (localePage === translationMaxPages - 1) {
             stillMissing.push(targetLocale);
             runFailures.push({
               locale: targetLocale,
@@ -1329,7 +1332,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         ].join("\n");
 
         let retryFailed = false;
-        for (let retryPage = 0; retryPage < FILE_TRANSLATION_MAX_PAGES; retryPage += 1) {
+        for (let retryPage = 0; retryPage < translationMaxPages; retryPage += 1) {
           const retryResult = await runHlForLocales([targetLocale], 2, {
             retryFeedback: feedback,
             // Page 0 forces a clean rewrite; later pages omit --force so the
@@ -1357,7 +1360,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           if (retryResult.deferredByLimit <= 0) {
             break;
           }
-          if (retryPage === FILE_TRANSLATION_MAX_PAGES - 1) {
+          if (retryPage === translationMaxPages - 1) {
             translatedByLocale.delete(targetLocale);
             stillFailing.push({ targetLocale, failures });
             retryFailed = true;

--- a/apps/hyperlocalise-web/src/workflows/file-translation-pagination.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-pagination.ts
@@ -10,8 +10,37 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-export const FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION = 1000;
+export const FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION = 100;
 export const FILE_TRANSLATION_MAX_PAGES = 500;
+export const FILE_TRANSLATION_TIME_PER_KEY_LOCALE_MS = 3_000;
+export const FILE_TRANSLATION_SANDBOX_OVERHEAD_MS = 2 * 60 * 1_000;
+export const FILE_TRANSLATION_MIN_SANDBOX_TIMEOUT_MS = 10 * 60 * 1_000;
+export const FILE_TRANSLATION_MAX_SANDBOX_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
+
+export function countPendingFileTranslations(
+  sourceEntries: Record<string, string>,
+  targetLocales: string[],
+  prefilledByLocale: Record<string, Record<string, string>>,
+): number {
+  const sourceKeys = Object.keys(sourceEntries);
+  return targetLocales.reduce((total, locale) => {
+    const prefilled = prefilledByLocale[locale] ?? {};
+    const pendingForLocale = sourceKeys.filter((key) => !(key in prefilled)).length;
+    return total + pendingForLocale;
+  }, 0);
+}
+
+export function calculateFileTranslationSandboxTimeoutMs(translationCount: number): number {
+  const normalizedTranslationCount = Math.max(0, Math.floor(translationCount));
+  const workloadTimeoutMs =
+    normalizedTranslationCount * FILE_TRANSLATION_TIME_PER_KEY_LOCALE_MS +
+    FILE_TRANSLATION_SANDBOX_OVERHEAD_MS;
+
+  return Math.min(
+    FILE_TRANSLATION_MAX_SANDBOX_TIMEOUT_MS,
+    Math.max(FILE_TRANSLATION_MIN_SANDBOX_TIMEOUT_MS, workloadTimeoutMs),
+  );
+}
 
 /** Parse `deferred_by_limit=N` from `hl run` stdout. Missing marker means 0. */
 export function parseDeferredByLimit(output: string): number {

--- a/apps/hyperlocalise-web/src/workflows/file-translation-pagination.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-pagination.ts
@@ -11,7 +11,7 @@
  * Version 2.0 or later.
  */
 export const FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION = 100;
-export const FILE_TRANSLATION_MAX_PAGES = 500;
+export const FILE_TRANSLATION_MIN_PAGES = 5_000;
 export const FILE_TRANSLATION_TIME_PER_KEY_LOCALE_MS = 3_000;
 export const FILE_TRANSLATION_SANDBOX_OVERHEAD_MS = 2 * 60 * 1_000;
 export const FILE_TRANSLATION_MIN_SANDBOX_TIMEOUT_MS = 10 * 60 * 1_000;
@@ -39,6 +39,14 @@ export function calculateFileTranslationSandboxTimeoutMs(translationCount: numbe
   return Math.min(
     FILE_TRANSLATION_MAX_SANDBOX_TIMEOUT_MS,
     Math.max(FILE_TRANSLATION_MIN_SANDBOX_TIMEOUT_MS, workloadTimeoutMs),
+  );
+}
+
+export function calculateFileTranslationMaxPages(pendingTranslationCount: number): number {
+  const normalizedPendingCount = Math.max(0, Math.floor(pendingTranslationCount));
+  return Math.max(
+    FILE_TRANSLATION_MIN_PAGES,
+    Math.ceil(normalizedPendingCount / FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION),
   );
 }
 

--- a/docs/adr/2026-08-27-dynamic-file-translation-sandbox-timeouts-design.md
+++ b/docs/adr/2026-08-27-dynamic-file-translation-sandbox-timeouts-design.md
@@ -12,11 +12,13 @@ Budget three seconds for each key-locale translation and add a fixed setup and c
 
 Run at most 100 translations per CLI invocation. After each invocation, preserve the current lockfile-based resume behavior and persist any readable translations. Later invocations omit `--force`, allowing the CLI to skip completed work.
 
+Preserve the previous 500,000-translation pagination capacity by allowing at least 5,000 pages of 100 translations. When the known pending workload is larger, derive the page ceiling from `ceil(pending translations / 100)`. Use the same ceiling for the initial pass, per-locale recovery, and glossary retry loops.
+
 Bound each detached translation command below the five-minute workflow function limit. When the command exceeds that deadline, kill it inside the sandbox and return a stable `sandbox_timeout` failure. This gives the workflow time to record a failed job and stop the sandbox instead of relying on infrastructure termination.
 
 ## Error Handling
 
-Map `sandbox_timeout` to a specific temporary-failure message. Do not classify it as a transport disconnect or recreate the sandbox automatically. The normal workflow failure path records the failure and runs best-effort cleanup.
+Map `sandbox_timeout` to a specific temporary-failure message. Do not promise that progress was saved because a timed-out command can exit before readable output is persisted, and non-repository uploads have no reusable persistence path. Do not classify the timeout as a transport disconnect or recreate the sandbox automatically. The normal workflow failure path records the failure and runs best-effort cleanup.
 
 ## Testing
 

--- a/docs/adr/2026-08-27-dynamic-file-translation-sandbox-timeouts-design.md
+++ b/docs/adr/2026-08-27-dynamic-file-translation-sandbox-timeouts-design.md
@@ -1,0 +1,23 @@
+# Dynamic File Translation Sandbox Timeouts
+
+## Context
+
+File translation sandboxes currently have a fixed ten-minute lifetime. Large jobs can exceed that lifetime, while an individual workflow step can wait indefinitely for a detached sandbox command. Workflow retries can then leave the job running for much longer than the sandbox lifetime.
+
+## Design
+
+Use one sandbox for each file translation job. Create it with the existing ten-minute minimum so source upload and entry extraction can run. After extracting the source entries, calculate the translation workload as the source key count multiplied by the target locale count.
+
+Budget three seconds for each key-locale translation and add a fixed setup and cleanup allowance. Increase the running sandbox's total timeout to the larger of the existing ten-minute minimum or the calculated budget plus the allowance.
+
+Run at most 100 translations per CLI invocation. After each invocation, preserve the current lockfile-based resume behavior and persist any readable translations. Later invocations omit `--force`, allowing the CLI to skip completed work.
+
+Bound each detached translation command below the five-minute workflow function limit. When the command exceeds that deadline, kill it inside the sandbox and return a stable `sandbox_timeout` failure. This gives the workflow time to record a failed job and stop the sandbox instead of relying on infrastructure termination.
+
+## Error Handling
+
+Map `sandbox_timeout` to a specific temporary-failure message. Do not classify it as a transport disconnect or recreate the sandbox automatically. The normal workflow failure path records the failure and runs best-effort cleanup.
+
+## Testing
+
+Add tests for workload-based timeout calculation, sandbox timeout updates, command timeout propagation, and user-facing timeout mapping. Run the web test and check commands required by the repository instructions.

--- a/docs/adr/2026-08-27-dynamic-file-translation-sandbox-timeouts-design.md
+++ b/docs/adr/2026-08-27-dynamic-file-translation-sandbox-timeouts-design.md
@@ -6,7 +6,7 @@ File translation sandboxes currently have a fixed ten-minute lifetime. Large job
 
 ## Design
 
-Use one sandbox for each file translation job. Create it with the existing ten-minute minimum so source upload and entry extraction can run. After extracting the source entries, calculate the translation workload as the source key count multiplied by the target locale count.
+Use one sandbox for each file translation job. Create it with the existing ten-minute minimum so source upload and entry extraction can run. After extracting the source entries and loading project and translation-memory prefills, calculate the remaining translation workload. For each target locale, count source keys that are absent from the merged prefill set, then sum those locale-specific counts. This is equivalent to subtracting completed translations while also accounting for translation-memory matches, hidden-key prefills, and non-repository uploads.
 
 Budget three seconds for each key-locale translation and add a fixed setup and cleanup allowance. Increase the running sandbox's total timeout to the larger of the existing ten-minute minimum or the calculated budget plus the allowance.
 


### PR DESCRIPTION
## What changed

- Calculate the sandbox lifetime from pending key-locale translations at three seconds each, with a ten-minute minimum and two-minute overhead.
- Count pending work across all target locales after project and translation-memory prefills are merged.
- Reduce each CLI batch from 1,000 to 100 translations so progress is saved more frequently.
- Limit translation commands to 4.5 minutes and report a stable `sandbox_timeout` failure.
- Disable automatic retries for the long-running translation step; explicit disconnect recovery remains in place.
- Preserve the calculated timeout when recreating a disconnected sandbox.
- Document the timeout and batching design.

## How to test

- `vp test src/workflows/file-translation-job-pagination.test.ts src/lib/translation/sandbox-translation.test.ts`
  - 36 tests passed.
- `vp check --fix`
  - Formatting, lint, and type checks passed across 2,772 files.
- `vp test`
  - Could not complete in the current environment because `DATABASE_URL` is missing and sandbox restrictions block localhost connections to PostgreSQL on port 5432 and the web server on port 3000.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review