### PR TITLE
refactor(web): use Hono RPC client for issue sheet, inbox, and CAT issues

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-assignee-table-cell.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-assignee-table-cell.tsx
@@ -16,11 +16,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { IssueAssigneePicker } from "./issue-assignee-picker";
 import { issueDetailPanelMessages } from "./issue-detail-panel.messages";
-import { issueSheetApiPath } from "./issue-detail-utils";
+import { isIssueDetailIssue } from "./issue-detail-utils";
 import {
   patchIssueSheetListCacheForAssignee,
   patchOrganizationIssueListCaches,
@@ -53,23 +54,23 @@ export function IssueAssigneeTableCell({
 
   const updateAssignee = useMutation({
     mutationFn: async (nextAssigneeUserId: string | null) => {
-      const response = await fetch(
-        `${issueSheetApiPath(organizationSlug, projectId)}/${encodeURIComponent(issueId)}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ assigneeUserId: nextAssigneeUserId }),
-        },
-      );
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ][":issueId"].$patch({
+        param: { organizationSlug, projectId, issueId },
+        json: { assigneeUserId: nextAssigneeUserId },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(
           response,
           intl.formatMessage(issueDetailPanelMessages.updateFailed),
         );
       }
-      return (await response.json()) as {
-        issue: { assigneeUserId: string | null; assignee: string | null };
-      };
+      const body = await response.json();
+      if (!isIssueDetailIssue(body.issue)) {
+        throw new Error(intl.formatMessage(issueDetailPanelMessages.updateFailed));
+      }
+      return { issue: body.issue };
     },
     onSuccess: async (result) => {
       if (actorUserId) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-composer.tsx
@@ -27,6 +27,7 @@ import {
 import { markdownEditorMessages } from "@/components/markdown-editor/markdown-editor.messages";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/primitives/cn";
 
 import { issueCommentMessages as messages } from "./issue-comment.messages";
@@ -106,36 +107,14 @@ export function IssueCommentComposer({
       usersSectionLabel: intl.formatMessage(markdownEditorMessages.mentionUsersSection),
       issuesSectionLabel: intl.formatMessage(markdownEditorMessages.mentionIssuesSection),
       search: async (query) => {
-        const params = new URLSearchParams({
-          q: query,
-          projectId,
-          issueId,
-          limit: "5",
-        });
-        const response = await fetch(
-          `/api/orgs/${encodeURIComponent(organizationSlug)}/mentions?${params.toString()}`,
-        );
-        if (!response.ok) {
+        const response = await apiClient.api.orgs[":organizationSlug"].mentions.$get({
+          param: { organizationSlug },
+          query: { q: query, projectId, issueId, limit: "5" },
+        } as never);
+        if (response.status !== 200) {
           return { users: [], issues: [] };
         }
-        const body = (await response.json()) as {
-          mentionSuggestions: {
-            users: {
-              userId: string;
-              displayName: string;
-              email: string;
-              avatarUrl: string | null;
-              isAgent?: boolean;
-            }[];
-            issues: {
-              issueId: string;
-              projectId: string;
-              displayKey: string;
-              title: string;
-              status: string;
-            }[];
-          };
-        };
+        const body = await response.json();
         return {
           users: body.mentionSuggestions.users.map((entry) => ({
             kind: "user" as const,
@@ -144,7 +123,7 @@ export function IssueCommentComposer({
             displayName: entry.displayName,
             email: entry.email,
             avatarUrl: entry.avatarUrl,
-            isAgent: entry.isAgent,
+            isAgent: false,
           })),
           issues: body.mentionSuggestions.issues.map((issue) => ({
             kind: "issue" as const,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-thread.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-thread.tsx
@@ -40,6 +40,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
 import { assertNever } from "@/lib/primitives/assert-never/assert-never";
 import { cn } from "@/lib/primitives/cn";
 
@@ -57,7 +58,22 @@ import { IssueRelationshipKindIcon } from "./issue-relationship-kind";
 import { IssueStatusIcon } from "./issue-status-icon";
 import { useIssueCommentMutations, type IssueComment } from "./use-issue-comments";
 import { useIssueFeedQuery } from "./use-issue-feed";
-import type { IssueActivity } from "./use-issue-activities";
+import type { IssueRelationshipPresentedKind } from "./use-issue-relationships-query";
+
+type IssueFeedActivity = Extract<
+  NonNullable<ReturnType<typeof useIssueFeedQuery>["data"]>["pages"][number]["items"][number],
+  { kind: "activity" }
+>["activity"];
+
+function isPresentedRelationshipKind(kind: string): kind is IssueRelationshipPresentedKind {
+  return (
+    kind === "related" ||
+    kind === "blocks" ||
+    kind === "blocked_by" ||
+    kind === "duplicate_of" ||
+    kind === "duplicate"
+  );
+}
 
 function initials(name: string) {
   return name
@@ -377,7 +393,7 @@ function IssueFeedActivityRow({
 function relationshipAddedCopy(
   intl: ReturnType<typeof useIntl>,
   actor: ReactNode,
-  activity: Extract<IssueActivity, { type: "relationship_added" }>,
+  activity: Extract<IssueFeedActivity, { type: "relationship_added" }>,
 ) {
   const relatedIssue = activityName(
     activity.relatedIssue.title ?? intl.formatMessage(messages.unknownIssue),
@@ -406,14 +422,16 @@ function relationshipAddedCopy(
         />
       );
     default:
-      return assertNever(activity.relationshipKind);
+      return (
+        <FormattedMessage {...messages.relationshipAddedRelated} values={{ actor, relatedIssue }} />
+      );
   }
 }
 
 function relationshipRemovedCopy(
   intl: ReturnType<typeof useIntl>,
   actor: ReactNode,
-  activity: Extract<IssueActivity, { type: "relationship_removed" }>,
+  activity: Extract<IssueFeedActivity, { type: "relationship_removed" }>,
 ) {
   const relatedIssue = activityName(
     activity.relatedIssue.title ?? intl.formatMessage(messages.unknownIssue),
@@ -455,7 +473,12 @@ function relationshipRemovedCopy(
         />
       );
     default:
-      return assertNever(activity.relationshipKind);
+      return (
+        <FormattedMessage
+          {...messages.relationshipRemovedRelated}
+          values={{ actor, relatedIssue }}
+        />
+      );
   }
 }
 
@@ -464,7 +487,7 @@ function IssueActivityRow({
   connectAbove = false,
   connectBelow = false,
 }: {
-  activity: IssueActivity;
+  activity: IssueFeedActivity;
   connectAbove?: boolean;
   connectBelow?: boolean;
 }) {
@@ -547,11 +570,15 @@ function IssueActivityRow({
       break;
     case "relationship_added":
       copy = relationshipAddedCopy(intl, actor, activity);
-      icon = <IssueRelationshipKindIcon kind={activity.relationshipKind} />;
+      icon = isPresentedRelationshipKind(activity.relationshipKind) ? (
+        <IssueRelationshipKindIcon kind={activity.relationshipKind} />
+      ) : null;
       break;
     case "relationship_removed":
       copy = relationshipRemovedCopy(intl, actor, activity);
-      icon = <IssueRelationshipKindIcon kind={activity.relationshipKind} />;
+      icon = isPresentedRelationshipKind(activity.relationshipKind) ? (
+        <IssueRelationshipKindIcon kind={activity.relationshipKind} />
+      ) : null;
       break;
     default:
       assertNever(activity);
@@ -593,36 +620,14 @@ export function IssueCommentThread({
     usersSectionLabel: intl.formatMessage(markdownEditorMessages.mentionUsersSection),
     issuesSectionLabel: intl.formatMessage(markdownEditorMessages.mentionIssuesSection),
     search: async (query) => {
-      const params = new URLSearchParams({
-        q: query,
-        projectId,
-        issueId,
-        limit: "5",
-      });
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(organizationSlug)}/mentions?${params.toString()}`,
-      );
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].mentions.$get({
+        param: { organizationSlug },
+        query: { q: query, projectId, issueId, limit: "5" },
+      } as never);
+      if (response.status !== 200) {
         return { users: [], issues: [] };
       }
-      const body = (await response.json()) as {
-        mentionSuggestions: {
-          users: {
-            userId: string;
-            displayName: string;
-            email: string;
-            avatarUrl: string | null;
-            isAgent?: boolean;
-          }[];
-          issues: {
-            issueId: string;
-            projectId: string;
-            displayKey: string;
-            title: string;
-            status: string;
-          }[];
-        };
-      };
+      const body = await response.json();
       return {
         users: body.mentionSuggestions.users.map((user) => ({
           kind: "user" as const,
@@ -631,7 +636,7 @@ export function IssueCommentThread({
           displayName: user.displayName,
           email: user.email,
           avatarUrl: user.avatarUrl,
-          isAgent: user.isAgent,
+          isAgent: false,
         })),
         issues: body.mentionSuggestions.issues.map((issue) => ({
           kind: "issue" as const,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils.ts
@@ -67,6 +67,17 @@ export type IssueDetailIssue = {
   isWatching: boolean;
 };
 
+export function isIssueDetailIssue(value: unknown): value is IssueDetailIssue {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    "assigneeUserId" in value &&
+    "assignee" in value &&
+    "isWatching" in value
+  );
+}
+
 function formatUnknownLabel(value: string) {
   return value.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-relationship-section.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-relationship-section.test.tsx
@@ -24,8 +24,6 @@ import type { IssueRelationship } from "./use-issue-relationships-query";
 const organizationSlug = "acme";
 const projectId = "project_website";
 const issueId = "issue_001";
-const relationshipsPath = `/api/orgs/${organizationSlug}/projects/${projectId}/issue-sheet/${issueId}/relationships`;
-const searchPathPrefix = `/api/orgs/${organizationSlug}/issue-sheet/search`;
 
 function resolveFetchUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") {
@@ -115,7 +113,7 @@ describe("IssueRelationshipSection", () => {
     const user = userEvent.setup();
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = resolveFetchUrl(input);
-      if (url === `${relationshipsPath}/rel_blocks` && init?.method === "DELETE") {
+      if (url.includes("/relationships/rel_blocks") && init?.method === "DELETE") {
         return new Response(null, { status: 204 });
       }
       throw new Error(`Unexpected fetch: ${url} ${init?.method ?? "GET"}`);
@@ -125,9 +123,10 @@ describe("IssueRelationshipSection", () => {
     await user.click(screen.getAllByRole("button", { name: "Remove relationship" })[0]!);
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(`${relationshipsPath}/rel_blocks`, {
-        method: "DELETE",
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/relationships/rel_blocks"),
+        expect.objectContaining({ method: "DELETE" }),
+      );
     });
   });
 
@@ -135,7 +134,7 @@ describe("IssueRelationshipSection", () => {
     const user = userEvent.setup();
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = resolveFetchUrl(input);
-      if (url.startsWith(searchPathPrefix)) {
+      if (url.includes("/issue-sheet/search")) {
         return new Response(
           JSON.stringify({
             issues: [{ issueId: "issue_target", projectId, title: "Target issue", status: "open" }],
@@ -143,7 +142,7 @@ describe("IssueRelationshipSection", () => {
           { status: 200 },
         );
       }
-      if (url === relationshipsPath && init?.method === "POST") {
+      if (url.includes("/relationships") && init?.method === "POST") {
         return new Response(JSON.stringify({ relationship: { id: "rel_new" } }), { status: 201 });
       }
       throw new Error(`Unexpected fetch: ${url} ${init?.method ?? "GET"}`);
@@ -157,7 +156,7 @@ describe("IssueRelationshipSection", () => {
 
     await waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        relationshipsPath,
+        expect.stringContaining("/relationships"),
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ relatedIssueId: "issue_target", kind: "related" }),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-watch-control.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-watch-control.test.tsx
@@ -23,8 +23,6 @@ import { IssueWatchControl } from "./issue-watch-control";
 const organizationSlug = "acme";
 const projectId = "project_website";
 const issueId = "issue_001";
-const subscribersPath = `/api/orgs/${organizationSlug}/projects/${projectId}/issue-sheet/${issueId}/subscriptions`;
-const subscriptionPath = `/api/orgs/${organizationSlug}/projects/${projectId}/issue-sheet/${issueId}/subscription`;
 
 const subscribersFixture = [
   {
@@ -52,13 +50,13 @@ function resolveFetchUrl(input: RequestInfo | URL): string {
 function mockFetch() {
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
     const url = resolveFetchUrl(input);
-    if (url === subscribersPath) {
+    if (url.includes("/subscriptions")) {
       return new Response(JSON.stringify({ subscribers: subscribersFixture }), { status: 200 });
     }
-    if (url === subscriptionPath && init?.method === "DELETE") {
+    if (url.includes("/subscription") && init?.method === "DELETE") {
       return new Response(null, { status: 204 });
     }
-    if (url === subscriptionPath && init?.method === "POST") {
+    if (url.includes("/subscription") && init?.method === "POST") {
       return new Response(
         JSON.stringify({
           subscription: {
@@ -134,7 +132,10 @@ describe("IssueWatchControl", () => {
     await user.click(await screen.findByRole("button", { name: "Unsubscribe" }));
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(subscriptionPath, { method: "DELETE" });
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(`/subscription`),
+        expect.objectContaining({ method: "DELETE" }),
+      );
     });
   });
 
@@ -146,7 +147,10 @@ describe("IssueWatchControl", () => {
     await user.click(await screen.findByRole("button", { name: "Subscribe" }));
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(subscriptionPath, { method: "POST" });
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(`/subscription`),
+        expect.objectContaining({ method: "POST" }),
+      );
     });
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-assignable-issue-members.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-assignable-issue-members.ts
@@ -50,7 +50,7 @@ export function useAssignableIssueMembersQuery({
       ]["assignable-members"].$get({
         param: { organizationSlug, projectId: projectId! },
       } as never);
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load assignable members");
       }
       return response.json();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-comments.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-comments.ts
@@ -14,9 +14,9 @@
  */
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
-import { issueSheetApiPath } from "./issue-detail-utils";
 import { issueFeedQueryKey } from "./use-issue-feed";
 
 export type IssueCommentAuthor = {
@@ -44,10 +44,6 @@ export type IssueComment = {
   canDelete: boolean;
 };
 
-function commentsApiPath(organizationSlug: string, projectId: string, issueId: string) {
-  return `${issueSheetApiPath(organizationSlug, projectId)}/${encodeURIComponent(issueId)}/comments`;
-}
-
 export function useIssueCommentMutations({
   organizationSlug,
   projectId,
@@ -59,6 +55,9 @@ export function useIssueCommentMutations({
 }) {
   const queryClient = useQueryClient();
   const feedQueryKey = issueFeedQueryKey(organizationSlug, projectId, issueId);
+  const comments =
+    apiClient.api.orgs[":organizationSlug"].projects[":projectId"]["issue-sheet"][":issueId"]
+      .comments;
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: feedQueryKey });
 
@@ -69,15 +68,14 @@ export function useIssueCommentMutations({
       mentionedUserIds?: string[];
       mentionedIssueIds?: string[];
     }) => {
-      const response = await fetch(commentsApiPath(organizationSlug, projectId, issueId), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(input),
-      });
-      if (!response.ok) {
+      const response = await comments.$post({
+        param: { organizationSlug, projectId, issueId },
+        json: input,
+      } as never);
+      if (response.status !== 201) {
         throw await readApiResponseError(response, "Failed to create comment");
       }
-      return (await response.json()) as { issueComment: IssueComment };
+      return response.json();
     },
     onSuccess: invalidate,
   });
@@ -89,33 +87,28 @@ export function useIssueCommentMutations({
       mentionedUserIds?: string[];
       mentionedIssueIds?: string[];
     }) => {
-      const response = await fetch(
-        `${commentsApiPath(organizationSlug, projectId, issueId)}/${encodeURIComponent(input.commentId)}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            body: input.body,
-            mentionedUserIds: input.mentionedUserIds,
-            mentionedIssueIds: input.mentionedIssueIds,
-          }),
+      const response = await comments[":commentId"].$patch({
+        param: { organizationSlug, projectId, issueId, commentId: input.commentId },
+        json: {
+          body: input.body,
+          mentionedUserIds: input.mentionedUserIds,
+          mentionedIssueIds: input.mentionedIssueIds,
         },
-      );
-      if (!response.ok) {
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to update comment");
       }
-      return (await response.json()) as { issueComment: IssueComment };
+      return response.json();
     },
     onSuccess: invalidate,
   });
 
   const deleteComment = useMutation({
     mutationFn: async (commentId: string) => {
-      const response = await fetch(
-        `${commentsApiPath(organizationSlug, projectId, issueId)}/${encodeURIComponent(commentId)}`,
-        { method: "DELETE" },
-      );
-      if (!response.ok) {
+      const response = await comments[":commentId"].$delete({
+        param: { organizationSlug, projectId, issueId, commentId },
+      } as never);
+      if (response.status !== 204) {
         throw await readApiResponseError(response, "Failed to delete comment");
       }
     },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-mutations.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-mutations.ts
@@ -17,24 +17,17 @@ import { useRef } from "react";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messages";
-import { issueSheetApiPath, type IssueDetailIssue } from "./issue-detail-utils";
+import { type IssueDetailIssue, isIssueDetailIssue } from "./issue-detail-utils";
 import {
   patchIssueSheetListCacheForAssignee,
   patchOrganizationIssueListCaches,
 } from "./patch-organization-issue-list-caches";
 import { issueDetailQueryKey } from "./use-issue-detail-query";
 import { issueFeedQueryKey } from "./use-issue-feed";
-
-async function readJsonOrThrow<T>(response: Response, fallbackMessage: string): Promise<T> {
-  if (!response.ok) {
-    const error = await readApiResponseError(response, fallbackMessage);
-    throw new Error(error.message || fallbackMessage);
-  }
-  return (await response.json()) as T;
-}
 
 function isAbortError(error: unknown) {
   return error instanceof DOMException
@@ -132,33 +125,41 @@ export function useIssueDetailMutations({
   };
 
   const updateIssue = useMutation({
-    mutationFn: async (body: Record<string, unknown>) => {
+    mutationFn: async (patch: Record<string, unknown>) => {
       const controller = new AbortController();
       trackAbortController(updateAbortControllersRef.current, controller);
       try {
-        const response = await fetch(
-          `${issueSheetApiPath(organizationSlug, projectId)}/${issueId}`,
+        const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+          "issue-sheet"
+        ][":issueId"].$patch(
           {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(body),
-            signal: controller.signal,
-          },
+            param: { organizationSlug, projectId, issueId },
+            json: patch,
+          } as never,
+          { init: { signal: controller.signal } },
         );
-        return readJsonOrThrow<{ issue: IssueDetailIssue }>(response, requestFailed);
+        if (response.status !== 200) {
+          const error = await readApiResponseError(response, requestFailed);
+          throw new Error(error.message || requestFailed);
+        }
+        const payload = await response.json();
+        if (!isIssueDetailIssue(payload.issue)) {
+          throw new Error(requestFailed);
+        }
+        return { issue: payload.issue };
       } finally {
         releaseAbortController(updateAbortControllersRef.current, controller);
       }
     },
-    onSuccess: async (result, body) => {
+    onSuccess: async (result, patch) => {
       queryClient.setQueryData(
         issueDetailQueryKey(organizationSlug, projectId, issueId),
-        (current: IssueDetailIssue | undefined) => mergeIssuePatch(current, body, result.issue),
+        (current: IssueDetailIssue | undefined) => mergeIssuePatch(current, patch, result.issue),
       );
-      if (Object.hasOwn(body, "assigneeUserId")) {
+      if (Object.hasOwn(patch, "assigneeUserId")) {
         patchListCachesForAssignee(result.issue);
       }
-      await invalidate(body);
+      await invalidate(patch);
     },
     onError: (error) => {
       if (isAbortError(error)) {
@@ -173,16 +174,20 @@ export function useIssueDetailMutations({
       const controller = new AbortController();
       trackAbortController(setValueAbortControllersRef.current, controller);
       try {
-        const response = await fetch(
-          `${issueSheetApiPath(organizationSlug, projectId)}/${issueId}/values`,
+        const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+          "issue-sheet"
+        ][":issueId"].values.$patch(
           {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ columnKey, value }),
-            signal: controller.signal,
-          },
+            param: { organizationSlug, projectId, issueId },
+            json: { columnKey, value },
+          } as never,
+          { init: { signal: controller.signal } },
         );
-        return readJsonOrThrow<{ value: unknown }>(response, requestFailed);
+        if (response.status !== 200) {
+          const error = await readApiResponseError(response, requestFailed);
+          throw new Error(error.message || requestFailed);
+        }
+        return response.json();
       } finally {
         releaseAbortController(setValueAbortControllersRef.current, controller);
       }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-query.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-query.ts
@@ -14,9 +14,8 @@
  */
 import { useQuery } from "@tanstack/react-query";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
-
-import { issueSheetApiPath, type IssueDetailIssue } from "./issue-detail-utils";
 
 export function issueDetailQueryKey(organizationSlug: string, projectId: string, issueId: string) {
   return ["issue-detail", organizationSlug, projectId, issueId] as const;
@@ -37,11 +36,15 @@ export function useIssueDetailQuery({
     queryKey: issueDetailQueryKey(organizationSlug, projectId ?? "", issueId ?? ""),
     enabled: enabled && Boolean(projectId && issueId),
     queryFn: async () => {
-      const response = await fetch(`${issueSheetApiPath(organizationSlug, projectId!)}/${issueId}`);
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ][":issueId"].$get({
+        param: { organizationSlug, projectId: projectId!, issueId: issueId! },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load issue");
       }
-      const body = (await response.json()) as { issue: IssueDetailIssue };
+      const body = await response.json();
       return body.issue;
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-feed.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-feed.ts
@@ -14,9 +14,9 @@
  */
 import { useInfiniteQuery } from "@tanstack/react-query";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
-import { issueSheetApiPath } from "./issue-detail-utils";
 import type { IssueComment } from "./use-issue-comments";
 import type { IssueActivity } from "./use-issue-activities";
 
@@ -56,19 +56,19 @@ export function useIssueFeedQuery({
     enabled: Boolean(organizationSlug && projectId && issueId && enabled),
     initialPageParam: null as string | null,
     queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({
-        limit: String(ISSUE_FEED_PAGE_SIZE),
-      });
-      if (pageParam) {
-        params.set("cursor", pageParam);
-      }
-      const response = await fetch(
-        `${issueSheetApiPath(organizationSlug, projectId)}/${encodeURIComponent(issueId)}/feed?${params.toString()}`,
-      );
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ][":issueId"].feed.$get({
+        param: { organizationSlug, projectId, issueId },
+        query: {
+          limit: String(ISSUE_FEED_PAGE_SIZE),
+          ...(pageParam ? { cursor: pageParam } : {}),
+        },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load issue feed");
       }
-      return (await response.json()) as IssueFeedPage;
+      return response.json();
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-relationship-mutations.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-relationship-mutations.ts
@@ -14,9 +14,9 @@
  */
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
-import { issueSheetApiPath } from "./issue-detail-utils";
 import { issueFeedQueryKey } from "./use-issue-feed";
 import { ISSUE_RELATIONSHIPS_QUERY_PREFIX } from "./use-issue-relationships-query";
 
@@ -33,7 +33,9 @@ export function useIssueRelationshipMutations({
 }) {
   const queryClient = useQueryClient();
   const feedKey = issueFeedQueryKey(organizationSlug, projectId, issueId);
-  const basePath = `${issueSheetApiPath(organizationSlug, projectId)}/${issueId}/relationships`;
+  const relationships =
+    apiClient.api.orgs[":organizationSlug"].projects[":projectId"]["issue-sheet"][":issueId"]
+      .relationships;
 
   const invalidate = () => {
     // A relationship is visible from both endpoint issues, but only this issue's
@@ -50,12 +52,11 @@ export function useIssueRelationshipMutations({
 
   const createRelationship = useMutation({
     mutationFn: async (input: { relatedIssueId: string; kind: IssueRelationshipRequestKind }) => {
-      const response = await fetch(basePath, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(input),
-      });
-      if (!response.ok) {
+      const response = await relationships.$post({
+        param: { organizationSlug, projectId, issueId },
+        json: input,
+      } as never);
+      if (response.status !== 201) {
         throw await readApiResponseError(response, "Failed to create relationship");
       }
     },
@@ -64,8 +65,10 @@ export function useIssueRelationshipMutations({
 
   const deleteRelationship = useMutation({
     mutationFn: async (relationshipId: string) => {
-      const response = await fetch(`${basePath}/${relationshipId}`, { method: "DELETE" });
-      if (!response.ok) {
+      const response = await relationships[":relationshipId"].$delete({
+        param: { organizationSlug, projectId, issueId, relationshipId },
+      } as never);
+      if (response.status !== 204) {
         throw await readApiResponseError(response, "Failed to remove relationship");
       }
     },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-relationship-search.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-relationship-search.ts
@@ -15,6 +15,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 export type IssueSearchResult = {
@@ -53,14 +54,14 @@ export function useIssueRelationshipSearch({
     queryKey: ["issue-relationship-search", organizationSlug, excludeIssueId, debouncedQuery],
     enabled,
     queryFn: async () => {
-      const params = new URLSearchParams({ q: debouncedQuery, excludeIssueId });
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(organizationSlug)}/issue-sheet/search?${params.toString()}`,
-      );
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"]["issue-sheet"].search.$get({
+        param: { organizationSlug },
+        query: { q: debouncedQuery, excludeIssueId, limit: "20" },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to search issues");
       }
-      const body = (await response.json()) as { issues: IssueSearchResult[] };
+      const body = await response.json();
       return body.issues;
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-relationships-query.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-relationships-query.ts
@@ -14,9 +14,8 @@
  */
 import { useQuery } from "@tanstack/react-query";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
-
-import { issueSheetApiPath } from "./issue-detail-utils";
 
 export type IssueRelationshipPresentedKind =
   | "related"
@@ -55,13 +54,15 @@ export function useIssueRelationshipsQuery({
     queryKey: issueRelationshipsQueryKey(organizationSlug, projectId ?? "", issueId ?? ""),
     enabled: Boolean(projectId && issueId),
     queryFn: async () => {
-      const response = await fetch(
-        `${issueSheetApiPath(organizationSlug, projectId!)}/${issueId}/relationships`,
-      );
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ][":issueId"].relationships.$get({
+        param: { organizationSlug, projectId: projectId!, issueId: issueId! },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load relationships");
       }
-      const body = (await response.json()) as { relationships: IssueRelationship[] };
+      const body = await response.json();
       return body.relationships;
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-sheet-columns-query.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-sheet-columns-query.ts
@@ -14,10 +14,8 @@
  */
 import { useQuery } from "@tanstack/react-query";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
-
-import { issueSheetApiPath } from "./issue-detail-utils";
-import type { IssueSheetColumn } from "./issue-sheet-column-types";
 
 export function issueSheetColumnsQueryKey(organizationSlug: string, projectId: string) {
   return ["issue-sheet-columns", organizationSlug, projectId] as const;
@@ -36,11 +34,15 @@ export function useIssueSheetColumnsQuery({
     queryKey: issueSheetColumnsQueryKey(organizationSlug, projectId),
     enabled,
     queryFn: async () => {
-      const response = await fetch(`${issueSheetApiPath(organizationSlug, projectId)}/columns`);
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].columns.$get({
+        param: { organizationSlug, projectId },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load issue sheet columns");
       }
-      const body = (await response.json()) as { columns: IssueSheetColumn[] };
+      const body = await response.json();
       return body.columns;
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-sheet-template-config-query.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-sheet-template-config-query.ts
@@ -14,9 +14,8 @@
  */
 import { useQuery } from "@tanstack/react-query";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
-
-import { issueSheetApiPath } from "./issue-detail-utils";
 
 export type IssueSheetTemplateAssigneeBinding = {
   templateKey: string;
@@ -49,13 +48,15 @@ export function useIssueSheetTemplateConfigQuery({
     queryKey: issueSheetTemplateConfigQueryKey(organizationSlug, projectId ?? ""),
     enabled: Boolean(organizationSlug && projectId && enabled),
     queryFn: async () => {
-      const response = await fetch(
-        `${issueSheetApiPath(organizationSlug, projectId!)}/template-config`,
-      );
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ]["template-config"].$get({
+        param: { organizationSlug, projectId: projectId! },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load issue template config");
       }
-      const body = (await response.json()) as { templateConfig: IssueSheetTemplateConfig };
+      const body = await response.json();
       return body.templateConfig;
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-subscribers-query.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-subscribers-query.ts
@@ -14,9 +14,8 @@
  */
 import { useQuery } from "@tanstack/react-query";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
-
-import { issueSheetApiPath } from "./issue-detail-utils";
 
 export type IssueSubscriber = {
   userId: string;
@@ -47,13 +46,15 @@ export function useIssueSubscribersQuery({
     queryKey: issueSubscribersQueryKey(organizationSlug, projectId, issueId),
     enabled,
     queryFn: async () => {
-      const response = await fetch(
-        `${issueSheetApiPath(organizationSlug, projectId)}/${issueId}/subscriptions`,
-      );
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ][":issueId"].subscriptions.$get({
+        param: { organizationSlug, projectId, issueId },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load issue subscribers");
       }
-      const body = (await response.json()) as { subscribers: IssueSubscriber[] };
+      const body = await response.json();
       return body.subscribers;
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-subscription.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-subscription.ts
@@ -16,10 +16,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { issueWatchControlMessages as messages } from "./issue-watch-control.messages";
-import { issueSheetApiPath, type IssueDetailIssue } from "./issue-detail-utils";
+import { type IssueDetailIssue } from "./issue-detail-utils";
 import { issueDetailQueryKey } from "./use-issue-detail-query";
 import { issueSubscribersQueryKey } from "./use-issue-subscribers-query";
 
@@ -36,7 +37,9 @@ export function useIssueSubscriptionMutations({
   const queryClient = useQueryClient();
   const detailKey = issueDetailQueryKey(organizationSlug, projectId, issueId);
   const subscribersKey = issueSubscribersQueryKey(organizationSlug, projectId, issueId);
-  const basePath = `${issueSheetApiPath(organizationSlug, projectId)}/${issueId}/subscription`;
+  const subscription =
+    apiClient.api.orgs[":organizationSlug"].projects[":projectId"]["issue-sheet"][":issueId"]
+      .subscription;
 
   const setWatching = (isWatching: boolean) => {
     queryClient.setQueryData<IssueDetailIssue>(detailKey, (current) =>
@@ -46,8 +49,10 @@ export function useIssueSubscriptionMutations({
 
   const watch = useMutation({
     mutationFn: async () => {
-      const response = await fetch(basePath, { method: "POST" });
-      if (!response.ok) {
+      const response = await subscription.$post({
+        param: { organizationSlug, projectId, issueId },
+      } as never);
+      if (response.status !== 201) {
         throw await readApiResponseError(response, "Failed to watch issue");
       }
     },
@@ -66,8 +71,10 @@ export function useIssueSubscriptionMutations({
 
   const unwatch = useMutation({
     mutationFn: async () => {
-      const response = await fetch(basePath, { method: "DELETE" });
-      if (!response.ok) {
+      const response = await subscription.$delete({
+        param: { organizationSlug, projectId, issueId },
+      } as never);
+      if (response.status !== 204) {
         throw await readApiResponseError(response, "Failed to unwatch issue");
       }
     },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/use-issue-bulk-actions.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/use-issue-bulk-actions.ts
@@ -17,29 +17,10 @@ import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import type { IssueBulkActionBody } from "@/api/routes/issues/issues-bulk.schema";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { issueBulkActionBarMessages as messages } from "./issue-bulk-action-bar.messages";
-
-type BulkActionResponse = {
-  bulkAction: {
-    action: IssueBulkActionBody["action"];
-    requested: number;
-    succeeded: number;
-    failed: number;
-    unchanged: number;
-    results: Array<{
-      issueId: string;
-      projectId: string;
-      outcome: "updated" | "unchanged" | "failed";
-      error?: { code: string; message?: string };
-    }>;
-  };
-};
-
-function organizationBulkActionsPath(organizationSlug: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/issues/bulk-actions`;
-}
 
 export function useIssueBulkActions({
   organizationSlug,
@@ -53,15 +34,14 @@ export function useIssueBulkActions({
 
   const mutation = useMutation({
     mutationFn: async (body: IssueBulkActionBody) => {
-      const response = await fetch(organizationBulkActionsPath(organizationSlug), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].issues["bulk-actions"].$post({
+        param: { organizationSlug },
+        json: body,
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, intl.formatMessage(messages.bulkFailed));
       }
-      return (await response.json()) as BulkActionResponse;
+      return response.json();
     },
     onSuccess: async (result) => {
       const { bulkAction } = result;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.test.ts
@@ -17,45 +17,58 @@ import { createInboxApi } from "./inbox-api";
 const FILE_ONLY_CONVERSATION_TEXT = "Please translate the attached source file.";
 
 function stubInboxApiClient() {
+  const createConversationPost = vi.fn();
+  const sendMessagePost = vi.fn();
   return {
-    api: {
-      orgs: {
-        ":organizationSlug": {
-          conversations: {
-            $get: vi.fn(),
-            ":conversationId": {
-              messages: { $get: vi.fn() },
-              jobs: { $get: vi.fn() },
+    createConversationPost,
+    sendMessagePost,
+    client: {
+      api: {
+        orgs: {
+          ":organizationSlug": {
+            conversations: {
+              $get: vi.fn(),
+              $post: createConversationPost,
+              ":conversationId": {
+                messages: { $get: vi.fn(), $post: sendMessagePost },
+                jobs: { $get: vi.fn() },
+              },
             },
-          },
-          "github-installation": {
-            repositories: { $get: vi.fn() },
+            "github-installation": {
+              repositories: { $get: vi.fn() },
+            },
           },
         },
       },
-    },
-  } as never;
+    } as never,
+  };
+}
+
+function jsonResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 describe("createInboxApi FormData", () => {
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
   it("substitutes file-only placeholder text when createConversation text is blank", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
+    const { client, createConversationPost } = stubInboxApiClient();
+    createConversationPost.mockResolvedValue(
+      jsonResponse(
+        {
           conversation: { id: "conv_1", title: "File request" },
           message: { id: "msg_1", text: FILE_ONLY_CONVERSATION_TEXT },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
+        },
+        201,
       ),
     );
-    vi.stubGlobal("fetch", fetchMock);
 
-    const api = createInboxApi(stubInboxApiClient());
+    const api = createInboxApi(client);
     const file = new File(["source"], "source.json", { type: "application/json" });
 
     await api.createConversation("acme", {
@@ -65,44 +78,45 @@ describe("createInboxApi FormData", () => {
       repositoryFullName: "acme/web",
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("/api/orgs/acme/conversations");
-    expect(init.method).toBe("POST");
-    const formData = init.body as FormData;
-    expect(formData.get("text")).toBe(FILE_ONLY_CONVERSATION_TEXT);
-    expect(formData.get("projectId")).toBe("project_1");
-    expect(formData.get("repositoryFullName")).toBe("acme/web");
-    expect(formData.getAll("files")).toHaveLength(1);
+    expect(createConversationPost).toHaveBeenCalledTimes(1);
+    expect(createConversationPost).toHaveBeenCalledWith({
+      param: { organizationSlug: "acme" },
+      form: {
+        text: FILE_ONLY_CONVERSATION_TEXT,
+        projectId: "project_1",
+        repositoryFullName: "acme/web",
+        files: [file],
+      },
+    });
   });
 
   it("preserves trimmed createConversation text and does not rewrite sendMessage blanks", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ conversation: { id: "conv_2" } }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
-    vi.stubGlobal("fetch", fetchMock);
+    const { client, createConversationPost, sendMessagePost } = stubInboxApiClient();
+    createConversationPost.mockResolvedValue(jsonResponse({ conversation: { id: "conv_2" } }, 201));
+    sendMessagePost.mockResolvedValue(jsonResponse({ message: { id: "msg_2" } }, 201));
 
-    const api = createInboxApi(stubInboxApiClient());
+    const api = createInboxApi(client);
 
     await api.createConversation("acme", {
       text: "  Translate this UI  ",
       files: [],
     });
-    const createForm = (fetchMock.mock.calls[0] as [string, RequestInit])[1].body as FormData;
-    expect(createForm.get("text")).toBe("Translate this UI");
+    expect(createConversationPost).toHaveBeenCalledWith({
+      param: { organizationSlug: "acme" },
+      form: {
+        text: "Translate this UI",
+      },
+    });
 
     await api.sendMessage("acme", "conv_2", {
       text: "   ",
       files: [],
     });
-    const sendForm = (fetchMock.mock.calls[1] as [string, RequestInit])[1].body as FormData;
-    // Reply path keeps the raw text; only new-request compose substitutes file-only copy.
-    expect(sendForm.get("text")).toBe("   ");
+    expect(sendMessagePost).toHaveBeenCalledWith({
+      param: { organizationSlug: "acme", conversationId: "conv_2" },
+      form: {
+        text: "   ",
+      },
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -48,17 +48,26 @@ type ApiClient = ReturnType<typeof createApiClient>;
 
 const FILE_ONLY_CONVERSATION_TEXT = "Please translate the attached source file.";
 
-function appendConversationFormData(formData: FormData, input: SendConversationMessageInput) {
-  formData.set("text", input.text.trim() || FILE_ONLY_CONVERSATION_TEXT);
-  if (input.projectId) {
-    formData.set("projectId", input.projectId);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isConversationMessages(value: unknown): value is ConversationMessage[] {
+  return Array.isArray(value);
+}
+
+function isLinkedJobs(value: unknown): value is LinkedJob[] {
+  return Array.isArray(value);
+}
+
+function isCreatedConversation(value: unknown): value is {
+  conversation: { id: string; title?: string };
+  message?: { id: string; text: string };
+} {
+  if (!isRecord(value) || !isRecord(value.conversation)) {
+    return false;
   }
-  if (input.repositoryFullName) {
-    formData.set("repositoryFullName", input.repositoryFullName);
-  }
-  for (const file of input.files) {
-    formData.append("files", file);
-  }
+  return typeof value.conversation.id === "string";
 }
 
 export function createInboxApi(client: ApiClient): InboxApi {
@@ -70,32 +79,38 @@ export function createInboxApi(client: ApiClient): InboxApi {
         param: { organizationSlug },
         query: { limit: String(limit) },
       });
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load conversations");
       }
-      const body = (await response.json()) as { conversations: Conversation[] };
+      const body = await response.json();
       return body.conversations;
     },
 
     async listMessages(organizationSlug, conversationId) {
       const response = await conversations[":conversationId"].messages.$get({
         param: { organizationSlug, conversationId },
-      });
-      if (!response.ok) {
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load messages");
       }
-      const body = (await response.json()) as { messages: ConversationMessage[] };
+      const body = await response.json();
+      if (!isRecord(body) || !isConversationMessages(body.messages)) {
+        throw new Error("Failed to load messages");
+      }
       return body.messages;
     },
 
     async listLinkedJobs(organizationSlug, conversationId) {
       const response = await conversations[":conversationId"].jobs.$get({
         param: { organizationSlug, conversationId },
-      });
-      if (!response.ok) {
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load jobs");
       }
-      const body = (await response.json()) as { jobs: LinkedJob[] };
+      const body = await response.json();
+      if (!isRecord(body) || !isLinkedJobs(body.jobs)) {
+        throw new Error("Failed to load jobs");
+      }
       return body.jobs;
     },
 
@@ -106,55 +121,45 @@ export function createInboxApi(client: ApiClient): InboxApi {
         param: { organizationSlug },
         query: {},
       });
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load GitHub repositories");
       }
-      const body = (await response.json()) as { repositories: InboxGithubRepository[] };
+      const body = await response.json();
       return body.repositories.filter((repository) => repository.enabled && !repository.archived);
     },
 
     async createConversation(organizationSlug, input) {
-      const formData = new FormData();
-      appendConversationFormData(formData, input);
-
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(organizationSlug)}/conversations`,
-        {
-          method: "POST",
-          body: formData,
+      const response = await conversations.$post({
+        param: { organizationSlug },
+        form: {
+          text: input.text.trim() || FILE_ONLY_CONVERSATION_TEXT,
+          ...(input.projectId ? { projectId: input.projectId } : {}),
+          ...(input.repositoryFullName ? { repositoryFullName: input.repositoryFullName } : {}),
+          ...(input.files.length > 0 ? { files: input.files } : {}),
         },
-      );
-      if (!response.ok) {
+      } as never);
+      if (response.status !== 201) {
         throw await readApiResponseError(response, "Failed to create conversation");
       }
-      return response.json() as Promise<{
-        conversation: { id: string; title?: string };
-        message?: { id: string; text: string };
-      }>;
+      const body = await response.json();
+      if (!isCreatedConversation(body)) {
+        throw new Error("Failed to create conversation");
+      }
+      return body;
     },
 
     async sendMessage(organizationSlug, conversationId, input) {
-      const formData = new FormData();
-      formData.append("text", input.text);
-      if (input.projectId) {
-        formData.append("projectId", input.projectId);
-      }
-      if (input.repositoryFullName) {
-        formData.append("repositoryFullName", input.repositoryFullName);
-      }
-      for (const file of input.files) {
-        formData.append("files", file);
-      }
-
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(organizationSlug)}/conversations/${encodeURIComponent(conversationId)}/messages`,
-        {
-          method: "POST",
-          body: formData,
+      const response = await conversations[":conversationId"].messages.$post({
+        param: { organizationSlug, conversationId },
+        form: {
+          text: input.text,
+          ...(input.projectId ? { projectId: input.projectId } : {}),
+          ...(input.repositoryFullName ? { repositoryFullName: input.repositoryFullName } : {}),
+          ...(input.files.length > 0 ? { files: input.files } : {}),
         },
-      );
+      } as never);
 
-      if (!response.ok) {
+      if (response.status !== 201) {
         throw await readApiResponseError(response, "Failed to send message");
       }
     },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-notifications-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-notifications-api.ts
@@ -10,8 +10,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { readApiResponseError } from "@/lib/api-error";
 import type { IssueNotificationType } from "@/lib/database/schema/issue-sheet";
+import type { createApiClient } from "@/lib/api-client";
+import { readApiResponseError } from "@/lib/api-error";
 
 export type InboxIssueNotification = {
   id: string;
@@ -53,72 +54,68 @@ export type InboxNotificationsApi = {
   getById(organizationSlug: string, notificationId: string): Promise<InboxIssueNotification>;
 };
 
-function notificationsBase(organizationSlug: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/notifications`;
-}
+type ApiClient = ReturnType<typeof createApiClient>;
 
-export function createInboxNotificationsApi(): InboxNotificationsApi {
+export function createInboxNotificationsApi(client: ApiClient): InboxNotificationsApi {
+  const notifications = client.api.orgs[":organizationSlug"].notifications;
+
   return {
     async list(organizationSlug, options = {}) {
-      const query = new URLSearchParams({
-        limit: String(options.limit ?? 50),
-        offset: String(options.offset ?? 0),
-      });
-      if (options.unreadOnly) {
-        query.set("unreadOnly", "true");
-      }
-      const response = await fetch(`${notificationsBase(organizationSlug)}?${query.toString()}`);
-      if (!response.ok) {
+      const response = await notifications.$get({
+        param: { organizationSlug },
+        query: {
+          limit: String(options.limit ?? 50),
+          offset: String(options.offset ?? 0),
+          ...(options.unreadOnly ? { unreadOnly: "true" } : {}),
+        },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load notifications");
       }
-      return (await response.json()) as {
-        notifications: InboxIssueNotification[];
-        total: number;
-      };
+      return response.json();
     },
 
     async unreadCount(organizationSlug) {
-      const response = await fetch(`${notificationsBase(organizationSlug)}/unread-count`);
-      if (!response.ok) {
+      const response = await notifications["unread-count"].$get({
+        param: { organizationSlug },
+      });
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load unread notification count");
       }
-      const body = (await response.json()) as { unreadCount: number };
+      const body = await response.json();
       return body.unreadCount;
     },
 
     async markRead(organizationSlug, notificationId) {
-      const response = await fetch(
-        `${notificationsBase(organizationSlug)}/${encodeURIComponent(notificationId)}/read`,
-        { method: "POST" },
-      );
-      if (!response.ok) {
+      const response = await notifications[":notificationId"].read.$post({
+        param: { organizationSlug, notificationId },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to mark notification as read");
       }
-      const body = (await response.json()) as {
-        notification: { id: string; readAt: string | null };
-      };
+      const body = await response.json();
       return body.notification;
     },
 
     async markAllRead(organizationSlug) {
-      const response = await fetch(`${notificationsBase(organizationSlug)}/read-all`, {
-        method: "POST",
+      const response = await notifications["read-all"].$post({
+        param: { organizationSlug },
       });
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to mark all notifications as read");
       }
-      const body = (await response.json()) as { markedCount: number };
+      const body = await response.json();
       return body.markedCount;
     },
 
     async getById(organizationSlug, notificationId) {
-      const response = await fetch(
-        `${notificationsBase(organizationSlug)}/${encodeURIComponent(notificationId)}`,
-      );
-      if (!response.ok) {
+      const response = await notifications[":notificationId"].$get({
+        param: { organizationSlug, notificationId },
+      } as never);
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load notification");
       }
-      const body = (await response.json()) as { notification: InboxIssueNotification };
+      const body = await response.json();
       return body.notification;
     },
   };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -37,7 +37,7 @@ import { InboxPageView } from "./inbox-page-view";
 import type { InboxCurrentUser, StreamedAssistantMessage } from "./inbox-types";
 
 const inboxApi = createInboxApi(apiClient);
-const notificationsApi = createInboxNotificationsApi();
+const notificationsApi = createInboxNotificationsApi(apiClient);
 
 const NOTIFICATIONS_PAGE_SIZE = 50;
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -49,7 +49,6 @@ import {
   type ChatProjectOption,
 } from "../../_components/project-selector-model";
 import { useTmsLiveProjects } from "../../_hooks/use-tms-live-projects";
-import type { ApiProject } from "../../projects/_components/project-list";
 import { createInboxApi, type InboxApi, type InboxGithubRepository } from "./inbox-api";
 import { replyComposerMessages } from "./reply-composer.messages";
 
@@ -299,10 +298,10 @@ export const ReplyComposer = memo(function ReplyComposer({
       const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
         param: { organizationSlug },
       });
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load projects");
       }
-      const body = (await response.json()) as { projects: ApiProject[] };
+      const body = await response.json();
       return body.projects;
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-actions.tsx
@@ -19,21 +19,12 @@ import { useQuery } from "@tanstack/react-query";
 import { FormattedMessage } from "react-intl";
 
 import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { IssueSheetCreateIssueDialog } from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog";
 import { issuesActionsMessages } from "./issues-actions.messages";
 import { IssuesProjectImportDialog } from "./issues-project-import-dialog";
-
-type ProjectOption = {
-  id: string;
-  name: string;
-  targetLocales?: string[];
-};
-
-function organizationProjectsPath(organizationSlug: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects`;
-}
 
 export function IssuesActions({
   organizationSlug,
@@ -48,11 +39,13 @@ export function IssuesActions({
   const projectsQuery = useQuery({
     queryKey: ["projects", organizationSlug],
     queryFn: async () => {
-      const response = await fetch(organizationProjectsPath(organizationSlug));
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load projects");
       }
-      const body = (await response.json()) as { projects: ProjectOption[] };
+      const body = await response.json();
       return body.projects.map((project) => ({
         id: project.id,
         name: project.name,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
@@ -16,6 +16,7 @@ import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-quer
 import { useRouter } from "next/navigation";
 
 import { readApiResponseError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
 
 import { buildIssueDetailHref } from "../../_components/issue-detail/issue-detail-utils";
 import { IssueBulkActionBar } from "../../_components/issue-bulk-action-bar";
@@ -29,24 +30,6 @@ import { ISSUES_PAGE_SIZE, IssuesPageView, type OrganizationIssue } from "./issu
 
 const issuesQueryKey = (organizationSlug: string, query: Record<string, string>) =>
   ["organization-issues", organizationSlug, query] as const;
-
-function organizationIssuesPath(organizationSlug: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/issues`;
-}
-
-type OrganizationIssuesResponse = {
-  issues: OrganizationIssue[];
-  total: number;
-  summary: {
-    total: number;
-    open: number;
-    inProgress: number;
-    resolved: number;
-    wontFix: number;
-  };
-};
-
-type ProjectOption = { id: string; name: string; targetLocales?: string[] };
 
 export function IssuesPageContent({
   organizationSlug,
@@ -69,11 +52,13 @@ export function IssuesPageContent({
   const projectsQuery = useQuery({
     queryKey: ["organization-issues-projects", organizationSlug],
     queryFn: async () => {
-      const response = await fetch(`/api/orgs/${encodeURIComponent(organizationSlug)}/projects`);
-      if (!response.ok) {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load projects");
       }
-      const body = (await response.json()) as { projects: ProjectOption[] };
+      const body = await response.json();
       return body.projects.map((project) => ({
         id: project.id,
         name: project.name,
@@ -86,23 +71,21 @@ export function IssuesPageContent({
     queryKey: issuesQueryKey(organizationSlug, apiQuery),
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams(
-        issueListStateToApiQuery(state, {
-          includeProject: true,
-          limit: ISSUES_PAGE_SIZE,
-          offset: pageParam,
-        }),
-      );
+      const query = issueListStateToApiQuery(state, {
+        includeProject: true,
+        limit: ISSUES_PAGE_SIZE,
+        offset: pageParam,
+      });
+      const response = await apiClient.api.orgs[":organizationSlug"].issues.$get({
+        param: { organizationSlug },
+        query,
+      } as never);
 
-      const response = await fetch(
-        `${organizationIssuesPath(organizationSlug)}?${params.toString()}`,
-      );
-
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw await readApiResponseError(response, "Failed to load issues");
       }
 
-      return (await response.json()) as OrganizationIssuesResponse;
+      return response.json();
     },
     getNextPageParam: (lastPage, pages) => {
       const loaded = pages.reduce((sum, page) => sum + page.issues.length, 0);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.tsx
@@ -32,33 +32,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { IssueSheetImportDialog } from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog";
 import { issuesProjectImportDialogMessages } from "./issues-project-import-dialog.messages";
-
-type IssueSheetColumn = {
-  id: string;
-  key: string;
-  label: string;
-  type: string;
-};
-
-type IssueSheetResponse = {
-  columns: IssueSheetColumn[];
-};
-
-function issueSheetPath(organizationSlug: string, projectId: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
-}
-
-async function readJsonOrThrow<T>(response: Response): Promise<T> {
-  if (!response.ok) {
-    const error = await readApiResponseError(response, "Request failed");
-    throw new Error(error.message || "Request failed");
-  }
-  return (await response.json()) as T;
-}
 
 export function IssuesProjectImportDialog({
   open,
@@ -91,8 +69,17 @@ export function IssuesProjectImportDialog({
     queryKey: ["issue-sheet", organizationSlug, selectedProjectId, "import-columns"],
     enabled: Boolean(selectedProjectId),
     queryFn: async () => {
-      const response = await fetch(issueSheetPath(organizationSlug, selectedProjectId));
-      return readJsonOrThrow<IssueSheetResponse>(response);
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].$get({
+        param: { organizationSlug, projectId: selectedProjectId },
+      } as never);
+      if (response.status !== 200) {
+        throw new Error(
+          (await readApiResponseError(response, "Request failed")).message || "Request failed",
+        );
+      }
+      return response.json();
     },
   });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.tsx
@@ -68,6 +68,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import { cn } from "@/lib/primitives/cn";
 
@@ -110,18 +111,6 @@ const NO_TEMPLATE_VALUE = "__no_template__";
 const propertyTriggerClassName =
   "h-7 gap-1.5 rounded-md border-0 bg-transparent px-1.5 text-xs font-normal text-muted-foreground shadow-none hover:bg-muted/60 hover:text-foreground";
 
-function issueSheetPath(organizationSlug: string, projectId: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
-}
-
-async function readJsonOrThrow<T>(response: Response, fallbackMessage: string): Promise<T> {
-  if (!response.ok) {
-    const error = await readApiResponseError(response, fallbackMessage);
-    throw new Error(error.message || fallbackMessage);
-  }
-  return (await response.json()) as T;
-}
-
 function isCreateCompactCustomColumn(column: IssueSheetColumn) {
   return (
     !column.hidden &&
@@ -139,6 +128,25 @@ function buildValuesPayload(drafts: Record<string, string>) {
     }
   }
   return Object.keys(values).length > 0 ? values : undefined;
+}
+
+function columnSelectOptions(config: { options?: unknown }) {
+  if (!Array.isArray(config.options)) {
+    return [];
+  }
+  return config.options.flatMap((option) => {
+    if (
+      !option ||
+      typeof option !== "object" ||
+      !("id" in option) ||
+      !("label" in option) ||
+      typeof option.id !== "string" ||
+      typeof option.label !== "string"
+    ) {
+      return [];
+    }
+    return [{ id: option.id, label: option.label }];
+  });
 }
 
 function stopMenuKeyboardPropagation(event: KeyboardEvent<HTMLDivElement>) {
@@ -616,49 +624,52 @@ export function IssueSheetCreateIssueDialog({
       // prompts, not to "clean up" a manually-typed description — a user who writes their own
       // `## Follow-up` heading with nothing under it yet is not asking for it to be deleted.
       const submittedDescription = templateKey ? stripEmptySections(description) : description;
-      const response = await fetch(issueSheetPath(organizationSlug, resolvedProjectId), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(
-          stringLink
-            ? {
-                title: trimmedTitle,
-                description: submittedDescription,
-                issueType,
-                status,
-                targetLocale: stringLink.targetLocale,
-                sourcePath: stringLink.sourcePath,
-                segmentId: stringLink.segmentId,
-                translationKeyId: stringLink.translationKeyId,
-                linkKind: "cat_segment",
-                linkLabel: linkLabel.trim() || stringLink.linkLabel || undefined,
-                linkUrl: linkUrl.trim() || stringLink.linkUrl || undefined,
-                priority,
-                ...(assigneeUserId ? { assigneeUserId } : {}),
-                ...(values ? { values } : {}),
-                ...(templateKey ? { templateKey } : {}),
-              }
-            : {
-                title: trimmedTitle,
-                description: submittedDescription,
-                issueType,
-                status,
-                targetLocale: targetLocale.trim() || undefined,
-                sourcePath: sourcePath.trim() || undefined,
-                linkKind: linkUrl.trim() ? "url" : "manual",
-                linkLabel: linkLabel.trim() || undefined,
-                linkUrl: linkUrl.trim() || undefined,
-                priority,
-                ...(assigneeUserId ? { assigneeUserId } : {}),
-                ...(values ? { values } : {}),
-                ...(templateKey ? { templateKey } : {}),
-              },
-        ),
-      });
-      return readJsonOrThrow<{ issue: { id: string } }>(
-        response,
-        intl.formatMessage(messages.requestFailed),
-      );
+      const json = stringLink
+        ? {
+            title: trimmedTitle,
+            description: submittedDescription,
+            issueType,
+            status,
+            targetLocale: stringLink.targetLocale,
+            sourcePath: stringLink.sourcePath,
+            segmentId: stringLink.segmentId,
+            translationKeyId: stringLink.translationKeyId,
+            linkKind: "cat_segment" as const,
+            linkLabel: linkLabel.trim() || stringLink.linkLabel || undefined,
+            linkUrl: linkUrl.trim() || stringLink.linkUrl || undefined,
+            priority,
+            ...(assigneeUserId ? { assigneeUserId } : {}),
+            ...(values ? { values } : {}),
+            ...(templateKey ? { templateKey } : {}),
+          }
+        : {
+            title: trimmedTitle,
+            description: submittedDescription,
+            issueType,
+            status,
+            targetLocale: targetLocale.trim() || undefined,
+            sourcePath: sourcePath.trim() || undefined,
+            linkKind: linkUrl.trim() ? ("url" as const) : ("manual" as const),
+            linkLabel: linkLabel.trim() || undefined,
+            linkUrl: linkUrl.trim() || undefined,
+            priority,
+            ...(assigneeUserId ? { assigneeUserId } : {}),
+            ...(values ? { values } : {}),
+            ...(templateKey ? { templateKey } : {}),
+          };
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].$post({
+        param: { organizationSlug, projectId: resolvedProjectId },
+        json,
+      } as never);
+      if (response.status !== 201) {
+        throw new Error(
+          (await readApiResponseError(response, intl.formatMessage(messages.requestFailed)))
+            .message || intl.formatMessage(messages.requestFailed),
+        );
+      }
+      return response.json();
     },
     onSuccess: async () => {
       toast.success(intl.formatMessage(messages.issueAdded));
@@ -1025,7 +1036,7 @@ export function IssueSheetCreateIssueDialog({
                           });
 
                           if (column.type === "select") {
-                            const options = column.config.options ?? [];
+                            const options = columnSelectOptions(column.config);
                             return (
                               <DropdownMenuSub key={column.id}>
                                 <DropdownMenuSubTrigger>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.tsx
@@ -37,6 +37,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import {
   issueSheetSystemFields,
@@ -74,18 +75,6 @@ type ImportResponse = {
 type ImportStep = "upload" | "map" | "preview" | "done";
 
 const createTypeValues: IssueSheetImportColumnType[] = ["text", "long_text", "select"];
-
-function issueSheetImportPath(organizationSlug: string, projectId: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet/import`;
-}
-
-async function readJsonOrThrow<T>(response: Response, fallbackMessage: string): Promise<T> {
-  if (!response.ok) {
-    const error = await readApiResponseError(response, fallbackMessage);
-    throw new Error(error.message || fallbackMessage);
-  }
-  return (await response.json()) as T;
-}
 
 function systemFieldLabel(intl: IntlShape, field: IssueSheetSystemField) {
   switch (field) {
@@ -220,10 +209,11 @@ export function IssueSheetImportDialog({
 
   const importMutation = useMutation({
     mutationFn: async (dryRun: boolean) => {
-      const response = await fetch(issueSheetImportPath(organizationSlug, projectId), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ]["import"].$post({
+        param: { organizationSlug, projectId },
+        json: {
           content: csvContent,
           dryRun,
           mapping: mappings.map((entry) => ({
@@ -231,9 +221,14 @@ export function IssueSheetImportDialog({
             target: entry.target,
           })),
           options: { skipInvalidRows: true },
-        }),
-      });
-      return readJsonOrThrow<ImportResponse>(response, importFailed);
+        },
+      } as never);
+      if (response.status !== 200 && response.status !== 201) {
+        throw new Error(
+          (await readApiResponseError(response, importFailed)).message || importFailed,
+        );
+      }
+      return response.json();
     },
     onError: (error) => toast.error(error instanceof Error ? error.message : importFailed),
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -38,6 +38,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { buildIssueDetailHref } from "../../../../_components/issue-detail/issue-detail-utils";
@@ -57,69 +58,8 @@ import { IssueSheetCreateIssueDialog } from "./issue-sheet-create-issue-dialog";
 import { IssueSheetImportDialog } from "./issue-sheet-import-dialog";
 import { useRouter } from "next/navigation";
 
-type IssueSheetColumn = {
-  id: string;
-  key: string;
-  label: string;
-  layer: string;
-  type: string;
-  config: { options?: { id: string; label: string; color?: string }[] };
-  sortOrder: number;
-  hidden?: boolean;
-  icon?: string | null;
-};
-
-type IssueSheetIssue = {
-  id: string;
-  identifier: string;
-  title: string;
-  description: string;
-  issueType: string;
-  status: string;
-  targetLocale: string | null;
-  sourcePath: string | null;
-  segmentId: string | null;
-  linkKind: string | null;
-  linkLabel: string | null;
-  linkUrl: string | null;
-  assigneeUserId: string | null;
-  reporter: string | null;
-  assignee: string | null;
-  key: string | null;
-  sourceText: string | null;
-  createdAt: string;
-  updatedAt: string;
-  resolvedAt: string | null;
-  values: Record<string, unknown>;
-};
-
-type IssueSheetResponse = {
-  issues: IssueSheetIssue[];
-  columns: IssueSheetColumn[];
-  total: number;
-  summary: {
-    total: number;
-    open: number;
-    inProgress: number;
-    resolved: number;
-    wontFix: number;
-  };
-};
-
 const columnTypeValues = ["text", "long_text", "select", "user"] as const;
 type ColumnTypeValue = (typeof columnTypeValues)[number];
-
-function issueSheetPath(organizationSlug: string, projectId: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
-}
-
-async function readJsonOrThrow<T>(response: Response, fallbackMessage: string): Promise<T> {
-  if (!response.ok) {
-    const error = await readApiResponseError(response, fallbackMessage);
-    throw new Error(error.message || fallbackMessage);
-  }
-  return (await response.json()) as T;
-}
 
 function formString(formData: FormData, key: string, fallback = "") {
   const value = formData.get(key);
@@ -176,9 +116,18 @@ export function IssueSheetPageContent({
   const issueSheetQuery = useQuery({
     queryKey,
     queryFn: async () => {
-      const params = new URLSearchParams(apiQuery);
-      const response = await fetch(`${issueSheetPath(organizationSlug, projectId)}?${params}`);
-      return readJsonOrThrow<IssueSheetResponse>(response, requestFailed);
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].$get({
+        param: { organizationSlug, projectId },
+        query: apiQuery,
+      } as never);
+      if (response.status !== 200) {
+        throw new Error(
+          (await readApiResponseError(response, requestFailed)).message || requestFailed,
+        );
+      }
+      return response.json();
     },
   });
 
@@ -374,18 +323,24 @@ function CreateColumnDialog({
         .map((option) => option.trim())
         .filter(Boolean)
         .map((option) => ({ id: option, label: option }));
-      const response = await fetch(`${issueSheetPath(organizationSlug, projectId)}/columns`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].columns.$post({
+        param: { organizationSlug, projectId },
+        json: {
           key: formString(formData, "key"),
           label: formString(formData, "label"),
           type,
           icon,
           config: type === "select" ? { options } : {},
-        }),
-      });
-      return readJsonOrThrow<{ column: IssueSheetColumn }>(response, requestFailed);
+        },
+      } as never);
+      if (response.status !== 201) {
+        throw new Error(
+          (await readApiResponseError(response, requestFailed)).message || requestFailed,
+        );
+      }
+      return response.json();
     },
     onSuccess: async () => {
       toast.success(intl.formatMessage(messages.columnAdded));

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-columns-settings.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-columns-settings.tsx
@@ -57,6 +57,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { IssueColumnIcon } from "@/components/issue-column-icon/issue-column-icon";
 import { IssueColumnIconPicker } from "@/components/issue-column-icon/issue-column-icon-picker";
 import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import {
   canDeleteIssueSheetColumn,
@@ -83,21 +84,14 @@ import { projectIssueColumnsSettingsMessages as messages } from "./project-issue
 
 const COLUMN_TYPE_VALUES = ["text", "long_text", "select", "user"] as const;
 
-function issueSheetColumnsPath(organizationSlug: string, projectId: string) {
-  return `/api/orgs/${organizationSlug}/projects/${projectId}/issue-sheet/columns`;
-}
-
 function formString(formData: FormData, key: string, fallback = "") {
   const value = formData.get(key);
   return typeof value === "string" ? value : fallback;
 }
 
-async function readJsonOrThrow<T>(response: Response, fallback: string): Promise<T> {
-  if (!response.ok) {
-    const error = await readApiResponseError(response, fallback);
-    throw new Error(error.message || fallback);
-  }
-  return (await response.json()) as T;
+async function throwApiError(response: Response, fallback: string): Promise<never> {
+  const error = await readApiResponseError(response, fallback);
+  throw new Error(error.message || fallback);
 }
 
 function columnTypeLabel(intl: ReturnType<typeof useIntl>, type: string) {
@@ -162,18 +156,17 @@ export function ProjectIssueColumnsSettings({
         config?: { options?: { id: string; label: string; color?: string }[] };
       };
     }) => {
-      const response = await fetch(
-        `${issueSheetColumnsPath(organizationSlug, projectId)}/${input.columnId}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(input.body),
-        },
-      );
-      return readJsonOrThrow<{ column: IssueSheetColumn }>(
-        response,
-        intl.formatMessage(messages.toastError),
-      );
+      const toastError = intl.formatMessage(messages.toastError);
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].columns[":columnId"].$patch({
+        param: { organizationSlug, projectId, columnId: input.columnId },
+        json: input.body,
+      } as never);
+      if (response.status !== 200) {
+        await throwApiError(response, toastError);
+      }
+      return response.json();
     },
     onSuccess: async (_data, variables) => {
       await invalidateColumns();
@@ -194,15 +187,17 @@ export function ProjectIssueColumnsSettings({
 
   const reorderColumns = useMutation({
     mutationFn: async (columnIds: string[]) => {
-      const response = await fetch(`${issueSheetColumnsPath(organizationSlug, projectId)}/order`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ columnIds }),
-      });
-      return readJsonOrThrow<{ columns: IssueSheetColumn[] }>(
-        response,
-        intl.formatMessage(messages.toastError),
-      );
+      const toastError = intl.formatMessage(messages.toastError);
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].columns.order.$put({
+        param: { organizationSlug, projectId },
+        json: { columnIds },
+      } as never);
+      if (response.status !== 200) {
+        await throwApiError(response, toastError);
+      }
+      return response.json();
     },
     onSuccess: async () => {
       await invalidateColumns();
@@ -215,13 +210,14 @@ export function ProjectIssueColumnsSettings({
 
   const removeColumn = useMutation({
     mutationFn: async (columnId: string) => {
-      const response = await fetch(
-        `${issueSheetColumnsPath(organizationSlug, projectId)}/${columnId}`,
-        { method: "DELETE" },
-      );
-      if (!response.ok && response.status !== 204) {
-        const error = await readApiResponseError(response, intl.formatMessage(messages.toastError));
-        throw new Error(error.message || intl.formatMessage(messages.toastError));
+      const toastError = intl.formatMessage(messages.toastError);
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].columns[":columnId"].$delete({
+        param: { organizationSlug, projectId, columnId },
+      } as never);
+      if (response.status !== 204) {
+        await throwApiError(response, toastError);
       }
     },
     onSuccess: async () => {
@@ -238,10 +234,12 @@ export function ProjectIssueColumnsSettings({
     mutationFn: async (formData: FormData) => {
       const type = formString(formData, "type", "text");
       const rawOptions = formString(formData, "options");
-      const response = await fetch(issueSheetColumnsPath(organizationSlug, projectId), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      const toastError = intl.formatMessage(messages.toastError);
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].columns.$post({
+        param: { organizationSlug, projectId },
+        json: {
           key: formString(formData, "key").trim(),
           label: formString(formData, "label").trim(),
           type,
@@ -250,12 +248,12 @@ export function ProjectIssueColumnsSettings({
             type === "select"
               ? { options: selectOptionsFromLabels(parseOptionLabelsCsv(rawOptions)) }
               : {},
-        }),
-      });
-      return readJsonOrThrow<{ column: IssueSheetColumn }>(
-        response,
-        intl.formatMessage(messages.toastError),
-      );
+        },
+      } as never);
+      if (response.status !== 201) {
+        await throwApiError(response, toastError);
+      }
+      return response.json();
     },
     onSuccess: async () => {
       await invalidateColumns();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-templates-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-templates-panel.tsx
@@ -24,6 +24,7 @@ import { Field, FieldLabel } from "@/components/ui/field";
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import {
   issueSheetTemplateLabel,
@@ -32,7 +33,6 @@ import {
 import { issueSheetTemplateMessages } from "@/lib/projects/issue-sheet/issue-sheet-templates.messages";
 
 import { IssueAssigneePicker } from "../../../../_components/issue-detail/issue-assignee-picker";
-import { issueSheetApiPath } from "../../../../_components/issue-detail/issue-detail-utils";
 import { useAssignableIssueMembersQuery } from "../../../../_components/issue-detail/use-assignable-issue-members";
 import {
   issueSheetTemplateConfigQueryKey,
@@ -90,23 +90,21 @@ export function ProjectIssueTemplatesPanel({
           return !(serverBinding && !serverBinding.assignable && serverBinding.userId === userId);
         }),
       );
-      const response = await fetch(
-        `${issueSheetApiPath(organizationSlug, projectId)}/template-config`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            defaultTemplateKey,
-            assigneeByTemplate: assigneeByTemplateToSave,
-          }),
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ]["template-config"].$put({
+        param: { organizationSlug, projectId },
+        json: {
+          defaultTemplateKey,
+          assigneeByTemplate: assigneeByTemplateToSave,
         },
-      );
-      if (!response.ok) {
+      } as never);
+      if (response.status !== 200) {
         throw new Error(
           (await readApiResponseError(response, intl.formatMessage(messages.saveError))).message,
         );
       }
-      const body = (await response.json()) as { templateConfig: IssueSheetTemplateConfig };
+      const body = await response.json();
       return body.templateConfig;
     },
     onSuccess: (templateConfig) => {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -52,7 +52,7 @@ import {
 } from "./navigation-config";
 import { useAppShellStore } from "./store/app-shell-store-context";
 
-const inboxNotificationsApi = createInboxNotificationsApi();
+const inboxNotificationsApi = createInboxNotificationsApi(apiClient);
 
 type AppShellNavigationProps = {
   organizationSlug: string;
@@ -177,10 +177,10 @@ function ProjectNavigation({
       const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].$get({
         param: { organizationSlug, projectId },
       });
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(`Failed to load project (${response.status})`);
       }
-      const body = (await response.json()) as { project: { id: string; name: string } };
+      const body = await response.json();
       return body.project;
     },
   });

--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-editor-issues-section.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-editor-issues-section.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog";
 import { Button } from "@/components/ui/button";
 import { isOpenIssueStatus } from "@/components/cat/queue/cat-queue-filter";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import {
@@ -51,30 +52,12 @@ type IssueSheetListIssue = {
   values?: Record<string, unknown>;
 };
 
-type IssueSheetListResponse = {
-  issues: IssueSheetListIssue[];
-  /** Row count for the requested filters, independent of paging. */
-  total?: number;
-};
-
 /** Maximum accepted by the issue sheet list endpoint. */
 const SEGMENT_ISSUE_PAGE_SIZE = 100;
 /** Bounds the paging loop; one string in one locale never gets close to this. */
 const SEGMENT_ISSUE_MAX_PAGES = 5;
 const ISSUE_PANEL_FRAME_CLASSNAME =
   "fixed inset-x-2 bottom-[calc(var(--app-shell-plan-footer-height)+0.5rem)] z-50 flex h-[min(44rem,calc(100svh-var(--app-shell-plan-footer-height)-1rem))] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15 sm:inset-x-auto sm:right-3 sm:w-[38rem]";
-
-function issueSheetPath(organizationSlug: string, projectId: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
-}
-
-async function readJsonOrThrow<T>(response: Response, fallbackMessage: string): Promise<T> {
-  if (!response.ok) {
-    const error = await readApiResponseError(response, fallbackMessage);
-    throw new Error(error.message || fallbackMessage);
-  }
-  return (await response.json()) as T;
-}
 
 function cellString(value: unknown) {
   if (value == null) {
@@ -175,12 +158,21 @@ export function CatEditorIssuesSection({
       const issues: IssueSheetListIssue[] = [];
 
       for (let page = 0; page < SEGMENT_ISSUE_MAX_PAGES; page += 1) {
-        const params = new URLSearchParams(apiQuery);
-        params.set("offset", String(page * SEGMENT_ISSUE_PAGE_SIZE));
-        const response = await fetch(
-          `${issueSheetPath(organizationSlug, projectId)}?${params.toString()}`,
-        );
-        const body = await readJsonOrThrow<IssueSheetListResponse>(response, requestFailed);
+        const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+          "issue-sheet"
+        ].$get({
+          param: { organizationSlug, projectId },
+          query: {
+            ...apiQuery,
+            offset: String(page * SEGMENT_ISSUE_PAGE_SIZE),
+          },
+        } as never);
+        if (response.status !== 200) {
+          throw new Error(
+            (await readApiResponseError(response, requestFailed)).message || requestFailed,
+          );
+        }
+        const body = await response.json();
         issues.push(...body.issues);
 
         const total = body.total ?? issues.length;
@@ -189,7 +181,7 @@ export function CatEditorIssuesSection({
         }
       }
 
-      return { issues } satisfies IssueSheetListResponse;
+      return { issues };
     },
   });
 

--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issues-dialog.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issues-dialog.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
+import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { catLinkedIssuesDialogMessages as messages } from "./cat-linked-issues-dialog.messages";
@@ -51,25 +52,6 @@ export type CatLinkedIssueSegmentContext = {
   targetLocale: string;
   sourcePath: string;
 };
-
-type LinkedIssueListItem = {
-  id: string;
-  title: string;
-  status: string;
-  translationKeyId: string | null;
-};
-
-function issueSheetPath(organizationSlug: string, projectId: string) {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
-}
-
-async function readJsonOrThrow<T>(response: Response, fallbackMessage: string): Promise<T> {
-  if (!response.ok) {
-    const error = await readApiResponseError(response, fallbackMessage);
-    throw new Error(error.message || fallbackMessage);
-  }
-  return (await response.json()) as T;
-}
 
 export function CatLinkedIssuesDialog({
   open,
@@ -102,20 +84,25 @@ export function CatLinkedIssuesDialog({
     queryKey: linkedQueryKey,
     enabled: open && Boolean(translationKeyId),
     queryFn: async () => {
-      const params = new URLSearchParams({
-        translationKeyId: translationKeyId!,
-        status: "all",
-        sort: "updated_at",
-        sortDir: "desc",
-        limit: "50",
-      });
-      const response = await fetch(
-        `${issueSheetPath(organizationSlug, projectId)}?${params.toString()}`,
-      );
-      const body = await readJsonOrThrow<{ issues: LinkedIssueListItem[] }>(
-        response,
-        intl.formatMessage(messages.requestFailed),
-      );
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].$get({
+        param: { organizationSlug, projectId },
+        query: {
+          translationKeyId: translationKeyId!,
+          status: "all",
+          sort: "updated_at",
+          sortDir: "desc",
+          limit: "50",
+        },
+      } as never);
+      if (response.status !== 200) {
+        throw new Error(
+          (await readApiResponseError(response, intl.formatMessage(messages.requestFailed)))
+            .message || intl.formatMessage(messages.requestFailed),
+        );
+      }
+      const body = await response.json();
       return body.issues;
     },
   });
@@ -124,22 +111,25 @@ export function CatLinkedIssuesDialog({
     queryKey: ["cat-linkable-issues", organizationSlug, projectId, linkSearch],
     enabled: open && linkPickerOpen && canManageLinks,
     queryFn: async () => {
-      const params = new URLSearchParams({
-        status: "all",
-        sort: "updated_at",
-        sortDir: "desc",
-        limit: "25",
-      });
-      if (linkSearch.trim()) {
-        params.set("search", linkSearch.trim());
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ].$get({
+        param: { organizationSlug, projectId },
+        query: {
+          status: "all",
+          sort: "updated_at",
+          sortDir: "desc",
+          limit: "25",
+          ...(linkSearch.trim() ? { search: linkSearch.trim() } : {}),
+        },
+      } as never);
+      if (response.status !== 200) {
+        throw new Error(
+          (await readApiResponseError(response, intl.formatMessage(messages.requestFailed)))
+            .message || intl.formatMessage(messages.requestFailed),
+        );
       }
-      const response = await fetch(
-        `${issueSheetPath(organizationSlug, projectId)}?${params.toString()}`,
-      );
-      const body = await readJsonOrThrow<{ issues: LinkedIssueListItem[] }>(
-        response,
-        intl.formatMessage(messages.requestFailed),
-      );
+      const body = await response.json();
       return body.issues;
     },
   });
@@ -153,24 +143,25 @@ export function CatLinkedIssuesDialog({
       if (!segment?.translationKeyId) {
         throw new Error(intl.formatMessage(messages.linkingUnavailable));
       }
-      const response = await fetch(
-        `${issueSheetPath(organizationSlug, projectId)}/${encodeURIComponent(issueId)}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            translationKeyId: segment.translationKeyId,
-            segmentId: segment.segmentId,
-            sourcePath: segment.sourcePath,
-            targetLocale: segment.targetLocale,
-            linkKind: "cat_segment",
-          }),
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ][":issueId"].$patch({
+        param: { organizationSlug, projectId, issueId },
+        json: {
+          translationKeyId: segment.translationKeyId,
+          segmentId: segment.segmentId,
+          sourcePath: segment.sourcePath,
+          targetLocale: segment.targetLocale,
+          linkKind: "cat_segment",
         },
-      );
-      return readJsonOrThrow<{ issue: LinkedIssueListItem }>(
-        response,
-        intl.formatMessage(messages.linkFailed),
-      );
+      } as never);
+      if (response.status !== 200) {
+        throw new Error(
+          (await readApiResponseError(response, intl.formatMessage(messages.linkFailed))).message ||
+            intl.formatMessage(messages.linkFailed),
+        );
+      }
+      return response.json();
     },
     onSuccess: async () => {
       toast.success(intl.formatMessage(messages.linked));
@@ -184,18 +175,19 @@ export function CatLinkedIssuesDialog({
 
   const unlinkIssue = useMutation({
     mutationFn: async (issueId: string) => {
-      const response = await fetch(
-        `${issueSheetPath(organizationSlug, projectId)}/${encodeURIComponent(issueId)}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ translationKeyId: null }),
-        },
-      );
-      return readJsonOrThrow<{ issue: LinkedIssueListItem }>(
-        response,
-        intl.formatMessage(messages.unlinkFailed),
-      );
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "issue-sheet"
+      ][":issueId"].$patch({
+        param: { organizationSlug, projectId, issueId },
+        json: { translationKeyId: null },
+      } as never);
+      if (response.status !== 200) {
+        throw new Error(
+          (await readApiResponseError(response, intl.formatMessage(messages.unlinkFailed)))
+            .message || intl.formatMessage(messages.unlinkFailed),
+        );
+      }
+      return response.json();
     },
     onSuccess: async () => {
       toast.success(intl.formatMessage(messages.unlinked));


### PR DESCRIPTION
## What changed

Replace remaining `fetch` + `(await response.json()) as T` clients with the typed Hono RPC client for issue sheet (detail, comments, feed, columns, bulk actions), inbox/notifications, and CAT-linked issues. Response bodies stay inferred after explicit status checks.

## How to test

- [ ] Open an issue sheet issue and edit title/status/assignee, add a comment, watch/unwatch, and add/remove a relationship
- [ ] Create a column, import CSV, and run a bulk action from the issues list
- [ ] Send an inbox reply and confirm the unread notification badge updates
- [ ] From CAT, list, create, link, and unlink issues for a segment
- [ ] `vp check --fix` in `apps/hyperlocalise-web`
- [ ] `vp test` covering issue-detail, inbox-api, create-issue dialog, and CAT issues tests

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; client tests for these surfaces)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)