### PR TITLE
build(go-svc): package Hunspell runtime and dictionaries

### DIFF
--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -23,11 +23,17 @@ RUN go mod download
 
 RUN CGO_ENABLED=1 GOOS=linux go build -tags cgo_hunspell -o /dev/null ./apps/go-svc/internal/hunspell
 
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /service ./apps/go-svc
+RUN CGO_ENABLED=1 GOOS=linux go build -trimpath -ldflags="-s -w" -o /service ./apps/go-svc
 
-FROM gcr.io/distroless/static-debian12:nonroot
+RUN set -eux; \
+    triplet="$(gcc -dumpmachine)"; \
+    mkdir -p "/runtime-libs/usr/lib/${triplet}"; \
+    cp -P "/usr/lib/${triplet}/libhunspell-1.7.so.0" "/usr/lib/${triplet}/libhunspell-1.7.so.0.0.1" "/runtime-libs/usr/lib/${triplet}/"
+
+FROM gcr.io/distroless/cc-debian12:nonroot
 WORKDIR /
 COPY --from=builder /service /service
+COPY --from=builder /runtime-libs/ /
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/service"]

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -1,9 +1,18 @@
 # syntax=docker/dockerfile:1
 # Go container service build. Build context is the repository root.
+#
+# Use a Debian/glibc builder so the cgo_hunspell wrapper can build
+# against Hunspell's development headers and pkg-config metadata.
 
-FROM golang:1.27.0-alpine AS builder
+FROM golang:1.27.0-bookworm AS builder
 WORKDIR /repo
-RUN apk add --no-cache git ca-certificates
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates=20250419~deb12u1 \
+        git=1:2.39.5-0+deb12u3 \
+        libhunspell-dev=1.7.1-1 \
+        pkg-config=1.8.1-1 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY go.mod go.sum ./
 COPY third_party ./third_party
@@ -11,6 +20,9 @@ COPY internal/i18n ./internal/i18n
 COPY apps/go-svc ./apps/go-svc
 
 RUN go mod download
+
+RUN CGO_ENABLED=1 GOOS=linux go build -tags cgo_hunspell -o /dev/null ./apps/go-svc/internal/hunspell
+
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /service ./apps/go-svc
 
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -30,10 +30,14 @@ RUN set -eux; \
     mkdir -p "/runtime-libs/usr/lib/${triplet}"; \
     cp -P "/usr/lib/${triplet}/libhunspell-1.7.so.0" "/usr/lib/${triplet}/libhunspell-1.7.so.0.0.1" "/runtime-libs/usr/lib/${triplet}/"
 
+RUN bash apps/go-svc/build/fetch-dictionaries.sh /repo /dictionaries-staging/hunspell /dictionaries-staging/licenses
+
 FROM gcr.io/distroless/cc-debian12:nonroot
 WORKDIR /
 COPY --from=builder /service /service
 COPY --from=builder /runtime-libs/ /
+COPY --from=builder /dictionaries-staging/hunspell/ /usr/share/hunspell/
+COPY --from=builder /dictionaries-staging/licenses/ /usr/share/doc/hunspell-dictionaries/
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/service"]

--- a/apps/go-svc/build/fetch-dictionaries.sh
+++ b/apps/go-svc/build/fetch-dictionaries.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Stages the approved Hunspell dictionaries and licence evidence.
+# DICTIONARIES.md is the source of truth for supported locales and files.
+#
+# Usage: fetch-dictionaries.sh <repo-root> <dict-staging-dir> <licence-staging-dir>
+set -euo pipefail
+
+REPO_ROOT="${1:?repo root required}"
+STAGE_DICT="${2:?dictionary staging dir required}"
+STAGE_LICENSE="${3:?licence staging dir required}"
+MANIFEST="${REPO_ROOT}/internal/i18n/spellcheck/DICTIONARIES.md"
+
+# Commit pins select the upstream snapshots; checksums verify downloaded content.
+LIBREOFFICE_COMMIT="32b006a2c22a4ac7e8ed3f03346f7b3d85a970a4"
+LIBREOFFICE_SHA256="cbd790eca560de5e8ec8bd64117a00dfd0bc06b091c8f52d23e44ea00d3e8461"
+HUNSPELL_MS_COMMIT="d8b98cfc76ff54d620d5acd068704f86d8314208"
+HUNSPELL_MS_SHA256="1929c3f0e8b36042b70ea035d4c5714ef2a07c29ab9728fd70b62e72f4102340"
+
+if [ ! -f "$MANIFEST" ]; then
+    echo "fetch-dictionaries: manifest not found at $MANIFEST" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$STAGE_DICT" "$STAGE_LICENSE"
+
+fetch_and_verify() {
+    local url="$1" sha="$2" dest="$3"
+    curl -fsSL -o "$dest" "$url"
+    echo "${sha}  ${dest}" | sha256sum -c -
+}
+
+echo "fetch-dictionaries: downloading LibreOffice/dictionaries@${LIBREOFFICE_COMMIT}"
+fetch_and_verify \
+    "https://github.com/LibreOffice/dictionaries/archive/${LIBREOFFICE_COMMIT}.tar.gz" \
+    "$LIBREOFFICE_SHA256" \
+    "$WORK/libreoffice.tar.gz"
+tar -xzf "$WORK/libreoffice.tar.gz" -C "$WORK"
+LIBRE_ROOT="$WORK/dictionaries-${LIBREOFFICE_COMMIT}"
+
+echo "fetch-dictionaries: downloading syafiqhadzir/hunspell-ms@${HUNSPELL_MS_COMMIT}"
+fetch_and_verify \
+    "https://github.com/syafiqhadzir/hunspell-ms/archive/${HUNSPELL_MS_COMMIT}.tar.gz" \
+    "$HUNSPELL_MS_SHA256" \
+    "$WORK/hunspell-ms.tar.gz"
+tar -xzf "$WORK/hunspell-ms.tar.gz" -C "$WORK"
+MS_ROOT="$WORK/hunspell-ms-${HUNSPELL_MS_COMMIT}"
+
+# Parse the supported-locales table directly to avoid a duplicate manifest.
+rows="$(awk -v libre_commit="$LIBREOFFICE_COMMIT" -v ms_commit="$HUNSPELL_MS_COMMIT" '
+    BEGIN { FS = "|" }
+    /^## Supported locales/ { intable = 1; next }
+    intable && /^## / { intable = 0 }
+    intable && /^\| `/ {
+        bcp47 = $2; aff = $3; dic = $4; pinned = $6; evidence = $8
+        gsub(/^[ \t]+|[ \t]+$/, "", bcp47); gsub(/`/, "", bcp47)
+        gsub(/^[ \t]+|[ \t]+$/, "", aff);   gsub(/`/, "", aff)
+        gsub(/^[ \t]+|[ \t]+$/, "", dic);   gsub(/`/, "", dic)
+        gsub(/^[ \t]+|[ \t]+$/, "", evidence); gsub(/`/, "", evidence)
+        if (pinned ~ ms_commit)         repo = "hunspell-ms"
+        else if (pinned ~ libre_commit) repo = "libreoffice"
+        else                            repo = "unknown"
+        print bcp47 "\t" aff "\t" dic "\t" evidence "\t" repo
+    }
+' "$MANIFEST")"
+
+if [ -z "$rows" ]; then
+    echo "fetch-dictionaries: no locale rows parsed from $MANIFEST; manifest format changed?" >&2
+    exit 1
+fi
+
+# Ensure partial manifest parsing cannot silently omit locales.
+declared_count="$(grep -m1 -oE '^## Supported locales \([0-9]+\)' "$MANIFEST" | grep -oE '[0-9]+')"
+parsed_count=$(($(wc -l <<<"$rows")))
+if [ -z "$declared_count" ]; then
+    echo "fetch-dictionaries: could not read declared locale count from '## Supported locales (N)' heading; manifest format changed?" >&2
+    exit 1
+fi
+if [ "$parsed_count" -ne "$declared_count" ]; then
+    echo "fetch-dictionaries: parsed ${parsed_count} row(s) but manifest heading declares ${declared_count}; manifest format changed?" >&2
+    exit 1
+fi
+
+missing=0
+
+while IFS=$'\t' read -r bcp47 aff dic evidence_csv repo; do
+    case "$repo" in
+        hunspell-ms) root="$MS_ROOT" ;;
+        libreoffice) root="$LIBRE_ROOT" ;;
+        *)
+            echo "fetch-dictionaries: unknown repo '$repo' for $bcp47" >&2
+            missing=$((missing + 1))
+            continue
+            ;;
+    esac
+
+    aff_src="$(find "$root" -type f -name "$aff")"
+    dic_src="$(find "$root" -type f -name "$dic")"
+
+    if [ -z "$aff_src" ] || [ "$(wc -l <<<"$aff_src")" -ne 1 ]; then
+        echo "fetch-dictionaries: expected exactly one '$aff' under $root for $bcp47, found: ${aff_src:-none}" >&2
+        missing=$((missing + 1))
+        continue
+    fi
+    if [ -z "$dic_src" ] || [ "$(wc -l <<<"$dic_src")" -ne 1 ]; then
+        echo "fetch-dictionaries: expected exactly one '$dic' under $root for $bcp47, found: ${dic_src:-none}" >&2
+        missing=$((missing + 1))
+        continue
+    fi
+
+    cp "$aff_src" "$STAGE_DICT/$aff"
+    cp "$dic_src" "$STAGE_DICT/$dic"
+
+    license_dir="$STAGE_LICENSE/$bcp47"
+    mkdir -p "$license_dir"
+    IFS=',' read -ra evidence_files <<<"$evidence_csv"
+    for raw in "${evidence_files[@]}"; do
+        # Strip parenthetical manifest notes from licence evidence paths.
+        ev="$(sed -E 's/\([^)]*\)//g' <<<"$raw" | xargs)"
+        ev_src="$root/$ev"
+        if [ ! -f "$ev_src" ]; then
+            echo "fetch-dictionaries: evidence file '$ev' not found at $ev_src for $bcp47" >&2
+            missing=$((missing + 1))
+            continue
+        fi
+        cp "$ev_src" "$license_dir/$(basename "$ev")"
+    done
+done <<<"$rows"
+
+echo "fetch-dictionaries: staged ${parsed_count} locale(s) from manifest"
+
+if [ "$missing" -gt 0 ]; then
+    echo "fetch-dictionaries: FAILED - ${missing} manifest-listed file(s) could not be staged" >&2
+    exit 1
+fi


### PR DESCRIPTION
## What changed

- Moved the `go-svc` builder to Debian Bookworm with pinned Hunspell/CGO build dependencies.
- Enabled CGO and switched the runtime from `distroless/static-debian12` to `distroless/cc-debian12`, while keeping it non-root and free of build tooling.
- Added a builder-only verification build for the HL-600 Hunspell wrapper.
- Added reproducible staging of the 20 HL-596-approved dictionaries and licence evidence from pinned, checksum-verified upstream sources.
- Application wiring is unchanged; `NoopSpellChecker` remains configured.

**Image size:** 58.2 MB → 171 MB (+~113 MB), primarily from the dictionary files.

## How to test

- `make docker-build-go-svc`
- `make fmt`
- `make lint`
- `make test`
- Verified `/health` returns `200`.
- Verified all 40 `.aff`/`.dic` files and 20 licence directories are present.
- Verified the runtime runs as `nonroot:nonroot` with no shell, package manager, compiler, `pkg-config`, or Hunspell development headers.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
