### PR TITLE
feat(cat): show untranslated glossary concepts using translatable

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
@@ -12,7 +12,7 @@
  */
 import { useEffect, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect, fn, userEvent } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { AppShellStoreProvider } from "@/components/app-shell/store/app-shell-store-context";
 import {
@@ -20,7 +20,12 @@ import {
   EMPTY_CAT_ISSUE_GUIDANCE_STATUS,
   setCatIssueGuidanceStatus,
 } from "@/components/cat/issues/cat-issue-guidance-event";
-import { CAT_GLOSSARY_GUIDANCE_OPEN_EVENT } from "@/components/cat/intelligence/cat-glossary-guidance-event";
+import {
+  CAT_GLOSSARY_GUIDANCE_OPEN_EVENT,
+  EMPTY_CAT_GLOSSARY_GUIDANCE_STATUS,
+  setCatGlossaryGuidanceStatus,
+  type CatGlossaryGuidanceStatus,
+} from "@/components/cat/intelligence/cat-glossary-guidance-event";
 
 import type { InboxCurrentUser } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
 import { AppShellFooter } from "./app-shell-footer";
@@ -48,9 +53,29 @@ function FooterStoryFrame({ children }: { children: ReactNode }) {
 
 function GuidanceStatusFrame({ children }: { children: ReactNode }) {
   setCatIssueGuidanceStatus({ available: true, openIssueCount: 2 });
+  setCatGlossaryGuidanceStatus({ preferredCount: 2, notRecommendedCount: 1, matchCount: 2 });
 
   useEffect(() => {
-    return () => setCatIssueGuidanceStatus(EMPTY_CAT_ISSUE_GUIDANCE_STATUS);
+    return () => {
+      setCatIssueGuidanceStatus(EMPTY_CAT_ISSUE_GUIDANCE_STATUS);
+      setCatGlossaryGuidanceStatus(EMPTY_CAT_GLOSSARY_GUIDANCE_STATUS);
+    };
+  }, []);
+
+  return children;
+}
+
+function GlossaryStatusFrame({
+  status,
+  children,
+}: {
+  status: CatGlossaryGuidanceStatus;
+  children: ReactNode;
+}) {
+  setCatGlossaryGuidanceStatus(status);
+
+  useEffect(() => {
+    return () => setCatGlossaryGuidanceStatus(EMPTY_CAT_GLOSSARY_GUIDANCE_STATUS);
   }, []);
 
   return children;
@@ -112,22 +137,60 @@ export const GuidanceAvailable: Story = {
     window.addEventListener(CAT_GLOSSARY_GUIDANCE_OPEN_EVENT, glossaryGuidanceOpened);
     window.addEventListener(CAT_ISSUE_GUIDANCE_OPEN_EVENT, issueGuidanceOpened);
 
-    await expect(
-      canvas.getByRole("button", { name: "Open glossary guidance" }),
-    ).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Open issues, 2 open" })).toBeInTheDocument();
-    await expect(canvas.getByText("2")).toBeInTheDocument();
+    const glossaryButton = canvas.getByRole("button", {
+      name: "Glossary guidance, concept matches available",
+    });
+    const issuesButton = canvas.getByRole("button", { name: "Open issues, 2 open" });
+
+    await expect(glossaryButton).toBeInTheDocument();
+    await expect(issuesButton).toBeInTheDocument();
+    await expect(within(glossaryButton).getByText("2")).toBeInTheDocument();
+    await expect(within(glossaryButton).getByText("1")).toBeInTheDocument();
+    await expect(within(issuesButton).getByText("2")).toBeInTheDocument();
 
     try {
-      await userEvent.click(canvas.getByRole("button", { name: "Open glossary guidance" }));
+      await userEvent.click(glossaryButton);
       await expect(glossaryGuidanceOpened).toHaveBeenCalledTimes(1);
 
-      await userEvent.click(canvas.getByRole("button", { name: "Open issues, 2 open" }));
+      await userEvent.click(issuesButton);
       await expect(issueGuidanceOpened).toHaveBeenCalledTimes(1);
     } finally {
       window.removeEventListener(CAT_GLOSSARY_GUIDANCE_OPEN_EVENT, glossaryGuidanceOpened);
       window.removeEventListener(CAT_ISSUE_GUIDANCE_OPEN_EVENT, issueGuidanceOpened);
     }
+  },
+};
+
+export const GlossaryDraftMatchAvailable: Story = {
+  args: {
+    showGlossaryGuidance: true,
+  },
+  decorators: [
+    (Story) => (
+      <GlossaryStatusFrame status={{ preferredCount: 0, notRecommendedCount: 0, matchCount: 1 }}>
+        <Story />
+      </GlossaryStatusFrame>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const glossaryButton = canvas.getByRole("button", {
+      name: "Glossary guidance, concept matches available",
+    });
+
+    await expect(glossaryButton).toBeInTheDocument();
+    await expect(within(glossaryButton).queryByText("1")).not.toBeInTheDocument();
+    await expect(within(glossaryButton).queryByText("2")).not.toBeInTheDocument();
+  },
+};
+
+export const GlossaryDefault: Story = {
+  args: {
+    showGlossaryGuidance: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("button", { name: "Open glossary guidance" }),
+    ).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -95,7 +95,8 @@ export function AppShellFooter({
                 className="gap-1.5 px-2"
                 onClick={requestCatGlossaryGuidance}
                 aria-label={intl.formatMessage(
-                  glossaryGuidanceStatus.preferredCount > 0 ||
+                  glossaryGuidanceStatus.matchCount > 0 ||
+                    glossaryGuidanceStatus.preferredCount > 0 ||
                     glossaryGuidanceStatus.notRecommendedCount > 0
                     ? appShellFooterMessages.glossaryGuidanceAvailableAriaLabel
                     : appShellFooterMessages.glossaryGuidanceAriaLabel,

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-checks.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-checks.test.ts
@@ -102,6 +102,50 @@ describe("glossaryFormatChecksForSegment", () => {
     ]);
   });
 
+  it("warns when an untranslatable source term is missing from the target", () => {
+    const checks = glossaryFormatChecksForSegment(
+      "Welcome to Hyperlocalise",
+      "Bienvenue",
+      [
+        {
+          id: "brand-term",
+          source: "Hyperlocalise",
+          target: "Hyperlocalise",
+          approved: true,
+          forbidden: false,
+        },
+      ],
+      testIntl,
+    );
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        id: "glossary-missing-brand-term",
+        status: "warn",
+        category: "glossary",
+      }),
+    ]);
+  });
+
+  it("does not warn for source-only translatable terms with an empty target", () => {
+    const checks = glossaryFormatChecksForSegment(
+      "Open Dashboard settings",
+      "Mở cài đặt",
+      [
+        {
+          id: "draft-term",
+          source: "Dashboard",
+          target: "",
+          approved: false,
+          forbidden: false,
+        },
+      ],
+      testIntl,
+    );
+
+    expect(checks).toEqual([]);
+  });
+
   it("returns no checks when the target is empty", () => {
     expect(glossaryFormatChecksForSegment("Dashboard", "", glossaryTerms, testIntl)).toEqual([]);
   });

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.fixture.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { CatGlossaryConcept } from "@/components/cat/shared/types";
+
+export const matchedGlossaryConceptFixture: CatGlossaryConcept = {
+  id: "concept-reseller",
+  glossaryId: "glossary-partner",
+  glossaryName: "Partner Program",
+  glossaryUrl: "/org/acme/glossaries/glossary-partner",
+  conceptUrl: "/org/acme/glossaries/glossary-partner/concepts/concept-reseller",
+  primaryTerm: "Reseller",
+  definition: "A company or individual authorized to resell our product.",
+  translatable: true,
+  sourceTerms: [
+    {
+      id: "reseller-en",
+      locale: "en",
+      text: "Reseller",
+      status: "preferred",
+      preferred: true,
+    },
+  ],
+  targetTerms: [
+    {
+      id: "reseller-vi-preferred",
+      locale: "vi",
+      text: "Đại lý",
+      status: "preferred",
+      preferred: true,
+    },
+    {
+      id: "reseller-vi-alternate",
+      locale: "vi",
+      text: "Nhà bán lại",
+      status: "not_recommended",
+      forbidden: true,
+    },
+  ],
+};
+
+export const untranslatableGlossaryConceptFixture: CatGlossaryConcept = {
+  id: "concept-brand",
+  glossaryId: "glossary-brand",
+  glossaryName: "Brand terms",
+  glossaryUrl: "/org/acme/glossaries/glossary-brand",
+  conceptUrl: "/org/acme/glossaries/glossary-brand/concepts/concept-brand",
+  primaryTerm: "Hyperlocalise",
+  definition: "Brand name that must stay in English.",
+  translatable: false,
+  sourceTerms: [
+    {
+      id: "brand-en",
+      locale: "en",
+      text: "Hyperlocalise",
+      status: "preferred",
+      preferred: true,
+    },
+  ],
+  targetTerms: [
+    {
+      id: "brand-fr-hidden",
+      locale: "fr",
+      text: "Hyperlocalise FR",
+      status: "preferred",
+      preferred: true,
+    },
+  ],
+};
+
+export const sourceOnlyGlossaryConceptFixture: CatGlossaryConcept = {
+  id: "concept-dashboard",
+  glossaryId: "glossary-product",
+  glossaryName: "Product UI",
+  glossaryUrl: "/org/acme/glossaries/glossary-product",
+  conceptUrl: "/org/acme/glossaries/glossary-product/concepts/concept-dashboard",
+  primaryTerm: "Dashboard",
+  translatable: true,
+  sourceTerms: [
+    {
+      id: "dashboard-en",
+      locale: "en",
+      text: "Dashboard",
+      status: "draft",
+    },
+  ],
+  targetTerms: [],
+};
+
+export const primaryTermFallbackGlossaryConceptFixture: CatGlossaryConcept = {
+  id: "concept-api",
+  glossaryId: "glossary-product",
+  glossaryName: "Product UI",
+  primaryTerm: "API",
+  translatable: true,
+  sourceTerms: [],
+  targetTerms: [],
+};

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.stories.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent } from "storybook/test";
+
+import type { CatGlossaryConcept } from "@/components/cat/shared/types";
+
+import { CatGlossaryConceptCard } from "./cat-glossary-concept-card";
+import {
+  matchedGlossaryConceptFixture,
+  primaryTermFallbackGlossaryConceptFixture,
+  sourceOnlyGlossaryConceptFixture,
+  untranslatableGlossaryConceptFixture,
+} from "./cat-glossary-concept-card.fixture";
+
+function ConceptCardStoryHost({ concept }: { concept: CatGlossaryConcept }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <CatGlossaryConceptCard
+      concept={concept}
+      expanded={expanded}
+      onToggle={() => setExpanded((current) => !current)}
+    />
+  );
+}
+
+const meta = {
+  title: "CAT/Glossary Concept Card",
+  component: CatGlossaryConceptCard,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-md rounded-xl border border-border bg-background p-4 text-foreground">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CatGlossaryConceptCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MatchedConcept: Story = {
+  render: () => <ConceptCardStoryHost concept={matchedGlossaryConceptFixture} />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Reseller")).toBeInTheDocument();
+    await expect(canvas.getByText("Đại lý")).toBeInTheDocument();
+    await expect(canvas.getByText("Preferred")).toBeInTheDocument();
+    await expect(canvas.queryByText("Untranslatable")).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Show glossary concept details" }));
+    await expect(canvas.getByText("Nhà bán lại")).toBeInTheDocument();
+    await expect(canvas.getByText("Not recommended")).toBeInTheDocument();
+  },
+};
+
+export const UntranslatableConcept: Story = {
+  render: () => <ConceptCardStoryHost concept={untranslatableGlossaryConceptFixture} />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Hyperlocalise")).toBeInTheDocument();
+    await expect(canvas.getByText("Untranslatable")).toBeInTheDocument();
+    await expect(canvas.queryByText("Hyperlocalise FR")).not.toBeInTheDocument();
+    await expect(canvas.queryByText("Preferred")).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Show glossary concept details" }));
+    await expect(canvas.getByText("Brand name that must stay in English.")).toBeInTheDocument();
+    await expect(canvas.queryByText("Hyperlocalise FR")).not.toBeInTheDocument();
+  },
+};
+
+export const SourceOnlyConcept: Story = {
+  render: () => <ConceptCardStoryHost concept={sourceOnlyGlossaryConceptFixture} />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Dashboard")).toBeInTheDocument();
+    await expect(canvas.getByText("Draft")).toBeInTheDocument();
+    await expect(canvas.queryByText("Untranslatable")).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Show glossary concept details" }));
+    await expect(canvas.getAllByText("Dashboard")).toHaveLength(2);
+    await expect(canvas.queryByText("Untranslatable")).not.toBeInTheDocument();
+  },
+};
+
+export const PrimaryTermFallback: Story = {
+  render: () => <ConceptCardStoryHost concept={primaryTermFallbackGlossaryConceptFixture} />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("API")).toBeInTheDocument();
+    await expect(canvas.getByText("Draft")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.stories.tsx
@@ -38,7 +38,7 @@ function ConceptCardStoryHost({ concept }: { concept: CatGlossaryConcept }) {
 
 const meta = {
   title: "CAT/Glossary Concept Card",
-  component: CatGlossaryConceptCard,
+  component: ConceptCardStoryHost,
   parameters: {
     layout: "centered",
   },
@@ -49,13 +49,18 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof CatGlossaryConceptCard>;
+  args: {
+    concept: matchedGlossaryConceptFixture,
+  },
+} satisfies Meta<typeof ConceptCardStoryHost>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const MatchedConcept: Story = {
-  render: () => <ConceptCardStoryHost concept={matchedGlossaryConceptFixture} />,
+  args: {
+    concept: matchedGlossaryConceptFixture,
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Reseller")).toBeInTheDocument();
     await expect(canvas.getByText("Đại lý")).toBeInTheDocument();
@@ -69,7 +74,9 @@ export const MatchedConcept: Story = {
 };
 
 export const UntranslatableConcept: Story = {
-  render: () => <ConceptCardStoryHost concept={untranslatableGlossaryConceptFixture} />,
+  args: {
+    concept: untranslatableGlossaryConceptFixture,
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Hyperlocalise")).toBeInTheDocument();
     await expect(canvas.getByText("Untranslatable")).toBeInTheDocument();
@@ -83,7 +90,9 @@ export const UntranslatableConcept: Story = {
 };
 
 export const SourceOnlyConcept: Story = {
-  render: () => <ConceptCardStoryHost concept={sourceOnlyGlossaryConceptFixture} />,
+  args: {
+    concept: sourceOnlyGlossaryConceptFixture,
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Dashboard")).toBeInTheDocument();
     await expect(canvas.getByText("Draft")).toBeInTheDocument();
@@ -96,7 +105,9 @@ export const SourceOnlyConcept: Story = {
 };
 
 export const PrimaryTermFallback: Story = {
-  render: () => <ConceptCardStoryHost concept={primaryTermFallbackGlossaryConceptFixture} />,
+  args: {
+    concept: primaryTermFallbackGlossaryConceptFixture,
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("API")).toBeInTheDocument();
     await expect(canvas.getByText("Draft")).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
@@ -241,8 +241,7 @@ function resolveConceptDisplayTerms(concept: CatGlossaryConcept) {
         },
       ]
     : [];
-  const sourceTerms =
-    concept.sourceTerms.length > 0 ? concept.sourceTerms : fallbackSourceTerm;
+  const sourceTerms = concept.sourceTerms.length > 0 ? concept.sourceTerms : fallbackSourceTerm;
   const hasTargetTerms = concept.targetTerms.length > 0;
 
   if (isUntranslatable) {

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
@@ -104,7 +104,21 @@ function TermStatusIcon({ status }: { status: CatGlossaryTermStatus }) {
   );
 }
 
-function ConceptTermRow({ term }: { term: CatGlossaryConceptTerm }) {
+function UntranslatableBadge({ intl }: { intl: ReturnType<typeof useIntl> }) {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-slate-500/30 px-1.5 py-0.5 text-xs font-medium text-slate-300">
+      {intl.formatMessage(catIntelligencePanelMessages.glossaryUntranslatable)}
+    </span>
+  );
+}
+
+function ConceptTermRow({
+  term,
+  showUntranslatableBadge = false,
+}: {
+  term: CatGlossaryConceptTerm;
+  showUntranslatableBadge?: boolean;
+}) {
   const intl = useIntl();
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
   const status = termStatus(term, intl);
@@ -140,15 +154,19 @@ function ConceptTermRow({ term }: { term: CatGlossaryConceptTerm }) {
           {term.text}
         </p>
         <div className="flex flex-wrap gap-1">
-          <span
-            className={cn(
-              "inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs font-medium",
-              status.className,
-            )}
-          >
-            <TermStatusIcon status={status.status} />
-            {status.label}
-          </span>
+          {showUntranslatableBadge ? (
+            <UntranslatableBadge intl={intl} />
+          ) : (
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs font-medium",
+                status.className,
+              )}
+            >
+              <TermStatusIcon status={status.status} />
+              {status.label}
+            </span>
+          )}
           {metadata.map((value) => (
             <span
               key={value}
@@ -183,23 +201,74 @@ function ConceptTermRow({ term }: { term: CatGlossaryConceptTerm }) {
   );
 }
 
-function CollapsedTargetTermRow({ term }: { term: CatGlossaryConceptTerm }) {
+function CollapsedTermRow({
+  term,
+  showUntranslatableBadge = false,
+}: {
+  term: CatGlossaryConceptTerm;
+  showUntranslatableBadge?: boolean;
+}) {
   const intl = useIntl();
   const status = termStatus(term, intl);
   return (
     <div className="flex items-center justify-between gap-3 px-3 py-1.5">
       <span className="min-w-0 truncate text-sm font-medium text-foreground">{term.text}</span>
-      <span
-        className={cn(
-          "inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs font-medium",
-          status.className,
-        )}
-      >
-        <TermStatusIcon status={status.status} />
-        {status.label}
-      </span>
+      {showUntranslatableBadge ? (
+        <UntranslatableBadge intl={intl} />
+      ) : (
+        <span
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs font-medium",
+            status.className,
+          )}
+        >
+          <TermStatusIcon status={status.status} />
+          {status.label}
+        </span>
+      )}
     </div>
   );
+}
+
+function resolveConceptDisplayTerms(concept: CatGlossaryConcept) {
+  const isUntranslatable = concept.translatable === false;
+  const fallbackSourceTerm: CatGlossaryConceptTerm[] = concept.primaryTerm.trim()
+    ? [
+        {
+          id: `${concept.id}:primary`,
+          locale: concept.sourceTerms[0]?.locale ?? "source",
+          text: concept.primaryTerm,
+        },
+      ]
+    : [];
+  const sourceTerms =
+    concept.sourceTerms.length > 0 ? concept.sourceTerms : fallbackSourceTerm;
+  const hasTargetTerms = concept.targetTerms.length > 0;
+
+  if (isUntranslatable) {
+    return {
+      isUntranslatable: true,
+      sourceTerms,
+      targetTerms: [] as CatGlossaryConceptTerm[],
+      collapsedTerms: sourceTerms,
+    };
+  }
+
+  if (hasTargetTerms) {
+    return {
+      isUntranslatable: false,
+      sourceTerms,
+      targetTerms: concept.targetTerms,
+      collapsedTerms: concept.targetTerms,
+    };
+  }
+
+  return {
+    isUntranslatable: false,
+    sourceTerms,
+    targetTerms: [] as CatGlossaryConceptTerm[],
+    collapsedTerms: sourceTerms,
+  };
 }
 
 export function CatGlossaryConceptCard({
@@ -213,8 +282,8 @@ export function CatGlossaryConceptCard({
 }) {
   const intl = useIntl();
   const contentId = `glossary-concept-${concept.id.replaceAll(/[^a-zA-Z0-9_-]/g, "-")}`;
-  const sourceTerms = concept.sourceTerms.length > 0 ? concept.sourceTerms : concept.targetTerms;
-  const targetTerms = concept.targetTerms.length > 0 ? concept.targetTerms : concept.sourceTerms;
+  const { isUntranslatable, sourceTerms, targetTerms, collapsedTerms } =
+    resolveConceptDisplayTerms(concept);
 
   return (
     <article className="overflow-hidden rounded-xl bg-muted/40">
@@ -250,8 +319,12 @@ export function CatGlossaryConceptCard({
 
       {!expanded ? (
         <div className="space-y-1 px-3 pb-2">
-          {targetTerms.map((term) => (
-            <CollapsedTargetTermRow key={term.id} term={term} />
+          {collapsedTerms.map((term) => (
+            <CollapsedTermRow
+              key={term.id}
+              term={term}
+              showUntranslatableBadge={isUntranslatable}
+            />
           ))}
         </div>
       ) : null}
@@ -271,14 +344,20 @@ export function CatGlossaryConceptCard({
         <div className="space-y-2">
           <div className="space-y-1">
             {sourceTerms.map((term) => (
-              <ConceptTermRow key={term.id} term={term} />
+              <ConceptTermRow
+                key={term.id}
+                term={term}
+                showUntranslatableBadge={isUntranslatable}
+              />
             ))}
           </div>
-          <div className="space-y-1">
-            {targetTerms.map((term) => (
-              <ConceptTermRow key={term.id} term={term} />
-            ))}
-          </div>
+          {targetTerms.length > 0 ? (
+            <div className="space-y-1">
+              {targetTerms.map((term) => (
+                <ConceptTermRow key={term.id} term={term} />
+              ))}
+            </div>
+          ) : null}
         </div>
       </div>
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-guidance-event.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-guidance-event.test.ts
@@ -32,11 +32,12 @@ describe("cat-glossary-guidance-event", () => {
     const listener = vi.fn();
     const unsubscribe = subscribeCatGlossaryGuidance(listener);
 
-    setCatGlossaryGuidanceStatus({ preferredCount: 2, notRecommendedCount: 1 });
+    setCatGlossaryGuidanceStatus({ preferredCount: 2, notRecommendedCount: 1, matchCount: 3 });
 
     expect(getCatGlossaryGuidanceStatus()).toEqual({
       preferredCount: 2,
       notRecommendedCount: 1,
+      matchCount: 3,
     });
     expect(listener).toHaveBeenCalledTimes(1);
 
@@ -47,8 +48,8 @@ describe("cat-glossary-guidance-event", () => {
     const listener = vi.fn();
     const unsubscribe = subscribeCatGlossaryGuidance(listener);
 
-    setCatGlossaryGuidanceStatus({ preferredCount: 1, notRecommendedCount: 0 });
-    setCatGlossaryGuidanceStatus({ preferredCount: 1, notRecommendedCount: 0 });
+    setCatGlossaryGuidanceStatus({ preferredCount: 1, notRecommendedCount: 0, matchCount: 1 });
+    setCatGlossaryGuidanceStatus({ preferredCount: 1, notRecommendedCount: 0, matchCount: 1 });
 
     expect(listener).toHaveBeenCalledTimes(1);
 
@@ -60,7 +61,7 @@ describe("cat-glossary-guidance-event", () => {
     const unsubscribe = subscribeCatGlossaryGuidance(listener);
 
     unsubscribe();
-    setCatGlossaryGuidanceStatus({ preferredCount: 3, notRecommendedCount: 2 });
+    setCatGlossaryGuidanceStatus({ preferredCount: 3, notRecommendedCount: 2, matchCount: 4 });
 
     expect(listener).not.toHaveBeenCalled();
   });
@@ -75,8 +76,24 @@ describe("cat-glossary-guidance-event", () => {
     window.removeEventListener(CAT_GLOSSARY_GUIDANCE_OPEN_EVENT, handler);
   });
 
+  it("marks guidance available when only matchCount is set", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeCatGlossaryGuidance(listener);
+
+    setCatGlossaryGuidanceStatus({ preferredCount: 0, notRecommendedCount: 0, matchCount: 2 });
+
+    expect(getCatGlossaryGuidanceStatus()).toEqual({
+      preferredCount: 0,
+      notRecommendedCount: 0,
+      matchCount: 2,
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
   it("returns an empty server snapshot", () => {
-    setCatGlossaryGuidanceStatus({ preferredCount: 4, notRecommendedCount: 1 });
+    setCatGlossaryGuidanceStatus({ preferredCount: 4, notRecommendedCount: 1, matchCount: 2 });
     expect(getCatGlossaryGuidanceServerSnapshot()).toEqual(EMPTY_CAT_GLOSSARY_GUIDANCE_STATUS);
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-guidance-event.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-guidance-event.ts
@@ -15,11 +15,13 @@ export const CAT_GLOSSARY_GUIDANCE_OPEN_EVENT = "cat-glossary-guidance:open";
 export const EMPTY_CAT_GLOSSARY_GUIDANCE_STATUS = {
   preferredCount: 0,
   notRecommendedCount: 0,
+  matchCount: 0,
 } as const;
 
 export type CatGlossaryGuidanceStatus = {
   preferredCount: number;
   notRecommendedCount: number;
+  matchCount: number;
 };
 
 type CatGlossaryGuidanceListener = () => void;
@@ -38,7 +40,8 @@ export function requestCatGlossaryGuidance() {
 export function setCatGlossaryGuidanceStatus(status: CatGlossaryGuidanceStatus) {
   if (
     glossaryGuidanceStatus.preferredCount === status.preferredCount &&
-    glossaryGuidanceStatus.notRecommendedCount === status.notRecommendedCount
+    glossaryGuidanceStatus.notRecommendedCount === status.notRecommendedCount &&
+    glossaryGuidanceStatus.matchCount === status.matchCount
   ) {
     return;
   }

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
@@ -18,55 +18,19 @@ import type { CatSegmentIntelligence } from "@/components/cat/shared/types";
 
 import { CatIntelligencePanel } from "./cat-intelligence-panel";
 import { requestCatGlossaryGuidance } from "./cat-glossary-guidance-event";
+import {
+  matchedGlossaryConceptFixture,
+  primaryTermFallbackGlossaryConceptFixture,
+  sourceOnlyGlossaryConceptFixture,
+  untranslatableGlossaryConceptFixture,
+} from "./cat-glossary-concept-card.fixture";
 
 const defaultTargetText = catSegmentsFixture[1]?.targetText ?? "";
 
 const conceptIntelligence: CatSegmentIntelligence = {
   ...catIntelligenceFixture,
   glossaryConcepts: [
-    {
-      id: "concept-reseller",
-      glossaryId: "glossary-partner",
-      glossaryName: "Partner Program",
-      glossaryUrl: "/org/acme/glossaries/glossary-partner",
-      conceptUrl: "/org/acme/glossaries/glossary-partner/concepts/concept-reseller",
-      primaryTerm: "Reseller",
-      definition: "A company or individual authorized to resell our product.",
-      sourceTerms: [
-        {
-          id: "reseller-en",
-          locale: "en",
-          text: "Reseller",
-          status: "preferred",
-          preferred: true,
-          termType: "full form",
-          partOfSpeech: "noun",
-          gender: "neuter",
-        },
-      ],
-      targetTerms: [
-        {
-          id: "reseller-vi-preferred",
-          locale: "vi",
-          text: "Đại lý",
-          status: "preferred",
-          preferred: true,
-          termType: "full form",
-          partOfSpeech: "noun",
-          gender: "neuter",
-        },
-        {
-          id: "reseller-vi-alternate",
-          locale: "vi",
-          text: "Nhà bán lại",
-          status: "not_recommended",
-          forbidden: true,
-          termType: "full form",
-          partOfSpeech: "noun",
-          gender: "masculine",
-        },
-      ],
-    },
+    matchedGlossaryConceptFixture,
     {
       id: "concept-review",
       glossaryId: "glossary-product",
@@ -74,6 +38,7 @@ const conceptIntelligence: CatSegmentIntelligence = {
       glossaryUrl: "/org/acme/glossaries/glossary-product",
       conceptUrl: "/org/acme/glossaries/glossary-product/concepts/concept-review",
       primaryTerm: "Review",
+      translatable: true,
       sourceTerms: [{ id: "review-en", locale: "en", text: "Review", preferred: true }],
       targetTerms: [{ id: "review-vi", locale: "vi", text: "Đánh giá", preferred: true }],
     },
@@ -185,6 +150,62 @@ export const ReadOnly: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Dashboard card", { exact: true })).toBeInTheDocument();
     await expect(canvas.queryByRole("button", { name: "Use" })).not.toBeInTheDocument();
+  },
+};
+
+const untranslatableConceptIntelligence: CatSegmentIntelligence = {
+  ...catIntelligenceFixture,
+  glossaryConcepts: [untranslatableGlossaryConceptFixture],
+};
+
+export const UntranslatableConcept: Story = {
+  args: {
+    intelligence: untranslatableConceptIntelligence,
+  },
+  play: async ({ canvas }) => {
+    requestCatGlossaryGuidance();
+    await expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    await expect(canvas.getByText("Untranslatable")).toBeInTheDocument();
+    await expect(canvas.getByText("Hyperlocalise FR")).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Show glossary concept details" }));
+    await expect(canvas.getByText("Brand name that must stay in English.")).toBeInTheDocument();
+    await expect(canvas.getByText("Hyperlocalise FR")).not.toBeInTheDocument();
+  },
+};
+
+const sourceOnlyConceptIntelligence: CatSegmentIntelligence = {
+  ...catIntelligenceFixture,
+  glossaryConcepts: [sourceOnlyGlossaryConceptFixture],
+};
+
+export const SourceOnlyConcept: Story = {
+  args: {
+    intelligence: sourceOnlyConceptIntelligence,
+  },
+  play: async ({ canvas }) => {
+    requestCatGlossaryGuidance();
+    await expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    await expect(canvas.getByText("Dashboard")).toBeInTheDocument();
+    await expect(canvas.getByText("Draft")).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Show glossary concept details" }));
+    await expect(canvas.getAllByText("Dashboard")).toHaveLength(2);
+  },
+};
+
+export const PrimaryTermFallback: Story = {
+  args: {
+    intelligence: {
+      ...catIntelligenceFixture,
+      glossaryConcepts: [primaryTermFallbackGlossaryConceptFixture],
+    },
+  },
+  play: async ({ canvas }) => {
+    requestCatGlossaryGuidance();
+    await expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    await expect(canvas.getByText("API")).toBeInTheDocument();
+    await expect(canvas.getByText("Draft")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -219,10 +219,11 @@ export function CatIntelligencePanel({
   const glossaryGuidanceStatus = useMemo(() => {
     const terms = glossaryConcepts.flatMap((concept) => [
       ...concept.sourceTerms,
-      ...concept.targetTerms,
+      ...(concept.translatable === false ? [] : concept.targetTerms),
     ]);
 
     return {
+      matchCount: glossaryConcepts.length,
       preferredCount: terms.filter((term) => normalizedCatGlossaryTermStatus(term) === "preferred")
         .length,
       notRecommendedCount: terms.filter(
@@ -240,11 +241,13 @@ export function CatIntelligencePanel({
 
   useEffect(() => {
     setCatGlossaryGuidanceStatus(
-      isConcordanceLoading ? { preferredCount: 0, notRecommendedCount: 0 } : glossaryGuidanceStatus,
+      isConcordanceLoading
+        ? { preferredCount: 0, notRecommendedCount: 0, matchCount: 0 }
+        : glossaryGuidanceStatus,
     );
 
     return () => {
-      setCatGlossaryGuidanceStatus({ preferredCount: 0, notRecommendedCount: 0 });
+      setCatGlossaryGuidanceStatus({ preferredCount: 0, notRecommendedCount: 0, matchCount: 0 });
     };
   }, [glossaryConceptKey, glossaryGuidanceStatus, isConcordanceLoading]);
 

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -677,7 +677,7 @@ export const catIntelligencePanelMessages = defineMessages({
   },
   glossaryUntranslatable: {
     defaultMessage: "Untranslatable",
-    id: "glossaryUntranslatableCat",
+    id: 'IKexpxBOZ5',
     description: "Status badge for a glossary concept marked as untranslatable",
   },
   projectGlossary: {

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -675,6 +675,11 @@ export const catIntelligencePanelMessages = defineMessages({
     id: "+pwP0Po+Io",
     description: "Status badge for an obsolete glossary term",
   },
+  glossaryUntranslatable: {
+    defaultMessage: "Untranslatable",
+    id: "glossaryUntranslatableCat",
+    description: "Status badge for a glossary concept marked as untranslatable",
+  },
   projectGlossary: {
     defaultMessage: "Project Glossary",
     id: "SLnLYAC4Ib",

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -677,7 +677,7 @@ export const catIntelligencePanelMessages = defineMessages({
   },
   glossaryUntranslatable: {
     defaultMessage: "Untranslatable",
-    id: 'IKexpxBOZ5',
+    id: "IKexpxBOZ5",
     description: "Status badge for a glossary concept marked as untranslatable",
   },
   projectGlossary: {

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -160,6 +160,7 @@ export interface CatGlossaryConcept {
   primaryTerm: string;
   subject?: string | null;
   definition?: string | null;
+  translatable?: boolean;
   sourceTerms: CatGlossaryConceptTerm[];
   targetTerms: CatGlossaryConceptTerm[];
 }

--- a/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary-concordance-batch.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary-concordance-batch.test.ts
@@ -144,9 +144,15 @@ describe("searchAttachedCrowdinGlossaryConcordance", () => {
     });
 
     expect(mocks.glossaryConcordanceSearch).toHaveBeenCalledTimes(2);
-    expect(matches).toHaveLength(2);
+    expect(matches).toHaveLength(4);
     expect(matches.map((match) => match.glossaryId)).toEqual(
-      expect.arrayContaining(["crowdin:glossary:718785", "crowdin:glossary:900001"]),
+      expect.arrayContaining([
+        "crowdin:glossary:718785",
+        "crowdin:glossary:900001",
+        "crowdin:glossary:718785",
+        "crowdin:glossary:900001",
+      ]),
     );
+    expect(new Set(matches.map((match) => match.targetLocale))).toEqual(new Set(["fr", "de"]));
   });
 });

--- a/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
@@ -20,7 +20,12 @@ import type {
   CrowdinGlossaryConcordanceSearchResult,
 } from "@/lib/providers/adapters/crowdin/crowdin-api";
 import { CrowdinApiClient } from "@/lib/providers/adapters/crowdin/crowdin-api";
-import { mapCrowdinGlossaryConcordanceSearchResult } from "@/lib/providers/adapters/crowdin/crowdin-glossary-concordance";
+import {
+  loadCrowdinConcordanceTranslatableByConceptId,
+  mapCrowdinGlossaryConcordanceSearchResult,
+  resolveCrowdinConcordanceTranslatableFromResult,
+  sortCrowdinConcordanceMatches,
+} from "@/lib/providers/adapters/crowdin/crowdin-glossary-concordance";
 import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
@@ -690,6 +695,7 @@ export async function searchAttachedCrowdinGlossaryConcordance(input: {
   const limit = input.query.limit ?? 20;
   const sourceLanguageId = toCrowdinGlossaryLanguageId(input.query.sourceLocale);
   const matches: NormalizedGlossaryMatch[] = [];
+  const resultsByTargetLocale = new Map<string, CrowdinGlossaryConcordanceSearchResult[]>();
 
   for (const targetLocale of input.query.targetLocales) {
     const targetLanguageId = toCrowdinGlossaryLanguageId(targetLocale);
@@ -704,6 +710,16 @@ export async function searchAttachedCrowdinGlossaryConcordance(input: {
       continue;
     }
 
+    resultsByTargetLocale.set(targetLocale, results);
+  }
+
+  const allResults = [...resultsByTargetLocale.values()].flat();
+  const translatableByConceptId = await loadCrowdinConcordanceTranslatableByConceptId({
+    client,
+    results: allResults,
+  });
+
+  for (const [targetLocale, results] of resultsByTargetLocale) {
     for (const [index, result] of results.entries()) {
       const glossary = glossariesByCrowdinId.get(result.glossary.id);
       if (!glossary) {
@@ -718,6 +734,10 @@ export async function searchAttachedCrowdinGlossaryConcordance(input: {
         sourceLocale: input.query.sourceLocale,
         targetLocale,
         stableTermIdGlossaryKey: glossary.id,
+        translatable: resolveCrowdinConcordanceTranslatableFromResult(
+          result,
+          translatableByConceptId,
+        ),
       });
       if (match) {
         matches.push(match);
@@ -725,5 +745,5 @@ export async function searchAttachedCrowdinGlossaryConcordance(input: {
     }
   }
 
-  return matches.toSorted((left, right) => right.rank - left.rank).slice(0, limit);
+  return sortCrowdinConcordanceMatches(matches, limit);
 }

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -20,6 +20,7 @@ import {
   normalizedGlossaryTermStatusFromStatus,
 } from "@/lib/providers/contracts/glossary-term-status";
 import {
+  hasGlossaryExpectedTarget,
   normalizeSyncedDatabaseGlossaryMatch,
   type NormalizedGlossaryConcept,
   type NormalizedGlossaryConceptTerm,
@@ -128,6 +129,7 @@ function buildNormalizedConcept(input: {
     subject: input.concept.subject,
     definition: input.concept.definition,
     glossaryUrl: input.glossaryUrl ?? null,
+    translatable: input.concept.translatable ?? true,
     sourceTerms: conceptTerms.filter((term) => term.locale === input.sourceLocale),
     targetTerms: filterConcordanceTargetTerms(conceptTerms, input.targetLocales),
   };
@@ -1048,16 +1050,62 @@ export class NativeGlossary extends Glossary {
       });
 
       for (const targetLocale of query.targetLocales) {
+        const isUntranslatable = concept.translatable === false;
         const preferredTarget = pickPreferredTermForLocale(
           normalizedConcept.targetTerms,
           targetLocale,
         );
-        if (!preferredTarget) {
+        const sourceStatus = normalizedGlossaryTermStatusFromStatus(hit.sourceStatus);
+
+        if (isUntranslatable) {
+          matches.push(
+            normalizeSyncedDatabaseGlossaryMatch({
+              id: `${hit.matchedSourceTermId}:${targetLocale}`,
+              glossaryId: hit.glossaryId,
+              glossaryName: hit.glossaryName,
+              sourceTerm: hit.matchedSourceTerm,
+              targetTerm: hit.matchedSourceTerm,
+              sourceLocale,
+              targetLocale,
+              description: concept.definition || null,
+              forbidden: sourceStatus.forbidden,
+              preferred: sourceStatus.preferred,
+              caseSensitive: hit.caseSensitive ?? false,
+              rank: hit.rank || 1,
+              providerKind: null,
+              externalResourceId: null,
+              externalTermId: null,
+              concept: normalizedConcept,
+            }),
+          );
           continue;
         }
 
-        const sourceStatus = normalizedGlossaryTermStatusFromStatus(hit.sourceStatus);
-        const targetStatus = normalizedGlossaryTermStatusFromStatus(preferredTarget.status);
+        if (preferredTarget) {
+          const targetStatus = normalizedGlossaryTermStatusFromStatus(preferredTarget.status);
+
+          matches.push(
+            normalizeSyncedDatabaseGlossaryMatch({
+              id: `${hit.matchedSourceTermId}:${targetLocale}`,
+              glossaryId: hit.glossaryId,
+              glossaryName: hit.glossaryName,
+              sourceTerm: hit.matchedSourceTerm,
+              targetTerm: preferredTarget.text,
+              sourceLocale,
+              targetLocale,
+              description: concept.definition || null,
+              forbidden: sourceStatus.forbidden || targetStatus.forbidden,
+              preferred: targetStatus.preferred,
+              caseSensitive: hit.caseSensitive ?? false,
+              rank: hit.rank || 1,
+              providerKind: null,
+              externalResourceId: null,
+              externalTermId: null,
+              concept: normalizedConcept,
+            }),
+          );
+          continue;
+        }
 
         matches.push(
           normalizeSyncedDatabaseGlossaryMatch({
@@ -1065,12 +1113,12 @@ export class NativeGlossary extends Glossary {
             glossaryId: hit.glossaryId,
             glossaryName: hit.glossaryName,
             sourceTerm: hit.matchedSourceTerm,
-            targetTerm: preferredTarget.text,
+            targetTerm: "",
             sourceLocale,
             targetLocale,
             description: concept.definition || null,
-            forbidden: sourceStatus.forbidden || targetStatus.forbidden,
-            preferred: targetStatus.preferred,
+            forbidden: sourceStatus.forbidden,
+            preferred: false,
             caseSensitive: hit.caseSensitive ?? false,
             rank: hit.rank || 1,
             providerKind: null,
@@ -1082,6 +1130,15 @@ export class NativeGlossary extends Glossary {
       }
     }
 
-    return matches.toSorted((left, right) => right.rank - left.rank).slice(0, limit);
+    return matches
+      .toSorted((left, right) => {
+        const leftHasExpectedTarget = hasGlossaryExpectedTarget(left);
+        const rightHasExpectedTarget = hasGlossaryExpectedTarget(right);
+        if (leftHasExpectedTarget !== rightHasExpectedTarget) {
+          return leftHasExpectedTarget ? -1 : 1;
+        }
+        return right.rank - left.rank;
+      })
+      .slice(0, limit);
   }
 }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -727,6 +727,7 @@ export interface CrowdinGlossaryConcordanceSearchResult {
     subject?: string | null;
     definition?: string | null;
     url?: string | null;
+    translatable?: boolean;
   } | null;
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
@@ -252,7 +252,9 @@ describe("searchCrowdinCatConcordance", () => {
           glossary: { id: 7, name: "Brand terms" },
           concept: { id: 3, translatable: false },
           sourceTerms: [{ id: 11, languageId: "en", text: "Hyperlocalise", status: "preferred" }],
-          targetTerms: [{ id: 12, languageId: "fr", text: "Hyperlocalise FR", status: "preferred" }],
+          targetTerms: [
+            { id: 12, languageId: "fr", text: "Hyperlocalise FR", status: "preferred" },
+          ],
         },
       ]),
       concordanceSearch: vi.fn().mockResolvedValue([]),

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
@@ -244,4 +244,98 @@ describe("searchCrowdinCatConcordance", () => {
     });
     expect(result.glossaryTerms[0]?.externalConceptId).toBe("3");
   });
+
+  it("maps untranslatable Crowdin concepts with source as the expected target", async () => {
+    const client = {
+      glossaryConcordanceSearch: vi.fn().mockResolvedValue([
+        {
+          glossary: { id: 7, name: "Brand terms" },
+          concept: { id: 3, translatable: false },
+          sourceTerms: [{ id: 11, languageId: "en", text: "Hyperlocalise", status: "preferred" }],
+          targetTerms: [{ id: 12, languageId: "fr", text: "Hyperlocalise FR", status: "preferred" }],
+        },
+      ]),
+      concordanceSearch: vi.fn().mockResolvedValue([]),
+    } as unknown as CrowdinApiClient;
+
+    const result = await crowdinTmsProvider.searchCatConcordance({
+      client,
+      externalProjectId: "42",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Hyperlocalise",
+    });
+
+    expect(result.glossaryTerms[0]).toMatchObject({
+      sourceTerm: "Hyperlocalise",
+      targetTerm: "Hyperlocalise",
+      concept: {
+        translatable: false,
+      },
+    });
+  });
+
+  it("keeps source-only translatable Crowdin concepts with an empty target term", async () => {
+    const client = {
+      glossaryConcordanceSearch: vi.fn().mockResolvedValue([
+        {
+          glossary: { id: 7, name: "Product terms" },
+          concept: { id: 4, translatable: true },
+          sourceTerms: [{ id: 11, languageId: "en", text: "Dashboard", status: "draft" }],
+          targetTerms: [],
+        },
+      ]),
+      concordanceSearch: vi.fn().mockResolvedValue([]),
+    } as unknown as CrowdinApiClient;
+
+    const result = await crowdinTmsProvider.searchCatConcordance({
+      client,
+      externalProjectId: "42",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Dashboard",
+    });
+
+    expect(result.glossaryTerms[0]).toMatchObject({
+      sourceTerm: "Dashboard",
+      targetTerm: "",
+      concept: {
+        translatable: true,
+        targetTerms: [],
+      },
+    });
+  });
+
+  it("loads missing translatable flags from getGlossaryConcept", async () => {
+    const getGlossaryConcept = vi.fn().mockResolvedValue({ translatable: false });
+    const client = {
+      glossaryConcordanceSearch: vi.fn().mockResolvedValue([
+        {
+          glossary: { id: 7, name: "Brand terms" },
+          concept: null,
+          sourceTerms: [{ id: 11, conceptId: 3, languageId: "en", text: "Hyperlocalise" }],
+          targetTerms: [],
+        },
+      ]),
+      concordanceSearch: vi.fn().mockResolvedValue([]),
+      getGlossaryConcept,
+    } as unknown as CrowdinApiClient;
+
+    const result = await crowdinTmsProvider.searchCatConcordance({
+      client,
+      externalProjectId: "42",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Hyperlocalise",
+    });
+
+    expect(getGlossaryConcept).toHaveBeenCalledWith(7, 3);
+    expect(result.glossaryTerms[0]).toMatchObject({
+      sourceTerm: "Hyperlocalise",
+      targetTerm: "Hyperlocalise",
+      concept: {
+        translatable: false,
+      },
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-concordance.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { CrowdinApiClient } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import {
+  loadCrowdinConcordanceTranslatableByConceptId,
+  mapCrowdinGlossaryConcordanceSearchResult,
+  resolveCrowdinConcordanceTranslatableFromResult,
+  sortCrowdinConcordanceMatches,
+} from "@/lib/providers/adapters/crowdin/crowdin-glossary-concordance";
+import { hasGlossaryExpectedTarget } from "@/lib/providers/contracts/glossary-match";
+
+describe("mapCrowdinGlossaryConcordanceSearchResult", () => {
+  it("maps untranslatable concepts with source as the expected target", () => {
+    const match = mapCrowdinGlossaryConcordanceSearchResult({
+      result: {
+        glossary: { id: 7, name: "Brand terms" },
+        concept: { id: 3, translatable: false },
+        sourceTerms: [{ id: 11, languageId: "en", text: "Hyperlocalise", status: "preferred" }],
+        targetTerms: [{ id: 12, languageId: "fr", text: "Hyperlocalise FR", status: "preferred" }],
+      },
+      index: 0,
+      resourceId: "glossary-1",
+      glossaryName: "Brand terms",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      translatable: false,
+    });
+
+    expect(match).toMatchObject({
+      sourceTerm: "Hyperlocalise",
+      targetTerm: "Hyperlocalise",
+      concept: {
+        translatable: false,
+      },
+    });
+    expect(hasGlossaryExpectedTarget(match!)).toBe(true);
+  });
+
+  it("keeps source-only translatable concepts with an empty target term", () => {
+    const match = mapCrowdinGlossaryConcordanceSearchResult({
+      result: {
+        glossary: { id: 7, name: "Product terms" },
+        concept: { id: 4, translatable: true },
+        sourceTerms: [{ id: 11, languageId: "en", text: "Dashboard", status: "draft" }],
+        targetTerms: [],
+      },
+      index: 0,
+      resourceId: "glossary-1",
+      glossaryName: "Product terms",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      translatable: true,
+    });
+
+    expect(match).toMatchObject({
+      sourceTerm: "Dashboard",
+      targetTerm: "",
+      concept: {
+        translatable: true,
+        targetTerms: [],
+      },
+    });
+    expect(hasGlossaryExpectedTarget(match!)).toBe(false);
+  });
+
+  it("drops matches without a source term", () => {
+    const match = mapCrowdinGlossaryConcordanceSearchResult({
+      result: {
+        glossary: { id: 7, name: "Product terms" },
+        sourceTerms: [],
+        targetTerms: [{ id: 12, languageId: "fr", text: "Tableau de bord", status: "preferred" }],
+      },
+      index: 0,
+      resourceId: "glossary-1",
+      glossaryName: "Product terms",
+      sourceLocale: "en",
+      targetLocale: "fr",
+    });
+
+    expect(match).toBeNull();
+  });
+});
+
+describe("resolveCrowdinConcordanceTranslatableFromResult", () => {
+  it("uses concordance concept translatable when present", () => {
+    expect(
+      resolveCrowdinConcordanceTranslatableFromResult({
+        glossary: { id: 1, name: "Glossary" },
+        sourceTerms: [{ id: 1, languageId: "en", text: "API" }],
+        targetTerms: [],
+        concept: { id: 2, translatable: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to loaded concept translatable by id", () => {
+    expect(
+      resolveCrowdinConcordanceTranslatableFromResult(
+        {
+          glossary: { id: 1, name: "Glossary" },
+          sourceTerms: [{ id: 1, conceptId: 2, languageId: "en", text: "API" }],
+          targetTerms: [],
+          concept: null,
+        },
+        new Map([["1:2", false]]),
+      ),
+    ).toBe(false);
+  });
+
+  it("defaults to true when no concept id is available", () => {
+    expect(
+      resolveCrowdinConcordanceTranslatableFromResult({
+        glossary: { id: 1, name: "Glossary" },
+        sourceTerms: [{ id: 1, languageId: "en", text: "API" }],
+        targetTerms: [{ id: 2, languageId: "fr", text: "API" }],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("loadCrowdinConcordanceTranslatableByConceptId", () => {
+  it("loads missing translatable flags with bounded concurrency", async () => {
+    const getGlossaryConcept = vi.fn().mockResolvedValue({ translatable: false });
+    const client = { getGlossaryConcept } as unknown as CrowdinApiClient;
+
+    const resolved = await loadCrowdinConcordanceTranslatableByConceptId({
+      client,
+      results: [
+        {
+          glossary: { id: 7, name: "Brand terms" },
+          sourceTerms: [{ id: 11, conceptId: 3, languageId: "en", text: "Hyperlocalise" }],
+          targetTerms: [],
+          concept: null,
+        },
+      ],
+    });
+
+    expect(getGlossaryConcept).toHaveBeenCalledWith(7, 3);
+    expect(resolved.get("7:3")).toBe(false);
+  });
+});
+
+describe("sortCrowdinConcordanceMatches", () => {
+  it("ranks expected-target matches ahead of source-only matches", () => {
+    const sourceOnly = mapCrowdinGlossaryConcordanceSearchResult({
+      result: {
+        glossary: { id: 7, name: "Product terms" },
+        sourceTerms: [{ id: 11, languageId: "en", text: "Dashboard", status: "draft" }],
+        targetTerms: [],
+      },
+      index: 0,
+      resourceId: "glossary-1",
+      glossaryName: "Product terms",
+      sourceLocale: "en",
+      targetLocale: "fr",
+    })!;
+    const withTarget = mapCrowdinGlossaryConcordanceSearchResult({
+      result: {
+        glossary: { id: 7, name: "Product terms" },
+        sourceTerms: [{ id: 21, languageId: "en", text: "Save", status: "preferred" }],
+        targetTerms: [{ id: 22, languageId: "fr", text: "Enregistrer", status: "preferred" }],
+      },
+      index: 1,
+      resourceId: "glossary-1",
+      glossaryName: "Product terms",
+      sourceLocale: "en",
+      targetLocale: "fr",
+    })!;
+
+    const sorted = sortCrowdinConcordanceMatches([sourceOnly, withTarget], 2);
+    expect(sorted[0]?.sourceTerm).toBe("Save");
+    expect(sorted[1]?.sourceTerm).toBe("Dashboard");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-concordance.ts
@@ -17,10 +17,13 @@ import {
   toNativeGlossaryLocale,
 } from "@/lib/providers/adapters/crowdin/crowdin-glossary-language";
 import type {
+  CrowdinApiClient,
   CrowdinGlossaryConcordanceSearchResult,
   CrowdinGlossaryConcordanceTerm,
 } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import {
+  hasGlossaryExpectedTarget,
   normalizeProviderGlossaryMatch,
   type NormalizedGlossaryConcept,
   type NormalizedGlossaryConceptTerm,
@@ -68,6 +71,76 @@ export function resolveCrowdinConcordanceExternalConceptId(
   return termConceptId != null ? String(termConceptId) : null;
 }
 
+export function resolveCrowdinConcordanceTranslatableKey(
+  result: CrowdinGlossaryConcordanceSearchResult,
+): string | null {
+  const conceptId = resolveCrowdinConcordanceExternalConceptId(result);
+  if (conceptId == null) {
+    return null;
+  }
+
+  return `${result.glossary.id}:${conceptId}`;
+}
+
+export function resolveCrowdinConcordanceTranslatableFromResult(
+  result: CrowdinGlossaryConcordanceSearchResult,
+  resolvedByConceptId?: Map<string, boolean>,
+): boolean {
+  if (result.concept?.translatable !== undefined) {
+    return result.concept.translatable;
+  }
+
+  const key = resolveCrowdinConcordanceTranslatableKey(result);
+  if (key != null) {
+    const resolved = resolvedByConceptId?.get(key);
+    if (resolved !== undefined) {
+      return resolved;
+    }
+  }
+
+  return true;
+}
+
+export async function loadCrowdinConcordanceTranslatableByConceptId(input: {
+  client: CrowdinApiClient;
+  results: CrowdinGlossaryConcordanceSearchResult[];
+}): Promise<Map<string, boolean>> {
+  const pending = new Map<string, { glossaryId: number; conceptId: number }>();
+
+  for (const result of input.results) {
+    if (result.concept?.translatable !== undefined) {
+      continue;
+    }
+
+    const key = resolveCrowdinConcordanceTranslatableKey(result);
+    if (key == null) {
+      continue;
+    }
+
+    const conceptId = resolveCrowdinConcordanceExternalConceptId(result);
+    if (conceptId == null) {
+      continue;
+    }
+
+    pending.set(key, {
+      glossaryId: result.glossary.id,
+      conceptId: Number(conceptId),
+    });
+  }
+
+  const resolved = new Map<string, boolean>();
+  await mapWithConcurrency([...pending.entries()], 5, async ([key, { glossaryId, conceptId }]) => {
+    try {
+      const concept = await input.client.getGlossaryConcept(glossaryId, conceptId);
+      resolved.set(key, concept.translatable);
+    } catch {
+      resolved.set(key, true);
+    }
+  });
+
+  return resolved;
+}
+
 export function toCrowdinConcordanceConceptTerm(
   term: CrowdinGlossaryConcordanceTerm,
   preferredLocales: string[],
@@ -94,14 +167,19 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
   sourceLocale: string;
   targetLocale: string;
   stableTermIdGlossaryKey?: string;
+  translatable?: boolean;
 }): NormalizedGlossaryMatch | null {
   const sourceLanguageId = toCrowdinGlossaryLanguageId(input.sourceLocale);
   const targetLanguageId = toCrowdinGlossaryLanguageId(input.targetLocale);
   const sourceTerm = pickCrowdinConcordanceTermText(input.result.sourceTerms, sourceLanguageId);
   const targetTerm = pickCrowdinConcordanceTermText(input.result.targetTerms, targetLanguageId);
-  if (!sourceTerm || !targetTerm) {
+  if (!sourceTerm) {
     return null;
   }
+
+  const translatable = input.translatable ?? true;
+  const isUntranslatable = translatable === false;
+  const effectiveTargetTerm = isUntranslatable ? sourceTerm : (targetTerm ?? "");
 
   const externalGlossaryId = String(input.result.glossary.id);
   const status =
@@ -123,6 +201,7 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
     subject: input.result.concept?.subject,
     definition: input.result.concept?.definition,
     glossaryUrl: null,
+    translatable,
     sourceTerms: input.result.sourceTerms.map((term) =>
       toCrowdinConcordanceConceptTerm(term, preferredLocales),
     ),
@@ -133,7 +212,7 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
 
   return normalizeProviderGlossaryMatch({
     sourceTerm,
-    targetTerm,
+    targetTerm: effectiveTargetTerm,
     sourceLocale: input.sourceLocale,
     targetLocale: input.targetLocale,
     providerKind: "crowdin",
@@ -146,4 +225,20 @@ export function mapCrowdinGlossaryConcordanceSearchResult(input: {
     status: { status },
     concept,
   });
+}
+
+export function sortCrowdinConcordanceMatches(
+  matches: NormalizedGlossaryMatch[],
+  limit: number,
+): NormalizedGlossaryMatch[] {
+  return matches
+    .toSorted((left, right) => {
+      const leftHasExpectedTarget = hasGlossaryExpectedTarget(left);
+      const rightHasExpectedTarget = hasGlossaryExpectedTarget(right);
+      if (leftHasExpectedTarget !== rightHasExpectedTarget) {
+        return leftHasExpectedTarget ? -1 : 1;
+      }
+      return right.rank - left.rank;
+    })
+    .slice(0, limit);
 }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -58,7 +58,12 @@ import {
   toNativeGlossaryLocale,
 } from "@/lib/providers/adapters/crowdin/crowdin-glossary-language";
 import { crowdinAuth } from "@/lib/providers/adapters/crowdin/crowdin-auth";
-import { mapCrowdinGlossaryConcordanceSearchResult } from "@/lib/providers/adapters/crowdin/crowdin-glossary-concordance";
+import {
+  loadCrowdinConcordanceTranslatableByConceptId,
+  mapCrowdinGlossaryConcordanceSearchResult,
+  resolveCrowdinConcordanceTranslatableFromResult,
+  sortCrowdinConcordanceMatches,
+} from "@/lib/providers/adapters/crowdin/crowdin-glossary-concordance";
 import {
   TmsProvider,
   type TmsProviderCommentPushScope,
@@ -2767,6 +2772,10 @@ export class CrowdinTmsProvider extends TmsProvider {
     }
 
     const glossaryTerms: NormalizedGlossaryMatch[] = [];
+    const translatableByConceptId = await loadCrowdinConcordanceTranslatableByConceptId({
+      client: input.client,
+      results: glossaryResults,
+    });
 
     for (const [index, result] of glossaryResults.entries()) {
       const externalGlossaryId = String(result.glossary.id);
@@ -2778,6 +2787,10 @@ export class CrowdinTmsProvider extends TmsProvider {
         sourceLocale: input.sourceLocale,
         targetLocale: input.targetLocale,
         stableTermIdGlossaryKey: externalGlossaryId,
+        translatable: resolveCrowdinConcordanceTranslatableFromResult(
+          result,
+          translatableByConceptId,
+        ),
       });
       if (match) {
         glossaryTerms.push(match);
@@ -2803,7 +2816,7 @@ export class CrowdinTmsProvider extends TmsProvider {
       );
 
     return {
-      glossaryTerms: glossaryTerms.slice(0, glossaryLimit),
+      glossaryTerms: sortCrowdinConcordanceMatches(glossaryTerms, glossaryLimit),
       translationMemoryMatches,
     };
   }

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-match.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-match.ts
@@ -42,6 +42,7 @@ export type NormalizedGlossaryConcept = {
   subject?: string | null;
   definition?: string | null;
   glossaryUrl?: string | null;
+  translatable?: boolean;
   sourceTerms: NormalizedGlossaryConceptTerm[];
   targetTerms: NormalizedGlossaryConceptTerm[];
 };
@@ -97,6 +98,22 @@ export type AgentRunGlossaryMatchUsage = {
   resourceId: string;
   externalResourceId: string | null;
 };
+
+function isNonEmptyGlossaryTerm(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function hasGlossaryExpectedTarget(match: {
+  targetTerm: string;
+  sourceTerm: string;
+  concept?: Pick<NormalizedGlossaryConcept, "translatable"> | null;
+}): boolean {
+  if (match.concept?.translatable === false) {
+    return isNonEmptyGlossaryTerm(match.sourceTerm);
+  }
+
+  return isNonEmptyGlossaryTerm(match.targetTerm);
+}
 
 export type ProviderGlossaryMatchInput = {
   sourceTerm: string;
@@ -203,13 +220,20 @@ export function normalizeSyncedDatabaseGlossaryMatch(input: {
   };
 }
 
-export function toContextGlossaryMatch(match: NormalizedGlossaryMatch): ContextGlossaryMatch {
+export function toContextGlossaryMatch(match: NormalizedGlossaryMatch): ContextGlossaryMatch | null {
+  if (!hasGlossaryExpectedTarget(match)) {
+    return null;
+  }
+
+  const targetTerm =
+    match.concept?.translatable === false ? match.sourceTerm.trim() : match.targetTerm.trim();
+
   return {
     id: match.id,
     glossaryId: match.glossaryId,
     glossaryName: match.glossaryName,
     sourceTerm: match.sourceTerm,
-    targetTerm: match.targetTerm,
+    targetTerm,
     targetLocale: match.targetLocale,
     description: match.description,
     forbidden: match.termStatus.forbidden,
@@ -224,12 +248,19 @@ export function toContextGlossaryMatch(match: NormalizedGlossaryMatch): ContextG
 
 export function toAgentRunGlossaryMatchUsage(
   match: NormalizedGlossaryMatch,
-): AgentRunGlossaryMatchUsage {
+): AgentRunGlossaryMatchUsage | null {
+  if (!hasGlossaryExpectedTarget(match)) {
+    return null;
+  }
+
+  const targetTerm =
+    match.concept?.translatable === false ? match.sourceTerm.trim() : match.targetTerm.trim();
+
   return {
     glossaryId: match.glossaryId,
     glossaryName: match.glossaryName,
     sourceTerm: match.sourceTerm,
-    targetTerm: match.targetTerm,
+    targetTerm,
     targetLocale: match.targetLocale,
     forbidden: match.termStatus.forbidden,
     preferred: match.termStatus.preferred,

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-match.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/glossary-match.ts
@@ -220,7 +220,9 @@ export function normalizeSyncedDatabaseGlossaryMatch(input: {
   };
 }
 
-export function toContextGlossaryMatch(match: NormalizedGlossaryMatch): ContextGlossaryMatch | null {
+export function toContextGlossaryMatch(
+  match: NormalizedGlossaryMatch,
+): ContextGlossaryMatch | null {
   if (!hasGlossaryExpectedTarget(match)) {
     return null;
   }

--- a/apps/hyperlocalise-web/src/lib/translation/cat-recommendation-mapper.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/cat-recommendation-mapper.ts
@@ -37,13 +37,15 @@ export function mapCatConcordanceForAiRecommendation(
   targetLocale: string,
 ): CatRecommendationConcordanceContext {
   return {
-    glossaryTerms: concordance.glossaryTerms.map((term) => ({
-      sourceTerm: term.source,
-      targetTerm: term.target,
-      targetLocale,
-      forbidden: term.forbidden,
-      description: null,
-    })),
+    glossaryTerms: concordance.glossaryTerms
+      .filter((term) => term.target.trim().length > 0)
+      .map((term) => ({
+        sourceTerm: term.source,
+        targetTerm: term.target,
+        targetLocale,
+        forbidden: term.forbidden,
+        description: null,
+      })),
     translationMemoryMatches: concordance.translationMemoryMatches.map((match) => ({
       sourceText: match.sourceText,
       targetText: match.targetText,

--- a/apps/hyperlocalise-web/src/lib/translation/cat.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/cat.ts
@@ -38,6 +38,7 @@ import type {
   NormalizedGlossaryConceptTerm,
   NormalizedGlossaryMatch,
 } from "@/lib/providers/contracts/glossary-match";
+import { hasGlossaryExpectedTarget } from "@/lib/providers/contracts/glossary-match";
 import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
 import {
   defaultGlossaryMatchResolution,
@@ -139,6 +140,10 @@ function resolveCatGlossaryNavigationUrls(
   return { glossaryUrl, conceptUrl };
 }
 
+function toCatGlossaryTermsForAi(matches: NormalizedGlossaryMatch[]): CatGlossaryTerm[] {
+  return matches.filter(hasGlossaryExpectedTarget).map(toCatGlossaryTerm);
+}
+
 function toCatGlossaryConcept(
   match: NormalizedGlossaryMatch,
   organizationSlug?: string,
@@ -155,6 +160,7 @@ function toCatGlossaryConcept(
       primaryTerm: concept.primaryTerm || match.sourceTerm,
       subject: concept.subject,
       definition: concept.definition ?? match.description,
+      translatable: concept.translatable ?? true,
       sourceTerms: concept.sourceTerms.map(toCatGlossaryConceptTerm),
       targetTerms: concept.targetTerms.map(toCatGlossaryConceptTerm),
     };
@@ -168,6 +174,7 @@ function toCatGlossaryConcept(
     conceptUrl: navigationUrls.conceptUrl,
     primaryTerm: match.sourceTerm,
     definition: match.description,
+    translatable: true,
     sourceTerms: [
       {
         id: `${match.id}:source`,
@@ -177,15 +184,17 @@ function toCatGlossaryConcept(
         forbidden: match.termStatus.forbidden,
       },
     ],
-    targetTerms: [
-      {
-        id: `${match.id}:target`,
-        locale: match.targetLocale,
-        text: match.targetTerm,
-        preferred: match.termStatus.preferred,
-        forbidden: match.termStatus.forbidden,
-      },
-    ],
+    targetTerms: match.targetTerm.trim()
+      ? [
+          {
+            id: `${match.id}:target`,
+            locale: match.targetLocale,
+            text: match.targetTerm,
+            preferred: match.termStatus.preferred,
+            forbidden: match.termStatus.forbidden,
+          },
+        ]
+      : [],
   };
 }
 
@@ -427,7 +436,7 @@ export class CatConcordanceService {
 
         if (liveMatches) {
           return {
-            glossaryTerms: liveMatches.glossaryTerms.map(toCatGlossaryTerm),
+            glossaryTerms: toCatGlossaryTermsForAi(liveMatches.glossaryTerms),
             glossaryConcepts: toCatGlossaryConcepts(
               liveMatches.glossaryTerms,
               input.organizationSlug,
@@ -463,7 +472,7 @@ export class CatConcordanceService {
     ]);
 
     return {
-      glossaryTerms: glossaryMatches.map(toCatGlossaryTerm),
+      glossaryTerms: toCatGlossaryTermsForAi(glossaryMatches),
       glossaryConcepts: toCatGlossaryConcepts(glossaryMatches, input.organizationSlug),
       translationMemoryMatches: translationMemoryMatches.map((match) =>
         toCatTranslationMemoryMatch(match, input.sourceText),

--- a/apps/hyperlocalise-web/src/lib/translation/concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/concordance.ts
@@ -566,7 +566,10 @@ export class GlossaryConcordanceService {
       usage.push({
         externalStringId: unit.externalStringId,
         key: unit.key,
-        matches: matches.map(toAgentRunGlossaryMatchUsage),
+        matches: matches.flatMap((match) => {
+          const usage = toAgentRunGlossaryMatchUsage(match);
+          return usage ? [usage] : [];
+        }),
       });
     }
 

--- a/apps/hyperlocalise-web/src/lib/translation/context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/context.ts
@@ -153,7 +153,12 @@ export class TranslationContextBuilder {
           sourceText: jobInput.sourceText,
           glossaryMatchResolution: options?.glossaryMatchResolution,
         })
-        .then((matches) => matches.map(toContextGlossaryMatch)),
+        .then((matches) =>
+          matches.flatMap((match) => {
+            const contextMatch = toContextGlossaryMatch(match);
+            return contextMatch ? [contextMatch] : [];
+          }),
+        ),
       this.memoryService
         .searchForContext({
           projectId,

--- a/apps/hyperlocalise-web/src/lib/translation/glossary-match.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/glossary-match.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  hasGlossaryExpectedTarget,
   mergeGlossaryMatches,
   normalizeGlossaryTermStatus,
   normalizeProviderGlossaryMatch,
@@ -282,6 +283,73 @@ describe("context and agent run projections", () => {
       preferred: false,
       forbidden: false,
       glossaryName: "Synced glossary",
+    });
+  });
+
+  it("omits source-only translatable matches from context and agent usage", () => {
+    const sourceOnly = normalizeSyncedDatabaseGlossaryMatch({
+      id: "term-2",
+      glossaryId: "glossary-1",
+      glossaryName: "Synced glossary",
+      sourceTerm: "Dashboard",
+      targetTerm: "",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      description: null,
+      forbidden: false,
+      caseSensitive: false,
+      rank: 1,
+      providerKind: null,
+      externalResourceId: null,
+      externalTermId: null,
+      concept: {
+        id: "concept-1",
+        primaryTerm: "Dashboard",
+        translatable: true,
+        sourceTerms: [{ id: "s1", locale: "en", text: "Dashboard", status: "draft" }],
+        targetTerms: [],
+      },
+    });
+
+    expect(hasGlossaryExpectedTarget(sourceOnly)).toBe(false);
+    expect(toContextGlossaryMatch(sourceOnly)).toBeNull();
+    expect(toAgentRunGlossaryMatchUsage(sourceOnly)).toBeNull();
+  });
+
+  it("includes untranslatable matches with source as the expected target", () => {
+    const untranslatable = normalizeSyncedDatabaseGlossaryMatch({
+      id: "term-3",
+      glossaryId: "glossary-1",
+      glossaryName: "Synced glossary",
+      sourceTerm: "Hyperlocalise",
+      targetTerm: "Hyperlocalise",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      description: null,
+      forbidden: false,
+      preferred: true,
+      caseSensitive: false,
+      rank: 1,
+      providerKind: null,
+      externalResourceId: null,
+      externalTermId: null,
+      concept: {
+        id: "concept-2",
+        primaryTerm: "Hyperlocalise",
+        translatable: false,
+        sourceTerms: [{ id: "s1", locale: "en", text: "Hyperlocalise", status: "preferred" }],
+        targetTerms: [{ id: "t1", locale: "fr", text: "Hyperlocalise FR", status: "preferred" }],
+      },
+    });
+
+    expect(hasGlossaryExpectedTarget(untranslatable)).toBe(true);
+    expect(toContextGlossaryMatch(untranslatable)).toMatchObject({
+      sourceTerm: "Hyperlocalise",
+      targetTerm: "Hyperlocalise",
+    });
+    expect(toAgentRunGlossaryMatchUsage(untranslatable)).toMatchObject({
+      sourceTerm: "Hyperlocalise",
+      targetTerm: "Hyperlocalise",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/glossary-match.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/glossary-match.ts
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 export {
+  hasGlossaryExpectedTarget,
   mergeGlossaryMatches,
   normalizeGlossaryTermStatus,
   normalizeProviderGlossaryMatch,


### PR DESCRIPTION
## What changed

CAT glossary guidance now respects the concept-level `translatable` flag instead of dropping source hits that lack a target-locale term.

- **Untranslatable concepts** (`translatable === false`): show the source term with an Untranslatable badge; expected rendering is the source term for QA/AI.
- **Translatable, no target term**: show source terms only in the concept card (collapsed and expanded); no invented target row.
- **Translatable with target**: unchanged source + target UI.

Concordance changes cover native and Crowdin paths, including `getGlossaryConcept` fallback when Crowdin omits `translatable`. Empty `targetTerm` matches are kept for `glossaryConcepts` only; `glossaryTerms`, translation context, agent usage, and AI recommendation mapping filter them via `hasGlossaryExpectedTarget`.

Footer glossary guidance now exposes `matchCount` so the button is available when any concept matches, including source-only drafts with no preferred/not-recommended counts.

Storybook adds dedicated concept card stories and updates intelligence panel and footer stories for the new states.

## How to test

- [ ] `cd apps/hyperlocalise-web && vp test`
- [ ] `cd apps/hyperlocalise-web && vp check --fix`
- [ ] Open CAT on a segment with a glossary source hit but no target term — concept appears in guidance with source terms only
- [ ] Open CAT on an untranslatable concept — Untranslatable badge shows, target locale terms are hidden
- [ ] Confirm AI/context prompts do not include `source -> ` blank mappings
- [ ] Storybook: **CAT/Glossary Concept Card**, **CAT/Translation Intelligence** (UntranslatableConcept, SourceOnlyConcept), **App Shell/Footer** (GlossaryDraftMatchAvailable)

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)