### PR TITLE
fix(crowdin): add IsHidden query filter parity to SourceStringsListOptions

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-31 - Add IsHidden query filter parity to SourceStringsListOptions
+
+**Learning:** In Crowdin API v2, the List Source Strings endpoint (`GET /api/v2/projects/{projectId}/strings`) accepts an optional `isHidden` query parameter (0 - not hidden, 1 - hidden) to filter source strings by their hidden status. The SDK's `SourceStringsListOptions` previously lacked `IsHidden`, preventing callers from filtering source strings by hidden status in list requests.
+
+**Action:** Added `IsHidden *int json:"isHidden,omitempty"` to `SourceStringsListOptions` in `third_party/crowdin-api-client-go/crowdin/model/source_strings.go` and updated its `Values()` query parameter serialization logic to encode `isHidden` when `IsHidden` is set to 0 or 1. Added unit and contract tests in `crowdin/model/source_strings_test.go` and `crowdin/source_strings_test.go`.
+
 ## 2026-12-31 - Add omitempty struct tags to BundleAddRequest optional boolean pointers
 
 **Learning:** In Crowdin API v2, `isMultilingual` and `includeProjectSourceLanguage` are optional boolean parameters when creating a bundle (`POST /api/v2/projects/{projectId}/bundles`). Unset pointer fields without `omitempty` in Go standard `json.Marshal` serialize as `null` rather than being omitted from the request payload, which can trigger API validation errors.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -85,6 +85,8 @@ type SourceStringsListOptions struct {
 	CroQL string `json:"croql,omitempty"`
 	// Filter strings by isIcu. Enum: 0, 1.
 	IsIcu *int `json:"isIcu,omitempty"`
+	// Filter strings by isHidden. Enum: 0, 1.
+	IsHidden *int `json:"isHidden,omitempty"`
 	// Filter strings by `identifier`, `text` or `context`.
 	Filter string `json:"filter,omitempty"`
 	// Specify field to be the target of filtering. It can be one scope or
@@ -116,6 +118,9 @@ func (o *SourceStringsListOptions) Values() (url.Values, bool) {
 	}
 	if o.IsIcu != nil && (*o.IsIcu == 0 || *o.IsIcu == 1) {
 		v.Add("isIcu", strconv.Itoa(*o.IsIcu))
+	}
+	if o.IsHidden != nil && (*o.IsHidden == 0 || *o.IsHidden == 1) {
+		v.Add("isHidden", strconv.Itoa(*o.IsHidden))
 	}
 	if len(o.LabelIDs) > 0 {
 		v.Add("labelIds", JoinSlice(o.LabelIDs))

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
@@ -31,6 +31,16 @@ func TestSourceStringsListOptionsValues(t *testing.T) {
 			out:  "isIcu=1",
 		},
 		{
+			name: "with IsHidden = 0",
+			opts: &SourceStringsListOptions{IsHidden: toPtr(0)},
+			out:  "isHidden=0",
+		},
+		{
+			name: "with IsHidden = 1",
+			opts: &SourceStringsListOptions{IsHidden: toPtr(1)},
+			out:  "isHidden=1",
+		},
+		{
 			name: "with ExcludeLabelIDs",
 			opts: &SourceStringsListOptions{ExcludeLabelIDs: []int{4, 5}},
 			out:  "excludeLabelIds=4%2C5",
@@ -45,9 +55,9 @@ func TestSourceStringsListOptionsValues(t *testing.T) {
 			opts: &SourceStringsListOptions{
 				DenormalizePlaceholders: toPtr(1), LabelIDs: []int{1, 2, 3}, ExcludeLabelIDs: []int{4, 5},
 				FileID: 1, BranchID: 1, DirectoryID: 1, TaskID: 2, CroQL: "croql", Filter: "text", Scope: "identifier",
-				IsIcu: toPtr(0), OrderBy: "id",
+				IsIcu: toPtr(0), IsHidden: toPtr(1), OrderBy: "id",
 			},
-			out: "branchId=1&croql=croql&denormalizePlaceholders=1&directoryId=1&excludeLabelIds=4%2C5&fileId=1&filter=text&isIcu=0&labelIds=1%2C2%2C3&orderBy=id&scope=identifier&taskId=2",
+			out: "branchId=1&croql=croql&denormalizePlaceholders=1&directoryId=1&excludeLabelIds=4%2C5&fileId=1&filter=text&isHidden=1&isIcu=0&labelIds=1%2C2%2C3&orderBy=id&scope=identifier&taskId=2",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -166,6 +166,8 @@ func TestSourceStringsService_ListQueryParams(t *testing.T) {
 		{"empty query", nil, ""},
 		{"DenormalizePlaceholders=1", &model.SourceStringsListOptions{DenormalizePlaceholders: ToPtr(1)}, "denormalizePlaceholders=1"},
 		{"DenormalizePlaceholders=0", &model.SourceStringsListOptions{DenormalizePlaceholders: ToPtr(0)}, "denormalizePlaceholders=0"},
+		{"IsHidden=1", &model.SourceStringsListOptions{IsHidden: ToPtr(1)}, "isHidden=1"},
+		{"IsHidden=0", &model.SourceStringsListOptions{IsHidden: ToPtr(0)}, "isHidden=0"},
 		{"LabelIDs", &model.SourceStringsListOptions{LabelIDs: []int{1, 2, 3, 4, 5}}, "labelIds=1%2C2%2C3%2C4%2C5"},
 		{"FileID", &model.SourceStringsListOptions{FileID: 1}, "fileId=1"},
 		{"BranchID", &model.SourceStringsListOptions{BranchID: 2}, "branchId=2"},


### PR DESCRIPTION
What: Added IsHidden (*int) field and query parameter encoding to SourceStringsListOptions in the Crowdin Go client fork.
Why: Aligns List Source Strings (GET /api/v2/projects/{projectId}/strings) with official Crowdin API v2 contract specifications, enabling callers to filter source strings by hidden status (isHidden=0 or isHidden=1).
Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.strings.getMany
Scope: third_party/crowdin-api-client-go/crowdin/model/source_strings.go, third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go, third_party/crowdin-api-client-go/crowdin/source_strings_test.go
Tests: go test ./third_party/crowdin-api-client-go/...
Confidence: Fully backwards compatible, verified with unit and contract tests.

---
*PR created automatically by Jules for task [4934228719344585126](https://jules.google.com/task/4934228719344585126) started by @cungminh2710*