### PR TITLE
fix(web): keep visual workflow sample out of Vercel-ignored fixtures

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.fixture.ts
@@ -10,45 +10,4 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { fromCanonicalDraft } from "@/lib/visual-workflows/mock/to-canonical-draft";
-import { VISUAL_WORKFLOW_SCHEMA_VERSION } from "@/lib/visual-workflows/mock/types";
-
-export const visualWorkflowDemoDraft = fromCanonicalDraft({
-  schemaVersion: VISUAL_WORKFLOW_SCHEMA_VERSION,
-  name: "Lead ping",
-  nodes: [
-    {
-      id: "trigger",
-      type: "trigger.manual",
-      config: { kind: "trigger.manual" },
-    },
-    {
-      id: "http",
-      type: "action.http",
-      config: { kind: "action.http", method: "GET", url: "https://example.test/leads" },
-    },
-    {
-      id: "branch",
-      type: "logic.if",
-      config: { kind: "logic.if", condition: "status == 200" },
-    },
-    {
-      id: "agent",
-      type: "ai.agent",
-      config: { kind: "ai.agent", prompt: "Summarize the lead." },
-    },
-  ],
-  edges: [
-    { id: "e1", source: "trigger", target: "http", sourceHandle: null, targetHandle: null },
-    { id: "e2", source: "http", target: "branch", sourceHandle: null, targetHandle: null },
-    { id: "e3", source: "branch", target: "agent", sourceHandle: "true", targetHandle: null },
-  ],
-  editor: {
-    positions: {
-      trigger: { x: 40, y: 160 },
-      http: { x: 300, y: 160 },
-      branch: { x: 560, y: 160 },
-      agent: { x: 820, y: 80 },
-    },
-  },
-});
+export { visualWorkflowDemoDraft } from "@/lib/visual-workflows/mock/demo-draft";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.tsx
@@ -29,6 +29,7 @@ import {
   getVisualNodeDimensions,
   isTriggerType,
 } from "@/lib/visual-workflows/mock/node-catalog";
+import { visualWorkflowDemoDraft } from "@/lib/visual-workflows/mock/demo-draft";
 import { toCanonicalDraft } from "@/lib/visual-workflows/mock/to-canonical-draft";
 import type {
   MockNodeRunStatus,
@@ -46,7 +47,6 @@ import {
 } from "./visual-workflow-canvas-actions";
 import { VisualWorkflowChrome } from "./visual-workflow-chrome";
 import { VisualWorkflowConfigPanel } from "./visual-workflow-config-panel";
-import { visualWorkflowDemoDraft } from "./visual-workflow-editor.fixture";
 import { visualWorkflowEditorMessages as messages } from "./visual-workflow-editor.messages";
 import { VisualWorkflowNodePicker } from "./visual-workflow-node-picker";
 

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/mock/demo-draft.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/mock/demo-draft.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { fromCanonicalDraft } from "./to-canonical-draft";
+import { VISUAL_WORKFLOW_SCHEMA_VERSION } from "./types";
+
+export const visualWorkflowDemoDraft = fromCanonicalDraft({
+  schemaVersion: VISUAL_WORKFLOW_SCHEMA_VERSION,
+  name: "Lead ping",
+  nodes: [
+    {
+      id: "trigger",
+      type: "trigger.manual",
+      config: { kind: "trigger.manual" },
+    },
+    {
+      id: "http",
+      type: "action.http",
+      config: { kind: "action.http", method: "GET", url: "https://example.test/leads" },
+    },
+    {
+      id: "branch",
+      type: "logic.if",
+      config: { kind: "logic.if", condition: "status == 200" },
+    },
+    {
+      id: "agent",
+      type: "ai.agent",
+      config: { kind: "ai.agent", prompt: "Summarize the lead." },
+    },
+  ],
+  edges: [
+    { id: "e1", source: "trigger", target: "http", sourceHandle: null, targetHandle: null },
+    { id: "e2", source: "http", target: "branch", sourceHandle: null, targetHandle: null },
+    { id: "e3", source: "branch", target: "agent", sourceHandle: "true", targetHandle: null },
+  ],
+  editor: {
+    positions: {
+      trigger: { x: 40, y: 160 },
+      http: { x: 300, y: 160 },
+      branch: { x: 560, y: 160 },
+      agent: { x: 820, y: 80 },
+    },
+  },
+});

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/mock/visual-workflow-mock.test.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/mock/visual-workflow-mock.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
+import { visualWorkflowDemoDraft } from "./demo-draft";
 import { createDefaultConfig } from "./node-catalog";
 import { fromCanonicalDraft, toCanonicalDraft } from "./to-canonical-draft";
 import { validateMockWorkflow } from "./validate-mock-workflow";
@@ -89,6 +90,13 @@ describe("validateMockWorkflow", () => {
       [],
     );
     expect(issues.map((issue) => issue.code)).toEqual(["multiple_triggers", "orphan_node"]);
+  });
+
+  it("accepts the shipped sample graph", () => {
+    expect(
+      validateMockWorkflow(visualWorkflowDemoDraft.nodes, visualWorkflowDemoDraft.edges),
+    ).toEqual([]);
+    expect(visualWorkflowDemoDraft.name).toBe("Lead ping");
   });
 
   it("accepts a connected trigger to http graph", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`.vercelignore` excludes `*.fixture.ts`, so `next build` on Vercel cannot resolve the sample graph the visual workflow editor imported from `visual-workflow-editor.fixture`.

The sample now lives in `src/lib/visual-workflows/mock/demo-draft.ts`. The editor imports that module. The fixture re-exports it for Storybook.

## How to test

- [x] `cd apps/hyperlocalise-web && vp test src/lib/visual-workflows/mock/visual-workflow-mock.test.ts` (9/9)
- [x] `cd apps/hyperlocalise-web && vp check --fix` on the files in this PR
- [x] `tsc --noEmit` with `.vercelignore` globs excluded — no `TS2307` / `TS2589`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test` on the mock module)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0450e-2365-7e27-846c-7fd1dbf622b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0450e-2365-7e27-846c-7fd1dbf622b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

