### PR TITLE
feat(memory): add paginated TM entry explorer

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
@@ -489,7 +489,7 @@ describe("glossaryRoutes", () => {
       .update(schema.glossaries)
       .set({
         source: "external_tms",
-        externalProviderKind: "crowdin",
+        externalProviderKind: "lokalise",
         externalProjectId: "external-project-1",
         externalResourceType: "glossary",
         externalGlossaryId: "external-glossary-1",
@@ -691,7 +691,7 @@ describe("glossaryRoutes", () => {
     expect(conceptResponse.status).toBe(201);
     expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.glossaryTermCreated, {
       status: "created",
-      source: "glossary",
+      source: "glossary_concept",
     });
     trackSpy.mockRestore();
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.messages.ts
@@ -1,0 +1,314 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const tmEntryExplorerMessages = defineMessages({
+    searchLabel: {
+        defaultMessage: "Search source and target text",
+        id: "tmEntryExplorer.searchLabel",
+        description: "Accessible label for the translation memory entry search field",
+    },
+    searchPlaceholder: {
+        defaultMessage: "Search source or target text",
+        id: "tmEntryExplorer.searchPlaceholder",
+        description: "Placeholder for the translation memory entry search field",
+    },
+    filterButton: {
+        defaultMessage: "Filters",
+        id: "tmEntryExplorer.filterButton",
+        description: "Button that opens translation memory entry filters",
+    },
+    filterButtonWithCount: {
+        defaultMessage: "Filters ({count})",
+        id: "tmEntryExplorer.filterButtonWithCount",
+        description: "Filter button label when translation memory entry filters are active",
+    },
+    filterPopoverTitle: {
+        defaultMessage: "Filter entries",
+        id: "tmEntryExplorer.filterPopoverTitle",
+        description: "Title of the translation memory entry filter popover",
+    },
+    sourceLocaleLabel: {
+        defaultMessage: "Source locale",
+        id: "tmEntryExplorer.sourceLocaleLabel",
+        description: "Label for the source locale filter",
+    },
+    targetLocaleLabel: {
+        defaultMessage: "Target locale",
+        id: "tmEntryExplorer.targetLocaleLabel",
+        description: "Label for the target locale filter",
+    },
+    reviewStatusLabel: {
+        defaultMessage: "Review state",
+        id: "tmEntryExplorer.reviewStatusLabel",
+        description: "Label for the review status filter",
+    },
+    originLabel: {
+        defaultMessage: "Origin",
+        id: "tmEntryExplorer.originLabel",
+        description: "Label for the origin filter",
+    },
+    providerLabel: {
+        defaultMessage: "Provider",
+        id: "tmEntryExplorer.providerLabel",
+        description: "Label for the provider filter",
+    },
+    creatorLabel: {
+        defaultMessage: "Creator",
+        id: "tmEntryExplorer.creatorLabel",
+        description: "Label for the creator filter",
+    },
+    creatorPlaceholder: {
+        defaultMessage: "Creator user ID",
+        id: "tmEntryExplorer.creatorPlaceholder",
+        description: "Placeholder for the creator user ID filter",
+    },
+    modifiedFromLabel: {
+        defaultMessage: "Modified from",
+        id: "tmEntryExplorer.modifiedFromLabel",
+        description: "Label for the modified-from date filter",
+    },
+    modifiedToLabel: {
+        defaultMessage: "Modified to",
+        id: "tmEntryExplorer.modifiedToLabel",
+        description: "Label for the modified-to date filter",
+    },
+    importBatchLabel: {
+        defaultMessage: "Import batch",
+        id: "tmEntryExplorer.importBatchLabel",
+        description: "Label for the import batch filter",
+    },
+    importBatchPlaceholder: {
+        defaultMessage: "Import batch ID",
+        id: "tmEntryExplorer.importBatchPlaceholder",
+        description: "Placeholder for the import batch ID filter",
+    },
+    anyValue: {
+        defaultMessage: "Any",
+        id: "tmEntryExplorer.anyValue",
+        description: "Option that clears a translation memory entry filter",
+    },
+    sortByLabel: {
+        defaultMessage: "Sort by",
+        id: "tmEntryExplorer.sortByLabel",
+        description: "Accessible label for the translation memory entry sort field",
+    },
+    orderLabel: {
+        defaultMessage: "Order",
+        id: "tmEntryExplorer.orderLabel",
+        description: "Accessible label for the translation memory entry sort direction",
+    },
+    sortCreatedAt: {
+        defaultMessage: "Created",
+        id: "tmEntryExplorer.sortCreatedAt",
+        description: "Sort option for translation memory entry created time",
+    },
+    sortUpdatedAt: {
+        defaultMessage: "Modified",
+        id: "tmEntryExplorer.sortUpdatedAt",
+        description: "Sort option for translation memory entry modified time",
+    },
+    sortDirDesc: {
+        defaultMessage: "Newest first",
+        id: "tmEntryExplorer.sortDirDesc",
+        description: "Descending sort direction for translation memory entries",
+    },
+    sortDirAsc: {
+        defaultMessage: "Oldest first",
+        id: "tmEntryExplorer.sortDirAsc",
+        description: "Ascending sort direction for translation memory entries",
+    },
+    reviewApproved: {
+        defaultMessage: "Approved",
+        id: "tmEntryExplorer.reviewApproved",
+        description: "Approved review status for a translation memory entry",
+    },
+    reviewPending: {
+        defaultMessage: "Pending",
+        id: "tmEntryExplorer.reviewPending",
+        description: "Pending review status for a translation memory entry",
+    },
+    reviewRejected: {
+        defaultMessage: "Rejected",
+        id: "tmEntryExplorer.reviewRejected",
+        description: "Rejected review status for a translation memory entry",
+    },
+    originManual: {
+        defaultMessage: "Manual",
+        id: "tmEntryExplorer.originManual",
+        description: "Manual origin for a translation memory entry",
+    },
+    originImport: {
+        defaultMessage: "Import",
+        id: "tmEntryExplorer.originImport",
+        description: "Import origin for a translation memory entry",
+    },
+    originSync: {
+        defaultMessage: "Sync",
+        id: "tmEntryExplorer.originSync",
+        description: "Sync origin for a translation memory entry",
+    },
+    clearFilters: {
+        defaultMessage: "Clear filters",
+        id: "tmEntryExplorer.clearFilters",
+        description: "Button that clears translation memory entry filters",
+    },
+    removeChipAriaLabel: {
+        defaultMessage: "Remove {label} filter",
+        id: "tmEntryExplorer.removeChipAriaLabel",
+        description: "Accessible label for removing an active translation memory entry filter chip",
+    },
+    chipSearch: {
+        defaultMessage: "Search: {value}",
+        id: "tmEntryExplorer.chipSearch",
+        description: "Chip label for the active translation memory entry search",
+    },
+    chipSourceLocale: {
+        defaultMessage: "Source: {value}",
+        id: "tmEntryExplorer.chipSourceLocale",
+        description: "Chip label for the active source locale filter",
+    },
+    chipTargetLocale: {
+        defaultMessage: "Target: {value}",
+        id: "tmEntryExplorer.chipTargetLocale",
+        description: "Chip label for the active target locale filter",
+    },
+    chipReviewStatus: {
+        defaultMessage: "Review: {value}",
+        id: "tmEntryExplorer.chipReviewStatus",
+        description: "Chip label for the active review status filter",
+    },
+    chipOrigin: {
+        defaultMessage: "Origin: {value}",
+        id: "tmEntryExplorer.chipOrigin",
+        description: "Chip label for the active origin filter",
+    },
+    chipProvider: {
+        defaultMessage: "Provider: {value}",
+        id: "tmEntryExplorer.chipProvider",
+        description: "Chip label for the active provider filter",
+    },
+    chipCreator: {
+        defaultMessage: "Creator: {value}",
+        id: "tmEntryExplorer.chipCreator",
+        description: "Chip label for the active creator filter",
+    },
+    chipModifiedFrom: {
+        defaultMessage: "From {value}",
+        id: "tmEntryExplorer.chipModifiedFrom",
+        description: "Chip label for the modified-from filter",
+    },
+    chipModifiedTo: {
+        defaultMessage: "To {value}",
+        id: "tmEntryExplorer.chipModifiedTo",
+        description: "Chip label for the modified-to filter",
+    },
+    chipImportBatch: {
+        defaultMessage: "Batch: {value}",
+        id: "tmEntryExplorer.chipImportBatch",
+        description: "Chip label for the active import batch filter",
+    },
+    loadingAria: {
+        defaultMessage: "Loading translation memory entries",
+        id: "tmEntryExplorer.loadingAria",
+        description: "Accessible label for the translation memory entry loading state",
+    },
+    statusLoading: {
+        defaultMessage: "Loading entries",
+        id: "tmEntryExplorer.statusLoading",
+        description: "Live status announced while translation memory entries are loading",
+    },
+    statusCount: {
+        defaultMessage:
+            "{shown, plural, one {# entry} other {# entries}} on this page of {total, plural, one {# match} other {# matches}}",
+        id: "tmEntryExplorer.statusCount",
+        description: "Live status announcing the current translation memory entry page count",
+    },
+    empty: {
+        defaultMessage: "No entries match this search.",
+        id: "tmEntryExplorer.empty",
+        description: "Empty state when translation memory entry search returns no rows",
+    },
+    emptyNoFilters: {
+        defaultMessage: "No entries yet.",
+        id: "tmEntryExplorer.emptyNoFilters",
+        description: "Empty state when a translation memory has no entries",
+    },
+    error: {
+        defaultMessage: "Unable to load entries.",
+        id: "tmEntryExplorer.error",
+        description: "Error state when translation memory entries fail to load",
+    },
+    retry: {
+        defaultMessage: "Try again",
+        id: "tmEntryExplorer.retry",
+        description: "Button to retry loading translation memory entries",
+    },
+    previousPage: {
+        defaultMessage: "Previous",
+        id: "tmEntryExplorer.previousPage",
+        description: "Button to go to the previous translation memory entry page",
+    },
+    nextPage: {
+        defaultMessage: "Next",
+        id: "tmEntryExplorer.nextPage",
+        description: "Button to go to the next translation memory entry page",
+    },
+    localePair: {
+        defaultMessage: "{sourceLocale} → {targetLocale}",
+        id: "tmEntryExplorer.localePair",
+        description: "Locale pair shown on a translation memory entry row",
+    },
+    openEntryAria: {
+        defaultMessage: "Open entry {sourceText}",
+        id: "tmEntryExplorer.openEntryAria",
+        description: "Accessible label for opening a translation memory entry",
+    },
+    closeEntry: {
+        defaultMessage: "Back to results",
+        id: "tmEntryExplorer.closeEntry",
+        description: "Button that returns from a selected translation memory entry to the list",
+    },
+    selectedEntry: {
+        defaultMessage: "Selected entry",
+        id: "tmEntryExplorer.selectedEntry",
+        description: "Heading for the currently selected translation memory entry",
+    },
+    filterByCreator: {
+        defaultMessage: "Filter by creator",
+        id: "tmEntryExplorer.filterByCreator",
+        description: "Button that applies the current entry creator as a filter",
+    },
+    filterByBatch: {
+        defaultMessage: "Filter by import batch",
+        id: "tmEntryExplorer.filterByBatch",
+        description: "Button that applies the current entry import batch as a filter",
+    },
+    invalidCursor: {
+        defaultMessage: "That page is no longer valid. Showing the first page.",
+        id: "tmEntryExplorer.invalidCursor",
+        description: "Status announced when a translation memory entry cursor can no longer be used",
+    },
+    editEntry: {
+        defaultMessage: "Edit",
+        id: "tmEntryExplorer.editEntry",
+        description: "Button to edit a translation memory entry",
+    },
+    deleteEntry: {
+        defaultMessage: "Delete",
+        id: "tmEntryExplorer.deleteEntry",
+        description: "Button to delete a translation memory entry",
+    },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.messages.ts
@@ -15,300 +15,299 @@
 import { defineMessages } from "react-intl";
 
 export const tmEntryExplorerMessages = defineMessages({
-    searchLabel: {
-        defaultMessage: "Search source and target text",
-        id: "tmEntryExplorer.searchLabel",
-        description: "Accessible label for the translation memory entry search field",
-    },
-    searchPlaceholder: {
-        defaultMessage: "Search source or target text",
-        id: "tmEntryExplorer.searchPlaceholder",
-        description: "Placeholder for the translation memory entry search field",
-    },
-    filterButton: {
-        defaultMessage: "Filters",
-        id: "tmEntryExplorer.filterButton",
-        description: "Button that opens translation memory entry filters",
-    },
-    filterButtonWithCount: {
-        defaultMessage: "Filters ({count})",
-        id: "tmEntryExplorer.filterButtonWithCount",
-        description: "Filter button label when translation memory entry filters are active",
-    },
-    filterPopoverTitle: {
-        defaultMessage: "Filter entries",
-        id: "tmEntryExplorer.filterPopoverTitle",
-        description: "Title of the translation memory entry filter popover",
-    },
-    sourceLocaleLabel: {
-        defaultMessage: "Source locale",
-        id: "tmEntryExplorer.sourceLocaleLabel",
-        description: "Label for the source locale filter",
-    },
-    targetLocaleLabel: {
-        defaultMessage: "Target locale",
-        id: "tmEntryExplorer.targetLocaleLabel",
-        description: "Label for the target locale filter",
-    },
-    reviewStatusLabel: {
-        defaultMessage: "Review state",
-        id: "tmEntryExplorer.reviewStatusLabel",
-        description: "Label for the review status filter",
-    },
-    originLabel: {
-        defaultMessage: "Origin",
-        id: "tmEntryExplorer.originLabel",
-        description: "Label for the origin filter",
-    },
-    providerLabel: {
-        defaultMessage: "Provider",
-        id: "tmEntryExplorer.providerLabel",
-        description: "Label for the provider filter",
-    },
-    creatorLabel: {
-        defaultMessage: "Creator",
-        id: "tmEntryExplorer.creatorLabel",
-        description: "Label for the creator filter",
-    },
-    creatorPlaceholder: {
-        defaultMessage: "Creator user ID",
-        id: "tmEntryExplorer.creatorPlaceholder",
-        description: "Placeholder for the creator user ID filter",
-    },
-    modifiedFromLabel: {
-        defaultMessage: "Modified from",
-        id: "tmEntryExplorer.modifiedFromLabel",
-        description: "Label for the modified-from date filter",
-    },
-    modifiedToLabel: {
-        defaultMessage: "Modified to",
-        id: "tmEntryExplorer.modifiedToLabel",
-        description: "Label for the modified-to date filter",
-    },
-    importBatchLabel: {
-        defaultMessage: "Import batch",
-        id: "tmEntryExplorer.importBatchLabel",
-        description: "Label for the import batch filter",
-    },
-    importBatchPlaceholder: {
-        defaultMessage: "Import batch ID",
-        id: "tmEntryExplorer.importBatchPlaceholder",
-        description: "Placeholder for the import batch ID filter",
-    },
-    anyValue: {
-        defaultMessage: "Any",
-        id: "tmEntryExplorer.anyValue",
-        description: "Option that clears a translation memory entry filter",
-    },
-    sortByLabel: {
-        defaultMessage: "Sort by",
-        id: "tmEntryExplorer.sortByLabel",
-        description: "Accessible label for the translation memory entry sort field",
-    },
-    orderLabel: {
-        defaultMessage: "Order",
-        id: "tmEntryExplorer.orderLabel",
-        description: "Accessible label for the translation memory entry sort direction",
-    },
-    sortCreatedAt: {
-        defaultMessage: "Created",
-        id: "tmEntryExplorer.sortCreatedAt",
-        description: "Sort option for translation memory entry created time",
-    },
-    sortUpdatedAt: {
-        defaultMessage: "Modified",
-        id: "tmEntryExplorer.sortUpdatedAt",
-        description: "Sort option for translation memory entry modified time",
-    },
-    sortDirDesc: {
-        defaultMessage: "Newest first",
-        id: "tmEntryExplorer.sortDirDesc",
-        description: "Descending sort direction for translation memory entries",
-    },
-    sortDirAsc: {
-        defaultMessage: "Oldest first",
-        id: "tmEntryExplorer.sortDirAsc",
-        description: "Ascending sort direction for translation memory entries",
-    },
-    reviewApproved: {
-        defaultMessage: "Approved",
-        id: "tmEntryExplorer.reviewApproved",
-        description: "Approved review status for a translation memory entry",
-    },
-    reviewPending: {
-        defaultMessage: "Pending",
-        id: "tmEntryExplorer.reviewPending",
-        description: "Pending review status for a translation memory entry",
-    },
-    reviewRejected: {
-        defaultMessage: "Rejected",
-        id: "tmEntryExplorer.reviewRejected",
-        description: "Rejected review status for a translation memory entry",
-    },
-    originManual: {
-        defaultMessage: "Manual",
-        id: "tmEntryExplorer.originManual",
-        description: "Manual origin for a translation memory entry",
-    },
-    originImport: {
-        defaultMessage: "Import",
-        id: "tmEntryExplorer.originImport",
-        description: "Import origin for a translation memory entry",
-    },
-    originSync: {
-        defaultMessage: "Sync",
-        id: "tmEntryExplorer.originSync",
-        description: "Sync origin for a translation memory entry",
-    },
-    clearFilters: {
-        defaultMessage: "Clear filters",
-        id: "tmEntryExplorer.clearFilters",
-        description: "Button that clears translation memory entry filters",
-    },
-    removeChipAriaLabel: {
-        defaultMessage: "Remove {label} filter",
-        id: "tmEntryExplorer.removeChipAriaLabel",
-        description: "Accessible label for removing an active translation memory entry filter chip",
-    },
-    chipSearch: {
-        defaultMessage: "Search: {value}",
-        id: "tmEntryExplorer.chipSearch",
-        description: "Chip label for the active translation memory entry search",
-    },
-    chipSourceLocale: {
-        defaultMessage: "Source: {value}",
-        id: "tmEntryExplorer.chipSourceLocale",
-        description: "Chip label for the active source locale filter",
-    },
-    chipTargetLocale: {
-        defaultMessage: "Target: {value}",
-        id: "tmEntryExplorer.chipTargetLocale",
-        description: "Chip label for the active target locale filter",
-    },
-    chipReviewStatus: {
-        defaultMessage: "Review: {value}",
-        id: "tmEntryExplorer.chipReviewStatus",
-        description: "Chip label for the active review status filter",
-    },
-    chipOrigin: {
-        defaultMessage: "Origin: {value}",
-        id: "tmEntryExplorer.chipOrigin",
-        description: "Chip label for the active origin filter",
-    },
-    chipProvider: {
-        defaultMessage: "Provider: {value}",
-        id: "tmEntryExplorer.chipProvider",
-        description: "Chip label for the active provider filter",
-    },
-    chipCreator: {
-        defaultMessage: "Creator: {value}",
-        id: "tmEntryExplorer.chipCreator",
-        description: "Chip label for the active creator filter",
-    },
-    chipModifiedFrom: {
-        defaultMessage: "From {value}",
-        id: "tmEntryExplorer.chipModifiedFrom",
-        description: "Chip label for the modified-from filter",
-    },
-    chipModifiedTo: {
-        defaultMessage: "To {value}",
-        id: "tmEntryExplorer.chipModifiedTo",
-        description: "Chip label for the modified-to filter",
-    },
-    chipImportBatch: {
-        defaultMessage: "Batch: {value}",
-        id: "tmEntryExplorer.chipImportBatch",
-        description: "Chip label for the active import batch filter",
-    },
-    loadingAria: {
-        defaultMessage: "Loading translation memory entries",
-        id: "tmEntryExplorer.loadingAria",
-        description: "Accessible label for the translation memory entry loading state",
-    },
-    statusLoading: {
-        defaultMessage: "Loading entries",
-        id: "tmEntryExplorer.statusLoading",
-        description: "Live status announced while translation memory entries are loading",
-    },
-    statusCount: {
-        defaultMessage:
-            "{shown, plural, one {# entry} other {# entries}} on this page of {total, plural, one {# match} other {# matches}}",
-        id: "tmEntryExplorer.statusCount",
-        description: "Live status announcing the current translation memory entry page count",
-    },
-    empty: {
-        defaultMessage: "No entries match this search.",
-        id: "tmEntryExplorer.empty",
-        description: "Empty state when translation memory entry search returns no rows",
-    },
-    emptyNoFilters: {
-        defaultMessage: "No entries yet.",
-        id: "tmEntryExplorer.emptyNoFilters",
-        description: "Empty state when a translation memory has no entries",
-    },
-    error: {
-        defaultMessage: "Unable to load entries.",
-        id: "tmEntryExplorer.error",
-        description: "Error state when translation memory entries fail to load",
-    },
-    retry: {
-        defaultMessage: "Try again",
-        id: "tmEntryExplorer.retry",
-        description: "Button to retry loading translation memory entries",
-    },
-    previousPage: {
-        defaultMessage: "Previous",
-        id: "tmEntryExplorer.previousPage",
-        description: "Button to go to the previous translation memory entry page",
-    },
-    nextPage: {
-        defaultMessage: "Next",
-        id: "tmEntryExplorer.nextPage",
-        description: "Button to go to the next translation memory entry page",
-    },
-    localePair: {
-        defaultMessage: "{sourceLocale} → {targetLocale}",
-        id: "tmEntryExplorer.localePair",
-        description: "Locale pair shown on a translation memory entry row",
-    },
-    openEntryAria: {
-        defaultMessage: "Open entry {sourceText}",
-        id: "tmEntryExplorer.openEntryAria",
-        description: "Accessible label for opening a translation memory entry",
-    },
-    closeEntry: {
-        defaultMessage: "Back to results",
-        id: "tmEntryExplorer.closeEntry",
-        description: "Button that returns from a selected translation memory entry to the list",
-    },
-    selectedEntry: {
-        defaultMessage: "Selected entry",
-        id: "tmEntryExplorer.selectedEntry",
-        description: "Heading for the currently selected translation memory entry",
-    },
-    filterByCreator: {
-        defaultMessage: "Filter by creator",
-        id: "tmEntryExplorer.filterByCreator",
-        description: "Button that applies the current entry creator as a filter",
-    },
-    filterByBatch: {
-        defaultMessage: "Filter by import batch",
-        id: "tmEntryExplorer.filterByBatch",
-        description: "Button that applies the current entry import batch as a filter",
-    },
-    invalidCursor: {
-        defaultMessage: "That page is no longer valid. Showing the first page.",
-        id: "tmEntryExplorer.invalidCursor",
-        description: "Status announced when a translation memory entry cursor can no longer be used",
-    },
-    editEntry: {
-        defaultMessage: "Edit",
-        id: "tmEntryExplorer.editEntry",
-        description: "Button to edit a translation memory entry",
-    },
-    deleteEntry: {
-        defaultMessage: "Delete",
-        id: "tmEntryExplorer.deleteEntry",
-        description: "Button to delete a translation memory entry",
-    },
+  searchLabel: {
+    defaultMessage: "Search source and target text",
+    id: "XBIwe6jLdQ",
+    description: "Accessible label for the translation memory entry search field",
+  },
+  searchPlaceholder: {
+    defaultMessage: "Search source or target text",
+    id: "4aTkFyER33",
+    description: "Placeholder for the translation memory entry search field",
+  },
+  filterButton: {
+    defaultMessage: "Filters",
+    id: "cq8+wKJLJG",
+    description: "Button that opens translation memory entry filters",
+  },
+  filterButtonWithCount: {
+    defaultMessage: "Filters ({count})",
+    id: "KhRVjtTnTz",
+    description: "Filter button label when translation memory entry filters are active",
+  },
+  filterPopoverTitle: {
+    defaultMessage: "Filter entries",
+    id: "V3RuMxqgSZ",
+    description: "Title of the translation memory entry filter popover",
+  },
+  sourceLocaleLabel: {
+    defaultMessage: "Source locale",
+    id: "aa15mSwX4W",
+    description: "Label for the source locale filter",
+  },
+  targetLocaleLabel: {
+    defaultMessage: "Target locale",
+    id: "C4Rv6cR7my",
+    description: "Label for the target locale filter",
+  },
+  reviewStatusLabel: {
+    defaultMessage: "Review state",
+    id: "CFK4BGiWin",
+    description: "Label for the review status filter",
+  },
+  originLabel: {
+    defaultMessage: "Origin",
+    id: "n7fzXxI33N",
+    description: "Label for the origin filter",
+  },
+  providerLabel: {
+    defaultMessage: "Provider",
+    id: "jgywbYAAhH",
+    description: "Label for the provider filter",
+  },
+  creatorLabel: {
+    defaultMessage: "Creator",
+    id: "EaYWwlX+vF",
+    description: "Label for the creator filter",
+  },
+  creatorPlaceholder: {
+    defaultMessage: "Creator user ID",
+    id: "6vcGtoPKc6",
+    description: "Placeholder for the creator user ID filter",
+  },
+  modifiedFromLabel: {
+    defaultMessage: "Modified from",
+    id: "7aOYNlbDse",
+    description: "Label for the modified-from date filter",
+  },
+  modifiedToLabel: {
+    defaultMessage: "Modified to",
+    id: "VvUOA2CC3F",
+    description: "Label for the modified-to date filter",
+  },
+  importBatchLabel: {
+    defaultMessage: "Import batch",
+    id: "3Gmldz+Qzp",
+    description: "Label for the import batch filter",
+  },
+  importBatchPlaceholder: {
+    defaultMessage: "Import batch ID",
+    id: "nxVF3ARuwj",
+    description: "Placeholder for the import batch ID filter",
+  },
+  anyValue: {
+    defaultMessage: "Any",
+    id: "HIVm1saP2n",
+    description: "Option that clears a translation memory entry filter",
+  },
+  sortByLabel: {
+    defaultMessage: "Sort by",
+    id: "cTgMLHmn1U",
+    description: "Accessible label for the translation memory entry sort field",
+  },
+  orderLabel: {
+    defaultMessage: "Order",
+    id: "x5RsQtpxzS",
+    description: "Accessible label for the translation memory entry sort direction",
+  },
+  sortCreatedAt: {
+    defaultMessage: "Created",
+    id: "ENzJH/YOAt",
+    description: "Sort option for translation memory entry created time",
+  },
+  sortUpdatedAt: {
+    defaultMessage: "Modified",
+    id: "8UVXVLYDSf",
+    description: "Sort option for translation memory entry modified time",
+  },
+  sortDirDesc: {
+    defaultMessage: "Newest first",
+    id: "NczS6RXjPB",
+    description: "Descending sort direction for translation memory entries",
+  },
+  sortDirAsc: {
+    defaultMessage: "Oldest first",
+    id: "N5Oh6UkBrk",
+    description: "Ascending sort direction for translation memory entries",
+  },
+  reviewApproved: {
+    defaultMessage: "Approved",
+    id: "yDRqU0S/W9",
+    description: "Approved review status for a translation memory entry",
+  },
+  reviewPending: {
+    defaultMessage: "Pending",
+    id: "HXvIFMFODd",
+    description: "Pending review status for a translation memory entry",
+  },
+  reviewRejected: {
+    defaultMessage: "Rejected",
+    id: "vch5agnkDa",
+    description: "Rejected review status for a translation memory entry",
+  },
+  originManual: {
+    defaultMessage: "Manual",
+    id: "EcDz2IQknb",
+    description: "Manual origin for a translation memory entry",
+  },
+  originImport: {
+    defaultMessage: "Import",
+    id: "biOvOrRTZF",
+    description: "Import origin for a translation memory entry",
+  },
+  originSync: {
+    defaultMessage: "Sync",
+    id: "gBuKJZ8SD6",
+    description: "Sync origin for a translation memory entry",
+  },
+  clearFilters: {
+    defaultMessage: "Clear filters",
+    id: "+H/71gbTfh",
+    description: "Button that clears translation memory entry filters",
+  },
+  removeChipAriaLabel: {
+    defaultMessage: "Remove {label} filter",
+    id: "oiv9XDlV5Q",
+    description: "Accessible label for removing an active translation memory entry filter chip",
+  },
+  chipSearch: {
+    defaultMessage: "Search: {value}",
+    id: "or4mLWN3nr",
+    description: "Chip label for the active translation memory entry search",
+  },
+  chipSourceLocale: {
+    defaultMessage: "Source: {value}",
+    id: "Wlx+O8qTTn",
+    description: "Chip label for the active source locale filter",
+  },
+  chipTargetLocale: {
+    defaultMessage: "Target: {value}",
+    id: "oJhe7yX8oA",
+    description: "Chip label for the active target locale filter",
+  },
+  chipReviewStatus: {
+    defaultMessage: "Review: {value}",
+    id: "1jAp3L0qGd",
+    description: "Chip label for the active review status filter",
+  },
+  chipOrigin: {
+    defaultMessage: "Origin: {value}",
+    id: "jJ0I/EZEoA",
+    description: "Chip label for the active origin filter",
+  },
+  chipProvider: {
+    defaultMessage: "Provider: {value}",
+    id: "kDiXBdNQE9",
+    description: "Chip label for the active provider filter",
+  },
+  chipCreator: {
+    defaultMessage: "Creator: {value}",
+    id: "CALKqH15lR",
+    description: "Chip label for the active creator filter",
+  },
+  chipModifiedFrom: {
+    defaultMessage: "From {value}",
+    id: "RUxqjtA9CF",
+    description: "Chip label for the modified-from filter",
+  },
+  chipModifiedTo: {
+    defaultMessage: "To {value}",
+    id: "kQdK+U9dBZ",
+    description: "Chip label for the modified-to filter",
+  },
+  chipImportBatch: {
+    defaultMessage: "Batch: {value}",
+    id: "VG/iXFDz5w",
+    description: "Chip label for the active import batch filter",
+  },
+  loadingAria: {
+    defaultMessage: "Loading translation memory entries",
+    id: "Yt7zrC9Btd",
+    description: "Accessible label for the translation memory entry loading state",
+  },
+  statusLoading: {
+    defaultMessage: "Loading entries",
+    id: "mRzD1p2FiB",
+    description: "Live status announced while translation memory entries are loading",
+  },
+  statusCount: {
+    defaultMessage: "{total, plural, one {# matching entry} other {# matching entries}}",
+    id: "q7oSHUgy5r",
+    description: "Live status announcing how many translation memory entries match the query",
+  },
+  empty: {
+    defaultMessage: "No entries match this search.",
+    id: "UBL2U2Jzs0",
+    description: "Empty state when translation memory entry search returns no rows",
+  },
+  emptyNoFilters: {
+    defaultMessage: "No entries yet.",
+    id: "nYl8yPSIEu",
+    description: "Empty state when a translation memory has no entries",
+  },
+  error: {
+    defaultMessage: "Unable to load entries.",
+    id: "zY3jTIX8o6",
+    description: "Error state when translation memory entries fail to load",
+  },
+  retry: {
+    defaultMessage: "Try again",
+    id: "uOKEevBA23",
+    description: "Button to retry loading translation memory entries",
+  },
+  previousPage: {
+    defaultMessage: "Previous",
+    id: "GRBZS77KwX",
+    description: "Button to go to the previous translation memory entry page",
+  },
+  nextPage: {
+    defaultMessage: "Next",
+    id: "e+ec0C7jOE",
+    description: "Button to go to the next translation memory entry page",
+  },
+  localePair: {
+    defaultMessage: "{sourceLocale} → {targetLocale}",
+    id: "xj2EXXNNqx",
+    description: "Locale pair shown on a translation memory entry row",
+  },
+  openEntryAria: {
+    defaultMessage: "Open entry {sourceText}",
+    id: "Aslv6sgV4o",
+    description: "Accessible label for opening a translation memory entry",
+  },
+  closeEntry: {
+    defaultMessage: "Back to results",
+    id: "MYDqLAmTSX",
+    description: "Button that returns from a selected translation memory entry to the list",
+  },
+  selectedEntry: {
+    defaultMessage: "Selected entry",
+    id: "TN1PxXk6zi",
+    description: "Heading for the currently selected translation memory entry",
+  },
+  filterByCreator: {
+    defaultMessage: "Filter by creator",
+    id: "IiixLmh3Z0",
+    description: "Button that applies the current entry creator as a filter",
+  },
+  filterByBatch: {
+    defaultMessage: "Filter by import batch",
+    id: "M2MpuB71Nj",
+    description: "Button that applies the current entry import batch as a filter",
+  },
+  invalidCursor: {
+    defaultMessage: "That page is no longer valid. Showing the first page.",
+    id: "3xXiVgOezJ",
+    description: "Status announced when a translation memory entry cursor can no longer be used",
+  },
+  editEntry: {
+    defaultMessage: "Edit",
+    id: "fnnzeRJcnZ",
+    description: "Button to edit a translation memory entry",
+  },
+  deleteEntry: {
+    defaultMessage: "Delete",
+    id: "4mAN6mkTxq",
+    description: "Button to delete a translation memory entry",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.test.tsx
@@ -260,6 +260,27 @@ describe("TmEntryExplorer", () => {
     });
   });
 
+  it("disables Previous on a deep-linked page when the cursor stack is missing", async () => {
+    navigation.search = "cursor=cursor-3";
+    apiMocks.getEntries.mockResolvedValue(
+      jsonResponse(
+        createPage([createEntry({ sourceText: "Deep page" })], {
+          total: 150,
+          nextCursor: "cursor-4",
+          pagination: { limit: 50, returned: 1, hasMore: true },
+        }),
+      ),
+    );
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(screen.getByText("Deep page")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
+  });
+
   it("restores search, filters, and sort from the URL", async () => {
     navigation.search =
       "search=checkout&sourceLocale=en-US&targetLocale=fr-FR&reviewStatus=pending&origin=import&provider=crowdin&sort=updated_at&sortDir=asc";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.test.tsx
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { MemoryEntriesResponse, MemoryEntryRecord } from "@/api/routes/memory/memory.schema";
+import { ApiResponseError } from "@/lib/api-error";
+
+import { TmEntryExplorer } from "./tm-entry-explorer";
+
+const navigation = vi.hoisted(() => ({
+    pathname: "/en/org/acme/translation-memories/mem_1",
+    search: "",
+    replace: vi.fn(),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+    getEntries: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => navigation.pathname,
+    useRouter: () => ({
+        replace: navigation.replace,
+        push: vi.fn(),
+    }),
+    useSearchParams: () => new URLSearchParams(navigation.search),
+}));
+
+vi.mock("@/lib/api-client-instance", () => ({
+    apiClient: {
+        api: {
+            orgs: {
+                ":organizationSlug": {
+                    "translation-memories": {
+                        ":memoryId": {
+                            entries: {
+                                $get: (...args: unknown[]) => apiMocks.getEntries(...args),
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}));
+
+function createEntry(overrides?: Partial<MemoryEntryRecord>): MemoryEntryRecord {
+    return {
+        id: "33333333-3333-4333-8333-333333333333",
+        memoryId: "mem_1",
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+        sourceText: "Checkout",
+        targetText: "Paiement",
+        matchScore: 100,
+        provenance: "manual",
+        reviewStatus: "approved",
+        externalKey: null,
+        createdByUserId: "11111111-1111-4111-8111-111111111111",
+        importBatchId: null,
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-01T00:00:00.000Z",
+        ...overrides,
+    };
+}
+
+function createPage(
+    entries: MemoryEntryRecord[],
+    overrides?: Partial<MemoryEntriesResponse>,
+): MemoryEntriesResponse {
+    return {
+        memoryEntries: entries,
+        nextCursor: null,
+        total: entries.length,
+        pagination: {
+            limit: 50,
+            returned: entries.length,
+            hasMore: false,
+        },
+        ...overrides,
+    };
+}
+
+function jsonResponse(body: MemoryEntriesResponse) {
+    return {
+        ok: true,
+        json: async () => body,
+    };
+}
+
+function renderExplorer(): ReturnType<typeof render> {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, gcTime: 0 },
+        },
+    });
+    const ui: ReactElement = (
+        <IntlProvider locale="en" messages={{}}>
+            <QueryClientProvider client={queryClient}>
+                <TmEntryExplorer
+                    organizationSlug="acme"
+                    memoryId="mem_1"
+                    localeCoverage={["en-US", "fr-FR"]}
+                    canEdit
+                />
+            </QueryClientProvider>
+        </IntlProvider>
+    );
+    return render(ui);
+}
+
+describe("TmEntryExplorer", () => {
+    beforeEach(() => {
+        navigation.search = "";
+        navigation.replace.mockReset();
+        apiMocks.getEntries.mockReset();
+        sessionStorage.clear();
+    });
+
+    it("shows a loading state before entries arrive", async () => {
+        let resolvePage: ((value: ReturnType<typeof jsonResponse>) => void) | undefined;
+        apiMocks.getEntries.mockReturnValue(
+            new Promise((resolve) => {
+                resolvePage = resolve;
+            }),
+        );
+
+        renderExplorer();
+
+        expect(screen.getByLabelText("Loading translation memory entries")).toBeInTheDocument();
+        expect(screen.getByRole("status")).toHaveTextContent("Loading entries");
+
+        resolvePage?.(jsonResponse(createPage([])));
+        await waitFor(() => {
+            expect(screen.getByText("No entries yet.")).toBeInTheDocument();
+        });
+    });
+
+    it("shows an empty filtered state from the server result", async () => {
+        navigation.search = "search=invoice";
+        apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([])));
+
+        renderExplorer();
+
+        await waitFor(() => {
+            expect(screen.getByText("No entries match this search.")).toBeInTheDocument();
+        });
+        expect(apiMocks.getEntries).toHaveBeenCalledWith(
+            expect.objectContaining({
+                query: expect.objectContaining({ search: "invoice" }),
+            }),
+            expect.objectContaining({ init: expect.objectContaining({ signal: expect.any(AbortSignal) }) }),
+        );
+    });
+
+    it("shows an error state and retries the same query", async () => {
+        const user = userEvent.setup();
+        apiMocks.getEntries
+            .mockResolvedValueOnce({
+                ok: false,
+                json: async () => ({ error: "memory_unavailable", message: "Unable to load entries." }),
+            })
+            .mockResolvedValueOnce(jsonResponse(createPage([createEntry()])));
+
+        renderExplorer();
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole("button", { name: "Try again" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Checkout")).toBeInTheDocument();
+        });
+        expect(apiMocks.getEntries).toHaveBeenCalledTimes(2);
+    });
+
+    it("pages forward with the server cursor and can return to the first page", async () => {
+        const user = userEvent.setup();
+        const first = createEntry({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", sourceText: "First page" });
+        const second = createEntry({
+            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            sourceText: "Second page",
+        });
+
+        apiMocks.getEntries.mockImplementation(async (args: { query?: { cursor?: string } }) => {
+            if (args.query?.cursor === "cursor-2") {
+                return jsonResponse(
+                    createPage([second], {
+                        total: 2,
+                        nextCursor: null,
+                        pagination: { limit: 50, returned: 1, hasMore: false },
+                    }),
+                );
+            }
+            return jsonResponse(
+                createPage([first], {
+                    total: 2,
+                    nextCursor: "cursor-2",
+                    pagination: { limit: 50, returned: 1, hasMore: true },
+                }),
+            );
+        });
+
+        renderExplorer();
+
+        await waitFor(() => {
+            expect(screen.getByText("First page")).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole("button", { name: "Next" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Second page")).toBeInTheDocument();
+        });
+        expect(navigation.replace).toHaveBeenCalledWith(
+            expect.stringContaining("cursor=cursor-2"),
+            { scroll: false },
+        );
+        expect(screen.getByRole("button", { name: "Previous" })).toBeEnabled();
+
+        await user.click(screen.getByRole("button", { name: "Previous" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("First page")).toBeInTheDocument();
+        });
+    });
+
+    it("restores search, filters, and sort from the URL", async () => {
+        navigation.search =
+            "search=checkout&sourceLocale=en-US&targetLocale=fr-FR&reviewStatus=pending&origin=import&provider=crowdin&sort=updated_at&sortDir=asc";
+        apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([createEntry()])));
+
+        renderExplorer();
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue("checkout")).toBeInTheDocument();
+        });
+        expect(screen.getByText(/Search: checkout/)).toBeInTheDocument();
+        expect(screen.getByLabelText("Sort by")).toHaveTextContent("Modified");
+        expect(screen.getByLabelText("Order")).toHaveTextContent("Oldest first");
+        expect(apiMocks.getEntries).toHaveBeenCalledWith(
+            {
+                param: { organizationSlug: "acme", memoryId: "mem_1" },
+                query: {
+                    limit: "50",
+                    search: "checkout",
+                    sourceLocale: "en-US",
+                    targetLocale: "fr-FR",
+                    reviewStatus: "pending",
+                    origin: "import",
+                    provider: "crowdin",
+                    sort: "updated_at",
+                    sortDir: "asc",
+                },
+            },
+            expect.objectContaining({ init: expect.objectContaining({ signal: expect.any(AbortSignal) }) }),
+        );
+    });
+
+    it("does not display a stale page after a newer query resolves first", async () => {
+        const user = userEvent.setup();
+        let resolveStale: ((value: ReturnType<typeof jsonResponse>) => void) | undefined;
+        apiMocks.getEntries
+            .mockImplementationOnce((_args, options: { init?: { signal?: AbortSignal } }) => {
+                return new Promise((resolve, reject) => {
+                    options.init?.signal?.addEventListener("abort", () => {
+                        reject(new DOMException("Aborted", "AbortError"));
+                    });
+                    resolveStale = resolve;
+                });
+            })
+            .mockImplementationOnce(async () =>
+                jsonResponse(createPage([createEntry({ sourceText: "Invoice latest" })])),
+            );
+
+        renderExplorer();
+        expect(screen.getByLabelText("Loading translation memory entries")).toBeInTheDocument();
+
+        await user.type(screen.getByLabelText("Search source and target text"), "invoice");
+
+        await waitFor(
+            () => {
+                expect(apiMocks.getEntries).toHaveBeenCalledTimes(2);
+            },
+            { timeout: 1500 },
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("Invoice latest")).toBeInTheDocument();
+        });
+
+        resolveStale?.(jsonResponse(createPage([createEntry({ sourceText: "Stale checkout" })])));
+
+        await waitFor(() => {
+            expect(screen.getByText("Invoice latest")).toBeInTheDocument();
+        });
+        expect(screen.queryByText("Stale checkout")).not.toBeInTheDocument();
+    });
+
+    it("preserves query state when opening and returning from an entry", async () => {
+        const user = userEvent.setup();
+        navigation.search = "search=checkout";
+        apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([createEntry()])));
+
+        renderExplorer();
+
+        await waitFor(() => {
+            expect(screen.getByText("Checkout")).toBeInTheDocument();
+        });
+
+        await user.click(screen.getByRole("button", { name: "Open entry Checkout" }));
+
+        await waitFor(() => {
+            expect(navigation.replace).toHaveBeenCalledWith(
+                expect.stringMatching(/search=checkout.*entry=33333333-3333-4333-8333-333333333333/),
+                { scroll: false },
+            );
+        });
+
+        await user.click(screen.getByRole("button", { name: "Back to results" }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole("button", { name: "Back to results" })).not.toBeInTheDocument();
+        });
+        expect(screen.getByDisplayValue("checkout")).toBeInTheDocument();
+        expect(screen.getByText("Checkout")).toBeInTheDocument();
+    });
+
+    it("resets an invalid cursor to the first page", async () => {
+        navigation.search = "cursor=expired";
+        apiMocks.getEntries.mockImplementation(async (args: { query?: { cursor?: string } }) => {
+            if (args.query?.cursor) {
+                throw new ApiResponseError("Cursor is invalid", {
+                    code: "invalid_cursor",
+                    status: 400,
+                });
+            }
+            return jsonResponse(createPage([createEntry()]));
+        });
+
+        renderExplorer();
+
+        await waitFor(() => {
+            expect(screen.getByText("Checkout")).toBeInTheDocument();
+        });
+        expect(
+            screen.getAllByText("That page is no longer valid. Showing the first page.").length,
+        ).toBeGreaterThan(0);
+        expect(navigation.replace).toHaveBeenCalledWith(
+            "/en/org/acme/translation-memories/mem_1",
+            { scroll: false },
+        );
+    });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.test.tsx
@@ -37,349 +37,354 @@ import { ApiResponseError } from "@/lib/api-error";
 import { TmEntryExplorer } from "./tm-entry-explorer";
 
 const navigation = vi.hoisted(() => ({
-    pathname: "/en/org/acme/translation-memories/mem_1",
-    search: "",
-    replace: vi.fn(),
+  pathname: "/en/org/acme/translation-memories/mem_1",
+  search: "",
+  replace: vi.fn(),
 }));
 
 const apiMocks = vi.hoisted(() => ({
-    getEntries: vi.fn(),
+  getEntries: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
-    usePathname: () => navigation.pathname,
-    useRouter: () => ({
-        replace: navigation.replace,
-        push: vi.fn(),
-    }),
-    useSearchParams: () => new URLSearchParams(navigation.search),
+  usePathname: () => navigation.pathname,
+  useRouter: () => ({
+    replace: navigation.replace,
+    push: vi.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams(navigation.search),
 }));
 
 vi.mock("@/lib/api-client-instance", () => ({
-    apiClient: {
-        api: {
-            orgs: {
-                ":organizationSlug": {
-                    "translation-memories": {
-                        ":memoryId": {
-                            entries: {
-                                $get: (...args: unknown[]) => apiMocks.getEntries(...args),
-                            },
-                        },
-                    },
-                },
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          "translation-memories": {
+            ":memoryId": {
+              entries: {
+                $get: (...args: unknown[]) => apiMocks.getEntries(...args),
+              },
             },
+          },
         },
+      },
     },
+  },
 }));
 
 function createEntry(overrides?: Partial<MemoryEntryRecord>): MemoryEntryRecord {
-    return {
-        id: "33333333-3333-4333-8333-333333333333",
-        memoryId: "mem_1",
-        sourceLocale: "en-US",
-        targetLocale: "fr-FR",
-        sourceText: "Checkout",
-        targetText: "Paiement",
-        matchScore: 100,
-        provenance: "manual",
-        reviewStatus: "approved",
-        externalKey: null,
-        createdByUserId: "11111111-1111-4111-8111-111111111111",
-        importBatchId: null,
-        createdAt: "2026-08-01T00:00:00.000Z",
-        updatedAt: "2026-08-01T00:00:00.000Z",
-        ...overrides,
-    };
+  return {
+    id: "33333333-3333-4333-8333-333333333333",
+    memoryId: "mem_1",
+    sourceLocale: "en-US",
+    targetLocale: "fr-FR",
+    sourceText: "Checkout",
+    targetText: "Paiement",
+    matchScore: 100,
+    provenance: "manual",
+    reviewStatus: "approved",
+    externalKey: null,
+    createdByUserId: "11111111-1111-4111-8111-111111111111",
+    importBatchId: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
 }
 
 function createPage(
-    entries: MemoryEntryRecord[],
-    overrides?: Partial<MemoryEntriesResponse>,
+  entries: MemoryEntryRecord[],
+  overrides?: Partial<MemoryEntriesResponse>,
 ): MemoryEntriesResponse {
-    return {
-        memoryEntries: entries,
-        nextCursor: null,
-        total: entries.length,
-        pagination: {
-            limit: 50,
-            returned: entries.length,
-            hasMore: false,
-        },
-        ...overrides,
-    };
+  return {
+    memoryEntries: entries,
+    nextCursor: null,
+    total: entries.length,
+    pagination: {
+      limit: 50,
+      returned: entries.length,
+      hasMore: false,
+    },
+    ...overrides,
+  };
 }
 
 function jsonResponse(body: MemoryEntriesResponse) {
-    return {
-        ok: true,
-        json: async () => body,
-    };
+  return {
+    ok: true,
+    json: async () => body,
+  };
 }
 
 function renderExplorer(): ReturnType<typeof render> {
-    const queryClient = new QueryClient({
-        defaultOptions: {
-            queries: { retry: false, gcTime: 0 },
-        },
-    });
-    const ui: ReactElement = (
-        <IntlProvider locale="en" messages={{}}>
-            <QueryClientProvider client={queryClient}>
-                <TmEntryExplorer
-                    organizationSlug="acme"
-                    memoryId="mem_1"
-                    localeCoverage={["en-US", "fr-FR"]}
-                    canEdit
-                />
-            </QueryClientProvider>
-        </IntlProvider>
-    );
-    return render(ui);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  const ui: ReactElement = (
+    <IntlProvider locale="en" messages={{}}>
+      <QueryClientProvider client={queryClient}>
+        <TmEntryExplorer
+          organizationSlug="acme"
+          memoryId="mem_1"
+          localeCoverage={["en-US", "fr-FR"]}
+          canEdit
+        />
+      </QueryClientProvider>
+    </IntlProvider>
+  );
+  return render(ui);
 }
 
 describe("TmEntryExplorer", () => {
-    beforeEach(() => {
-        navigation.search = "";
-        navigation.replace.mockReset();
-        apiMocks.getEntries.mockReset();
-        sessionStorage.clear();
+  beforeEach(() => {
+    navigation.search = "";
+    navigation.replace.mockReset();
+    apiMocks.getEntries.mockReset();
+    sessionStorage.clear();
+  });
+
+  it("shows a loading state before entries arrive", async () => {
+    let resolvePage: ((value: ReturnType<typeof jsonResponse>) => void) | undefined;
+    apiMocks.getEntries.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+
+    renderExplorer();
+
+    expect(screen.getByLabelText("Loading translation memory entries")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading entries");
+
+    resolvePage?.(jsonResponse(createPage([])));
+    await waitFor(() => {
+      expect(screen.getByText("No entries yet.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows an empty filtered state from the server result", async () => {
+    navigation.search = "search=invoice";
+    apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([])));
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(screen.getByText("No entries match this search.")).toBeInTheDocument();
+    });
+    expect(apiMocks.getEntries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ search: "invoice" }),
+      }),
+      expect.objectContaining({
+        init: expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      }),
+    );
+  });
+
+  it("shows an error state and retries the same query", async () => {
+    const user = userEvent.setup();
+    apiMocks.getEntries
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "memory_unavailable", message: "Unable to load entries." }),
+      })
+      .mockResolvedValueOnce(jsonResponse(createPage([createEntry()])));
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
     });
 
-    it("shows a loading state before entries arrive", async () => {
-        let resolvePage: ((value: ReturnType<typeof jsonResponse>) => void) | undefined;
-        apiMocks.getEntries.mockReturnValue(
-            new Promise((resolve) => {
-                resolvePage = resolve;
-            }),
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Checkout")).toBeInTheDocument();
+    });
+    expect(apiMocks.getEntries).toHaveBeenCalledTimes(2);
+  });
+
+  it("pages forward with the server cursor and can return to the first page", async () => {
+    const user = userEvent.setup();
+    const first = createEntry({
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      sourceText: "First page",
+    });
+    const second = createEntry({
+      id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      sourceText: "Second page",
+    });
+
+    apiMocks.getEntries.mockImplementation(async (args: { query?: { cursor?: string } }) => {
+      if (args.query?.cursor === "cursor-2") {
+        return jsonResponse(
+          createPage([second], {
+            total: 2,
+            nextCursor: null,
+            pagination: { limit: 50, returned: 1, hasMore: false },
+          }),
         );
-
-        renderExplorer();
-
-        expect(screen.getByLabelText("Loading translation memory entries")).toBeInTheDocument();
-        expect(screen.getByRole("status")).toHaveTextContent("Loading entries");
-
-        resolvePage?.(jsonResponse(createPage([])));
-        await waitFor(() => {
-            expect(screen.getByText("No entries yet.")).toBeInTheDocument();
-        });
+      }
+      return jsonResponse(
+        createPage([first], {
+          total: 2,
+          nextCursor: "cursor-2",
+          pagination: { limit: 50, returned: 1, hasMore: true },
+        }),
+      );
     });
 
-    it("shows an empty filtered state from the server result", async () => {
-        navigation.search = "search=invoice";
-        apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([])));
+    renderExplorer();
 
-        renderExplorer();
-
-        await waitFor(() => {
-            expect(screen.getByText("No entries match this search.")).toBeInTheDocument();
-        });
-        expect(apiMocks.getEntries).toHaveBeenCalledWith(
-            expect.objectContaining({
-                query: expect.objectContaining({ search: "invoice" }),
-            }),
-            expect.objectContaining({ init: expect.objectContaining({ signal: expect.any(AbortSignal) }) }),
-        );
+    await waitFor(() => {
+      expect(screen.getByText("First page")).toBeInTheDocument();
     });
 
-    it("shows an error state and retries the same query", async () => {
-        const user = userEvent.setup();
-        apiMocks.getEntries
-            .mockResolvedValueOnce({
-                ok: false,
-                json: async () => ({ error: "memory_unavailable", message: "Unable to load entries." }),
-            })
-            .mockResolvedValueOnce(jsonResponse(createPage([createEntry()])));
+    await user.click(screen.getByRole("button", { name: "Next" }));
 
-        renderExplorer();
+    await waitFor(() => {
+      expect(screen.getByText("Second page")).toBeInTheDocument();
+    });
+    expect(navigation.replace).toHaveBeenCalledWith(expect.stringContaining("cursor=cursor-2"), {
+      scroll: false,
+    });
+    expect(screen.getByRole("button", { name: "Previous" })).toBeEnabled();
 
-        await waitFor(() => {
-            expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Previous" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("First page")).toBeInTheDocument();
+    });
+  });
+
+  it("restores search, filters, and sort from the URL", async () => {
+    navigation.search =
+      "search=checkout&sourceLocale=en-US&targetLocale=fr-FR&reviewStatus=pending&origin=import&provider=crowdin&sort=updated_at&sortDir=asc";
+    apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([createEntry()])));
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("checkout")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Search: checkout/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Sort by")).toHaveTextContent("Modified");
+    expect(screen.getByLabelText("Order")).toHaveTextContent("Oldest first");
+    expect(apiMocks.getEntries).toHaveBeenCalledWith(
+      {
+        param: { organizationSlug: "acme", memoryId: "mem_1" },
+        query: {
+          limit: "50",
+          search: "checkout",
+          sourceLocale: "en-US",
+          targetLocale: "fr-FR",
+          reviewStatus: "pending",
+          origin: "import",
+          provider: "crowdin",
+          sort: "updated_at",
+          sortDir: "asc",
+        },
+      },
+      expect.objectContaining({
+        init: expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      }),
+    );
+  });
+
+  it("does not display a stale page after a newer query resolves first", async () => {
+    const user = userEvent.setup();
+    let resolveStale: ((value: ReturnType<typeof jsonResponse>) => void) | undefined;
+    apiMocks.getEntries
+      .mockImplementationOnce((_args, options: { init?: { signal?: AbortSignal } }) => {
+        return new Promise((resolve, reject) => {
+          options.init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+          resolveStale = resolve;
         });
+      })
+      .mockImplementationOnce(async () =>
+        jsonResponse(createPage([createEntry({ sourceText: "Invoice latest" })])),
+      );
 
-        await user.click(screen.getByRole("button", { name: "Try again" }));
+    renderExplorer();
+    expect(screen.getByLabelText("Loading translation memory entries")).toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(screen.getByText("Checkout")).toBeInTheDocument();
-        });
+    await user.type(screen.getByLabelText("Search source and target text"), "invoice");
+
+    await waitFor(
+      () => {
         expect(apiMocks.getEntries).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 1500 },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Invoice latest")).toBeInTheDocument();
     });
 
-    it("pages forward with the server cursor and can return to the first page", async () => {
-        const user = userEvent.setup();
-        const first = createEntry({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", sourceText: "First page" });
-        const second = createEntry({
-            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-            sourceText: "Second page",
-        });
+    resolveStale?.(jsonResponse(createPage([createEntry({ sourceText: "Stale checkout" })])));
 
-        apiMocks.getEntries.mockImplementation(async (args: { query?: { cursor?: string } }) => {
-            if (args.query?.cursor === "cursor-2") {
-                return jsonResponse(
-                    createPage([second], {
-                        total: 2,
-                        nextCursor: null,
-                        pagination: { limit: 50, returned: 1, hasMore: false },
-                    }),
-                );
-            }
-            return jsonResponse(
-                createPage([first], {
-                    total: 2,
-                    nextCursor: "cursor-2",
-                    pagination: { limit: 50, returned: 1, hasMore: true },
-                }),
-            );
-        });
+    await waitFor(() => {
+      expect(screen.getByText("Invoice latest")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Stale checkout")).not.toBeInTheDocument();
+  });
 
-        renderExplorer();
+  it("preserves query state when opening and returning from an entry", async () => {
+    const user = userEvent.setup();
+    navigation.search = "search=checkout";
+    apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([createEntry()])));
 
-        await waitFor(() => {
-            expect(screen.getByText("First page")).toBeInTheDocument();
-        });
+    renderExplorer();
 
-        await user.click(screen.getByRole("button", { name: "Next" }));
-
-        await waitFor(() => {
-            expect(screen.getByText("Second page")).toBeInTheDocument();
-        });
-        expect(navigation.replace).toHaveBeenCalledWith(
-            expect.stringContaining("cursor=cursor-2"),
-            { scroll: false },
-        );
-        expect(screen.getByRole("button", { name: "Previous" })).toBeEnabled();
-
-        await user.click(screen.getByRole("button", { name: "Previous" }));
-
-        await waitFor(() => {
-            expect(screen.getByText("First page")).toBeInTheDocument();
-        });
+    await waitFor(() => {
+      expect(screen.getByText("Checkout")).toBeInTheDocument();
     });
 
-    it("restores search, filters, and sort from the URL", async () => {
-        navigation.search =
-            "search=checkout&sourceLocale=en-US&targetLocale=fr-FR&reviewStatus=pending&origin=import&provider=crowdin&sort=updated_at&sortDir=asc";
-        apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([createEntry()])));
+    await user.click(screen.getByRole("button", { name: "Open entry Checkout" }));
 
-        renderExplorer();
-
-        await waitFor(() => {
-            expect(screen.getByDisplayValue("checkout")).toBeInTheDocument();
-        });
-        expect(screen.getByText(/Search: checkout/)).toBeInTheDocument();
-        expect(screen.getByLabelText("Sort by")).toHaveTextContent("Modified");
-        expect(screen.getByLabelText("Order")).toHaveTextContent("Oldest first");
-        expect(apiMocks.getEntries).toHaveBeenCalledWith(
-            {
-                param: { organizationSlug: "acme", memoryId: "mem_1" },
-                query: {
-                    limit: "50",
-                    search: "checkout",
-                    sourceLocale: "en-US",
-                    targetLocale: "fr-FR",
-                    reviewStatus: "pending",
-                    origin: "import",
-                    provider: "crowdin",
-                    sort: "updated_at",
-                    sortDir: "asc",
-                },
-            },
-            expect.objectContaining({ init: expect.objectContaining({ signal: expect.any(AbortSignal) }) }),
-        );
+    await waitFor(() => {
+      expect(navigation.replace).toHaveBeenCalledWith(
+        expect.stringMatching(/search=checkout.*entry=33333333-3333-4333-8333-333333333333/),
+        { scroll: false },
+      );
     });
 
-    it("does not display a stale page after a newer query resolves first", async () => {
-        const user = userEvent.setup();
-        let resolveStale: ((value: ReturnType<typeof jsonResponse>) => void) | undefined;
-        apiMocks.getEntries
-            .mockImplementationOnce((_args, options: { init?: { signal?: AbortSignal } }) => {
-                return new Promise((resolve, reject) => {
-                    options.init?.signal?.addEventListener("abort", () => {
-                        reject(new DOMException("Aborted", "AbortError"));
-                    });
-                    resolveStale = resolve;
-                });
-            })
-            .mockImplementationOnce(async () =>
-                jsonResponse(createPage([createEntry({ sourceText: "Invoice latest" })])),
-            );
+    await user.click(screen.getByRole("button", { name: "Back to results" }));
 
-        renderExplorer();
-        expect(screen.getByLabelText("Loading translation memory entries")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Back to results" })).not.toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue("checkout")).toBeInTheDocument();
+    expect(screen.getByText("Checkout")).toBeInTheDocument();
+  });
 
-        await user.type(screen.getByLabelText("Search source and target text"), "invoice");
-
-        await waitFor(
-            () => {
-                expect(apiMocks.getEntries).toHaveBeenCalledTimes(2);
-            },
-            { timeout: 1500 },
-        );
-
-        await waitFor(() => {
-            expect(screen.getByText("Invoice latest")).toBeInTheDocument();
+  it("resets an invalid cursor to the first page", async () => {
+    navigation.search = "cursor=expired";
+    apiMocks.getEntries.mockImplementation(async (args: { query?: { cursor?: string } }) => {
+      if (args.query?.cursor) {
+        throw new ApiResponseError("Cursor is invalid", {
+          code: "invalid_cursor",
+          status: 400,
         });
-
-        resolveStale?.(jsonResponse(createPage([createEntry({ sourceText: "Stale checkout" })])));
-
-        await waitFor(() => {
-            expect(screen.getByText("Invoice latest")).toBeInTheDocument();
-        });
-        expect(screen.queryByText("Stale checkout")).not.toBeInTheDocument();
+      }
+      return jsonResponse(createPage([createEntry()]));
     });
 
-    it("preserves query state when opening and returning from an entry", async () => {
-        const user = userEvent.setup();
-        navigation.search = "search=checkout";
-        apiMocks.getEntries.mockResolvedValue(jsonResponse(createPage([createEntry()])));
+    renderExplorer();
 
-        renderExplorer();
-
-        await waitFor(() => {
-            expect(screen.getByText("Checkout")).toBeInTheDocument();
-        });
-
-        await user.click(screen.getByRole("button", { name: "Open entry Checkout" }));
-
-        await waitFor(() => {
-            expect(navigation.replace).toHaveBeenCalledWith(
-                expect.stringMatching(/search=checkout.*entry=33333333-3333-4333-8333-333333333333/),
-                { scroll: false },
-            );
-        });
-
-        await user.click(screen.getByRole("button", { name: "Back to results" }));
-
-        await waitFor(() => {
-            expect(screen.queryByRole("button", { name: "Back to results" })).not.toBeInTheDocument();
-        });
-        expect(screen.getByDisplayValue("checkout")).toBeInTheDocument();
-        expect(screen.getByText("Checkout")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Checkout")).toBeInTheDocument();
     });
-
-    it("resets an invalid cursor to the first page", async () => {
-        navigation.search = "cursor=expired";
-        apiMocks.getEntries.mockImplementation(async (args: { query?: { cursor?: string } }) => {
-            if (args.query?.cursor) {
-                throw new ApiResponseError("Cursor is invalid", {
-                    code: "invalid_cursor",
-                    status: 400,
-                });
-            }
-            return jsonResponse(createPage([createEntry()]));
-        });
-
-        renderExplorer();
-
-        await waitFor(() => {
-            expect(screen.getByText("Checkout")).toBeInTheDocument();
-        });
-        expect(
-            screen.getAllByText("That page is no longer valid. Showing the first page.").length,
-        ).toBeGreaterThan(0);
-        expect(navigation.replace).toHaveBeenCalledWith(
-            "/en/org/acme/translation-memories/mem_1",
-            { scroll: false },
-        );
+    expect(
+      screen.getAllByText("That page is no longer valid. Showing the first page.").length,
+    ).toBeGreaterThan(0);
+    expect(navigation.replace).toHaveBeenCalledWith("/en/org/acme/translation-memories/mem_1", {
+      scroll: false,
     });
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import type { MemoryEntryRecord } from "@/api/routes/memory/memory.schema";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyP } from "@/components/ui/typography";
+import { formatLocaleOptionLabel } from "@/lib/i18n/locale-display-names.messages";
+import { cn } from "@/lib/primitives/cn";
+
+import { tmEntryExplorerMessages as messages } from "./tm-entry-explorer.messages";
+import { TmEntryListToolbar } from "./tm-entry-list-toolbar";
+import {
+    buildTmEntryLocaleOptions,
+    getActiveTmEntryFilterChips,
+    readTmEntryCursorStack,
+    readTmEntryScrollOffset,
+    tmEntryCursorStackStorageKey,
+    tmEntryListStateToApiQuery,
+    tmEntryScrollStorageKey,
+    writeTmEntryCursorStack,
+    writeTmEntryScrollOffset,
+} from "./tm-entry-list-state";
+import {
+    fetchTmEntrySearchPage,
+    isAbortError,
+    isInvalidCursorError,
+    shouldApplyTmEntrySearchResult,
+    tmEntrySearchQueryKey,
+} from "./tm-entry-search";
+import { useTmEntryListUrlState } from "./use-tm-entry-list-url-state";
+
+export function TmEntryExplorer({
+    organizationSlug,
+    memoryId,
+    localeCoverage,
+    canEdit,
+    onEditEntry,
+    onDeleteEntry,
+    isDeleting = false,
+}: {
+    organizationSlug: string;
+    memoryId: string;
+    localeCoverage: string[];
+    canEdit: boolean;
+    onEditEntry?: (entry: MemoryEntryRecord) => void;
+    onDeleteEntry?: (entryId: string) => void;
+    isDeleting?: boolean;
+}) {
+    const intl = useIntl();
+    const { state, searchDraft, setSearchDraft, updateState, clearFilters } =
+        useTmEntryListUrlState();
+    const listRef = useRef<HTMLDivElement>(null);
+    const requestIdRef = useRef(0);
+    const [cursorNotice, setCursorNotice] = useState<string | null>(null);
+    const apiQuery = tmEntryListStateToApiQuery(state);
+    const cursorStackKey = tmEntryCursorStackStorageKey(memoryId, state);
+    const [cursorStack, setCursorStack] = useState(() => readTmEntryCursorStack(cursorStackKey));
+
+    useEffect(() => {
+        setCursorStack(readTmEntryCursorStack(cursorStackKey));
+    }, [cursorStackKey]);
+
+    const localeOptions = useMemo(
+        () =>
+            buildTmEntryLocaleOptions({
+                localeCoverage: [
+                    ...localeCoverage,
+                    state.sourceLocale,
+                    state.targetLocale,
+                ].filter((locale): locale is string => Boolean(locale)),
+            }),
+        [localeCoverage, state.sourceLocale, state.targetLocale],
+    );
+
+    const entriesQuery = useQuery({
+        queryKey: tmEntrySearchQueryKey(organizationSlug, memoryId, apiQuery),
+        queryFn: async ({ signal }) => {
+            const requestId = requestIdRef.current + 1;
+            requestIdRef.current = requestId;
+            try {
+                const page = await fetchTmEntrySearchPage({
+                    organizationSlug,
+                    memoryId,
+                    state,
+                    cursor: state.cursor,
+                    signal,
+                    fallbackMessage: intl.formatMessage(messages.error),
+                });
+                if (
+                    !shouldApplyTmEntrySearchResult({
+                        requestId,
+                        latestRequestId: requestIdRef.current,
+                        aborted: signal.aborted,
+                    })
+                ) {
+                    throw new DOMException("Aborted", "AbortError");
+                }
+                return page;
+            } catch (error) {
+                if (isAbortError(error) || signal.aborted) {
+                    throw error;
+                }
+                if (
+                    !shouldApplyTmEntrySearchResult({
+                        requestId,
+                        latestRequestId: requestIdRef.current,
+                    })
+                ) {
+                    throw new DOMException("Aborted", "AbortError");
+                }
+                throw error;
+            }
+        },
+    });
+
+    useEffect(() => {
+        if (!entriesQuery.isError || !isInvalidCursorError(entriesQuery.error) || !state.cursor) {
+            return;
+        }
+        setCursorNotice(intl.formatMessage(messages.invalidCursor));
+        writeTmEntryCursorStack(cursorStackKey, []);
+        setCursorStack([]);
+        updateState({ cursor: undefined });
+    }, [
+        cursorStackKey,
+        entriesQuery.error,
+        entriesQuery.isError,
+        intl,
+        state.cursor,
+        updateState,
+    ]);
+
+    useEffect(() => {
+        setCursorNotice(null);
+    }, [cursorStackKey]);
+
+    useEffect(() => {
+        const stored = readTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId));
+        if (stored === null || !listRef.current) {
+            return;
+        }
+        listRef.current.scrollTop = stored;
+    }, [memoryId, entriesQuery.dataUpdatedAt]);
+
+    const entries = entriesQuery.data?.memoryEntries ?? [];
+    const total = entriesQuery.data?.total ?? 0;
+    const hasMore = entriesQuery.data?.pagination.hasMore ?? Boolean(entriesQuery.data?.nextCursor);
+    const selectedEntry = entries.find((entry) => entry.id === state.entry) ?? null;
+    const hasFilters = getActiveTmEntryFilterChips(state).length > 0;
+
+    const persistScroll = () => {
+        if (listRef.current) {
+            writeTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId), listRef.current.scrollTop);
+        }
+    };
+
+    const openEntry = (entry: MemoryEntryRecord) => {
+        persistScroll();
+        updateState({ entry: entry.id });
+        listRef.current
+            ?.querySelector<HTMLElement>(`[data-entry-id="${entry.id}"]`)
+            ?.focus();
+    };
+
+    const closeEntry = () => {
+        updateState({ entry: undefined });
+        const stored = readTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId));
+        if (stored !== null && listRef.current) {
+            listRef.current.scrollTop = stored;
+        }
+    };
+
+    const goNext = () => {
+        const nextCursor = entriesQuery.data?.nextCursor;
+        if (!nextCursor) {
+            return;
+        }
+        persistScroll();
+        const nextStack = [...cursorStack, state.cursor ?? ""];
+        writeTmEntryCursorStack(cursorStackKey, nextStack);
+        setCursorStack(nextStack);
+        updateState({ cursor: nextCursor });
+    };
+
+    const goPrevious = () => {
+        persistScroll();
+        const nextStack = [...cursorStack];
+        const previous = nextStack.pop();
+        writeTmEntryCursorStack(cursorStackKey, nextStack);
+        setCursorStack(nextStack);
+        updateState({ cursor: previous || undefined });
+    };
+
+    const statusMessage = entriesQuery.isFetching
+        ? intl.formatMessage(messages.statusLoading)
+        : cursorNotice ??
+          intl.formatMessage(messages.statusCount, {
+              shown: entries.length,
+              total,
+          });
+
+    return (
+        <div className="grid gap-4">
+            <TmEntryListToolbar
+                state={state}
+                searchDraft={searchDraft}
+                localeOptions={localeOptions}
+                onSearchDraftChange={setSearchDraft}
+                onStateChange={updateState}
+                onClearFilters={clearFilters}
+            />
+
+            <div className="sr-only" role="status" aria-live="polite">
+                {statusMessage}
+            </div>
+            {cursorNotice ? (
+                <TypographyP className="text-sm text-muted-foreground">{cursorNotice}</TypographyP>
+            ) : null}
+
+            {selectedEntry ? (
+                <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-3 py-2">
+                    <TypographyP className="text-sm font-medium">
+                        <FormattedMessage {...messages.selectedEntry} />
+                    </TypographyP>
+                    <Button type="button" size="sm" variant="outline" onClick={closeEntry}>
+                        <FormattedMessage {...messages.closeEntry} />
+                    </Button>
+                </div>
+            ) : null}
+
+            {entriesQuery.isLoading ? (
+                <div
+                    className="overflow-hidden rounded-lg border border-border"
+                    aria-busy="true"
+                    aria-label={intl.formatMessage(messages.loadingAria)}
+                >
+                    {Array.from({ length: 5 }).map((_, index) => (
+                        <div
+                            key={index}
+                            className="grid gap-2 border-b border-border px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto]"
+                        >
+                            <Skeleton className="h-5 w-3/4" />
+                            <Skeleton className="h-5 w-2/3" />
+                            <Skeleton className="h-8 w-24" />
+                        </div>
+                    ))}
+                </div>
+            ) : null}
+
+            {entriesQuery.isError && !isInvalidCursorError(entriesQuery.error) ? (
+                <div className="grid gap-3 rounded-lg border border-border px-4 py-10 text-center">
+                    <TypographyP className="text-sm text-muted-foreground">
+                        {entriesQuery.error instanceof Error
+                            ? entriesQuery.error.message
+                            : intl.formatMessage(messages.error)}
+                    </TypographyP>
+                    <div>
+                        <Button type="button" variant="outline" onClick={() => entriesQuery.refetch()}>
+                            <FormattedMessage {...messages.retry} />
+                        </Button>
+                    </div>
+                </div>
+            ) : null}
+
+            {entriesQuery.isSuccess && entries.length === 0 ? (
+                <TypographyP className="rounded-lg border border-border px-4 py-6 text-sm text-muted-foreground">
+                    <FormattedMessage {...(hasFilters ? messages.empty : messages.emptyNoFilters)} />
+                </TypographyP>
+            ) : null}
+
+            {entriesQuery.isSuccess && entries.length > 0 ? (
+                <div
+                    ref={listRef}
+                    className="max-h-[40rem] overflow-auto rounded-lg border border-border"
+                    aria-busy={entriesQuery.isFetching}
+                >
+                    {entries.map((entry) => {
+                        const isSelected = entry.id === state.entry;
+                        return (
+                            <div
+                                key={entry.id}
+                                data-entry-id={entry.id}
+                                role="button"
+                                tabIndex={0}
+                                aria-current={isSelected ? "true" : undefined}
+                                aria-label={intl.formatMessage(messages.openEntryAria, {
+                                    sourceText: entry.sourceText,
+                                })}
+                                className={cn(
+                                    "grid gap-2 border-b border-border px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto] md:items-center",
+                                    isSelected && "bg-muted/50",
+                                )}
+                                onClick={() => openEntry(entry)}
+                                onKeyDown={(event) => {
+                                    if (event.key === "Enter" || event.key === " ") {
+                                        event.preventDefault();
+                                        openEntry(entry);
+                                    }
+                                }}
+                            >
+                                <div>
+                                    <TypographyP className="text-sm font-medium">{entry.sourceText}</TypographyP>
+                                    <TypographyP className="text-xs text-muted-foreground">
+                                        <FormattedMessage
+                                            {...messages.localePair}
+                                            values={{
+                                                sourceLocale: formatLocaleOptionLabel(intl, entry.sourceLocale),
+                                                targetLocale: formatLocaleOptionLabel(intl, entry.targetLocale),
+                                            }}
+                                        />
+                                    </TypographyP>
+                                </div>
+                                <div className="grid gap-1">
+                                    <TypographyP className="text-sm text-subtle-foreground">
+                                        {entry.targetText}
+                                    </TypographyP>
+                                    <div className="flex flex-wrap gap-1">
+                                        <Badge variant="outline">{entry.reviewStatus}</Badge>
+                                        <Badge variant="outline">{entry.provenance}</Badge>
+                                    </div>
+                                </div>
+                                {canEdit ? (
+                                    <div className="flex gap-2">
+                                        <Button
+                                            type="button"
+                                            size="sm"
+                                            variant="outline"
+                                            onClick={(event) => {
+                                                event.stopPropagation();
+                                                openEntry(entry);
+                                                onEditEntry?.(entry);
+                                            }}
+                                        >
+                                            <FormattedMessage {...messages.editEntry} />
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            size="sm"
+                                            variant="ghost"
+                                            disabled={isDeleting}
+                                            onClick={(event) => {
+                                                event.stopPropagation();
+                                                onDeleteEntry?.(entry.id);
+                                            }}
+                                        >
+                                            <FormattedMessage {...messages.deleteEntry} />
+                                        </Button>
+                                    </div>
+                                ) : null}
+                            </div>
+                        );
+                    })}
+                </div>
+            ) : null}
+
+            {selectedEntry && (selectedEntry.createdByUserId || selectedEntry.importBatchId) ? (
+                <div className="flex flex-wrap gap-2">
+                    {selectedEntry.createdByUserId ? (
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            onClick={() =>
+                                updateState({ createdByUserId: selectedEntry.createdByUserId ?? undefined })
+                            }
+                        >
+                            <FormattedMessage {...messages.filterByCreator} />
+                        </Button>
+                    ) : null}
+                    {selectedEntry.importBatchId ? (
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            onClick={() =>
+                                updateState({ importBatchId: selectedEntry.importBatchId ?? undefined })
+                            }
+                        >
+                            <FormattedMessage {...messages.filterByBatch} />
+                        </Button>
+                    ) : null}
+                </div>
+            ) : null}
+
+            {entriesQuery.isSuccess && (hasMore || Boolean(state.cursor)) ? (
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    <TypographyP className="text-xs text-muted-foreground">{statusMessage}</TypographyP>
+                    <div className="flex gap-2">
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            disabled={!state.cursor || entriesQuery.isFetching}
+                            onClick={goPrevious}
+                        >
+                            <FormattedMessage {...messages.previousPage} />
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            disabled={!hasMore || entriesQuery.isFetching}
+                            onClick={goNext}
+                        >
+                            <FormattedMessage {...messages.nextPage} />
+                        </Button>
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
@@ -28,6 +28,7 @@ import { tmEntryExplorerMessages as messages } from "./tm-entry-explorer.message
 import { TmEntryListToolbar } from "./tm-entry-list-toolbar";
 import {
   buildTmEntryLocaleOptions,
+  canGoToPreviousTmEntryPage,
   getActiveTmEntryFilterChips,
   readTmEntryCursorStack,
   readTmEntryScrollOffset,
@@ -188,7 +189,15 @@ export function TmEntryExplorer({
     updateState({ cursor: nextCursor });
   };
 
+  const canGoPrevious = canGoToPreviousTmEntryPage({
+    cursor: state.cursor,
+    cursorStack,
+  });
+
   const goPrevious = () => {
+    if (!canGoPrevious) {
+      return;
+    }
     persistScroll();
     const nextStack = [...cursorStack];
     const previous = nextStack.pop();
@@ -395,7 +404,7 @@ export function TmEntryExplorer({
               type="button"
               size="sm"
               variant="outline"
-              disabled={!state.cursor || entriesQuery.isFetching}
+              disabled={!canGoPrevious || entriesQuery.isFetching}
               onClick={goPrevious}
             >
               <FormattedMessage {...messages.previousPage} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
@@ -27,403 +27,391 @@ import { cn } from "@/lib/primitives/cn";
 import { tmEntryExplorerMessages as messages } from "./tm-entry-explorer.messages";
 import { TmEntryListToolbar } from "./tm-entry-list-toolbar";
 import {
-    buildTmEntryLocaleOptions,
-    getActiveTmEntryFilterChips,
-    readTmEntryCursorStack,
-    readTmEntryScrollOffset,
-    tmEntryCursorStackStorageKey,
-    tmEntryListStateToApiQuery,
-    tmEntryScrollStorageKey,
-    writeTmEntryCursorStack,
-    writeTmEntryScrollOffset,
+  buildTmEntryLocaleOptions,
+  getActiveTmEntryFilterChips,
+  readTmEntryCursorStack,
+  readTmEntryScrollOffset,
+  tmEntryCursorStackStorageKey,
+  tmEntryListStateToApiQuery,
+  tmEntryScrollStorageKey,
+  writeTmEntryCursorStack,
+  writeTmEntryScrollOffset,
 } from "./tm-entry-list-state";
 import {
-    fetchTmEntrySearchPage,
-    isAbortError,
-    isInvalidCursorError,
-    shouldApplyTmEntrySearchResult,
-    tmEntrySearchQueryKey,
+  fetchTmEntrySearchPage,
+  isAbortError,
+  isInvalidCursorError,
+  shouldApplyTmEntrySearchResult,
+  tmEntrySearchQueryKey,
 } from "./tm-entry-search";
 import { useTmEntryListUrlState } from "./use-tm-entry-list-url-state";
 
 export function TmEntryExplorer({
-    organizationSlug,
-    memoryId,
-    localeCoverage,
-    canEdit,
-    onEditEntry,
-    onDeleteEntry,
-    isDeleting = false,
+  organizationSlug,
+  memoryId,
+  localeCoverage,
+  canEdit,
+  onEditEntry,
+  onDeleteEntry,
+  isDeleting = false,
 }: {
-    organizationSlug: string;
-    memoryId: string;
-    localeCoverage: string[];
-    canEdit: boolean;
-    onEditEntry?: (entry: MemoryEntryRecord) => void;
-    onDeleteEntry?: (entryId: string) => void;
-    isDeleting?: boolean;
+  organizationSlug: string;
+  memoryId: string;
+  localeCoverage: string[];
+  canEdit: boolean;
+  onEditEntry?: (entry: MemoryEntryRecord) => void;
+  onDeleteEntry?: (entryId: string) => void;
+  isDeleting?: boolean;
 }) {
-    const intl = useIntl();
-    const { state, searchDraft, setSearchDraft, updateState, clearFilters } =
-        useTmEntryListUrlState();
-    const listRef = useRef<HTMLDivElement>(null);
-    const requestIdRef = useRef(0);
-    const [cursorNotice, setCursorNotice] = useState<string | null>(null);
-    const apiQuery = tmEntryListStateToApiQuery(state);
-    const cursorStackKey = tmEntryCursorStackStorageKey(memoryId, state);
-    const [cursorStack, setCursorStack] = useState(() => readTmEntryCursorStack(cursorStackKey));
+  const intl = useIntl();
+  const { state, searchDraft, setSearchDraft, updateState, clearFilters } =
+    useTmEntryListUrlState();
+  const listRef = useRef<HTMLDivElement>(null);
+  const requestIdRef = useRef(0);
+  const [cursorNotice, setCursorNotice] = useState<string | null>(null);
+  const apiQuery = tmEntryListStateToApiQuery(state);
+  const cursorStackKey = tmEntryCursorStackStorageKey(memoryId, state);
+  const [cursorStack, setCursorStack] = useState(() => readTmEntryCursorStack(cursorStackKey));
 
-    useEffect(() => {
-        setCursorStack(readTmEntryCursorStack(cursorStackKey));
-    }, [cursorStackKey]);
+  useEffect(() => {
+    setCursorStack(readTmEntryCursorStack(cursorStackKey));
+  }, [cursorStackKey]);
 
-    const localeOptions = useMemo(
-        () =>
-            buildTmEntryLocaleOptions({
-                localeCoverage: [
-                    ...localeCoverage,
-                    state.sourceLocale,
-                    state.targetLocale,
-                ].filter((locale): locale is string => Boolean(locale)),
-            }),
-        [localeCoverage, state.sourceLocale, state.targetLocale],
-    );
+  const localeOptions = useMemo(
+    () =>
+      buildTmEntryLocaleOptions({
+        localeCoverage: [...localeCoverage, state.sourceLocale, state.targetLocale].filter(
+          (locale): locale is string => Boolean(locale),
+        ),
+      }),
+    [localeCoverage, state.sourceLocale, state.targetLocale],
+  );
 
-    const entriesQuery = useQuery({
-        queryKey: tmEntrySearchQueryKey(organizationSlug, memoryId, apiQuery),
-        queryFn: async ({ signal }) => {
-            const requestId = requestIdRef.current + 1;
-            requestIdRef.current = requestId;
-            try {
-                const page = await fetchTmEntrySearchPage({
-                    organizationSlug,
-                    memoryId,
-                    state,
-                    cursor: state.cursor,
-                    signal,
-                    fallbackMessage: intl.formatMessage(messages.error),
-                });
-                if (
-                    !shouldApplyTmEntrySearchResult({
-                        requestId,
-                        latestRequestId: requestIdRef.current,
-                        aborted: signal.aborted,
-                    })
-                ) {
-                    throw new DOMException("Aborted", "AbortError");
-                }
-                return page;
-            } catch (error) {
-                if (isAbortError(error) || signal.aborted) {
-                    throw error;
-                }
-                if (
-                    !shouldApplyTmEntrySearchResult({
-                        requestId,
-                        latestRequestId: requestIdRef.current,
-                    })
-                ) {
-                    throw new DOMException("Aborted", "AbortError");
-                }
-                throw error;
-            }
-        },
-    });
-
-    useEffect(() => {
-        if (!entriesQuery.isError || !isInvalidCursorError(entriesQuery.error) || !state.cursor) {
-            return;
+  const entriesQuery = useQuery({
+    queryKey: tmEntrySearchQueryKey(organizationSlug, memoryId, apiQuery),
+    queryFn: async ({ signal }) => {
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+      try {
+        const page = await fetchTmEntrySearchPage({
+          organizationSlug,
+          memoryId,
+          state,
+          cursor: state.cursor,
+          signal,
+          fallbackMessage: intl.formatMessage(messages.error),
+        });
+        if (
+          !shouldApplyTmEntrySearchResult({
+            requestId,
+            latestRequestId: requestIdRef.current,
+            aborted: signal.aborted,
+          })
+        ) {
+          throw new DOMException("Aborted", "AbortError");
         }
-        setCursorNotice(intl.formatMessage(messages.invalidCursor));
-        writeTmEntryCursorStack(cursorStackKey, []);
-        setCursorStack([]);
-        updateState({ cursor: undefined });
-    }, [
-        cursorStackKey,
-        entriesQuery.error,
-        entriesQuery.isError,
-        intl,
-        state.cursor,
-        updateState,
-    ]);
-
-    useEffect(() => {
-        setCursorNotice(null);
-    }, [cursorStackKey]);
-
-    useEffect(() => {
-        const stored = readTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId));
-        if (stored === null || !listRef.current) {
-            return;
+        return page;
+      } catch (error) {
+        if (isAbortError(error) || signal.aborted) {
+          throw error;
         }
-        listRef.current.scrollTop = stored;
-    }, [memoryId, entriesQuery.dataUpdatedAt]);
-
-    const entries = entriesQuery.data?.memoryEntries ?? [];
-    const total = entriesQuery.data?.total ?? 0;
-    const hasMore = entriesQuery.data?.pagination.hasMore ?? Boolean(entriesQuery.data?.nextCursor);
-    const selectedEntry = entries.find((entry) => entry.id === state.entry) ?? null;
-    const hasFilters = getActiveTmEntryFilterChips(state).length > 0;
-
-    const persistScroll = () => {
-        if (listRef.current) {
-            writeTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId), listRef.current.scrollTop);
+        if (
+          !shouldApplyTmEntrySearchResult({
+            requestId,
+            latestRequestId: requestIdRef.current,
+          })
+        ) {
+          throw new DOMException("Aborted", "AbortError");
         }
-    };
+        throw error;
+      }
+    },
+  });
 
-    const openEntry = (entry: MemoryEntryRecord) => {
-        persistScroll();
-        updateState({ entry: entry.id });
-        listRef.current
-            ?.querySelector<HTMLElement>(`[data-entry-id="${entry.id}"]`)
-            ?.focus();
-    };
+  useEffect(() => {
+    if (!entriesQuery.isError || !isInvalidCursorError(entriesQuery.error) || !state.cursor) {
+      return;
+    }
+    setCursorNotice(intl.formatMessage(messages.invalidCursor));
+    writeTmEntryCursorStack(cursorStackKey, []);
+    setCursorStack([]);
+    updateState({ cursor: undefined });
+  }, [cursorStackKey, entriesQuery.error, entriesQuery.isError, intl, state.cursor, updateState]);
 
-    const closeEntry = () => {
-        updateState({ entry: undefined });
-        const stored = readTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId));
-        if (stored !== null && listRef.current) {
-            listRef.current.scrollTop = stored;
-        }
-    };
+  useEffect(() => {
+    setCursorNotice(null);
+  }, [cursorStackKey]);
 
-    const goNext = () => {
-        const nextCursor = entriesQuery.data?.nextCursor;
-        if (!nextCursor) {
-            return;
-        }
-        persistScroll();
-        const nextStack = [...cursorStack, state.cursor ?? ""];
-        writeTmEntryCursorStack(cursorStackKey, nextStack);
-        setCursorStack(nextStack);
-        updateState({ cursor: nextCursor });
-    };
+  useEffect(() => {
+    const stored = readTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId));
+    if (stored === null || !listRef.current) {
+      return;
+    }
+    listRef.current.scrollTop = stored;
+  }, [memoryId, entriesQuery.dataUpdatedAt]);
 
-    const goPrevious = () => {
-        persistScroll();
-        const nextStack = [...cursorStack];
-        const previous = nextStack.pop();
-        writeTmEntryCursorStack(cursorStackKey, nextStack);
-        setCursorStack(nextStack);
-        updateState({ cursor: previous || undefined });
-    };
+  const entries = entriesQuery.data?.memoryEntries ?? [];
+  const total = entriesQuery.data?.total ?? 0;
+  const hasMore = entriesQuery.data?.pagination.hasMore ?? Boolean(entriesQuery.data?.nextCursor);
+  const selectedEntry = entries.find((entry) => entry.id === state.entry) ?? null;
+  const hasFilters = getActiveTmEntryFilterChips(state).length > 0;
 
-    const statusMessage = entriesQuery.isFetching
-        ? intl.formatMessage(messages.statusLoading)
-        : cursorNotice ??
-          intl.formatMessage(messages.statusCount, {
-              shown: entries.length,
-              total,
-          });
+  const persistScroll = () => {
+    if (listRef.current) {
+      writeTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId), listRef.current.scrollTop);
+    }
+  };
 
-    return (
-        <div className="grid gap-4">
-            <TmEntryListToolbar
-                state={state}
-                searchDraft={searchDraft}
-                localeOptions={localeOptions}
-                onSearchDraftChange={setSearchDraft}
-                onStateChange={updateState}
-                onClearFilters={clearFilters}
-            />
+  const openEntry = (entry: MemoryEntryRecord) => {
+    persistScroll();
+    updateState({ entry: entry.id });
+    listRef.current?.querySelector<HTMLElement>(`[data-entry-id="${entry.id}"]`)?.focus();
+  };
 
-            <div className="sr-only" role="status" aria-live="polite">
-                {statusMessage}
-            </div>
-            {cursorNotice ? (
-                <TypographyP className="text-sm text-muted-foreground">{cursorNotice}</TypographyP>
-            ) : null}
+  const closeEntry = () => {
+    updateState({ entry: undefined });
+    const stored = readTmEntryScrollOffset(tmEntryScrollStorageKey(memoryId));
+    if (stored !== null && listRef.current) {
+      listRef.current.scrollTop = stored;
+    }
+  };
 
-            {selectedEntry ? (
-                <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-3 py-2">
-                    <TypographyP className="text-sm font-medium">
-                        <FormattedMessage {...messages.selectedEntry} />
-                    </TypographyP>
-                    <Button type="button" size="sm" variant="outline" onClick={closeEntry}>
-                        <FormattedMessage {...messages.closeEntry} />
-                    </Button>
-                </div>
-            ) : null}
+  const goNext = () => {
+    const nextCursor = entriesQuery.data?.nextCursor;
+    if (!nextCursor) {
+      return;
+    }
+    persistScroll();
+    const nextStack = [...cursorStack, state.cursor ?? ""];
+    writeTmEntryCursorStack(cursorStackKey, nextStack);
+    setCursorStack(nextStack);
+    updateState({ cursor: nextCursor });
+  };
 
-            {entriesQuery.isLoading ? (
-                <div
-                    className="overflow-hidden rounded-lg border border-border"
-                    aria-busy="true"
-                    aria-label={intl.formatMessage(messages.loadingAria)}
-                >
-                    {Array.from({ length: 5 }).map((_, index) => (
-                        <div
-                            key={index}
-                            className="grid gap-2 border-b border-border px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto]"
-                        >
-                            <Skeleton className="h-5 w-3/4" />
-                            <Skeleton className="h-5 w-2/3" />
-                            <Skeleton className="h-8 w-24" />
-                        </div>
-                    ))}
-                </div>
-            ) : null}
+  const goPrevious = () => {
+    persistScroll();
+    const nextStack = [...cursorStack];
+    const previous = nextStack.pop();
+    writeTmEntryCursorStack(cursorStackKey, nextStack);
+    setCursorStack(nextStack);
+    updateState({ cursor: previous || undefined });
+  };
 
-            {entriesQuery.isError && !isInvalidCursorError(entriesQuery.error) ? (
-                <div className="grid gap-3 rounded-lg border border-border px-4 py-10 text-center">
-                    <TypographyP className="text-sm text-muted-foreground">
-                        {entriesQuery.error instanceof Error
-                            ? entriesQuery.error.message
-                            : intl.formatMessage(messages.error)}
-                    </TypographyP>
-                    <div>
-                        <Button type="button" variant="outline" onClick={() => entriesQuery.refetch()}>
-                            <FormattedMessage {...messages.retry} />
-                        </Button>
-                    </div>
-                </div>
-            ) : null}
+  const statusMessage = entriesQuery.isFetching
+    ? intl.formatMessage(messages.statusLoading)
+    : (cursorNotice ??
+      intl.formatMessage(messages.statusCount, {
+        total,
+      }));
 
-            {entriesQuery.isSuccess && entries.length === 0 ? (
-                <TypographyP className="rounded-lg border border-border px-4 py-6 text-sm text-muted-foreground">
-                    <FormattedMessage {...(hasFilters ? messages.empty : messages.emptyNoFilters)} />
-                </TypographyP>
-            ) : null}
+  return (
+    <div className="grid gap-4">
+      <TmEntryListToolbar
+        state={state}
+        searchDraft={searchDraft}
+        localeOptions={localeOptions}
+        onSearchDraftChange={setSearchDraft}
+        onStateChange={updateState}
+        onClearFilters={clearFilters}
+      />
 
-            {entriesQuery.isSuccess && entries.length > 0 ? (
-                <div
-                    ref={listRef}
-                    className="max-h-[40rem] overflow-auto rounded-lg border border-border"
-                    aria-busy={entriesQuery.isFetching}
-                >
-                    {entries.map((entry) => {
-                        const isSelected = entry.id === state.entry;
-                        return (
-                            <div
-                                key={entry.id}
-                                data-entry-id={entry.id}
-                                role="button"
-                                tabIndex={0}
-                                aria-current={isSelected ? "true" : undefined}
-                                aria-label={intl.formatMessage(messages.openEntryAria, {
-                                    sourceText: entry.sourceText,
-                                })}
-                                className={cn(
-                                    "grid gap-2 border-b border-border px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto] md:items-center",
-                                    isSelected && "bg-muted/50",
-                                )}
-                                onClick={() => openEntry(entry)}
-                                onKeyDown={(event) => {
-                                    if (event.key === "Enter" || event.key === " ") {
-                                        event.preventDefault();
-                                        openEntry(entry);
-                                    }
-                                }}
-                            >
-                                <div>
-                                    <TypographyP className="text-sm font-medium">{entry.sourceText}</TypographyP>
-                                    <TypographyP className="text-xs text-muted-foreground">
-                                        <FormattedMessage
-                                            {...messages.localePair}
-                                            values={{
-                                                sourceLocale: formatLocaleOptionLabel(intl, entry.sourceLocale),
-                                                targetLocale: formatLocaleOptionLabel(intl, entry.targetLocale),
-                                            }}
-                                        />
-                                    </TypographyP>
-                                </div>
-                                <div className="grid gap-1">
-                                    <TypographyP className="text-sm text-subtle-foreground">
-                                        {entry.targetText}
-                                    </TypographyP>
-                                    <div className="flex flex-wrap gap-1">
-                                        <Badge variant="outline">{entry.reviewStatus}</Badge>
-                                        <Badge variant="outline">{entry.provenance}</Badge>
-                                    </div>
-                                </div>
-                                {canEdit ? (
-                                    <div className="flex gap-2">
-                                        <Button
-                                            type="button"
-                                            size="sm"
-                                            variant="outline"
-                                            onClick={(event) => {
-                                                event.stopPropagation();
-                                                openEntry(entry);
-                                                onEditEntry?.(entry);
-                                            }}
-                                        >
-                                            <FormattedMessage {...messages.editEntry} />
-                                        </Button>
-                                        <Button
-                                            type="button"
-                                            size="sm"
-                                            variant="ghost"
-                                            disabled={isDeleting}
-                                            onClick={(event) => {
-                                                event.stopPropagation();
-                                                onDeleteEntry?.(entry.id);
-                                            }}
-                                        >
-                                            <FormattedMessage {...messages.deleteEntry} />
-                                        </Button>
-                                    </div>
-                                ) : null}
-                            </div>
-                        );
-                    })}
-                </div>
-            ) : null}
+      <div className="sr-only" role="status" aria-live="polite">
+        {statusMessage}
+      </div>
+      {cursorNotice ? (
+        <TypographyP className="text-sm text-muted-foreground">{cursorNotice}</TypographyP>
+      ) : null}
 
-            {selectedEntry && (selectedEntry.createdByUserId || selectedEntry.importBatchId) ? (
-                <div className="flex flex-wrap gap-2">
-                    {selectedEntry.createdByUserId ? (
-                        <Button
-                            type="button"
-                            size="sm"
-                            variant="ghost"
-                            onClick={() =>
-                                updateState({ createdByUserId: selectedEntry.createdByUserId ?? undefined })
-                            }
-                        >
-                            <FormattedMessage {...messages.filterByCreator} />
-                        </Button>
-                    ) : null}
-                    {selectedEntry.importBatchId ? (
-                        <Button
-                            type="button"
-                            size="sm"
-                            variant="ghost"
-                            onClick={() =>
-                                updateState({ importBatchId: selectedEntry.importBatchId ?? undefined })
-                            }
-                        >
-                            <FormattedMessage {...messages.filterByBatch} />
-                        </Button>
-                    ) : null}
-                </div>
-            ) : null}
-
-            {entriesQuery.isSuccess && (hasMore || Boolean(state.cursor)) ? (
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                    <TypographyP className="text-xs text-muted-foreground">{statusMessage}</TypographyP>
-                    <div className="flex gap-2">
-                        <Button
-                            type="button"
-                            size="sm"
-                            variant="outline"
-                            disabled={!state.cursor || entriesQuery.isFetching}
-                            onClick={goPrevious}
-                        >
-                            <FormattedMessage {...messages.previousPage} />
-                        </Button>
-                        <Button
-                            type="button"
-                            size="sm"
-                            variant="outline"
-                            disabled={!hasMore || entriesQuery.isFetching}
-                            onClick={goNext}
-                        >
-                            <FormattedMessage {...messages.nextPage} />
-                        </Button>
-                    </div>
-                </div>
-            ) : null}
+      {selectedEntry ? (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-3 py-2">
+          <TypographyP className="text-sm font-medium">
+            <FormattedMessage {...messages.selectedEntry} />
+          </TypographyP>
+          <Button type="button" size="sm" variant="outline" onClick={closeEntry}>
+            <FormattedMessage {...messages.closeEntry} />
+          </Button>
         </div>
-    );
+      ) : null}
+
+      {entriesQuery.isLoading ? (
+        <div
+          className="overflow-hidden rounded-lg border border-border"
+          aria-busy="true"
+          aria-label={intl.formatMessage(messages.loadingAria)}
+        >
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div
+              key={index}
+              className="grid gap-2 border-b border-border px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto]"
+            >
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-5 w-2/3" />
+              <Skeleton className="h-8 w-24" />
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {entriesQuery.isError && !isInvalidCursorError(entriesQuery.error) ? (
+        <div className="grid gap-3 rounded-lg border border-border px-4 py-10 text-center">
+          <TypographyP className="text-sm text-muted-foreground">
+            {entriesQuery.error instanceof Error
+              ? entriesQuery.error.message
+              : intl.formatMessage(messages.error)}
+          </TypographyP>
+          <div>
+            <Button type="button" variant="outline" onClick={() => entriesQuery.refetch()}>
+              <FormattedMessage {...messages.retry} />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {entriesQuery.isSuccess && entries.length === 0 ? (
+        <TypographyP className="rounded-lg border border-border px-4 py-6 text-sm text-muted-foreground">
+          <FormattedMessage {...(hasFilters ? messages.empty : messages.emptyNoFilters)} />
+        </TypographyP>
+      ) : null}
+
+      {entriesQuery.isSuccess && entries.length > 0 ? (
+        <div
+          ref={listRef}
+          className="max-h-[40rem] overflow-auto rounded-lg border border-border"
+          aria-busy={entriesQuery.isFetching}
+        >
+          {entries.map((entry) => {
+            const isSelected = entry.id === state.entry;
+            return (
+              <div
+                key={entry.id}
+                data-entry-id={entry.id}
+                role="button"
+                tabIndex={0}
+                aria-current={isSelected ? "true" : undefined}
+                aria-label={intl.formatMessage(messages.openEntryAria, {
+                  sourceText: entry.sourceText,
+                })}
+                className={cn(
+                  "grid gap-2 border-b border-border px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto] md:items-center",
+                  isSelected && "bg-muted/50",
+                )}
+                onClick={() => openEntry(entry)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    openEntry(entry);
+                  }
+                }}
+              >
+                <div>
+                  <TypographyP className="text-sm font-medium">{entry.sourceText}</TypographyP>
+                  <TypographyP className="text-xs text-muted-foreground">
+                    <FormattedMessage
+                      {...messages.localePair}
+                      values={{
+                        sourceLocale: formatLocaleOptionLabel(intl, entry.sourceLocale),
+                        targetLocale: formatLocaleOptionLabel(intl, entry.targetLocale),
+                      }}
+                    />
+                  </TypographyP>
+                </div>
+                <div className="grid gap-1">
+                  <TypographyP className="text-sm text-subtle-foreground">
+                    {entry.targetText}
+                  </TypographyP>
+                  <div className="flex flex-wrap gap-1">
+                    <Badge variant="outline">{entry.reviewStatus}</Badge>
+                    <Badge variant="outline">{entry.provenance}</Badge>
+                  </div>
+                </div>
+                {canEdit ? (
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        openEntry(entry);
+                        onEditEntry?.(entry);
+                      }}
+                    >
+                      <FormattedMessage {...messages.editEntry} />
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      disabled={isDeleting}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onDeleteEntry?.(entry.id);
+                      }}
+                    >
+                      <FormattedMessage {...messages.deleteEntry} />
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {selectedEntry && (selectedEntry.createdByUserId || selectedEntry.importBatchId) ? (
+        <div className="flex flex-wrap gap-2">
+          {selectedEntry.createdByUserId ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() =>
+                updateState({ createdByUserId: selectedEntry.createdByUserId ?? undefined })
+              }
+            >
+              <FormattedMessage {...messages.filterByCreator} />
+            </Button>
+          ) : null}
+          {selectedEntry.importBatchId ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() =>
+                updateState({ importBatchId: selectedEntry.importBatchId ?? undefined })
+              }
+            >
+              <FormattedMessage {...messages.filterByBatch} />
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {entriesQuery.isSuccess && (hasMore || Boolean(state.cursor)) ? (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <TypographyP className="text-xs text-muted-foreground">{statusMessage}</TypographyP>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={!state.cursor || entriesQuery.isFetching}
+              onClick={goPrevious}
+            >
+              <FormattedMessage {...messages.previousPage} />
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={!hasMore || entriesQuery.isFetching}
+              onClick={goNext}
+            >
+              <FormattedMessage {...messages.nextPage} />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.test.ts
@@ -29,183 +29,181 @@ import { describe, expect, it } from "vite-plus/test";
 import { COMMON_LOCALES } from "@/lib/i18n/locales";
 
 import {
-    applyTmEntryListStatePatch,
-    buildTmEntryListHref,
-    buildTmEntryListSearchParams,
-    buildTmEntryLocaleOptions,
-    clearTmEntryListFilters,
-    getActiveTmEntryFilterChips,
-    modifiedDateToApiDateTime,
-    parseTmEntryListSearchParams,
-    readTmEntryCursorStack,
-    tmEntryListStateToApiQuery,
-    writeTmEntryCursorStack,
-    type TmEntryListUrlState,
+  applyTmEntryListStatePatch,
+  buildTmEntryListHref,
+  buildTmEntryListSearchParams,
+  buildTmEntryLocaleOptions,
+  clearTmEntryListFilters,
+  getActiveTmEntryFilterChips,
+  modifiedDateToApiDateTime,
+  parseTmEntryListSearchParams,
+  readTmEntryCursorStack,
+  tmEntryListStateToApiQuery,
+  writeTmEntryCursorStack,
+  type TmEntryListUrlState,
 } from "./tm-entry-list-state";
 
 const FULL_STATE: TmEntryListUrlState = {
-    search: "checkout",
-    sourceLocale: "en-US",
-    targetLocale: "fr-FR",
-    reviewStatus: "pending",
-    origin: "import",
-    provider: "crowdin",
-    createdByUserId: "11111111-1111-4111-8111-111111111111",
-    modifiedFrom: "2026-01-01",
-    modifiedTo: "2026-01-31",
-    importBatchId: "22222222-2222-4222-8222-222222222222",
-    sort: "updated_at",
-    sortDir: "asc",
-    cursor: "cursor.token",
-    entry: "33333333-3333-4333-8333-333333333333",
+  search: "checkout",
+  sourceLocale: "en-US",
+  targetLocale: "fr-FR",
+  reviewStatus: "pending",
+  origin: "import",
+  provider: "crowdin",
+  createdByUserId: "11111111-1111-4111-8111-111111111111",
+  modifiedFrom: "2026-01-01",
+  modifiedTo: "2026-01-31",
+  importBatchId: "22222222-2222-4222-8222-222222222222",
+  sort: "updated_at",
+  sortDir: "asc",
+  cursor: "cursor.token",
+  entry: "33333333-3333-4333-8333-333333333333",
 };
 
 describe("tm-entry-list-state", () => {
-    it("parses and rebuilds explorer query state from the URL", () => {
-        const params = buildTmEntryListSearchParams(FULL_STATE);
-        const restored = parseTmEntryListSearchParams(params);
+  it("parses and rebuilds explorer query state from the URL", () => {
+    const params = buildTmEntryListSearchParams(FULL_STATE);
+    const restored = parseTmEntryListSearchParams(params);
 
-        expect(restored).toEqual(FULL_STATE);
-        expect(buildTmEntryListHref("/org/acme/translation-memories/mem_1", restored)).toBe(
-            `/org/acme/translation-memories/mem_1?${params.toString()}`,
-        );
+    expect(restored).toEqual(FULL_STATE);
+    expect(buildTmEntryListHref("/org/acme/translation-memories/mem_1", restored)).toBe(
+      `/org/acme/translation-memories/mem_1?${params.toString()}`,
+    );
+  });
+
+  it("omits default sort values from the URL", () => {
+    const params = buildTmEntryListSearchParams({
+      search: "",
+      sort: "created_at",
+      sortDir: "desc",
     });
 
-    it("omits default sort values from the URL", () => {
-        const params = buildTmEntryListSearchParams({
-            search: "",
-            sort: "created_at",
-            sortDir: "desc",
-        });
+    expect(params.toString()).toBe("");
+  });
 
-        expect(params.toString()).toBe("");
+  it("ignores invalid enum, locale-empty, and non-uuid values", () => {
+    const restored = parseTmEntryListSearchParams(
+      new URLSearchParams({
+        reviewStatus: "published",
+        sort: "source_text",
+        sortDir: "sideways",
+        createdByUserId: "not-a-uuid",
+        importBatchId: "also-not",
+        entry: "nope",
+        modifiedFrom: "yesterday",
+        sourceLocale: "  ",
+      }),
+    );
+
+    expect(restored).toEqual({
+      search: "",
+      sort: "created_at",
+      sortDir: "desc",
+    });
+  });
+
+  it("canonicalizes locale query values", () => {
+    const restored = parseTmEntryListSearchParams(
+      new URLSearchParams({
+        sourceLocale: "en-us",
+        targetLocale: "fr-fr",
+      }),
+    );
+
+    expect(restored.sourceLocale).toBe("en-US");
+    expect(restored.targetLocale).toBe("fr-FR");
+  });
+
+  it("resets the cursor when filters or sort change", () => {
+    const withSearch = applyTmEntryListStatePatch(FULL_STATE, { search: "invoice" });
+    expect(withSearch.cursor).toBeUndefined();
+    expect(withSearch.search).toBe("invoice");
+
+    const withSort = applyTmEntryListStatePatch(FULL_STATE, { sort: "created_at" });
+    expect(withSort.cursor).toBeUndefined();
+
+    const withEntry = applyTmEntryListStatePatch(FULL_STATE, {
+      entry: "44444444-4444-4444-8444-444444444444",
+    });
+    expect(withEntry.cursor).toBe("cursor.token");
+
+    const withCursor = applyTmEntryListStatePatch(FULL_STATE, { cursor: "next.token" });
+    expect(withCursor.cursor).toBe("next.token");
+    expect(withCursor.search).toBe("checkout");
+  });
+
+  it("clears filters without dropping the selected entry or sort", () => {
+    const cleared = clearTmEntryListFilters(FULL_STATE);
+
+    expect(cleared).toEqual({
+      search: "",
+      sort: "updated_at",
+      sortDir: "asc",
+      entry: FULL_STATE.entry,
+    });
+    expect(getActiveTmEntryFilterChips(cleared)).toEqual([]);
+  });
+
+  it("maps explorer state to the cursor-paginated API query", () => {
+    expect(tmEntryListStateToApiQuery(FULL_STATE)).toEqual({
+      limit: "50",
+      cursor: "cursor.token",
+      search: "checkout",
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+      reviewStatus: "pending",
+      origin: "import",
+      provider: "crowdin",
+      createdByUserId: "11111111-1111-4111-8111-111111111111",
+      modifiedFrom: "2026-01-01T00:00:00.000Z",
+      modifiedTo: "2026-01-31T23:59:59.999Z",
+      importBatchId: "22222222-2222-4222-8222-222222222222",
+      sort: "updated_at",
+      sortDir: "asc",
     });
 
-    it("ignores invalid enum, locale-empty, and non-uuid values", () => {
-        const restored = parseTmEntryListSearchParams(
-            new URLSearchParams({
-                reviewStatus: "published",
-                sort: "source_text",
-                sortDir: "sideways",
-                createdByUserId: "not-a-uuid",
-                importBatchId: "also-not",
-                entry: "nope",
-                modifiedFrom: "yesterday",
-                sourceLocale: "  ",
-            }),
-        );
+    expect(tmEntryListStateToApiQuery(FULL_STATE, { limit: 25, cursor: null })).toEqual({
+      limit: "25",
+      search: "checkout",
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+      reviewStatus: "pending",
+      origin: "import",
+      provider: "crowdin",
+      createdByUserId: "11111111-1111-4111-8111-111111111111",
+      modifiedFrom: "2026-01-01T00:00:00.000Z",
+      modifiedTo: "2026-01-31T23:59:59.999Z",
+      importBatchId: "22222222-2222-4222-8222-222222222222",
+      sort: "updated_at",
+      sortDir: "asc",
+    });
+  });
 
-        expect(restored).toEqual({
-            search: "",
-            sort: "created_at",
-            sortDir: "desc",
-        });
+  it("builds locale options from the canonical catalog and memory coverage", () => {
+    const options = buildTmEntryLocaleOptions({
+      localeCoverage: ["vi-VN", "en-us"],
+      selected: "sw-KE",
     });
 
-    it("canonicalizes locale query values", () => {
-        const restored = parseTmEntryListSearchParams(
-            new URLSearchParams({
-                sourceLocale: "en-us",
-                targetLocale: "fr-fr",
-            }),
-        );
+    expect(options).toContain("en-US");
+    expect(options).toContain("vi-VN");
+    expect(options).toContain("sw-KE");
+    expect(options).toEqual(expect.arrayContaining([...COMMON_LOCALES]));
+    expect(options).not.toContain("ja");
+  });
 
-        expect(restored.sourceLocale).toBe("en-US");
-        expect(restored.targetLocale).toBe("fr-FR");
-    });
+  it("persists and restores the cursor walk stack", () => {
+    const key = "tm-entry-explorer-cursors:test";
+    writeTmEntryCursorStack(key, ["", "cursor-2"]);
+    expect(readTmEntryCursorStack(key)).toEqual(["", "cursor-2"]);
+    expect(readTmEntryCursorStack("missing")).toEqual([]);
+  });
 
-    it("resets the cursor when filters or sort change", () => {
-        const withSearch = applyTmEntryListStatePatch(FULL_STATE, { search: "invoice" });
-        expect(withSearch.cursor).toBeUndefined();
-        expect(withSearch.search).toBe("invoice");
-
-        const withSort = applyTmEntryListStatePatch(FULL_STATE, { sort: "created_at" });
-        expect(withSort.cursor).toBeUndefined();
-
-        const withEntry = applyTmEntryListStatePatch(FULL_STATE, {
-            entry: "44444444-4444-4444-8444-444444444444",
-        });
-        expect(withEntry.cursor).toBe("cursor.token");
-
-        const withCursor = applyTmEntryListStatePatch(FULL_STATE, { cursor: "next.token" });
-        expect(withCursor.cursor).toBe("next.token");
-        expect(withCursor.search).toBe("checkout");
-    });
-
-    it("clears filters without dropping the selected entry or sort", () => {
-        const cleared = clearTmEntryListFilters(FULL_STATE);
-
-        expect(cleared).toEqual({
-            search: "",
-            sort: "updated_at",
-            sortDir: "asc",
-            entry: FULL_STATE.entry,
-        });
-        expect(getActiveTmEntryFilterChips(cleared)).toEqual([]);
-    });
-
-    it("maps explorer state to the cursor-paginated API query", () => {
-        expect(tmEntryListStateToApiQuery(FULL_STATE)).toEqual({
-            limit: "50",
-            cursor: "cursor.token",
-            search: "checkout",
-            sourceLocale: "en-US",
-            targetLocale: "fr-FR",
-            reviewStatus: "pending",
-            origin: "import",
-            provider: "crowdin",
-            createdByUserId: "11111111-1111-4111-8111-111111111111",
-            modifiedFrom: "2026-01-01T00:00:00.000Z",
-            modifiedTo: "2026-01-31T23:59:59.999Z",
-            importBatchId: "22222222-2222-4222-8222-222222222222",
-            sort: "updated_at",
-            sortDir: "asc",
-        });
-
-        expect(
-            tmEntryListStateToApiQuery(FULL_STATE, { limit: 25, cursor: null }),
-        ).toEqual({
-            limit: "25",
-            search: "checkout",
-            sourceLocale: "en-US",
-            targetLocale: "fr-FR",
-            reviewStatus: "pending",
-            origin: "import",
-            provider: "crowdin",
-            createdByUserId: "11111111-1111-4111-8111-111111111111",
-            modifiedFrom: "2026-01-01T00:00:00.000Z",
-            modifiedTo: "2026-01-31T23:59:59.999Z",
-            importBatchId: "22222222-2222-4222-8222-222222222222",
-            sort: "updated_at",
-            sortDir: "asc",
-        });
-    });
-
-    it("builds locale options from the canonical catalog and memory coverage", () => {
-        const options = buildTmEntryLocaleOptions({
-            localeCoverage: ["vi-VN", "en-us"],
-            selected: "sw-KE",
-        });
-
-        expect(options).toContain("en-US");
-        expect(options).toContain("vi-VN");
-        expect(options).toContain("sw-KE");
-        expect(options).toEqual(expect.arrayContaining([...COMMON_LOCALES]));
-        expect(options).not.toContain("ja");
-    });
-
-    it("persists and restores the cursor walk stack", () => {
-        const key = "tm-entry-explorer-cursors:test";
-        writeTmEntryCursorStack(key, ["", "cursor-2"]);
-        expect(readTmEntryCursorStack(key)).toEqual(["", "cursor-2"]);
-        expect(readTmEntryCursorStack("missing")).toEqual([]);
-    });
-
-    it("converts date-only bounds to inclusive ISO datetimes", () => {
-        expect(modifiedDateToApiDateTime("2026-08-01", "start")).toBe("2026-08-01T00:00:00.000Z");
-        expect(modifiedDateToApiDateTime("2026-08-01", "end")).toBe("2026-08-01T23:59:59.999Z");
-        expect(modifiedDateToApiDateTime("2026-08-01T12:00:00.000Z", "start")).toBe(
-            "2026-08-01T12:00:00.000Z",
-        );
-    });
+  it("converts date-only bounds to inclusive ISO datetimes", () => {
+    expect(modifiedDateToApiDateTime("2026-08-01", "start")).toBe("2026-08-01T00:00:00.000Z");
+    expect(modifiedDateToApiDateTime("2026-08-01", "end")).toBe("2026-08-01T23:59:59.999Z");
+    expect(modifiedDateToApiDateTime("2026-08-01T12:00:00.000Z", "start")).toBe(
+      "2026-08-01T12:00:00.000Z",
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.test.ts
@@ -33,6 +33,7 @@ import {
   buildTmEntryListHref,
   buildTmEntryListSearchParams,
   buildTmEntryLocaleOptions,
+  canGoToPreviousTmEntryPage,
   clearTmEntryListFilters,
   getActiveTmEntryFilterChips,
   modifiedDateToApiDateTime,
@@ -197,6 +198,12 @@ describe("tm-entry-list-state", () => {
     writeTmEntryCursorStack(key, ["", "cursor-2"]);
     expect(readTmEntryCursorStack(key)).toEqual(["", "cursor-2"]);
     expect(readTmEntryCursorStack("missing")).toEqual([]);
+  });
+
+  it("allows Previous only when a recovered previous cursor exists", () => {
+    expect(canGoToPreviousTmEntryPage({ cursor: "cursor-3", cursorStack: [] })).toBe(false);
+    expect(canGoToPreviousTmEntryPage({ cursor: undefined, cursorStack: [""] })).toBe(false);
+    expect(canGoToPreviousTmEntryPage({ cursor: "cursor-2", cursorStack: [""] })).toBe(true);
   });
 
   it("converts date-only bounds to inclusive ISO datetimes", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { COMMON_LOCALES } from "@/lib/i18n/locales";
+
+import {
+    applyTmEntryListStatePatch,
+    buildTmEntryListHref,
+    buildTmEntryListSearchParams,
+    buildTmEntryLocaleOptions,
+    clearTmEntryListFilters,
+    getActiveTmEntryFilterChips,
+    modifiedDateToApiDateTime,
+    parseTmEntryListSearchParams,
+    readTmEntryCursorStack,
+    tmEntryListStateToApiQuery,
+    writeTmEntryCursorStack,
+    type TmEntryListUrlState,
+} from "./tm-entry-list-state";
+
+const FULL_STATE: TmEntryListUrlState = {
+    search: "checkout",
+    sourceLocale: "en-US",
+    targetLocale: "fr-FR",
+    reviewStatus: "pending",
+    origin: "import",
+    provider: "crowdin",
+    createdByUserId: "11111111-1111-4111-8111-111111111111",
+    modifiedFrom: "2026-01-01",
+    modifiedTo: "2026-01-31",
+    importBatchId: "22222222-2222-4222-8222-222222222222",
+    sort: "updated_at",
+    sortDir: "asc",
+    cursor: "cursor.token",
+    entry: "33333333-3333-4333-8333-333333333333",
+};
+
+describe("tm-entry-list-state", () => {
+    it("parses and rebuilds explorer query state from the URL", () => {
+        const params = buildTmEntryListSearchParams(FULL_STATE);
+        const restored = parseTmEntryListSearchParams(params);
+
+        expect(restored).toEqual(FULL_STATE);
+        expect(buildTmEntryListHref("/org/acme/translation-memories/mem_1", restored)).toBe(
+            `/org/acme/translation-memories/mem_1?${params.toString()}`,
+        );
+    });
+
+    it("omits default sort values from the URL", () => {
+        const params = buildTmEntryListSearchParams({
+            search: "",
+            sort: "created_at",
+            sortDir: "desc",
+        });
+
+        expect(params.toString()).toBe("");
+    });
+
+    it("ignores invalid enum, locale-empty, and non-uuid values", () => {
+        const restored = parseTmEntryListSearchParams(
+            new URLSearchParams({
+                reviewStatus: "published",
+                sort: "source_text",
+                sortDir: "sideways",
+                createdByUserId: "not-a-uuid",
+                importBatchId: "also-not",
+                entry: "nope",
+                modifiedFrom: "yesterday",
+                sourceLocale: "  ",
+            }),
+        );
+
+        expect(restored).toEqual({
+            search: "",
+            sort: "created_at",
+            sortDir: "desc",
+        });
+    });
+
+    it("canonicalizes locale query values", () => {
+        const restored = parseTmEntryListSearchParams(
+            new URLSearchParams({
+                sourceLocale: "en-us",
+                targetLocale: "fr-fr",
+            }),
+        );
+
+        expect(restored.sourceLocale).toBe("en-US");
+        expect(restored.targetLocale).toBe("fr-FR");
+    });
+
+    it("resets the cursor when filters or sort change", () => {
+        const withSearch = applyTmEntryListStatePatch(FULL_STATE, { search: "invoice" });
+        expect(withSearch.cursor).toBeUndefined();
+        expect(withSearch.search).toBe("invoice");
+
+        const withSort = applyTmEntryListStatePatch(FULL_STATE, { sort: "created_at" });
+        expect(withSort.cursor).toBeUndefined();
+
+        const withEntry = applyTmEntryListStatePatch(FULL_STATE, {
+            entry: "44444444-4444-4444-8444-444444444444",
+        });
+        expect(withEntry.cursor).toBe("cursor.token");
+
+        const withCursor = applyTmEntryListStatePatch(FULL_STATE, { cursor: "next.token" });
+        expect(withCursor.cursor).toBe("next.token");
+        expect(withCursor.search).toBe("checkout");
+    });
+
+    it("clears filters without dropping the selected entry or sort", () => {
+        const cleared = clearTmEntryListFilters(FULL_STATE);
+
+        expect(cleared).toEqual({
+            search: "",
+            sort: "updated_at",
+            sortDir: "asc",
+            entry: FULL_STATE.entry,
+        });
+        expect(getActiveTmEntryFilterChips(cleared)).toEqual([]);
+    });
+
+    it("maps explorer state to the cursor-paginated API query", () => {
+        expect(tmEntryListStateToApiQuery(FULL_STATE)).toEqual({
+            limit: "50",
+            cursor: "cursor.token",
+            search: "checkout",
+            sourceLocale: "en-US",
+            targetLocale: "fr-FR",
+            reviewStatus: "pending",
+            origin: "import",
+            provider: "crowdin",
+            createdByUserId: "11111111-1111-4111-8111-111111111111",
+            modifiedFrom: "2026-01-01T00:00:00.000Z",
+            modifiedTo: "2026-01-31T23:59:59.999Z",
+            importBatchId: "22222222-2222-4222-8222-222222222222",
+            sort: "updated_at",
+            sortDir: "asc",
+        });
+
+        expect(
+            tmEntryListStateToApiQuery(FULL_STATE, { limit: 25, cursor: null }),
+        ).toEqual({
+            limit: "25",
+            search: "checkout",
+            sourceLocale: "en-US",
+            targetLocale: "fr-FR",
+            reviewStatus: "pending",
+            origin: "import",
+            provider: "crowdin",
+            createdByUserId: "11111111-1111-4111-8111-111111111111",
+            modifiedFrom: "2026-01-01T00:00:00.000Z",
+            modifiedTo: "2026-01-31T23:59:59.999Z",
+            importBatchId: "22222222-2222-4222-8222-222222222222",
+            sort: "updated_at",
+            sortDir: "asc",
+        });
+    });
+
+    it("builds locale options from the canonical catalog and memory coverage", () => {
+        const options = buildTmEntryLocaleOptions({
+            localeCoverage: ["vi-VN", "en-us"],
+            selected: "sw-KE",
+        });
+
+        expect(options).toContain("en-US");
+        expect(options).toContain("vi-VN");
+        expect(options).toContain("sw-KE");
+        expect(options).toEqual(expect.arrayContaining([...COMMON_LOCALES]));
+        expect(options).not.toContain("ja");
+    });
+
+    it("persists and restores the cursor walk stack", () => {
+        const key = "tm-entry-explorer-cursors:test";
+        writeTmEntryCursorStack(key, ["", "cursor-2"]);
+        expect(readTmEntryCursorStack(key)).toEqual(["", "cursor-2"]);
+        expect(readTmEntryCursorStack("missing")).toEqual([]);
+    });
+
+    it("converts date-only bounds to inclusive ISO datetimes", () => {
+        expect(modifiedDateToApiDateTime("2026-08-01", "start")).toBe("2026-08-01T00:00:00.000Z");
+        expect(modifiedDateToApiDateTime("2026-08-01", "end")).toBe("2026-08-01T23:59:59.999Z");
+        expect(modifiedDateToApiDateTime("2026-08-01T12:00:00.000Z", "start")).toBe(
+            "2026-08-01T12:00:00.000Z",
+        );
+    });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.ts
@@ -412,6 +412,13 @@ export function writeTmEntryCursorStack(key: string, stack: string[]): void {
   writeSessionJson(key, stack);
 }
 
+export function canGoToPreviousTmEntryPage(input: {
+  cursor?: string;
+  cursorStack: readonly string[];
+}): boolean {
+  return Boolean(input.cursor) && input.cursorStack.length > 0;
+}
+
 export function readTmEntryScrollOffset(key: string): number | null {
   const parsed = readSessionJson(key);
   return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : null;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.ts
@@ -30,393 +30,393 @@ export type TmEntrySortDir = (typeof TM_ENTRY_SORT_DIRS)[number];
 export type TmEntryProvider = (typeof TM_ENTRY_PROVIDERS)[number];
 
 export type TmEntryListUrlState = {
-    search: string;
-    sourceLocale?: string;
-    targetLocale?: string;
-    reviewStatus?: TmEntryReviewStatus;
-    origin?: string;
-    provider?: string;
-    createdByUserId?: string;
-    modifiedFrom?: string;
-    modifiedTo?: string;
-    importBatchId?: string;
-    sort: TmEntrySort;
-    sortDir: TmEntrySortDir;
-    cursor?: string;
-    entry?: string;
+  search: string;
+  sourceLocale?: string;
+  targetLocale?: string;
+  reviewStatus?: TmEntryReviewStatus;
+  origin?: string;
+  provider?: string;
+  createdByUserId?: string;
+  modifiedFrom?: string;
+  modifiedTo?: string;
+  importBatchId?: string;
+  sort: TmEntrySort;
+  sortDir: TmEntrySortDir;
+  cursor?: string;
+  entry?: string;
 };
 
 export type TmEntryListApiQuery = {
-    limit: string;
-    cursor?: string;
-    search?: string;
-    sourceLocale?: string;
-    targetLocale?: string;
-    reviewStatus?: TmEntryReviewStatus;
-    origin?: string;
-    provider?: string;
-    createdByUserId?: string;
-    modifiedFrom?: string;
-    modifiedTo?: string;
-    importBatchId?: string;
-    sort?: TmEntrySort;
-    sortDir?: TmEntrySortDir;
+  limit: string;
+  cursor?: string;
+  search?: string;
+  sourceLocale?: string;
+  targetLocale?: string;
+  reviewStatus?: TmEntryReviewStatus;
+  origin?: string;
+  provider?: string;
+  createdByUserId?: string;
+  modifiedFrom?: string;
+  modifiedTo?: string;
+  importBatchId?: string;
+  sort?: TmEntrySort;
+  sortDir?: TmEntrySortDir;
 };
 
 export type TmEntryFilterChip =
-    | { key: "search"; value: string }
-    | { key: "sourceLocale"; value: string }
-    | { key: "targetLocale"; value: string }
-    | { key: "reviewStatus"; value: TmEntryReviewStatus }
-    | { key: "origin"; value: string }
-    | { key: "provider"; value: string }
-    | { key: "createdByUserId"; value: string }
-    | { key: "modifiedFrom"; value: string }
-    | { key: "modifiedTo"; value: string }
-    | { key: "importBatchId"; value: string };
+  | { key: "search"; value: string }
+  | { key: "sourceLocale"; value: string }
+  | { key: "targetLocale"; value: string }
+  | { key: "reviewStatus"; value: TmEntryReviewStatus }
+  | { key: "origin"; value: string }
+  | { key: "provider"; value: string }
+  | { key: "createdByUserId"; value: string }
+  | { key: "modifiedFrom"; value: string }
+  | { key: "modifiedTo"; value: string }
+  | { key: "importBatchId"; value: string };
 
 const DEFAULT_STATE: TmEntryListUrlState = {
-    search: "",
-    sort: "created_at",
-    sortDir: "desc",
+  search: "",
+  sort: "created_at",
+  sortDir: "desc",
 };
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 const FILTER_KEYS = [
-    "search",
-    "sourceLocale",
-    "targetLocale",
-    "reviewStatus",
-    "origin",
-    "provider",
-    "createdByUserId",
-    "modifiedFrom",
-    "modifiedTo",
-    "importBatchId",
-    "sort",
-    "sortDir",
+  "search",
+  "sourceLocale",
+  "targetLocale",
+  "reviewStatus",
+  "origin",
+  "provider",
+  "createdByUserId",
+  "modifiedFrom",
+  "modifiedTo",
+  "importBatchId",
+  "sort",
+  "sortDir",
 ] as const satisfies readonly (keyof TmEntryListUrlState)[];
 
 function readAllowedValue<T extends string>(
-    searchParams: URLSearchParams,
-    key: string,
-    allowed: readonly T[],
+  searchParams: URLSearchParams,
+  key: string,
+  allowed: readonly T[],
 ): T | undefined {
-    const value = searchParams.get(key);
-    if (value && (allowed as readonly string[]).includes(value)) {
-        return value as T;
-    }
-    return undefined;
+  const value = searchParams.get(key);
+  if (value && (allowed as readonly string[]).includes(value)) {
+    return value as T;
+  }
+  return undefined;
 }
 
 function readTrimmedParam(searchParams: URLSearchParams, key: string): string | undefined {
-    const value = searchParams.get(key)?.trim();
-    return value ? value : undefined;
+  const value = searchParams.get(key)?.trim();
+  return value ? value : undefined;
 }
 
 function readUuidParam(searchParams: URLSearchParams, key: string): string | undefined {
-    const value = readTrimmedParam(searchParams, key);
-    if (!value || !UUID_PATTERN.test(value)) {
-        return undefined;
-    }
-    return value.toLowerCase();
+  const value = readTrimmedParam(searchParams, key);
+  if (!value || !UUID_PATTERN.test(value)) {
+    return undefined;
+  }
+  return value.toLowerCase();
 }
 
 export function parseModifiedDateParam(value: string | null | undefined): string | undefined {
-    const trimmed = value?.trim();
-    if (!trimmed) {
-        return undefined;
-    }
-    if (DATE_ONLY_PATTERN.test(trimmed)) {
-        return trimmed;
-    }
-    const parsed = Date.parse(trimmed);
-    if (Number.isNaN(parsed)) {
-        return undefined;
-    }
-    return new Date(parsed).toISOString().slice(0, 10);
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (DATE_ONLY_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  const parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) {
+    return undefined;
+  }
+  return new Date(parsed).toISOString().slice(0, 10);
 }
 
 export function modifiedDateToApiDateTime(date: string, bound: "start" | "end"): string {
-    if (date.includes("T")) {
-        return date;
-    }
-    return bound === "start" ? `${date}T00:00:00.000Z` : `${date}T23:59:59.999Z`;
+  if (date.includes("T")) {
+    return date;
+  }
+  return bound === "start" ? `${date}T00:00:00.000Z` : `${date}T23:59:59.999Z`;
 }
 
 export function parseCanonicalLocaleParam(value: string | null | undefined): string | undefined {
-    const trimmed = value?.trim();
-    if (!trimmed) {
-        return undefined;
-    }
-    return canonicalizeLocale(trimmed) ?? trimmed;
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return canonicalizeLocale(trimmed) ?? trimmed;
 }
 
 export function parseTmEntryListSearchParams(searchParams: URLSearchParams): TmEntryListUrlState {
-    const sort = readAllowedValue(searchParams, "sort", TM_ENTRY_SORTS) ?? DEFAULT_STATE.sort;
-    const sortDir =
-        readAllowedValue(searchParams, "sortDir", TM_ENTRY_SORT_DIRS) ?? DEFAULT_STATE.sortDir;
-    const search = (searchParams.get("search") ?? "").trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH);
-    const origin = readTrimmedParam(searchParams, "origin");
-    const provider = readTrimmedParam(searchParams, "provider");
+  const sort = readAllowedValue(searchParams, "sort", TM_ENTRY_SORTS) ?? DEFAULT_STATE.sort;
+  const sortDir =
+    readAllowedValue(searchParams, "sortDir", TM_ENTRY_SORT_DIRS) ?? DEFAULT_STATE.sortDir;
+  const search = (searchParams.get("search") ?? "").trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH);
+  const origin = readTrimmedParam(searchParams, "origin");
+  const provider = readTrimmedParam(searchParams, "provider");
 
-    return {
-        search,
-        sourceLocale: parseCanonicalLocaleParam(searchParams.get("sourceLocale")),
-        targetLocale: parseCanonicalLocaleParam(searchParams.get("targetLocale")),
-        reviewStatus: readAllowedValue(searchParams, "reviewStatus", TM_ENTRY_REVIEW_STATUSES),
-        origin,
-        provider,
-        createdByUserId: readUuidParam(searchParams, "createdByUserId"),
-        modifiedFrom: parseModifiedDateParam(searchParams.get("modifiedFrom")),
-        modifiedTo: parseModifiedDateParam(searchParams.get("modifiedTo")),
-        importBatchId: readUuidParam(searchParams, "importBatchId"),
-        sort,
-        sortDir,
-        cursor: readTrimmedParam(searchParams, "cursor"),
-        entry: readUuidParam(searchParams, "entry"),
-    };
+  return {
+    search,
+    sourceLocale: parseCanonicalLocaleParam(searchParams.get("sourceLocale")),
+    targetLocale: parseCanonicalLocaleParam(searchParams.get("targetLocale")),
+    reviewStatus: readAllowedValue(searchParams, "reviewStatus", TM_ENTRY_REVIEW_STATUSES),
+    origin,
+    provider,
+    createdByUserId: readUuidParam(searchParams, "createdByUserId"),
+    modifiedFrom: parseModifiedDateParam(searchParams.get("modifiedFrom")),
+    modifiedTo: parseModifiedDateParam(searchParams.get("modifiedTo")),
+    importBatchId: readUuidParam(searchParams, "importBatchId"),
+    sort,
+    sortDir,
+    cursor: readTrimmedParam(searchParams, "cursor"),
+    entry: readUuidParam(searchParams, "entry"),
+  };
 }
 
 export function buildTmEntryListSearchParams(state: TmEntryListUrlState): URLSearchParams {
-    const params = new URLSearchParams();
-    if (state.search.trim()) {
-        params.set("search", state.search.trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH));
-    }
-    if (state.sourceLocale) {
-        params.set("sourceLocale", state.sourceLocale);
-    }
-    if (state.targetLocale) {
-        params.set("targetLocale", state.targetLocale);
-    }
-    if (state.reviewStatus) {
-        params.set("reviewStatus", state.reviewStatus);
-    }
-    if (state.origin) {
-        params.set("origin", state.origin);
-    }
-    if (state.provider) {
-        params.set("provider", state.provider);
-    }
-    if (state.createdByUserId) {
-        params.set("createdByUserId", state.createdByUserId);
-    }
-    if (state.modifiedFrom) {
-        params.set("modifiedFrom", state.modifiedFrom);
-    }
-    if (state.modifiedTo) {
-        params.set("modifiedTo", state.modifiedTo);
-    }
-    if (state.importBatchId) {
-        params.set("importBatchId", state.importBatchId);
-    }
-    if (state.sort !== DEFAULT_STATE.sort) {
-        params.set("sort", state.sort);
-    }
-    if (state.sortDir !== DEFAULT_STATE.sortDir) {
-        params.set("sortDir", state.sortDir);
-    }
-    if (state.cursor) {
-        params.set("cursor", state.cursor);
-    }
-    if (state.entry) {
-        params.set("entry", state.entry);
-    }
-    return params;
+  const params = new URLSearchParams();
+  if (state.search.trim()) {
+    params.set("search", state.search.trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH));
+  }
+  if (state.sourceLocale) {
+    params.set("sourceLocale", state.sourceLocale);
+  }
+  if (state.targetLocale) {
+    params.set("targetLocale", state.targetLocale);
+  }
+  if (state.reviewStatus) {
+    params.set("reviewStatus", state.reviewStatus);
+  }
+  if (state.origin) {
+    params.set("origin", state.origin);
+  }
+  if (state.provider) {
+    params.set("provider", state.provider);
+  }
+  if (state.createdByUserId) {
+    params.set("createdByUserId", state.createdByUserId);
+  }
+  if (state.modifiedFrom) {
+    params.set("modifiedFrom", state.modifiedFrom);
+  }
+  if (state.modifiedTo) {
+    params.set("modifiedTo", state.modifiedTo);
+  }
+  if (state.importBatchId) {
+    params.set("importBatchId", state.importBatchId);
+  }
+  if (state.sort !== DEFAULT_STATE.sort) {
+    params.set("sort", state.sort);
+  }
+  if (state.sortDir !== DEFAULT_STATE.sortDir) {
+    params.set("sortDir", state.sortDir);
+  }
+  if (state.cursor) {
+    params.set("cursor", state.cursor);
+  }
+  if (state.entry) {
+    params.set("entry", state.entry);
+  }
+  return params;
 }
 
 export function buildTmEntryListHref(pathname: string, state: TmEntryListUrlState): string {
-    const query = buildTmEntryListSearchParams(state).toString();
-    return query ? `${pathname}?${query}` : pathname;
+  const query = buildTmEntryListSearchParams(state).toString();
+  return query ? `${pathname}?${query}` : pathname;
 }
 
 export function tmEntryListFiltersEqual(
-    left: TmEntryListUrlState,
-    right: TmEntryListUrlState,
+  left: TmEntryListUrlState,
+  right: TmEntryListUrlState,
 ): boolean {
-    return FILTER_KEYS.every((key) => (left[key] ?? "") === (right[key] ?? ""));
+  return FILTER_KEYS.every((key) => (left[key] ?? "") === (right[key] ?? ""));
 }
 
 export function applyTmEntryListStatePatch(
-    current: TmEntryListUrlState,
-    patch: Partial<TmEntryListUrlState>,
+  current: TmEntryListUrlState,
+  patch: Partial<TmEntryListUrlState>,
 ): TmEntryListUrlState {
-    const next = { ...current, ...patch };
-    if (patch.cursor === undefined && !tmEntryListFiltersEqual(current, next)) {
-        next.cursor = undefined;
-    }
-    return next;
+  const next = { ...current, ...patch };
+  if (patch.cursor === undefined && !tmEntryListFiltersEqual(current, next)) {
+    next.cursor = undefined;
+  }
+  return next;
 }
 
 export function clearTmEntryListFilters(state: TmEntryListUrlState): TmEntryListUrlState {
-    return {
-        search: "",
-        sort: state.sort,
-        sortDir: state.sortDir,
-        entry: state.entry,
-    };
+  return {
+    search: "",
+    sort: state.sort,
+    sortDir: state.sortDir,
+    entry: state.entry,
+  };
 }
 
 export function getActiveTmEntryFilterChips(state: TmEntryListUrlState): TmEntryFilterChip[] {
-    const chips: TmEntryFilterChip[] = [];
-    if (state.search.trim()) {
-        chips.push({ key: "search", value: state.search.trim() });
-    }
-    if (state.sourceLocale) {
-        chips.push({ key: "sourceLocale", value: state.sourceLocale });
-    }
-    if (state.targetLocale) {
-        chips.push({ key: "targetLocale", value: state.targetLocale });
-    }
-    if (state.reviewStatus) {
-        chips.push({ key: "reviewStatus", value: state.reviewStatus });
-    }
-    if (state.origin) {
-        chips.push({ key: "origin", value: state.origin });
-    }
-    if (state.provider) {
-        chips.push({ key: "provider", value: state.provider });
-    }
-    if (state.createdByUserId) {
-        chips.push({ key: "createdByUserId", value: state.createdByUserId });
-    }
-    if (state.modifiedFrom) {
-        chips.push({ key: "modifiedFrom", value: state.modifiedFrom });
-    }
-    if (state.modifiedTo) {
-        chips.push({ key: "modifiedTo", value: state.modifiedTo });
-    }
-    if (state.importBatchId) {
-        chips.push({ key: "importBatchId", value: state.importBatchId });
-    }
-    return chips;
+  const chips: TmEntryFilterChip[] = [];
+  if (state.search.trim()) {
+    chips.push({ key: "search", value: state.search.trim() });
+  }
+  if (state.sourceLocale) {
+    chips.push({ key: "sourceLocale", value: state.sourceLocale });
+  }
+  if (state.targetLocale) {
+    chips.push({ key: "targetLocale", value: state.targetLocale });
+  }
+  if (state.reviewStatus) {
+    chips.push({ key: "reviewStatus", value: state.reviewStatus });
+  }
+  if (state.origin) {
+    chips.push({ key: "origin", value: state.origin });
+  }
+  if (state.provider) {
+    chips.push({ key: "provider", value: state.provider });
+  }
+  if (state.createdByUserId) {
+    chips.push({ key: "createdByUserId", value: state.createdByUserId });
+  }
+  if (state.modifiedFrom) {
+    chips.push({ key: "modifiedFrom", value: state.modifiedFrom });
+  }
+  if (state.modifiedTo) {
+    chips.push({ key: "modifiedTo", value: state.modifiedTo });
+  }
+  if (state.importBatchId) {
+    chips.push({ key: "importBatchId", value: state.importBatchId });
+  }
+  return chips;
 }
 
 export function tmEntryListStateToApiQuery(
-    state: TmEntryListUrlState,
-    options?: { limit?: number; cursor?: string | null },
+  state: TmEntryListUrlState,
+  options?: { limit?: number; cursor?: string | null },
 ): TmEntryListApiQuery {
-    const query: TmEntryListApiQuery = {
-        limit: String(options?.limit ?? TM_ENTRY_PAGE_SIZE),
-    };
-    const cursor = options?.cursor === undefined ? state.cursor : (options.cursor ?? undefined);
-    if (cursor) {
-        query.cursor = cursor;
-    }
-    if (state.search.trim()) {
-        query.search = state.search.trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH);
-    }
-    if (state.sourceLocale) {
-        query.sourceLocale = state.sourceLocale;
-    }
-    if (state.targetLocale) {
-        query.targetLocale = state.targetLocale;
-    }
-    if (state.reviewStatus) {
-        query.reviewStatus = state.reviewStatus;
-    }
-    if (state.origin) {
-        query.origin = state.origin;
-    }
-    if (state.provider) {
-        query.provider = state.provider;
-    }
-    if (state.createdByUserId) {
-        query.createdByUserId = state.createdByUserId;
-    }
-    if (state.modifiedFrom) {
-        query.modifiedFrom = modifiedDateToApiDateTime(state.modifiedFrom, "start");
-    }
-    if (state.modifiedTo) {
-        query.modifiedTo = modifiedDateToApiDateTime(state.modifiedTo, "end");
-    }
-    if (state.importBatchId) {
-        query.importBatchId = state.importBatchId;
-    }
-    if (state.sort !== DEFAULT_STATE.sort) {
-        query.sort = state.sort;
-    }
-    if (state.sortDir !== DEFAULT_STATE.sortDir) {
-        query.sortDir = state.sortDir;
-    }
-    return query;
+  const query: TmEntryListApiQuery = {
+    limit: String(options?.limit ?? TM_ENTRY_PAGE_SIZE),
+  };
+  const cursor = options?.cursor === undefined ? state.cursor : (options.cursor ?? undefined);
+  if (cursor) {
+    query.cursor = cursor;
+  }
+  if (state.search.trim()) {
+    query.search = state.search.trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH);
+  }
+  if (state.sourceLocale) {
+    query.sourceLocale = state.sourceLocale;
+  }
+  if (state.targetLocale) {
+    query.targetLocale = state.targetLocale;
+  }
+  if (state.reviewStatus) {
+    query.reviewStatus = state.reviewStatus;
+  }
+  if (state.origin) {
+    query.origin = state.origin;
+  }
+  if (state.provider) {
+    query.provider = state.provider;
+  }
+  if (state.createdByUserId) {
+    query.createdByUserId = state.createdByUserId;
+  }
+  if (state.modifiedFrom) {
+    query.modifiedFrom = modifiedDateToApiDateTime(state.modifiedFrom, "start");
+  }
+  if (state.modifiedTo) {
+    query.modifiedTo = modifiedDateToApiDateTime(state.modifiedTo, "end");
+  }
+  if (state.importBatchId) {
+    query.importBatchId = state.importBatchId;
+  }
+  if (state.sort !== DEFAULT_STATE.sort) {
+    query.sort = state.sort;
+  }
+  if (state.sortDir !== DEFAULT_STATE.sortDir) {
+    query.sortDir = state.sortDir;
+  }
+  return query;
 }
 
 export function buildTmEntryLocaleOptions(input: {
-    localeCoverage?: string[];
-    selected?: string;
+  localeCoverage?: string[];
+  selected?: string;
 }): string[] {
-    const merged = new Set<string>(COMMON_LOCALES);
-    for (const locale of input.localeCoverage ?? []) {
-        const canonical = parseCanonicalLocaleParam(locale);
-        if (canonical) {
-            merged.add(canonical);
-        }
+  const merged = new Set<string>(COMMON_LOCALES);
+  for (const locale of input.localeCoverage ?? []) {
+    const canonical = parseCanonicalLocaleParam(locale);
+    if (canonical) {
+      merged.add(canonical);
     }
-    const selected = parseCanonicalLocaleParam(input.selected);
-    if (selected) {
-        merged.add(selected);
-    }
-    return [...merged].toSorted((left, right) =>
-        left.localeCompare(right, undefined, { sensitivity: "base" }),
-    );
+  }
+  const selected = parseCanonicalLocaleParam(input.selected);
+  if (selected) {
+    merged.add(selected);
+  }
+  return [...merged].toSorted((left, right) =>
+    left.localeCompare(right, undefined, { sensitivity: "base" }),
+  );
 }
 
 export function tmEntryCursorStackStorageKey(memoryId: string, state: TmEntryListUrlState): string {
-    const filters = FILTER_KEYS.map((key) => `${key}=${state[key] ?? ""}`).join("&");
-    return `tm-entry-explorer-cursors:${memoryId}:${filters}`;
+  const filters = FILTER_KEYS.map((key) => `${key}=${state[key] ?? ""}`).join("&");
+  return `tm-entry-explorer-cursors:${memoryId}:${filters}`;
 }
 
 export function tmEntryScrollStorageKey(memoryId: string): string {
-    return `tm-entry-explorer-scroll:${memoryId}`;
+  return `tm-entry-explorer-scroll:${memoryId}`;
 }
 
 export function isUuid(value: string): boolean {
-    return UUID_PATTERN.test(value);
+  return UUID_PATTERN.test(value);
 }
 
 function readSessionJson(key: string): unknown {
-    if (typeof sessionStorage === "undefined") {
-        return null;
-    }
-    try {
-        const raw = sessionStorage.getItem(key);
-        return raw ? JSON.parse(raw) : null;
-    } catch {
-        return null;
-    }
+  if (typeof sessionStorage === "undefined") {
+    return null;
+  }
+  try {
+    const raw = sessionStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
 }
 
 function writeSessionJson(key: string, value: unknown): void {
-    if (typeof sessionStorage === "undefined") {
-        return;
-    }
-    try {
-        sessionStorage.setItem(key, JSON.stringify(value));
-    } catch {
-        // Ignore quota and private-mode failures.
-    }
+  if (typeof sessionStorage === "undefined") {
+    return;
+  }
+  try {
+    sessionStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Ignore quota and private-mode failures.
+  }
 }
 
 export function readTmEntryCursorStack(key: string): string[] {
-    const parsed = readSessionJson(key);
-    if (!Array.isArray(parsed)) {
-        return [];
-    }
-    return parsed.filter((item): item is string => typeof item === "string");
+  const parsed = readSessionJson(key);
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed.filter((item): item is string => typeof item === "string");
 }
 
 export function writeTmEntryCursorStack(key: string, stack: string[]): void {
-    writeSessionJson(key, stack);
+  writeSessionJson(key, stack);
 }
 
 export function readTmEntryScrollOffset(key: string): number | null {
-    const parsed = readSessionJson(key);
-    return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : null;
+  const parsed = readSessionJson(key);
+  return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : null;
 }
 
 export function writeTmEntryScrollOffset(key: string, offset: number): void {
-    writeSessionJson(key, offset);
+  writeSessionJson(key, offset);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-state.ts
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { externalTmsProviderKinds } from "@/lib/providers/contracts/external-tms-provider-kind";
+import { canonicalizeLocale, COMMON_LOCALES } from "@/lib/i18n/locales";
+
+export const TM_ENTRY_PAGE_SIZE = 50;
+export const TM_ENTRY_SEARCH_DEBOUNCE_MS = 250;
+export const TM_ENTRY_SEARCH_MAX_LENGTH = 200;
+
+export const TM_ENTRY_REVIEW_STATUSES = ["approved", "pending", "rejected"] as const;
+export const TM_ENTRY_ORIGINS = ["manual", "import", "sync"] as const;
+export const TM_ENTRY_SORTS = ["created_at", "updated_at"] as const;
+export const TM_ENTRY_SORT_DIRS = ["asc", "desc"] as const;
+export const TM_ENTRY_PROVIDERS = externalTmsProviderKinds;
+
+export type TmEntryReviewStatus = (typeof TM_ENTRY_REVIEW_STATUSES)[number];
+export type TmEntryOrigin = (typeof TM_ENTRY_ORIGINS)[number];
+export type TmEntrySort = (typeof TM_ENTRY_SORTS)[number];
+export type TmEntrySortDir = (typeof TM_ENTRY_SORT_DIRS)[number];
+export type TmEntryProvider = (typeof TM_ENTRY_PROVIDERS)[number];
+
+export type TmEntryListUrlState = {
+    search: string;
+    sourceLocale?: string;
+    targetLocale?: string;
+    reviewStatus?: TmEntryReviewStatus;
+    origin?: string;
+    provider?: string;
+    createdByUserId?: string;
+    modifiedFrom?: string;
+    modifiedTo?: string;
+    importBatchId?: string;
+    sort: TmEntrySort;
+    sortDir: TmEntrySortDir;
+    cursor?: string;
+    entry?: string;
+};
+
+export type TmEntryListApiQuery = {
+    limit: string;
+    cursor?: string;
+    search?: string;
+    sourceLocale?: string;
+    targetLocale?: string;
+    reviewStatus?: TmEntryReviewStatus;
+    origin?: string;
+    provider?: string;
+    createdByUserId?: string;
+    modifiedFrom?: string;
+    modifiedTo?: string;
+    importBatchId?: string;
+    sort?: TmEntrySort;
+    sortDir?: TmEntrySortDir;
+};
+
+export type TmEntryFilterChip =
+    | { key: "search"; value: string }
+    | { key: "sourceLocale"; value: string }
+    | { key: "targetLocale"; value: string }
+    | { key: "reviewStatus"; value: TmEntryReviewStatus }
+    | { key: "origin"; value: string }
+    | { key: "provider"; value: string }
+    | { key: "createdByUserId"; value: string }
+    | { key: "modifiedFrom"; value: string }
+    | { key: "modifiedTo"; value: string }
+    | { key: "importBatchId"; value: string };
+
+const DEFAULT_STATE: TmEntryListUrlState = {
+    search: "",
+    sort: "created_at",
+    sortDir: "desc",
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const FILTER_KEYS = [
+    "search",
+    "sourceLocale",
+    "targetLocale",
+    "reviewStatus",
+    "origin",
+    "provider",
+    "createdByUserId",
+    "modifiedFrom",
+    "modifiedTo",
+    "importBatchId",
+    "sort",
+    "sortDir",
+] as const satisfies readonly (keyof TmEntryListUrlState)[];
+
+function readAllowedValue<T extends string>(
+    searchParams: URLSearchParams,
+    key: string,
+    allowed: readonly T[],
+): T | undefined {
+    const value = searchParams.get(key);
+    if (value && (allowed as readonly string[]).includes(value)) {
+        return value as T;
+    }
+    return undefined;
+}
+
+function readTrimmedParam(searchParams: URLSearchParams, key: string): string | undefined {
+    const value = searchParams.get(key)?.trim();
+    return value ? value : undefined;
+}
+
+function readUuidParam(searchParams: URLSearchParams, key: string): string | undefined {
+    const value = readTrimmedParam(searchParams, key);
+    if (!value || !UUID_PATTERN.test(value)) {
+        return undefined;
+    }
+    return value.toLowerCase();
+}
+
+export function parseModifiedDateParam(value: string | null | undefined): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    if (DATE_ONLY_PATTERN.test(trimmed)) {
+        return trimmed;
+    }
+    const parsed = Date.parse(trimmed);
+    if (Number.isNaN(parsed)) {
+        return undefined;
+    }
+    return new Date(parsed).toISOString().slice(0, 10);
+}
+
+export function modifiedDateToApiDateTime(date: string, bound: "start" | "end"): string {
+    if (date.includes("T")) {
+        return date;
+    }
+    return bound === "start" ? `${date}T00:00:00.000Z` : `${date}T23:59:59.999Z`;
+}
+
+export function parseCanonicalLocaleParam(value: string | null | undefined): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    return canonicalizeLocale(trimmed) ?? trimmed;
+}
+
+export function parseTmEntryListSearchParams(searchParams: URLSearchParams): TmEntryListUrlState {
+    const sort = readAllowedValue(searchParams, "sort", TM_ENTRY_SORTS) ?? DEFAULT_STATE.sort;
+    const sortDir =
+        readAllowedValue(searchParams, "sortDir", TM_ENTRY_SORT_DIRS) ?? DEFAULT_STATE.sortDir;
+    const search = (searchParams.get("search") ?? "").trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH);
+    const origin = readTrimmedParam(searchParams, "origin");
+    const provider = readTrimmedParam(searchParams, "provider");
+
+    return {
+        search,
+        sourceLocale: parseCanonicalLocaleParam(searchParams.get("sourceLocale")),
+        targetLocale: parseCanonicalLocaleParam(searchParams.get("targetLocale")),
+        reviewStatus: readAllowedValue(searchParams, "reviewStatus", TM_ENTRY_REVIEW_STATUSES),
+        origin,
+        provider,
+        createdByUserId: readUuidParam(searchParams, "createdByUserId"),
+        modifiedFrom: parseModifiedDateParam(searchParams.get("modifiedFrom")),
+        modifiedTo: parseModifiedDateParam(searchParams.get("modifiedTo")),
+        importBatchId: readUuidParam(searchParams, "importBatchId"),
+        sort,
+        sortDir,
+        cursor: readTrimmedParam(searchParams, "cursor"),
+        entry: readUuidParam(searchParams, "entry"),
+    };
+}
+
+export function buildTmEntryListSearchParams(state: TmEntryListUrlState): URLSearchParams {
+    const params = new URLSearchParams();
+    if (state.search.trim()) {
+        params.set("search", state.search.trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH));
+    }
+    if (state.sourceLocale) {
+        params.set("sourceLocale", state.sourceLocale);
+    }
+    if (state.targetLocale) {
+        params.set("targetLocale", state.targetLocale);
+    }
+    if (state.reviewStatus) {
+        params.set("reviewStatus", state.reviewStatus);
+    }
+    if (state.origin) {
+        params.set("origin", state.origin);
+    }
+    if (state.provider) {
+        params.set("provider", state.provider);
+    }
+    if (state.createdByUserId) {
+        params.set("createdByUserId", state.createdByUserId);
+    }
+    if (state.modifiedFrom) {
+        params.set("modifiedFrom", state.modifiedFrom);
+    }
+    if (state.modifiedTo) {
+        params.set("modifiedTo", state.modifiedTo);
+    }
+    if (state.importBatchId) {
+        params.set("importBatchId", state.importBatchId);
+    }
+    if (state.sort !== DEFAULT_STATE.sort) {
+        params.set("sort", state.sort);
+    }
+    if (state.sortDir !== DEFAULT_STATE.sortDir) {
+        params.set("sortDir", state.sortDir);
+    }
+    if (state.cursor) {
+        params.set("cursor", state.cursor);
+    }
+    if (state.entry) {
+        params.set("entry", state.entry);
+    }
+    return params;
+}
+
+export function buildTmEntryListHref(pathname: string, state: TmEntryListUrlState): string {
+    const query = buildTmEntryListSearchParams(state).toString();
+    return query ? `${pathname}?${query}` : pathname;
+}
+
+export function tmEntryListFiltersEqual(
+    left: TmEntryListUrlState,
+    right: TmEntryListUrlState,
+): boolean {
+    return FILTER_KEYS.every((key) => (left[key] ?? "") === (right[key] ?? ""));
+}
+
+export function applyTmEntryListStatePatch(
+    current: TmEntryListUrlState,
+    patch: Partial<TmEntryListUrlState>,
+): TmEntryListUrlState {
+    const next = { ...current, ...patch };
+    if (patch.cursor === undefined && !tmEntryListFiltersEqual(current, next)) {
+        next.cursor = undefined;
+    }
+    return next;
+}
+
+export function clearTmEntryListFilters(state: TmEntryListUrlState): TmEntryListUrlState {
+    return {
+        search: "",
+        sort: state.sort,
+        sortDir: state.sortDir,
+        entry: state.entry,
+    };
+}
+
+export function getActiveTmEntryFilterChips(state: TmEntryListUrlState): TmEntryFilterChip[] {
+    const chips: TmEntryFilterChip[] = [];
+    if (state.search.trim()) {
+        chips.push({ key: "search", value: state.search.trim() });
+    }
+    if (state.sourceLocale) {
+        chips.push({ key: "sourceLocale", value: state.sourceLocale });
+    }
+    if (state.targetLocale) {
+        chips.push({ key: "targetLocale", value: state.targetLocale });
+    }
+    if (state.reviewStatus) {
+        chips.push({ key: "reviewStatus", value: state.reviewStatus });
+    }
+    if (state.origin) {
+        chips.push({ key: "origin", value: state.origin });
+    }
+    if (state.provider) {
+        chips.push({ key: "provider", value: state.provider });
+    }
+    if (state.createdByUserId) {
+        chips.push({ key: "createdByUserId", value: state.createdByUserId });
+    }
+    if (state.modifiedFrom) {
+        chips.push({ key: "modifiedFrom", value: state.modifiedFrom });
+    }
+    if (state.modifiedTo) {
+        chips.push({ key: "modifiedTo", value: state.modifiedTo });
+    }
+    if (state.importBatchId) {
+        chips.push({ key: "importBatchId", value: state.importBatchId });
+    }
+    return chips;
+}
+
+export function tmEntryListStateToApiQuery(
+    state: TmEntryListUrlState,
+    options?: { limit?: number; cursor?: string | null },
+): TmEntryListApiQuery {
+    const query: TmEntryListApiQuery = {
+        limit: String(options?.limit ?? TM_ENTRY_PAGE_SIZE),
+    };
+    const cursor = options?.cursor === undefined ? state.cursor : (options.cursor ?? undefined);
+    if (cursor) {
+        query.cursor = cursor;
+    }
+    if (state.search.trim()) {
+        query.search = state.search.trim().slice(0, TM_ENTRY_SEARCH_MAX_LENGTH);
+    }
+    if (state.sourceLocale) {
+        query.sourceLocale = state.sourceLocale;
+    }
+    if (state.targetLocale) {
+        query.targetLocale = state.targetLocale;
+    }
+    if (state.reviewStatus) {
+        query.reviewStatus = state.reviewStatus;
+    }
+    if (state.origin) {
+        query.origin = state.origin;
+    }
+    if (state.provider) {
+        query.provider = state.provider;
+    }
+    if (state.createdByUserId) {
+        query.createdByUserId = state.createdByUserId;
+    }
+    if (state.modifiedFrom) {
+        query.modifiedFrom = modifiedDateToApiDateTime(state.modifiedFrom, "start");
+    }
+    if (state.modifiedTo) {
+        query.modifiedTo = modifiedDateToApiDateTime(state.modifiedTo, "end");
+    }
+    if (state.importBatchId) {
+        query.importBatchId = state.importBatchId;
+    }
+    if (state.sort !== DEFAULT_STATE.sort) {
+        query.sort = state.sort;
+    }
+    if (state.sortDir !== DEFAULT_STATE.sortDir) {
+        query.sortDir = state.sortDir;
+    }
+    return query;
+}
+
+export function buildTmEntryLocaleOptions(input: {
+    localeCoverage?: string[];
+    selected?: string;
+}): string[] {
+    const merged = new Set<string>(COMMON_LOCALES);
+    for (const locale of input.localeCoverage ?? []) {
+        const canonical = parseCanonicalLocaleParam(locale);
+        if (canonical) {
+            merged.add(canonical);
+        }
+    }
+    const selected = parseCanonicalLocaleParam(input.selected);
+    if (selected) {
+        merged.add(selected);
+    }
+    return [...merged].toSorted((left, right) =>
+        left.localeCompare(right, undefined, { sensitivity: "base" }),
+    );
+}
+
+export function tmEntryCursorStackStorageKey(memoryId: string, state: TmEntryListUrlState): string {
+    const filters = FILTER_KEYS.map((key) => `${key}=${state[key] ?? ""}`).join("&");
+    return `tm-entry-explorer-cursors:${memoryId}:${filters}`;
+}
+
+export function tmEntryScrollStorageKey(memoryId: string): string {
+    return `tm-entry-explorer-scroll:${memoryId}`;
+}
+
+export function isUuid(value: string): boolean {
+    return UUID_PATTERN.test(value);
+}
+
+function readSessionJson(key: string): unknown {
+    if (typeof sessionStorage === "undefined") {
+        return null;
+    }
+    try {
+        const raw = sessionStorage.getItem(key);
+        return raw ? JSON.parse(raw) : null;
+    } catch {
+        return null;
+    }
+}
+
+function writeSessionJson(key: string, value: unknown): void {
+    if (typeof sessionStorage === "undefined") {
+        return;
+    }
+    try {
+        sessionStorage.setItem(key, JSON.stringify(value));
+    } catch {
+        // Ignore quota and private-mode failures.
+    }
+}
+
+export function readTmEntryCursorStack(key: string): string[] {
+    const parsed = readSessionJson(key);
+    if (!Array.isArray(parsed)) {
+        return [];
+    }
+    return parsed.filter((item): item is string => typeof item === "string");
+}
+
+export function writeTmEntryCursorStack(key: string, stack: string[]): void {
+    writeSessionJson(key, stack);
+}
+
+export function readTmEntryScrollOffset(key: string): number | null {
+    const parsed = readSessionJson(key);
+    return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : null;
+}
+
+export function writeTmEntryScrollOffset(key: string, offset: number): void {
+    writeSessionJson(key, offset);
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-toolbar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-toolbar.tsx
@@ -1,0 +1,458 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useState } from "react";
+import { Cancel01Icon, FilterIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+    Popover,
+    PopoverContent,
+    PopoverHeader,
+    PopoverTitle,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { formatLocaleOptionLabel } from "@/lib/i18n/locale-display-names.messages";
+
+import { IssueLocalePicker } from "../../../_components/issue-detail/issue-locale-picker";
+import {
+    WorkspaceFilterField,
+    workspaceFilterTriggerClassName,
+} from "../../../_components/workspace-resource-shared";
+import { tmEntryExplorerMessages as messages } from "./tm-entry-explorer.messages";
+import {
+    getActiveTmEntryFilterChips,
+    isUuid,
+    TM_ENTRY_ORIGINS,
+    TM_ENTRY_PROVIDERS,
+    TM_ENTRY_REVIEW_STATUSES,
+    TM_ENTRY_SORT_DIRS,
+    TM_ENTRY_SORTS,
+    type TmEntryFilterChip,
+    type TmEntryListUrlState,
+    type TmEntryReviewStatus,
+    type TmEntrySort,
+    type TmEntrySortDir,
+} from "./tm-entry-list-state";
+
+function reviewStatusLabel(
+    intl: ReturnType<typeof useIntl>,
+    status: TmEntryReviewStatus,
+): string {
+    switch (status) {
+        case "approved":
+            return intl.formatMessage(messages.reviewApproved);
+        case "pending":
+            return intl.formatMessage(messages.reviewPending);
+        case "rejected":
+            return intl.formatMessage(messages.reviewRejected);
+    }
+}
+
+function originLabel(intl: ReturnType<typeof useIntl>, origin: string): string {
+    switch (origin) {
+        case "manual":
+            return intl.formatMessage(messages.originManual);
+        case "import":
+            return intl.formatMessage(messages.originImport);
+        case "sync":
+            return intl.formatMessage(messages.originSync);
+        default:
+            return origin;
+    }
+}
+
+function sortLabel(intl: ReturnType<typeof useIntl>, sort: TmEntrySort): string {
+    return intl.formatMessage(sort === "updated_at" ? messages.sortUpdatedAt : messages.sortCreatedAt);
+}
+
+function sortDirLabel(intl: ReturnType<typeof useIntl>, sortDir: TmEntrySortDir): string {
+    return intl.formatMessage(sortDir === "asc" ? messages.sortDirAsc : messages.sortDirDesc);
+}
+
+function formatChipLabel(intl: ReturnType<typeof useIntl>, chip: TmEntryFilterChip): string {
+    switch (chip.key) {
+        case "search":
+            return intl.formatMessage(messages.chipSearch, { value: chip.value });
+        case "sourceLocale":
+            return intl.formatMessage(messages.chipSourceLocale, {
+                value: formatLocaleOptionLabel(intl, chip.value),
+            });
+        case "targetLocale":
+            return intl.formatMessage(messages.chipTargetLocale, {
+                value: formatLocaleOptionLabel(intl, chip.value),
+            });
+        case "reviewStatus":
+            return intl.formatMessage(messages.chipReviewStatus, {
+                value: reviewStatusLabel(intl, chip.value),
+            });
+        case "origin":
+            return intl.formatMessage(messages.chipOrigin, { value: originLabel(intl, chip.value) });
+        case "provider":
+            return intl.formatMessage(messages.chipProvider, { value: chip.value });
+        case "createdByUserId":
+            return intl.formatMessage(messages.chipCreator, { value: chip.value });
+        case "modifiedFrom":
+            return intl.formatMessage(messages.chipModifiedFrom, { value: chip.value });
+        case "modifiedTo":
+            return intl.formatMessage(messages.chipModifiedTo, { value: chip.value });
+        case "importBatchId":
+            return intl.formatMessage(messages.chipImportBatch, { value: chip.value });
+    }
+}
+
+function commitUuidFilter(
+    value: string,
+    onCommit: (next: string | undefined) => void,
+): void {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        onCommit(undefined);
+        return;
+    }
+    if (isUuid(trimmed)) {
+        onCommit(trimmed.toLowerCase());
+    }
+}
+
+export function TmEntryListToolbar({
+    state,
+    searchDraft,
+    localeOptions,
+    onSearchDraftChange,
+    onStateChange,
+    onClearFilters,
+}: {
+    state: TmEntryListUrlState;
+    searchDraft: string;
+    localeOptions: string[];
+    onSearchDraftChange: (value: string) => void;
+    onStateChange: (patch: Partial<TmEntryListUrlState>) => void;
+    onClearFilters: () => void;
+}) {
+    const intl = useIntl();
+    const chips = getActiveTmEntryFilterChips(state);
+    const filterChipCount = chips.filter((chip) => chip.key !== "search").length;
+    const [creatorDraft, setCreatorDraft] = useState(state.createdByUserId ?? "");
+    const [importBatchDraft, setImportBatchDraft] = useState(state.importBatchId ?? "");
+
+    useEffect(() => {
+        setCreatorDraft(state.createdByUserId ?? "");
+    }, [state.createdByUserId]);
+
+    useEffect(() => {
+        setImportBatchDraft(state.importBatchId ?? "");
+    }, [state.importBatchId]);
+
+    const sortOptions = TM_ENTRY_SORTS.map((value) => ({
+        value,
+        label: sortLabel(intl, value),
+    }));
+    const sortDirOptions = TM_ENTRY_SORT_DIRS.map((value) => ({
+        value,
+        label: sortDirLabel(intl, value),
+    }));
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <Input
+                    value={searchDraft}
+                    onChange={(event) => onSearchDraftChange(event.currentTarget.value)}
+                    placeholder={intl.formatMessage(messages.searchPlaceholder)}
+                    className="h-9 min-w-[12rem] flex-1 md:max-w-md"
+                    aria-label={intl.formatMessage(messages.searchLabel)}
+                />
+
+                <Popover>
+                    <PopoverTrigger
+                        render={<Button type="button" variant="outline" size="sm" className="gap-1.5" />}
+                    >
+                        <HugeiconsIcon icon={FilterIcon} strokeWidth={2} className="size-3.5" />
+                        {filterChipCount > 0 ? (
+                            <FormattedMessage
+                                {...messages.filterButtonWithCount}
+                                values={{ count: filterChipCount }}
+                            />
+                        ) : (
+                            <FormattedMessage {...messages.filterButton} />
+                        )}
+                    </PopoverTrigger>
+                    <PopoverContent align="end" className="w-[22rem] gap-3 p-3 sm:w-[28rem]">
+                        <PopoverHeader className="px-1">
+                            <PopoverTitle className="text-sm font-medium">
+                                <FormattedMessage {...messages.filterPopoverTitle} />
+                            </PopoverTitle>
+                        </PopoverHeader>
+                        <div className="grid gap-3 sm:grid-cols-2">
+                            <WorkspaceFilterField label={intl.formatMessage(messages.sourceLocaleLabel)}>
+                                <IssueLocalePicker
+                                    value={state.sourceLocale}
+                                    locales={localeOptions}
+                                    allowClear
+                                    onValueChange={(locale) =>
+                                        onStateChange({ sourceLocale: locale ?? undefined })
+                                    }
+                                    aria-label={intl.formatMessage(messages.sourceLocaleLabel)}
+                                    triggerClassName={workspaceFilterTriggerClassName}
+                                />
+                            </WorkspaceFilterField>
+                            <WorkspaceFilterField label={intl.formatMessage(messages.targetLocaleLabel)}>
+                                <IssueLocalePicker
+                                    value={state.targetLocale}
+                                    locales={localeOptions}
+                                    allowClear
+                                    onValueChange={(locale) =>
+                                        onStateChange({ targetLocale: locale ?? undefined })
+                                    }
+                                    aria-label={intl.formatMessage(messages.targetLocaleLabel)}
+                                    triggerClassName={workspaceFilterTriggerClassName}
+                                />
+                            </WorkspaceFilterField>
+                            <WorkspaceFilterField label={intl.formatMessage(messages.reviewStatusLabel)}>
+                                <Select
+                                    value={state.reviewStatus ?? "all"}
+                                    onValueChange={(value) =>
+                                        onStateChange({
+                                            reviewStatus:
+                                                value && value !== "all"
+                                                    ? (value as TmEntryReviewStatus)
+                                                    : undefined,
+                                        })
+                                    }
+                                >
+                                    <SelectTrigger className={workspaceFilterTriggerClassName}>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
+                                            <FormattedMessage {...messages.anyValue} />
+                                        </SelectItem>
+                                        {TM_ENTRY_REVIEW_STATUSES.map((status) => (
+                                            <SelectItem
+                                                key={status}
+                                                value={status}
+                                                label={reviewStatusLabel(intl, status)}
+                                            >
+                                                {reviewStatusLabel(intl, status)}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </WorkspaceFilterField>
+                            <WorkspaceFilterField label={intl.formatMessage(messages.originLabel)}>
+                                <Select
+                                    value={state.origin ?? "all"}
+                                    onValueChange={(value) =>
+                                        onStateChange({
+                                            origin: value && value !== "all" ? value : undefined,
+                                        })
+                                    }
+                                >
+                                    <SelectTrigger className={workspaceFilterTriggerClassName}>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
+                                            <FormattedMessage {...messages.anyValue} />
+                                        </SelectItem>
+                                        {TM_ENTRY_ORIGINS.map((origin) => (
+                                            <SelectItem
+                                                key={origin}
+                                                value={origin}
+                                                label={originLabel(intl, origin)}
+                                            >
+                                                {originLabel(intl, origin)}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </WorkspaceFilterField>
+                            <WorkspaceFilterField label={intl.formatMessage(messages.providerLabel)}>
+                                <Select
+                                    value={state.provider ?? "all"}
+                                    onValueChange={(value) =>
+                                        onStateChange({
+                                            provider: value && value !== "all" ? value : undefined,
+                                        })
+                                    }
+                                >
+                                    <SelectTrigger className={workspaceFilterTriggerClassName}>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
+                                            <FormattedMessage {...messages.anyValue} />
+                                        </SelectItem>
+                                        {TM_ENTRY_PROVIDERS.map((provider) => (
+                                            <SelectItem key={provider} value={provider} label={provider}>
+                                                {provider}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </WorkspaceFilterField>
+                            <WorkspaceFilterField label={intl.formatMessage(messages.creatorLabel)}>
+                                <Input
+                                    value={creatorDraft}
+                                    onChange={(event) => setCreatorDraft(event.currentTarget.value)}
+                                    onBlur={() =>
+                                        commitUuidFilter(creatorDraft, (createdByUserId) =>
+                                            onStateChange({ createdByUserId }),
+                                        )
+                                    }
+                                    placeholder={intl.formatMessage(messages.creatorPlaceholder)}
+                                    aria-label={intl.formatMessage(messages.creatorLabel)}
+                                    className="h-9"
+                                />
+                            </WorkspaceFilterField>
+                            <WorkspaceFilterField label={intl.formatMessage(messages.modifiedFromLabel)}>
+                                <Input
+                                    type="date"
+                                    value={state.modifiedFrom ?? ""}
+                                    onChange={(event) =>
+                                        onStateChange({
+                                            modifiedFrom: event.currentTarget.value || undefined,
+                                        })
+                                    }
+                                    aria-label={intl.formatMessage(messages.modifiedFromLabel)}
+                                    className="h-9"
+                                />
+                            </WorkspaceFilterField>
+                            <WorkspaceFilterField label={intl.formatMessage(messages.modifiedToLabel)}>
+                                <Input
+                                    type="date"
+                                    value={state.modifiedTo ?? ""}
+                                    onChange={(event) =>
+                                        onStateChange({
+                                            modifiedTo: event.currentTarget.value || undefined,
+                                        })
+                                    }
+                                    aria-label={intl.formatMessage(messages.modifiedToLabel)}
+                                    className="h-9"
+                                />
+                            </WorkspaceFilterField>
+                            <WorkspaceFilterField
+                                className="sm:col-span-2"
+                                label={intl.formatMessage(messages.importBatchLabel)}
+                            >
+                                <Input
+                                    value={importBatchDraft}
+                                    onChange={(event) => setImportBatchDraft(event.currentTarget.value)}
+                                    onBlur={() =>
+                                        commitUuidFilter(importBatchDraft, (importBatchId) =>
+                                            onStateChange({ importBatchId }),
+                                        )
+                                    }
+                                    placeholder={intl.formatMessage(messages.importBatchPlaceholder)}
+                                    aria-label={intl.formatMessage(messages.importBatchLabel)}
+                                    className="h-9"
+                                />
+                            </WorkspaceFilterField>
+                        </div>
+                    </PopoverContent>
+                </Popover>
+
+                <div className="flex items-center gap-1.5">
+                    <Select
+                        value={state.sort}
+                        items={sortOptions}
+                        onValueChange={(value) =>
+                            onStateChange({ sort: (value ?? "created_at") as TmEntrySort })
+                        }
+                    >
+                        <SelectTrigger
+                            size="sm"
+                            className="h-8 w-[8.5rem]"
+                            aria-label={intl.formatMessage(messages.sortByLabel)}
+                        >
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {sortOptions.map((item) => (
+                                <SelectItem key={item.value} value={item.value} label={item.label}>
+                                    {item.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <Select
+                        value={state.sortDir}
+                        items={sortDirOptions}
+                        onValueChange={(value) =>
+                            onStateChange({ sortDir: (value ?? "desc") as TmEntrySortDir })
+                        }
+                    >
+                        <SelectTrigger
+                            size="sm"
+                            className="h-8 w-[8.5rem]"
+                            aria-label={intl.formatMessage(messages.orderLabel)}
+                        >
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {sortDirOptions.map((item) => (
+                                <SelectItem key={item.value} value={item.value} label={item.label}>
+                                    {item.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </div>
+
+            {chips.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-2">
+                    {chips.map((chip) => {
+                        const label = formatChipLabel(intl, chip);
+                        return (
+                            <Badge key={chip.key} variant="secondary" className="gap-1 rounded-full pe-1">
+                                <span>{label}</span>
+                                <button
+                                    type="button"
+                                    className="rounded-full p-0.5 hover:bg-muted"
+                                    aria-label={intl.formatMessage(messages.removeChipAriaLabel, { label })}
+                                    onClick={() => {
+                                        if (chip.key === "search") {
+                                            onSearchDraftChange("");
+                                        }
+                                        onStateChange({
+                                            [chip.key]: chip.key === "search" ? "" : undefined,
+                                        });
+                                    }}
+                                >
+                                    <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+                                </button>
+                            </Badge>
+                        );
+                    })}
+                    <Button type="button" variant="ghost" size="sm" onClick={onClearFilters}>
+                        <FormattedMessage {...messages.clearFilters} />
+                    </Button>
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-toolbar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-toolbar.tsx
@@ -21,438 +21,424 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-    Popover,
-    PopoverContent,
-    PopoverHeader,
-    PopoverTitle,
-    PopoverTrigger,
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
 } from "@/components/ui/popover";
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
 import { formatLocaleOptionLabel } from "@/lib/i18n/locale-display-names.messages";
 
 import { IssueLocalePicker } from "../../../_components/issue-detail/issue-locale-picker";
 import {
-    WorkspaceFilterField,
-    workspaceFilterTriggerClassName,
+  WorkspaceFilterField,
+  workspaceFilterTriggerClassName,
 } from "../../../_components/workspace-resource-shared";
 import { tmEntryExplorerMessages as messages } from "./tm-entry-explorer.messages";
 import {
-    getActiveTmEntryFilterChips,
-    isUuid,
-    TM_ENTRY_ORIGINS,
-    TM_ENTRY_PROVIDERS,
-    TM_ENTRY_REVIEW_STATUSES,
-    TM_ENTRY_SORT_DIRS,
-    TM_ENTRY_SORTS,
-    type TmEntryFilterChip,
-    type TmEntryListUrlState,
-    type TmEntryReviewStatus,
-    type TmEntrySort,
-    type TmEntrySortDir,
+  getActiveTmEntryFilterChips,
+  isUuid,
+  TM_ENTRY_ORIGINS,
+  TM_ENTRY_PROVIDERS,
+  TM_ENTRY_REVIEW_STATUSES,
+  TM_ENTRY_SORT_DIRS,
+  TM_ENTRY_SORTS,
+  type TmEntryFilterChip,
+  type TmEntryListUrlState,
+  type TmEntryReviewStatus,
+  type TmEntrySort,
+  type TmEntrySortDir,
 } from "./tm-entry-list-state";
 
-function reviewStatusLabel(
-    intl: ReturnType<typeof useIntl>,
-    status: TmEntryReviewStatus,
-): string {
-    switch (status) {
-        case "approved":
-            return intl.formatMessage(messages.reviewApproved);
-        case "pending":
-            return intl.formatMessage(messages.reviewPending);
-        case "rejected":
-            return intl.formatMessage(messages.reviewRejected);
-    }
+function reviewStatusLabel(intl: ReturnType<typeof useIntl>, status: TmEntryReviewStatus): string {
+  switch (status) {
+    case "approved":
+      return intl.formatMessage(messages.reviewApproved);
+    case "pending":
+      return intl.formatMessage(messages.reviewPending);
+    case "rejected":
+      return intl.formatMessage(messages.reviewRejected);
+  }
 }
 
 function originLabel(intl: ReturnType<typeof useIntl>, origin: string): string {
-    switch (origin) {
-        case "manual":
-            return intl.formatMessage(messages.originManual);
-        case "import":
-            return intl.formatMessage(messages.originImport);
-        case "sync":
-            return intl.formatMessage(messages.originSync);
-        default:
-            return origin;
-    }
+  switch (origin) {
+    case "manual":
+      return intl.formatMessage(messages.originManual);
+    case "import":
+      return intl.formatMessage(messages.originImport);
+    case "sync":
+      return intl.formatMessage(messages.originSync);
+    default:
+      return origin;
+  }
 }
 
 function sortLabel(intl: ReturnType<typeof useIntl>, sort: TmEntrySort): string {
-    return intl.formatMessage(sort === "updated_at" ? messages.sortUpdatedAt : messages.sortCreatedAt);
+  return intl.formatMessage(
+    sort === "updated_at" ? messages.sortUpdatedAt : messages.sortCreatedAt,
+  );
 }
 
 function sortDirLabel(intl: ReturnType<typeof useIntl>, sortDir: TmEntrySortDir): string {
-    return intl.formatMessage(sortDir === "asc" ? messages.sortDirAsc : messages.sortDirDesc);
+  return intl.formatMessage(sortDir === "asc" ? messages.sortDirAsc : messages.sortDirDesc);
 }
 
 function formatChipLabel(intl: ReturnType<typeof useIntl>, chip: TmEntryFilterChip): string {
-    switch (chip.key) {
-        case "search":
-            return intl.formatMessage(messages.chipSearch, { value: chip.value });
-        case "sourceLocale":
-            return intl.formatMessage(messages.chipSourceLocale, {
-                value: formatLocaleOptionLabel(intl, chip.value),
-            });
-        case "targetLocale":
-            return intl.formatMessage(messages.chipTargetLocale, {
-                value: formatLocaleOptionLabel(intl, chip.value),
-            });
-        case "reviewStatus":
-            return intl.formatMessage(messages.chipReviewStatus, {
-                value: reviewStatusLabel(intl, chip.value),
-            });
-        case "origin":
-            return intl.formatMessage(messages.chipOrigin, { value: originLabel(intl, chip.value) });
-        case "provider":
-            return intl.formatMessage(messages.chipProvider, { value: chip.value });
-        case "createdByUserId":
-            return intl.formatMessage(messages.chipCreator, { value: chip.value });
-        case "modifiedFrom":
-            return intl.formatMessage(messages.chipModifiedFrom, { value: chip.value });
-        case "modifiedTo":
-            return intl.formatMessage(messages.chipModifiedTo, { value: chip.value });
-        case "importBatchId":
-            return intl.formatMessage(messages.chipImportBatch, { value: chip.value });
-    }
+  switch (chip.key) {
+    case "search":
+      return intl.formatMessage(messages.chipSearch, { value: chip.value });
+    case "sourceLocale":
+      return intl.formatMessage(messages.chipSourceLocale, {
+        value: formatLocaleOptionLabel(intl, chip.value),
+      });
+    case "targetLocale":
+      return intl.formatMessage(messages.chipTargetLocale, {
+        value: formatLocaleOptionLabel(intl, chip.value),
+      });
+    case "reviewStatus":
+      return intl.formatMessage(messages.chipReviewStatus, {
+        value: reviewStatusLabel(intl, chip.value),
+      });
+    case "origin":
+      return intl.formatMessage(messages.chipOrigin, { value: originLabel(intl, chip.value) });
+    case "provider":
+      return intl.formatMessage(messages.chipProvider, { value: chip.value });
+    case "createdByUserId":
+      return intl.formatMessage(messages.chipCreator, { value: chip.value });
+    case "modifiedFrom":
+      return intl.formatMessage(messages.chipModifiedFrom, { value: chip.value });
+    case "modifiedTo":
+      return intl.formatMessage(messages.chipModifiedTo, { value: chip.value });
+    case "importBatchId":
+      return intl.formatMessage(messages.chipImportBatch, { value: chip.value });
+  }
 }
 
-function commitUuidFilter(
-    value: string,
-    onCommit: (next: string | undefined) => void,
-): void {
-    const trimmed = value.trim();
-    if (!trimmed) {
-        onCommit(undefined);
-        return;
-    }
-    if (isUuid(trimmed)) {
-        onCommit(trimmed.toLowerCase());
-    }
+function commitUuidFilter(value: string, onCommit: (next: string | undefined) => void): void {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    onCommit(undefined);
+    return;
+  }
+  if (isUuid(trimmed)) {
+    onCommit(trimmed.toLowerCase());
+  }
 }
 
 export function TmEntryListToolbar({
-    state,
-    searchDraft,
-    localeOptions,
-    onSearchDraftChange,
-    onStateChange,
-    onClearFilters,
+  state,
+  searchDraft,
+  localeOptions,
+  onSearchDraftChange,
+  onStateChange,
+  onClearFilters,
 }: {
-    state: TmEntryListUrlState;
-    searchDraft: string;
-    localeOptions: string[];
-    onSearchDraftChange: (value: string) => void;
-    onStateChange: (patch: Partial<TmEntryListUrlState>) => void;
-    onClearFilters: () => void;
+  state: TmEntryListUrlState;
+  searchDraft: string;
+  localeOptions: string[];
+  onSearchDraftChange: (value: string) => void;
+  onStateChange: (patch: Partial<TmEntryListUrlState>) => void;
+  onClearFilters: () => void;
 }) {
-    const intl = useIntl();
-    const chips = getActiveTmEntryFilterChips(state);
-    const filterChipCount = chips.filter((chip) => chip.key !== "search").length;
-    const [creatorDraft, setCreatorDraft] = useState(state.createdByUserId ?? "");
-    const [importBatchDraft, setImportBatchDraft] = useState(state.importBatchId ?? "");
+  const intl = useIntl();
+  const chips = getActiveTmEntryFilterChips(state);
+  const filterChipCount = chips.filter((chip) => chip.key !== "search").length;
+  const [creatorDraft, setCreatorDraft] = useState(state.createdByUserId ?? "");
+  const [importBatchDraft, setImportBatchDraft] = useState(state.importBatchId ?? "");
 
-    useEffect(() => {
-        setCreatorDraft(state.createdByUserId ?? "");
-    }, [state.createdByUserId]);
+  useEffect(() => {
+    setCreatorDraft(state.createdByUserId ?? "");
+  }, [state.createdByUserId]);
 
-    useEffect(() => {
-        setImportBatchDraft(state.importBatchId ?? "");
-    }, [state.importBatchId]);
+  useEffect(() => {
+    setImportBatchDraft(state.importBatchId ?? "");
+  }, [state.importBatchId]);
 
-    const sortOptions = TM_ENTRY_SORTS.map((value) => ({
-        value,
-        label: sortLabel(intl, value),
-    }));
-    const sortDirOptions = TM_ENTRY_SORT_DIRS.map((value) => ({
-        value,
-        label: sortDirLabel(intl, value),
-    }));
+  const sortOptions = TM_ENTRY_SORTS.map((value) => ({
+    value,
+    label: sortLabel(intl, value),
+  }));
+  const sortDirOptions = TM_ENTRY_SORT_DIRS.map((value) => ({
+    value,
+    label: sortDirLabel(intl, value),
+  }));
 
-    return (
-        <div className="space-y-3">
-            <div className="flex flex-wrap items-center gap-2">
-                <Input
-                    value={searchDraft}
-                    onChange={(event) => onSearchDraftChange(event.currentTarget.value)}
-                    placeholder={intl.formatMessage(messages.searchPlaceholder)}
-                    className="h-9 min-w-[12rem] flex-1 md:max-w-md"
-                    aria-label={intl.formatMessage(messages.searchLabel)}
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          value={searchDraft}
+          onChange={(event) => onSearchDraftChange(event.currentTarget.value)}
+          placeholder={intl.formatMessage(messages.searchPlaceholder)}
+          className="h-9 min-w-[12rem] flex-1 md:max-w-md"
+          aria-label={intl.formatMessage(messages.searchLabel)}
+        />
+
+        <Popover>
+          <PopoverTrigger
+            render={<Button type="button" variant="outline" size="sm" className="gap-1.5" />}
+          >
+            <HugeiconsIcon icon={FilterIcon} strokeWidth={2} className="size-3.5" />
+            {filterChipCount > 0 ? (
+              <FormattedMessage
+                {...messages.filterButtonWithCount}
+                values={{ count: filterChipCount }}
+              />
+            ) : (
+              <FormattedMessage {...messages.filterButton} />
+            )}
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-[22rem] gap-3 p-3 sm:w-[28rem]">
+            <PopoverHeader className="px-1">
+              <PopoverTitle className="text-sm font-medium">
+                <FormattedMessage {...messages.filterPopoverTitle} />
+              </PopoverTitle>
+            </PopoverHeader>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <WorkspaceFilterField label={intl.formatMessage(messages.sourceLocaleLabel)}>
+                <IssueLocalePicker
+                  value={state.sourceLocale}
+                  locales={localeOptions}
+                  allowClear
+                  onValueChange={(locale) => onStateChange({ sourceLocale: locale ?? undefined })}
+                  aria-label={intl.formatMessage(messages.sourceLocaleLabel)}
+                  triggerClassName={workspaceFilterTriggerClassName}
                 />
-
-                <Popover>
-                    <PopoverTrigger
-                        render={<Button type="button" variant="outline" size="sm" className="gap-1.5" />}
-                    >
-                        <HugeiconsIcon icon={FilterIcon} strokeWidth={2} className="size-3.5" />
-                        {filterChipCount > 0 ? (
-                            <FormattedMessage
-                                {...messages.filterButtonWithCount}
-                                values={{ count: filterChipCount }}
-                            />
-                        ) : (
-                            <FormattedMessage {...messages.filterButton} />
-                        )}
-                    </PopoverTrigger>
-                    <PopoverContent align="end" className="w-[22rem] gap-3 p-3 sm:w-[28rem]">
-                        <PopoverHeader className="px-1">
-                            <PopoverTitle className="text-sm font-medium">
-                                <FormattedMessage {...messages.filterPopoverTitle} />
-                            </PopoverTitle>
-                        </PopoverHeader>
-                        <div className="grid gap-3 sm:grid-cols-2">
-                            <WorkspaceFilterField label={intl.formatMessage(messages.sourceLocaleLabel)}>
-                                <IssueLocalePicker
-                                    value={state.sourceLocale}
-                                    locales={localeOptions}
-                                    allowClear
-                                    onValueChange={(locale) =>
-                                        onStateChange({ sourceLocale: locale ?? undefined })
-                                    }
-                                    aria-label={intl.formatMessage(messages.sourceLocaleLabel)}
-                                    triggerClassName={workspaceFilterTriggerClassName}
-                                />
-                            </WorkspaceFilterField>
-                            <WorkspaceFilterField label={intl.formatMessage(messages.targetLocaleLabel)}>
-                                <IssueLocalePicker
-                                    value={state.targetLocale}
-                                    locales={localeOptions}
-                                    allowClear
-                                    onValueChange={(locale) =>
-                                        onStateChange({ targetLocale: locale ?? undefined })
-                                    }
-                                    aria-label={intl.formatMessage(messages.targetLocaleLabel)}
-                                    triggerClassName={workspaceFilterTriggerClassName}
-                                />
-                            </WorkspaceFilterField>
-                            <WorkspaceFilterField label={intl.formatMessage(messages.reviewStatusLabel)}>
-                                <Select
-                                    value={state.reviewStatus ?? "all"}
-                                    onValueChange={(value) =>
-                                        onStateChange({
-                                            reviewStatus:
-                                                value && value !== "all"
-                                                    ? (value as TmEntryReviewStatus)
-                                                    : undefined,
-                                        })
-                                    }
-                                >
-                                    <SelectTrigger className={workspaceFilterTriggerClassName}>
-                                        <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
-                                            <FormattedMessage {...messages.anyValue} />
-                                        </SelectItem>
-                                        {TM_ENTRY_REVIEW_STATUSES.map((status) => (
-                                            <SelectItem
-                                                key={status}
-                                                value={status}
-                                                label={reviewStatusLabel(intl, status)}
-                                            >
-                                                {reviewStatusLabel(intl, status)}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </WorkspaceFilterField>
-                            <WorkspaceFilterField label={intl.formatMessage(messages.originLabel)}>
-                                <Select
-                                    value={state.origin ?? "all"}
-                                    onValueChange={(value) =>
-                                        onStateChange({
-                                            origin: value && value !== "all" ? value : undefined,
-                                        })
-                                    }
-                                >
-                                    <SelectTrigger className={workspaceFilterTriggerClassName}>
-                                        <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
-                                            <FormattedMessage {...messages.anyValue} />
-                                        </SelectItem>
-                                        {TM_ENTRY_ORIGINS.map((origin) => (
-                                            <SelectItem
-                                                key={origin}
-                                                value={origin}
-                                                label={originLabel(intl, origin)}
-                                            >
-                                                {originLabel(intl, origin)}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </WorkspaceFilterField>
-                            <WorkspaceFilterField label={intl.formatMessage(messages.providerLabel)}>
-                                <Select
-                                    value={state.provider ?? "all"}
-                                    onValueChange={(value) =>
-                                        onStateChange({
-                                            provider: value && value !== "all" ? value : undefined,
-                                        })
-                                    }
-                                >
-                                    <SelectTrigger className={workspaceFilterTriggerClassName}>
-                                        <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
-                                            <FormattedMessage {...messages.anyValue} />
-                                        </SelectItem>
-                                        {TM_ENTRY_PROVIDERS.map((provider) => (
-                                            <SelectItem key={provider} value={provider} label={provider}>
-                                                {provider}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </WorkspaceFilterField>
-                            <WorkspaceFilterField label={intl.formatMessage(messages.creatorLabel)}>
-                                <Input
-                                    value={creatorDraft}
-                                    onChange={(event) => setCreatorDraft(event.currentTarget.value)}
-                                    onBlur={() =>
-                                        commitUuidFilter(creatorDraft, (createdByUserId) =>
-                                            onStateChange({ createdByUserId }),
-                                        )
-                                    }
-                                    placeholder={intl.formatMessage(messages.creatorPlaceholder)}
-                                    aria-label={intl.formatMessage(messages.creatorLabel)}
-                                    className="h-9"
-                                />
-                            </WorkspaceFilterField>
-                            <WorkspaceFilterField label={intl.formatMessage(messages.modifiedFromLabel)}>
-                                <Input
-                                    type="date"
-                                    value={state.modifiedFrom ?? ""}
-                                    onChange={(event) =>
-                                        onStateChange({
-                                            modifiedFrom: event.currentTarget.value || undefined,
-                                        })
-                                    }
-                                    aria-label={intl.formatMessage(messages.modifiedFromLabel)}
-                                    className="h-9"
-                                />
-                            </WorkspaceFilterField>
-                            <WorkspaceFilterField label={intl.formatMessage(messages.modifiedToLabel)}>
-                                <Input
-                                    type="date"
-                                    value={state.modifiedTo ?? ""}
-                                    onChange={(event) =>
-                                        onStateChange({
-                                            modifiedTo: event.currentTarget.value || undefined,
-                                        })
-                                    }
-                                    aria-label={intl.formatMessage(messages.modifiedToLabel)}
-                                    className="h-9"
-                                />
-                            </WorkspaceFilterField>
-                            <WorkspaceFilterField
-                                className="sm:col-span-2"
-                                label={intl.formatMessage(messages.importBatchLabel)}
-                            >
-                                <Input
-                                    value={importBatchDraft}
-                                    onChange={(event) => setImportBatchDraft(event.currentTarget.value)}
-                                    onBlur={() =>
-                                        commitUuidFilter(importBatchDraft, (importBatchId) =>
-                                            onStateChange({ importBatchId }),
-                                        )
-                                    }
-                                    placeholder={intl.formatMessage(messages.importBatchPlaceholder)}
-                                    aria-label={intl.formatMessage(messages.importBatchLabel)}
-                                    className="h-9"
-                                />
-                            </WorkspaceFilterField>
-                        </div>
-                    </PopoverContent>
-                </Popover>
-
-                <div className="flex items-center gap-1.5">
-                    <Select
-                        value={state.sort}
-                        items={sortOptions}
-                        onValueChange={(value) =>
-                            onStateChange({ sort: (value ?? "created_at") as TmEntrySort })
-                        }
-                    >
-                        <SelectTrigger
-                            size="sm"
-                            className="h-8 w-[8.5rem]"
-                            aria-label={intl.formatMessage(messages.sortByLabel)}
-                        >
-                            <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {sortOptions.map((item) => (
-                                <SelectItem key={item.value} value={item.value} label={item.label}>
-                                    {item.label}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                    <Select
-                        value={state.sortDir}
-                        items={sortDirOptions}
-                        onValueChange={(value) =>
-                            onStateChange({ sortDir: (value ?? "desc") as TmEntrySortDir })
-                        }
-                    >
-                        <SelectTrigger
-                            size="sm"
-                            className="h-8 w-[8.5rem]"
-                            aria-label={intl.formatMessage(messages.orderLabel)}
-                        >
-                            <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {sortDirOptions.map((item) => (
-                                <SelectItem key={item.value} value={item.value} label={item.label}>
-                                    {item.label}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                </div>
+              </WorkspaceFilterField>
+              <WorkspaceFilterField label={intl.formatMessage(messages.targetLocaleLabel)}>
+                <IssueLocalePicker
+                  value={state.targetLocale}
+                  locales={localeOptions}
+                  allowClear
+                  onValueChange={(locale) => onStateChange({ targetLocale: locale ?? undefined })}
+                  aria-label={intl.formatMessage(messages.targetLocaleLabel)}
+                  triggerClassName={workspaceFilterTriggerClassName}
+                />
+              </WorkspaceFilterField>
+              <WorkspaceFilterField label={intl.formatMessage(messages.reviewStatusLabel)}>
+                <Select
+                  value={state.reviewStatus ?? "all"}
+                  onValueChange={(value) =>
+                    onStateChange({
+                      reviewStatus:
+                        value && value !== "all" ? (value as TmEntryReviewStatus) : undefined,
+                    })
+                  }
+                >
+                  <SelectTrigger className={workspaceFilterTriggerClassName}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
+                      <FormattedMessage {...messages.anyValue} />
+                    </SelectItem>
+                    {TM_ENTRY_REVIEW_STATUSES.map((status) => (
+                      <SelectItem
+                        key={status}
+                        value={status}
+                        label={reviewStatusLabel(intl, status)}
+                      >
+                        {reviewStatusLabel(intl, status)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </WorkspaceFilterField>
+              <WorkspaceFilterField label={intl.formatMessage(messages.originLabel)}>
+                <Select
+                  value={state.origin ?? "all"}
+                  onValueChange={(value) =>
+                    onStateChange({
+                      origin: value && value !== "all" ? value : undefined,
+                    })
+                  }
+                >
+                  <SelectTrigger className={workspaceFilterTriggerClassName}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
+                      <FormattedMessage {...messages.anyValue} />
+                    </SelectItem>
+                    {TM_ENTRY_ORIGINS.map((origin) => (
+                      <SelectItem key={origin} value={origin} label={originLabel(intl, origin)}>
+                        {originLabel(intl, origin)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </WorkspaceFilterField>
+              <WorkspaceFilterField label={intl.formatMessage(messages.providerLabel)}>
+                <Select
+                  value={state.provider ?? "all"}
+                  onValueChange={(value) =>
+                    onStateChange({
+                      provider: value && value !== "all" ? value : undefined,
+                    })
+                  }
+                >
+                  <SelectTrigger className={workspaceFilterTriggerClassName}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all" label={intl.formatMessage(messages.anyValue)}>
+                      <FormattedMessage {...messages.anyValue} />
+                    </SelectItem>
+                    {TM_ENTRY_PROVIDERS.map((provider) => (
+                      <SelectItem key={provider} value={provider} label={provider}>
+                        {provider}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </WorkspaceFilterField>
+              <WorkspaceFilterField label={intl.formatMessage(messages.creatorLabel)}>
+                <Input
+                  value={creatorDraft}
+                  onChange={(event) => setCreatorDraft(event.currentTarget.value)}
+                  onBlur={() =>
+                    commitUuidFilter(creatorDraft, (createdByUserId) =>
+                      onStateChange({ createdByUserId }),
+                    )
+                  }
+                  placeholder={intl.formatMessage(messages.creatorPlaceholder)}
+                  aria-label={intl.formatMessage(messages.creatorLabel)}
+                  className="h-9"
+                />
+              </WorkspaceFilterField>
+              <WorkspaceFilterField label={intl.formatMessage(messages.modifiedFromLabel)}>
+                <Input
+                  type="date"
+                  value={state.modifiedFrom ?? ""}
+                  onChange={(event) =>
+                    onStateChange({
+                      modifiedFrom: event.currentTarget.value || undefined,
+                    })
+                  }
+                  aria-label={intl.formatMessage(messages.modifiedFromLabel)}
+                  className="h-9"
+                />
+              </WorkspaceFilterField>
+              <WorkspaceFilterField label={intl.formatMessage(messages.modifiedToLabel)}>
+                <Input
+                  type="date"
+                  value={state.modifiedTo ?? ""}
+                  onChange={(event) =>
+                    onStateChange({
+                      modifiedTo: event.currentTarget.value || undefined,
+                    })
+                  }
+                  aria-label={intl.formatMessage(messages.modifiedToLabel)}
+                  className="h-9"
+                />
+              </WorkspaceFilterField>
+              <WorkspaceFilterField
+                className="sm:col-span-2"
+                label={intl.formatMessage(messages.importBatchLabel)}
+              >
+                <Input
+                  value={importBatchDraft}
+                  onChange={(event) => setImportBatchDraft(event.currentTarget.value)}
+                  onBlur={() =>
+                    commitUuidFilter(importBatchDraft, (importBatchId) =>
+                      onStateChange({ importBatchId }),
+                    )
+                  }
+                  placeholder={intl.formatMessage(messages.importBatchPlaceholder)}
+                  aria-label={intl.formatMessage(messages.importBatchLabel)}
+                  className="h-9"
+                />
+              </WorkspaceFilterField>
             </div>
+          </PopoverContent>
+        </Popover>
 
-            {chips.length > 0 ? (
-                <div className="flex flex-wrap items-center gap-2">
-                    {chips.map((chip) => {
-                        const label = formatChipLabel(intl, chip);
-                        return (
-                            <Badge key={chip.key} variant="secondary" className="gap-1 rounded-full pe-1">
-                                <span>{label}</span>
-                                <button
-                                    type="button"
-                                    className="rounded-full p-0.5 hover:bg-muted"
-                                    aria-label={intl.formatMessage(messages.removeChipAriaLabel, { label })}
-                                    onClick={() => {
-                                        if (chip.key === "search") {
-                                            onSearchDraftChange("");
-                                        }
-                                        onStateChange({
-                                            [chip.key]: chip.key === "search" ? "" : undefined,
-                                        });
-                                    }}
-                                >
-                                    <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
-                                </button>
-                            </Badge>
-                        );
-                    })}
-                    <Button type="button" variant="ghost" size="sm" onClick={onClearFilters}>
-                        <FormattedMessage {...messages.clearFilters} />
-                    </Button>
-                </div>
-            ) : null}
+        <div className="flex items-center gap-1.5">
+          <Select
+            value={state.sort}
+            items={sortOptions}
+            onValueChange={(value) =>
+              onStateChange({ sort: (value ?? "created_at") as TmEntrySort })
+            }
+          >
+            <SelectTrigger
+              size="sm"
+              className="h-8 w-[8.5rem]"
+              aria-label={intl.formatMessage(messages.sortByLabel)}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {sortOptions.map((item) => (
+                <SelectItem key={item.value} value={item.value} label={item.label}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={state.sortDir}
+            items={sortDirOptions}
+            onValueChange={(value) =>
+              onStateChange({ sortDir: (value ?? "desc") as TmEntrySortDir })
+            }
+          >
+            <SelectTrigger
+              size="sm"
+              className="h-8 w-[8.5rem]"
+              aria-label={intl.formatMessage(messages.orderLabel)}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {sortDirOptions.map((item) => (
+                <SelectItem key={item.value} value={item.value} label={item.label}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-    );
+      </div>
+
+      {chips.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {chips.map((chip) => {
+            const label = formatChipLabel(intl, chip);
+            return (
+              <Badge key={chip.key} variant="secondary" className="gap-1 rounded-full pe-1">
+                <span>{label}</span>
+                <button
+                  type="button"
+                  className="rounded-full p-0.5 hover:bg-muted"
+                  aria-label={intl.formatMessage(messages.removeChipAriaLabel, { label })}
+                  onClick={() => {
+                    if (chip.key === "search") {
+                      onSearchDraftChange("");
+                    }
+                    onStateChange({
+                      [chip.key]: chip.key === "search" ? "" : undefined,
+                    });
+                  }}
+                >
+                  <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+                </button>
+              </Badge>
+            );
+          })}
+          <Button type="button" variant="ghost" size="sm" onClick={onClearFilters}>
+            <FormattedMessage {...messages.clearFilters} />
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.messages.ts
@@ -1,0 +1,38 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const tmEntryLocaleFieldMessages = defineMessages({
+  useCustomLocale: {
+    defaultMessage: "Use a custom locale",
+    id: "tmEntryLocaleUseCustom",
+    description: "Button that reveals a custom BCP-47 locale input",
+  },
+  customLocalePlaceholder: {
+    defaultMessage: "e.g. sw-KE",
+    id: "tmEntryLocaleCustomPlaceholder",
+    description: "Placeholder for a custom BCP-47 locale tag",
+  },
+  applyCustomLocale: {
+    defaultMessage: "Use locale",
+    id: "tmEntryLocaleApplyCustom",
+    description: "Button that applies a custom BCP-47 locale",
+  },
+  invalidCustomLocale: {
+    defaultMessage: "Enter a valid BCP-47 locale (e.g. fr-FR, zh-Hant-TW).",
+    id: "tmEntryLocaleInvalidCustom",
+    description: "Validation error for an invalid custom translation memory locale",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.messages.ts
@@ -17,22 +17,22 @@ import { defineMessages } from "react-intl";
 export const tmEntryLocaleFieldMessages = defineMessages({
   useCustomLocale: {
     defaultMessage: "Use a custom locale",
-    id: "tmEntryLocaleUseCustom",
+    id: "9p6Zd7Fce0",
     description: "Button that reveals a custom BCP-47 locale input",
   },
   customLocalePlaceholder: {
     defaultMessage: "e.g. sw-KE",
-    id: "tmEntryLocaleCustomPlaceholder",
+    id: "g9zYSipfZt",
     description: "Placeholder for a custom BCP-47 locale tag",
   },
   applyCustomLocale: {
     defaultMessage: "Use locale",
-    id: "tmEntryLocaleApplyCustom",
+    id: "it5/fNQT1d",
     description: "Button that applies a custom BCP-47 locale",
   },
   invalidCustomLocale: {
     defaultMessage: "Enter a valid BCP-47 locale (e.g. fr-FR, zh-Hant-TW).",
-    id: "tmEntryLocaleInvalidCustom",
+    id: "cn9H9r7cR1",
     description: "Validation error for an invalid custom translation memory locale",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.test.tsx
@@ -55,7 +55,9 @@ describe("TmEntryLocaleField", () => {
     await user.click(screen.getByRole("button", { name: "Use locale" }));
 
     expect(onValueChange).toHaveBeenCalledWith("sw-KE");
-    expect(screen.getByRole("combobox", { name: "Source locale" })).toHaveTextContent("sw-KE");
+    expect(screen.getByRole("combobox", { name: "Source locale" })).toHaveTextContent(
+      "Swahili (Kenya)",
+    );
   });
 
   it("rejects an invalid custom locale", async () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { TmEntryLocaleField } from "./tm-entry-locale-field";
+
+function Harness({
+  onValueChange = vi.fn(),
+  initialValue = "en-US",
+}: {
+  onValueChange?: (locale: string) => void;
+  initialValue?: string;
+}) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <IntlProvider locale="en" messages={{}}>
+      <TmEntryLocaleField
+        label="Source locale"
+        value={value}
+        locales={["en-US", "fr-FR"]}
+        onValueChange={(locale) => {
+          setValue(locale);
+          onValueChange(locale);
+        }}
+      />
+    </IntlProvider>
+  );
+}
+
+describe("TmEntryLocaleField", () => {
+  it("applies a valid custom BCP-47 locale outside the curated list", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(<Harness onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Use a custom locale" }));
+    await user.type(screen.getByLabelText("e.g. sw-KE"), "sw-ke");
+    await user.click(screen.getByRole("button", { name: "Use locale" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("sw-KE");
+    expect(screen.getByRole("combobox", { name: "Source locale" })).toHaveTextContent("sw-KE");
+  });
+
+  it("rejects an invalid custom locale", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(<Harness onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Use a custom locale" }));
+    await user.type(screen.getByLabelText("e.g. sw-KE"), "not-a-locale!!!");
+    await user.click(screen.getByRole("button", { name: "Use locale" }));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Enter a valid BCP-47 locale (e.g. fr-FR, zh-Hant-TW)."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useId, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { canonicalizeLocale } from "@/lib/i18n/locales";
+
+import { IssueLocalePicker } from "../../../_components/issue-detail/issue-locale-picker";
+import { tmEntryLocaleFieldMessages as messages } from "./tm-entry-locale-field.messages";
+
+export function TmEntryLocaleField({
+  label,
+  value,
+  locales,
+  onValueChange,
+}: {
+  label: string;
+  value: string;
+  locales: string[];
+  onValueChange: (locale: string) => void;
+}) {
+  const intl = useIntl();
+  const customId = useId();
+  const [showCustomInput, setShowCustomInput] = useState(false);
+  const [customLocale, setCustomLocale] = useState("");
+  const [customError, setCustomError] = useState<string | undefined>();
+
+  const applyCustomLocale = () => {
+    const canonical = canonicalizeLocale(customLocale);
+    if (!canonical) {
+      setCustomError(intl.formatMessage(messages.invalidCustomLocale));
+      return;
+    }
+
+    onValueChange(canonical);
+    setCustomLocale("");
+    setCustomError(undefined);
+    setShowCustomInput(false);
+  };
+
+  return (
+    <Field className="gap-1.5">
+      <FieldLabel>
+        {label}
+      </FieldLabel>
+      <IssueLocalePicker
+        value={value}
+        locales={locales}
+        onValueChange={(locale) => {
+          if (locale) {
+            onValueChange(locale);
+          }
+        }}
+        aria-label={label}
+      />
+      {showCustomInput ? (
+        <div className="grid gap-2">
+          <div className="flex gap-2">
+            <Input
+              id={customId}
+              value={customLocale}
+              onChange={(event) => {
+                setCustomLocale(event.target.value);
+                setCustomError(undefined);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  applyCustomLocale();
+                }
+                if (event.key === "Escape") {
+                  setShowCustomInput(false);
+                  setCustomLocale("");
+                  setCustomError(undefined);
+                }
+              }}
+              placeholder={intl.formatMessage(messages.customLocalePlaceholder)}
+              aria-label={intl.formatMessage(messages.customLocalePlaceholder)}
+            />
+            <Button type="button" variant="outline" size="sm" className="shrink-0" onClick={applyCustomLocale}>
+              <FormattedMessage {...messages.applyCustomLocale} />
+            </Button>
+          </div>
+          <FieldError errors={customError ? [{ message: customError }] : undefined} />
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 justify-start px-0 text-xs text-muted-foreground"
+          onClick={() => setShowCustomInput(true)}
+        >
+          <FormattedMessage {...messages.useCustomLocale} />
+        </Button>
+      )}
+    </Field>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-locale-field.tsx
@@ -55,9 +55,7 @@ export function TmEntryLocaleField({
 
   return (
     <Field className="gap-1.5">
-      <FieldLabel>
-        {label}
-      </FieldLabel>
+      <FieldLabel>{label}</FieldLabel>
       <IssueLocalePicker
         value={value}
         locales={locales}
@@ -92,7 +90,13 @@ export function TmEntryLocaleField({
               placeholder={intl.formatMessage(messages.customLocalePlaceholder)}
               aria-label={intl.formatMessage(messages.customLocalePlaceholder)}
             />
-            <Button type="button" variant="outline" size="sm" className="shrink-0" onClick={applyCustomLocale}>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              onClick={applyCustomLocale}
+            >
               <FormattedMessage {...messages.applyCustomLocale} />
             </Button>
           </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-search.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-search.test.ts
@@ -15,113 +15,113 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { ApiResponseError } from "@/lib/api-error";
 
 import {
-    fetchTmEntrySearchPage,
-    isAbortError,
-    isInvalidCursorError,
-    shouldApplyTmEntrySearchResult,
+  fetchTmEntrySearchPage,
+  isAbortError,
+  isInvalidCursorError,
+  shouldApplyTmEntrySearchResult,
 } from "./tm-entry-search";
 
 const { getEntriesMock } = vi.hoisted(() => ({
-    getEntriesMock: vi.fn(),
+  getEntriesMock: vi.fn(),
 }));
 
 vi.mock("@/lib/api-client-instance", () => ({
-    apiClient: {
-        api: {
-            orgs: {
-                ":organizationSlug": {
-                    "translation-memories": {
-                        ":memoryId": {
-                            entries: {
-                                $get: getEntriesMock,
-                            },
-                        },
-                    },
-                },
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          "translation-memories": {
+            ":memoryId": {
+              entries: {
+                $get: getEntriesMock,
+              },
             },
+          },
         },
+      },
     },
+  },
 }));
 
 describe("tm-entry-search", () => {
-    it("passes the abort signal and current query to the list API", async () => {
-        const signal = new AbortController().signal;
-        getEntriesMock.mockResolvedValue({
-            ok: true,
-            json: async () => ({
-                memoryEntries: [],
-                nextCursor: null,
-                total: 0,
-                pagination: { limit: 50, returned: 0, hasMore: false },
-            }),
-        });
-
-        await fetchTmEntrySearchPage({
-            organizationSlug: "acme",
-            memoryId: "mem_1",
-            state: {
-                search: "invoice",
-                sourceLocale: "en-US",
-                sort: "created_at",
-                sortDir: "desc",
-            },
-            signal,
-            fallbackMessage: "Unable to load entries",
-        });
-
-        expect(getEntriesMock).toHaveBeenCalledWith(
-            {
-                param: { organizationSlug: "acme", memoryId: "mem_1" },
-                query: {
-                    limit: "50",
-                    search: "invoice",
-                    sourceLocale: "en-US",
-                },
-            },
-            { init: { signal } },
-        );
+  it("passes the abort signal and current query to the list API", async () => {
+    const signal = new AbortController().signal;
+    getEntriesMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        memoryEntries: [],
+        nextCursor: null,
+        total: 0,
+        pagination: { limit: 50, returned: 0, hasMore: false },
+      }),
     });
 
-    it("does not apply an older response after a newer request starts", () => {
-        expect(
-            shouldApplyTmEntrySearchResult({
-                requestId: 1,
-                latestRequestId: 2,
-            }),
-        ).toBe(false);
-        expect(
-            shouldApplyTmEntrySearchResult({
-                requestId: 2,
-                latestRequestId: 2,
-            }),
-        ).toBe(true);
-        expect(
-            shouldApplyTmEntrySearchResult({
-                requestId: 2,
-                latestRequestId: 2,
-                aborted: true,
-            }),
-        ).toBe(false);
+    await fetchTmEntrySearchPage({
+      organizationSlug: "acme",
+      memoryId: "mem_1",
+      state: {
+        search: "invoice",
+        sourceLocale: "en-US",
+        sort: "created_at",
+        sortDir: "desc",
+      },
+      signal,
+      fallbackMessage: "Unable to load entries",
     });
 
-    it("treats abort and invalid-cursor failures as distinct cases", () => {
-        expect(isAbortError(new DOMException("Aborted", "AbortError"))).toBe(true);
-        expect(isAbortError(new Error("nope"))).toBe(false);
-        expect(
-            isInvalidCursorError(
-                new ApiResponseError("Cursor is invalid", {
-                    code: "invalid_cursor",
-                    status: 400,
-                }),
-            ),
-        ).toBe(true);
-        expect(
-            isInvalidCursorError(
-                new ApiResponseError("Unable to load entries", {
-                    code: "memory_not_found",
-                    status: 404,
-                }),
-            ),
-        ).toBe(false);
-    });
+    expect(getEntriesMock).toHaveBeenCalledWith(
+      {
+        param: { organizationSlug: "acme", memoryId: "mem_1" },
+        query: {
+          limit: "50",
+          search: "invoice",
+          sourceLocale: "en-US",
+        },
+      },
+      { init: { signal } },
+    );
+  });
+
+  it("does not apply an older response after a newer request starts", () => {
+    expect(
+      shouldApplyTmEntrySearchResult({
+        requestId: 1,
+        latestRequestId: 2,
+      }),
+    ).toBe(false);
+    expect(
+      shouldApplyTmEntrySearchResult({
+        requestId: 2,
+        latestRequestId: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldApplyTmEntrySearchResult({
+        requestId: 2,
+        latestRequestId: 2,
+        aborted: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats abort and invalid-cursor failures as distinct cases", () => {
+    expect(isAbortError(new DOMException("Aborted", "AbortError"))).toBe(true);
+    expect(isAbortError(new Error("nope"))).toBe(false);
+    expect(
+      isInvalidCursorError(
+        new ApiResponseError("Cursor is invalid", {
+          code: "invalid_cursor",
+          status: 400,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isInvalidCursorError(
+        new ApiResponseError("Unable to load entries", {
+          code: "memory_not_found",
+          status: 404,
+        }),
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-search.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-search.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { ApiResponseError } from "@/lib/api-error";
+
+import {
+    fetchTmEntrySearchPage,
+    isAbortError,
+    isInvalidCursorError,
+    shouldApplyTmEntrySearchResult,
+} from "./tm-entry-search";
+
+const { getEntriesMock } = vi.hoisted(() => ({
+    getEntriesMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client-instance", () => ({
+    apiClient: {
+        api: {
+            orgs: {
+                ":organizationSlug": {
+                    "translation-memories": {
+                        ":memoryId": {
+                            entries: {
+                                $get: getEntriesMock,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}));
+
+describe("tm-entry-search", () => {
+    it("passes the abort signal and current query to the list API", async () => {
+        const signal = new AbortController().signal;
+        getEntriesMock.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                memoryEntries: [],
+                nextCursor: null,
+                total: 0,
+                pagination: { limit: 50, returned: 0, hasMore: false },
+            }),
+        });
+
+        await fetchTmEntrySearchPage({
+            organizationSlug: "acme",
+            memoryId: "mem_1",
+            state: {
+                search: "invoice",
+                sourceLocale: "en-US",
+                sort: "created_at",
+                sortDir: "desc",
+            },
+            signal,
+            fallbackMessage: "Unable to load entries",
+        });
+
+        expect(getEntriesMock).toHaveBeenCalledWith(
+            {
+                param: { organizationSlug: "acme", memoryId: "mem_1" },
+                query: {
+                    limit: "50",
+                    search: "invoice",
+                    sourceLocale: "en-US",
+                },
+            },
+            { init: { signal } },
+        );
+    });
+
+    it("does not apply an older response after a newer request starts", () => {
+        expect(
+            shouldApplyTmEntrySearchResult({
+                requestId: 1,
+                latestRequestId: 2,
+            }),
+        ).toBe(false);
+        expect(
+            shouldApplyTmEntrySearchResult({
+                requestId: 2,
+                latestRequestId: 2,
+            }),
+        ).toBe(true);
+        expect(
+            shouldApplyTmEntrySearchResult({
+                requestId: 2,
+                latestRequestId: 2,
+                aborted: true,
+            }),
+        ).toBe(false);
+    });
+
+    it("treats abort and invalid-cursor failures as distinct cases", () => {
+        expect(isAbortError(new DOMException("Aborted", "AbortError"))).toBe(true);
+        expect(isAbortError(new Error("nope"))).toBe(false);
+        expect(
+            isInvalidCursorError(
+                new ApiResponseError("Cursor is invalid", {
+                    code: "invalid_cursor",
+                    status: 400,
+                }),
+            ),
+        ).toBe(true);
+        expect(
+            isInvalidCursorError(
+                new ApiResponseError("Unable to load entries", {
+                    code: "memory_not_found",
+                    status: 404,
+                }),
+            ),
+        ).toBe(false);
+    });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-search.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-search.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { MemoryEntriesResponse } from "@/api/routes/memory/memory.schema";
+import { ApiResponseError, readApiResponseError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+
+import {
+    tmEntryListStateToApiQuery,
+    type TmEntryListApiQuery,
+    type TmEntryListUrlState,
+} from "./tm-entry-list-state";
+
+export const TM_ENTRY_SEARCH_QUERY_KEY = "translation-memory-entries" as const;
+
+export function tmEntrySearchQueryKey(
+    organizationSlug: string,
+    memoryId: string,
+    query: TmEntryListApiQuery,
+) {
+    return [TM_ENTRY_SEARCH_QUERY_KEY, organizationSlug, memoryId, query] as const;
+}
+
+export function isInvalidCursorError(error: unknown): boolean {
+    return error instanceof ApiResponseError && error.code === "invalid_cursor";
+}
+
+export function isAbortError(error: unknown): boolean {
+    return (
+        (error instanceof DOMException && error.name === "AbortError") ||
+        (error instanceof Error && error.name === "AbortError")
+    );
+}
+
+export function shouldApplyTmEntrySearchResult(input: {
+    requestId: number;
+    latestRequestId: number;
+    aborted?: boolean;
+}): boolean {
+    return !input.aborted && input.requestId === input.latestRequestId;
+}
+
+export async function fetchTmEntrySearchPage(input: {
+    organizationSlug: string;
+    memoryId: string;
+    state: TmEntryListUrlState;
+    cursor?: string | null;
+    signal?: AbortSignal;
+    fallbackMessage: string;
+}): Promise<MemoryEntriesResponse> {
+    const query = tmEntryListStateToApiQuery(input.state, { cursor: input.cursor });
+    const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+    ].entries.$get(
+        {
+            param: {
+                organizationSlug: input.organizationSlug,
+                memoryId: input.memoryId,
+            },
+            query,
+        },
+        { init: { signal: input.signal } },
+    );
+
+    if (!response.ok) {
+        throw await readApiResponseError(response, input.fallbackMessage);
+    }
+
+    return (await response.json()) as MemoryEntriesResponse;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-search.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-search.ts
@@ -15,65 +15,65 @@ import { ApiResponseError, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import {
-    tmEntryListStateToApiQuery,
-    type TmEntryListApiQuery,
-    type TmEntryListUrlState,
+  tmEntryListStateToApiQuery,
+  type TmEntryListApiQuery,
+  type TmEntryListUrlState,
 } from "./tm-entry-list-state";
 
 export const TM_ENTRY_SEARCH_QUERY_KEY = "translation-memory-entries" as const;
 
 export function tmEntrySearchQueryKey(
-    organizationSlug: string,
-    memoryId: string,
-    query: TmEntryListApiQuery,
+  organizationSlug: string,
+  memoryId: string,
+  query: TmEntryListApiQuery,
 ) {
-    return [TM_ENTRY_SEARCH_QUERY_KEY, organizationSlug, memoryId, query] as const;
+  return [TM_ENTRY_SEARCH_QUERY_KEY, organizationSlug, memoryId, query] as const;
 }
 
 export function isInvalidCursorError(error: unknown): boolean {
-    return error instanceof ApiResponseError && error.code === "invalid_cursor";
+  return error instanceof ApiResponseError && error.code === "invalid_cursor";
 }
 
 export function isAbortError(error: unknown): boolean {
-    return (
-        (error instanceof DOMException && error.name === "AbortError") ||
-        (error instanceof Error && error.name === "AbortError")
-    );
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
 }
 
 export function shouldApplyTmEntrySearchResult(input: {
-    requestId: number;
-    latestRequestId: number;
-    aborted?: boolean;
+  requestId: number;
+  latestRequestId: number;
+  aborted?: boolean;
 }): boolean {
-    return !input.aborted && input.requestId === input.latestRequestId;
+  return !input.aborted && input.requestId === input.latestRequestId;
 }
 
 export async function fetchTmEntrySearchPage(input: {
-    organizationSlug: string;
-    memoryId: string;
-    state: TmEntryListUrlState;
-    cursor?: string | null;
-    signal?: AbortSignal;
-    fallbackMessage: string;
+  organizationSlug: string;
+  memoryId: string;
+  state: TmEntryListUrlState;
+  cursor?: string | null;
+  signal?: AbortSignal;
+  fallbackMessage: string;
 }): Promise<MemoryEntriesResponse> {
-    const query = tmEntryListStateToApiQuery(input.state, { cursor: input.cursor });
-    const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
-        ":memoryId"
-    ].entries.$get(
-        {
-            param: {
-                organizationSlug: input.organizationSlug,
-                memoryId: input.memoryId,
-            },
-            query,
-        },
-        { init: { signal: input.signal } },
-    );
+  const query = tmEntryListStateToApiQuery(input.state, { cursor: input.cursor });
+  const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+    ":memoryId"
+  ].entries.$get(
+    {
+      param: {
+        organizationSlug: input.organizationSlug,
+        memoryId: input.memoryId,
+      },
+      query,
+    },
+    { init: { signal: input.signal } },
+  );
 
-    if (!response.ok) {
-        throw await readApiResponseError(response, input.fallbackMessage);
-    }
+  if (!response.ok) {
+    throw await readApiResponseError(response, input.fallbackMessage);
+  }
 
-    return (await response.json()) as MemoryEntriesResponse;
+  return (await response.json()) as MemoryEntriesResponse;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -41,6 +41,10 @@ import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
+import { IssueLocalePicker } from "../../../_components/issue-detail/issue-locale-picker";
+import { TmEntryExplorer } from "./tm-entry-explorer";
+import { buildTmEntryLocaleOptions } from "./tm-entry-list-state";
+import { TM_ENTRY_SEARCH_QUERY_KEY } from "./tm-entry-search";
 import { translationMemoryDetailPageContentMessages as messages } from "./translation-memory-detail-page-content.messages";
 
 type EntryForm = {
@@ -87,24 +91,6 @@ export function TranslationMemoryDetailPageContent({
     },
   });
 
-  const entriesQuery = useQuery({
-    queryKey: ["translation-memory-entries", organizationSlug, memoryId],
-    queryFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
-        ":memoryId"
-      ].entries.$get({
-        param: { organizationSlug, memoryId },
-        query: { limit: "50" },
-      });
-      if (!response.ok)
-        throw new Error(
-          await readApiError(response, intl.formatMessage(messages.loadEntriesFailed)),
-        );
-      const body = (await response.json()) as { memoryEntries: MemoryEntryRecord[] };
-      return body.memoryEntries;
-    },
-  });
-
   const attachedProjectsQuery = useQuery({
     queryKey: ["translation-memory-projects", organizationSlug, memoryId],
     queryFn: async () => {
@@ -137,7 +123,7 @@ export function TranslationMemoryDetailPageContent({
 
   const invalidateEntries = () =>
     queryClient.invalidateQueries({
-      queryKey: ["translation-memory-entries", organizationSlug, memoryId],
+      queryKey: [TM_ENTRY_SEARCH_QUERY_KEY, organizationSlug, memoryId],
     });
   const invalidateProjects = () =>
     queryClient.invalidateQueries({
@@ -342,22 +328,38 @@ export function TranslationMemoryDetailPageContent({
               <FieldLabel>
                 <FormattedMessage {...messages.sourceLocaleLabel} />
               </FieldLabel>
-              <Input
+              <IssueLocalePicker
                 value={entryForm.sourceLocale}
-                onChange={(event) =>
-                  setEntryForm((current) => ({ ...current, sourceLocale: event.target.value }))
+                locales={buildTmEntryLocaleOptions({
+                  localeCoverage: memory.localeCoverage,
+                  selected: entryForm.sourceLocale,
+                })}
+                onValueChange={(locale) =>
+                  setEntryForm((current) => ({
+                    ...current,
+                    sourceLocale: locale ?? current.sourceLocale,
+                  }))
                 }
+                aria-label={intl.formatMessage(messages.sourceLocaleLabel)}
               />
             </Field>
             <Field className="gap-1.5">
               <FieldLabel>
                 <FormattedMessage {...messages.targetLocaleLabel} />
               </FieldLabel>
-              <Input
+              <IssueLocalePicker
                 value={entryForm.targetLocale}
-                onChange={(event) =>
-                  setEntryForm((current) => ({ ...current, targetLocale: event.target.value }))
+                locales={buildTmEntryLocaleOptions({
+                  localeCoverage: memory.localeCoverage,
+                  selected: entryForm.targetLocale,
+                })}
+                onValueChange={(locale) =>
+                  setEntryForm((current) => ({
+                    ...current,
+                    targetLocale: locale ?? current.targetLocale,
+                  }))
                 }
+                aria-label={intl.formatMessage(messages.targetLocaleLabel)}
               />
             </Field>
             <Field className="gap-1.5">
@@ -416,63 +418,23 @@ export function TranslationMemoryDetailPageContent({
           </div>
         ) : null}
 
-        <div className="overflow-hidden rounded-lg border border-border">
-          {(entriesQuery.data ?? []).map((entry) => (
-            <div
-              key={entry.id}
-              className="grid gap-2 border-b border-border px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto] md:items-center"
-            >
-              <div>
-                <TypographyP className="text-sm font-medium">{entry.sourceText}</TypographyP>
-                <TypographyP className="text-xs text-muted-foreground">
-                  <FormattedMessage
-                    {...messages.localePair}
-                    values={{
-                      sourceLocale: entry.sourceLocale,
-                      targetLocale: entry.targetLocale,
-                    }}
-                  />
-                </TypographyP>
-              </div>
-              <TypographyP className="text-sm text-subtle-foreground">
-                {entry.targetText}
-              </TypographyP>
-              {canEdit ? (
-                <div className="flex gap-2">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      setEditingEntryId(entry.id);
-                      setEntryForm({
-                        sourceLocale: entry.sourceLocale,
-                        targetLocale: entry.targetLocale,
-                        sourceText: entry.sourceText,
-                        targetText: entry.targetText,
-                      });
-                    }}
-                  >
-                    <FormattedMessage {...messages.editEntry} />
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => deleteEntry.mutate(entry.id)}
-                  >
-                    <FormattedMessage {...messages.deleteEntry} />
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-          ))}
-          {entriesQuery.isSuccess && (entriesQuery.data ?? []).length === 0 ? (
-            <TypographyP className="px-4 py-6 text-sm text-muted-foreground">
-              <FormattedMessage {...messages.noEntries} />
-            </TypographyP>
-          ) : null}
-        </div>
+        <TmEntryExplorer
+          organizationSlug={organizationSlug}
+          memoryId={memoryId}
+          localeCoverage={memory.localeCoverage}
+          canEdit={canEdit}
+          isDeleting={deleteEntry.isPending}
+          onEditEntry={(entry) => {
+            setEditingEntryId(entry.id);
+            setEntryForm({
+              sourceLocale: entry.sourceLocale,
+              targetLocale: entry.targetLocale,
+              sourceText: entry.sourceText,
+              targetText: entry.targetText,
+            });
+          }}
+          onDeleteEntry={(entryId) => deleteEntry.mutate(entryId)}
+        />
       </section>
 
       <section className="grid gap-4 rounded-lg border border-border p-4">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -20,11 +20,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
-import type {
-  MemoryEntryRecord,
-  MemoryProjectRecord,
-  MemoryRecord,
-} from "@/api/routes/memory/memory.schema";
+import type { MemoryProjectRecord, MemoryRecord } from "@/api/routes/memory/memory.schema";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -37,8 +37,8 @@ import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
-import { IssueLocalePicker } from "../../../_components/issue-detail/issue-locale-picker";
 import { TmEntryExplorer } from "./tm-entry-explorer";
+import { TmEntryLocaleField } from "./tm-entry-locale-field";
 import { buildTmEntryLocaleOptions } from "./tm-entry-list-state";
 import { TM_ENTRY_SEARCH_QUERY_KEY } from "./tm-entry-search";
 import { translationMemoryDetailPageContentMessages as messages } from "./translation-memory-detail-page-content.messages";
@@ -320,44 +320,34 @@ export function TranslationMemoryDetailPageContent({
 
         {canEdit ? (
           <div className="grid gap-3 md:grid-cols-2">
-            <Field className="gap-1.5">
-              <FieldLabel>
-                <FormattedMessage {...messages.sourceLocaleLabel} />
-              </FieldLabel>
-              <IssueLocalePicker
-                value={entryForm.sourceLocale}
-                locales={buildTmEntryLocaleOptions({
-                  localeCoverage: memory.localeCoverage,
-                  selected: entryForm.sourceLocale,
-                })}
-                onValueChange={(locale) =>
-                  setEntryForm((current) => ({
-                    ...current,
-                    sourceLocale: locale ?? current.sourceLocale,
-                  }))
-                }
-                aria-label={intl.formatMessage(messages.sourceLocaleLabel)}
-              />
-            </Field>
-            <Field className="gap-1.5">
-              <FieldLabel>
-                <FormattedMessage {...messages.targetLocaleLabel} />
-              </FieldLabel>
-              <IssueLocalePicker
-                value={entryForm.targetLocale}
-                locales={buildTmEntryLocaleOptions({
-                  localeCoverage: memory.localeCoverage,
-                  selected: entryForm.targetLocale,
-                })}
-                onValueChange={(locale) =>
-                  setEntryForm((current) => ({
-                    ...current,
-                    targetLocale: locale ?? current.targetLocale,
-                  }))
-                }
-                aria-label={intl.formatMessage(messages.targetLocaleLabel)}
-              />
-            </Field>
+            <TmEntryLocaleField
+              label={intl.formatMessage(messages.sourceLocaleLabel)}
+              value={entryForm.sourceLocale}
+              locales={buildTmEntryLocaleOptions({
+                localeCoverage: memory.localeCoverage,
+                selected: entryForm.sourceLocale,
+              })}
+              onValueChange={(locale) =>
+                setEntryForm((current) => ({
+                  ...current,
+                  sourceLocale: locale,
+                }))
+              }
+            />
+            <TmEntryLocaleField
+              label={intl.formatMessage(messages.targetLocaleLabel)}
+              value={entryForm.targetLocale}
+              locales={buildTmEntryLocaleOptions({
+                localeCoverage: memory.localeCoverage,
+                selected: entryForm.targetLocale,
+              })}
+              onValueChange={(locale) =>
+                setEntryForm((current) => ({
+                  ...current,
+                  targetLocale: locale,
+                }))
+              }
+            />
             <Field className="gap-1.5">
               <FieldLabel>
                 <FormattedMessage {...messages.sourceTextLabel} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/use-tm-entry-list-url-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/use-tm-entry-list-url-state.ts
@@ -1,0 +1,88 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import {
+    applyTmEntryListStatePatch,
+    buildTmEntryListHref,
+    clearTmEntryListFilters,
+    parseTmEntryListSearchParams,
+    TM_ENTRY_SEARCH_DEBOUNCE_MS,
+    type TmEntryListUrlState,
+} from "./tm-entry-list-state";
+
+export function useTmEntryListUrlState() {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const searchParamsKey = searchParams.toString();
+    const searchParamsKeyRef = useRef(searchParamsKey);
+
+    const [state, setState] = useState(() =>
+        parseTmEntryListSearchParams(new URLSearchParams(searchParamsKey)),
+    );
+    const [searchDraft, setSearchDraft] = useState(state.search);
+    const skipNextUrlSync = useRef(false);
+
+    useEffect(() => {
+        searchParamsKeyRef.current = searchParamsKey;
+        const next = parseTmEntryListSearchParams(new URLSearchParams(searchParamsKey));
+        skipNextUrlSync.current = true;
+        setState(next);
+        setSearchDraft(next.search);
+    }, [searchParamsKey]);
+
+    useEffect(() => {
+        if (skipNextUrlSync.current) {
+            skipNextUrlSync.current = false;
+            return;
+        }
+        const href = buildTmEntryListHref(pathname, state);
+        const currentKey = searchParamsKeyRef.current;
+        const current = currentKey ? `${pathname}?${currentKey}` : pathname;
+        if (href !== current) {
+            router.replace(href, { scroll: false });
+        }
+    }, [pathname, router, state]);
+
+    useEffect(() => {
+        const timeout = window.setTimeout(() => {
+            setState((current) =>
+                current.search === searchDraft
+                    ? current
+                    : applyTmEntryListStatePatch(current, { search: searchDraft }),
+            );
+        }, TM_ENTRY_SEARCH_DEBOUNCE_MS);
+        return () => window.clearTimeout(timeout);
+    }, [searchDraft]);
+
+    const updateState = useCallback((patch: Partial<TmEntryListUrlState>) => {
+        setState((current) => applyTmEntryListStatePatch(current, patch));
+    }, []);
+
+    const clearFilters = useCallback(() => {
+        setState((current) => clearTmEntryListFilters(current));
+        setSearchDraft("");
+    }, []);
+
+    return {
+        state,
+        searchDraft,
+        setSearchDraft,
+        updateState,
+        clearFilters,
+    };
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/use-tm-entry-list-url-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/use-tm-entry-list-url-state.ts
@@ -16,73 +16,73 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import {
-    applyTmEntryListStatePatch,
-    buildTmEntryListHref,
-    clearTmEntryListFilters,
-    parseTmEntryListSearchParams,
-    TM_ENTRY_SEARCH_DEBOUNCE_MS,
-    type TmEntryListUrlState,
+  applyTmEntryListStatePatch,
+  buildTmEntryListHref,
+  clearTmEntryListFilters,
+  parseTmEntryListSearchParams,
+  TM_ENTRY_SEARCH_DEBOUNCE_MS,
+  type TmEntryListUrlState,
 } from "./tm-entry-list-state";
 
 export function useTmEntryListUrlState() {
-    const router = useRouter();
-    const pathname = usePathname();
-    const searchParams = useSearchParams();
-    const searchParamsKey = searchParams.toString();
-    const searchParamsKeyRef = useRef(searchParamsKey);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsKey = searchParams.toString();
+  const searchParamsKeyRef = useRef(searchParamsKey);
 
-    const [state, setState] = useState(() =>
-        parseTmEntryListSearchParams(new URLSearchParams(searchParamsKey)),
-    );
-    const [searchDraft, setSearchDraft] = useState(state.search);
-    const skipNextUrlSync = useRef(false);
+  const [state, setState] = useState(() =>
+    parseTmEntryListSearchParams(new URLSearchParams(searchParamsKey)),
+  );
+  const [searchDraft, setSearchDraft] = useState(state.search);
+  const skipNextUrlSync = useRef(false);
 
-    useEffect(() => {
-        searchParamsKeyRef.current = searchParamsKey;
-        const next = parseTmEntryListSearchParams(new URLSearchParams(searchParamsKey));
-        skipNextUrlSync.current = true;
-        setState(next);
-        setSearchDraft(next.search);
-    }, [searchParamsKey]);
+  useEffect(() => {
+    searchParamsKeyRef.current = searchParamsKey;
+    const next = parseTmEntryListSearchParams(new URLSearchParams(searchParamsKey));
+    skipNextUrlSync.current = true;
+    setState(next);
+    setSearchDraft(next.search);
+  }, [searchParamsKey]);
 
-    useEffect(() => {
-        if (skipNextUrlSync.current) {
-            skipNextUrlSync.current = false;
-            return;
-        }
-        const href = buildTmEntryListHref(pathname, state);
-        const currentKey = searchParamsKeyRef.current;
-        const current = currentKey ? `${pathname}?${currentKey}` : pathname;
-        if (href !== current) {
-            router.replace(href, { scroll: false });
-        }
-    }, [pathname, router, state]);
+  useEffect(() => {
+    if (skipNextUrlSync.current) {
+      skipNextUrlSync.current = false;
+      return;
+    }
+    const href = buildTmEntryListHref(pathname, state);
+    const currentKey = searchParamsKeyRef.current;
+    const current = currentKey ? `${pathname}?${currentKey}` : pathname;
+    if (href !== current) {
+      router.replace(href, { scroll: false });
+    }
+  }, [pathname, router, state]);
 
-    useEffect(() => {
-        const timeout = window.setTimeout(() => {
-            setState((current) =>
-                current.search === searchDraft
-                    ? current
-                    : applyTmEntryListStatePatch(current, { search: searchDraft }),
-            );
-        }, TM_ENTRY_SEARCH_DEBOUNCE_MS);
-        return () => window.clearTimeout(timeout);
-    }, [searchDraft]);
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setState((current) =>
+        current.search === searchDraft
+          ? current
+          : applyTmEntryListStatePatch(current, { search: searchDraft }),
+      );
+    }, TM_ENTRY_SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [searchDraft]);
 
-    const updateState = useCallback((patch: Partial<TmEntryListUrlState>) => {
-        setState((current) => applyTmEntryListStatePatch(current, patch));
-    }, []);
+  const updateState = useCallback((patch: Partial<TmEntryListUrlState>) => {
+    setState((current) => applyTmEntryListStatePatch(current, patch));
+  }, []);
 
-    const clearFilters = useCallback(() => {
-        setState((current) => clearTmEntryListFilters(current));
-        setSearchDraft("");
-    }, []);
+  const clearFilters = useCallback(() => {
+    setState((current) => clearTmEntryListFilters(current));
+    setSearchDraft("");
+  }, []);
 
-    return {
-        state,
-        searchDraft,
-        setSearchDraft,
-        updateState,
-        clearFilters,
-    };
+  return {
+    state,
+    searchDraft,
+    setSearchDraft,
+    updateState,
+    clearFilters,
+  };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a server-backed, cursor-paginated translation-memory entry explorer on the TM detail page, replacing the hard-coded first-50 list.

- Search, filters, and sort live in the URL (`search`, locales, review status, origin, provider, creator, modified range, import batch).
- Forward-only paging uses the listing API cursor; previous cursors stay in `sessionStorage`.
- Invalid cursors reset to the first page with a notice.
- `?entry=` highlights a row and offers “Back to results” without a separate detail route.
- Entry form locale pickers keep a custom BCP-47 path so tags outside `COMMON_LOCALES` / coverage (for example `sw-KE`) still work.
- Previous is disabled on deep-linked pages when the cursor stack is missing, so it no longer jumps to page one.

Also aligns two glossary route tests left behind by #2069 so Web CI can pass.

## How to test

- `vp test` for TM explorer files, `tm-entry-locale-field.test.tsx`, and `src/api/routes/glossary/glossary.route.test.ts`
- `vp check --fix`
- Open a translation memory and confirm search, filters, sort, next/previous, custom locale entry, and `?entry=` highlight work
- Open a bookmarked `?cursor=` URL in a fresh session and confirm Previous stays disabled

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-643](https://linear.app/hyperlocalise/issue/HL-643/build-paginated-tm-entry-explorer-with-server-backed-search-and)

<div><a href="https://cursor.com/agents/bc-83382265-c707-4b8c-aab2-8feef88e7acd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83382265-c707-4b8c-aab2-8feef88e7acd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

