### PR TITLE
fix(crowdin): add GlossaryIDs parity to GlossaryConcordanceSearchRequest

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-31 - Add GlossaryIDs parity to GlossaryConcordanceSearchRequest
+
+**Learning:** In Crowdin API v2, Glossary Concordance Search (`POST /api/v2/projects/{projectId}/glossaries/concordance`) accepts an optional `glossaryIds` array in the request body to filter concordance search across specific glossaries. The SDK's `GlossaryConcordanceSearchRequest` previously lacked `GlossaryIDs`, preventing callers from restricting glossary concordance search to selected glossaries.
+
+**Action:** Added `GlossaryIDs []int json:"glossaryIds,omitempty"` to `GlossaryConcordanceSearchRequest` in `third_party/crowdin-api-client-go/crowdin/model/glossaries.go`. Added unit test assertions in `third_party/crowdin-api-client-go/crowdin/model/glossaries_test.go` and `third_party/crowdin-api-client-go/crowdin/glossaries_test.go`.
+
 ## 2026-12-31 - Add IsHidden query filter parity to SourceStringsListOptions
 
 **Learning:** In Crowdin API v2, the List Source Strings endpoint (`GET /api/v2/projects/{projectId}/strings`) accepts an optional `isHidden` query parameter (0 - not hidden, 1 - hidden) to filter source strings by their hidden status. The SDK's `SourceStringsListOptions` previously lacked `IsHidden`, preventing callers from filtering source strings by hidden status in list requests.

--- a/third_party/crowdin-api-client-go/crowdin/glossaries_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/glossaries_test.go
@@ -852,7 +852,7 @@ func TestGlossariesService_ConcordanceSearch(t *testing.T) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, path)
-		testBody(t, r, `{"sourceLanguageId":"en","targetLanguageId":"de","expressions":["Welcome!","Save as...","View","About..."]}`+"\n")
+		testBody(t, r, `{"sourceLanguageId":"en","targetLanguageId":"de","expressions":["Welcome!","Save as...","View","About..."],"glossaryIds":[2,6]}`+"\n")
 
 		fmt.Fprint(w, `{
 			"data": [
@@ -930,6 +930,7 @@ func TestGlossariesService_ConcordanceSearch(t *testing.T) {
 			"View",
 			"About...",
 		},
+		GlossaryIDs: []int{2, 6},
 	}
 	searches, resp, err := client.Glossaries.ConcordanceSearch(context.Background(), 1, req)
 	require.NoError(t, err)

--- a/third_party/crowdin-api-client-go/crowdin/model/glossaries.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/glossaries.go
@@ -367,6 +367,8 @@ type GlossaryConcordanceSearchRequest struct {
 	TargetLanguageID string `json:"targetLanguageId"`
 	// Expressions to search.
 	Expressions []string `json:"expressions"`
+	// Glossary Identifiers.
+	GlossaryIDs []int `json:"glossaryIds,omitempty"`
 }
 
 // Validate checks if the request is valid.

--- a/third_party/crowdin-api-client-go/crowdin/model/glossaries_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/glossaries_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -320,6 +321,27 @@ func TestGlossaryImportRequestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGlossaryConcordanceSearchRequest_JSON(t *testing.T) {
+	req := &GlossaryConcordanceSearchRequest{
+		SourceLanguageID: "en",
+		TargetLanguageID: "de",
+		Expressions:      []string{"Welcome!"},
+		GlossaryIDs:      []int{1, 2},
+	}
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"sourceLanguageId":"en","targetLanguageId":"de","expressions":["Welcome!"],"glossaryIds":[1,2]}`, string(data))
+
+	reqOmit := &GlossaryConcordanceSearchRequest{
+		SourceLanguageID: "en",
+		TargetLanguageID: "de",
+		Expressions:      []string{"Welcome!"},
+	}
+	dataOmit, err := json.Marshal(reqOmit)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"sourceLanguageId":"en","targetLanguageId":"de","expressions":["Welcome!"]}`, string(dataOmit))
 }
 
 func TestGlossaryConcordanceSearchRequestValidate(t *testing.T) {


### PR DESCRIPTION
### What
Updated `GlossaryConcordanceSearchRequest` in `third_party/crowdin-api-client-go/crowdin/model/glossaries.go` to include `GlossaryIDs []int json:"glossaryIds,omitempty"`.

### Why
In Crowdin API v2, Glossary Concordance Search (`POST /api/v2/projects/{projectId}/glossaries/concordance`) supports filtering concordance search across specific glossaries by passing `glossaryIds`. `GlossaryConcordanceSearchRequest` previously omitted this parameter, preventing callers from filtering concordance search results by glossary IDs.

### Docs
https://developer.crowdin.com/api/v2/#operation/api.projects.glossaries.concordance.post

### Scope
- `third_party/crowdin-api-client-go/crowdin/model/glossaries.go`
- `third_party/crowdin-api-client-go/crowdin/model/glossaries_test.go`
- `third_party/crowdin-api-client-go/crowdin/glossaries_test.go`
- `.jules/crowdin-steward.md`

### Tests
Ran `go test ./...` in `third_party/crowdin-api-client-go` and `make fmt && make test` from repo root.

### Confidence
High confidence. Added `GlossaryIDs` with `omitempty` JSON tag ensuring complete backward compatibility while restoring API parity with official Crowdin API v2 specifications.

---
*PR created automatically by Jules for task [9037320394020903020](https://jules.google.com/task/9037320394020903020) started by @cungminh2710*