### PR TITLE
feat(mcp): Add list_issues tool to the hosted MCP server

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -56,9 +56,7 @@ function pkceChallenge(verifier: string) {
   return createHash("sha256").update(verifier).digest("base64url");
 }
 
-async function mcpAccessTokenForMember(
-  memberAuth: NonNullable<typeof globalThis.__testApiAuthContext>,
-) {
+async function mcpAccessTokenForAuth(auth: NonNullable<typeof globalThis.__testApiAuthContext>) {
   const verifier = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
   const code = createAuthorizationCode({
     clientId: "test-client",
@@ -66,8 +64,8 @@ async function mcpAccessTokenForMember(
     codeChallenge: pkceChallenge(verifier),
     codeChallengeMethod: "S256",
     scope: "mcp",
-    userId: memberAuth.user.localUserId,
-    organizationId: memberAuth.organization.localOrganizationId,
+    userId: auth.user.localUserId,
+    organizationId: auth.organization.localOrganizationId,
   });
 
   const response = await mcpApp.request("http://localhost/mcp/token", {
@@ -145,11 +143,17 @@ afterEach(async () => {
 });
 
 describe("MCP team-scoped access", () => {
-  it("scopes list_projects and get_project to the member's teams", async () => {
+  it("scopes projects and issues to the member's teams", async () => {
     const admin = projectFixture.createWorkosIdentityWithRole("admin");
     const member = projectFixture.createWorkosIdentityForOrganization(admin.organization, "member");
 
     await projectFixture.authHeadersFor(admin);
+
+    const adminAuth = globalThis.__testApiAuthContext;
+    if (!adminAuth) {
+      throw new Error("expected admin auth context");
+    }
+
     await projectFixture.authHeadersFor(member);
     const memberAuth = globalThis.__testApiAuthContext;
     if (!memberAuth) {
@@ -198,7 +202,82 @@ describe("MCP team-scoped access", () => {
     expect(betaProjectResponse.status).toBe(201);
     const betaProjectBody = (await betaProjectResponse.json()) as ProjectResponse;
 
-    const accessToken = await mcpAccessTokenForMember(memberAuth);
+    const [alphaIssue, betaIssue] = await db
+      .insert(schema.issueSheetIssues)
+      .values([
+        {
+          organizationId: memberAuth.organization.localOrganizationId,
+          projectId: alphaProjectBody.project.id,
+          number: 1,
+          identifier: "ALPHA-1",
+          title: "Accessible team issue",
+          issueType: "qa_failure",
+          status: "open",
+        },
+        {
+          organizationId: memberAuth.organization.localOrganizationId,
+          projectId: betaProjectBody.project.id,
+          number: 1,
+          identifier: "BETA-1",
+          title: "Inaccessible team issue",
+          issueType: "qa_failure",
+          status: "open",
+        },
+      ])
+      .returning({
+        id: schema.issueSheetIssues.id,
+      });
+
+    if (!alphaIssue || !betaIssue) {
+      throw new Error("expected issue fixtures");
+    }
+
+    const { organization: externalOrganization, project: externalProject } =
+      await projectFixture.createStoredProjectFixture();
+
+    const [externalIssue] = await db
+      .insert(schema.issueSheetIssues)
+      .values({
+        organizationId: externalOrganization.id,
+        projectId: externalProject.id,
+        number: 1,
+        identifier: "EXTERNAL-1",
+        title: "External organization issue",
+        issueType: "qa_failure",
+        status: "open",
+      })
+      .returning({
+        id: schema.issueSheetIssues.id,
+      });
+
+    if (!externalIssue) {
+      throw new Error("expected external issue fixture");
+    }
+
+    const accessToken = await mcpAccessTokenForAuth(memberAuth);
+
+    const adminAccessToken = await mcpAccessTokenForAuth(adminAuth);
+
+    const adminIssuesResponse = await callMcpTool(adminAccessToken, "list_issues", {
+      status: "open",
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(adminIssuesResponse.status).toBe(200);
+
+    const adminIssuesBody = parseToolResultText(await adminIssuesResponse.json()) as {
+      total: number;
+      issues: Array<{
+        id: string;
+      }>;
+    };
+
+    expect(adminIssuesBody.issues.map((issue) => issue.id)).not.toContain(externalIssue.id);
+    expect(adminIssuesBody.total).toBe(2);
+    expect(adminIssuesBody.issues.map((issue) => issue.id).sort()).toEqual(
+      [alphaIssue.id, betaIssue.id].sort(),
+    );
 
     const listResponse = await callMcpTool(accessToken, "list_projects", { limit: 50 });
     expect(listResponse.status).toBe(200);
@@ -210,6 +289,35 @@ describe("MCP team-scoped access", () => {
     const getDeniedResponse = await callMcpTool(accessToken, "get_project", {
       projectId: betaProjectBody.project.id,
     });
+
+    const issuesResponse = await callMcpTool(accessToken, "list_issues", {
+      status: "open",
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(issuesResponse.status).toBe(200);
+
+    const issuesBody = parseToolResultText(await issuesResponse.json()) as {
+      total: number;
+      issues: Array<{
+        id: string;
+        projectId: string;
+        title: string;
+      }>;
+    };
+
+    expect(issuesBody.issues.map((issue) => issue.id)).not.toContain(externalIssue.id);
+    expect(issuesBody.total).toBe(1);
+    expect(issuesBody.issues).toEqual([
+      expect.objectContaining({
+        id: alphaIssue.id,
+        projectId: alphaProjectBody.project.id,
+        title: "Accessible team issue",
+      }),
+    ]);
+    expect(issuesBody.issues.map((issue) => issue.id)).not.toContain(betaIssue.id);
+
     expect(getDeniedResponse.status).toBe(200);
     const getDeniedBody = parseToolResultText(await getDeniedResponse.json()) as {
       project: { id: string } | null;

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -1267,7 +1267,11 @@ describe("mcpRoutes", () => {
     }
   });
 
-  it("returns invalid_issue_query for invalid list_issues filters", async () => {
+  it.each([
+    ["out-of-range pagination", { limit: 101, offset: -1 }],
+    ["a type-invalid status", { status: 1 }],
+    ["a type-invalid search", { search: [] }],
+  ])("returns invalid_issue_query for %s", async (_label, args) => {
     const headers = await authenticatedMcpHeaders();
 
     const response = await app.request("http://localhost/mcp/sse", {
@@ -1283,10 +1287,7 @@ describe("mcpRoutes", () => {
         method: "tools/call",
         params: {
           name: "list_issues",
-          arguments: {
-            limit: 101,
-            offset: -1,
-          },
+          arguments: args,
         },
       }),
     });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -21,6 +21,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
 
 import {
   createAuthorizationCode,
@@ -962,8 +963,58 @@ describe("mcpRoutes", () => {
         },
       });
 
+      const issuesResult = await client.callTool({
+        name: "list_issues",
+        arguments: {
+          limit: 1,
+          offset: 0,
+        },
+      });
+
+      const issuesContent = (
+        issuesResult as {
+          content?: Array<{
+            type?: string;
+            text?: string;
+          }>;
+        }
+      ).content?.find((item) => item.type === "text");
+
+      if (!issuesContent?.text) {
+        throw new Error("expected list_issues text content");
+      }
+
+      const issuesOutput = JSON.parse(issuesContent.text) as {
+        total: number;
+        pagination: {
+          limit: number;
+          offset: number;
+          hasMore: boolean;
+          nextOffset: number | null;
+        };
+        issues: unknown[];
+      };
+
+      expect(issuesOutput).toEqual({
+        total: 0,
+        summary: {
+          total: 0,
+          open: 0,
+          inProgress: 0,
+          resolved: 0,
+          wontFix: 0,
+        },
+        pagination: {
+          limit: 1,
+          offset: 0,
+          hasMore: false,
+          nextOffset: null,
+        },
+        issues: [],
+      });
+
       expect(result.content).toEqual(expect.any(Array));
-      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(4);
+      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(5);
       expect(requestMethods.filter((method) => method === "GET")).toHaveLength(1);
       expect(requestMethods.every((method) => method === "POST" || method === "GET")).toBe(true);
       expect(transportErrors).toEqual([]);
@@ -992,5 +1043,270 @@ describe("mcpRoutes", () => {
     });
 
     expect(response.status).toBe(400);
+  });
+
+  it("advertises the list_issues tool with a bounded input schema", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "list_issues");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("organization");
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: expect.any(Object),
+      view: expect.any(Object),
+      status: expect.any(Object),
+      issueType: expect.any(Object),
+      priority: expect.any(Object),
+      locale: expect.any(Object),
+      assignee: expect.any(Object),
+      search: expect.any(Object),
+      sort: expect.any(Object),
+      sortDir: expect.any(Object),
+      limit: expect.any(Object),
+      offset: expect.any(Object),
+    });
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      locale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 32,
+      },
+      search: {
+        type: "string",
+        maxLength: 200,
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 100,
+        default: 50,
+      },
+      offset: {
+        type: "integer",
+        minimum: 0,
+        default: 0,
+      },
+    });
+  });
+
+  it("returns compact issues with pagination metadata", async () => {
+    const headers = await authenticatedMcpHeaders();
+    const description = "x".repeat(600);
+
+    const listSpy = vi.spyOn(organizationIssueService, "list").mockResolvedValueOnce({
+      total: 3,
+      summary: {
+        total: 3,
+        open: 2,
+        inProgress: 1,
+        resolved: 0,
+        wontFix: 0,
+      },
+      issues: [
+        {
+          id: "issue-id",
+          identifier: "HL-123",
+          number: 123,
+          projectId: "project-id",
+          projectName: "Example project",
+          title: "Example issue",
+          description,
+          issueType: "qa_failure",
+          status: "open",
+          targetLocale: "fr-FR",
+          sourcePath: "src/messages.json",
+          segmentId: "segment-id",
+          linkKind: null,
+          linkLabel: null,
+          linkUrl: null,
+          templateKey: null,
+          reporter: null,
+          assignee: "Thomas",
+          assigneeUserId: "user-id",
+          key: "homepage.title",
+          sourceText: "Welcome",
+          priority: "P0",
+          createdAt: "2026-08-28T00:00:00.000Z",
+          updatedAt: "2026-08-28T01:00:00.000Z",
+          resolvedAt: null,
+        },
+      ],
+    });
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "list_issues",
+            arguments: {
+              projectId: "project-id",
+              view: "qa_triage",
+              status: "open",
+              issueType: "qa_failure",
+              priority: "P0",
+              locale: "fr-FR",
+              assignee: "me",
+              search: "Example",
+              sort: "created_at",
+              sortDir: "asc",
+              limit: 1,
+              offset: 1,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          content?: Array<{
+            type: string;
+            text?: string;
+          }>;
+        };
+      };
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+
+      const output = JSON.parse(text!) as {
+        total: number;
+        pagination: {
+          limit: number;
+          offset: number;
+          hasMore: boolean;
+          nextOffset: number | null;
+        };
+        issues: Array<{
+          id: string;
+          description: string;
+        }>;
+      };
+
+      expect(output).toMatchObject({
+        total: 3,
+        pagination: {
+          limit: 1,
+          offset: 1,
+          hasMore: true,
+          nextOffset: 2,
+        },
+      });
+      expect(output.issues[0]).toMatchObject({
+        id: "issue-id",
+        description: "x".repeat(500),
+      });
+
+      expect(listSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: expect.any(Object),
+          user: expect.any(Object),
+        }),
+        {
+          projectId: "project-id",
+          view: "qa_triage",
+          status: "open",
+          issueType: "qa_failure",
+          priority: "P0",
+          locale: "fr-FR",
+          assignee: "me",
+          search: "Example",
+          sort: "created_at",
+          sortDir: "asc",
+          limit: 1,
+          offset: 1,
+        },
+      );
+    } finally {
+      listSpy.mockRestore();
+    }
+  });
+
+  it("returns invalid_issue_query for invalid list_issues filters", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "list_issues",
+          arguments: {
+            limit: 101,
+            offset: -1,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{
+          type: string;
+          text?: string;
+        }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    const text = body.result?.content?.[0]?.text;
+    expect(text).toBeDefined();
+    expect(text).toContain("invalid_issue_query");
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -328,16 +328,42 @@ const mcpAuthEnabledMiddleware = createMiddleware(async (c, next) => {
   await next();
 });
 
-const mcpListIssuesInputSchema = organizationIssuesQuerySchema.check((context) => {
-  if (context.issues.length > 0) {
-    context.issues.push({
-      code: "custom",
-      input: context.value,
-      message: "invalid_issue_query",
-      path: [],
-    });
-  }
-});
+const invalidIssueQuery = Symbol("invalid_issue_query");
+const issueQueryShape = organizationIssuesQuerySchema.shape;
+
+const mcpListIssuesInputSchema = z
+  .object({
+    view: issueQueryShape.view.catch(invalidIssueQuery as never).meta({ default: undefined }),
+    status: issueQueryShape.status.catch(invalidIssueQuery as never).meta({ default: undefined }),
+    issueType: issueQueryShape.issueType
+      .catch(invalidIssueQuery as never)
+      .meta({ default: undefined }),
+    priority: issueQueryShape.priority
+      .catch(invalidIssueQuery as never)
+      .meta({ default: undefined }),
+    locale: issueQueryShape.locale.catch(invalidIssueQuery as never).meta({ default: undefined }),
+    assignee: issueQueryShape.assignee
+      .catch(invalidIssueQuery as never)
+      .meta({ default: undefined }),
+    projectId: issueQueryShape.projectId
+      .catch(invalidIssueQuery as never)
+      .meta({ default: undefined }),
+    search: issueQueryShape.search.catch(invalidIssueQuery as never).meta({ default: undefined }),
+    sort: issueQueryShape.sort.catch(invalidIssueQuery as never).meta({ default: "status" }),
+    sortDir: issueQueryShape.sortDir.catch(invalidIssueQuery as never).meta({ default: undefined }),
+    limit: issueQueryShape.limit.catch(invalidIssueQuery as never).meta({ default: 50 }),
+    offset: issueQueryShape.offset.catch(invalidIssueQuery as never).meta({ default: 0 }),
+  })
+  .check((context) => {
+    if (Object.values(context.value).some((value) => (value as unknown) === invalidIssueQuery)) {
+      context.issues.push({
+        code: "custom",
+        input: context.value,
+        message: "invalid_issue_query",
+        path: [],
+      });
+    }
+  });
 
 function compactMcpIssue(issue: OrganizationIssueListItem) {
   return {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -19,6 +19,14 @@ import { createMiddleware } from "hono/factory";
 import { validator } from "hono/validator";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import {
+  organizationIssuesQuerySchema,
+  type OrganizationIssuesQuery,
+} from "@/api/routes/issues/issues.schema";
+import {
+  organizationIssueService,
+  type OrganizationIssueListItem,
+} from "@/lib/projects/issue-sheet/organization-issue-service";
 import { z } from "zod";
 
 import { apiAuthContextFromMcpAuth } from "@/api/auth/mcp-access";
@@ -320,6 +328,45 @@ const mcpAuthEnabledMiddleware = createMiddleware(async (c, next) => {
   await next();
 });
 
+const mcpListIssuesInputSchema = organizationIssuesQuerySchema.check((context) => {
+  if (context.issues.length > 0) {
+    context.issues.push({
+      code: "custom",
+      input: context.value,
+      message: "invalid_issue_query",
+      path: [],
+    });
+  }
+});
+
+function compactMcpIssue(issue: OrganizationIssueListItem) {
+  return {
+    id: issue.id,
+    identifier: issue.identifier,
+    projectId: issue.projectId,
+    projectName: issue.projectName,
+    title: issue.title,
+    description: issue.description.slice(0, 500),
+    issueType: issue.issueType,
+    status: issue.status,
+    priority: issue.priority,
+    targetLocale: issue.targetLocale,
+    assignee: issue.assignee,
+    assigneeUserId: issue.assigneeUserId,
+    sourcePath: issue.sourcePath,
+    segmentId: issue.segmentId,
+    linkKind: issue.linkKind,
+    linkLabel: issue.linkLabel,
+    linkUrl: issue.linkUrl,
+    templateKey: issue.templateKey,
+    key: issue.key,
+    sourceText: issue.sourceText,
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    resolvedAt: issue.resolvedAt,
+  };
+}
+
 async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
   const apiAuth = apiAuthContextFromMcpAuth(auth);
   const server = new McpServer({
@@ -380,6 +427,41 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
 
       return {
         content: [{ type: "text", text: JSON.stringify({ project: project ?? null }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "list_issues",
+    {
+      description:
+        "List issues visible to the authenticated organization with filtering, sorting, and pagination.",
+      inputSchema: mcpListIssuesInputSchema,
+    },
+    async (query: OrganizationIssuesQuery) => {
+      const result = await organizationIssueService.list(apiAuth, query);
+      const nextOffset = query.offset + result.issues.length;
+      const hasMore = nextOffset < result.total;
+
+      const output = {
+        total: result.total,
+        summary: result.summary,
+        pagination: {
+          limit: query.limit,
+          offset: query.offset,
+          hasMore,
+          nextOffset: hasMore ? nextOffset : null,
+        },
+        issues: result.issues.map(compactMcpIssue),
+      };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(output),
+          },
+        ],
       };
     },
   );


### PR DESCRIPTION
## What changed

- Added an organization-scoped `list_issues` tool to the hosted MCP server.
- Reused `organizationIssuesQuerySchema` for the existing issue filter vocabulary and bounds.
- Reused `organizationIssueService.list` for filtering, sorting, pagination, organization isolation, and team-based project access.
- Added compact issue output with truncated descriptions, summary counts, and pagination metadata.
- Added stable `invalid_issue_query` MCP errors for invalid filters without changing the shared HTTP schema.
- Added real MCP SDK coverage through the canonical `/mcp/sse` endpoint.
- Added access-control coverage for organization admins, team-restricted members, and cross-organization isolation.

## How to test

```bash
vp check
vp exec tsc --noEmit --pretty false

vp test \
  src/api/routes/mcp/mcp.route.test.ts \
  src/api/routes/mcp/mcp-team-access.test.ts \
  src/api/routes/issues/issues.route.test.ts

vp exec next build
```

Results:
- 44/44 scoped integration tests passed.
- Production build passed.
- Full vp test: 5,235 passed. Three unrelated macOS-only sandbox tests fail because they invoke GNU realpath -m, that unsupported by my laptop system which is macOS.

## Checklist
- I ran relevant checks locally (vp check, scoped tests, TypeScript, and production build)
- I updated docs, comments, or examples when needed
- This PR is scoped and ready for review