### PR TITLE
chore(web): silence passing test logs and cache Vitest in CI

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -113,6 +113,15 @@ jobs:
       - name: Migrate hyperlocalise-web database
         run: vp run db:migrate
 
+      - name: Cache Vitest
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: apps/hyperlocalise-web/.cache/vitest
+          key: ${{ runner.os }}-vitest-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/vite.config.ts') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-vitest-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/vite.config.ts') }}-
+            ${{ runner.os }}-vitest-
+
       - name: Test hyperlocalise-web
         run: vp test
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -116,7 +116,9 @@ jobs:
       - name: Cache Vitest
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: apps/hyperlocalise-web/.cache/vitest
+          path: |
+            apps/hyperlocalise-web/.cache/vitest
+            apps/hyperlocalise-web/.cache/vite
           key: ${{ runner.os }}-vitest-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/vite.config.ts') }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-vitest-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/vite.config.ts') }}-

--- a/apps/hyperlocalise-web/vite.config.ts
+++ b/apps/hyperlocalise-web/vite.config.ts
@@ -59,9 +59,14 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    silent: "passed-only",
     setupFiles: ["./src/test/setup-dom.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: ["src/e2e/**"],
+    experimental: {
+      fsModuleCache: true,
+      fsModuleCachePath: ".cache/vitest",
+    },
     server: {
       deps: {
         inline: ["@workos-inc/authkit-nextjs"],

--- a/apps/hyperlocalise-web/vite.config.ts
+++ b/apps/hyperlocalise-web/vite.config.ts
@@ -90,7 +90,6 @@ export default defineConfig({
         client: {
           enabled: true,
           include: [
-            "@testing-library/dom",
             "@testing-library/jest-dom",
             "@testing-library/react",
             "react",

--- a/apps/hyperlocalise-web/vite.config.ts
+++ b/apps/hyperlocalise-web/vite.config.ts
@@ -34,7 +34,10 @@ const translatedIgnorePatterns = translatedLocales.flatMap((locale) => [
   `lang/${locale}.json`,
 ]);
 
+const isCi = process.env.CI === "true";
+
 export default defineConfig({
+  cacheDir: ".cache/vite",
   fmt: {
     ignorePatterns: ["drizzle/**", "pnpm-*.yaml", ...translatedIgnorePatterns],
   },
@@ -60,12 +63,54 @@ export default defineConfig({
   test: {
     environment: "node",
     silent: "passed-only",
+    pool: "threads",
+    reporters: isCi ? ["dot", "github-actions"] : ["default"],
     setupFiles: ["./src/test/setup-dom.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: ["src/e2e/**"],
     experimental: {
       fsModuleCache: true,
       fsModuleCachePath: ".cache/vitest",
+    },
+    deps: {
+      optimizer: {
+        ssr: {
+          enabled: true,
+          include: [
+            "drizzle-orm",
+            "drizzle-orm/node-postgres",
+            "hono",
+            "pg",
+            "react",
+            "react-dom",
+            "react-intl",
+            "zod",
+          ],
+        },
+        client: {
+          enabled: true,
+          include: [
+            "@testing-library/dom",
+            "@testing-library/jest-dom",
+            "@testing-library/react",
+            "react",
+            "react-dom",
+            "react-intl",
+          ],
+        },
+      },
+    },
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          disableCSSFileLoading: true,
+          disableJavaScriptFileLoading: true,
+          navigation: {
+            disableChildFrameNavigation: true,
+            disableChildPageNavigation: true,
+          },
+        },
+      },
     },
     server: {
       deps: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Vitest now hides console output from passing tests (`silent: "passed-only"`), so CI logs stay readable while failing tests still print their output.

The filesystem module cache is enabled and stored under `.cache/vitest`. Vite's transform cache lives under `.cache/vite`. Web CI restores and saves both directories so later runs can reuse transformed modules and test-ordering stats.

Additional test-config performance work:

- `pool: "threads"` instead of the default forks pool
- Dependency optimizer for heavy SSR and DOM packages
- Dot + GitHub Actions reporters in CI
- Happy DOM skips CSS/JS file loading and child-frame navigation

Isolation stays on. Many files use `vi.mock`, so `isolate: false` would leak mocks across files.

## How to test

- `cd apps/hyperlocalise-web && vp check --fix`
- `cd apps/hyperlocalise-web && vp test src/lib src/api/routes/team/team.test.ts src/components/cat/segment`
- Confirm `.cache/vitest` and `.cache/vite` are created after a test run

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c870788b-2d67-4412-88ff-ac83a9ef4b50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c870788b-2d67-4412-88ff-ac83a9ef4b50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

