### PR TITLE
fix(mcp): correct stateless HTTP GET lifecycle

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -17,6 +17,10 @@ import { createHash } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { OAuthProtectedResourceMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 import {
   createAuthorizationCode,
@@ -114,6 +118,34 @@ async function refreshToken(refreshToken: string) {
     },
     body,
   });
+}
+
+async function authenticatedMcpHeaders() {
+  const identity = fixture.createWorkosIdentity();
+  const headers = await fixture.authHeadersFor(identity);
+
+  const accessToken = generateMcpToken();
+  const refreshToken = generateMcpToken();
+
+  const auth = globalThis.__testApiAuthContext;
+  if (!auth) {
+    throw new Error("expected test auth context");
+  }
+
+  await db.insert(schema.mcpSessions).values({
+    userId: auth.user.localUserId,
+    organizationId: auth.organization.localOrganizationId,
+    scope: "mcp",
+    accessTokenHash: hashMcpToken(accessToken),
+    refreshTokenHash: hashMcpToken(refreshToken),
+    expiresAt: new Date(Date.now() + 60_000),
+    refreshExpiresAt: new Date(Date.now() + 120_000),
+  });
+
+  return {
+    ...headers,
+    authorization: `Bearer ${accessToken}`,
+  };
 }
 
 function setMcpAuthEnabled(value: boolean) {
@@ -686,5 +718,279 @@ describe("mcpRoutes", () => {
       error: "invalid_request",
     });
     expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
+  it.each([
+    ["canonical endpoint", "/mcp/sse"],
+    ["compatibility alias", "/mcp/message"],
+  ])("returns 405 for an authenticated GET to the $0", async (_label, endpoint) => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request(`http://localhost${endpoint}`, {
+      method: "GET",
+      headers,
+    });
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST");
+  });
+
+  it("closes the MCP server when POST handling fails", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const handleRequestSpy = vi
+      .spyOn(WebStandardStreamableHTTPServerTransport.prototype, "handleRequest")
+      .mockRejectedValueOnce(new Error("transport failure"));
+
+    const closeSpy = vi.spyOn(McpServer.prototype, "close");
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+        }),
+      });
+
+      expect(response.status).toBe(500);
+      expect(handleRequestSpy).toHaveBeenCalledOnce();
+      expect(closeSpy).toHaveBeenCalledOnce();
+    } finally {
+      handleRequestSpy.mockRestore();
+      closeSpy.mockRestore();
+    }
+  });
+
+  it("closes the MCP server after a successful JSON POST response", async () => {
+    const headers = await authenticatedMcpHeaders();
+    const closeSpy = vi.spyOn(McpServer.prototype, "close");
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("application/json");
+
+      await expect(response.json()).resolves.toMatchObject({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          tools: expect.any(Array),
+        },
+      });
+
+      expect(closeSpy).toHaveBeenCalledOnce();
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it("supports the stateless MCP POST lifecycle on the canonical endpoint", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const postMcp = (message: unknown) =>
+      app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(message),
+      });
+
+    const initializeResponse = await postMcp({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: {
+          name: "HL-608 integration test",
+          version: "1.0.0",
+        },
+      },
+    });
+
+    expect(initializeResponse.status).toBe(200);
+    await expect(initializeResponse.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        protocolVersion: "2025-11-25",
+      },
+    });
+
+    const initializedResponse = await postMcp({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    });
+
+    expect(initializedResponse.status).toBe(202);
+
+    const toolsListResponse = await postMcp({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+
+    expect(toolsListResponse.status).toBe(200);
+    await expect(toolsListResponse.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        tools: expect.any(Array),
+      },
+    });
+
+    const toolsCallResponse = await postMcp({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "list_projects",
+        arguments: {
+          limit: 1,
+        },
+      },
+    });
+
+    expect(toolsCallResponse.status).toBe(200);
+    await expect(toolsCallResponse.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: 3,
+      result: {
+        content: expect.any(Array),
+      },
+    });
+  });
+
+  it("keeps /mcp/message as a POST compatibility alias", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp/message", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        tools: expect.any(Array),
+      },
+    });
+  });
+
+  it("works with a real Streamable HTTP MCP client without GET reconnects or errors", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const requestMethods: string[] = [];
+    const transportErrors: Error[] = [];
+
+    const transport = new StreamableHTTPClientTransport(new URL("http://localhost/mcp/sse"), {
+      requestInit: {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+      },
+      fetch: async (url, init) => {
+        requestMethods.push(init?.method ?? "GET");
+        return app.request(String(url), init);
+      },
+    });
+
+    transport.onerror = (error) => {
+      transportErrors.push(error);
+    };
+
+    const client = new Client(
+      {
+        name: "HL-608 integration test",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    try {
+      await client.connect(transport);
+
+      const tools = await client.listTools();
+      expect(tools.tools.length).toBeGreaterThan(0);
+
+      const result = await client.callTool({
+        name: "list_projects",
+        arguments: {
+          limit: 1,
+        },
+      });
+
+      expect(result.content).toEqual(expect.any(Array));
+      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(4);
+      expect(requestMethods.filter((method) => method === "GET")).toHaveLength(1);
+      expect(requestMethods.every((method) => method === "POST" || method === "GET")).toBe(true);
+      expect(transportErrors).toEqual([]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("preserves MCP protocol-version validation for POST requests", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+        "mcp-protocol-version": "unsupported-version",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(400);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -479,17 +479,27 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
 }
 
 async function handleMcpTransport(request: Request, auth: McpAuthVariables["mcpAuth"]) {
+  if (request.method !== "POST") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        Allow: "POST",
+      },
+    });
+  }
+
   const server = await createMcpServerForRequest(auth);
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,
   });
 
-  await server.connect(transport);
-  const response = await transport.handleRequest(request);
-  await server.close();
-
-  return response;
+  try {
+    await server.connect(transport);
+    return await transport.handleRequest(request);
+  } finally {
+    await server.close();
+  }
 }
 
 const validateAuthorizationQuery = validator("query", (value, c) => {
@@ -515,6 +525,8 @@ const validateRegisterBody = validator("json", (value, c) => {
 export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
   const apiBasePath = options.apiBasePath ?? "/api";
 
+  // `/mcp/sse` is the canonical Streamable HTTP endpoint advertised by
+  // protected-resource metadata. `/mcp/message` remains a compatibility alias.
   return new Hono<{ Variables: McpAuthVariables }>()
     .get("/.well-known/oauth-authorization-server", (c) =>
       c.json(getMcpAuthorizationServerMetadata(endpointOrigin(c), apiBasePath), 200),


### PR DESCRIPTION
## What changed

- Return `405 Method Not Allowed` with `Allow: POST` for authenticated GET requests to stateless MCP transport endpoints.
- Keep `/mcp/sse` as the canonical Streamable HTTP endpoint.
- Keep `/mcp/message` as a compatibility alias for POST requests.
- Ensure the MCP server is closed through `try/finally` after both successful and failed request handling.
- Preserve POST initialization, notifications, tool listing, tool calls, and protocol-version validation.
- Add integration coverage using the real MCP `StreamableHTTPClientTransport`.

## How to test

```bash
vp run db:migrate
vp check
vp test
vp run build
```

Focused MCP route test:
```
vp test src/api/routes/mcp/mcp.route.test.ts
```

##Checklist
- I ran relevant checks locally (vp check, vp test, vp run build)
- I updated docs, comments, or examples when needed
- This PR is scoped and ready for review