### PR TITLE
fix(agent-runtime): confine applyPatch and writeFile against symlink escapes

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/apply-patch.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/apply-patch.ts
@@ -45,14 +45,72 @@ const GIT_INDEX_MODE = new RegExp(
   "i",
 );
 
+const SPECIAL_GIT_PATH_ERROR = "Patch must not create or modify symbolic links or git submodules.";
+
 /** Reject git symlink (120000) and submodule/gitlink (160000) modes before `git apply`. */
 export function disallowedGitFileModeError(patch: string): string | undefined {
   for (const rawLine of patch.split("\n")) {
     const line = rawLine.replace(/\r$/, "");
     if (GIT_MODE_HEADER.test(line) || GIT_INDEX_MODE.test(line)) {
-      return "Patch must not create or modify symbolic links or git submodules.";
+      return SPECIAL_GIT_PATH_ERROR;
     }
   }
+  return undefined;
+}
+
+function lineHasDisallowedGitMode(line: string): boolean {
+  const mode = line.trim().split(/\s+/)[0];
+  return mode === "120000" || mode === "160000";
+}
+
+function gitOutputHasDisallowedMode(stdout: string): boolean {
+  return stdout.split("\n").some((line) => lineHasDisallowedGitMode(line));
+}
+
+function targetAndParents(path: string): string[] {
+  const prefixes: string[] = [];
+  let current = "";
+  for (const segment of path.split("/")) {
+    if (!segment || segment === ".") {
+      continue;
+    }
+    current = current ? `${current}/${segment}` : segment;
+    prefixes.push(current);
+  }
+  return prefixes;
+}
+
+/**
+ * Reject patches whose targets are already a symlink or gitlink in the
+ * index, HEAD tree, or worktree. A hunk can retarget an existing symlink
+ * without emitting mode/index headers.
+ */
+export async function existingSpecialGitPathError(
+  repo: RepoToolContext,
+  paths: string[],
+): Promise<string | undefined> {
+  const staged = await repo.bash.exec("git", {
+    args: ["ls-files", "--stage", "--", ...paths],
+  });
+  if (staged.exitCode === 0 && gitOutputHasDisallowedMode(staged.stdout)) {
+    return SPECIAL_GIT_PATH_ERROR;
+  }
+
+  const tree = await repo.bash.exec("git", {
+    args: ["ls-tree", "HEAD", "--", ...paths],
+  });
+  if (tree.exitCode === 0 && gitOutputHasDisallowedMode(tree.stdout)) {
+    return SPECIAL_GIT_PATH_ERROR;
+  }
+
+  const candidates = [...new Set(paths.flatMap(targetAndParents))];
+  for (const candidate of candidates) {
+    const link = await repo.bash.exec("test", { args: ["-L", candidate] });
+    if (link.exitCode === 0) {
+      return SPECIAL_GIT_PATH_ERROR;
+    }
+  }
+
   return undefined;
 }
 
@@ -91,7 +149,7 @@ WHEN NOT TO USE:
 
 IMPORTANT:
 - The patch is validated with git apply --check before it is applied
-- Symbolic links and git submodules (modes 120000 and 160000) are rejected
+- Symbolic links and git submodules (modes 120000 and 160000) are rejected, including existing checkout targets
 - This is a repository write action and may be denied by workspace policy`,
     inputSchema: applyPatchInputSchema,
     execute: async ({ patch }) => {
@@ -121,6 +179,11 @@ IMPORTANT:
       }
       if (paths.length === 0) {
         return { success: false as const, error: "Patch does not contain any file paths." };
+      }
+
+      const existingModeError = await existingSpecialGitPathError(repo, paths);
+      if (existingModeError) {
+        return { success: false as const, error: existingModeError, changedPaths: paths };
       }
 
       const patchPath = `.hyperlocalise-agent/patches/${crypto.randomUUID()}.diff`;

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/apply-patch.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/apply-patch.ts
@@ -36,6 +36,26 @@ function parsePatchPath(value: string) {
   return normalizeWorkspacePath(stripDiffPathPrefix(path));
 }
 
+const DISALLOWED_GIT_FILE_MODE = "120000|160000";
+const GIT_MODE_HEADER = new RegExp(
+  `^(?:old mode|new mode|new file mode|deleted file mode)\\s+0*(?:${DISALLOWED_GIT_FILE_MODE})\\s*$`,
+);
+const GIT_INDEX_MODE = new RegExp(
+  `^index\\s+[0-9a-f]+\\.\\.[0-9a-f]+\\s+0*(?:${DISALLOWED_GIT_FILE_MODE})\\s*$`,
+  "i",
+);
+
+/** Reject git symlink (120000) and submodule/gitlink (160000) modes before `git apply`. */
+export function disallowedGitFileModeError(patch: string): string | undefined {
+  for (const rawLine of patch.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    if (GIT_MODE_HEADER.test(line) || GIT_INDEX_MODE.test(line)) {
+      return "Patch must not create or modify symbolic links or git submodules.";
+    }
+  }
+  return undefined;
+}
+
 function extractPatchPaths(patch: string): { paths: string[]; error?: string } {
   const paths = new Set<string>();
 
@@ -71,6 +91,7 @@ WHEN NOT TO USE:
 
 IMPORTANT:
 - The patch is validated with git apply --check before it is applied
+- Symbolic links and git submodules (modes 120000 and 160000) are rejected
 - This is a repository write action and may be denied by workspace policy`,
     inputSchema: applyPatchInputSchema,
     execute: async ({ patch }) => {
@@ -87,6 +108,11 @@ IMPORTANT:
 
       if (!patch.trim()) {
         return { success: false as const, error: "Patch is empty." };
+      }
+
+      const modeError = disallowedGitFileModeError(patch);
+      if (modeError) {
+        return { success: false as const, error: modeError };
       }
 
       const { paths, error } = extractPatchPaths(patch);

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
-import { createApplyPatchTool } from "./apply-patch";
+import { createApplyPatchTool, disallowedGitFileModeError } from "./apply-patch";
 import { createWriteTool } from "./write";
 import type { RepoToolContext } from "./types";
 
@@ -153,5 +153,82 @@ describe("createApplyPatchTool", () => {
       error: "Patch contains a path outside the workspace.",
     });
     expect(writeWorkspaceFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects git symlink and submodule file modes before writing the patch", async () => {
+    const { exec, repo, writeWorkspaceFile } = createRepoContext();
+    const applyPatch = createApplyPatchTool(createWriteContext(), repo);
+    const symlinkPatch = [
+      "diff --git a/playwright b/playwright",
+      "new file mode 120000",
+      "index 0000000..2aae6c3",
+      "--- /dev/null",
+      "+++ b/playwright",
+      "@@ -0,0 +1 @@",
+      "+/tmp/hyperlocalise-browser-runtime/node_modules/playwright",
+      "",
+    ].join("\n");
+
+    const result = await applyPatch.execute!({ patch: symlinkPatch }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Patch must not create or modify symbolic links or git submodules.",
+    });
+    expect(writeWorkspaceFile).not.toHaveBeenCalled();
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("rejects index-line symlink modes and submodule gitlinks", () => {
+    expect(
+      disallowedGitFileModeError(
+        [
+          "diff --git a/link b/link",
+          "index 1111111..2222222 120000",
+          "--- a/link",
+          "+++ b/link",
+          "@@ -1 +1 @@",
+          "-/old",
+          "+/tmp/hyperlocalise-browser-runtime",
+          "",
+        ].join("\n"),
+      ),
+    ).toBe("Patch must not create or modify symbolic links or git submodules.");
+
+    expect(
+      disallowedGitFileModeError(
+        [
+          "diff --git a/vendor/lib b/vendor/lib",
+          "new file mode 160000",
+          "index 0000000..abcdef1",
+          "--- /dev/null",
+          "+++ b/vendor/lib",
+          "@@ -0,0 +1 @@",
+          "+Subproject commit abcdef1",
+          "",
+        ].join("\n"),
+      ),
+    ).toBe("Patch must not create or modify symbolic links or git submodules.");
+
+    expect(
+      disallowedGitFileModeError(
+        ["old mode 100644", "new mode 120000", "--- a/src/app.tsx", "+++ b/src/app.tsx"].join("\n"),
+      ),
+    ).toBe("Patch must not create or modify symbolic links or git submodules.");
+  });
+
+  it("does not treat file content that mentions git modes as a symlink patch", () => {
+    const patch = [
+      "diff --git a/README.md b/README.md",
+      "index 1111111..2222222 100644",
+      "--- a/README.md",
+      "+++ b/README.md",
+      "@@ -1 +1,2 @@",
+      " docs",
+      "+new file mode 120000",
+      "",
+    ].join("\n");
+
+    expect(disallowedGitFileModeError(patch)).toBeUndefined();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.test.ts
@@ -37,7 +37,13 @@ function createWriteContext(overrides: Partial<ToolContext> = {}): ToolContext {
 }
 
 function createRepoContext(overrides: Partial<RepoToolContext["bash"]> = {}) {
-  const exec = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "", env: {} }));
+  const exec = vi.fn(async (command: string, options?: { args?: string[] }) => {
+    const args = options?.args ?? [];
+    if (command === "test" && args[0] === "-L") {
+      return { exitCode: 1, stdout: "", stderr: "", env: {} };
+    }
+    return { exitCode: 0, stdout: "", stderr: "", env: {} };
+  });
   const readFile = vi.fn(async () => "");
   const writeWorkspaceFile = vi.fn(async () => undefined);
   const repo: RepoToolContext = {
@@ -114,17 +120,25 @@ describe("createApplyPatchTool", () => {
       expect.stringMatching(/^\.hyperlocalise-agent\/patches\/.+\.diff$/),
       patch,
     );
-    expect(exec).toHaveBeenNthCalledWith(1, "git", {
+    expect(exec).toHaveBeenCalledWith("git", {
+      args: ["ls-files", "--stage", "--", "src/mock.tsx"],
+    });
+    expect(exec).toHaveBeenCalledWith("git", {
+      args: ["ls-tree", "HEAD", "--", "src/mock.tsx"],
+    });
+    expect(exec).toHaveBeenCalledWith("test", { args: ["-L", "src"] });
+    expect(exec).toHaveBeenCalledWith("test", { args: ["-L", "src/mock.tsx"] });
+    expect(exec).toHaveBeenCalledWith("git", {
       args: [
         "apply",
         "--check",
         expect.stringMatching(/^\.hyperlocalise-agent\/patches\/.+\.diff$/),
       ],
     });
-    expect(exec).toHaveBeenNthCalledWith(2, "git", {
+    expect(exec).toHaveBeenCalledWith("git", {
       args: ["apply", expect.stringMatching(/^\.hyperlocalise-agent\/patches\/.+\.diff$/)],
     });
-    expect(exec).toHaveBeenNthCalledWith(3, "rm", {
+    expect(exec).toHaveBeenCalledWith("rm", {
       args: ["-f", expect.stringMatching(/^\.hyperlocalise-agent\/patches\/.+\.diff$/)],
     });
   });
@@ -230,5 +244,83 @@ describe("createApplyPatchTool", () => {
     ].join("\n");
 
     expect(disallowedGitFileModeError(patch)).toBeUndefined();
+  });
+
+  it("rejects a headerless hunk that retargets an existing index symlink", async () => {
+    const { exec, repo, writeWorkspaceFile } = createRepoContext();
+    exec.mockImplementation(async (command: string, options?: { args?: string[] }) => {
+      const args = options?.args ?? [];
+      if (command === "git" && args[0] === "ls-files") {
+        return {
+          exitCode: 0,
+          stdout: "120000 2aae6c35c94fcfb415dbe95f408b9ce442564d5a 0\tplaywright\n",
+          stderr: "",
+          env: {},
+        };
+      }
+      if (command === "test" && args[0] === "-L") {
+        return { exitCode: 1, stdout: "", stderr: "", env: {} };
+      }
+      return { exitCode: 0, stdout: "", stderr: "", env: {} };
+    });
+    const applyPatch = createApplyPatchTool(createWriteContext(), repo);
+    const patch = [
+      "diff --git a/playwright b/playwright",
+      "--- a/playwright",
+      "+++ b/playwright",
+      "@@ -1 +1 @@",
+      "-old",
+      "+/tmp/hyperlocalise-browser-runtime",
+      "",
+    ].join("\n");
+
+    const result = await applyPatch.execute!({ patch }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Patch must not create or modify symbolic links or git submodules.",
+      changedPaths: ["playwright"],
+    });
+    expect(writeWorkspaceFile).not.toHaveBeenCalled();
+    expect(exec).not.toHaveBeenCalledWith(
+      "git",
+      expect.objectContaining({ args: expect.arrayContaining(["apply"]) }),
+    );
+  });
+
+  it("rejects a headerless hunk that retargets a worktree symlink missing from the index", async () => {
+    const { exec, repo, writeWorkspaceFile } = createRepoContext();
+    exec.mockImplementation(async (command: string, options?: { args?: string[] }) => {
+      const args = options?.args ?? [];
+      if (command === "test" && args[0] === "-L" && args[1] === "playwright") {
+        return { exitCode: 0, stdout: "", stderr: "", env: {} };
+      }
+      if (command === "test" && args[0] === "-L") {
+        return { exitCode: 1, stdout: "", stderr: "", env: {} };
+      }
+      return { exitCode: 0, stdout: "", stderr: "", env: {} };
+    });
+    const applyPatch = createApplyPatchTool(createWriteContext(), repo);
+    const patch = [
+      "diff --git a/playwright b/playwright",
+      "--- a/playwright",
+      "+++ b/playwright",
+      "@@ -1 +1 @@",
+      "-old",
+      "+../../outside",
+      "",
+    ].join("\n");
+
+    const result = await applyPatch.execute!({ patch }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Patch must not create or modify symbolic links or git submodules.",
+    });
+    expect(writeWorkspaceFile).not.toHaveBeenCalled();
+    expect(exec).not.toHaveBeenCalledWith(
+      "git",
+      expect.objectContaining({ args: expect.arrayContaining(["apply"]) }),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
@@ -10,7 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const sandboxMocks = vi.hoisted(() => {
   const get = vi.fn();
@@ -25,8 +31,40 @@ vi.mock("@vercel/sandbox", () => ({
   },
 }));
 
-import { VercelSandboxCommandError, VercelSandboxRuntime } from "./vercel-sandbox-runtime";
+import {
+  buildSandboxWriteFileScript,
+  SANDBOX_WRITE_OUTSIDE_WORKSPACE,
+  SANDBOX_WRITE_SYMLINK_DENIED,
+  VercelSandboxCommandError,
+  VercelSandboxRuntime,
+} from "./vercel-sandbox-runtime";
 import { serializeErrorForLog } from "@/lib/serialize-error-for-log";
+
+const execFileAsync = promisify(execFile);
+const tempRoots: string[] = [];
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "sandbox-write-guard-"));
+  tempRoots.push(root);
+  return root;
+}
+
+async function runWriteGuard(cwd: string, path: string, content: string) {
+  const script = buildSandboxWriteFileScript(path, Buffer.from(content).toString("base64"));
+  try {
+    await execFileAsync("bash", ["-c", script], { cwd });
+    return { exitCode: 0 };
+  } catch (error) {
+    const failed = error as { code?: number | string; status?: number };
+    if (typeof failed.status === "number") {
+      return { exitCode: failed.status };
+    }
+    if (typeof failed.code === "number") {
+      return { exitCode: failed.code };
+    }
+    return { exitCode: 1 };
+  }
+}
 
 describe("VercelSandboxRuntime", () => {
   beforeEach(() => {
@@ -110,5 +148,101 @@ describe("VercelSandboxRuntime", () => {
       "bash",
       expect.arrayContaining(["-lc", expect.stringContaining(`printf '%s' "$resolved"`)]),
     );
+  });
+
+  it("maps symlink and outside-workspace write denials from the sandbox guard", async () => {
+    sandboxMocks.runCommand
+      .mockResolvedValueOnce({
+        exitCode: SANDBOX_WRITE_SYMLINK_DENIED,
+        output: async () => "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: SANDBOX_WRITE_OUTSIDE_WORKSPACE,
+        output: async () => "",
+      });
+    sandboxMocks.get
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      })
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      });
+
+    const runtime = new VercelSandboxRuntime("sbx_123");
+    await expect(runtime.writeFile("playwright", "pwned")).rejects.toThrow(
+      "Symlink writes are not allowed.",
+    );
+    await expect(runtime.writeFile("../outside.txt", "pwned")).rejects.toThrow(
+      "Path resolves outside the workspace.",
+    );
+    expect(sandboxMocks.runCommand).toHaveBeenCalledWith(
+      "bash",
+      expect.arrayContaining(["-lc", expect.stringContaining("realpath -m")]),
+    );
+  });
+});
+
+describe("buildSandboxWriteFileScript", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+    );
+  });
+
+  it("writes a new file inside the workspace root", async () => {
+    const root = await createWorkspaceRoot();
+    await mkdir(join(root, "src"), { recursive: true });
+
+    await expect(runWriteGuard(root, "src/mock.tsx", "export const value = 1;\n")).resolves.toEqual(
+      {
+        exitCode: 0,
+      },
+    );
+    await expect(readFile(join(root, "src/mock.tsx"), "utf8")).resolves.toBe(
+      "export const value = 1;\n",
+    );
+  });
+
+  it("refuses to follow a planted leaf symlink out of the workspace", async () => {
+    const root = await createWorkspaceRoot();
+    const outsideDir = await mkdtemp(join(tmpdir(), "sandbox-write-outside-"));
+    tempRoots.push(outsideDir);
+    const outsideFile = join(outsideDir, "playwright.js");
+    await writeFile(outsideFile, "original");
+    await symlink(outsideFile, join(root, "playwright"));
+
+    await expect(runWriteGuard(root, "playwright", "pwned")).resolves.toEqual({
+      exitCode: SANDBOX_WRITE_SYMLINK_DENIED,
+    });
+    await expect(readFile(outsideFile, "utf8")).resolves.toBe("original");
+  });
+
+  it("refuses to follow a parent-directory symlink out of the workspace", async () => {
+    const root = await createWorkspaceRoot();
+    const outsideDir = await mkdtemp(join(tmpdir(), "hyperlocalise-browser-runtime-"));
+    tempRoots.push(outsideDir);
+    await mkdir(join(outsideDir, "node_modules", "playwright"), { recursive: true });
+    await writeFile(join(outsideDir, "node_modules", "playwright", "index.js"), "original");
+    await symlink(outsideDir, join(root, "runtime"));
+
+    await expect(
+      runWriteGuard(root, "runtime/node_modules/playwright/index.js", "pwned"),
+    ).resolves.toEqual({
+      exitCode: SANDBOX_WRITE_OUTSIDE_WORKSPACE,
+    });
+    await expect(
+      readFile(join(outsideDir, "node_modules", "playwright", "index.js"), "utf8"),
+    ).resolves.toBe("original");
+  });
+
+  it("rejects path traversal even when no symlink is present", async () => {
+    const root = await createWorkspaceRoot();
+    const escapeName = `sandbox-write-escape-${Date.now()}.txt`;
+    const outsideFile = join(root, "..", escapeName);
+
+    await expect(runWriteGuard(root, `../${escapeName}`, "pwned")).resolves.toEqual({
+      exitCode: SANDBOX_WRITE_OUTSIDE_WORKSPACE,
+    });
+    await rm(outsideFile, { force: true });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts
@@ -133,8 +133,68 @@ function extractVercelSandboxErrorDetails(error: unknown) {
   };
 }
 
+export const SANDBOX_WRITE_SYMLINK_DENIED = 42;
+export const SANDBOX_WRITE_PATH_INVALID = 43;
+export const SANDBOX_WRITE_OUTSIDE_WORKSPACE = 44;
+export const SANDBOX_WRITE_ROOT_UNAVAILABLE = 45;
+
 function shellQuote(value: string) {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * Write only after the destination canonicalizes inside `pwd -P`.
+ * Rejects leaf or parent-path symlinks so planted or applyPatch-created
+ * links cannot escape the workspace.
+ */
+export function buildSandboxWriteFileScript(path: string, base64Content: string): string {
+  return [
+    "set -euo pipefail",
+    `target=${shellQuote(path)}`,
+    `encoded=${shellQuote(base64Content)}`,
+    "root=$(pwd -P)",
+    `if [ -z "$root" ]; then exit ${SANDBOX_WRITE_ROOT_UNAVAILABLE}; fi`,
+    `if [ -z "$target" ]; then exit ${SANDBOX_WRITE_PATH_INVALID}; fi`,
+    `if [ -L "$target" ]; then exit ${SANDBOX_WRITE_SYMLINK_DENIED}; fi`,
+    'case "$target" in',
+    "  /*) dest=$target ;;",
+    "  *) dest=$root/$target ;;",
+    "esac",
+    `if ! command -v realpath >/dev/null 2>&1; then exit ${SANDBOX_WRITE_ROOT_UNAVAILABLE}; fi`,
+    'resolved=$(realpath -m -- "$dest")',
+    'case "$resolved" in',
+    `  "$root"|"$root"/*) ;;`,
+    `  *) exit ${SANDBOX_WRITE_OUTSIDE_WORKSPACE} ;;`,
+    "esac",
+    "remaining=$target",
+    "current=.",
+    // Relative paths only: walk each component and refuse any symlink.
+    'if [ "${target#/}" = "$target" ]; then',
+    '  while [ -n "$remaining" ]; do',
+    '    case "$remaining" in',
+    "      */*)",
+    "        component=${remaining%%/*}",
+    "        remaining=${remaining#*/}",
+    "        ;;",
+    "      *)",
+    "        component=$remaining",
+    "        remaining=",
+    "        ;;",
+    "    esac",
+    '    [ -n "$component" ] || continue',
+    '    [ "$component" = "." ] && continue',
+    `    if [ "$component" = ".." ]; then exit ${SANDBOX_WRITE_OUTSIDE_WORKSPACE}; fi`,
+    '    if [ "$current" = "." ]; then',
+    "      current=$component",
+    "    else",
+    "      current=$current/$component",
+    "    fi",
+    `    if [ -L "$current" ]; then exit ${SANDBOX_WRITE_SYMLINK_DENIED}; fi`,
+    "  done",
+    "fi",
+    'mkdir -p -- "$(dirname -- "$resolved")"',
+    'printf %s "$encoded" | base64 -d > "$resolved"',
+  ].join("\n");
 }
 
 export class VercelSandboxRuntime implements WorkspaceRuntime {
@@ -205,8 +265,14 @@ export class VercelSandboxRuntime implements WorkspaceRuntime {
     const encoded = Buffer.from(content).toString("base64");
     const result = await this.runCommand("bash", [
       "-lc",
-      `mkdir -p "$(dirname ${shellQuote(path)})" && printf %s ${shellQuote(encoded)} | base64 -d > ${shellQuote(path)}`,
+      buildSandboxWriteFileScript(path, encoded),
     ]);
+    if (result.exitCode === SANDBOX_WRITE_SYMLINK_DENIED) {
+      throw new Error("Symlink writes are not allowed.");
+    }
+    if (result.exitCode === SANDBOX_WRITE_OUTSIDE_WORKSPACE) {
+      throw new Error("Path resolves outside the workspace.");
+    }
     if (result.exitCode !== 0) {
       throw new Error(result.output || `Failed to write ${path}`);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`applyPatch` can create a git symlink (`new file mode 120000`) inside the sandbox. `writeFile` then followed that link with an unguarded `>` redirect, so a write-mode agent could plant files outside the workspace (for example under `/tmp/hyperlocalise-browser-runtime`) and later reach allowlist-bypassing RCE via `captureScreenshot`.

This change:

- Rejects git symlink (`120000`) and submodule/gitlink (`160000`) modes in `applyPatch` before the patch is written or passed to `git apply`.
- Inspects each parsed target in the git index, `HEAD` tree, and worktree so a headerless hunk cannot retarget an existing checkout symlink (for example `old` → `../../outside`).
- Allowlists `writeFile` destinations under the sandbox workspace root (`pwd -P` + `realpath -m`) and refuses leaf or parent-path symlinks, so neither planted repo links nor patch-created links escape.

## How to test

```
cd apps/hyperlocalise-web
vp test src/lib/agent-runtime/tools/workspace/write.test.ts src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
vp check --fix src/lib/agent-runtime/tools/workspace/apply-patch.ts src/lib/agent-runtime/tools/workspace/write.test.ts src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
```

Verified locally:

- 9 `write.test.ts` cases passed, including headerless retargets of index and worktree symlinks.
- 14 earlier targeted tests passed, including live bash runs of the write guard against planted leaf and parent-directory symlinks.
- `vp check --fix` passed on the touched files.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; targeted `vp test` for the changed agent-runtime files)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-568e748b-c3f6-4377-86d6-8ac476a14d79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-568e748b-c3f6-4377-86d6-8ac476a14d79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

