### PR TITLE
feat(web): add content ops interactive mock to homepage

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-activity-feed.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-activity-feed.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FormattedMessage } from "react-intl";
+
+import { cn } from "@/lib/primitives/cn";
+
+import type { ContentOpsMockTabId } from "./content-ops-mock-stage.messages";
+import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
+
+export type ContentOpsActivityItem = {
+  time: string;
+  source: string;
+  message: string;
+};
+
+export function ContentOpsActivityFeed({
+  items,
+  className,
+}: {
+  items: ContentOpsActivityItem[];
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-xl border border-border/70 bg-muted/20 px-4 py-3",
+        className,
+      )}
+      aria-live="polite"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          Activity
+        </span>
+        <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-primary">
+          <span className="size-1.5 animate-pulse rounded-full bg-primary" aria-hidden />
+          <FormattedMessage {...contentOpsMockStageMessages.activityLive} />
+        </span>
+      </div>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={`${item.time}-${item.source}-${item.message}`} className="flex gap-3 text-xs">
+            <span className="w-8 shrink-0 font-mono text-[10px] text-muted-foreground/70">
+              {item.time}
+            </span>
+            <span className="w-16 shrink-0 font-medium text-muted-foreground">{item.source}</span>
+            <span className="min-w-0 text-foreground/85">{item.message}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export type { ContentOpsMockTabId };

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-activity-feed.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-activity-feed.tsx
@@ -12,7 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { FormattedMessage } from "react-intl";
+import { PauseIcon, PlayIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { cn } from "@/lib/primitives/cn";
 
@@ -27,27 +29,61 @@ export type ContentOpsActivityItem = {
 
 export function ContentOpsActivityFeed({
   items,
+  autoplayEnabled,
+  onAutoplayToggle,
   className,
 }: {
   items: ContentOpsActivityItem[];
+  autoplayEnabled: boolean;
+  onAutoplayToggle: () => void;
   className?: string;
 }) {
+  const intl = useIntl();
+
   return (
     <div
       className={cn(
         "overflow-hidden rounded-xl border border-border/70 bg-muted/20 px-4 py-3",
         className,
       )}
-      aria-live="polite"
     >
       <div className="mb-2 flex items-center justify-between gap-2">
         <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-          Activity
+          <FormattedMessage {...contentOpsMockStageMessages.activityTitle} />
         </span>
-        <span className="inline-flex items-center gap-1.5 text-[10px] font-medium text-primary">
-          <span className="size-1.5 animate-pulse rounded-full bg-primary" aria-hidden />
-          <FormattedMessage {...contentOpsMockStageMessages.activityLive} />
-        </span>
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1.5 text-[10px] font-medium",
+              autoplayEnabled ? "text-primary" : "text-muted-foreground",
+            )}
+          >
+            {autoplayEnabled ? (
+              <span className="size-1.5 animate-pulse rounded-full bg-primary" aria-hidden />
+            ) : null}
+            {autoplayEnabled ? (
+              <FormattedMessage {...contentOpsMockStageMessages.activityLive} />
+            ) : (
+              <FormattedMessage {...contentOpsMockStageMessages.activityPaused} />
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={onAutoplayToggle}
+            className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md border border-border/60 bg-background text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+            aria-label={intl.formatMessage(
+              autoplayEnabled
+                ? contentOpsMockStageMessages.activityAutoplayPause
+                : contentOpsMockStageMessages.activityAutoplayResume,
+            )}
+          >
+            <HugeiconsIcon
+              icon={autoplayEnabled ? PauseIcon : PlayIcon}
+              strokeWidth={2}
+              className="size-3"
+            />
+          </button>
+        </div>
       </div>
       <ul className="space-y-2">
         {items.map((item) => (

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-agent-terminal.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-agent-terminal.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useState, type ReactNode } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import Image from "next/image";
+import { FormattedMessage } from "react-intl";
+
+import { cn } from "@/lib/primitives/cn";
+
+import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
+
+export type ContentOpsStepStatus = "pending" | "running" | "done" | "warning";
+
+export type ContentOpsTerminalStep = {
+  label: string;
+  status: ContentOpsStepStatus;
+};
+
+export type ContentOpsTerminalScene = {
+  id: string;
+  triggerIcon: ReactNode;
+  triggerLabel: string;
+  tools: string[];
+  steps: string[];
+  highlightSteps?: ReadonlySet<string>;
+};
+
+const STEP_INTERVAL_MS = 900;
+
+function StepIcon({ status }: { status: ContentOpsStepStatus }) {
+  if (status === "running") {
+    return (
+      <span className="inline-block size-3.5 animate-spin rounded-full border border-primary/40 border-t-primary" />
+    );
+  }
+  if (status === "warning") {
+    return <span className="text-[11px] leading-none text-amber-700">⚠</span>;
+  }
+  if (status === "done") {
+    return <span className="text-[11px] leading-none text-emerald-500">✓</span>;
+  }
+  return <span className="size-3.5 rounded-full border border-border/40" />;
+}
+
+export function ContentOpsAgentTerminal({
+  scene,
+  pauseAutoplay = false,
+  onStepIndexChange,
+}: {
+  scene: ContentOpsTerminalScene;
+  pauseAutoplay?: boolean;
+  onStepIndexChange?: (stepIndex: number) => void;
+}) {
+  const shouldReduceMotion = useReducedMotion() ?? false;
+  const [visibleStepCount, setVisibleStepCount] = useState(1);
+
+  useEffect(() => {
+    setVisibleStepCount(1);
+  }, [scene.id]);
+
+  useEffect(() => {
+    onStepIndexChange?.(Math.max(0, visibleStepCount - 1));
+  }, [onStepIndexChange, visibleStepCount]);
+
+  useEffect(() => {
+    if (pauseAutoplay || shouldReduceMotion) {
+      if (shouldReduceMotion) {
+        setVisibleStepCount(scene.steps.length);
+      }
+      return;
+    }
+
+    if (visibleStepCount < scene.steps.length) {
+      const timer = setTimeout(() => setVisibleStepCount((count) => count + 1), STEP_INTERVAL_MS);
+      return () => clearTimeout(timer);
+    }
+  }, [pauseAutoplay, scene.steps.length, shouldReduceMotion, visibleStepCount]);
+
+  const visibleSteps: ContentOpsTerminalStep[] = scene.steps.slice(0, visibleStepCount).map(
+    (label, index) => {
+      const isLast = index === visibleStepCount - 1;
+      const isHighlight = scene.highlightSteps?.has(label) ?? false;
+      return {
+        label,
+        status:
+          isLast && visibleStepCount < scene.steps.length
+            ? "running"
+            : isHighlight
+              ? "warning"
+              : "done",
+      };
+    },
+  );
+
+  const progress = visibleSteps.length / scene.steps.length;
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="flex items-center gap-2 border-b border-border/50 px-4 py-3">
+        <Image
+          src="/images/logo.png"
+          alt="Hyperlocalise"
+          width={14}
+          height={14}
+          className="size-3.5"
+        />
+        <span className="text-xs font-semibold text-foreground">
+          <FormattedMessage {...contentOpsMockStageMessages.botLabel} />
+        </span>
+      </div>
+
+      <div className="flex items-center gap-1.5 border-b border-border/30 px-4 py-2.5 text-xs text-muted-foreground">
+        {scene.triggerIcon}
+        <span>{scene.triggerLabel}</span>
+      </div>
+
+      <div className="flex min-h-[10rem] flex-col gap-2 px-4 py-4 font-mono">
+        <AnimatePresence mode="popLayout">
+          {visibleSteps.map((step, index) => (
+            <motion.div
+              key={`${scene.id}-${index}`}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              className="flex items-center gap-2.5"
+            >
+              <StepIcon status={step.status} />
+              <span
+                className={cn(
+                  "text-xs leading-relaxed",
+                  step.status === "done" && "text-foreground/80",
+                  step.status === "running" && "text-muted-foreground",
+                  step.status === "warning" && "text-amber-700",
+                  step.status === "pending" && "text-muted-foreground/40",
+                )}
+              >
+                {step.label}
+              </span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+
+      <div className="border-t border-border/30 px-4 py-3">
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {scene.tools.map((tool) => (
+            <span
+              key={tool}
+              className="rounded-full border border-border/60 bg-muted/40 px-2.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+            >
+              {tool}
+            </span>
+          ))}
+        </div>
+        <div className="h-0.5 w-full overflow-hidden rounded-full bg-border/40">
+          <motion.div
+            className="h-full rounded-full bg-primary/60"
+            initial={{ width: 0 }}
+            animate={{ width: `${progress * 100}%` }}
+            transition={{ duration: 0.5, ease: "easeOut" }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-agent-terminal.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-agent-terminal.tsx
@@ -88,8 +88,9 @@ export function ContentOpsAgentTerminal({
     }
   }, [pauseAutoplay, scene.steps.length, shouldReduceMotion, visibleStepCount]);
 
-  const visibleSteps: ContentOpsTerminalStep[] = scene.steps.slice(0, visibleStepCount).map(
-    (label, index) => {
+  const visibleSteps: ContentOpsTerminalStep[] = scene.steps
+    .slice(0, visibleStepCount)
+    .map((label, index) => {
       const isLast = index === visibleStepCount - 1;
       const isHighlight = scene.highlightSteps?.has(label) ?? false;
       return {
@@ -101,8 +102,7 @@ export function ContentOpsAgentTerminal({
               ? "warning"
               : "done",
       };
-    },
-  );
+    });
 
   const progress = visibleSteps.length / scene.steps.length;
 

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-brand-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-brand-panel.tsx
@@ -20,13 +20,11 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { Tool, ToolHeader } from "@/components/ai-elements/tool";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/primitives/cn";
 
 import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
 
 const TOOL_RESOLVE_MS = 520;
 const STEP_MS = 720;
-const EASE_OUT = [0.19, 1, 0.22, 1] as const;
 
 type PlaybackPhase = "idle" | "playing" | "done";
 
@@ -130,16 +128,17 @@ export function ContentOpsBrandPanel({
 
         <div className="space-y-4 p-4">
           <div className="flex flex-wrap gap-2">
-            {[contentOpsMockStageMessages.brandRuleTone, contentOpsMockStageMessages.brandRuleCta].map(
-              (rule) => (
-                <span
-                  key={rule.id}
-                  className="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] font-medium text-foreground"
-                >
-                  <FormattedMessage {...rule} />
-                </span>
-              ),
-            )}
+            {[
+              contentOpsMockStageMessages.brandRuleTone,
+              contentOpsMockStageMessages.brandRuleCta,
+            ].map((rule) => (
+              <span
+                key={rule.id}
+                className="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] font-medium text-foreground"
+              >
+                <FormattedMessage {...rule} />
+              </span>
+            ))}
           </div>
 
           <div className="rounded-xl border border-border/60 bg-muted/20 p-4">

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-brand-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-brand-panel.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Chat01Icon, RefreshIcon, SentIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Tool, ToolHeader } from "@/components/ai-elements/tool";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
+
+const TOOL_RESOLVE_MS = 520;
+const STEP_MS = 720;
+const EASE_OUT = [0.19, 1, 0.22, 1] as const;
+
+type PlaybackPhase = "idle" | "playing" | "done";
+
+export function ContentOpsBrandPanel({
+  pauseAutoplay = false,
+  onPhaseChange,
+}: {
+  pauseAutoplay?: boolean;
+  onPhaseChange?: (phase: PlaybackPhase) => void;
+}) {
+  const intl = useIntl();
+  const shouldReduceMotion = useReducedMotion() ?? false;
+  const [phase, setPhase] = useState<PlaybackPhase>("idle");
+  const [showTool, setShowTool] = useState(false);
+  const [toolResolved, setToolResolved] = useState(false);
+  const [showAnswer, setShowAnswer] = useState(false);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const prompt = intl.formatMessage(contentOpsMockStageMessages.brandChatPrompt);
+  const answerSections = [
+    {
+      label: intl.formatMessage(contentOpsMockStageMessages.brandVerdictLabel),
+      body: intl.formatMessage(contentOpsMockStageMessages.brandVerdictBody),
+    },
+    {
+      label: intl.formatMessage(contentOpsMockStageMessages.brandGuidelineLabel),
+      body: intl.formatMessage(contentOpsMockStageMessages.brandGuidelineBody),
+    },
+    {
+      label: intl.formatMessage(contentOpsMockStageMessages.brandSuggestLabel),
+      body: intl.formatMessage(contentOpsMockStageMessages.brandSuggestBody),
+    },
+  ];
+
+  const clearTimers = () => {
+    for (const timer of timersRef.current) {
+      clearTimeout(timer);
+    }
+    timersRef.current = [];
+  };
+
+  const resetPlayback = () => {
+    clearTimers();
+    setPhase("idle");
+    setShowTool(false);
+    setToolResolved(false);
+    setShowAnswer(false);
+    onPhaseChange?.("idle");
+  };
+
+  const schedule = (fn: () => void, delay: number) => {
+    const timer = setTimeout(fn, delay);
+    timersRef.current.push(timer);
+  };
+
+  const startPlayback = useCallback(() => {
+    clearTimers();
+    setPhase("playing");
+    setShowTool(false);
+    setToolResolved(false);
+    setShowAnswer(false);
+    onPhaseChange?.("playing");
+
+    let elapsed = shouldReduceMotion ? 0 : 180;
+
+    schedule(() => setShowTool(true), elapsed);
+    elapsed += shouldReduceMotion ? 0 : TOOL_RESOLVE_MS;
+    schedule(() => setToolResolved(true), elapsed);
+    elapsed += shouldReduceMotion ? 0 : STEP_MS;
+    schedule(() => {
+      setShowAnswer(true);
+      setPhase("done");
+      onPhaseChange?.("done");
+    }, elapsed);
+  }, [onPhaseChange, shouldReduceMotion]);
+
+  useEffect(() => {
+    if (pauseAutoplay || shouldReduceMotion) {
+      return;
+    }
+
+    const timer = setTimeout(() => startPlayback(), 400);
+    return () => clearTimeout(timer);
+  }, [pauseAutoplay, shouldReduceMotion, startPlayback]);
+
+  useEffect(() => () => clearTimers(), []);
+
+  const showAppliedStyle = showAnswer;
+
+  return (
+    <div className="grid w-full gap-4 lg:grid-cols-2">
+      <div className="flex flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+        <div className="border-b border-border/50 px-4 py-3">
+          <div className="text-sm font-semibold text-foreground">
+            <FormattedMessage {...contentOpsMockStageMessages.brandStyleTitle} />
+          </div>
+          <div className="text-xs text-muted-foreground">
+            <FormattedMessage {...contentOpsMockStageMessages.brandStyleSubtitle} />
+          </div>
+        </div>
+
+        <div className="space-y-4 p-4">
+          <div className="flex flex-wrap gap-2">
+            {[contentOpsMockStageMessages.brandRuleTone, contentOpsMockStageMessages.brandRuleCta].map(
+              (rule) => (
+                <span
+                  key={rule.id}
+                  className="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] font-medium text-foreground"
+                >
+                  <FormattedMessage {...rule} />
+                </span>
+              ),
+            )}
+          </div>
+
+          <div className="rounded-xl border border-border/60 bg-muted/20 p-4">
+            <div className="space-y-3">
+              <div className="rounded-lg border border-border/50 bg-background/70 px-3 py-2.5">
+                <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <FormattedMessage {...contentOpsMockStageMessages.brandBeforeLabel} />
+                </div>
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  <FormattedMessage {...contentOpsMockStageMessages.brandBeforeCopy} />
+                </p>
+              </div>
+
+              <AnimatePresence mode="wait">
+                {showAppliedStyle ? (
+                  <motion.div
+                    key="after"
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -6 }}
+                    transition={{ duration: 0.24 }}
+                  >
+                    <div className="rounded-lg border border-primary/25 bg-primary/5 px-3 py-2.5">
+                      <div className="mb-1 flex items-center justify-between gap-2">
+                        <span className="text-[10px] font-medium uppercase tracking-wide text-primary/80">
+                          <FormattedMessage {...contentOpsMockStageMessages.brandAfterLabel} />
+                        </span>
+                        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                          <FormattedMessage {...contentOpsMockStageMessages.brandAppliedBadge} />
+                        </span>
+                      </div>
+                      <p className="text-sm font-medium leading-relaxed text-foreground">
+                        <FormattedMessage {...contentOpsMockStageMessages.brandAfterCopy} />
+                      </p>
+                    </div>
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="flex h-[22rem] flex-col overflow-hidden rounded-xl border border-border bg-background/95 shadow-lg backdrop-blur-sm sm:h-[24rem]"
+        role="region"
+        aria-label={intl.formatMessage(contentOpsMockStageMessages.brandChatTitle)}
+      >
+        <header className="flex h-11 shrink-0 items-center border-b border-border px-3">
+          <p className="text-sm font-medium text-foreground">
+            <FormattedMessage {...contentOpsMockStageMessages.brandChatTitle} />
+          </p>
+        </header>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-4">
+          {phase === "idle" ? (
+            <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 text-center">
+              <div className="flex size-9 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <HugeiconsIcon icon={Chat01Icon} strokeWidth={1.8} className="size-4" />
+              </div>
+              <p className="max-w-xs text-sm text-muted-foreground">{prompt}</p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              <div className="ms-auto max-w-[95%] rounded-2xl bg-muted px-3.5 py-2.5 text-sm leading-6 text-foreground">
+                {prompt}
+              </div>
+
+              {showTool ? (
+                <div className="rounded-lg border border-border/70 bg-muted/20 px-3 py-2">
+                  <Tool defaultOpen={toolResolved}>
+                    <ToolHeader
+                      type="dynamic-tool"
+                      toolName={intl.formatMessage(contentOpsMockStageMessages.brandToolName)}
+                      state={toolResolved ? "output-available" : "input-available"}
+                      detail={intl.formatMessage(contentOpsMockStageMessages.brandToolDetail)}
+                      input={{
+                        query: "brand voice CTA DE",
+                      }}
+                    />
+                  </Tool>
+                </div>
+              ) : null}
+
+              {showAnswer ? (
+                <motion.div
+                  initial={shouldReduceMotion ? false : { opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="space-y-3 text-sm leading-6"
+                >
+                  {answerSections.map((section) => (
+                    <div key={section.label} className="space-y-1">
+                      <p className="font-medium text-foreground">{section.label}</p>
+                      <p className="text-muted-foreground">{section.body}</p>
+                    </div>
+                  ))}
+                </motion.div>
+              ) : null}
+            </div>
+          )}
+        </div>
+
+        <div className="shrink-0 border-t border-border p-3">
+          <div className="flex items-center justify-end gap-2">
+            {phase === "done" ? (
+              <Button type="button" size="sm" variant="secondary" onClick={resetPlayback}>
+                <HugeiconsIcon
+                  data-icon="inline-start"
+                  icon={RefreshIcon}
+                  strokeWidth={2}
+                  className="size-3.5"
+                />
+                <FormattedMessage {...contentOpsMockStageMessages.brandReplay} />
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                size="sm"
+                disabled={phase === "playing"}
+                onClick={startPlayback}
+              >
+                <HugeiconsIcon
+                  data-icon="inline-start"
+                  icon={SentIcon}
+                  strokeWidth={2}
+                  className="size-3.5"
+                />
+                <FormattedMessage {...contentOpsMockStageMessages.brandSend} />
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-brand-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-brand-panel.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
 import { Chat01Icon, RefreshIcon, SentIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -26,18 +26,19 @@ import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
 const TOOL_RESOLVE_MS = 520;
 const STEP_MS = 720;
 
-type PlaybackPhase = "idle" | "playing" | "done";
+export type BrandPlaybackPhase = "idle" | "playing" | "done";
 
 export function ContentOpsBrandPanel({
   pauseAutoplay = false,
   onPhaseChange,
 }: {
   pauseAutoplay?: boolean;
-  onPhaseChange?: (phase: PlaybackPhase) => void;
+  onPhaseChange?: (phase: BrandPlaybackPhase) => void;
 }) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion() ?? false;
-  const [phase, setPhase] = useState<PlaybackPhase>("idle");
+  const hasAutoStartedRef = useRef(false);
+  const [phase, setPhase] = useState<BrandPlaybackPhase>("idle");
   const [showTool, setShowTool] = useState(false);
   const [toolResolved, setToolResolved] = useState(false);
   const [showAnswer, setShowAnswer] = useState(false);
@@ -66,13 +67,17 @@ export function ContentOpsBrandPanel({
     timersRef.current = [];
   };
 
+  const notifyPhaseChange = useEffectEvent((nextPhase: BrandPlaybackPhase) => {
+    onPhaseChange?.(nextPhase);
+  });
+
   const resetPlayback = () => {
     clearTimers();
     setPhase("idle");
     setShowTool(false);
     setToolResolved(false);
     setShowAnswer(false);
-    onPhaseChange?.("idle");
+    notifyPhaseChange("idle");
   };
 
   const schedule = (fn: () => void, delay: number) => {
@@ -86,7 +91,7 @@ export function ContentOpsBrandPanel({
     setShowTool(false);
     setToolResolved(false);
     setShowAnswer(false);
-    onPhaseChange?.("playing");
+    notifyPhaseChange("playing");
 
     let elapsed = shouldReduceMotion ? 0 : 180;
 
@@ -97,15 +102,16 @@ export function ContentOpsBrandPanel({
     schedule(() => {
       setShowAnswer(true);
       setPhase("done");
-      onPhaseChange?.("done");
+      notifyPhaseChange("done");
     }, elapsed);
-  }, [onPhaseChange, shouldReduceMotion]);
+  }, [shouldReduceMotion]);
 
   useEffect(() => {
-    if (pauseAutoplay || shouldReduceMotion) {
+    if (pauseAutoplay || shouldReduceMotion || hasAutoStartedRef.current) {
       return;
     }
 
+    hasAutoStartedRef.current = true;
     const timer = setTimeout(() => startPlayback(), 400);
     return () => clearTimeout(timer);
   }, [pauseAutoplay, shouldReduceMotion, startPlayback]);

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-editor-panel.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { HeroFrameLoadingShell } from "@/components/marketing/hero-frame-mesh-stage";
+import { cn } from "@/lib/primitives/cn";
+
+import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
+
+const ClientHeroFrame = dynamic(
+  () => import("@/components/marketing/hero-frame").then((module) => module.HeroFrame),
+  {
+    loading: HeroFrameLoadingShell,
+    ssr: false,
+  },
+);
+
+const EDITOR_WORKSPACE_CLASSNAME = "flex h-[26rem] flex-col sm:h-[28rem]";
+
+type EditorSceneId = "file-content" | "glossary" | "issues" | "intelligence";
+
+const EDITOR_SCENE_ORDER: EditorSceneId[] = ["file-content", "glossary", "issues", "intelligence"];
+
+const SCENE_SEGMENT: Record<EditorSceneId, string> = {
+  "file-content": "hero-title",
+  glossary: "qa-warning",
+  issues: "hero-cta",
+  intelligence: "hero-title",
+};
+
+const SCENE_HOLD_MS = 3400;
+
+type EditorSceneConfig = {
+  id: EditorSceneId;
+  labelKey:
+    | "editorSceneFileContent"
+    | "editorSceneGlossary"
+    | "editorSceneIssues"
+    | "editorSceneIntelligence";
+};
+
+const EDITOR_SCENES: EditorSceneConfig[] = [
+  { id: "file-content", labelKey: "editorSceneFileContent" },
+  { id: "glossary", labelKey: "editorSceneGlossary" },
+  { id: "issues", labelKey: "editorSceneIssues" },
+  { id: "intelligence", labelKey: "editorSceneIntelligence" },
+];
+
+function EditorPanelHighlight({ side, label }: { side: "center" | "right"; label: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute inset-y-2 z-10 rounded-xl ring-2 ring-primary/45 ring-offset-2 ring-offset-background transition-opacity duration-300",
+        side === "right" ? "right-2 w-[30%]" : "left-[28%] right-[28%]",
+      )}
+    >
+      <span className="absolute -top-2.5 left-3 rounded-full bg-primary px-2 py-0.5 text-[10px] font-semibold text-primary-foreground shadow-sm">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function EditorIssuesOverlay() {
+  const intl = useIntl();
+
+  const issues = [
+    {
+      id: "web-2",
+      identifier: "WEB-2",
+      title: intl.formatMessage(contentOpsMockStageMessages.issueWeb2Title),
+      detail: intl.formatMessage(contentOpsMockStageMessages.issueWeb2Detail),
+      status: intl.formatMessage(contentOpsMockStageMessages.statusInProgress),
+    },
+    {
+      id: "mob-1",
+      identifier: "MOB-1",
+      title: intl.formatMessage(contentOpsMockStageMessages.issueMob1Title),
+      detail: intl.formatMessage(contentOpsMockStageMessages.issueMob1Detail),
+      status: intl.formatMessage(contentOpsMockStageMessages.statusOpen),
+    },
+  ];
+
+  return (
+    <section
+      aria-label={intl.formatMessage(contentOpsMockStageMessages.editorIssuesPanelTitle)}
+      className="absolute inset-x-3 bottom-3 z-20 flex max-h-[14rem] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15 sm:inset-x-auto sm:right-3 sm:w-[22rem]"
+    >
+      <header className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-3">
+        <h3 className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+          <FormattedMessage {...contentOpsMockStageMessages.editorIssuesPanelTitle} />
+        </h3>
+        <button
+          type="button"
+          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground"
+          aria-hidden
+          tabIndex={-1}
+        >
+          <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+        </button>
+      </header>
+      <ul className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2">
+        {issues.map((issue) => (
+          <li key={issue.id} className="rounded-lg border border-border/70 bg-muted/20 px-3 py-2.5">
+            <div className="flex items-start justify-between gap-2">
+              <span className="font-mono text-[10px] font-medium text-muted-foreground">
+                {issue.identifier}
+              </span>
+              <span className="shrink-0 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:text-amber-200">
+                {issue.status}
+              </span>
+            </div>
+            <p className="mt-1 text-xs font-medium text-foreground">{issue.title}</p>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">{issue.detail}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function ContentOpsEditorPanel({
+  pauseAutoplay = false,
+  onSceneChange,
+}: {
+  pauseAutoplay?: boolean;
+  onSceneChange?: (sceneIndex: number) => void;
+}) {
+  const intl = useIntl();
+  const [scene, setScene] = useState<EditorSceneId>("file-content");
+
+  const sceneIndex = EDITOR_SCENE_ORDER.indexOf(scene);
+
+  const highlight = useMemo(() => {
+    switch (scene) {
+      case "glossary":
+        return {
+          side: "right" as const,
+          label: intl.formatMessage(contentOpsMockStageMessages.editorHighlightGlossary),
+        };
+      case "intelligence":
+        return {
+          side: "right" as const,
+          label: intl.formatMessage(contentOpsMockStageMessages.editorHighlightIntelligence),
+        };
+      case "file-content":
+        return {
+          side: "center" as const,
+          label: intl.formatMessage(contentOpsMockStageMessages.editorHighlightEditor),
+        };
+      default:
+        return null;
+    }
+  }, [intl, scene]);
+
+  const handleSceneSelect = useCallback((nextScene: EditorSceneId) => {
+    setScene(nextScene);
+  }, []);
+
+  useEffect(() => {
+    onSceneChange?.(sceneIndex);
+  }, [onSceneChange, sceneIndex]);
+
+  useEffect(() => {
+    if (pauseAutoplay) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setScene((current) => {
+        const index = EDITOR_SCENE_ORDER.indexOf(current);
+        return EDITOR_SCENE_ORDER[(index + 1) % EDITOR_SCENE_ORDER.length]!;
+      });
+    }, SCENE_HOLD_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [pauseAutoplay, scene]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2 px-0.5">
+        {EDITOR_SCENES.map((entry) => (
+          <button
+            key={entry.id}
+            type="button"
+            onClick={() => handleSceneSelect(entry.id)}
+            className={cn(
+              "cursor-pointer rounded-full border px-3 py-1.5 text-left text-xs font-medium transition-all duration-200",
+              scene === entry.id
+                ? "border-primary/35 bg-primary/8 text-foreground shadow-sm"
+                : "border-border/60 bg-background/90 text-muted-foreground hover:border-border hover:text-foreground",
+            )}
+          >
+            {intl.formatMessage(contentOpsMockStageMessages[entry.labelKey])}
+          </button>
+        ))}
+      </div>
+
+      <div className="relative">
+        <ClientHeroFrame
+          key={scene}
+          layout="contained"
+          className="shadow-lg"
+          initialSelectedSegmentId={SCENE_SEGMENT[scene]}
+          workspaceClassName={EDITOR_WORKSPACE_CLASSNAME}
+        />
+
+        {highlight ? <EditorPanelHighlight side={highlight.side} label={highlight.label} /> : null}
+        {scene === "issues" ? <EditorIssuesOverlay /> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-flow-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-flow-panel.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useMemo, useState } from "react";
+import {
+  Handle,
+  Position,
+  type Edge,
+  type Node,
+  type NodeProps,
+} from "@xyflow/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Canvas } from "@/components/ai-elements/canvas";
+import { Edge as FlowEdge } from "@/components/ai-elements/edge";
+import { cn } from "@/lib/primitives/cn";
+
+import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
+
+type FlowTemplateId = "brief" | "campaign" | "seo";
+
+type FlowNodeData = {
+  label: string;
+  active?: boolean;
+};
+
+function WorkflowNode({ data }: NodeProps<Node<FlowNodeData>>) {
+  return (
+    <div
+      className={cn(
+        "min-w-[7.5rem] rounded-lg border border-border bg-background px-3 py-2 text-center text-[11px] font-medium shadow-sm transition-all",
+        data.active && "border-primary/50 bg-primary/5 ring-2 ring-primary/25",
+      )}
+    >
+      <Handle className="!size-1.5 !border-border !bg-muted-foreground" position={Position.Left} type="target" />
+      <span className="text-foreground">{data.label}</span>
+      <Handle className="!size-1.5 !border-border !bg-muted-foreground" position={Position.Right} type="source" />
+    </div>
+  );
+}
+
+const nodeTypes = { workflow: WorkflowNode };
+const edgeTypes = { animated: FlowEdge.Animated };
+
+const NODE_SPACING_X = 160;
+const NODE_Y = 72;
+
+function buildLinearFlow(
+  templateId: FlowTemplateId,
+  labels: string[],
+  activeIndex: number,
+): { nodes: Node<FlowNodeData>[]; edges: Edge[] } {
+  const nodes: Node<FlowNodeData>[] = labels.map((label, index) => ({
+    id: `${templateId}-${index}`,
+    type: "workflow",
+    position: { x: index * NODE_SPACING_X, y: NODE_Y },
+    data: { label, active: index === activeIndex },
+    draggable: false,
+  }));
+
+  const edges: Edge[] = labels.slice(0, -1).map((_, index) => ({
+    id: `${templateId}-e-${index}`,
+    source: `${templateId}-${index}`,
+    target: `${templateId}-${index + 1}`,
+    type: index === activeIndex ? "animated" : "default",
+    animated: index === activeIndex,
+  }));
+
+  return { nodes, edges };
+}
+
+export function ContentOpsFlowPanel({
+  pauseAutoplay = false,
+  onActiveNodeChange,
+}: {
+  pauseAutoplay?: boolean;
+  onActiveNodeChange?: (nodeIndex: number) => void;
+}) {
+  const intl = useIntl();
+  const [templateId, setTemplateId] = useState<FlowTemplateId>("brief");
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const templateLabels = useMemo(
+    () => ({
+      brief: [
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeBrief),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeLocalise),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeBrandQa),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeReview),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeCms),
+      ],
+      campaign: [
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeBrief),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeLocalise),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeReview),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeStaging),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeSlack),
+      ],
+      seo: [
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeSchedule),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeKeywords),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeLocalise),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeDraft),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeSlack),
+      ],
+    }),
+    [intl],
+  );
+
+  const labels = templateLabels[templateId];
+  const { nodes, edges } = useMemo(
+    () => buildLinearFlow(templateId, labels, activeIndex),
+    [activeIndex, labels, templateId],
+  );
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [templateId]);
+
+  useEffect(() => {
+    onActiveNodeChange?.(activeIndex);
+  }, [activeIndex, onActiveNodeChange]);
+
+  useEffect(() => {
+    if (pauseAutoplay) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setActiveIndex((index) => (index + 1) % labels.length);
+    }, 1400);
+
+    return () => clearInterval(timer);
+  }, [labels.length, pauseAutoplay]);
+
+  const templates: { id: FlowTemplateId; label: typeof contentOpsMockStageMessages.flowTemplateBrief }[] =
+    [
+      { id: "brief", label: contentOpsMockStageMessages.flowTemplateBrief },
+      { id: "campaign", label: contentOpsMockStageMessages.flowTemplateCampaign },
+      { id: "seo", label: contentOpsMockStageMessages.flowTemplateSeo },
+    ];
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <div className="text-sm font-semibold text-foreground">
+          <FormattedMessage {...contentOpsMockStageMessages.flowTitle} />
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {templates.map((template) => (
+            <button
+              key={template.id}
+              type="button"
+              onClick={() => setTemplateId(template.id)}
+              className={cn(
+                "cursor-pointer rounded-full border px-2.5 py-1 text-[10px] font-medium transition-colors",
+                templateId === template.id
+                  ? "border-primary/40 bg-primary/10 text-foreground"
+                  : "border-border/60 text-muted-foreground hover:border-border hover:text-foreground",
+              )}
+            >
+              <FormattedMessage {...template.label} />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="h-[14rem] w-full sm:h-[16rem]">
+        <Canvas
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          nodesConnectable={false}
+          nodesDraggable={false}
+          elementsSelectable={false}
+          zoomOnScroll={false}
+          panOnScroll={false}
+          panOnDrag={false}
+          preventScrolling={false}
+          proOptions={{ hideAttribution: true }}
+          fitView
+          fitViewOptions={{ padding: 0.35 }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-flow-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-flow-panel.tsx
@@ -13,13 +13,7 @@
  * Version 2.0 or later.
  */
 import { useEffect, useMemo, useState } from "react";
-import {
-  Handle,
-  Position,
-  type Edge,
-  type Node,
-  type NodeProps,
-} from "@xyflow/react";
+import { Handle, Position, type Edge, type Node, type NodeProps } from "@xyflow/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Canvas } from "@/components/ai-elements/canvas";
@@ -43,9 +37,17 @@ function WorkflowNode({ data }: NodeProps<Node<FlowNodeData>>) {
         data.active && "border-primary/50 bg-primary/5 ring-2 ring-primary/25",
       )}
     >
-      <Handle className="!size-1.5 !border-border !bg-muted-foreground" position={Position.Left} type="target" />
+      <Handle
+        className="!size-1.5 !border-border !bg-muted-foreground"
+        position={Position.Left}
+        type="target"
+      />
       <span className="text-foreground">{data.label}</span>
-      <Handle className="!size-1.5 !border-border !bg-muted-foreground" position={Position.Right} type="source" />
+      <Handle
+        className="!size-1.5 !border-border !bg-muted-foreground"
+        position={Position.Right}
+        type="source"
+      />
     </div>
   );
 }
@@ -144,12 +146,14 @@ export function ContentOpsFlowPanel({
     return () => clearInterval(timer);
   }, [labels.length, pauseAutoplay]);
 
-  const templates: { id: FlowTemplateId; label: typeof contentOpsMockStageMessages.flowTemplateBrief }[] =
-    [
-      { id: "brief", label: contentOpsMockStageMessages.flowTemplateBrief },
-      { id: "campaign", label: contentOpsMockStageMessages.flowTemplateCampaign },
-      { id: "seo", label: contentOpsMockStageMessages.flowTemplateSeo },
-    ];
+  const templates: {
+    id: FlowTemplateId;
+    label: typeof contentOpsMockStageMessages.flowTemplateBrief;
+  }[] = [
+    { id: "brief", label: contentOpsMockStageMessages.flowTemplateBrief },
+    { id: "campaign", label: contentOpsMockStageMessages.flowTemplateCampaign },
+    { id: "seo", label: contentOpsMockStageMessages.flowTemplateSeo },
+  ];
 
   return (
     <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-issues-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-issues-panel.tsx
@@ -28,11 +28,7 @@ type IssueRow = {
   highlighted?: boolean;
 };
 
-export function ContentOpsIssuesPanel({
-  highlightedIndex = 1,
-}: {
-  highlightedIndex?: number;
-}) {
+export function ContentOpsIssuesPanel({ highlightedIndex = 1 }: { highlightedIndex?: number }) {
   const intl = useIntl();
 
   const rows: IssueRow[] = [

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-issues-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-issues-panel.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { cn } from "@/lib/primitives/cn";
+
+import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
+
+type IssueRow = {
+  id: string;
+  identifier: string;
+  title: string;
+  detail: string;
+  locale: string;
+  statusKey: "statusOpen" | "statusInProgress" | "statusResolved";
+  highlighted?: boolean;
+};
+
+export function ContentOpsIssuesPanel({
+  highlightedIndex = 1,
+}: {
+  highlightedIndex?: number;
+}) {
+  const intl = useIntl();
+
+  const rows: IssueRow[] = [
+    {
+      id: "web-2",
+      identifier: "WEB-2",
+      title: intl.formatMessage(contentOpsMockStageMessages.issueWeb2Title),
+      detail: intl.formatMessage(contentOpsMockStageMessages.issueWeb2Detail),
+      locale: "fr-FR",
+      statusKey: "statusInProgress",
+    },
+    {
+      id: "mob-1",
+      identifier: "MOB-1",
+      title: intl.formatMessage(contentOpsMockStageMessages.issueMob1Title),
+      detail: intl.formatMessage(contentOpsMockStageMessages.issueMob1Detail),
+      locale: "es-ES",
+      statusKey: "statusOpen",
+    },
+    {
+      id: "web-3",
+      identifier: "WEB-3",
+      title: intl.formatMessage(contentOpsMockStageMessages.issueWeb3Title),
+      detail: intl.formatMessage(contentOpsMockStageMessages.issueWeb3Detail),
+      locale: "de-DE",
+      statusKey: "statusResolved",
+    },
+  ];
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="border-b border-border/50 px-4 py-3">
+        <div className="text-sm font-semibold text-foreground">
+          <FormattedMessage {...contentOpsMockStageMessages.issuesTitle} />
+        </div>
+        <div className="mt-1 text-xs text-muted-foreground">
+          <FormattedMessage
+            {...contentOpsMockStageMessages.issuesSummary}
+            values={{ open: 2, inProgress: 1, resolved: 1 }}
+          />
+        </div>
+      </div>
+
+      <div className="divide-y divide-border/40">
+        {rows.map((row, index) => {
+          const highlighted = index === highlightedIndex;
+          return (
+            <div
+              key={row.id}
+              className={cn(
+                "flex items-start gap-3 px-4 py-3.5 transition-colors",
+                highlighted && "bg-primary/5",
+              )}
+            >
+              <div
+                className={cn(
+                  "mt-1 w-0.5 self-stretch rounded-full",
+                  highlighted ? "bg-primary" : "bg-transparent",
+                )}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-[10px] font-medium text-muted-foreground">
+                    {row.identifier}
+                  </span>
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                    {row.locale}
+                  </span>
+                  <span
+                    className={cn(
+                      "ms-auto text-[10px] font-medium",
+                      row.statusKey === "statusResolved"
+                        ? "text-emerald-600"
+                        : row.statusKey === "statusInProgress"
+                          ? "text-primary"
+                          : "text-amber-700",
+                    )}
+                  >
+                    <FormattedMessage {...contentOpsMockStageMessages[row.statusKey]} />
+                  </span>
+                </div>
+                <p className="mt-1 text-sm font-medium leading-snug text-foreground">{row.title}</p>
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{row.detail}</p>
+                {highlighted ? (
+                  <p className="mt-2 text-xs font-medium text-primary">
+                    <FormattedMessage {...contentOpsMockStageMessages.openInCat} />
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -46,6 +46,52 @@ export const contentOpsMockStageMessages = defineMessages({
     id: "h/nQhr+VQ1",
     description: "Content ops mock tab label for brief-to-publish workflow",
   },
+  tabEditor: {
+    defaultMessage: "Editor",
+    id: "rQDAKZnTf9",
+    description: "Content ops mock tab label for the CAT file content editor",
+  },
+
+  editorSceneFileContent: {
+    defaultMessage: "Review file content",
+    id: "kXJXJXMmTt",
+    description: "Editor mock use case pill for reviewing source file strings",
+  },
+  editorSceneGlossary: {
+    defaultMessage: "Glossary checks",
+    id: "kM/dmaarD3",
+    description: "Editor mock use case pill for glossary term enforcement",
+  },
+  editorSceneIssues: {
+    defaultMessage: "Linked issues",
+    id: "K76rTMej1a",
+    description: "Editor mock use case pill for issues linked to strings",
+  },
+  editorSceneIntelligence: {
+    defaultMessage: "Translation intelligence",
+    id: "zjJkVSEvVu",
+    description: "Editor mock use case pill for TM, context, and AI suggestions",
+  },
+  editorIssuesPanelTitle: {
+    defaultMessage: "Issues · this string",
+    id: "ncf9XHFPKV",
+    description: "Title on the editor mock issues overlay",
+  },
+  editorHighlightEditor: {
+    defaultMessage: "File editor",
+    id: "/ApELcd47S",
+    description: "Highlight badge on the CAT file content editor panel",
+  },
+  editorHighlightGlossary: {
+    defaultMessage: "Glossary",
+    id: "hmabVdb4tH",
+    description: "Highlight badge on the glossary section in intelligence panel",
+  },
+  editorHighlightIntelligence: {
+    defaultMessage: "Intelligence",
+    id: "E451cDD6K/",
+    description: "Highlight badge on the translation intelligence panel",
+  },
 
   botLabel: {
     defaultMessage: "Use Hyperlocalise Agent",
@@ -377,4 +423,10 @@ export const contentOpsMockStageMessages = defineMessages({
   },
 });
 
-export type ContentOpsMockTabId = "triage" | "campaign" | "seo-blog" | "brand" | "brief-to-publish";
+export type ContentOpsMockTabId =
+  | "triage"
+  | "campaign"
+  | "seo-blog"
+  | "brand"
+  | "brief-to-publish"
+  | "editor";

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -1,0 +1,385 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const contentOpsMockStageMessages = defineMessages({
+  activityLive: {
+    defaultMessage: "Live",
+    id: "CoPsLive01",
+    description: "Live indicator label on the content ops activity feed",
+  },
+
+  tabTriage: {
+    defaultMessage: "Triage open questions",
+    id: "CoPsTab01",
+    description: "Content ops mock tab label for issues triage",
+  },
+  tabCampaign: {
+    defaultMessage: "Localize campaign copy",
+    id: "CoPsTab02",
+    description: "Content ops mock tab label for campaign localisation",
+  },
+  tabSeoBlog: {
+    defaultMessage: "Publish localised SEO blogs",
+    id: "CoPsTab03",
+    description: "Content ops mock tab label for SEO blog publishing",
+  },
+  tabBrand: {
+    defaultMessage: "Keep brand consistent",
+    id: "CoPsTab04",
+    description: "Content ops mock tab label for brand governance",
+  },
+  tabBriefToPublish: {
+    defaultMessage: "Automate brief to publish",
+    id: "CoPsTab05",
+    description: "Content ops mock tab label for brief-to-publish workflow",
+  },
+
+  botLabel: {
+    defaultMessage: "Use Hyperlocalise Agent",
+    id: "CoPsBot01",
+    description: "Agent terminal title in content ops mock",
+  },
+
+  triggerGtmBrief: {
+    defaultMessage: "GTM brief approved · Q2 launch",
+    id: "CoPsTrg01",
+    description: "GTM trigger label in content ops campaign mock",
+  },
+  triggerSeoSchedule: {
+    defaultMessage: "Scheduled run · 1st of month",
+    id: "CoPsTrg02",
+    description: "SEO schedule trigger label in content ops mock",
+  },
+
+  toolCms: {
+    defaultMessage: "CMS",
+    id: "CoPsTl001",
+    description: "CMS tool chip in content ops terminal mock",
+  },
+  toolTranslate: {
+    defaultMessage: "Translate",
+    id: "CoPsTl002",
+    description: "Translate tool chip in content ops terminal mock",
+  },
+  toolSlack: {
+    defaultMessage: "Slack",
+    id: "CoPsTl003",
+    description: "Slack tool chip in content ops terminal mock",
+  },
+  toolSearch: {
+    defaultMessage: "Search",
+    id: "CoPsTl004",
+    description: "Search tool chip in content ops terminal mock",
+  },
+  toolAhrefs: {
+    defaultMessage: "Ahrefs",
+    id: "CoPsTl005",
+    description: "Ahrefs tool chip in content ops terminal mock",
+  },
+
+  stepGtm1: {
+    defaultMessage: "Brief received · 4 markets, 12 assets",
+    id: "CoPsGt001",
+    description: "Campaign mock step 1",
+  },
+  stepGtm2: {
+    defaultMessage: "Generating localized landing page drafts...",
+    id: "CoPsGt002",
+    description: "Campaign mock step 2",
+  },
+  stepGtm3: {
+    defaultMessage: "FR and DE routed for review",
+    id: "CoPsGt003",
+    description: "Campaign mock step 3",
+  },
+  stepGtm4: {
+    defaultMessage: "Published to staging · notified #gtm",
+    id: "CoPsGt004",
+    description: "Campaign mock step 4",
+  },
+
+  stepSeo1: {
+    defaultMessage: "Pulling search volume for core product terms",
+    id: "CoPsSe001",
+    description: "SEO blog mock step 1",
+  },
+  stepSeo2: {
+    defaultMessage: "EN · FR · DE · JA demand compared",
+    id: "CoPsSe002",
+    description: "SEO blog mock step 2",
+  },
+  stepSeo3: {
+    defaultMessage: "12 high-intent gaps found in DE",
+    id: "CoPsSe003",
+    description: "SEO blog mock step 3",
+  },
+  stepSeo4: {
+    defaultMessage: "Localised SEO draft · meta + H1 adapted",
+    id: "CoPsSe004",
+    description: "SEO blog mock step 4",
+  },
+  stepSeo5: {
+    defaultMessage: "QA passed · draft written to CMS · #content notified",
+    id: "CoPsSe005",
+    description: "SEO blog mock step 5",
+  },
+
+  issuesTitle: {
+    defaultMessage: "Issues · acme workspace",
+    id: "CoPsIs001",
+    description: "Issues panel title in content ops mock",
+  },
+  issuesSummary: {
+    defaultMessage: "{open} open · {inProgress} in progress · {resolved} resolved",
+    id: "CoPsIs002",
+    description: "Issues summary line in content ops mock",
+  },
+  issueWeb2Title: {
+    defaultMessage: "Translation mistake in checkout",
+    id: "CoPsIs003",
+    description: "Issue row title in content ops mock",
+  },
+  issueWeb2Detail: {
+    defaultMessage: "Payment button label too long · checkout.json",
+    id: "CoPsIs004",
+    description: "Issue row detail in content ops mock",
+  },
+  issueMob1Title: {
+    defaultMessage: "Glossary violation in onboarding",
+    id: "CoPsIs005",
+    description: "Issue row title in content ops mock",
+  },
+  issueMob1Detail: {
+    defaultMessage: "Product name should stay untranslated",
+    id: "CoPsIs006",
+    description: "Issue row detail in content ops mock",
+  },
+  issueWeb3Title: {
+    defaultMessage: "QA failure on hero headline",
+    id: "CoPsIs007",
+    description: "Issue row title in content ops mock",
+  },
+  issueWeb3Detail: {
+    defaultMessage: "Length check failed for German headline",
+    id: "CoPsIs008",
+    description: "Issue row detail in content ops mock",
+  },
+  statusOpen: {
+    defaultMessage: "Open",
+    id: "CoPsSt001",
+    description: "Issue status open",
+  },
+  statusInProgress: {
+    defaultMessage: "In progress",
+    id: "CoPsSt002",
+    description: "Issue status in progress",
+  },
+  statusResolved: {
+    defaultMessage: "Resolved",
+    id: "CoPsSt003",
+    description: "Issue status resolved",
+  },
+  openInCat: {
+    defaultMessage: "Open in CAT",
+    id: "CoPsCat01",
+    description: "Link label to open issue in CAT editor",
+  },
+
+  brandStyleTitle: {
+    defaultMessage: "Brand voice · Style guide",
+    id: "CoPsBr001",
+    description: "Brand style guide panel title",
+  },
+  brandStyleSubtitle: {
+    defaultMessage: "Applied while reviewing DE checkout CTA",
+    id: "CoPsBr002",
+    description: "Brand style guide panel subtitle",
+  },
+  brandRuleTone: {
+    defaultMessage: "Tone: friendly, direct",
+    id: "CoPsBr003",
+    description: "Brand style rule chip",
+  },
+  brandRuleCta: {
+    defaultMessage: "CTA: short verb",
+    id: "CoPsBr004",
+    description: "Brand style rule chip",
+  },
+  brandBeforeLabel: {
+    defaultMessage: "Before",
+    id: "CoPsBr005",
+    description: "Before copy label in brand mock",
+  },
+  brandAfterLabel: {
+    defaultMessage: "After",
+    id: "CoPsBr006",
+    description: "After copy label in brand mock",
+  },
+  brandBeforeCopy: {
+    defaultMessage: "Nutzen Sie unsere innovative Plattform",
+    id: "CoPsBr007",
+    description: "Before copy sample in brand mock",
+  },
+  brandAfterCopy: {
+    defaultMessage: "Jetzt starten",
+    id: "CoPsBr008",
+    description: "After copy sample in brand mock",
+  },
+  brandAppliedBadge: {
+    defaultMessage: "Applied",
+    id: "CoPsBr009",
+    description: "Applied badge on brand style correction",
+  },
+  brandChatTitle: {
+    defaultMessage: "Brand review chat",
+    id: "CoPsBr010",
+    description: "Brand chat dock title",
+  },
+  brandChatPrompt: {
+    defaultMessage:
+      "Does this German CTA follow our brand guidelines? \"Nutzen Sie unsere innovative Plattform\"",
+    id: "CoPsBr011",
+    description: "User prompt in brand chat mock",
+  },
+  brandToolName: {
+    defaultMessage: "recall_knowledge_files",
+    id: "CoPsBr012",
+    description: "Tool name shown in brand chat mock",
+  },
+  brandToolDetail: {
+    defaultMessage: "brand-voice-style-guide.pdf",
+    id: "CoPsBr013",
+    description: "Tool detail in brand chat mock",
+  },
+  brandVerdictLabel: {
+    defaultMessage: "Verdict",
+    id: "CoPsBr014",
+    description: "Verdict section in brand chat answer",
+  },
+  brandVerdictBody: {
+    defaultMessage: "Off-brand — too formal and jargon-heavy for DE checkout.",
+    id: "CoPsBr015",
+    description: "Verdict body in brand chat answer",
+  },
+  brandGuidelineLabel: {
+    defaultMessage: "Guideline",
+    id: "CoPsBr016",
+    description: "Guideline section in brand chat answer",
+  },
+  brandGuidelineBody: {
+    defaultMessage: "Tone: friendly, direct · CTA: short verb, max 24 characters.",
+    id: "CoPsBr017",
+    description: "Guideline body in brand chat answer",
+  },
+  brandSuggestLabel: {
+    defaultMessage: "Suggested copy",
+    id: "CoPsBr018",
+    description: "Suggested copy section in brand chat answer",
+  },
+  brandSuggestBody: {
+    defaultMessage: "Jetzt starten",
+    id: "CoPsBr019",
+    description: "Suggested copy body in brand chat answer",
+  },
+  brandSend: {
+    defaultMessage: "Send",
+    id: "CoPsBr020",
+    description: "Send button in brand chat mock",
+  },
+  brandReplay: {
+    defaultMessage: "Replay",
+    id: "CoPsBr021",
+    description: "Replay button in brand chat mock",
+  },
+
+  flowTitle: {
+    defaultMessage: "Brief to publish · workflow",
+    id: "CoPsFl001",
+    description: "Flow panel title",
+  },
+  flowTemplateCampaign: {
+    defaultMessage: "Campaign",
+    id: "CoPsFl002",
+    description: "Flow template pill for campaign",
+  },
+  flowTemplateSeo: {
+    defaultMessage: "SEO blog",
+    id: "CoPsFl003",
+    description: "Flow template pill for SEO blog",
+  },
+  flowTemplateBrief: {
+    defaultMessage: "Brief to publish",
+    id: "CoPsFl004",
+    description: "Flow template pill for brief to publish",
+  },
+  flowNodeBrief: {
+    defaultMessage: "GTM brief",
+    id: "CoPsFn001",
+    description: "Flow node label",
+  },
+  flowNodeLocalise: {
+    defaultMessage: "Localise",
+    id: "CoPsFn002",
+    description: "Flow node label",
+  },
+  flowNodeBrandQa: {
+    defaultMessage: "Brand QA",
+    id: "CoPsFn003",
+    description: "Flow node label",
+  },
+  flowNodeReview: {
+    defaultMessage: "Review",
+    id: "CoPsFn004",
+    description: "Flow node label",
+  },
+  flowNodeCms: {
+    defaultMessage: "CMS publish",
+    id: "CoPsFn005",
+    description: "Flow node label",
+  },
+  flowNodeSchedule: {
+    defaultMessage: "Scheduled run",
+    id: "CoPsFn006",
+    description: "Flow node label",
+  },
+  flowNodeKeywords: {
+    defaultMessage: "Keyword research",
+    id: "CoPsFn007",
+    description: "Flow node label",
+  },
+  flowNodeDraft: {
+    defaultMessage: "CMS draft",
+    id: "CoPsFn008",
+    description: "Flow node label",
+  },
+  flowNodeSlack: {
+    defaultMessage: "Slack notify",
+    id: "CoPsFn009",
+    description: "Flow node label",
+  },
+  flowNodeStaging: {
+    defaultMessage: "Staging",
+    id: "CoPsFn010",
+    description: "Flow node label",
+  },
+});
+
+export type ContentOpsMockTabId =
+  | "triage"
+  | "campaign"
+  | "seo-blog"
+  | "brand"
+  | "brief-to-publish";

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -20,6 +20,554 @@ export const contentOpsMockStageMessages = defineMessages({
     id: "B4VkdPz+2q",
     description: "Live indicator label on the content ops activity feed",
   },
+  activityPaused: {
+    defaultMessage: "Paused",
+    id: "jvqi5j3K1U",
+    description: "Paused indicator when content ops mock autoplay is stopped",
+  },
+  activityTitle: {
+    defaultMessage: "Activity",
+    id: "PYzdvGniCi",
+    description: "Heading for the content ops activity feed",
+  },
+  activityAutoplayPause: {
+    defaultMessage: "Pause demo rotation",
+    id: "VbgjobTz9L",
+    description: "Accessible label for pausing content ops tab autoplay",
+  },
+  activityAutoplayResume: {
+    defaultMessage: "Resume demo rotation",
+    id: "vf2HgEHa0O",
+    description: "Accessible label for resuming content ops tab autoplay",
+  },
+
+  activityTimeNow: {
+    defaultMessage: "now",
+    id: "yldTcvr61y",
+    description: "Relative time label for activity feed",
+  },
+  activityTime4m: {
+    defaultMessage: "4m",
+    id: "UtCNRO3Hpb",
+    description: "Relative time label for activity feed",
+  },
+  activityTime5m: {
+    defaultMessage: "5m",
+    id: "L13YqrEkVX",
+    description: "Relative time label for activity feed",
+  },
+  activityTime6m: {
+    defaultMessage: "6m",
+    id: "UkyZJgCMc4",
+    description: "Relative time label for activity feed",
+  },
+  activityTime8m: {
+    defaultMessage: "8m",
+    id: "JxRiYxg9Qs",
+    description: "Relative time label for activity feed",
+  },
+  activityTime9m: {
+    defaultMessage: "9m",
+    id: "i47dt33mDU",
+    description: "Relative time label for activity feed",
+  },
+  activityTime10m: {
+    defaultMessage: "10m",
+    id: "OikIBnINAa",
+    description: "Relative time label for activity feed",
+  },
+  activityTime12m: {
+    defaultMessage: "12m",
+    id: "Bg6lYlgqhD",
+    description: "Relative time label for activity feed",
+  },
+
+  activitySourceBrief: {
+    defaultMessage: "Brief",
+    id: "HeC4WbLOJp",
+    description: "Activity feed source label",
+  },
+  activitySourceDrafts: {
+    defaultMessage: "Drafts",
+    id: "xC+/N2onOr",
+    description: "Activity feed source label",
+  },
+  activitySourceReview: {
+    defaultMessage: "Review",
+    id: "2rYRR19Jf0",
+    description: "Activity feed source label",
+  },
+  activitySourceAgent: {
+    defaultMessage: "Agent",
+    id: "0TbmGo1n4/",
+    description: "Activity feed source label",
+  },
+  activitySourceStaging: {
+    defaultMessage: "Staging",
+    id: "CT81WY4BD9",
+    description: "Activity feed source label",
+  },
+  activitySourceSlack: {
+    defaultMessage: "Slack",
+    id: "3n70tRu4m4",
+    description: "Activity feed source label",
+  },
+  activitySourceCms: {
+    defaultMessage: "CMS",
+    id: "70Q0NIB0wW",
+    description: "Activity feed source label",
+  },
+  activitySourceResearch: {
+    defaultMessage: "Research",
+    id: "TimJVK7Lpn",
+    description: "Activity feed source label",
+  },
+  activitySourceLocales: {
+    defaultMessage: "Locales",
+    id: "jov/yKhQef",
+    description: "Activity feed source label",
+  },
+  activitySourceGaps: {
+    defaultMessage: "Gaps",
+    id: "dYssR6em17",
+    description: "Activity feed source label",
+  },
+  activitySourceDraft: {
+    defaultMessage: "Draft",
+    id: "fEHDQiLfQy",
+    description: "Activity feed source label",
+  },
+  activitySourceQa: {
+    defaultMessage: "QA",
+    id: "xkWDMMRbBh",
+    description: "Activity feed source label",
+  },
+  activitySourcePublish: {
+    defaultMessage: "Publish",
+    id: "JRhsEwQe0f",
+    description: "Activity feed source label",
+  },
+  activitySourceIntent: {
+    defaultMessage: "Intent",
+    id: "b5cW7aN4Hd",
+    description: "Activity feed source label",
+  },
+  activitySourceSchedule: {
+    defaultMessage: "Schedule",
+    id: "Ae3sDjYSDE",
+    description: "Activity feed source label",
+  },
+  activitySourceChat: {
+    defaultMessage: "Chat",
+    id: "IdvmBW+pxV",
+    description: "Activity feed source label",
+  },
+  activitySourceGuide: {
+    defaultMessage: "Guide",
+    id: "ShxpEFKVDy",
+    description: "Activity feed source label",
+  },
+  activitySourceVerdict: {
+    defaultMessage: "Verdict",
+    id: "Z2om0bPNMD",
+    description: "Activity feed source label",
+  },
+  activitySourceKnowledge: {
+    defaultMessage: "Knowledge",
+    id: "AwFC+uLxC8",
+    description: "Activity feed source label",
+  },
+  activitySourceRule: {
+    defaultMessage: "Rule",
+    id: "j+ge9KuPgD",
+    description: "Activity feed source label",
+  },
+  activitySourceCopy: {
+    defaultMessage: "Copy",
+    id: "YmCV0t1AdI",
+    description: "Activity feed source label",
+  },
+  activitySourceApplied: {
+    defaultMessage: "Applied",
+    id: "mrC2BPzHqU",
+    description: "Activity feed source label",
+  },
+  activitySourceFlow: {
+    defaultMessage: "Flow",
+    id: "0bqwSoBvAO",
+    description: "Activity feed source label",
+  },
+  activitySourceStep: {
+    defaultMessage: "Step",
+    id: "J0BqX1wxHr",
+    description: "Activity feed source label",
+  },
+  activitySourceHandoff: {
+    defaultMessage: "Handoff",
+    id: "ictx5IinpD",
+    description: "Activity feed source label",
+  },
+  activitySourceLocalise: {
+    defaultMessage: "Localise",
+    id: "MZghIxfTxV",
+    description: "Activity feed source label",
+  },
+  activitySourceBrandQa: {
+    defaultMessage: "Brand QA",
+    id: "OF3udZacB2",
+    description: "Activity feed source label",
+  },
+  activitySourceTemplate: {
+    defaultMessage: "Template",
+    id: "3R639sxHr2",
+    description: "Activity feed source label",
+  },
+  activitySourceKeywords: {
+    defaultMessage: "Keywords",
+    id: "Srs/Utz5vI",
+    description: "Activity feed source label",
+  },
+  activitySourceEditor: {
+    defaultMessage: "Editor",
+    id: "3sph2ylLp6",
+    description: "Activity feed source label",
+  },
+  activitySourceSegment: {
+    defaultMessage: "Segment",
+    id: "ouV+kqOWV+",
+    description: "Activity feed source label",
+  },
+  activitySourceQueue: {
+    defaultMessage: "Queue",
+    id: "VAiLQOWFRD",
+    description: "Activity feed source label",
+  },
+  activitySourceGlossary: {
+    defaultMessage: "Glossary",
+    id: "q5hEzlXFsg",
+    description: "Activity feed source label",
+  },
+  activitySourceIssues: {
+    defaultMessage: "Issues",
+    id: "UvgE84P8Ua",
+    description: "Activity feed source label",
+  },
+  activitySourceTriage: {
+    defaultMessage: "Triage",
+    id: "kNiZnqyUZa",
+    description: "Activity feed source label",
+  },
+  activitySourceIntelligence: {
+    defaultMessage: "Intelligence",
+    id: "neQcg9GFWA",
+    description: "Activity feed source label",
+  },
+  activitySourceContext: {
+    defaultMessage: "Context",
+    id: "vqPmiXWIxH",
+    description: "Activity feed source label",
+  },
+  activitySourceAi: {
+    defaultMessage: "AI",
+    id: "NkoXJPgv6b",
+    description: "Activity feed source label",
+  },
+  activitySourceCat: {
+    defaultMessage: "CAT",
+    id: "9fiUHC+2VJ",
+    description: "Activity feed source label",
+  },
+
+  activityTriageAssignedFrCheckout: {
+    defaultMessage: "Assigned · FR checkout CTA too long",
+    id: "WSVwtNWuKm",
+    description: "Triage activity feed message",
+  },
+  activityTriageGlossaryBreakEs: {
+    defaultMessage: "Glossary break · es-ES · unassigned",
+    id: "ZR9JhUs4+U",
+    description: "Triage activity feed message",
+  },
+  activityTriageQaResolvedDe: {
+    defaultMessage: "QA failure resolved · de-DE headline",
+    id: "ILRMtLqdn2",
+    description: "Triage activity feed message",
+  },
+  activityTriageInProgressPayment: {
+    defaultMessage: "In progress · payment button label",
+    id: "1t9zbEkIB7",
+    description: "Triage activity feed message",
+  },
+  activityTriageOpenInCat: {
+    defaultMessage: "Open in CAT · checkout.json",
+    id: "orm3tG8EsL",
+    description: "Triage activity feed message",
+  },
+  activityTriageResolvedHero: {
+    defaultMessage: "Resolved · hero headline length check",
+    id: "505wZmu59b",
+    description: "Triage activity feed message",
+  },
+  activityTriageMistakeFr: {
+    defaultMessage: "Translation mistake flagged · fr-FR",
+    id: "mf6LDumuKi",
+    description: "Triage activity feed message",
+  },
+  activityTriageLengthFailedDe: {
+    defaultMessage: "Length check failed · de-DE",
+    id: "4Ezk2Binde",
+    description: "Triage activity feed message",
+  },
+
+  activityCampaignQ2Launch: {
+    defaultMessage: "Q2 launch · 4 markets · 12 assets",
+    id: "FX3/YLfPRM",
+    description: "Campaign activity feed message",
+  },
+  activityCampaignLandingDrafts: {
+    defaultMessage: "Localized landing pages generating",
+    id: "y9a+N9ATb+",
+    description: "Campaign activity feed message",
+  },
+  activityCampaignFrDeQueued: {
+    defaultMessage: "FR and DE queued",
+    id: "dcHDj5eTEB",
+    description: "Campaign activity feed message",
+  },
+  activityCampaignNotifiedGtm: {
+    defaultMessage: "Notified #gtm",
+    id: "17nuqX7zHl",
+    description: "Campaign activity feed message",
+  },
+  activityCampaignPublishedStaging: {
+    defaultMessage: "12 assets published to staging",
+    id: "49eBSdYB68",
+    description: "Campaign activity feed message",
+  },
+  activityCampaignBriefComplete: {
+    defaultMessage: "Q2 launch brief complete",
+    id: "CIvf6hBZPb",
+    description: "Campaign activity feed message",
+  },
+
+  activitySeoPullingVolume: {
+    defaultMessage: "Pulling search volume · core terms",
+    id: "a7JnsekqqO",
+    description: "SEO activity feed message",
+  },
+  activitySeoLocalesCompared: {
+    defaultMessage: "EN · FR · DE · JA demand compared",
+    id: "R4Wi6C8Ql2",
+    description: "SEO activity feed message",
+  },
+  activitySeoMetaH1De: {
+    defaultMessage: "Meta + H1 adapted for DE intent",
+    id: "Rr26d0W4jR",
+    description: "SEO activity feed message",
+  },
+  activitySeoNotifiedContent: {
+    defaultMessage: "Notified #content",
+    id: "9rZekOqxRy",
+    description: "SEO activity feed message",
+  },
+  activitySeoMonthlyComplete: {
+    defaultMessage: "Monthly SEO run complete",
+    id: "qQqnrMWBuX",
+    description: "SEO activity feed message",
+  },
+  activitySeoDeDraftReview: {
+    defaultMessage: "DE SEO draft awaiting review",
+    id: "l0sMLrUTNV",
+    description: "SEO activity feed message",
+  },
+  activitySeoLocalSearchIntent: {
+    defaultMessage: "Adapted for local search · not literal EN→DE",
+    id: "yTySez9tLk",
+    description: "SEO activity feed message",
+  },
+  activitySeoNextRun: {
+    defaultMessage: "Next run · 1st of month",
+    id: "sZEcE138S3",
+    description: "SEO activity feed message",
+  },
+
+  activityBrandReviewAsked: {
+    defaultMessage: "Brand review asked · DE checkout CTA",
+    id: "NsIsf9D+fH",
+    description: "Brand activity feed message",
+  },
+  activityBrandGuideRecalled: {
+    defaultMessage: "Style guide recalled · tone + CTA rules",
+    id: "luGVae/AqD",
+    description: "Brand activity feed message",
+  },
+  activityBrandOffBrandRewrite: {
+    defaultMessage: "Off-brand · suggested rewrite ready",
+    id: "oYuDY/G9ye",
+    description: "Brand activity feed message",
+  },
+  activityBrandGuideMatched: {
+    defaultMessage: "brand-voice-style-guide.pdf matched",
+    id: "oNrbP6Kfwx",
+    description: "Brand activity feed message",
+  },
+  activityBrandToneRule: {
+    defaultMessage: "Tone: friendly, direct",
+    id: "fvB4xcNYxK",
+    description: "Brand activity feed message",
+  },
+  activityBrandSuggestedCopy: {
+    defaultMessage: "Suggested · Jetzt starten",
+    id: "M/v6Ec5/ZA",
+    description: "Brand activity feed message",
+  },
+  activityBrandCorrectionApplied: {
+    defaultMessage: "Style correction applied to DE CTA",
+    id: "pD6rbm6KOO",
+    description: "Brand activity feed message",
+  },
+  activityBrandCtaLengthRule: {
+    defaultMessage: "CTA length rule enforced",
+    id: "Q8szy9VuMQ",
+    description: "Brand activity feed message",
+  },
+
+  activityFlowWorkflowActive: {
+    defaultMessage: "Brief to publish · workflow active",
+    id: "X55ISVbO+Y",
+    description: "Flow activity feed message",
+  },
+  activityFlowGtmBriefReceived: {
+    defaultMessage: "GTM brief received",
+    id: "BO4zL9cP+Z",
+    description: "Flow activity feed message",
+  },
+  activityFlowRoutingLocalise: {
+    defaultMessage: "Routing to localise",
+    id: "XVTGyntMBx",
+    description: "Flow activity feed message",
+  },
+  activityFlowLocaleDrafts: {
+    defaultMessage: "Locale drafts in progress",
+    id: "P2XJpaePEf",
+    description: "Flow activity feed message",
+  },
+  activityFlowStyleChecking: {
+    defaultMessage: "Style rules checking",
+    id: "GvFCGTKlPG",
+    description: "Flow activity feed message",
+  },
+  activityFlowReviewerQueue: {
+    defaultMessage: "Reviewer queue updated",
+    id: "GDeB6oyCIs",
+    description: "Flow activity feed message",
+  },
+  activityFlowDraftReady: {
+    defaultMessage: "Draft ready for publish",
+    id: "lyUxeHq9xA",
+    description: "Flow activity feed message",
+  },
+  activityFlowTeamNotified: {
+    defaultMessage: "Team notified · #content",
+    id: "2vvl50MJwP",
+    description: "Flow activity feed message",
+  },
+  activityFlowComplete: {
+    defaultMessage: "Brief to publish complete",
+    id: "9gMRfobxmP",
+    description: "Flow activity feed message",
+  },
+  activityFlowSeoSelected: {
+    defaultMessage: "SEO blog workflow selected",
+    id: "WWW5nLljZ1",
+    description: "Flow activity feed message",
+  },
+  activityFlowResearchActive: {
+    defaultMessage: "Research node active",
+    id: "1wx0AD55AP",
+    description: "Flow activity feed message",
+  },
+  activityFlowCmsHandoff: {
+    defaultMessage: "CMS draft handoff",
+    id: "QK7vc710Th",
+    description: "Flow activity feed message",
+  },
+  activityFlowCampaignSelected: {
+    defaultMessage: "Campaign workflow selected",
+    id: "IhrWCxkhb6",
+    description: "Flow activity feed message",
+  },
+  activityFlowAssetsRouted: {
+    defaultMessage: "Assets routed for review",
+    id: "3Z6IJTBR/U",
+    description: "Flow activity feed message",
+  },
+  activityFlowLaunchNotified: {
+    defaultMessage: "Launch channel notified",
+    id: "9RKWXCbIdt",
+    description: "Flow activity feed message",
+  },
+
+  activityEditorFileOpened: {
+    defaultMessage: "hero-section.tsx · fr-FR · 14 strings",
+    id: "so9QGdkdV9",
+    description: "Editor activity feed message",
+  },
+  activityEditorHeroNeedsReview: {
+    defaultMessage: "Homepage hero · needs review",
+    id: "vapBIbYjsV",
+    description: "Editor activity feed message",
+  },
+  activityEditorSegmentsFlagged: {
+    defaultMessage: "3 segments flagged in file",
+    id: "cBynSuVROy",
+    description: "Editor activity feed message",
+  },
+  activityEditorTermMismatch: {
+    defaultMessage: "Term mismatch · review → validation",
+    id: "LgTlWd3OgE",
+    description: "Editor activity feed message",
+  },
+  activityEditorTermSuggested: {
+    defaultMessage: "Approved term suggested for banner copy",
+    id: "RM4XFP9DWJ",
+    description: "Editor activity feed message",
+  },
+  activityEditorGlossaryCheck: {
+    defaultMessage: "Glossary check on qa-warning segment",
+    id: "ztaySGILBS",
+    description: "Editor activity feed message",
+  },
+  activityEditorIssueLinked: {
+    defaultMessage: "WEB-2 linked · checkout CTA too long",
+    id: "I+qo5eCLeO",
+    description: "Editor activity feed message",
+  },
+  activityEditorOpenQuestion: {
+    defaultMessage: "Open question · glossary violation",
+    id: "j5aTOW5nqn",
+    description: "Editor activity feed message",
+  },
+  activityEditorOpenedFromTriage: {
+    defaultMessage: "Opened from issues board",
+    id: "igAfv5C/QH",
+    description: "Editor activity feed message",
+  },
+  activityEditorTmMatch: {
+    defaultMessage: "TM match · 92% · hero headline",
+    id: "Vhmhc1uF/V",
+    description: "Editor activity feed message",
+  },
+  activityEditorContextLoaded: {
+    defaultMessage: "Component path + repo context loaded",
+    id: "V3NLDwgBXQ",
+    description: "Editor activity feed message",
+  },
+  activityEditorSuggestionReady: {
+    defaultMessage: "Suggestion ready · length check passed",
+    id: "lrzFf+e6vi",
+    description: "Editor activity feed message",
+  },
 
   tabTriage: {
     defaultMessage: "Triage open questions",

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -17,369 +17,364 @@ import { defineMessages } from "react-intl";
 export const contentOpsMockStageMessages = defineMessages({
   activityLive: {
     defaultMessage: "Live",
-    id: "CoPsLive01",
+    id: "B4VkdPz+2q",
     description: "Live indicator label on the content ops activity feed",
   },
 
   tabTriage: {
     defaultMessage: "Triage open questions",
-    id: "CoPsTab01",
+    id: "Eb4afW9TDL",
     description: "Content ops mock tab label for issues triage",
   },
   tabCampaign: {
     defaultMessage: "Localize campaign copy",
-    id: "CoPsTab02",
+    id: "756ODq6uhK",
     description: "Content ops mock tab label for campaign localisation",
   },
   tabSeoBlog: {
     defaultMessage: "Publish localised SEO blogs",
-    id: "CoPsTab03",
+    id: "Zga+q71c0X",
     description: "Content ops mock tab label for SEO blog publishing",
   },
   tabBrand: {
     defaultMessage: "Keep brand consistent",
-    id: "CoPsTab04",
+    id: "ccqv17M0Ia",
     description: "Content ops mock tab label for brand governance",
   },
   tabBriefToPublish: {
     defaultMessage: "Automate brief to publish",
-    id: "CoPsTab05",
+    id: "h/nQhr+VQ1",
     description: "Content ops mock tab label for brief-to-publish workflow",
   },
 
   botLabel: {
     defaultMessage: "Use Hyperlocalise Agent",
-    id: "CoPsBot01",
+    id: "bH9+5GUIgE",
     description: "Agent terminal title in content ops mock",
   },
 
   triggerGtmBrief: {
     defaultMessage: "GTM brief approved · Q2 launch",
-    id: "CoPsTrg01",
+    id: "MNCmDu8OgB",
     description: "GTM trigger label in content ops campaign mock",
   },
   triggerSeoSchedule: {
     defaultMessage: "Scheduled run · 1st of month",
-    id: "CoPsTrg02",
+    id: "Tl0CYs/kQf",
     description: "SEO schedule trigger label in content ops mock",
   },
 
   toolCms: {
     defaultMessage: "CMS",
-    id: "CoPsTl001",
+    id: "Zrmv5cA+Lc",
     description: "CMS tool chip in content ops terminal mock",
   },
   toolTranslate: {
     defaultMessage: "Translate",
-    id: "CoPsTl002",
+    id: "mWl7zKHq+b",
     description: "Translate tool chip in content ops terminal mock",
   },
   toolSlack: {
     defaultMessage: "Slack",
-    id: "CoPsTl003",
+    id: "AIFi7wN5lY",
     description: "Slack tool chip in content ops terminal mock",
   },
   toolSearch: {
     defaultMessage: "Search",
-    id: "CoPsTl004",
+    id: "QgqbdcDGCR",
     description: "Search tool chip in content ops terminal mock",
   },
   toolAhrefs: {
     defaultMessage: "Ahrefs",
-    id: "CoPsTl005",
+    id: "eQIxzTUwry",
     description: "Ahrefs tool chip in content ops terminal mock",
   },
 
   stepGtm1: {
     defaultMessage: "Brief received · 4 markets, 12 assets",
-    id: "CoPsGt001",
+    id: "mlbMDyLQpv",
     description: "Campaign mock step 1",
   },
   stepGtm2: {
     defaultMessage: "Generating localized landing page drafts...",
-    id: "CoPsGt002",
+    id: "EVH8TUWi0h",
     description: "Campaign mock step 2",
   },
   stepGtm3: {
     defaultMessage: "FR and DE routed for review",
-    id: "CoPsGt003",
+    id: "6JT4j+EKwy",
     description: "Campaign mock step 3",
   },
   stepGtm4: {
     defaultMessage: "Published to staging · notified #gtm",
-    id: "CoPsGt004",
+    id: "ZV8a5iOSNX",
     description: "Campaign mock step 4",
   },
 
   stepSeo1: {
     defaultMessage: "Pulling search volume for core product terms",
-    id: "CoPsSe001",
+    id: "nlurA4/IRm",
     description: "SEO blog mock step 1",
   },
   stepSeo2: {
     defaultMessage: "EN · FR · DE · JA demand compared",
-    id: "CoPsSe002",
+    id: "a0ooXAWwaq",
     description: "SEO blog mock step 2",
   },
   stepSeo3: {
     defaultMessage: "12 high-intent gaps found in DE",
-    id: "CoPsSe003",
+    id: "tIIkL73dX1",
     description: "SEO blog mock step 3",
   },
   stepSeo4: {
     defaultMessage: "Localised SEO draft · meta + H1 adapted",
-    id: "CoPsSe004",
+    id: "Wnrfau6YGS",
     description: "SEO blog mock step 4",
   },
   stepSeo5: {
     defaultMessage: "QA passed · draft written to CMS · #content notified",
-    id: "CoPsSe005",
+    id: "ieOgNf/WnJ",
     description: "SEO blog mock step 5",
   },
 
   issuesTitle: {
     defaultMessage: "Issues · acme workspace",
-    id: "CoPsIs001",
+    id: "rugkgwDED8",
     description: "Issues panel title in content ops mock",
   },
   issuesSummary: {
     defaultMessage: "{open} open · {inProgress} in progress · {resolved} resolved",
-    id: "CoPsIs002",
+    id: "MMFb5MTldp",
     description: "Issues summary line in content ops mock",
   },
   issueWeb2Title: {
     defaultMessage: "Translation mistake in checkout",
-    id: "CoPsIs003",
+    id: "LE5VKYLxU+",
     description: "Issue row title in content ops mock",
   },
   issueWeb2Detail: {
     defaultMessage: "Payment button label too long · checkout.json",
-    id: "CoPsIs004",
+    id: "Mk8D3Ht2wh",
     description: "Issue row detail in content ops mock",
   },
   issueMob1Title: {
     defaultMessage: "Glossary violation in onboarding",
-    id: "CoPsIs005",
+    id: "qjpFG9aLeM",
     description: "Issue row title in content ops mock",
   },
   issueMob1Detail: {
     defaultMessage: "Product name should stay untranslated",
-    id: "CoPsIs006",
+    id: "pHD22l59Uc",
     description: "Issue row detail in content ops mock",
   },
   issueWeb3Title: {
     defaultMessage: "QA failure on hero headline",
-    id: "CoPsIs007",
+    id: "2a9969NmAV",
     description: "Issue row title in content ops mock",
   },
   issueWeb3Detail: {
     defaultMessage: "Length check failed for German headline",
-    id: "CoPsIs008",
+    id: "PvTDEYL5Rz",
     description: "Issue row detail in content ops mock",
   },
   statusOpen: {
     defaultMessage: "Open",
-    id: "CoPsSt001",
+    id: "BA/hJPgmbP",
     description: "Issue status open",
   },
   statusInProgress: {
     defaultMessage: "In progress",
-    id: "CoPsSt002",
+    id: "MXGPxAzEmG",
     description: "Issue status in progress",
   },
   statusResolved: {
     defaultMessage: "Resolved",
-    id: "CoPsSt003",
+    id: "e+WPqvuP5X",
     description: "Issue status resolved",
   },
   openInCat: {
     defaultMessage: "Open in CAT",
-    id: "CoPsCat01",
+    id: "dpL071W81r",
     description: "Link label to open issue in CAT editor",
   },
 
   brandStyleTitle: {
     defaultMessage: "Brand voice · Style guide",
-    id: "CoPsBr001",
+    id: "wr3AKpuOi3",
     description: "Brand style guide panel title",
   },
   brandStyleSubtitle: {
     defaultMessage: "Applied while reviewing DE checkout CTA",
-    id: "CoPsBr002",
+    id: "zL0L4Vvw8O",
     description: "Brand style guide panel subtitle",
   },
   brandRuleTone: {
     defaultMessage: "Tone: friendly, direct",
-    id: "CoPsBr003",
+    id: "6ZNG5E8172",
     description: "Brand style rule chip",
   },
   brandRuleCta: {
     defaultMessage: "CTA: short verb",
-    id: "CoPsBr004",
+    id: "4yshvtwLy5",
     description: "Brand style rule chip",
   },
   brandBeforeLabel: {
     defaultMessage: "Before",
-    id: "CoPsBr005",
+    id: "IuT/Zm3PzS",
     description: "Before copy label in brand mock",
   },
   brandAfterLabel: {
     defaultMessage: "After",
-    id: "CoPsBr006",
+    id: "oiaT335RnA",
     description: "After copy label in brand mock",
   },
   brandBeforeCopy: {
     defaultMessage: "Nutzen Sie unsere innovative Plattform",
-    id: "CoPsBr007",
+    id: "44BRBm86tt",
     description: "Before copy sample in brand mock",
   },
   brandAfterCopy: {
     defaultMessage: "Jetzt starten",
-    id: "CoPsBr008",
+    id: "EwGaDUWfx3",
     description: "After copy sample in brand mock",
   },
   brandAppliedBadge: {
     defaultMessage: "Applied",
-    id: "CoPsBr009",
+    id: "mq4AvDs4i5",
     description: "Applied badge on brand style correction",
   },
   brandChatTitle: {
     defaultMessage: "Brand review chat",
-    id: "CoPsBr010",
+    id: "US+0MJLvUO",
     description: "Brand chat dock title",
   },
   brandChatPrompt: {
     defaultMessage:
-      "Does this German CTA follow our brand guidelines? \"Nutzen Sie unsere innovative Plattform\"",
-    id: "CoPsBr011",
+      'Does this German CTA follow our brand guidelines? "Nutzen Sie unsere innovative Plattform"',
+    id: "DYjZeqplYa",
     description: "User prompt in brand chat mock",
   },
   brandToolName: {
     defaultMessage: "recall_knowledge_files",
-    id: "CoPsBr012",
+    id: "U9t/eIwVYM",
     description: "Tool name shown in brand chat mock",
   },
   brandToolDetail: {
     defaultMessage: "brand-voice-style-guide.pdf",
-    id: "CoPsBr013",
+    id: "/4z8WJXCPb",
     description: "Tool detail in brand chat mock",
   },
   brandVerdictLabel: {
     defaultMessage: "Verdict",
-    id: "CoPsBr014",
+    id: "wi8LFLVfQY",
     description: "Verdict section in brand chat answer",
   },
   brandVerdictBody: {
     defaultMessage: "Off-brand — too formal and jargon-heavy for DE checkout.",
-    id: "CoPsBr015",
+    id: "I/IBBrTtGZ",
     description: "Verdict body in brand chat answer",
   },
   brandGuidelineLabel: {
     defaultMessage: "Guideline",
-    id: "CoPsBr016",
+    id: "d3ASNb05IP",
     description: "Guideline section in brand chat answer",
   },
   brandGuidelineBody: {
     defaultMessage: "Tone: friendly, direct · CTA: short verb, max 24 characters.",
-    id: "CoPsBr017",
+    id: "MVrchtGazs",
     description: "Guideline body in brand chat answer",
   },
   brandSuggestLabel: {
     defaultMessage: "Suggested copy",
-    id: "CoPsBr018",
+    id: "DsRoK8kvzv",
     description: "Suggested copy section in brand chat answer",
   },
   brandSuggestBody: {
     defaultMessage: "Jetzt starten",
-    id: "CoPsBr019",
+    id: "jn5bLV1i0/",
     description: "Suggested copy body in brand chat answer",
   },
   brandSend: {
     defaultMessage: "Send",
-    id: "CoPsBr020",
+    id: "N0qPsNFkOT",
     description: "Send button in brand chat mock",
   },
   brandReplay: {
     defaultMessage: "Replay",
-    id: "CoPsBr021",
+    id: "aRwWx+LFBU",
     description: "Replay button in brand chat mock",
   },
 
   flowTitle: {
     defaultMessage: "Brief to publish · workflow",
-    id: "CoPsFl001",
+    id: "+TDSJ1bdrZ",
     description: "Flow panel title",
   },
   flowTemplateCampaign: {
     defaultMessage: "Campaign",
-    id: "CoPsFl002",
+    id: "+ek/FknpQJ",
     description: "Flow template pill for campaign",
   },
   flowTemplateSeo: {
     defaultMessage: "SEO blog",
-    id: "CoPsFl003",
+    id: "1WYC40KrqC",
     description: "Flow template pill for SEO blog",
   },
   flowTemplateBrief: {
     defaultMessage: "Brief to publish",
-    id: "CoPsFl004",
+    id: "Unt4qWzIK1",
     description: "Flow template pill for brief to publish",
   },
   flowNodeBrief: {
     defaultMessage: "GTM brief",
-    id: "CoPsFn001",
+    id: "0h6ygVHD06",
     description: "Flow node label",
   },
   flowNodeLocalise: {
     defaultMessage: "Localise",
-    id: "CoPsFn002",
+    id: "F3gTJhCvdi",
     description: "Flow node label",
   },
   flowNodeBrandQa: {
     defaultMessage: "Brand QA",
-    id: "CoPsFn003",
+    id: "qDJ1AfMuj+",
     description: "Flow node label",
   },
   flowNodeReview: {
     defaultMessage: "Review",
-    id: "CoPsFn004",
+    id: "vZn7h5Bl2j",
     description: "Flow node label",
   },
   flowNodeCms: {
     defaultMessage: "CMS publish",
-    id: "CoPsFn005",
+    id: "2JUwOE/z9B",
     description: "Flow node label",
   },
   flowNodeSchedule: {
     defaultMessage: "Scheduled run",
-    id: "CoPsFn006",
+    id: "cvuRKz2hMS",
     description: "Flow node label",
   },
   flowNodeKeywords: {
     defaultMessage: "Keyword research",
-    id: "CoPsFn007",
+    id: "3wOLsPOjf5",
     description: "Flow node label",
   },
   flowNodeDraft: {
     defaultMessage: "CMS draft",
-    id: "CoPsFn008",
+    id: "DN35BCM/UE",
     description: "Flow node label",
   },
   flowNodeSlack: {
     defaultMessage: "Slack notify",
-    id: "CoPsFn009",
+    id: "RicTjBrN9L",
     description: "Flow node label",
   },
   flowNodeStaging: {
     defaultMessage: "Staging",
-    id: "CoPsFn010",
+    id: "U499tVTudb",
     description: "Flow node label",
   },
 });
 
-export type ContentOpsMockTabId =
-  | "triage"
-  | "campaign"
-  | "seo-blog"
-  | "brand"
-  | "brief-to-publish";
+export type ContentOpsMockTabId = "triage" | "campaign" | "seo-blog" | "brand" | "brief-to-publish";

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
@@ -30,7 +30,10 @@ import {
   type ContentOpsActivityItem,
   type ContentOpsMockTabId,
 } from "./content-ops-activity-feed";
-import { ContentOpsAgentTerminal, type ContentOpsTerminalScene } from "./content-ops-agent-terminal";
+import {
+  ContentOpsAgentTerminal,
+  type ContentOpsTerminalScene,
+} from "./content-ops-agent-terminal";
 import { ContentOpsBrandPanel } from "./content-ops-brand-panel";
 import { ContentOpsFlowPanel } from "./content-ops-flow-panel";
 import { ContentOpsIssuesPanel } from "./content-ops-issues-panel";
@@ -66,10 +69,7 @@ const TABS: TabConfig[] = [
   { id: "brief-to-publish", labelKey: "tabBriefToPublish" },
 ];
 
-function useActivityItems(
-  tabId: ContentOpsMockTabId,
-  stepIndex: number,
-): ContentOpsActivityItem[] {
+function useActivityItems(tabId: ContentOpsMockTabId, stepIndex: number): ContentOpsActivityItem[] {
   const intl = useIntl();
 
   return useMemo(() => {
@@ -98,17 +98,41 @@ function useActivityItems(
         { time: "8m", source: "Review", message: "FR and DE queued" },
       ],
       [
-        { time: "now", source: "Agent", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm2) },
-        { time: "4m", source: "Brief", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm1) },
-        { time: "8m", source: "Review", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm3) },
+        {
+          time: "now",
+          source: "Agent",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm2),
+        },
+        {
+          time: "4m",
+          source: "Brief",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm1),
+        },
+        {
+          time: "8m",
+          source: "Review",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm3),
+        },
       ],
       [
-        { time: "now", source: "Review", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm3) },
-        { time: "4m", source: "Staging", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm4) },
+        {
+          time: "now",
+          source: "Review",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm3),
+        },
+        {
+          time: "4m",
+          source: "Staging",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm4),
+        },
         { time: "8m", source: "Slack", message: "Notified #gtm" },
       ],
       [
-        { time: "now", source: "Staging", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm4) },
+        {
+          time: "now",
+          source: "Staging",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm4),
+        },
         { time: "6m", source: "CMS", message: "12 assets published to staging" },
         { time: "10m", source: "Brief", message: "Q2 launch brief complete" },
       ],
@@ -123,16 +147,32 @@ function useActivityItems(
       ],
       [
         { time: "now", source: "Gaps", message: seoStep3 },
-        { time: "4m", source: "Draft", message: intl.formatMessage(contentOpsMockStageMessages.stepSeo4) },
+        {
+          time: "4m",
+          source: "Draft",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepSeo4),
+        },
         { time: "8m", source: "QA", message: "Meta + H1 adapted for DE intent" },
       ],
       [
-        { time: "now", source: "Draft", message: intl.formatMessage(contentOpsMockStageMessages.stepSeo4) },
-        { time: "4m", source: "CMS", message: intl.formatMessage(contentOpsMockStageMessages.stepSeo5) },
+        {
+          time: "now",
+          source: "Draft",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepSeo4),
+        },
+        {
+          time: "4m",
+          source: "CMS",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepSeo5),
+        },
         { time: "8m", source: "Slack", message: "Notified #content" },
       ],
       [
-        { time: "now", source: "CMS", message: intl.formatMessage(contentOpsMockStageMessages.stepSeo5) },
+        {
+          time: "now",
+          source: "CMS",
+          message: intl.formatMessage(contentOpsMockStageMessages.stepSeo5),
+        },
         { time: "6m", source: "Research", message: "Monthly SEO run complete" },
         { time: "10m", source: "Gaps", message: seoStep3 },
       ],
@@ -202,7 +242,13 @@ function useActivityItems(
   }, [intl, stepIndex, tabId]);
 }
 
-export function ContentOpsMockStage({ className, priority = false }: { className?: string; priority?: boolean }) {
+export function ContentOpsMockStage({
+  className,
+  priority = false,
+}: {
+  className?: string;
+  priority?: boolean;
+}) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion() ?? false;
   const [activeTab, setActiveTab] = useState<ContentOpsMockTabId>("triage");

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
@@ -35,6 +35,7 @@ import {
   type ContentOpsTerminalScene,
 } from "./content-ops-agent-terminal";
 import { ContentOpsBrandPanel } from "./content-ops-brand-panel";
+import { ContentOpsEditorPanel } from "./content-ops-editor-panel";
 import { ContentOpsFlowPanel } from "./content-ops-flow-panel";
 import { ContentOpsIssuesPanel } from "./content-ops-issues-panel";
 import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
@@ -46,6 +47,7 @@ const TAB_ORDER: ContentOpsMockTabId[] = [
   "seo-blog",
   "brand",
   "brief-to-publish",
+  "editor",
 ];
 
 const MESH_BY_TAB: Record<ContentOpsMockTabId, string> = {
@@ -54,6 +56,7 @@ const MESH_BY_TAB: Record<ContentOpsMockTabId, string> = {
   "seo-blog": SAGE_MESH_GRADIENT_SRC,
   brand: LAVENDER_MESH_GRADIENT_SRC,
   "brief-to-publish": SAGE_MESH_GRADIENT_SRC,
+  editor: LAVENDER_MESH_GRADIENT_SRC,
 };
 
 type TabConfig = {
@@ -67,6 +70,7 @@ const TABS: TabConfig[] = [
   { id: "seo-blog", labelKey: "tabSeoBlog" },
   { id: "brand", labelKey: "tabBrand" },
   { id: "brief-to-publish", labelKey: "tabBriefToPublish" },
+  { id: "editor", labelKey: "tabEditor" },
 ];
 
 function useActivityItems(tabId: ContentOpsMockTabId, stepIndex: number): ContentOpsActivityItem[] {
@@ -229,12 +233,36 @@ function useActivityItems(tabId: ContentOpsMockTabId, stepIndex: number): Conten
       ],
     ];
 
+    const editorSets: ContentOpsActivityItem[][] = [
+      [
+        { time: "now", source: "Editor", message: "hero-section.tsx · fr-FR · 14 strings" },
+        { time: "4m", source: "Segment", message: "Homepage hero · needs review" },
+        { time: "8m", source: "Queue", message: "3 segments flagged in file" },
+      ],
+      [
+        { time: "now", source: "Glossary", message: "Term mismatch · review → validation" },
+        { time: "4m", source: "QA", message: "Approved term suggested for banner copy" },
+        { time: "8m", source: "Editor", message: "Glossary check on qa-warning segment" },
+      ],
+      [
+        { time: "now", source: "Issues", message: "WEB-2 linked · checkout CTA too long" },
+        { time: "4m", source: "MOB-1", message: "Open question · glossary violation" },
+        { time: "8m", source: "Triage", message: "Opened from issues board" },
+      ],
+      [
+        { time: "now", source: "Intelligence", message: "TM match · 92% · hero headline" },
+        { time: "4m", source: "Context", message: "Component path + repo context loaded" },
+        { time: "8m", source: "AI", message: "Suggestion ready · length check passed" },
+      ],
+    ];
+
     const setsByTab: Record<ContentOpsMockTabId, ContentOpsActivityItem[][]> = {
       triage: triageSets,
       campaign: campaignSets,
       "seo-blog": seoSets,
       brand: brandSets,
       "brief-to-publish": flowSets,
+      editor: editorSets,
     };
 
     const sets = setsByTab[tabId];
@@ -411,6 +439,12 @@ export function ContentOpsMockStage({
               <ContentOpsFlowPanel
                 pauseAutoplay={pauseAutoplay}
                 onActiveNodeChange={handleFlowNodeChange}
+              />
+            ) : null}
+            {activeTab === "editor" ? (
+              <ContentOpsEditorPanel
+                pauseAutoplay={pauseAutoplay}
+                onSceneChange={handleStepIndexChange}
               />
             ) : null}
           </motion.div>

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Clock01Icon, Rocket01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useIntl } from "react-intl";
+
+import {
+  LAVENDER_MESH_GRADIENT_SRC,
+  MeshStage,
+  SAGE_MESH_GRADIENT_SRC,
+} from "@/components/marketing/hero-frame-mesh-stage";
+import { cn } from "@/lib/primitives/cn";
+
+import {
+  ContentOpsActivityFeed,
+  type ContentOpsActivityItem,
+  type ContentOpsMockTabId,
+} from "./content-ops-activity-feed";
+import { ContentOpsAgentTerminal, type ContentOpsTerminalScene } from "./content-ops-agent-terminal";
+import { ContentOpsBrandPanel } from "./content-ops-brand-panel";
+import { ContentOpsFlowPanel } from "./content-ops-flow-panel";
+import { ContentOpsIssuesPanel } from "./content-ops-issues-panel";
+import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
+
+const TAB_HOLD_MS = 9000;
+const TAB_ORDER: ContentOpsMockTabId[] = [
+  "triage",
+  "campaign",
+  "seo-blog",
+  "brand",
+  "brief-to-publish",
+];
+
+const MESH_BY_TAB: Record<ContentOpsMockTabId, string> = {
+  triage: SAGE_MESH_GRADIENT_SRC,
+  campaign: LAVENDER_MESH_GRADIENT_SRC,
+  "seo-blog": SAGE_MESH_GRADIENT_SRC,
+  brand: LAVENDER_MESH_GRADIENT_SRC,
+  "brief-to-publish": SAGE_MESH_GRADIENT_SRC,
+};
+
+type TabConfig = {
+  id: ContentOpsMockTabId;
+  labelKey: keyof typeof contentOpsMockStageMessages;
+};
+
+const TABS: TabConfig[] = [
+  { id: "triage", labelKey: "tabTriage" },
+  { id: "campaign", labelKey: "tabCampaign" },
+  { id: "seo-blog", labelKey: "tabSeoBlog" },
+  { id: "brand", labelKey: "tabBrand" },
+  { id: "brief-to-publish", labelKey: "tabBriefToPublish" },
+];
+
+function useActivityItems(
+  tabId: ContentOpsMockTabId,
+  stepIndex: number,
+): ContentOpsActivityItem[] {
+  const intl = useIntl();
+
+  return useMemo(() => {
+    const triageSets: ContentOpsActivityItem[][] = [
+      [
+        { time: "now", source: "WEB-2", message: "Assigned · FR checkout CTA too long" },
+        { time: "4m", source: "MOB-1", message: "Glossary break · es-ES · unassigned" },
+        { time: "10m", source: "WEB-3", message: "QA failure resolved · de-DE headline" },
+      ],
+      [
+        { time: "now", source: "MOB-1", message: "Glossary break · es-ES · unassigned" },
+        { time: "4m", source: "WEB-2", message: "In progress · payment button label" },
+        { time: "10m", source: "CAT", message: "Open in CAT · checkout.json" },
+      ],
+      [
+        { time: "now", source: "WEB-3", message: "Resolved · hero headline length check" },
+        { time: "6m", source: "WEB-2", message: "Translation mistake flagged · fr-FR" },
+        { time: "12m", source: "QA", message: "Length check failed · de-DE" },
+      ],
+    ];
+
+    const campaignSets: ContentOpsActivityItem[][] = [
+      [
+        { time: "now", source: "Brief", message: "Q2 launch · 4 markets · 12 assets" },
+        { time: "4m", source: "Drafts", message: "Localized landing pages generating" },
+        { time: "8m", source: "Review", message: "FR and DE queued" },
+      ],
+      [
+        { time: "now", source: "Agent", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm2) },
+        { time: "4m", source: "Brief", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm1) },
+        { time: "8m", source: "Review", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm3) },
+      ],
+      [
+        { time: "now", source: "Review", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm3) },
+        { time: "4m", source: "Staging", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm4) },
+        { time: "8m", source: "Slack", message: "Notified #gtm" },
+      ],
+      [
+        { time: "now", source: "Staging", message: intl.formatMessage(contentOpsMockStageMessages.stepGtm4) },
+        { time: "6m", source: "CMS", message: "12 assets published to staging" },
+        { time: "10m", source: "Brief", message: "Q2 launch brief complete" },
+      ],
+    ];
+
+    const seoStep3 = intl.formatMessage(contentOpsMockStageMessages.stepSeo3);
+    const seoSets: ContentOpsActivityItem[][] = [
+      [
+        { time: "now", source: "Research", message: "Pulling search volume · core terms" },
+        { time: "4m", source: "Locales", message: "EN · FR · DE · JA compared" },
+        { time: "8m", source: "Gaps", message: seoStep3 },
+      ],
+      [
+        { time: "now", source: "Gaps", message: seoStep3 },
+        { time: "4m", source: "Draft", message: intl.formatMessage(contentOpsMockStageMessages.stepSeo4) },
+        { time: "8m", source: "QA", message: "Meta + H1 adapted for DE intent" },
+      ],
+      [
+        { time: "now", source: "Draft", message: intl.formatMessage(contentOpsMockStageMessages.stepSeo4) },
+        { time: "4m", source: "CMS", message: intl.formatMessage(contentOpsMockStageMessages.stepSeo5) },
+        { time: "8m", source: "Slack", message: "Notified #content" },
+      ],
+      [
+        { time: "now", source: "CMS", message: intl.formatMessage(contentOpsMockStageMessages.stepSeo5) },
+        { time: "6m", source: "Research", message: "Monthly SEO run complete" },
+        { time: "10m", source: "Gaps", message: seoStep3 },
+      ],
+      [
+        { time: "now", source: "Publish", message: "DE SEO draft awaiting review" },
+        { time: "5m", source: "Intent", message: "Adapted for local search · not literal EN→DE" },
+        { time: "9m", source: "Schedule", message: "Next run · 1st of month" },
+      ],
+    ];
+
+    const brandSets: ContentOpsActivityItem[][] = [
+      [
+        { time: "now", source: "Chat", message: "Brand review asked · DE checkout CTA" },
+        { time: "4m", source: "Guide", message: "Style guide recalled · tone + CTA rules" },
+        { time: "8m", source: "Verdict", message: "Off-brand · suggested rewrite ready" },
+      ],
+      [
+        { time: "now", source: "Knowledge", message: "brand-voice-style-guide.pdf matched" },
+        { time: "4m", source: "Rule", message: "Tone: friendly, direct" },
+        { time: "8m", source: "Copy", message: "Suggested · Jetzt starten" },
+      ],
+      [
+        { time: "now", source: "Applied", message: "Style correction applied to DE CTA" },
+        { time: "5m", source: "Chat", message: "Brand review asked · DE checkout CTA" },
+        { time: "10m", source: "Guide", message: "CTA length rule enforced" },
+      ],
+    ];
+
+    const flowSets: ContentOpsActivityItem[][] = [
+      [
+        { time: "now", source: "Flow", message: "Brief to publish · workflow active" },
+        { time: "4m", source: "Step", message: "GTM brief received" },
+        { time: "8m", source: "Handoff", message: "Routing to localise" },
+      ],
+      [
+        { time: "now", source: "Localise", message: "Locale drafts in progress" },
+        { time: "4m", source: "Brand QA", message: "Style rules checking" },
+        { time: "8m", source: "Review", message: "Reviewer queue updated" },
+      ],
+      [
+        { time: "now", source: "CMS", message: "Draft ready for publish" },
+        { time: "4m", source: "Slack", message: "Team notified · #content" },
+        { time: "8m", source: "Flow", message: "Brief to publish complete" },
+      ],
+      [
+        { time: "now", source: "Template", message: "SEO blog workflow selected" },
+        { time: "4m", source: "Keywords", message: "Research node active" },
+        { time: "8m", source: "Draft", message: "CMS draft handoff" },
+      ],
+      [
+        { time: "now", source: "Template", message: "Campaign workflow selected" },
+        { time: "4m", source: "Staging", message: "Assets routed for review" },
+        { time: "8m", source: "Slack", message: "Launch channel notified" },
+      ],
+    ];
+
+    const setsByTab: Record<ContentOpsMockTabId, ContentOpsActivityItem[][]> = {
+      triage: triageSets,
+      campaign: campaignSets,
+      "seo-blog": seoSets,
+      brand: brandSets,
+      "brief-to-publish": flowSets,
+    };
+
+    const sets = setsByTab[tabId];
+    return sets[Math.min(stepIndex, sets.length - 1)] ?? sets[0]!;
+  }, [intl, stepIndex, tabId]);
+}
+
+export function ContentOpsMockStage({ className, priority = false }: { className?: string; priority?: boolean }) {
+  const intl = useIntl();
+  const shouldReduceMotion = useReducedMotion() ?? false;
+  const [activeTab, setActiveTab] = useState<ContentOpsMockTabId>("triage");
+  const [isPaused, setIsPaused] = useState(false);
+  const [playbackStep, setPlaybackStep] = useState(0);
+
+  const campaignScene: ContentOpsTerminalScene = useMemo(
+    () => ({
+      id: "campaign",
+      triggerIcon: <HugeiconsIcon icon={Rocket01Icon} strokeWidth={1.8} className="size-3" />,
+      triggerLabel: intl.formatMessage(contentOpsMockStageMessages.triggerGtmBrief),
+      tools: [
+        intl.formatMessage(contentOpsMockStageMessages.toolCms),
+        intl.formatMessage(contentOpsMockStageMessages.toolTranslate),
+        intl.formatMessage(contentOpsMockStageMessages.toolSlack),
+      ],
+      steps: [
+        intl.formatMessage(contentOpsMockStageMessages.stepGtm1),
+        intl.formatMessage(contentOpsMockStageMessages.stepGtm2),
+        intl.formatMessage(contentOpsMockStageMessages.stepGtm3),
+        intl.formatMessage(contentOpsMockStageMessages.stepGtm4),
+      ],
+    }),
+    [intl],
+  );
+
+  const seoScene: ContentOpsTerminalScene = useMemo(() => {
+    const highlightStep = intl.formatMessage(contentOpsMockStageMessages.stepSeo3);
+    return {
+      id: "seo-blog",
+      triggerIcon: <HugeiconsIcon icon={Clock01Icon} strokeWidth={1.8} className="size-3" />,
+      triggerLabel: intl.formatMessage(contentOpsMockStageMessages.triggerSeoSchedule),
+      tools: [
+        intl.formatMessage(contentOpsMockStageMessages.toolSearch),
+        intl.formatMessage(contentOpsMockStageMessages.toolAhrefs),
+        intl.formatMessage(contentOpsMockStageMessages.toolCms),
+        intl.formatMessage(contentOpsMockStageMessages.toolSlack),
+      ],
+      steps: [
+        intl.formatMessage(contentOpsMockStageMessages.stepSeo1),
+        intl.formatMessage(contentOpsMockStageMessages.stepSeo2),
+        highlightStep,
+        intl.formatMessage(contentOpsMockStageMessages.stepSeo4),
+        intl.formatMessage(contentOpsMockStageMessages.stepSeo5),
+      ],
+      highlightSteps: new Set([highlightStep]),
+    };
+  }, [intl]);
+
+  const activityItems = useActivityItems(activeTab, playbackStep);
+
+  const handleTabSelect = useCallback((tabId: ContentOpsMockTabId) => {
+    setIsPaused(true);
+    setActiveTab(tabId);
+    setPlaybackStep(0);
+    window.setTimeout(() => setIsPaused(false), 600);
+  }, []);
+
+  useEffect(() => {
+    if (isPaused || shouldReduceMotion) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setActiveTab((current) => {
+        const index = TAB_ORDER.indexOf(current);
+        const next = TAB_ORDER[(index + 1) % TAB_ORDER.length]!;
+        return next;
+      });
+      setPlaybackStep(0);
+    }, TAB_HOLD_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [activeTab, isPaused, shouldReduceMotion]);
+
+  const handleStepIndexChange = useCallback((stepIndex: number) => {
+    setPlaybackStep(stepIndex);
+  }, []);
+
+  const handleFlowNodeChange = useCallback((nodeIndex: number) => {
+    setPlaybackStep(nodeIndex);
+  }, []);
+
+  const pauseAutoplay = isPaused || shouldReduceMotion;
+
+  useEffect(() => {
+    if (activeTab !== "triage" || pauseAutoplay) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setPlaybackStep((step) => step + 1);
+    }, 2600);
+
+    return () => window.clearInterval(timer);
+  }, [activeTab, pauseAutoplay]);
+
+  return (
+    <div className={cn("space-y-5", className)}>
+      <div className="-mx-1 flex gap-2 overflow-x-auto pb-1">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => handleTabSelect(tab.id)}
+            className={cn(
+              "shrink-0 cursor-pointer rounded-full border px-4 py-2 text-left text-sm font-medium transition-all duration-200",
+              activeTab === tab.id
+                ? "border-primary/35 bg-primary/8 text-foreground shadow-sm"
+                : "border-border/60 bg-background text-muted-foreground hover:border-border hover:text-foreground",
+            )}
+          >
+            {intl.formatMessage(contentOpsMockStageMessages[tab.labelKey])}
+          </button>
+        ))}
+      </div>
+
+      <ContentOpsActivityFeed items={activityItems} />
+
+      <MeshStage meshSrc={MESH_BY_TAB[activeTab]} priority={priority} layout="contained">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={activeTab}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.28, ease: [0.19, 1, 0.22, 1] }}
+            className="w-full"
+          >
+            {activeTab === "triage" ? (
+              <ContentOpsIssuesPanel highlightedIndex={playbackStep % 3} />
+            ) : null}
+            {activeTab === "campaign" ? (
+              <ContentOpsAgentTerminal
+                scene={campaignScene}
+                pauseAutoplay={pauseAutoplay}
+                onStepIndexChange={handleStepIndexChange}
+              />
+            ) : null}
+            {activeTab === "seo-blog" ? (
+              <ContentOpsAgentTerminal
+                scene={seoScene}
+                pauseAutoplay={pauseAutoplay}
+                onStepIndexChange={handleStepIndexChange}
+              />
+            ) : null}
+            {activeTab === "brand" ? (
+              <ContentOpsBrandPanel
+                pauseAutoplay={pauseAutoplay}
+                onPhaseChange={(phase) => {
+                  if (phase === "done") {
+                    setPlaybackStep(2);
+                  } else if (phase === "playing") {
+                    setPlaybackStep(0);
+                  }
+                }}
+              />
+            ) : null}
+            {activeTab === "brief-to-publish" ? (
+              <ContentOpsFlowPanel
+                pauseAutoplay={pauseAutoplay}
+                onActiveNodeChange={handleFlowNodeChange}
+              />
+            ) : null}
+          </motion.div>
+        </AnimatePresence>
+      </MeshStage>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
@@ -34,7 +34,7 @@ import {
   ContentOpsAgentTerminal,
   type ContentOpsTerminalScene,
 } from "./content-ops-agent-terminal";
-import { ContentOpsBrandPanel } from "./content-ops-brand-panel";
+import { ContentOpsBrandPanel, type BrandPlaybackPhase } from "./content-ops-brand-panel";
 import { ContentOpsEditorPanel } from "./content-ops-editor-panel";
 import { ContentOpsFlowPanel } from "./content-ops-flow-panel";
 import { ContentOpsIssuesPanel } from "./content-ops-issues-panel";
@@ -73,186 +73,223 @@ const TABS: TabConfig[] = [
   { id: "editor", labelKey: "tabEditor" },
 ];
 
+type ActivityMessages = typeof contentOpsMockStageMessages;
+
+function activityMsg(
+  intl: ReturnType<typeof useIntl>,
+  timeKey: keyof ActivityMessages,
+  sourceKey: keyof ActivityMessages,
+  messageKey: keyof ActivityMessages,
+): ContentOpsActivityItem {
+  return {
+    time: intl.formatMessage(contentOpsMockStageMessages[timeKey]),
+    source: intl.formatMessage(contentOpsMockStageMessages[sourceKey]),
+    message: intl.formatMessage(contentOpsMockStageMessages[messageKey]),
+  };
+}
+
+function activityIssue(
+  intl: ReturnType<typeof useIntl>,
+  timeKey: keyof ActivityMessages,
+  issueId: string,
+  messageKey: keyof ActivityMessages,
+): ContentOpsActivityItem {
+  return {
+    time: intl.formatMessage(contentOpsMockStageMessages[timeKey]),
+    source: issueId,
+    message: intl.formatMessage(contentOpsMockStageMessages[messageKey]),
+  };
+}
+
 function useActivityItems(tabId: ContentOpsMockTabId, stepIndex: number): ContentOpsActivityItem[] {
   const intl = useIntl();
 
   return useMemo(() => {
     const triageSets: ContentOpsActivityItem[][] = [
       [
-        { time: "now", source: "WEB-2", message: "Assigned · FR checkout CTA too long" },
-        { time: "4m", source: "MOB-1", message: "Glossary break · es-ES · unassigned" },
-        { time: "10m", source: "WEB-3", message: "QA failure resolved · de-DE headline" },
+        activityIssue(intl, "activityTimeNow", "WEB-2", "activityTriageAssignedFrCheckout"),
+        activityIssue(intl, "activityTime4m", "MOB-1", "activityTriageGlossaryBreakEs"),
+        activityIssue(intl, "activityTime10m", "WEB-3", "activityTriageQaResolvedDe"),
       ],
       [
-        { time: "now", source: "MOB-1", message: "Glossary break · es-ES · unassigned" },
-        { time: "4m", source: "WEB-2", message: "In progress · payment button label" },
-        { time: "10m", source: "CAT", message: "Open in CAT · checkout.json" },
+        activityIssue(intl, "activityTimeNow", "MOB-1", "activityTriageGlossaryBreakEs"),
+        activityIssue(intl, "activityTime4m", "WEB-2", "activityTriageInProgressPayment"),
+        activityMsg(intl, "activityTime10m", "activitySourceCat", "activityTriageOpenInCat"),
       ],
       [
-        { time: "now", source: "WEB-3", message: "Resolved · hero headline length check" },
-        { time: "6m", source: "WEB-2", message: "Translation mistake flagged · fr-FR" },
-        { time: "12m", source: "QA", message: "Length check failed · de-DE" },
+        activityIssue(intl, "activityTimeNow", "WEB-3", "activityTriageResolvedHero"),
+        activityIssue(intl, "activityTime6m", "WEB-2", "activityTriageMistakeFr"),
+        activityMsg(intl, "activityTime12m", "activitySourceQa", "activityTriageLengthFailedDe"),
       ],
     ];
 
     const campaignSets: ContentOpsActivityItem[][] = [
       [
-        { time: "now", source: "Brief", message: "Q2 launch · 4 markets · 12 assets" },
-        { time: "4m", source: "Drafts", message: "Localized landing pages generating" },
-        { time: "8m", source: "Review", message: "FR and DE queued" },
+        activityMsg(intl, "activityTimeNow", "activitySourceBrief", "activityCampaignQ2Launch"),
+        activityMsg(
+          intl,
+          "activityTime4m",
+          "activitySourceDrafts",
+          "activityCampaignLandingDrafts",
+        ),
+        activityMsg(intl, "activityTime8m", "activitySourceReview", "activityCampaignFrDeQueued"),
       ],
       [
-        {
-          time: "now",
-          source: "Agent",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm2),
-        },
-        {
-          time: "4m",
-          source: "Brief",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm1),
-        },
-        {
-          time: "8m",
-          source: "Review",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm3),
-        },
+        activityMsg(intl, "activityTimeNow", "activitySourceAgent", "stepGtm2"),
+        activityMsg(intl, "activityTime4m", "activitySourceBrief", "stepGtm1"),
+        activityMsg(intl, "activityTime8m", "activitySourceReview", "stepGtm3"),
       ],
       [
-        {
-          time: "now",
-          source: "Review",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm3),
-        },
-        {
-          time: "4m",
-          source: "Staging",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm4),
-        },
-        { time: "8m", source: "Slack", message: "Notified #gtm" },
+        activityMsg(intl, "activityTimeNow", "activitySourceReview", "stepGtm3"),
+        activityMsg(intl, "activityTime4m", "activitySourceStaging", "stepGtm4"),
+        activityMsg(intl, "activityTime8m", "activitySourceSlack", "activityCampaignNotifiedGtm"),
       ],
       [
-        {
-          time: "now",
-          source: "Staging",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepGtm4),
-        },
-        { time: "6m", source: "CMS", message: "12 assets published to staging" },
-        { time: "10m", source: "Brief", message: "Q2 launch brief complete" },
+        activityMsg(intl, "activityTimeNow", "activitySourceStaging", "stepGtm4"),
+        activityMsg(
+          intl,
+          "activityTime6m",
+          "activitySourceCms",
+          "activityCampaignPublishedStaging",
+        ),
+        activityMsg(
+          intl,
+          "activityTime10m",
+          "activitySourceBrief",
+          "activityCampaignBriefComplete",
+        ),
       ],
     ];
 
-    const seoStep3 = intl.formatMessage(contentOpsMockStageMessages.stepSeo3);
     const seoSets: ContentOpsActivityItem[][] = [
       [
-        { time: "now", source: "Research", message: "Pulling search volume · core terms" },
-        { time: "4m", source: "Locales", message: "EN · FR · DE · JA compared" },
-        { time: "8m", source: "Gaps", message: seoStep3 },
+        activityMsg(intl, "activityTimeNow", "activitySourceResearch", "activitySeoPullingVolume"),
+        activityMsg(intl, "activityTime4m", "activitySourceLocales", "activitySeoLocalesCompared"),
+        activityMsg(intl, "activityTime8m", "activitySourceGaps", "stepSeo3"),
       ],
       [
-        { time: "now", source: "Gaps", message: seoStep3 },
-        {
-          time: "4m",
-          source: "Draft",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepSeo4),
-        },
-        { time: "8m", source: "QA", message: "Meta + H1 adapted for DE intent" },
+        activityMsg(intl, "activityTimeNow", "activitySourceGaps", "stepSeo3"),
+        activityMsg(intl, "activityTime4m", "activitySourceDraft", "stepSeo4"),
+        activityMsg(intl, "activityTime8m", "activitySourceQa", "activitySeoMetaH1De"),
       ],
       [
-        {
-          time: "now",
-          source: "Draft",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepSeo4),
-        },
-        {
-          time: "4m",
-          source: "CMS",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepSeo5),
-        },
-        { time: "8m", source: "Slack", message: "Notified #content" },
+        activityMsg(intl, "activityTimeNow", "activitySourceDraft", "stepSeo4"),
+        activityMsg(intl, "activityTime4m", "activitySourceCms", "stepSeo5"),
+        activityMsg(intl, "activityTime8m", "activitySourceSlack", "activitySeoNotifiedContent"),
       ],
       [
-        {
-          time: "now",
-          source: "CMS",
-          message: intl.formatMessage(contentOpsMockStageMessages.stepSeo5),
-        },
-        { time: "6m", source: "Research", message: "Monthly SEO run complete" },
-        { time: "10m", source: "Gaps", message: seoStep3 },
+        activityMsg(intl, "activityTimeNow", "activitySourceCms", "stepSeo5"),
+        activityMsg(intl, "activityTime6m", "activitySourceResearch", "activitySeoMonthlyComplete"),
+        activityMsg(intl, "activityTime10m", "activitySourceGaps", "stepSeo3"),
       ],
       [
-        { time: "now", source: "Publish", message: "DE SEO draft awaiting review" },
-        { time: "5m", source: "Intent", message: "Adapted for local search · not literal EN→DE" },
-        { time: "9m", source: "Schedule", message: "Next run · 1st of month" },
+        activityMsg(intl, "activityTimeNow", "activitySourcePublish", "activitySeoDeDraftReview"),
+        activityMsg(intl, "activityTime5m", "activitySourceIntent", "activitySeoLocalSearchIntent"),
+        activityMsg(intl, "activityTime9m", "activitySourceSchedule", "activitySeoNextRun"),
       ],
     ];
 
     const brandSets: ContentOpsActivityItem[][] = [
       [
-        { time: "now", source: "Chat", message: "Brand review asked · DE checkout CTA" },
-        { time: "4m", source: "Guide", message: "Style guide recalled · tone + CTA rules" },
-        { time: "8m", source: "Verdict", message: "Off-brand · suggested rewrite ready" },
+        activityMsg(intl, "activityTimeNow", "activitySourceChat", "activityBrandReviewAsked"),
+        activityMsg(intl, "activityTime4m", "activitySourceGuide", "activityBrandGuideRecalled"),
+        activityMsg(
+          intl,
+          "activityTime8m",
+          "activitySourceVerdict",
+          "activityBrandOffBrandRewrite",
+        ),
       ],
       [
-        { time: "now", source: "Knowledge", message: "brand-voice-style-guide.pdf matched" },
-        { time: "4m", source: "Rule", message: "Tone: friendly, direct" },
-        { time: "8m", source: "Copy", message: "Suggested · Jetzt starten" },
+        activityMsg(
+          intl,
+          "activityTimeNow",
+          "activitySourceKnowledge",
+          "activityBrandGuideMatched",
+        ),
+        activityMsg(intl, "activityTime4m", "activitySourceRule", "activityBrandToneRule"),
+        activityMsg(intl, "activityTime8m", "activitySourceCopy", "activityBrandSuggestedCopy"),
       ],
       [
-        { time: "now", source: "Applied", message: "Style correction applied to DE CTA" },
-        { time: "5m", source: "Chat", message: "Brand review asked · DE checkout CTA" },
-        { time: "10m", source: "Guide", message: "CTA length rule enforced" },
+        activityMsg(
+          intl,
+          "activityTimeNow",
+          "activitySourceApplied",
+          "activityBrandCorrectionApplied",
+        ),
+        activityMsg(intl, "activityTime5m", "activitySourceChat", "activityBrandReviewAsked"),
+        activityMsg(intl, "activityTime10m", "activitySourceGuide", "activityBrandCtaLengthRule"),
       ],
     ];
 
     const flowSets: ContentOpsActivityItem[][] = [
       [
-        { time: "now", source: "Flow", message: "Brief to publish · workflow active" },
-        { time: "4m", source: "Step", message: "GTM brief received" },
-        { time: "8m", source: "Handoff", message: "Routing to localise" },
+        activityMsg(intl, "activityTimeNow", "activitySourceFlow", "activityFlowWorkflowActive"),
+        activityMsg(intl, "activityTime4m", "activitySourceStep", "activityFlowGtmBriefReceived"),
+        activityMsg(intl, "activityTime8m", "activitySourceHandoff", "activityFlowRoutingLocalise"),
       ],
       [
-        { time: "now", source: "Localise", message: "Locale drafts in progress" },
-        { time: "4m", source: "Brand QA", message: "Style rules checking" },
-        { time: "8m", source: "Review", message: "Reviewer queue updated" },
+        activityMsg(intl, "activityTimeNow", "activitySourceLocalise", "activityFlowLocaleDrafts"),
+        activityMsg(intl, "activityTime4m", "activitySourceBrandQa", "activityFlowStyleChecking"),
+        activityMsg(intl, "activityTime8m", "activitySourceReview", "activityFlowReviewerQueue"),
       ],
       [
-        { time: "now", source: "CMS", message: "Draft ready for publish" },
-        { time: "4m", source: "Slack", message: "Team notified · #content" },
-        { time: "8m", source: "Flow", message: "Brief to publish complete" },
+        activityMsg(intl, "activityTimeNow", "activitySourceCms", "activityFlowDraftReady"),
+        activityMsg(intl, "activityTime4m", "activitySourceSlack", "activityFlowTeamNotified"),
+        activityMsg(intl, "activityTime8m", "activitySourceFlow", "activityFlowComplete"),
       ],
       [
-        { time: "now", source: "Template", message: "SEO blog workflow selected" },
-        { time: "4m", source: "Keywords", message: "Research node active" },
-        { time: "8m", source: "Draft", message: "CMS draft handoff" },
+        activityMsg(intl, "activityTimeNow", "activitySourceTemplate", "activityFlowSeoSelected"),
+        activityMsg(intl, "activityTime4m", "activitySourceKeywords", "activityFlowResearchActive"),
+        activityMsg(intl, "activityTime8m", "activitySourceDraft", "activityFlowCmsHandoff"),
       ],
       [
-        { time: "now", source: "Template", message: "Campaign workflow selected" },
-        { time: "4m", source: "Staging", message: "Assets routed for review" },
-        { time: "8m", source: "Slack", message: "Launch channel notified" },
+        activityMsg(
+          intl,
+          "activityTimeNow",
+          "activitySourceTemplate",
+          "activityFlowCampaignSelected",
+        ),
+        activityMsg(intl, "activityTime4m", "activitySourceStaging", "activityFlowAssetsRouted"),
+        activityMsg(intl, "activityTime8m", "activitySourceSlack", "activityFlowLaunchNotified"),
       ],
     ];
 
     const editorSets: ContentOpsActivityItem[][] = [
       [
-        { time: "now", source: "Editor", message: "hero-section.tsx · fr-FR · 14 strings" },
-        { time: "4m", source: "Segment", message: "Homepage hero · needs review" },
-        { time: "8m", source: "Queue", message: "3 segments flagged in file" },
+        activityMsg(intl, "activityTimeNow", "activitySourceEditor", "activityEditorFileOpened"),
+        activityMsg(
+          intl,
+          "activityTime4m",
+          "activitySourceSegment",
+          "activityEditorHeroNeedsReview",
+        ),
+        activityMsg(intl, "activityTime8m", "activitySourceQueue", "activityEditorSegmentsFlagged"),
       ],
       [
-        { time: "now", source: "Glossary", message: "Term mismatch · review → validation" },
-        { time: "4m", source: "QA", message: "Approved term suggested for banner copy" },
-        { time: "8m", source: "Editor", message: "Glossary check on qa-warning segment" },
+        activityMsg(
+          intl,
+          "activityTimeNow",
+          "activitySourceGlossary",
+          "activityEditorTermMismatch",
+        ),
+        activityMsg(intl, "activityTime4m", "activitySourceQa", "activityEditorTermSuggested"),
+        activityMsg(intl, "activityTime8m", "activitySourceEditor", "activityEditorGlossaryCheck"),
       ],
       [
-        { time: "now", source: "Issues", message: "WEB-2 linked · checkout CTA too long" },
-        { time: "4m", source: "MOB-1", message: "Open question · glossary violation" },
-        { time: "8m", source: "Triage", message: "Opened from issues board" },
+        activityMsg(intl, "activityTimeNow", "activitySourceIssues", "activityEditorIssueLinked"),
+        activityIssue(intl, "activityTime4m", "MOB-1", "activityEditorOpenQuestion"),
+        activityMsg(
+          intl,
+          "activityTime8m",
+          "activitySourceTriage",
+          "activityEditorOpenedFromTriage",
+        ),
       ],
       [
-        { time: "now", source: "Intelligence", message: "TM match · 92% · hero headline" },
-        { time: "4m", source: "Context", message: "Component path + repo context loaded" },
-        { time: "8m", source: "AI", message: "Suggestion ready · length check passed" },
+        activityMsg(intl, "activityTimeNow", "activitySourceIntelligence", "activityEditorTmMatch"),
+        activityMsg(intl, "activityTime4m", "activitySourceContext", "activityEditorContextLoaded"),
+        activityMsg(intl, "activityTime8m", "activitySourceAi", "activityEditorSuggestionReady"),
       ],
     ];
 
@@ -280,7 +317,7 @@ export function ContentOpsMockStage({
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion() ?? false;
   const [activeTab, setActiveTab] = useState<ContentOpsMockTabId>("triage");
-  const [isPaused, setIsPaused] = useState(false);
+  const [autoplayEnabled, setAutoplayEnabled] = useState(true);
   const [playbackStep, setPlaybackStep] = useState(0);
 
   const campaignScene: ContentOpsTerminalScene = useMemo(
@@ -329,14 +366,25 @@ export function ContentOpsMockStage({
   const activityItems = useActivityItems(activeTab, playbackStep);
 
   const handleTabSelect = useCallback((tabId: ContentOpsMockTabId) => {
-    setIsPaused(true);
+    setAutoplayEnabled(false);
     setActiveTab(tabId);
     setPlaybackStep(0);
-    window.setTimeout(() => setIsPaused(false), 600);
+  }, []);
+
+  const handleAutoplayToggle = useCallback(() => {
+    setAutoplayEnabled((enabled) => !enabled);
+  }, []);
+
+  const handleBrandPhaseChange = useCallback((phase: BrandPlaybackPhase) => {
+    if (phase === "done") {
+      setPlaybackStep(2);
+    } else if (phase === "playing") {
+      setPlaybackStep(0);
+    }
   }, []);
 
   useEffect(() => {
-    if (isPaused || shouldReduceMotion) {
+    if (!autoplayEnabled || shouldReduceMotion) {
       return;
     }
 
@@ -350,7 +398,7 @@ export function ContentOpsMockStage({
     }, TAB_HOLD_MS);
 
     return () => window.clearTimeout(timer);
-  }, [activeTab, isPaused, shouldReduceMotion]);
+  }, [activeTab, autoplayEnabled, shouldReduceMotion]);
 
   const handleStepIndexChange = useCallback((stepIndex: number) => {
     setPlaybackStep(stepIndex);
@@ -360,7 +408,7 @@ export function ContentOpsMockStage({
     setPlaybackStep(nodeIndex);
   }, []);
 
-  const pauseAutoplay = isPaused || shouldReduceMotion;
+  const pauseAutoplay = !autoplayEnabled || shouldReduceMotion;
 
   useEffect(() => {
     if (activeTab !== "triage" || pauseAutoplay) {
@@ -394,7 +442,11 @@ export function ContentOpsMockStage({
         ))}
       </div>
 
-      <ContentOpsActivityFeed items={activityItems} />
+      <ContentOpsActivityFeed
+        items={activityItems}
+        autoplayEnabled={autoplayEnabled && !shouldReduceMotion}
+        onAutoplayToggle={handleAutoplayToggle}
+      />
 
       <MeshStage meshSrc={MESH_BY_TAB[activeTab]} priority={priority} layout="contained">
         <AnimatePresence mode="wait">
@@ -426,13 +478,7 @@ export function ContentOpsMockStage({
             {activeTab === "brand" ? (
               <ContentOpsBrandPanel
                 pauseAutoplay={pauseAutoplay}
-                onPhaseChange={(phase) => {
-                  if (phase === "done") {
-                    setPlaybackStep(2);
-                  } else if (phase === "playing") {
-                    setPlaybackStep(0);
-                  }
-                }}
+                onPhaseChange={handleBrandPhaseChange}
               />
             ) : null}
             {activeTab === "brief-to-publish" ? (

--- a/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
@@ -32,7 +32,14 @@ type HeroFrameProps = {
   /** `breakout` spans near the viewport; `contained` fills a parent stage. */
   layout?: "breakout" | "contained";
   className?: string;
+  /** Override the initially focused segment in the demo workspace. */
+  initialSelectedSegmentId?: string;
+  /** Override the workspace viewport height (contained layouts). */
+  workspaceClassName?: string;
 };
+
+const DEFAULT_WORKSPACE_CLASSNAME =
+  "flex h-[min(42rem,78svh)] min-h-136 flex-col lg:h-176 xl:h-184";
 
 const heroDemoSegments: CatSegment[] = [
   {
@@ -710,19 +717,28 @@ function createHeroDemoServices(intl: IntlShape, heroDemoState: CatWorkspaceStat
   };
 }
 
-export function HeroFrame({ layout = "breakout", className }: HeroFrameProps) {
+export function HeroFrame({
+  layout = "breakout",
+  className,
+  initialSelectedSegmentId,
+  workspaceClassName = DEFAULT_WORKSPACE_CLASSNAME,
+}: HeroFrameProps) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion();
   const heroDemoState = buildHeroDemoState(intl);
+  const initialState =
+    initialSelectedSegmentId != null
+      ? { ...heroDemoState, selectedSegmentId: initialSelectedSegmentId }
+      : heroDemoState;
   const services = createHeroDemoServices(intl, heroDemoState);
   const frameClassName = cn(
     "relative overflow-hidden rounded-2xl border border-border bg-background shadow-2xl shadow-gray-alpha-200",
     className,
   );
   const workspace = (
-    <div className="flex h-[min(42rem,78svh)] min-h-136 flex-col lg:h-176 xl:h-184">
+    <div className={workspaceClassName}>
       <CatWorkspaceContainer
-        initialState={heroDemoState}
+        initialState={initialState}
         initialViewMode="comfortable"
         services={services}
       />

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
@@ -17,13 +17,13 @@ import { defineMessages } from "react-intl";
 export const principlesSectionMessages = defineMessages({
   headline: {
     defaultMessage: "Run multilingual content ops from one place.",
-    id: "3DgHaZOLH3",
+    id: "fwsHBkkvhD",
     description: "Marketing homepage principles section headline",
   },
   subline: {
     defaultMessage:
       "Triage questions, localize campaigns, publish SEO blogs in every market, keep brand consistent, and automate brief to publish.",
-    id: "CoPsPrSub1",
+    id: "jPibzSMcAB",
     description: "Marketing homepage principles section supporting copy",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
@@ -22,8 +22,8 @@ export const principlesSectionMessages = defineMessages({
   },
   subline: {
     defaultMessage:
-      "Triage questions, localize campaigns, publish SEO blogs in every market, keep brand consistent, and automate brief to publish.",
-    id: "jPibzSMcAB",
+      "Triage questions, localize campaigns, publish SEO blogs in every market, keep brand consistent, automate brief to publish, and review file content in the Editor.",
+    id: "LgJRko5erC",
     description: "Marketing homepage principles section supporting copy",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
@@ -16,10 +16,14 @@ import { defineMessages } from "react-intl";
 
 export const principlesSectionMessages = defineMessages({
   headline: {
-    defaultMessage:
-      "Multilingual content operations, unified. <muted>From GTM brief to market release — generate more multilingual content without adding headcount.</muted>",
+    defaultMessage: "Run multilingual content ops from one place.",
     id: "3DgHaZOLH3",
-    description:
-      "Marketing homepage principles section headline; muted wraps the supporting sentence",
+    description: "Marketing homepage principles section headline",
+  },
+  subline: {
+    defaultMessage:
+      "Triage questions, localize campaigns, publish SEO blogs in every market, keep brand consistent, and automate brief to publish.",
+    id: "CoPsPrSub1",
+    description: "Marketing homepage principles section supporting copy",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.tsx
@@ -14,26 +14,24 @@
  */
 import { FormattedMessage } from "react-intl";
 
-import { TypographyH2 } from "@/components/ui/typography";
+import { TypographyH2, TypographyP } from "@/components/ui/typography";
 
-import { HeroFrameMeshStage } from "./hero-frame-mesh-stage";
+import { ContentOpsMockStage } from "./content-ops/content-ops-mock-stage";
 import { principlesSectionMessages } from "./principles-section.messages";
 
 export function PrinciplesSection() {
   return (
     <section id="overview">
-      <div className="max-w-5xl">
+      <div className="max-w-3xl space-y-4">
         <TypographyH2>
-          <FormattedMessage
-            {...principlesSectionMessages.headline}
-            values={{
-              muted: (chunks) => <span className="text-muted-foreground">{chunks}</span>,
-            }}
-          />
+          <FormattedMessage {...principlesSectionMessages.headline} />
         </TypographyH2>
+        <TypographyP className="text-lg text-muted-foreground">
+          <FormattedMessage {...principlesSectionMessages.subline} />
+        </TypographyP>
       </div>
 
-      <HeroFrameMeshStage className="mt-12 sm:mt-16" />
+      <ContentOpsMockStage className="mt-12 sm:mt-16" priority />
     </section>
   );
 }


### PR DESCRIPTION
## What changed

Replace the static CAT-only principles preview with an interactive **Content Ops mock stage** on the marketing homepage. Prospects can switch between five work-first tabs:

- **Triage open questions** — issues board with locale/status and “Open in CAT”
- **Localize campaign copy** — agent terminal for GTM brief → staging
- **Publish localised SEO blogs** — keyword gaps → localised draft → CMS
- **Keep brand consistent** — style guide before/after plus brand review chat (`recall_knowledge_files`)
- **Automate brief to publish** — React Flow workflow with Brief / Campaign / SEO templates

Each tab includes a live activity feed and autoplay (pauses on tab click). The principles section headline/subline were updated to match the content ops positioning.

## How to test

1. Run `vp run dev` in `apps/hyperlocalise-web` and open the homepage.
2. Scroll to the principles / overview section below the hero.
3. Click each pill tab and confirm the preview, activity feed, and animations update.
4. On **Keep brand consistent**, click **Send** or **Replay** to run the brand chat demo.
5. On **Automate brief to publish**, switch template pills (Brief / Campaign / SEO blog) and confirm the flow graph updates.
6. Run `vp check --fix` and `vp test` in `apps/hyperlocalise-web`.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review