### PR TITLE
refactor(cat): infer Hono client JSON types

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-editor-issues-section.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-editor-issues-section.tsx
@@ -14,6 +14,7 @@
  */
 import { useEffect, useEffectEvent, useMemo, useState, type ReactNode } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { InferResponseType } from "hono/client";
 import { useRouter } from "next/navigation";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Cancel01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
@@ -40,17 +41,10 @@ import {
 } from "./cat-issue-guidance-event";
 import { catEditorIssuesSectionMessages as messages } from "./cat-editor-issues-section.messages";
 
-type IssueSheetListIssue = {
-  id: string;
-  identifier: string;
-  title: string;
-  status: string;
-  targetLocale: string | null;
-  assignee: string | null;
-  assigneeUserId: string | null;
-  updatedAt: string;
-  values?: Record<string, unknown>;
-};
+type CatIssueSheetListResponse = InferResponseType<
+  (typeof apiClient.api.orgs)[":organizationSlug"]["projects"][":projectId"]["issue-sheet"]["$get"],
+  200
+>;
 
 /** Maximum accepted by the issue sheet list endpoint. */
 const SEGMENT_ISSUE_PAGE_SIZE = 100;
@@ -155,7 +149,7 @@ export function CatEditorIssuesSection({
     // the segment's filtered `total` is covered rather than showing a truncated
     // first page as if it were everything.
     queryFn: async () => {
-      const issues: IssueSheetListIssue[] = [];
+      const issues: CatIssueSheetListResponse["issues"] = [];
 
       for (let page = 0; page < SEGMENT_ISSUE_MAX_PAGES; page += 1) {
         const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][

--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issues-dialog-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issues-dialog-msw-handlers.ts
@@ -13,12 +13,31 @@
 import { delay, http, HttpResponse } from "msw";
 
 import {
+  issueSheetCreateIssueBodySchema,
+  issueSheetUpdateIssueBodySchema,
+} from "@/api/routes/project/issue-sheet.schema";
+
+import {
   catLinkableIssuesFixture,
   catLinkedIssuesAssignableMembersFixture,
   catLinkedIssuesListFixture,
   catLinkedIssuesTranslationKeyId,
   type CatLinkedIssueListItemFixture,
 } from "./cat-linked-issues-dialog.fixture";
+
+async function readIssueSheetPatchBody(request: Request) {
+  const parsed = issueSheetUpdateIssueBodySchema.safeParse(
+    await request.json().catch(() => undefined),
+  );
+  return parsed.success ? parsed.data : undefined;
+}
+
+async function readIssueSheetCreateBody(request: Request) {
+  const parsed = issueSheetCreateIssueBodySchema.safeParse(
+    await request.json().catch(() => undefined),
+  );
+  return parsed.success ? parsed.data : undefined;
+}
 
 const issueSheetBasePath = "/api/orgs/:organizationSlug/projects/:projectId/issue-sheet";
 
@@ -70,7 +89,7 @@ export const catLinkedIssuesMswHandlers = [
   ),
   http.get(issueSheetBasePath, ({ request }) => listResponse(linkedIssuesForRequest(request))),
   http.patch(`${issueSheetBasePath}/:issueId`, async ({ params, request }) => {
-    const body = (await request.json()) as Record<string, unknown>;
+    const body = await readIssueSheetPatchBody(request);
     const existing =
       catLinkableIssuesFixture.find((issue) => issue.id === params.issueId) ??
       catLinkedIssuesListFixture[0];
@@ -79,9 +98,9 @@ export const catLinkedIssuesMswHandlers = [
         ...existing,
         id: params.issueId,
         translationKeyId:
-          body.translationKeyId === null
+          body?.translationKeyId === null
             ? null
-            : typeof body.translationKeyId === "string"
+            : typeof body?.translationKeyId === "string"
               ? body.translationKeyId
               : (existing?.translationKeyId ?? catLinkedIssuesTranslationKeyId),
         title: existing?.title ?? "Linked issue",
@@ -90,17 +109,14 @@ export const catLinkedIssuesMswHandlers = [
     });
   }),
   http.post(issueSheetBasePath, async ({ request }) => {
-    const body = (await request.json()) as Record<string, unknown>;
+    const body = await readIssueSheetCreateBody(request);
     return HttpResponse.json(
       {
         issue: {
           id: "issue_created_from_string",
-          title: typeof body.title === "string" ? body.title : "New linked issue",
+          title: body?.title ?? "New linked issue",
           status: "open",
-          translationKeyId:
-            typeof body.translationKeyId === "string"
-              ? body.translationKeyId
-              : catLinkedIssuesTranslationKeyId,
+          translationKeyId: body?.translationKeyId ?? catLinkedIssuesTranslationKeyId,
         },
       },
       { status: 201 },
@@ -121,26 +137,26 @@ export const catLinkedIssuesEmptyMswHandlers = [
     return listResponse(catLinkableIssuesFixture.filter((issue) => issue.translationKeyId == null));
   }),
   http.patch(`${issueSheetBasePath}/:issueId`, async ({ params, request }) => {
-    const body = (await request.json()) as Record<string, unknown>;
+    const body = await readIssueSheetPatchBody(request);
     return HttpResponse.json({
       issue: {
         id: params.issueId,
         title: "Checkout pay button too long",
         status: "open",
-        translationKeyId: typeof body.translationKeyId === "string" ? body.translationKeyId : null,
+        translationKeyId: typeof body?.translationKeyId === "string" ? body.translationKeyId : null,
       },
     });
   }),
   http.post(issueSheetBasePath, async ({ request }) => {
-    const body = (await request.json()) as Record<string, unknown>;
+    const body = await readIssueSheetCreateBody(request);
     return HttpResponse.json(
       {
         issue: {
           id: "issue_created_empty",
-          title: typeof body.title === "string" ? body.title : "New issue",
+          title: body?.title ?? "New issue",
           status: "open",
           translationKeyId:
-            typeof body.translationKeyId === "string" ? body.translationKeyId : null,
+            typeof body?.translationKeyId === "string" ? body.translationKeyId : null,
         },
       },
       { status: 201 },

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.ts
@@ -161,7 +161,7 @@ export async function fetchProjectFileCatQueuePage(input: {
     },
   });
 
-  if (!response.ok) {
+  if (response.status !== 200) {
     throw new Error(
       await readApiError(
         response,
@@ -170,7 +170,7 @@ export async function fetchProjectFileCatQueuePage(input: {
     );
   }
 
-  const body = (await response.json()) as ProjectFileCatQueueResponse;
+  const body = await response.json();
   return body.catQueue;
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-export.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-export.ts
@@ -76,7 +76,7 @@ export async function downloadProjectFileCatExport(input: {
     },
   });
 
-  if (!response.ok) {
+  if (response.status !== 200) {
     throw new Error(
       await readApiError(
         response,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -17,11 +17,6 @@ import { AlertCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import type {
-  ProjectFileCatConcordanceResponse,
-  ProjectFileCatRecommendationResponse,
-  ProjectFileCatVisualContextResponse,
-} from "@/api/routes/project/project.schema";
 import {
   Select,
   SelectContent,
@@ -389,7 +384,7 @@ export function ProjectFileCatWorkspace({
             status: "approved",
           },
         });
-        if (!response.ok) {
+        if (response.status !== 200) {
           throw new Error(
             await readApiError(
               response,
@@ -594,7 +589,7 @@ export function ProjectFileCatWorkspace({
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -603,7 +598,7 @@ export function ProjectFileCatWorkspace({
         );
       }
 
-      const body = (await response.json()) as { stringContext: { summary: string | null } };
+      const body = await response.json();
       return body.stringContext.summary;
     },
     [intl, organizationSlug, projectId, repositoryFullName, sourcePath],
@@ -622,7 +617,7 @@ export function ProjectFileCatWorkspace({
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -631,7 +626,7 @@ export function ProjectFileCatWorkspace({
         );
       }
 
-      const body = (await response.json()) as ProjectFileCatConcordanceResponse;
+      const body = await response.json();
       return body.concordance;
     },
     [intl, organizationSlug, projectId],
@@ -649,7 +644,7 @@ export function ProjectFileCatWorkspace({
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -658,7 +653,7 @@ export function ProjectFileCatWorkspace({
         );
       }
 
-      const body = (await response.json()) as ProjectFileCatVisualContextResponse;
+      const body = await response.json();
       return body.visualContext;
     },
     [intl, organizationSlug, projectId, sourcePath],
@@ -699,7 +694,7 @@ export function ProjectFileCatWorkspace({
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -708,7 +703,7 @@ export function ProjectFileCatWorkspace({
         );
       }
 
-      const body = (await response.json()) as ProjectFileCatRecommendationResponse;
+      const body = await response.json();
       return body.recommendation;
     },
     [intl, organizationSlug, projectId, sourcePath, targetLocale],

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
@@ -18,9 +18,7 @@ import { useIntl, type IntlShape } from "react-intl";
 import {
   maxCatLockedStringBatch,
   maxNativeCatHiddenStringBatch,
-  type ProjectFileCatComment,
   type ProjectFileCatQueueFile,
-  type ProjectFileCatTranslation,
 } from "@/api/routes/project/project.schema";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
@@ -126,7 +124,7 @@ export function useCatMutations(input: {
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -135,7 +133,7 @@ export function useCatMutations(input: {
         );
       }
 
-      const body = (await response.json()) as { translation: ProjectFileCatTranslation };
+      const body = await response.json();
       return body.translation;
     },
     onSuccess: async (translation, variables) => {
@@ -198,7 +196,7 @@ export function useCatMutations(input: {
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -207,7 +205,7 @@ export function useCatMutations(input: {
         );
       }
 
-      const body = (await response.json()) as { comment: ProjectFileCatComment };
+      const body = await response.json();
       return body.comment;
     },
     onSuccess: async (_data, variables) => {
@@ -263,7 +261,7 @@ export function useCatMutations(input: {
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -272,7 +270,7 @@ export function useCatMutations(input: {
         );
       }
 
-      const body = (await response.json()) as { comment: ProjectFileCatComment };
+      const body = await response.json();
       return body.comment;
     },
     onSuccess: async (_data, variables) => {
@@ -354,7 +352,7 @@ export function useCatMutations(input: {
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -376,32 +374,29 @@ export function useCatMutations(input: {
       file: File;
       force?: boolean;
     }) => {
-      const { sourcePath } = resolveCatMutationFileIdentity(
+      const { sourcePath, externalResourceId } = resolveCatMutationFileIdentity(
         input,
         mutationInput.externalStringId,
         intl,
       );
-      const formData = new FormData();
-      formData.set("sourcePath", sourcePath);
-      formData.set("targetLocale", input.targetLocale);
-      formData.set("externalStringId", mutationInput.externalStringId);
-      if (mutationInput.force) {
-        formData.set("force", "true");
-      }
-      if (input.catFile?.provider) {
-        formData.set("externalResourceId", requireProviderExternalResourceId(input.catFile, intl));
-      }
-      formData.set("file", mutationInput.file);
-
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(input.organizationSlug)}/projects/${encodeURIComponent(input.projectId)}/files/detail/cat/images/upload`,
-        {
-          method: "POST",
-          body: formData,
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.images.upload.$post({
+        param: {
+          organizationSlug: input.organizationSlug,
+          projectId: input.projectId,
         },
-      );
+        form: {
+          sourcePath,
+          targetLocale: input.targetLocale,
+          externalStringId: mutationInput.externalStringId,
+          file: mutationInput.file,
+          ...(mutationInput.force ? { force: "true" } : {}),
+          ...(externalResourceId ? { externalResourceId } : {}),
+        },
+      } as never);
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -442,7 +437,7 @@ export function useCatMutations(input: {
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -482,7 +477,7 @@ export function useCatMutations(input: {
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,
@@ -519,7 +514,7 @@ export function useCatMutations(input: {
           },
         });
 
-        if (!response.ok) {
+        if (response.status !== 200) {
           throw new Error(
             await readApiError(
               response,
@@ -528,7 +523,7 @@ export function useCatMutations(input: {
           );
         }
 
-        const body = (await response.json()) as { updatedCount: number; isHidden: boolean };
+        const body = await response.json();
         updatedCount += body.updatedCount;
       }
 
@@ -561,7 +556,7 @@ export function useCatMutations(input: {
           },
         });
 
-        if (!response.ok) {
+        if (response.status !== 200) {
           throw new Error(
             await readApiError(
               response,
@@ -570,9 +565,7 @@ export function useCatMutations(input: {
           );
         }
 
-        const body = (await response.json()) as {
-          catSegmentLock: { updatedCount: number; isLocked: boolean };
-        };
+        const body = await response.json();
         updatedCount += body.catSegmentLock.updatedCount;
       }
 
@@ -606,7 +599,7 @@ export function useCatMutations(input: {
         },
       });
 
-      if (!response.ok) {
+      if (response.status !== 200) {
         throw new Error(
           await readApiError(
             response,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-comments.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-comments.ts
@@ -15,7 +15,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 
-import type { ProjectFileCatComment } from "@/api/routes/project/project.schema";
 import type { CatFormatMessageIntl } from "@/components/cat/message-format/cat-message-format-i18n";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
@@ -69,7 +68,7 @@ export async function fetchProjectFileCatSegmentComments(input: {
     },
   });
 
-  if (!response.ok) {
+  if (response.status !== 200) {
     throw new Error(
       await readApiError(
         response,
@@ -78,7 +77,7 @@ export async function fetchProjectFileCatSegmentComments(input: {
     );
   }
 
-  const body = (await response.json()) as { comments: ProjectFileCatComment[] };
+  const body = await response.json();
   return body.comments;
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-target.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-target.ts
@@ -70,7 +70,7 @@ export async function fetchProjectFileCatSegmentTarget(input: {
     },
   });
 
-  if (!response.ok) {
+  if (response.status !== 200) {
     throw new Error(
       await readApiError(
         response,
@@ -79,7 +79,7 @@ export async function fetchProjectFileCatSegmentTarget(input: {
     );
   }
 
-  const body = (await response.json()) as { target: ProjectFileCatTranslation | null };
+  const body = await response.json();
   return body.target;
 }
 


### PR DESCRIPTION
## What changed

CAT client calls already used the Hono `apiClient`, but they still asserted `(await response.json()) as …`. Success paths now check `response.status !== 200` so TypeScript narrows `response.json()` to the 200 body.

Image upload goes through `files.detail.cat.images.upload.$post({ form })` instead of raw `fetch`. Issue-sheet list rows are `InferResponseType<…, 200>`. MSW create/patch handlers parse bodies with the issue-sheet Zod schemas instead of `as Record<string, unknown>` (`InferRequestType` still leaks path params into JSON).

## How to test

- [ ] `cd apps/hyperlocalise-web && vp check --fix`
- [ ] `cd apps/hyperlocalise-web && vp test src/components/cat`
- [ ] In CAT, save a translation, post a comment, and confirm queue/target still refresh
- [ ] Upload a CAT image (same endpoint; now via the Hono client form helper)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test src/components/cat`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)