### PR TITLE
refactor(web): give sidebar nav items distinct silhouettes

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -14,7 +14,7 @@
  */
 import Link from "next/link";
 import { Fragment, useMemo, useState, type ReactNode } from "react";
-import { Add01Icon, SparklesIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, FlashIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -201,7 +201,7 @@ export function AutomationsPageView({
   return (
     <WorkspacePageShell>
       <PageHeader
-        icon={SparklesIcon}
+        icon={FlashIcon}
         label={intl.formatMessage(
           projectId
             ? automationsPageViewMessages.pageLabelProject

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -20,7 +20,7 @@ import {
   Chat01Icon,
   CheckmarkCircle02Icon,
   DashboardSquare01Icon,
-  FolderKanbanIcon,
+  CubeIcon,
   SlackIcon,
   TaskDone01Icon,
   TranslationIcon,
@@ -718,7 +718,7 @@ function DashboardProjectsPanel({
     <DashboardPanel
       title={title}
       description={description}
-      icon={FolderKanbanIcon}
+      icon={CubeIcon}
       footerHref={footerHref}
       footerLabel={intl.formatMessage(dashboardPageViewMessages.viewAllProjects)}
       isLoading={isLoading}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import type { ReactNode } from "react";
-import { ClipboardListIcon } from "@hugeicons/core-free-icons";
+import { Copy01Icon } from "@hugeicons/core-free-icons";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { IssueGroupedList } from "../../_components/issue-grouped-list";
@@ -96,7 +96,7 @@ export function IssuesPageView({
   return (
     <WorkspacePageShell>
       <PageHeader
-        icon={ClipboardListIcon}
+        icon={Copy01Icon}
         label="Workspace"
         title="Issues"
         description={intl.formatMessage(issuesPageViewMessages.pageDescription)}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -17,9 +17,8 @@ import {
   KanbanIcon,
   ListViewIcon,
   SearchIcon,
-  Task01Icon,
+  CenterFocusIcon,
   TranslateIcon,
-  WorkHistoryIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
@@ -978,7 +977,7 @@ export function JobsPageView({
     return (
       <ProjectPageShell>
         <ProjectSectionHeader
-          icon={Task01Icon}
+          icon={CenterFocusIcon}
           section={intl.formatMessage(jobsPageViewMessages.projectSectionLabel)}
           description={intl.formatMessage(jobsPageViewMessages.projectSectionDescription)}
           actions={headerActions}
@@ -991,7 +990,7 @@ export function JobsPageView({
   return (
     <WorkspacePageShell>
       <PageHeader
-        icon={isPersonalWork ? WorkHistoryIcon : Task01Icon}
+        icon={CenterFocusIcon}
         label={intl.formatMessage(jobsPageViewMessages.workspaceLabel)}
         title={
           isPersonalWork

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -12,7 +12,7 @@
  */
 "use client";
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { ClipboardListIcon, PlusSignIcon } from "@hugeicons/core-free-icons";
+import { Copy01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
@@ -176,7 +176,7 @@ export function IssueSheetPageContent({
     <ProjectPageShell>
       <div className="space-y-6">
         <ProjectSectionHeader
-          icon={ClipboardListIcon}
+          icon={Copy01Icon}
           section={intl.formatMessage(messages.sectionTitle)}
           description={intl.formatMessage(messages.sectionDescription)}
           actions={

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -14,7 +14,7 @@
  */
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Add01Icon, FolderKanbanIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, CubeIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -454,7 +454,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   return (
     <WorkspacePageShell>
       <PageHeader
-        icon={FolderKanbanIcon}
+        icon={CubeIcon}
         label={intl.formatMessage(projectsPageContentMessages.pageLabel)}
         title={intl.formatMessage(projectsPageContentMessages.pageTitle)}
         description={pageDescription}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
@@ -17,7 +17,7 @@ import {
   ArrowRight01Icon,
   Key01Icon,
   CreditCardIcon,
-  LinkSquare02Icon,
+  Globe02Icon,
   Settings01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -117,7 +117,7 @@ function buildSettingsRows(
       }),
       href: `/org/${organizationSlug}/domains`,
       absoluteHref: true,
-      icon: LinkSquare02Icon,
+      icon: Globe02Icon,
       requiredCapability: "projects:read",
       requiresDomainsFeature: true,
     },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -14,7 +14,7 @@
  */
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft01Icon, DatabaseSyncIcon } from "@hugeicons/core-free-icons";
+import { ArrowLeft01Icon, Database01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -294,7 +294,7 @@ export function TranslationMemoryDetailPageContent({
       <section className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-2">
           <HugeiconsIcon
-            icon={DatabaseSyncIcon}
+            icon={Database01Icon}
             className="size-5 text-muted-foreground"
             strokeWidth={1.8}
           />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Add01Icon, DatabaseSyncIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, Database01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -175,7 +175,7 @@ export function TranslationMemoriesPageView({
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
       <PageHeader
-        icon={DatabaseSyncIcon}
+        icon={Database01Icon}
         label={intl.formatMessage(translationMemoriesPageViewMessages.pageLabel)}
         title={intl.formatMessage(translationMemoriesPageViewMessages.pageTitle)}
         description={intl.formatMessage(translationMemoriesPageViewMessages.pageDescription)}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -16,9 +16,9 @@ import { useSyncExternalStore } from "react";
 import {
   BookOpenTextIcon,
   CheckmarkCircle02Icon,
+  Copy01Icon,
   CustomerSupportIcon,
   MinusSignCircleIcon,
-  ClipboardListIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -146,7 +146,7 @@ export function AppShellFooter({
                     : undefined,
                 )}
               >
-                <HugeiconsIcon icon={ClipboardListIcon} strokeWidth={2} className="size-3.5" />
+                <HugeiconsIcon icon={Copy01Icon} strokeWidth={2} className="size-3.5" />
                 <FormattedMessage {...appShellFooterMessages.issueGuidanceLabel} />
                 {issueGuidanceStatus.openIssueCount > 0 ? (
                   <span className="tabular-nums text-xs font-medium text-flame-900 dark:text-flame-100">

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -23,23 +23,23 @@ import {
 import { supportsCatAllFilesProvider } from "@/lib/projects/cat-all-files";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import {
-  AiBrain01Icon,
-  AiChipIcon,
   BookOpenTextIcon,
-  Chat01Icon,
-  ClipboardListIcon,
+  Bookmark01Icon,
+  CenterFocusIcon,
+  Copy01Icon,
+  CubeIcon,
   DashboardSquare01Icon,
-  DatabaseSyncIcon,
+  Database01Icon,
   File01Icon,
-  LanguageCircleIcon,
-  FolderKanbanIcon,
+  FlashIcon,
   Globe02Icon,
   InboxIcon,
-  LinkSquare02Icon,
+  LanguageCircleIcon,
+  PuzzleIcon,
+  SentIcon,
   Settings01Icon,
-  Task01Icon,
+  SparklesIcon,
   UserMultiple02Icon,
-  WorkHistoryIcon,
 } from "@hugeicons/core-free-icons";
 import type { HugeiconsIcon } from "@hugeicons/react";
 
@@ -121,7 +121,7 @@ export function buildGlobalNavigationGroups(
             description: "Sidebar navigation item for the current user’s jobs",
           }),
           href: org("my-work"),
-          icon: WorkHistoryIcon,
+          icon: CenterFocusIcon,
         },
         {
           label: intl.formatMessage({
@@ -130,7 +130,7 @@ export function buildGlobalNavigationGroups(
             description: "Sidebar navigation item for workspace issues",
           }),
           href: org("issues"),
-          icon: ClipboardListIcon,
+          icon: Copy01Icon,
         },
         {
           label: intl.formatMessage({
@@ -158,7 +158,7 @@ export function buildGlobalNavigationGroups(
           }),
           href: org("inbox/new"),
           exact: true,
-          icon: Chat01Icon,
+          icon: SentIcon,
           description: intl.formatMessage({
             defaultMessage: "Ask the localisation agent to prepare work",
             id: "z45OPLD254",
@@ -172,7 +172,7 @@ export function buildGlobalNavigationGroups(
             description: "Sidebar navigation item for workspace automations",
           }),
           href: org("automations"),
-          icon: Task01Icon,
+          icon: FlashIcon,
           description: intl.formatMessage({
             defaultMessage: "Scheduled and GitHub-triggered deterministic workflows",
             id: "TBagRGINiT",
@@ -192,7 +192,7 @@ export function buildGlobalNavigationGroups(
             description: "Sidebar navigation item for workspace AI model providers",
           }),
           href: org("ai-engine"),
-          icon: AiChipIcon,
+          icon: SparklesIcon,
           description: intl.formatMessage({
             defaultMessage: "Choose the model provider agents use",
             id: "ZnnVLUSfjR",
@@ -215,7 +215,7 @@ export function buildGlobalNavigationGroups(
             description: "Sidebar navigation item for the projects list",
           }),
           href: org("projects"),
-          icon: FolderKanbanIcon,
+          icon: CubeIcon,
         },
         {
           label: intl.formatMessage({
@@ -239,7 +239,7 @@ export function buildGlobalNavigationGroups(
             description: "Sidebar navigation item for workspace guideline",
           }),
           href: org("knowledge"),
-          icon: AiBrain01Icon,
+          icon: Bookmark01Icon,
           description: intl.formatMessage({
             defaultMessage: "Shared guidance for agents and teams",
             id: "dEzuHMWHq4",
@@ -263,7 +263,7 @@ export function buildGlobalNavigationGroups(
             description: "Sidebar navigation item for translation memories",
           }),
           href: org("translation-memories"),
-          icon: DatabaseSyncIcon,
+          icon: Database01Icon,
         },
         {
           label: intl.formatMessage({
@@ -272,7 +272,7 @@ export function buildGlobalNavigationGroups(
             description: "Sidebar navigation item for integrations",
           }),
           href: org("integrations"),
-          icon: LinkSquare02Icon,
+          icon: PuzzleIcon,
         },
         {
           label: intl.formatMessage({
@@ -319,7 +319,7 @@ export function buildProjectNavigationItems(
         description: "Project sidebar navigation item for the project overview",
       }),
       href: buildProjectPath(organizationSlug, projectId),
-      icon: FolderKanbanIcon,
+      icon: CubeIcon,
     },
     {
       label: intl.formatMessage({
@@ -353,7 +353,7 @@ export function buildProjectNavigationItems(
         description: "Project sidebar navigation item for project jobs",
       }),
       href: project("jobs"),
-      icon: Task01Icon,
+      icon: CenterFocusIcon,
     },
     {
       label: intl.formatMessage({
@@ -362,7 +362,7 @@ export function buildProjectNavigationItems(
         description: "Project sidebar navigation item for the project issue sheet",
       }),
       href: project("issue-sheet"),
-      icon: ClipboardListIcon,
+      icon: Copy01Icon,
     },
     {
       label: intl.formatMessage({
@@ -371,7 +371,7 @@ export function buildProjectNavigationItems(
         description: "Project sidebar navigation item for project automations",
       }),
       href: project("automations"),
-      icon: Task01Icon,
+      icon: FlashIcon,
       featureFlagKey: WORKSPACE_AUTOMATIONS_FLAG,
     },
     {
@@ -381,7 +381,7 @@ export function buildProjectNavigationItems(
         description: "Project sidebar navigation item for project guideline",
       }),
       href: project("knowledge"),
-      icon: AiBrain01Icon,
+      icon: Bookmark01Icon,
       description: intl.formatMessage({
         defaultMessage: "Project-specific guidance for agents and teams",
         id: "tMOiEvbyBd",

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-registry.ts
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-registry.ts
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { defineMessages, type MessageDescriptor } from "react-intl";
-import { AiBrain01Icon, Globe02Icon, Task01Icon } from "@hugeicons/core-free-icons";
+import { Bookmark01Icon, FlashIcon, Globe02Icon } from "@hugeicons/core-free-icons";
 
 import type { NavigationIcon } from "@/components/app-shell/navigation-config";
 
@@ -228,7 +228,7 @@ export const featureTeaserMessages = defineMessages({
 
 export const featureTeaserRegistry: Record<FeatureTeaserId, FeatureTeaserConfig> = {
   automations: {
-    icon: Task01Icon,
+    icon: FlashIcon,
     pageLabel: featureTeaserMessages.automationsPageLabel,
     pageLabelProject: featureTeaserMessages.automationsPageLabelProject,
     pageTitle: featureTeaserMessages.automationsTitle,
@@ -243,7 +243,7 @@ export const featureTeaserRegistry: Record<FeatureTeaserId, FeatureTeaserConfig>
     ],
   },
   guideline: {
-    icon: AiBrain01Icon,
+    icon: Bookmark01Icon,
     pageLabel: featureTeaserMessages.guidelinePageLabel,
     pageLabelProject: featureTeaserMessages.guidelinePageLabelProject,
     pageTitle: featureTeaserMessages.guidelineTitle,

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-app-shell.tsx
@@ -15,16 +15,17 @@
 import type { ReactNode } from "react";
 import Image from "next/image";
 import {
-  AiChipIcon,
   BookOpenTextIcon,
+  Bookmark01Icon,
   Chat01Icon,
   CheckmarkCircle02Icon,
-  ClipboardListIcon,
+  Copy01Icon,
   CreditCardIcon,
+  CubeIcon,
   CustomerSupportIcon,
   DashboardSquare01Icon,
   File01Icon,
-  FolderKanbanIcon,
+  FlashIcon,
   InboxIcon,
   Menu01Icon,
   MinusSignCircleIcon,
@@ -55,11 +56,11 @@ type MockNavItem = {
 
 const NAV_ITEMS: MockNavItem[] = [
   { id: "inbox", labelKey: "mockNavInbox", icon: InboxIcon },
-  { id: "issues", labelKey: "mockNavIssues", icon: ClipboardListIcon },
+  { id: "issues", labelKey: "mockNavIssues", icon: Copy01Icon },
   { id: "dashboard", labelKey: "mockNavDashboard", icon: DashboardSquare01Icon },
-  { id: "projects", labelKey: "mockNavProjects", icon: FolderKanbanIcon },
-  { id: "automations", labelKey: "mockNavAutomations", icon: AiChipIcon },
-  { id: "knowledge", labelKey: "mockNavKnowledge", icon: BookOpenTextIcon },
+  { id: "projects", labelKey: "mockNavProjects", icon: CubeIcon },
+  { id: "automations", labelKey: "mockNavAutomations", icon: FlashIcon },
+  { id: "knowledge", labelKey: "mockNavKnowledge", icon: Bookmark01Icon },
 ];
 
 const ACTIVE_NAV_BY_TAB: Record<ContentOpsMockTabId, MockNavId> = {
@@ -156,7 +157,7 @@ function MockEditorFooter() {
             tabIndex={-1}
             className="shrink-0 gap-1.5 px-2"
           >
-            <HugeiconsIcon icon={ClipboardListIcon} strokeWidth={2} className="size-3.5" />
+            <HugeiconsIcon icon={Copy01Icon} strokeWidth={2} className="size-3.5" />
             <FormattedMessage {...appShellFooterMessages.issueGuidanceLabel} />
             <span className="tabular-nums text-xs font-medium text-flame-900 dark:text-flame-100">
               {MOCK_EDITOR_OPEN_ISSUES}


### PR DESCRIPTION
## What changed

Give each sidebar item a unique silhouette so nearby entries stop looking like the same clipboard, gear, or rectangle. Issues uses overlapping cards, not a flag, so a later feature-flags item can take the flag icon. Matching page headers, teasers, and the content-ops mock follow the same set.

## How to test

- Open the workspace sidebar and confirm nearby items read as different shapes (tray, viewfinder, cards, grid, plane, bolt, sparkle, cube, globe, bookmark, book, cylinder, puzzle, people, gear).
- Open a project sidebar and confirm Jobs, Issues, Automations, Guideline, and Overview reuse those same icons.
- Spot-check Issues, Jobs, Projects, Automations, and Translation Memories page headers.
- `vp check --fix` in `apps/hyperlocalise-web` passed. Navigation unit tests passed.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; navigation tests)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)