### PR TITLE
feat(memory): standards-compliant TMX import/export with validation reports

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/memory/memory-tmx.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory-tmx.route.test.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+import { createApp } from "@/api/app";
+import { db, schema } from "@/lib/database";
+
+import { createMemoryTestFixture } from "./memory.fixture";
+
+const client = testClient(createApp());
+const fixture = createMemoryTestFixture(client);
+const fixtureDir = dirname(fileURLToPath(import.meta.url));
+
+function readTmxFixture(name: string) {
+  return readFileSync(
+    join(fixtureDir, "../../../lib/memory/tmx/fixtures", name),
+    "utf8",
+  );
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await fixture.cleanup();
+});
+
+describe("memory TMX import and export", () => {
+  it("previews a TMX dry run without writing entries", async () => {
+    const { identity, memory } = await fixture.createStoredMemoryFixture();
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: memory.id,
+        },
+        json: {
+          format: "tmx",
+          dryRun: true,
+          content: readTmxFixture("tmx-1.4-inline-codes.tmx"),
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      imported: number;
+      dryRun: boolean;
+      importBatchId: string | null;
+      report: { totalRead: number; created: number; failed: number };
+      preview: Array<{ sourceText: string; action: string }>;
+    };
+    expect(body).toMatchObject({
+      imported: 1,
+      dryRun: true,
+      importBatchId: null,
+      report: { totalRead: 1, created: 1, failed: 0 },
+    });
+    expect(body.preview[0]?.sourceText).toContain('<ph x="1"/>');
+
+    const listed = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: memory.id,
+        },
+      },
+      { headers },
+    );
+    expect(((await listed.json()) as { total: number }).total).toBe(0);
+  });
+
+  it("imports multilingual TMX, then re-imports the same tuids without duplicates", async () => {
+    const { identity, memory } = await fixture.createStoredMemoryFixture();
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const first = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: { organizationSlug, memoryId: memory.id },
+        json: { format: "tmx", content: readTmxFixture("tmx-phrase-like.tmx") },
+      },
+      { headers },
+    );
+    expect(first.status).toBe(201);
+    const firstBody = (await first.json()) as {
+      imported: number;
+      report: { created: number; variantCreated: number; updated: number };
+    };
+    expect(firstBody.report).toMatchObject({
+      created: 2,
+      variantCreated: 1,
+      updated: 0,
+    });
+    expect(firstBody.imported).toBe(3);
+
+    const second = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: { organizationSlug, memoryId: memory.id },
+        json: { format: "tmx", content: readTmxFixture("tmx-phrase-like.tmx") },
+      },
+      { headers },
+    );
+    expect(second.status).toBe(201);
+    const secondBody = (await second.json()) as {
+      imported: number;
+      report: { created: number; variantCreated: number; updated: number; skipped: number };
+    };
+    expect(secondBody.report.created).toBe(0);
+    expect(secondBody.report.variantCreated).toBe(0);
+    expect(secondBody.report.updated).toBe(3);
+    expect(secondBody.imported).toBe(0);
+
+    const listed = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.$get({ param: { organizationSlug, memoryId: memory.id } }, { headers });
+    expect(((await listed.json()) as { total: number }).total).toBe(3);
+  });
+
+  it("exports TMX that re-imports with the same segment text", async () => {
+    const { identity, organization, user, memory } = await fixture.createStoredMemoryFixture();
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    await fixture.insertMemoryEntry(memory.id, {
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: 'Hello <ph x="1"/> & friends',
+      targetText: 'Bonjour <ph x="1"/> & amis',
+      externalKey: "tmx:inline-1:en:fr",
+      metadata: { tuid: "inline-1", context: "hero", notes: ["Keep the placeholder."] },
+    });
+
+    const exported = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.export.$get(
+      { param: { organizationSlug, memoryId: memory.id }, query: { format: "tmx" } },
+      { headers },
+    );
+    expect(exported.status).toBe(200);
+    expect(exported.headers.get("content-type")).toContain("tmx");
+    const tmx = await exported.text();
+    expect(tmx).toContain('<ph x="1"/>');
+    expect(tmx).toContain("&amp;");
+
+    const [secondMemory] = await db
+      .insert(schema.memories)
+      .values({
+        organizationId: organization.id,
+        createdByUserId: user.id,
+        name: "Import target TM",
+      })
+      .returning();
+    const imported = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: {
+          organizationSlug,
+          memoryId: secondMemory.id,
+        },
+        json: { format: "tmx", content: tmx },
+      },
+      { headers },
+    );
+    expect(imported.status).toBe(201);
+    const body = (await imported.json()) as {
+      memoryEntries: Array<{ sourceText: string; targetText: string }>;
+      report: { created: number };
+    };
+    expect(body.report.created).toBe(1);
+    expect(body.memoryEntries[0]).toMatchObject({
+      sourceText: 'Hello <ph x="1"/> & friends',
+      targetText: 'Bonjour <ph x="1"/> & amis',
+    });
+  });
+
+  it("fails safely on malformed TMX and never silently truncates oversized files", async () => {
+    const { identity, memory } = await fixture.createStoredMemoryFixture();
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const malformed = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: { organizationSlug, memoryId: memory.id },
+        json: { format: "tmx", content: "<tmx><body><tu>" },
+      },
+      { headers },
+    );
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toMatchObject({ error: "malformed_xml" });
+
+    const units = Array.from({ length: 4 }, (_, index) => {
+      return `<tu tuid="u${index}"><tuv xml:lang="en"><seg>S${index}</seg></tuv><tuv xml:lang="fr"><seg>T${index}</seg></tuv></tu>`;
+    }).join("");
+    const oversized = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: { organizationSlug, memoryId: memory.id },
+        json: {
+          format: "tmx",
+          maxUnits: 3,
+          content: `<?xml version="1.0" encoding="UTF-8"?><tmx version="1.4"><header srclang="en" creationtool="t" creationtoolversion="1" segtype="sentence" o-tmf="t" adminlang="en" datatype="plaintext"/><body>${units}</body></tmx>`,
+        },
+      },
+      { headers },
+    );
+    expect(oversized.status).toBe(400);
+    await expect(oversized.json()).resolves.toMatchObject({
+      error: "unit_limit_exceeded",
+      details: { maxUnits: 3, unitCount: 4 },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory-tmx.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory-tmx.route.test.ts
@@ -223,6 +223,61 @@ describe("memory TMX import and export", () => {
     });
   });
 
+  it("applies review status from TMX on create and tuid upsert", async () => {
+    const { identity, memory } = await fixture.createStoredMemoryFixture();
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const tmx = (status: string) =>
+      `<?xml version="1.0" encoding="UTF-8"?><tmx version="1.4"><header srclang="en" creationtool="t" creationtoolversion="1" segtype="sentence" o-tmf="t" adminlang="en" datatype="plaintext"/><body><tu tuid="review-1"><prop type="x-review-status">${status}</prop><tuv xml:lang="en"><seg>Hello</seg></tuv><tuv xml:lang="fr"><seg>Bonjour</seg></tuv></tu></body></tmx>`;
+
+    const created = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: { organizationSlug, memoryId: memory.id },
+        json: { format: "tmx", content: tmx("rejected") },
+      },
+      { headers },
+    );
+    expect(created.status).toBe(201);
+
+    const listedAfterCreate = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.$get(
+      { param: { organizationSlug, memoryId: memory.id }, query: { limit: "50" } },
+      { headers },
+    );
+    const createdEntries = (await listedAfterCreate.json()) as {
+      memoryEntries: Array<{ reviewStatus: string }>;
+    };
+    expect(createdEntries.memoryEntries[0]?.reviewStatus).toBe("rejected");
+
+    const updated = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: { organizationSlug, memoryId: memory.id },
+        json: { format: "tmx", content: tmx("pending") },
+      },
+      { headers },
+    );
+    expect(updated.status).toBe(201);
+    expect(((await updated.json()) as { report: { updated: number } }).report.updated).toBe(1);
+
+    const listedAfterUpdate = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.$get(
+      { param: { organizationSlug, memoryId: memory.id }, query: { limit: "50" } },
+      { headers },
+    );
+    const updatedEntries = (await listedAfterUpdate.json()) as {
+      memoryEntries: Array<{ reviewStatus: string }>;
+      total: number;
+    };
+    expect(updatedEntries.total).toBe(1);
+    expect(updatedEntries.memoryEntries[0]?.reviewStatus).toBe("pending");
+  });
+
   it("fails safely on malformed TMX and never silently truncates oversized files", async () => {
     const { identity, memory } = await fixture.createStoredMemoryFixture();
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory-tmx.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory-tmx.route.test.ts
@@ -46,10 +46,7 @@ const fixture = createMemoryTestFixture(client);
 const fixtureDir = dirname(fileURLToPath(import.meta.url));
 
 function readTmxFixture(name: string) {
-  return readFileSync(
-    join(fixtureDir, "../../../lib/memory/tmx/fixtures", name),
-    "utf8",
-  );
+  return readFileSync(join(fixtureDir, "../../../lib/memory/tmx/fixtures", name), "utf8");
 }
 
 beforeAll(async () => {
@@ -107,6 +104,7 @@ describe("memory TMX import and export", () => {
           organizationSlug: identity.organization.slug ?? "missing-slug",
           memoryId: memory.id,
         },
+        query: { limit: "50" },
       },
       { headers },
     );
@@ -160,7 +158,10 @@ describe("memory TMX import and export", () => {
 
     const listed = await client.api.orgs[":organizationSlug"]["translation-memories"][
       ":memoryId"
-    ].entries.$get({ param: { organizationSlug, memoryId: memory.id } }, { headers });
+    ].entries.$get(
+      { param: { organizationSlug, memoryId: memory.id }, query: { limit: "50" } },
+      { headers },
+    );
     expect(((await listed.json()) as { total: number }).total).toBe(3);
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -26,9 +26,10 @@ import { conflictResponse, badRequestResponse, validationErrorResponse } from "@
 import { isErr } from "@/lib/primitives/result/results";
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
-import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 import { db, schema } from "@/lib/database";
 import type { Memory } from "@/lib/database/types";
+import { applyMemoryImport, parseMemoryImportContent } from "@/lib/memory/import-memory-entries";
+import { exportMemoryEntriesTmx } from "@/lib/memory/export-memory-entries";
 import { toMemoryRecord } from "@/lib/memory/memory-records";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 import { promoteApprovedProjectTranslationsToMemory } from "@/lib/projects/translations/project-translation-service";
@@ -38,6 +39,7 @@ import {
   attachMemoryProjectBodySchema,
   createMemoryEntryBodySchema,
   createMemoryBodySchema,
+  exportMemoryEntriesQuerySchema,
   importMemoryEntriesBodySchema,
   promoteMemoryFromProjectBodySchema,
   listMemoryEntriesQuerySchema,
@@ -50,7 +52,7 @@ import {
   type AttachMemoryProjectBody,
   type CreateMemoryEntryBody,
   type CreateMemoryBody,
-  type ImportMemoryEntriesBody,
+  type ExportMemoryEntriesQuery,
   type PromoteMemoryFromProjectBody,
   type ListMemoryQuery,
   type UpdateMemoryEntryBody,
@@ -184,61 +186,13 @@ function toMemoryEntryRecord(entry: MemoryEntry): MemoryEntryRecord {
   };
 }
 
-function parseMemoryImport(payload: ImportMemoryEntriesBody): CreateMemoryEntryBody[] {
-  if (payload.format === "csv") {
-    const rows = parseCsvRows(payload.content);
-    const [first, ...rest] = rows;
-    const hasHeader = first?.some((cell) => /source|target|locale|text/i.test(cell)) ?? false;
-    const dataRows = hasHeader ? rest : rows;
-
-    return dataRows.flatMap((row) => {
-      const [sourceLocale, targetLocale, sourceText, targetText, score] = row;
-      const rawScore = score ? Number.parseInt(score, 10) : 100;
-      const matchScore = Number.isFinite(rawScore) ? Math.min(100, Math.max(0, rawScore)) : 100;
-      return sourceLocale && targetLocale && sourceText && targetText
-        ? [
-            {
-              sourceLocale,
-              targetLocale,
-              sourceText,
-              targetText,
-              matchScore,
-            },
-          ]
-        : [];
-    });
-  }
-
-  const units = [...payload.content.matchAll(/<tu\b[\s\S]*?<\/tu>/gi)];
-  return units.flatMap((unit) => {
-    const variants = [
-      ...unit[0].matchAll(/<tuv\b[^>]*?xml:lang=["']([^"']+)["'][^>]*>([\s\S]*?)<\/tuv>/gi),
-    ];
-    if (variants.length < 2) {
-      return [];
-    }
-
-    const [source, target] = variants;
-    const sourceText = source[2]
-      ?.match(/<seg\b[^>]*>([\s\S]*?)<\/seg>/i)?.[1]
-      ?.replace(/[<>]/g, "")
-      .trim();
-    const targetText = target[2]
-      ?.match(/<seg\b[^>]*>([\s\S]*?)<\/seg>/i)?.[1]
-      ?.replace(/[<>]/g, "")
-      .trim();
-
-    return source[1] && target[1] && sourceText && targetText
-      ? [
-          {
-            sourceLocale: source[1],
-            targetLocale: target[1],
-            sourceText,
-            targetText,
-            matchScore: 100,
-          },
-        ]
-      : [];
+function tmxFatalResponse(
+  c: Parameters<typeof badRequestResponse>[0],
+  error: { code: string; message: string; unitCount?: number; maxUnits?: number },
+) {
+  return badRequestResponse(c, error.code, error.message, {
+    ...(error.unitCount !== undefined ? { unitCount: error.unitCount } : {}),
+    ...(error.maxUnits !== undefined ? { maxUnits: error.maxUnits } : {}),
   });
 }
 
@@ -284,34 +238,6 @@ async function createMemoryEntry(
   return entry ?? null;
 }
 
-async function createMemoryEntries(
-  memory: Memory,
-  payloads: CreateMemoryEntryBody[],
-  options?: { createdByUserId?: string; importBatchId?: string },
-): Promise<MemoryEntry[]> {
-  if (payloads.length === 0) {
-    return [];
-  }
-
-  return db
-    .insert(schema.memoryEntries)
-    .values(
-      payloads.map((payload) => ({
-        memoryId: memory.id,
-        sourceLocale: payload.sourceLocale,
-        targetLocale: payload.targetLocale,
-        sourceText: payload.sourceText,
-        normalizedSourceText: normalizeTranslationMemorySourceText(payload.sourceText),
-        targetText: payload.targetText,
-        matchScore: payload.matchScore,
-        provenance: "import",
-        createdByUserId: options?.createdByUserId,
-        importBatchId: options?.importBatchId,
-      })),
-    )
-    .onConflictDoNothing()
-    .returning();
-}
 
 async function listMemoryProjects(
   auth: ApiAuthContext,
@@ -429,6 +355,16 @@ const validateImportMemoryEntriesBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
+const validateExportMemoryEntriesQuery = validator("query", (value, c) => {
+  const parsed = exportMemoryEntriesQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidMemoryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
 const validatePromoteMemoryFromProjectBody = validator("json", (value, c) => {
   const parsed = promoteMemoryFromProjectBodySchema.safeParse(value);
 
@@ -510,6 +446,29 @@ export function createMemoryRoutes() {
         200,
       );
     })
+    .get("/:memoryId/entries/export", validateMemoryParams, validateExportMemoryEntriesQuery, async (c) => {
+      const params = c.req.valid("param");
+      const query: ExportMemoryEntriesQuery = c.req.valid("query");
+      const memory = await memoryStore.getById(c.var.auth, params.memoryId);
+
+      if (!memory) {
+        return memoryNotFoundResponse(c);
+      }
+
+      const exported = await exportMemoryEntriesTmx({
+        memoryId: memory.id,
+        memoryName: memory.name,
+        filters: {
+          sourceLocale: query.sourceLocale,
+          targetLocale: query.targetLocale,
+        },
+      });
+
+      return c.body(exported.body, 200, {
+        "Content-Type": "application/x-tmx+xml; charset=utf-8",
+        "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(exported.filename)}`,
+      });
+    })
     .post("/:memoryId/entries", validateMemoryParams, validateCreateMemoryEntryBody, async (c) => {
       if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
@@ -557,23 +516,35 @@ export function createMemoryRoutes() {
           return externalTmsMemoryImmutableResponse(c);
         }
 
-        const entries = parseMemoryImport(payload);
-        const limitedEntries = entries.slice(0, 5_000);
-        const importBatchId = randomUUID();
-        const created = await createMemoryEntries(memory, limitedEntries, {
+        const parsed = parseMemoryImportContent({
+          format: payload.format,
+          content: payload.content,
+          maxUnits: payload.maxUnits,
+        });
+        if (isErr(parsed)) {
+          return tmxFatalResponse(c, parsed.error);
+        }
+
+        const importBatchId = payload.dryRun ? undefined : randomUUID();
+        const applied = await applyMemoryImport({
+          memory,
+          parsed: parsed.value,
+          dryRun: payload.dryRun,
           createdByUserId: c.var.auth.user.localUserId,
           importBatchId,
         });
-        const skipped = limitedEntries.length - created.length;
 
         return c.json(
           {
-            memoryEntries: created.map(toMemoryEntryRecord),
-            imported: created.length,
-            skipped,
-            importBatchId,
+            memoryEntries: applied.createdEntries.map(toMemoryEntryRecord),
+            imported: applied.report.created + applied.report.variantCreated,
+            skipped: applied.report.skipped,
+            importBatchId: applied.importBatchId,
+            dryRun: Boolean(payload.dryRun),
+            preview: applied.preview,
+            report: applied.report,
           },
-          201,
+          payload.dryRun ? 200 : 201,
         );
       },
     )

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -238,7 +238,6 @@ async function createMemoryEntry(
   return entry ?? null;
 }
 
-
 async function listMemoryProjects(
   auth: ApiAuthContext,
   memoryId: string,
@@ -446,29 +445,34 @@ export function createMemoryRoutes() {
         200,
       );
     })
-    .get("/:memoryId/entries/export", validateMemoryParams, validateExportMemoryEntriesQuery, async (c) => {
-      const params = c.req.valid("param");
-      const query: ExportMemoryEntriesQuery = c.req.valid("query");
-      const memory = await memoryStore.getById(c.var.auth, params.memoryId);
+    .get(
+      "/:memoryId/entries/export",
+      validateMemoryParams,
+      validateExportMemoryEntriesQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query: ExportMemoryEntriesQuery = c.req.valid("query");
+        const memory = await memoryStore.getById(c.var.auth, params.memoryId);
 
-      if (!memory) {
-        return memoryNotFoundResponse(c);
-      }
+        if (!memory) {
+          return memoryNotFoundResponse(c);
+        }
 
-      const exported = await exportMemoryEntriesTmx({
-        memoryId: memory.id,
-        memoryName: memory.name,
-        filters: {
-          sourceLocale: query.sourceLocale,
-          targetLocale: query.targetLocale,
-        },
-      });
+        const exported = await exportMemoryEntriesTmx({
+          memoryId: memory.id,
+          memoryName: memory.name,
+          filters: {
+            sourceLocale: query.sourceLocale,
+            targetLocale: query.targetLocale,
+          },
+        });
 
-      return c.body(exported.body, 200, {
-        "Content-Type": "application/x-tmx+xml; charset=utf-8",
-        "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(exported.filename)}`,
-      });
-    })
+        return c.body(exported.body, 200, {
+          "Content-Type": "application/x-tmx+xml; charset=utf-8",
+          "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(exported.filename)}`,
+        });
+      },
+    )
     .post("/:memoryId/entries", validateMemoryParams, validateCreateMemoryEntryBody, async (c) => {
       if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
@@ -525,11 +529,12 @@ export function createMemoryRoutes() {
           return tmxFatalResponse(c, parsed.error);
         }
 
-        const importBatchId = payload.dryRun ? undefined : randomUUID();
+        const dryRun = payload.dryRun === true;
+        const importBatchId = dryRun ? undefined : randomUUID();
         const applied = await applyMemoryImport({
           memory,
           parsed: parsed.value,
-          dryRun: payload.dryRun,
+          dryRun,
           createdByUserId: c.var.auth.user.localUserId,
           importBatchId,
         });
@@ -540,11 +545,11 @@ export function createMemoryRoutes() {
             imported: applied.report.created + applied.report.variantCreated,
             skipped: applied.report.skipped,
             importBatchId: applied.importBatchId,
-            dryRun: Boolean(payload.dryRun),
+            dryRun,
             preview: applied.preview,
             report: applied.report,
           },
-          payload.dryRun ? 200 : 201,
+          dryRun ? 200 : 201,
         );
       },
     )

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { listMemoryEntriesQuerySchema } from "./memory.schema";
+import { importMemoryEntriesBodySchema, listMemoryEntriesQuerySchema } from "./memory.schema";
 
 describe("listMemoryEntriesQuerySchema", () => {
   it("defaults to a bounded created_at desc page", () => {
@@ -31,5 +31,25 @@ describe("listMemoryEntriesQuerySchema", () => {
 
   it("rejects an oversized page", () => {
     expect(listMemoryEntriesQuerySchema.safeParse({ limit: "101" }).success).toBe(false);
+  });
+});
+
+describe("importMemoryEntriesBodySchema", () => {
+  it("defaults dryRun to false and caps maxUnits at the documented limit", () => {
+    expect(
+      importMemoryEntriesBodySchema.parse({
+        format: "tmx",
+        content: "<tmx />",
+      }),
+    ).toMatchObject({
+      dryRun: false,
+    });
+    expect(
+      importMemoryEntriesBodySchema.safeParse({
+        format: "tmx",
+        content: "<tmx />",
+        maxUnits: 50_001,
+      }).success,
+    ).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.test.ts
@@ -12,6 +12,8 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
+import { TMX_DEFAULT_MAX_UNITS } from "@/lib/memory/tmx/tmx-constants";
+
 import { importMemoryEntriesBodySchema, listMemoryEntriesQuerySchema } from "./memory.schema";
 
 describe("listMemoryEntriesQuerySchema", () => {
@@ -46,8 +48,15 @@ describe("importMemoryEntriesBodySchema", () => {
       importMemoryEntriesBodySchema.safeParse({
         format: "tmx",
         content: "<tmx />",
-        maxUnits: 50_001,
+        maxUnits: TMX_DEFAULT_MAX_UNITS + 1,
       }).success,
     ).toBe(false);
+    expect(
+      importMemoryEntriesBodySchema.safeParse({
+        format: "tmx",
+        content: "<tmx />",
+        maxUnits: TMX_DEFAULT_MAX_UNITS,
+      }).success,
+    ).toBe(true);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.test.ts
@@ -35,15 +35,13 @@ describe("listMemoryEntriesQuerySchema", () => {
 });
 
 describe("importMemoryEntriesBodySchema", () => {
-  it("defaults dryRun to false and caps maxUnits at the documented limit", () => {
+  it("treats dryRun as optional and caps maxUnits at the documented limit", () => {
     expect(
       importMemoryEntriesBodySchema.parse({
         format: "tmx",
         content: "<tmx />",
-      }),
-    ).toMatchObject({
-      dryRun: false,
-    });
+      }).dryRun,
+    ).toBeUndefined();
     expect(
       importMemoryEntriesBodySchema.safeParse({
         format: "tmx",

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
@@ -130,7 +130,7 @@ export const promoteMemoryFromProjectBodySchema = z.object({
 export const importMemoryEntriesBodySchema = z.object({
   format: z.enum(["csv", "tmx"]),
   content: z.string().min(1).max(10_000_000),
-  dryRun: z.boolean().optional().default(false),
+  dryRun: z.boolean().optional(),
   maxUnits: z.number().int().min(1).max(50_000).optional(),
 });
 

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
@@ -12,8 +12,9 @@
  */
 import { z } from "zod";
 
-import { projectIdSchema } from "@/lib/projects/identity/project-id";
 import { schema } from "@/lib/database";
+import { TMX_DEFAULT_MAX_UNITS, TMX_MAX_IMPORT_CONTENT_CHARS } from "@/lib/memory/tmx/tmx-constants";
+import { projectIdSchema } from "@/lib/projects/identity/project-id";
 
 export const memoryIdParamsSchema = z.object({
   memoryId: z.string().trim().min(1).max(128),
@@ -129,9 +130,9 @@ export const promoteMemoryFromProjectBodySchema = z.object({
 
 export const importMemoryEntriesBodySchema = z.object({
   format: z.enum(["csv", "tmx"]),
-  content: z.string().min(1).max(10_000_000),
+  content: z.string().min(1).max(TMX_MAX_IMPORT_CONTENT_CHARS),
   dryRun: z.boolean().optional(),
-  maxUnits: z.number().int().min(1).max(50_000).optional(),
+  maxUnits: z.number().int().min(1).max(TMX_DEFAULT_MAX_UNITS).optional(),
 });
 
 export const exportMemoryEntriesQuerySchema = z.object({

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
@@ -130,6 +130,14 @@ export const promoteMemoryFromProjectBodySchema = z.object({
 export const importMemoryEntriesBodySchema = z.object({
   format: z.enum(["csv", "tmx"]),
   content: z.string().min(1).max(10_000_000),
+  dryRun: z.boolean().optional().default(false),
+  maxUnits: z.number().int().min(1).max(50_000).optional(),
+});
+
+export const exportMemoryEntriesQuerySchema = z.object({
+  format: z.enum(["tmx"]).optional().default("tmx"),
+  sourceLocale: z.string().trim().min(1).max(50).optional(),
+  targetLocale: z.string().trim().min(1).max(50).optional(),
 });
 
 export const attachMemoryProjectBodySchema = z.object({
@@ -216,6 +224,47 @@ export const memoryProjectsResponseSchema = z.object({
   projects: z.array(memoryProjectRecordSchema),
 });
 
+export const memoryImportIssueSchema = z.object({
+  severity: z.enum(["warning", "error"]),
+  code: z.string(),
+  message: z.string(),
+  unitIndex: z.number().int().optional(),
+  tuid: z.string().optional(),
+});
+
+export const memoryImportReportSchema = z.object({
+  totalRead: z.number().int().nonnegative(),
+  created: z.number().int().nonnegative(),
+  updated: z.number().int().nonnegative(),
+  variantCreated: z.number().int().nonnegative(),
+  skipped: z.number().int().nonnegative(),
+  warned: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  issues: z.array(memoryImportIssueSchema),
+  headerSrclang: z.string().optional(),
+  truncatedIssues: z.boolean(),
+});
+
+export const memoryImportPreviewEntrySchema = z.object({
+  sourceLocale: z.string(),
+  targetLocale: z.string(),
+  sourceText: z.string(),
+  targetText: z.string(),
+  externalKey: z.string().nullable(),
+  tuid: z.string().optional(),
+  action: z.enum(["create", "update", "variant", "skip"]),
+});
+
+export const memoryImportResponseSchema = z.object({
+  memoryEntries: z.array(memoryEntryRecordSchema),
+  imported: z.number().int().nonnegative(),
+  skipped: z.number().int().nonnegative(),
+  importBatchId: z.string().uuid().nullable(),
+  dryRun: z.boolean(),
+  preview: z.array(memoryImportPreviewEntrySchema),
+  report: memoryImportReportSchema,
+});
+
 export type MemoryIdParams = z.infer<typeof memoryIdParamsSchema>;
 export type MemoryEntryIdParams = z.infer<typeof memoryEntryIdParamsSchema>;
 export type MemoryProjectParams = z.infer<typeof memoryProjectParamsSchema>;
@@ -227,6 +276,9 @@ export type CreateMemoryEntryBody = z.infer<typeof createMemoryEntryBodySchema>;
 export type UpdateMemoryEntryBody = z.infer<typeof updateMemoryEntryBodySchema>;
 export type PromoteMemoryFromProjectBody = z.infer<typeof promoteMemoryFromProjectBodySchema>;
 export type ImportMemoryEntriesBody = z.infer<typeof importMemoryEntriesBodySchema>;
+export type ExportMemoryEntriesQuery = z.infer<typeof exportMemoryEntriesQuerySchema>;
+export type MemoryImportReport = z.infer<typeof memoryImportReportSchema>;
+export type MemoryImportResponse = z.infer<typeof memoryImportResponseSchema>;
 export type AttachMemoryProjectBody = z.infer<typeof attachMemoryProjectBodySchema>;
 export type MemoryRecord = z.infer<typeof memoryRecordSchema>;
 export type MemoryResponse = z.infer<typeof memoryResponseSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
@@ -13,7 +13,10 @@
 import { z } from "zod";
 
 import { schema } from "@/lib/database";
-import { TMX_DEFAULT_MAX_UNITS, TMX_MAX_IMPORT_CONTENT_CHARS } from "@/lib/memory/tmx/tmx-constants";
+import {
+  TMX_DEFAULT_MAX_UNITS,
+  TMX_MAX_IMPORT_CONTENT_CHARS,
+} from "@/lib/memory/tmx/tmx-constants";
 import { projectIdSchema } from "@/lib/projects/identity/project-id";
 
 export const memoryIdParamsSchema = z.object({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
@@ -17,140 +17,139 @@ import { defineMessages } from "react-intl";
 export const tmImportExportPanelMessages = defineMessages({
   importLabel: {
     defaultMessage: "Import CSV or TMX",
-    id: "k2Qm8nVw1A",
+    id: "4JzoGkf5qD",
     description: "Accessible label for the translation memory import file input",
   },
   previewTitle: {
     defaultMessage: "Import preview",
-    id: "p9L4xC2eR7",
+    id: "xdbeUj+7xL",
     description: "Title for the translation memory import preview dialog",
   },
   resultTitle: {
     defaultMessage: "Import report",
-    id: "s1H6bN8tK3",
+    id: "bD0gNEH+3/",
     description: "Title for the translation memory import result dialog",
   },
   previewDescription: {
     defaultMessage:
       "Review totals and warnings before writing entries. Nothing has been saved yet.",
-    id: "w4J0mD5uY9",
+    id: "EzYVHD/5u/",
     description: "Description for the translation memory import preview dialog",
   },
   resultDescription: {
     defaultMessage: "The import finished. Use these totals to confirm what changed.",
-    id: "a7F3qP1cL6",
+    id: "B9P8UkNbTI",
     description: "Description for the translation memory import result dialog",
   },
   confirmImport: {
     defaultMessage: "Import entries",
-    id: "e8R2vS0hZ5",
+    id: "ITgty4cmkV",
     description: "Button to confirm a translation memory import after preview",
   },
   cancelPreview: {
     defaultMessage: "Cancel",
-    id: "c3T9gB6nM2",
+    id: "07zZke+A8Q",
     description: "Button to close the translation memory import preview without writing",
   },
   closeReport: {
     defaultMessage: "Close",
-    id: "d5U1kW7oQ4",
+    id: "kDbyaphKwz",
     description: "Button to close the translation memory import report",
   },
   exportTmx: {
     defaultMessage: "Export TMX",
-    id: "f6V8iX2pR0",
+    id: "6/dB+QQNUG",
     description: "Button to open translation memory TMX export options",
   },
   exportTitle: {
     defaultMessage: "Export translation memory",
-    id: "g7W4jY9qS1",
+    id: "NiKahdIm+v",
     description: "Title for the translation memory TMX export dialog",
   },
   exportDescription: {
     defaultMessage:
       "Download the full memory, or limit the file to one source and target locale pair.",
-    id: "h8X5kZ0rT2",
+    id: "68oR+M/HhK",
     description: "Description for the translation memory TMX export dialog",
   },
   exportAll: {
     defaultMessage: "Download all locales",
-    id: "i9Y6lA1sU3",
+    id: "jUCQWPQBsD",
     description: "Button to export the full translation memory as TMX",
   },
   exportPair: {
     defaultMessage: "Download locale pair",
-    id: "j0Z7mB2tV4",
+    id: "USK9hbsD4S",
     description: "Button to export a filtered locale pair as TMX",
   },
   sourceLocaleLabel: {
     defaultMessage: "Source locale",
-    id: "k1A8nC3uW5",
+    id: "E5FKq7Jvuw",
     description: "Label for the optional TMX export source locale",
   },
   targetLocaleLabel: {
     defaultMessage: "Target locale",
-    id: "l2B9oD4vX6",
+    id: "0d2hyvxzDu",
     description: "Label for the optional TMX export target locale",
   },
   reportTotalRead: {
     defaultMessage: "Read {count, number}",
-    id: "m3C0pE5wY7",
+    id: "iBXkIW24Rq",
     description: "Import report count for translation units read from the file",
   },
   reportCreated: {
     defaultMessage: "Created {count, number}",
-    id: "n4D1qF6xZ8",
+    id: "vHk0Yz7eWC",
     description: "Import report count for created translation memory entries",
   },
   reportUpdated: {
     defaultMessage: "Updated {count, number}",
-    id: "o5E2rG7yA9",
+    id: "xdxiFYu6GL",
     description: "Import report count for updated translation memory entries",
   },
   reportVariants: {
     defaultMessage: "Variants {count, number}",
-    id: "p6F3sH8zB0",
+    id: "/bULn4h8+q",
     description: "Import report count for additional target-language variants created",
   },
   reportSkipped: {
     defaultMessage: "Skipped {count, number}",
-    id: "q7G4tI9aC1",
+    id: "NuqrR6P28s",
     description: "Import report count for skipped translation memory entries",
   },
   reportWarned: {
     defaultMessage: "Warnings {count, number}",
-    id: "r8H5uJ0bD2",
+    id: "9HTuUWVfNj",
     description: "Import report count for validation warnings",
   },
   reportFailed: {
     defaultMessage: "Failed {count, number}",
-    id: "s9I6vK1cE3",
+    id: "5e/b9i22H4",
     description: "Import report count for failed translation units",
   },
   issuesTitle: {
     defaultMessage: "Unit issues",
-    id: "t0J7wL2dF4",
+    id: "fA0++N9x3W",
     description: "Heading for import validation issues",
   },
   previewEntriesTitle: {
     defaultMessage: "Sample entries",
-    id: "u1K8xM3eG5",
+    id: "K5K8zG3viH",
     description: "Heading for import preview sample rows",
   },
   importFailed: {
     defaultMessage: "Unable to import entries",
-    id: "v2L9yN4fH6",
+    id: "VxRWiDyH8o",
     description: "Fallback error when translation memory import fails",
   },
   exportFailed: {
     defaultMessage: "Unable to export TMX",
-    id: "w3M0zO5gI7",
+    id: "AzlAJgQRne",
     description: "Fallback error when translation memory TMX export fails",
   },
   entriesImported: {
-    defaultMessage:
-      "Imported {created, number} new and {updated, number} updated entries",
-    id: "x4N1aP6hJ8",
+    defaultMessage: "Imported {created, number} new and {updated, number} updated entries",
+    id: "kZql9qccYD",
     description: "Toast after a translation memory import completes",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
@@ -140,7 +140,7 @@ export const tmImportExportPanelMessages = defineMessages({
   importFileTooLarge: {
     defaultMessage:
       "This file is larger than the {maxMegabytes, number} MB import limit. Split the memory into smaller TMX files.",
-    id: "tmImportFileTooLarge",
+    id: "S1WdU+6z/U",
     description: "Error when a translation memory import file exceeds the documented size limit",
   },
   importFailed: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
@@ -137,6 +137,12 @@ export const tmImportExportPanelMessages = defineMessages({
     id: "K5K8zG3viH",
     description: "Heading for import preview sample rows",
   },
+  importFileTooLarge: {
+    defaultMessage:
+      "This file is larger than the {maxMegabytes, number} MB import limit. Split the memory into smaller TMX files.",
+    id: "tmImportFileTooLarge",
+    description: "Error when a translation memory import file exceeds the documented size limit",
+  },
   importFailed: {
     defaultMessage: "Unable to import entries",
     id: "VxRWiDyH8o",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
@@ -1,0 +1,156 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const tmImportExportPanelMessages = defineMessages({
+  importLabel: {
+    defaultMessage: "Import CSV or TMX",
+    id: "k2Qm8nVw1A",
+    description: "Accessible label for the translation memory import file input",
+  },
+  previewTitle: {
+    defaultMessage: "Import preview",
+    id: "p9L4xC2eR7",
+    description: "Title for the translation memory import preview dialog",
+  },
+  resultTitle: {
+    defaultMessage: "Import report",
+    id: "s1H6bN8tK3",
+    description: "Title for the translation memory import result dialog",
+  },
+  previewDescription: {
+    defaultMessage:
+      "Review totals and warnings before writing entries. Nothing has been saved yet.",
+    id: "w4J0mD5uY9",
+    description: "Description for the translation memory import preview dialog",
+  },
+  resultDescription: {
+    defaultMessage: "The import finished. Use these totals to confirm what changed.",
+    id: "a7F3qP1cL6",
+    description: "Description for the translation memory import result dialog",
+  },
+  confirmImport: {
+    defaultMessage: "Import entries",
+    id: "e8R2vS0hZ5",
+    description: "Button to confirm a translation memory import after preview",
+  },
+  cancelPreview: {
+    defaultMessage: "Cancel",
+    id: "c3T9gB6nM2",
+    description: "Button to close the translation memory import preview without writing",
+  },
+  closeReport: {
+    defaultMessage: "Close",
+    id: "d5U1kW7oQ4",
+    description: "Button to close the translation memory import report",
+  },
+  exportTmx: {
+    defaultMessage: "Export TMX",
+    id: "f6V8iX2pR0",
+    description: "Button to open translation memory TMX export options",
+  },
+  exportTitle: {
+    defaultMessage: "Export translation memory",
+    id: "g7W4jY9qS1",
+    description: "Title for the translation memory TMX export dialog",
+  },
+  exportDescription: {
+    defaultMessage:
+      "Download the full memory, or limit the file to one source and target locale pair.",
+    id: "h8X5kZ0rT2",
+    description: "Description for the translation memory TMX export dialog",
+  },
+  exportAll: {
+    defaultMessage: "Download all locales",
+    id: "i9Y6lA1sU3",
+    description: "Button to export the full translation memory as TMX",
+  },
+  exportPair: {
+    defaultMessage: "Download locale pair",
+    id: "j0Z7mB2tV4",
+    description: "Button to export a filtered locale pair as TMX",
+  },
+  sourceLocaleLabel: {
+    defaultMessage: "Source locale",
+    id: "k1A8nC3uW5",
+    description: "Label for the optional TMX export source locale",
+  },
+  targetLocaleLabel: {
+    defaultMessage: "Target locale",
+    id: "l2B9oD4vX6",
+    description: "Label for the optional TMX export target locale",
+  },
+  reportTotalRead: {
+    defaultMessage: "Read {count, number}",
+    id: "m3C0pE5wY7",
+    description: "Import report count for translation units read from the file",
+  },
+  reportCreated: {
+    defaultMessage: "Created {count, number}",
+    id: "n4D1qF6xZ8",
+    description: "Import report count for created translation memory entries",
+  },
+  reportUpdated: {
+    defaultMessage: "Updated {count, number}",
+    id: "o5E2rG7yA9",
+    description: "Import report count for updated translation memory entries",
+  },
+  reportVariants: {
+    defaultMessage: "Variants {count, number}",
+    id: "p6F3sH8zB0",
+    description: "Import report count for additional target-language variants created",
+  },
+  reportSkipped: {
+    defaultMessage: "Skipped {count, number}",
+    id: "q7G4tI9aC1",
+    description: "Import report count for skipped translation memory entries",
+  },
+  reportWarned: {
+    defaultMessage: "Warnings {count, number}",
+    id: "r8H5uJ0bD2",
+    description: "Import report count for validation warnings",
+  },
+  reportFailed: {
+    defaultMessage: "Failed {count, number}",
+    id: "s9I6vK1cE3",
+    description: "Import report count for failed translation units",
+  },
+  issuesTitle: {
+    defaultMessage: "Unit issues",
+    id: "t0J7wL2dF4",
+    description: "Heading for import validation issues",
+  },
+  previewEntriesTitle: {
+    defaultMessage: "Sample entries",
+    id: "u1K8xM3eG5",
+    description: "Heading for import preview sample rows",
+  },
+  importFailed: {
+    defaultMessage: "Unable to import entries",
+    id: "v2L9yN4fH6",
+    description: "Fallback error when translation memory import fails",
+  },
+  exportFailed: {
+    defaultMessage: "Unable to export TMX",
+    id: "w3M0zO5gI7",
+    description: "Fallback error when translation memory TMX export fails",
+  },
+  entriesImported: {
+    defaultMessage:
+      "Imported {created, number} new and {updated, number} updated entries",
+    id: "x4N1aP6hJ8",
+    description: "Toast after a translation memory import completes",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import type { MemoryImportResponse } from "@/api/routes/memory/memory.schema";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { TypographyP } from "@/components/ui/typography";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+
+import { TmEntryLocaleField } from "./tm-entry-locale-field";
+import { buildTmEntryLocaleOptions } from "./tm-entry-list-state";
+import { tmImportExportPanelMessages as messages } from "./tm-import-export-panel.messages";
+
+type PendingImport = {
+  format: "csv" | "tmx";
+  content: string;
+};
+
+function reportCounts(report: MemoryImportResponse["report"]) {
+  return [
+    { key: "totalRead", count: report.totalRead, message: messages.reportTotalRead },
+    { key: "created", count: report.created, message: messages.reportCreated },
+    { key: "updated", count: report.updated, message: messages.reportUpdated },
+    { key: "variantCreated", count: report.variantCreated, message: messages.reportVariants },
+    { key: "skipped", count: report.skipped, message: messages.reportSkipped },
+    { key: "warned", count: report.warned, message: messages.reportWarned },
+    { key: "failed", count: report.failed, message: messages.reportFailed },
+  ] as const;
+}
+
+export function TmImportExportPanel({
+  organizationSlug,
+  memoryId,
+  localeCoverage,
+  canEdit,
+  onImported,
+}: {
+  organizationSlug: string;
+  memoryId: string;
+  localeCoverage: string[];
+  canEdit: boolean;
+  onImported: () => Promise<void> | void;
+}) {
+  const intl = useIntl();
+  const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
+  const [preview, setPreview] = useState<MemoryImportResponse | null>(null);
+  const [result, setResult] = useState<MemoryImportResponse | null>(null);
+  const [exportOpen, setExportOpen] = useState(false);
+  const [exportSourceLocale, setExportSourceLocale] = useState(localeCoverage[0] ?? "en-US");
+  const [exportTargetLocale, setExportTargetLocale] = useState(localeCoverage[1] ?? "fr-FR");
+
+  const previewImport = useMutation({
+    mutationFn: async (file: File) => {
+      const content = await file.text();
+      const format = file.name.toLowerCase().endsWith(".tmx") ? "tmx" : "csv";
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].entries["import"].$post({
+        param: { organizationSlug, memoryId },
+        json: { format, content, dryRun: true },
+      });
+      if (!response.ok) {
+        throw new Error(await readApiError(response, intl.formatMessage(messages.importFailed)));
+      }
+      return { format, content, body: (await response.json()) as MemoryImportResponse };
+    },
+    onSuccess: ({ format, content, body }) => {
+      setPendingImport({ format, content });
+      setPreview(body);
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const confirmImport = useMutation({
+    mutationFn: async (pending: PendingImport) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].entries["import"].$post({
+        param: { organizationSlug, memoryId },
+        json: { format: pending.format, content: pending.content, dryRun: false },
+      });
+      if (!response.ok) {
+        throw new Error(await readApiError(response, intl.formatMessage(messages.importFailed)));
+      }
+      return (await response.json()) as MemoryImportResponse;
+    },
+    onSuccess: async (body) => {
+      setPreview(null);
+      setPendingImport(null);
+      setResult(body);
+      await onImported();
+      toast.success(
+        intl.formatMessage(messages.entriesImported, {
+          created: body.report.created + body.report.variantCreated,
+          updated: body.report.updated,
+        }),
+      );
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const exportTmx = useMutation({
+    mutationFn: async (filters?: { sourceLocale?: string; targetLocale?: string }) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].entries.export.$get({
+        param: { organizationSlug, memoryId },
+        query: {
+          format: "tmx",
+          ...(filters?.sourceLocale ? { sourceLocale: filters.sourceLocale } : {}),
+          ...(filters?.targetLocale ? { targetLocale: filters.targetLocale } : {}),
+        },
+      });
+      if (!response.ok) {
+        throw new Error(await readApiError(response, intl.formatMessage(messages.exportFailed)));
+      }
+      const blob = await response.blob();
+      const filename =
+        response.headers.get("content-disposition")?.match(/filename\*=UTF-8''([^;]+)/)?.[1] ??
+        "translation-memory.tmx";
+      return { blob, filename: decodeURIComponent(filename) };
+    },
+    onSuccess: ({ blob, filename }) => {
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      link.click();
+      URL.revokeObjectURL(url);
+      setExportOpen(false);
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {canEdit ? (
+        <Input
+          type="file"
+          accept=".csv,.tmx,text/csv,application/xml,text/xml"
+          aria-label={intl.formatMessage(messages.importLabel)}
+          className="max-w-xs"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) previewImport.mutate(file);
+            event.currentTarget.value = "";
+          }}
+        />
+      ) : null}
+      <Button type="button" variant="outline" onClick={() => setExportOpen(true)}>
+        <FormattedMessage {...messages.exportTmx} />
+      </Button>
+
+      <Dialog
+        open={preview !== null}
+        onOpenChange={(open) => {
+          if (!open && !confirmImport.isPending) {
+            setPreview(null);
+            setPendingImport(null);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...messages.previewTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage {...messages.previewDescription} />
+            </DialogDescription>
+          </DialogHeader>
+          {preview ? <ImportReportBody report={preview} /> : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setPreview(null);
+                setPendingImport(null);
+              }}
+            >
+              <FormattedMessage {...messages.cancelPreview} />
+            </Button>
+            <Button
+              type="button"
+              disabled={!pendingImport || confirmImport.isPending}
+              onClick={() => pendingImport && confirmImport.mutate(pendingImport)}
+            >
+              <FormattedMessage {...messages.confirmImport} />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={result !== null} onOpenChange={(open) => !open && setResult(null)}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...messages.resultTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage {...messages.resultDescription} />
+            </DialogDescription>
+          </DialogHeader>
+          {result ? <ImportReportBody report={result} /> : null}
+          <DialogFooter>
+            <Button type="button" onClick={() => setResult(null)}>
+              <FormattedMessage {...messages.closeReport} />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={exportOpen} onOpenChange={setExportOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...messages.exportTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage {...messages.exportDescription} />
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3 md:grid-cols-2">
+            <TmEntryLocaleField
+              label={intl.formatMessage(messages.sourceLocaleLabel)}
+              value={exportSourceLocale}
+              locales={buildTmEntryLocaleOptions({
+                localeCoverage,
+                selected: exportSourceLocale,
+              })}
+              onValueChange={setExportSourceLocale}
+            />
+            <TmEntryLocaleField
+              label={intl.formatMessage(messages.targetLocaleLabel)}
+              value={exportTargetLocale}
+              locales={buildTmEntryLocaleOptions({
+                localeCoverage,
+                selected: exportTargetLocale,
+              })}
+              onValueChange={setExportTargetLocale}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={exportTmx.isPending}
+              onClick={() => exportTmx.mutate(undefined)}
+            >
+              <FormattedMessage {...messages.exportAll} />
+            </Button>
+            <Button
+              type="button"
+              disabled={
+                !exportSourceLocale.trim() || !exportTargetLocale.trim() || exportTmx.isPending
+              }
+              onClick={() =>
+                exportTmx.mutate({
+                  sourceLocale: exportSourceLocale.trim(),
+                  targetLocale: exportTargetLocale.trim(),
+                })
+              }
+            >
+              <FormattedMessage {...messages.exportPair} />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+    </div>
+  );
+}
+
+function ImportReportBody({ report }: { report: MemoryImportResponse }) {
+  return (
+    <div className="grid gap-4">
+      <div className="flex flex-wrap gap-2">
+        {reportCounts(report.report).map((item) => (
+          <TypographyP key={item.key} className="rounded-md border border-border px-2 py-1 text-xs">
+            <FormattedMessage {...item.message} values={{ count: item.count }} />
+          </TypographyP>
+        ))}
+      </div>
+      {report.preview.length > 0 ? (
+        <div className="grid gap-2">
+          <TypographyP className="text-sm font-medium">
+            <FormattedMessage {...messages.previewEntriesTitle} />
+          </TypographyP>
+          <div className="max-h-48 overflow-auto rounded-md border border-border">
+            {report.preview.map((entry, index) => (
+              <div key={`${entry.externalKey ?? entry.sourceText}-${index}`} className="border-b border-border px-3 py-2 last:border-b-0">
+                <TypographyP className="text-xs text-muted-foreground">
+                  {entry.sourceLocale} → {entry.targetLocale} · {entry.action}
+                </TypographyP>
+                <TypographyP className="text-sm">{entry.sourceText}</TypographyP>
+                <TypographyP className="text-sm text-muted-foreground">{entry.targetText}</TypographyP>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {report.report.issues.length > 0 ? (
+        <div className="grid gap-2">
+          <TypographyP className="text-sm font-medium">
+            <FormattedMessage {...messages.issuesTitle} />
+          </TypographyP>
+          <ul className="max-h-40 overflow-auto rounded-md border border-border px-3 py-2 text-xs">
+            {report.report.issues.map((issue, index) => (
+              <li key={`${issue.code}-${issue.unitIndex ?? index}`} className="py-1">
+                {issue.unitIndex ? `#${issue.unitIndex} · ` : null}
+                {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
@@ -31,6 +31,7 @@ import { Input } from "@/components/ui/input";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
+import { TMX_MAX_IMPORT_CONTENT_CHARS } from "@/lib/memory/tmx/tmx-constants";
 
 import { TmEntryLocaleField } from "./tm-entry-locale-field";
 import { buildTmEntryLocaleOptions } from "./tm-entry-list-state";
@@ -76,6 +77,13 @@ export function TmImportExportPanel({
 
   const previewImport = useMutation({
     mutationFn: async (file: File) => {
+      if (file.size > TMX_MAX_IMPORT_CONTENT_CHARS) {
+        throw new Error(
+          intl.formatMessage(messages.importFileTooLarge, {
+            maxMegabytes: Math.floor(TMX_MAX_IMPORT_CONTENT_CHARS / 1_000_000),
+          }),
+        );
+      }
       const content = await file.text();
       const format = file.name.toLowerCase().endsWith(".tmx") ? ("tmx" as const) : ("csv" as const);
       const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
@@ -77,7 +77,7 @@ export function TmImportExportPanel({
   const previewImport = useMutation({
     mutationFn: async (file: File) => {
       const content = await file.text();
-      const format = file.name.toLowerCase().endsWith(".tmx") ? "tmx" : "csv";
+      const format = file.name.toLowerCase().endsWith(".tmx") ? ("tmx" as const) : ("csv" as const);
       const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
         ":memoryId"
       ].entries["import"].$post({
@@ -292,7 +292,6 @@ export function TmImportExportPanel({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
     </div>
   );
 }
@@ -314,12 +313,17 @@ function ImportReportBody({ report }: { report: MemoryImportResponse }) {
           </TypographyP>
           <div className="max-h-48 overflow-auto rounded-md border border-border">
             {report.preview.map((entry, index) => (
-              <div key={`${entry.externalKey ?? entry.sourceText}-${index}`} className="border-b border-border px-3 py-2 last:border-b-0">
+              <div
+                key={`${entry.externalKey ?? entry.sourceText}-${index}`}
+                className="border-b border-border px-3 py-2 last:border-b-0"
+              >
                 <TypographyP className="text-xs text-muted-foreground">
                   {entry.sourceLocale} → {entry.targetLocale} · {entry.action}
                 </TypographyP>
                 <TypographyP className="text-sm">{entry.sourceText}</TypographyP>
-                <TypographyP className="text-sm text-muted-foreground">{entry.targetText}</TypographyP>
+                <TypographyP className="text-sm text-muted-foreground">
+                  {entry.targetText}
+                </TypographyP>
               </div>
             ))}
           </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
@@ -31,6 +31,7 @@ import { Input } from "@/components/ui/input";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
+import { readMemoryImportFile } from "@/lib/memory/decode-import-file";
 import { TMX_MAX_IMPORT_CONTENT_CHARS } from "@/lib/memory/tmx/tmx-constants";
 
 import { TmEntryLocaleField } from "./tm-entry-locale-field";
@@ -77,14 +78,15 @@ export function TmImportExportPanel({
 
   const previewImport = useMutation({
     mutationFn: async (file: File) => {
-      if (file.size > TMX_MAX_IMPORT_CONTENT_CHARS) {
+      const decoded = await readMemoryImportFile(file);
+      if (!decoded.ok) {
         throw new Error(
           intl.formatMessage(messages.importFileTooLarge, {
             maxMegabytes: Math.floor(TMX_MAX_IMPORT_CONTENT_CHARS / 1_000_000),
           }),
         );
       }
-      const content = await file.text();
+      const content = decoded.content;
       const format = file.name.toLowerCase().endsWith(".tmx") ? ("tmx" as const) : ("csv" as const);
       const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
         ":memoryId"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -24,7 +24,6 @@ import type { MemoryProjectRecord, MemoryRecord } from "@/api/routes/memory/memo
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -39,6 +38,7 @@ import { apiClient } from "@/lib/api-client-instance";
 
 import { TmEntryExplorer } from "./tm-entry-explorer";
 import { TmEntryLocaleField } from "./tm-entry-locale-field";
+import { TmImportExportPanel } from "./tm-import-export-panel";
 import { buildTmEntryLocaleOptions } from "./tm-entry-list-state";
 import { TM_ENTRY_SEARCH_QUERY_KEY } from "./tm-entry-search";
 import { translationMemoryDetailPageContentMessages as messages } from "./translation-memory-detail-page-content.messages";
@@ -178,29 +178,6 @@ export function TranslationMemoryDetailPageContent({
     onError: (error) => toast.error(error.message),
   });
 
-  const importEntries = useMutation({
-    mutationFn: async (file: File) => {
-      const content = await file.text();
-      const format = file.name.toLowerCase().endsWith(".tmx") ? "tmx" : "csv";
-      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
-        ":memoryId"
-      ].entries["import"].$post({
-        param: { organizationSlug, memoryId },
-        json: { format, content },
-      });
-      if (!response.ok)
-        throw new Error(
-          await readApiError(response, intl.formatMessage(messages.importEntriesFailed)),
-        );
-      return response.json();
-    },
-    onSuccess: async (body) => {
-      await invalidateEntries();
-      toast.success(intl.formatMessage(messages.entriesImported, { count: body.imported ?? 0 }));
-    },
-    onError: (error) => toast.error(error.message),
-  });
-
   const attachProject = useMutation({
     mutationFn: async (projectId: string) => {
       const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
@@ -304,18 +281,13 @@ export function TranslationMemoryDetailPageContent({
               <FormattedMessage {...messages.entriesDescription} />
             </TypographyP>
           </div>
-          {canEdit ? (
-            <Input
-              type="file"
-              accept=".csv,.tmx,text/csv"
-              className="max-w-xs"
-              onChange={(event) => {
-                const file = event.target.files?.[0];
-                if (file) importEntries.mutate(file);
-                event.currentTarget.value = "";
-              }}
-            />
-          ) : null}
+          <TmImportExportPanel
+            organizationSlug={organizationSlug}
+            memoryId={memoryId}
+            localeCoverage={memory.localeCoverage}
+            canEdit={canEdit}
+            onImported={invalidateEntries}
+          />
         </div>
 
         {canEdit ? (

--- a/apps/hyperlocalise-web/src/lib/memory/decode-import-file.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/decode-import-file.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { decodeMemoryImportBytes } from "./decode-import-file";
+
+const SAMPLE = '<?xml version="1.0"?><tmx version="1.4"><body/></tmx>';
+
+function utf16LeWithBom(text: string) {
+  const encoded = Buffer.from(text, "utf16le");
+  return Uint8Array.from([0xff, 0xfe, ...encoded]);
+}
+
+function utf16BeWithBom(text: string) {
+  const body = Buffer.alloc(text.length * 2);
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    body[index * 2] = (code >> 8) & 0xff;
+    body[index * 2 + 1] = code & 0xff;
+  }
+  return Uint8Array.from([0xfe, 0xff, ...body]);
+}
+
+describe("decodeMemoryImportBytes", () => {
+  it("decodes UTF-16 LE and BE TMX files from their BOM", () => {
+    expect(decodeMemoryImportBytes(utf16LeWithBom(SAMPLE)).replace(/^\uFEFF/, "")).toBe(SAMPLE);
+    expect(decodeMemoryImportBytes(utf16BeWithBom(SAMPLE)).replace(/^\uFEFF/, "")).toBe(SAMPLE);
+  });
+
+  it("keeps UTF-8 TMX unchanged", () => {
+    expect(decodeMemoryImportBytes(new TextEncoder().encode(SAMPLE))).toBe(SAMPLE);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/memory/decode-import-file.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/decode-import-file.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { TMX_MAX_IMPORT_CONTENT_CHARS } from "./tmx/tmx-constants";
+
+function looksLikeUtf16Le(bytes: Uint8Array) {
+  return (
+    bytes.length >= 10 &&
+    bytes[0] === 0x3c &&
+    bytes[1] === 0x00 &&
+    bytes[2] === 0x3f &&
+    bytes[3] === 0x00
+  );
+}
+
+function looksLikeUtf16Be(bytes: Uint8Array) {
+  return (
+    bytes.length >= 10 &&
+    bytes[0] === 0x00 &&
+    bytes[1] === 0x3c &&
+    bytes[2] === 0x00 &&
+    bytes[3] === 0x3f
+  );
+}
+
+export function decodeMemoryImportBytes(bytes: Uint8Array) {
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    return new TextDecoder("utf-16le").decode(bytes);
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    return new TextDecoder("utf-16be").decode(bytes);
+  }
+  if (looksLikeUtf16Le(bytes)) {
+    return new TextDecoder("utf-16le").decode(bytes);
+  }
+  if (looksLikeUtf16Be(bytes)) {
+    return new TextDecoder("utf-16be").decode(bytes);
+  }
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+export async function readMemoryImportFile(file: File) {
+  if (file.size > TMX_MAX_IMPORT_CONTENT_CHARS) {
+    return { ok: false as const, code: "oversized" as const };
+  }
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  if (bytes.byteLength > TMX_MAX_IMPORT_CONTENT_CHARS) {
+    return { ok: false as const, code: "oversized" as const };
+  }
+  return { ok: true as const, content: decodeMemoryImportBytes(bytes) };
+}

--- a/apps/hyperlocalise-web/src/lib/memory/export-memory-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/export-memory-entries.ts
@@ -87,7 +87,11 @@ export async function loadMemoryEntriesForExport(
 }
 
 export function buildMemoryTmxFilename(memoryName: string, filters: MemoryExportFilters) {
-  const slug = memoryName.trim().replace(/[^\w.-]+/g, "-").replace(/^-+|-+$/g, "") || "translation-memory";
+  const slug =
+    memoryName
+      .trim()
+      .replace(/[^\w.-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "translation-memory";
   if (filters.sourceLocale && filters.targetLocale) {
     return `${slug}-${filters.sourceLocale}-${filters.targetLocale}.tmx`;
   }

--- a/apps/hyperlocalise-web/src/lib/memory/export-memory-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/export-memory-entries.ts
@@ -10,14 +10,18 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, gt, or } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
-import { serializeMemoryEntriesTmx } from "./tmx/serialize-tmx";
+import { TMX_EXPORT_PAGE_SIZE } from "./tmx/tmx-constants";
+import {
+  groupEntriesForTmxExport,
+  serializeTmxFooterXml,
+  serializeTmxHeaderXml,
+  serializeTmxUnitsXml,
+} from "./tmx/serialize-tmx";
 import type { TmxExportEntry } from "./tmx/tmx-types";
-
-const EXPORT_PAGE_SIZE = 500;
 
 export type MemoryExportFilters = {
   sourceLocale?: string;
@@ -35,55 +39,76 @@ function asTuid(metadata: Record<string, unknown>, externalKey: string | null) {
   return undefined;
 }
 
-export async function loadMemoryEntriesForExport(
+function toExportEntry(row: {
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  targetText: string;
+  externalKey: string | null;
+  metadata: Record<string, unknown> | null;
+}): TmxExportEntry {
+  return {
+    sourceLocale: row.sourceLocale,
+    targetLocale: row.targetLocale,
+    sourceText: row.sourceText,
+    targetText: row.targetText,
+    tuid: asTuid(row.metadata ?? {}, row.externalKey),
+    metadata: row.metadata ?? {},
+  };
+}
+
+function trailingTuidGroup(entries: TmxExportEntry[]) {
+  const lastTuid = entries.at(-1)?.tuid;
+  if (!lastTuid) {
+    return { flush: entries, pending: [] as TmxExportEntry[] };
+  }
+  let start = entries.length - 1;
+  while (start > 0 && entries[start - 1]?.tuid === lastTuid) {
+    start -= 1;
+  }
+  return { flush: entries.slice(0, start), pending: entries.slice(start) };
+}
+
+async function loadExportPage(
   memoryId: string,
-  filters: MemoryExportFilters = {},
-): Promise<TmxExportEntry[]> {
-  const entries: TmxExportEntry[] = [];
-  let offset = 0;
-
-  for (;;) {
-    const conditions = [eq(schema.memoryEntries.memoryId, memoryId)];
-    if (filters.sourceLocale) {
-      conditions.push(eq(schema.memoryEntries.sourceLocale, filters.sourceLocale));
+  filters: MemoryExportFilters,
+  cursor?: { createdAt: Date; id: string },
+) {
+  const conditions = [eq(schema.memoryEntries.memoryId, memoryId)];
+  if (filters.sourceLocale) {
+    conditions.push(eq(schema.memoryEntries.sourceLocale, filters.sourceLocale));
+  }
+  if (filters.targetLocale) {
+    conditions.push(eq(schema.memoryEntries.targetLocale, filters.targetLocale));
+  }
+  if (cursor) {
+    const afterCursor = or(
+      gt(schema.memoryEntries.createdAt, cursor.createdAt),
+      and(
+        eq(schema.memoryEntries.createdAt, cursor.createdAt),
+        gt(schema.memoryEntries.id, cursor.id),
+      ),
+    );
+    if (afterCursor) {
+      conditions.push(afterCursor);
     }
-    if (filters.targetLocale) {
-      conditions.push(eq(schema.memoryEntries.targetLocale, filters.targetLocale));
-    }
-
-    const rows = await db
-      .select({
-        sourceLocale: schema.memoryEntries.sourceLocale,
-        targetLocale: schema.memoryEntries.targetLocale,
-        sourceText: schema.memoryEntries.sourceText,
-        targetText: schema.memoryEntries.targetText,
-        externalKey: schema.memoryEntries.externalKey,
-        metadata: schema.memoryEntries.metadata,
-      })
-      .from(schema.memoryEntries)
-      .where(and(...conditions))
-      .orderBy(asc(schema.memoryEntries.createdAt), asc(schema.memoryEntries.id))
-      .limit(EXPORT_PAGE_SIZE)
-      .offset(offset);
-
-    for (const row of rows) {
-      entries.push({
-        sourceLocale: row.sourceLocale,
-        targetLocale: row.targetLocale,
-        sourceText: row.sourceText,
-        targetText: row.targetText,
-        tuid: asTuid(row.metadata ?? {}, row.externalKey),
-        metadata: row.metadata ?? {},
-      });
-    }
-
-    if (rows.length < EXPORT_PAGE_SIZE) {
-      break;
-    }
-    offset += rows.length;
   }
 
-  return entries;
+  return db
+    .select({
+      id: schema.memoryEntries.id,
+      createdAt: schema.memoryEntries.createdAt,
+      sourceLocale: schema.memoryEntries.sourceLocale,
+      targetLocale: schema.memoryEntries.targetLocale,
+      sourceText: schema.memoryEntries.sourceText,
+      targetText: schema.memoryEntries.targetText,
+      externalKey: schema.memoryEntries.externalKey,
+      metadata: schema.memoryEntries.metadata,
+    })
+    .from(schema.memoryEntries)
+    .where(and(...conditions))
+    .orderBy(asc(schema.memoryEntries.createdAt), asc(schema.memoryEntries.id))
+    .limit(TMX_EXPORT_PAGE_SIZE);
 }
 
 export function buildMemoryTmxFilename(memoryName: string, filters: MemoryExportFilters) {
@@ -98,19 +123,81 @@ export function buildMemoryTmxFilename(memoryName: string, filters: MemoryExport
   return `${slug}.tmx`;
 }
 
+export function createMemoryTmxExportStream(input: {
+  memoryId: string;
+  filters?: MemoryExportFilters;
+}) {
+  const filters = input.filters ?? {};
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let cursor: { createdAt: Date; id: string } | undefined;
+      let pending: TmxExportEntry[] = [];
+      let wroteHeader = false;
+
+      try {
+        for (;;) {
+          const rows = await loadExportPage(input.memoryId, filters, cursor);
+          const page = rows.map(toExportEntry);
+          if (!wroteHeader) {
+            controller.enqueue(
+              encoder.encode(
+                `${serializeTmxHeaderXml(
+                  { creationtool: "Hyperlocalise" },
+                  filters.sourceLocale ?? page[0]?.sourceLocale,
+                )}\n`,
+              ),
+            );
+            wroteHeader = true;
+          }
+          if (page.length === 0) {
+            break;
+          }
+          const combined = [...pending, ...page];
+          const split =
+            rows.length === TMX_EXPORT_PAGE_SIZE
+              ? trailingTuidGroup(combined)
+              : { flush: combined, pending: [] as TmxExportEntry[] };
+          pending = split.pending;
+          if (split.flush.length > 0) {
+            const unitsXml = serializeTmxUnitsXml(groupEntriesForTmxExport(split.flush));
+            if (unitsXml) {
+              controller.enqueue(encoder.encode(`${unitsXml}\n`));
+            }
+          }
+          const last = rows.at(-1);
+          if (!last || rows.length < TMX_EXPORT_PAGE_SIZE) {
+            break;
+          }
+          cursor = { createdAt: last.createdAt, id: last.id };
+        }
+        if (pending.length > 0) {
+          const unitsXml = serializeTmxUnitsXml(groupEntriesForTmxExport(pending));
+          if (unitsXml) {
+            controller.enqueue(encoder.encode(`${unitsXml}\n`));
+          }
+        }
+        controller.enqueue(encoder.encode(serializeTmxFooterXml()));
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+  });
+}
+
 export async function exportMemoryEntriesTmx(input: {
   memoryId: string;
   memoryName: string;
   filters?: MemoryExportFilters;
 }) {
   const filters = input.filters ?? {};
-  const entries = await loadMemoryEntriesForExport(input.memoryId, filters);
   return {
-    body: serializeMemoryEntriesTmx(entries, {
-      srclang: filters.sourceLocale ?? entries[0]?.sourceLocale,
-      creationtool: "Hyperlocalise",
+    body: createMemoryTmxExportStream({
+      memoryId: input.memoryId,
+      filters,
     }),
     filename: buildMemoryTmxFilename(input.memoryName, filters),
-    entryCount: entries.length,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/memory/export-memory-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/export-memory-entries.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, asc, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+
+import { serializeMemoryEntriesTmx } from "./tmx/serialize-tmx";
+import type { TmxExportEntry } from "./tmx/tmx-types";
+
+const EXPORT_PAGE_SIZE = 500;
+
+export type MemoryExportFilters = {
+  sourceLocale?: string;
+  targetLocale?: string;
+};
+
+function asTuid(metadata: Record<string, unknown>, externalKey: string | null) {
+  if (typeof metadata.tuid === "string" && metadata.tuid.trim()) {
+    return metadata.tuid;
+  }
+  if (externalKey?.startsWith("tmx:")) {
+    const parts = externalKey.split(":");
+    return parts[1] || undefined;
+  }
+  return undefined;
+}
+
+export async function loadMemoryEntriesForExport(
+  memoryId: string,
+  filters: MemoryExportFilters = {},
+): Promise<TmxExportEntry[]> {
+  const entries: TmxExportEntry[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const conditions = [eq(schema.memoryEntries.memoryId, memoryId)];
+    if (filters.sourceLocale) {
+      conditions.push(eq(schema.memoryEntries.sourceLocale, filters.sourceLocale));
+    }
+    if (filters.targetLocale) {
+      conditions.push(eq(schema.memoryEntries.targetLocale, filters.targetLocale));
+    }
+
+    const rows = await db
+      .select({
+        sourceLocale: schema.memoryEntries.sourceLocale,
+        targetLocale: schema.memoryEntries.targetLocale,
+        sourceText: schema.memoryEntries.sourceText,
+        targetText: schema.memoryEntries.targetText,
+        externalKey: schema.memoryEntries.externalKey,
+        metadata: schema.memoryEntries.metadata,
+      })
+      .from(schema.memoryEntries)
+      .where(and(...conditions))
+      .orderBy(asc(schema.memoryEntries.createdAt), asc(schema.memoryEntries.id))
+      .limit(EXPORT_PAGE_SIZE)
+      .offset(offset);
+
+    for (const row of rows) {
+      entries.push({
+        sourceLocale: row.sourceLocale,
+        targetLocale: row.targetLocale,
+        sourceText: row.sourceText,
+        targetText: row.targetText,
+        tuid: asTuid(row.metadata ?? {}, row.externalKey),
+        metadata: row.metadata ?? {},
+      });
+    }
+
+    if (rows.length < EXPORT_PAGE_SIZE) {
+      break;
+    }
+    offset += rows.length;
+  }
+
+  return entries;
+}
+
+export function buildMemoryTmxFilename(memoryName: string, filters: MemoryExportFilters) {
+  const slug = memoryName.trim().replace(/[^\w.-]+/g, "-").replace(/^-+|-+$/g, "") || "translation-memory";
+  if (filters.sourceLocale && filters.targetLocale) {
+    return `${slug}-${filters.sourceLocale}-${filters.targetLocale}.tmx`;
+  }
+  return `${slug}.tmx`;
+}
+
+export async function exportMemoryEntriesTmx(input: {
+  memoryId: string;
+  memoryName: string;
+  filters?: MemoryExportFilters;
+}) {
+  const filters = input.filters ?? {};
+  const entries = await loadMemoryEntriesForExport(input.memoryId, filters);
+  return {
+    body: serializeMemoryEntriesTmx(entries, {
+      srclang: filters.sourceLocale ?? entries[0]?.sourceLocale,
+      creationtool: "Hyperlocalise",
+    }),
+    filename: buildMemoryTmxFilename(input.memoryName, filters),
+    entryCount: entries.length,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.ts
@@ -15,7 +15,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 import { db, schema } from "@/lib/database";
 import type { Memory } from "@/lib/database/types";
-import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import { isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
 import {
@@ -105,9 +105,11 @@ function parseCsvImport(content: string): ParsedMemoryImport {
   };
 }
 
-export function parseMemoryImportContent(
-  payload: { format: "csv" | "tmx"; content: string; maxUnits?: number },
-): Result<ParsedMemoryImport, TmxFatalError> {
+export function parseMemoryImportContent(payload: {
+  format: "csv" | "tmx";
+  content: string;
+  maxUnits?: number;
+}): Result<ParsedMemoryImport, TmxFatalError> {
   if (payload.format === "csv") {
     return ok(parseCsvImport(payload.content));
   }
@@ -145,7 +147,11 @@ function planImportActions(
   const reservedSource = new Set(existingBySourceKey.keys());
 
   for (const candidate of candidates) {
-    const nextSourceKey = sourceKey(candidate.sourceLocale, candidate.targetLocale, candidate.sourceText);
+    const nextSourceKey = sourceKey(
+      candidate.sourceLocale,
+      candidate.targetLocale,
+      candidate.sourceText,
+    );
     if (candidate.externalKey && reservedExternal.has(candidate.externalKey)) {
       const existing = existingByExternalKey.get(candidate.externalKey);
       planned.push({ candidate, action: "update", existingId: existing?.id });
@@ -179,14 +185,23 @@ async function loadExistingEntries(memoryId: string, candidates: MemoryImportCan
   const existingByExternalKey = new Map<string, MemoryEntryRow>();
   const existingBySourceKey = new Map<string, MemoryEntryRow>();
   const externalKeys = [
-    ...new Set(candidates.map((candidate) => candidate.externalKey).filter((key): key is string => Boolean(key))),
+    ...new Set(
+      candidates
+        .map((candidate) => candidate.externalKey)
+        .filter((key): key is string => Boolean(key)),
+    ),
   ];
 
   for (const keys of chunk(externalKeys, TMX_LOOKUP_BATCH_SIZE)) {
     const rows = await db
       .select()
       .from(schema.memoryEntries)
-      .where(and(eq(schema.memoryEntries.memoryId, memoryId), inArray(schema.memoryEntries.externalKey, keys)));
+      .where(
+        and(
+          eq(schema.memoryEntries.memoryId, memoryId),
+          inArray(schema.memoryEntries.externalKey, keys),
+        ),
+      );
     for (const row of rows) {
       if (row.externalKey) {
         existingByExternalKey.set(row.externalKey, row);
@@ -218,7 +233,10 @@ async function loadExistingEntries(memoryId: string, candidates: MemoryImportCan
         ),
       );
     const wanted = new Set(
-      localePairs.map((pair) => `${pair.sourceLocale}\u0000${pair.targetLocale}\u0000${pair.normalizedSourceText}`),
+      localePairs.map(
+        (pair) =>
+          `${pair.sourceLocale}\u0000${pair.targetLocale}\u0000${pair.normalizedSourceText}`,
+      ),
     );
     for (const row of rows) {
       const key = `${row.sourceLocale}\u0000${row.targetLocale}\u0000${row.normalizedSourceText}`;
@@ -237,7 +255,9 @@ function toInsertValues(
   options: { createdByUserId?: string; importBatchId?: string },
 ): MemoryEntryInsert {
   const reviewStatus =
-    typeof candidate.metadata.reviewStatus === "string" ? candidate.metadata.reviewStatus : "approved";
+    typeof candidate.metadata.reviewStatus === "string"
+      ? candidate.metadata.reviewStatus
+      : "approved";
   return {
     memoryId: memory.id,
     sourceLocale: candidate.sourceLocale,
@@ -273,7 +293,11 @@ export async function applyMemoryImport(input: {
     input.memory.id,
     input.parsed.candidates,
   );
-  const planned = planImportActions(input.parsed.candidates, existingByExternalKey, existingBySourceKey);
+  const planned = planImportActions(
+    input.parsed.candidates,
+    existingByExternalKey,
+    existingBySourceKey,
+  );
   const preview = planned.slice(0, TMX_MAX_PREVIEW_ENTRIES).map((item) => ({
     sourceLocale: item.candidate.sourceLocale,
     targetLocale: item.candidate.targetLocale,
@@ -321,13 +345,21 @@ export async function applyMemoryImport(input: {
         importBatchId: input.importBatchId,
       }),
     );
-    const inserted = await db.insert(schema.memoryEntries).values(values).onConflictDoNothing().returning();
+    const inserted = await db
+      .insert(schema.memoryEntries)
+      .values(values)
+      .onConflictDoNothing()
+      .returning();
     createdEntries.push(...inserted);
     const insertedKeys = new Set(
       inserted.map((row) => sourceKey(row.sourceLocale, row.targetLocale, row.sourceText)),
     );
     for (const item of batch) {
-      const key = sourceKey(item.candidate.sourceLocale, item.candidate.targetLocale, item.candidate.sourceText);
+      const key = sourceKey(
+        item.candidate.sourceLocale,
+        item.candidate.targetLocale,
+        item.candidate.sourceText,
+      );
       if (!insertedKeys.has(key)) {
         skipped += 1;
         continue;
@@ -362,7 +394,10 @@ export async function applyMemoryImport(input: {
             metadata: item.candidate.metadata,
           })
           .where(
-            and(eq(schema.memoryEntries.id, item.existingId), eq(schema.memoryEntries.memoryId, input.memory.id)),
+            and(
+              eq(schema.memoryEntries.id, item.existingId),
+              eq(schema.memoryEntries.memoryId, input.memory.id),
+            ),
           )
           .returning();
         if (row) {

--- a/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.ts
@@ -15,6 +15,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 import { db, schema } from "@/lib/database";
 import type { Memory } from "@/lib/database/types";
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import { isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
@@ -22,6 +23,7 @@ import {
   TMX_DEFAULT_BATCH_SIZE,
   TMX_DEFAULT_MAX_UNITS,
   TMX_LOOKUP_BATCH_SIZE,
+  TMX_LOOKUP_CONCURRENCY,
   TMX_MAX_PREVIEW_ENTRIES,
   TMX_MAX_RESPONSE_ENTRIES,
 } from "./tmx/tmx-constants";
@@ -41,6 +43,12 @@ import type {
 
 type MemoryEntryRow = typeof schema.memoryEntries.$inferSelect;
 type MemoryEntryInsert = typeof schema.memoryEntries.$inferInsert;
+
+function importedReviewStatus(candidate: MemoryImportCandidate) {
+  return typeof candidate.metadata.reviewStatus === "string"
+    ? candidate.metadata.reviewStatus
+    : undefined;
+}
 
 export type ParsedMemoryImport = {
   format: "csv" | "tmx";
@@ -192,59 +200,71 @@ async function loadExistingEntries(memoryId: string, candidates: MemoryImportCan
     ),
   ];
 
-  for (const keys of chunk(externalKeys, TMX_LOOKUP_BATCH_SIZE)) {
-    const rows = await db
-      .select()
-      .from(schema.memoryEntries)
-      .where(
-        and(
-          eq(schema.memoryEntries.memoryId, memoryId),
-          inArray(schema.memoryEntries.externalKey, keys),
-        ),
-      );
-    for (const row of rows) {
-      if (row.externalKey) {
-        existingByExternalKey.set(row.externalKey, row);
+  await mapWithConcurrency(
+    chunk(externalKeys, TMX_LOOKUP_BATCH_SIZE),
+    TMX_LOOKUP_CONCURRENCY,
+    async (keys) => {
+      const rows = await db
+        .select()
+        .from(schema.memoryEntries)
+        .where(
+          and(
+            eq(schema.memoryEntries.memoryId, memoryId),
+            inArray(schema.memoryEntries.externalKey, keys),
+          ),
+        );
+      for (const row of rows) {
+        if (row.externalKey) {
+          existingByExternalKey.set(row.externalKey, row);
+        }
       }
-    }
-  }
+    },
+  );
 
-  for (const batch of chunk(candidates, TMX_LOOKUP_BATCH_SIZE)) {
-    const localePairs = batch.map((candidate) => ({
-      sourceLocale: candidate.sourceLocale,
-      targetLocale: candidate.targetLocale,
-      normalizedSourceText: normalizeTranslationMemorySourceText(candidate.sourceText),
-    }));
-    const sourceLocales = [...new Set(localePairs.map((pair) => pair.sourceLocale))];
-    const targetLocales = [...new Set(localePairs.map((pair) => pair.targetLocale))];
-    const normalized = [...new Set(localePairs.map((pair) => pair.normalizedSourceText))];
-    if (sourceLocales.length === 0) {
-      continue;
-    }
-    const rows = await db
-      .select()
-      .from(schema.memoryEntries)
-      .where(
-        and(
-          eq(schema.memoryEntries.memoryId, memoryId),
-          inArray(schema.memoryEntries.sourceLocale, sourceLocales),
-          inArray(schema.memoryEntries.targetLocale, targetLocales),
-          inArray(schema.memoryEntries.normalizedSourceText, normalized),
+  const unresolvedCandidates = candidates.filter(
+    (candidate) => !candidate.externalKey || !existingByExternalKey.has(candidate.externalKey),
+  );
+
+  await mapWithConcurrency(
+    chunk(unresolvedCandidates, TMX_LOOKUP_BATCH_SIZE),
+    TMX_LOOKUP_CONCURRENCY,
+    async (batch) => {
+      const localePairs = batch.map((candidate) => ({
+        sourceLocale: candidate.sourceLocale,
+        targetLocale: candidate.targetLocale,
+        normalizedSourceText: normalizeTranslationMemorySourceText(candidate.sourceText),
+      }));
+      const sourceLocales = [...new Set(localePairs.map((pair) => pair.sourceLocale))];
+      const targetLocales = [...new Set(localePairs.map((pair) => pair.targetLocale))];
+      const normalized = [...new Set(localePairs.map((pair) => pair.normalizedSourceText))];
+      if (sourceLocales.length === 0) {
+        return;
+      }
+      const rows = await db
+        .select()
+        .from(schema.memoryEntries)
+        .where(
+          and(
+            eq(schema.memoryEntries.memoryId, memoryId),
+            inArray(schema.memoryEntries.sourceLocale, sourceLocales),
+            inArray(schema.memoryEntries.targetLocale, targetLocales),
+            inArray(schema.memoryEntries.normalizedSourceText, normalized),
+          ),
+        );
+      const wanted = new Set(
+        localePairs.map(
+          (pair) =>
+            `${pair.sourceLocale}\u0000${pair.targetLocale}\u0000${pair.normalizedSourceText}`,
         ),
       );
-    const wanted = new Set(
-      localePairs.map(
-        (pair) =>
-          `${pair.sourceLocale}\u0000${pair.targetLocale}\u0000${pair.normalizedSourceText}`,
-      ),
-    );
-    for (const row of rows) {
-      const key = `${row.sourceLocale}\u0000${row.targetLocale}\u0000${row.normalizedSourceText}`;
-      if (wanted.has(key)) {
-        existingBySourceKey.set(key, row);
+      for (const row of rows) {
+        const key = `${row.sourceLocale}\u0000${row.targetLocale}\u0000${row.normalizedSourceText}`;
+        if (wanted.has(key)) {
+          existingBySourceKey.set(key, row);
+        }
       }
-    }
-  }
+    },
+  );
 
   return { existingByExternalKey, existingBySourceKey };
 }
@@ -254,10 +274,7 @@ function toInsertValues(
   candidate: MemoryImportCandidate,
   options: { createdByUserId?: string; importBatchId?: string },
 ): MemoryEntryInsert {
-  const reviewStatus =
-    typeof candidate.metadata.reviewStatus === "string"
-      ? candidate.metadata.reviewStatus
-      : "approved";
+  const reviewStatus = importedReviewStatus(candidate) ?? "approved";
   return {
     memoryId: memory.id,
     sourceLocale: candidate.sourceLocale,
@@ -389,6 +406,7 @@ export async function applyMemoryImport(input: {
             targetText: item.candidate.targetText,
             matchScore: item.candidate.matchScore,
             provenance: "import",
+            reviewStatus: importedReviewStatus(item.candidate) ?? "approved",
             externalKey: item.candidate.externalKey,
             importBatchId: input.importBatchId,
             metadata: item.candidate.metadata,

--- a/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.ts
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq, inArray } from "drizzle-orm";
+
+import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
+import { db, schema } from "@/lib/database";
+import type { Memory } from "@/lib/database/types";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
+
+import {
+  TMX_DEFAULT_BATCH_SIZE,
+  TMX_DEFAULT_MAX_UNITS,
+  TMX_LOOKUP_BATCH_SIZE,
+  TMX_MAX_PREVIEW_ENTRIES,
+  TMX_MAX_RESPONSE_ENTRIES,
+} from "./tmx/tmx-constants";
+import { parseTmxDocument } from "./tmx/parse-tmx";
+import {
+  documentToImportCandidates,
+  emptyImportReport,
+  finalizeImportReport,
+} from "./tmx/tmx-import";
+import type {
+  MemoryImportCandidate,
+  MemoryImportPreviewEntry,
+  MemoryImportReport,
+  TmxFatalError,
+  TmxIssue,
+} from "./tmx/tmx-types";
+
+type MemoryEntryRow = typeof schema.memoryEntries.$inferSelect;
+type MemoryEntryInsert = typeof schema.memoryEntries.$inferInsert;
+
+export type ParsedMemoryImport = {
+  format: "csv" | "tmx";
+  candidates: MemoryImportCandidate[];
+  issues: TmxIssue[];
+  totalRead: number;
+  headerSrclang?: string;
+};
+
+function chunk<T>(items: readonly T[], size: number) {
+  const batches: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
+}
+
+function sourceKey(sourceLocale: string, targetLocale: string, sourceText: string) {
+  return `${sourceLocale}\u0000${targetLocale}\u0000${normalizeTranslationMemorySourceText(sourceText)}`;
+}
+
+function parseCsvImport(content: string): ParsedMemoryImport {
+  const rows = parseCsvRows(content);
+  const [first, ...rest] = rows;
+  const hasHeader = first?.some((cell) => /source|target|locale|text/i.test(cell)) ?? false;
+  const dataRows = hasHeader ? rest : rows;
+  const issues: TmxIssue[] = [];
+  const candidates: MemoryImportCandidate[] = [];
+
+  dataRows.forEach((row, index) => {
+    const unitIndex = index + 1;
+    const [sourceLocale, targetLocale, sourceText, targetText, score] = row;
+    if (!sourceLocale || !targetLocale || !sourceText || !targetText) {
+      issues.push({
+        severity: "error",
+        code: "invalid_csv_row",
+        message: "Row is missing a source locale, target locale, source text, or target text",
+        unitIndex,
+      });
+      return;
+    }
+    const rawScore = score ? Number.parseInt(score, 10) : 100;
+    const matchScore = Number.isFinite(rawScore) ? Math.min(100, Math.max(0, rawScore)) : 100;
+    candidates.push({
+      sourceLocale: sourceLocale.trim(),
+      targetLocale: targetLocale.trim(),
+      sourceText,
+      targetText,
+      matchScore,
+      externalKey: null,
+      metadata: {},
+      unitIndex,
+      isVariant: false,
+    });
+  });
+
+  return {
+    format: "csv",
+    candidates,
+    issues,
+    totalRead: dataRows.length,
+  };
+}
+
+export function parseMemoryImportContent(
+  payload: { format: "csv" | "tmx"; content: string; maxUnits?: number },
+): Result<ParsedMemoryImport, TmxFatalError> {
+  if (payload.format === "csv") {
+    return ok(parseCsvImport(payload.content));
+  }
+
+  const parsed = parseTmxDocument(payload.content, {
+    maxUnits: payload.maxUnits ?? TMX_DEFAULT_MAX_UNITS,
+  });
+  if (isErr(parsed)) {
+    return parsed;
+  }
+
+  const mapped = documentToImportCandidates(parsed.value);
+  return ok({
+    format: "tmx",
+    candidates: mapped.candidates,
+    issues: mapped.issues,
+    totalRead: parsed.value.totalUnits,
+    headerSrclang: parsed.value.header.srclang,
+  });
+}
+
+type PlannedAction = {
+  candidate: MemoryImportCandidate;
+  action: "create" | "update" | "variant" | "skip";
+  existingId?: string;
+};
+
+function planImportActions(
+  candidates: MemoryImportCandidate[],
+  existingByExternalKey: Map<string, MemoryEntryRow>,
+  existingBySourceKey: Map<string, MemoryEntryRow>,
+): PlannedAction[] {
+  const planned: PlannedAction[] = [];
+  const reservedExternal = new Set(existingByExternalKey.keys());
+  const reservedSource = new Set(existingBySourceKey.keys());
+
+  for (const candidate of candidates) {
+    const nextSourceKey = sourceKey(candidate.sourceLocale, candidate.targetLocale, candidate.sourceText);
+    if (candidate.externalKey && reservedExternal.has(candidate.externalKey)) {
+      const existing = existingByExternalKey.get(candidate.externalKey);
+      planned.push({ candidate, action: "update", existingId: existing?.id });
+      reservedSource.add(nextSourceKey);
+      continue;
+    }
+    if (reservedSource.has(nextSourceKey)) {
+      const existing = existingBySourceKey.get(nextSourceKey);
+      if (candidate.externalKey && existing && !existing.externalKey) {
+        planned.push({ candidate, action: "update", existingId: existing.id });
+        reservedExternal.add(candidate.externalKey);
+        continue;
+      }
+      planned.push({ candidate, action: "skip" });
+      continue;
+    }
+    reservedSource.add(nextSourceKey);
+    if (candidate.externalKey) {
+      reservedExternal.add(candidate.externalKey);
+    }
+    planned.push({
+      candidate,
+      action: candidate.isVariant ? "variant" : "create",
+    });
+  }
+
+  return planned;
+}
+
+async function loadExistingEntries(memoryId: string, candidates: MemoryImportCandidate[]) {
+  const existingByExternalKey = new Map<string, MemoryEntryRow>();
+  const existingBySourceKey = new Map<string, MemoryEntryRow>();
+  const externalKeys = [
+    ...new Set(candidates.map((candidate) => candidate.externalKey).filter((key): key is string => Boolean(key))),
+  ];
+
+  for (const keys of chunk(externalKeys, TMX_LOOKUP_BATCH_SIZE)) {
+    const rows = await db
+      .select()
+      .from(schema.memoryEntries)
+      .where(and(eq(schema.memoryEntries.memoryId, memoryId), inArray(schema.memoryEntries.externalKey, keys)));
+    for (const row of rows) {
+      if (row.externalKey) {
+        existingByExternalKey.set(row.externalKey, row);
+      }
+    }
+  }
+
+  for (const batch of chunk(candidates, TMX_LOOKUP_BATCH_SIZE)) {
+    const localePairs = batch.map((candidate) => ({
+      sourceLocale: candidate.sourceLocale,
+      targetLocale: candidate.targetLocale,
+      normalizedSourceText: normalizeTranslationMemorySourceText(candidate.sourceText),
+    }));
+    const sourceLocales = [...new Set(localePairs.map((pair) => pair.sourceLocale))];
+    const targetLocales = [...new Set(localePairs.map((pair) => pair.targetLocale))];
+    const normalized = [...new Set(localePairs.map((pair) => pair.normalizedSourceText))];
+    if (sourceLocales.length === 0) {
+      continue;
+    }
+    const rows = await db
+      .select()
+      .from(schema.memoryEntries)
+      .where(
+        and(
+          eq(schema.memoryEntries.memoryId, memoryId),
+          inArray(schema.memoryEntries.sourceLocale, sourceLocales),
+          inArray(schema.memoryEntries.targetLocale, targetLocales),
+          inArray(schema.memoryEntries.normalizedSourceText, normalized),
+        ),
+      );
+    const wanted = new Set(
+      localePairs.map((pair) => `${pair.sourceLocale}\u0000${pair.targetLocale}\u0000${pair.normalizedSourceText}`),
+    );
+    for (const row of rows) {
+      const key = `${row.sourceLocale}\u0000${row.targetLocale}\u0000${row.normalizedSourceText}`;
+      if (wanted.has(key)) {
+        existingBySourceKey.set(key, row);
+      }
+    }
+  }
+
+  return { existingByExternalKey, existingBySourceKey };
+}
+
+function toInsertValues(
+  memory: Memory,
+  candidate: MemoryImportCandidate,
+  options: { createdByUserId?: string; importBatchId?: string },
+): MemoryEntryInsert {
+  const reviewStatus =
+    typeof candidate.metadata.reviewStatus === "string" ? candidate.metadata.reviewStatus : "approved";
+  return {
+    memoryId: memory.id,
+    sourceLocale: candidate.sourceLocale,
+    targetLocale: candidate.targetLocale,
+    sourceText: candidate.sourceText,
+    normalizedSourceText: normalizeTranslationMemorySourceText(candidate.sourceText),
+    targetText: candidate.targetText,
+    matchScore: candidate.matchScore,
+    provenance: "import",
+    reviewStatus,
+    externalKey: candidate.externalKey,
+    createdByUserId: options.createdByUserId,
+    importBatchId: options.importBatchId,
+    metadata: candidate.metadata,
+  };
+}
+
+export type AppliedMemoryImport = {
+  report: MemoryImportReport;
+  preview: MemoryImportPreviewEntry[];
+  createdEntries: MemoryEntryRow[];
+  importBatchId: string | null;
+};
+
+export async function applyMemoryImport(input: {
+  memory: Memory;
+  parsed: ParsedMemoryImport;
+  dryRun?: boolean;
+  createdByUserId?: string;
+  importBatchId?: string;
+}): Promise<AppliedMemoryImport> {
+  const { existingByExternalKey, existingBySourceKey } = await loadExistingEntries(
+    input.memory.id,
+    input.parsed.candidates,
+  );
+  const planned = planImportActions(input.parsed.candidates, existingByExternalKey, existingBySourceKey);
+  const preview = planned.slice(0, TMX_MAX_PREVIEW_ENTRIES).map((item) => ({
+    sourceLocale: item.candidate.sourceLocale,
+    targetLocale: item.candidate.targetLocale,
+    sourceText: item.candidate.sourceText,
+    targetText: item.candidate.targetText,
+    externalKey: item.candidate.externalKey,
+    tuid: item.candidate.tuid,
+    action: item.action,
+  }));
+
+  let created = 0;
+  let updated = 0;
+  let variantCreated = 0;
+  let skipped = planned.filter((item) => item.action === "skip").length;
+  const issues = [...input.parsed.issues];
+
+  if (input.dryRun) {
+    created = planned.filter((item) => item.action === "create").length;
+    variantCreated = planned.filter((item) => item.action === "variant").length;
+    updated = planned.filter((item) => item.action === "update").length;
+    return {
+      report: finalizeImportReport({
+        totalRead: input.parsed.totalRead,
+        created,
+        updated,
+        variantCreated,
+        skipped,
+        issues,
+        headerSrclang: input.parsed.headerSrclang,
+      }),
+      preview,
+      createdEntries: [],
+      importBatchId: null,
+    };
+  }
+
+  const createdEntries: MemoryEntryRow[] = [];
+  const inserts = planned.filter((item) => item.action === "create" || item.action === "variant");
+  const updates = planned.filter((item) => item.action === "update" && item.existingId);
+
+  for (const batch of chunk(inserts, TMX_DEFAULT_BATCH_SIZE)) {
+    const values = batch.map((item) =>
+      toInsertValues(input.memory, item.candidate, {
+        createdByUserId: input.createdByUserId,
+        importBatchId: input.importBatchId,
+      }),
+    );
+    const inserted = await db.insert(schema.memoryEntries).values(values).onConflictDoNothing().returning();
+    createdEntries.push(...inserted);
+    const insertedKeys = new Set(
+      inserted.map((row) => sourceKey(row.sourceLocale, row.targetLocale, row.sourceText)),
+    );
+    for (const item of batch) {
+      const key = sourceKey(item.candidate.sourceLocale, item.candidate.targetLocale, item.candidate.sourceText);
+      if (!insertedKeys.has(key)) {
+        skipped += 1;
+        continue;
+      }
+      if (item.action === "variant") {
+        variantCreated += 1;
+      } else {
+        created += 1;
+      }
+    }
+  }
+
+  for (const batch of chunk(updates, TMX_DEFAULT_BATCH_SIZE)) {
+    for (const item of batch) {
+      if (!item.existingId) {
+        skipped += 1;
+        continue;
+      }
+      try {
+        const [row] = await db
+          .update(schema.memoryEntries)
+          .set({
+            sourceLocale: item.candidate.sourceLocale,
+            targetLocale: item.candidate.targetLocale,
+            sourceText: item.candidate.sourceText,
+            normalizedSourceText: normalizeTranslationMemorySourceText(item.candidate.sourceText),
+            targetText: item.candidate.targetText,
+            matchScore: item.candidate.matchScore,
+            provenance: "import",
+            externalKey: item.candidate.externalKey,
+            importBatchId: input.importBatchId,
+            metadata: item.candidate.metadata,
+          })
+          .where(
+            and(eq(schema.memoryEntries.id, item.existingId), eq(schema.memoryEntries.memoryId, input.memory.id)),
+          )
+          .returning();
+        if (row) {
+          updated += 1;
+        } else {
+          skipped += 1;
+        }
+      } catch {
+        issues.push({
+          severity: "error",
+          code: "update_conflict",
+          message: "Could not update an existing entry without creating a duplicate locale pair",
+          unitIndex: item.candidate.unitIndex,
+          tuid: item.candidate.tuid,
+        });
+      }
+    }
+  }
+
+  return {
+    report: finalizeImportReport({
+      totalRead: input.parsed.totalRead,
+      created,
+      updated,
+      variantCreated,
+      skipped,
+      issues,
+      headerSrclang: input.parsed.headerSrclang,
+    }),
+    preview,
+    createdEntries: createdEntries.slice(0, TMX_MAX_RESPONSE_ENTRIES),
+    importBatchId: input.importBatchId ?? null,
+  };
+}
+
+export function emptyParsedImport(): ParsedMemoryImport {
+  return {
+    format: "tmx",
+    candidates: [],
+    issues: [],
+    totalRead: 0,
+  };
+}
+
+export function fatalImportReport(error: TmxFatalError): MemoryImportReport {
+  return emptyImportReport([
+    {
+      severity: "error",
+      code: error.code,
+      message: error.message,
+    },
+  ]);
+}

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/fixtures/tmx-1.4-inline-codes.tmx
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/fixtures/tmx-1.4-inline-codes.tmx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tmx version="1.4">
+  <header creationtool="Hyperlocalise" creationtoolversion="1" segtype="sentence" o-tmf="Hyperlocalise" adminlang="en" srclang="en-US" datatype="plaintext"/>
+  <body>
+    <tu tuid="inline-1" creationdate="20240101T010101Z" creationid="alice">
+      <prop type="x-context">homepage hero</prop>
+      <note>Keep the placeholder.</note>
+      <tuv xml:lang="en-US"><seg>Hello <ph x="1"/> world &amp; friends</seg></tuv>
+      <tuv xml:lang="fr-FR"><seg>Bonjour <ph x="1"/> le monde &amp; les amis</seg></tuv>
+    </tu>
+  </body>
+</tmx>

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/fixtures/tmx-crowdin-like.tmx
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/fixtures/tmx-crowdin-like.tmx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tmx version="1.4">
+  <header creationtool="crowdin" creationtoolversion="1" segtype="sentence" o-tmf="crowdin" adminlang="en" srclang="en" datatype="plaintext"/>
+  <body>
+    <tu tuid="9">
+      <tuv xml:lang="en"><seg>Checkout &lt;now&gt;</seg></tuv>
+      <tuv xml:lang="fr"><seg>Commander &amp; payer</seg></tuv>
+    </tu>
+  </body>
+</tmx>

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/fixtures/tmx-phrase-like.tmx
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/fixtures/tmx-phrase-like.tmx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tmx version="1.4">
+  <header creationtool="Phrase" creationtoolversion="1" segtype="sentence" o-tmf="Phrase" adminlang="en-US" srclang="en-US" datatype="plaintext"/>
+  <body>
+    <tu tuid="seg-2" creationdate="20240101T010101Z" changedate="20240102T010101Z" creationid="alice" changeid="bob">
+      <tuv lang="fr-FR"><seg>Paiement</seg></tuv>
+      <tuv lang="en-US"><seg>Checkout</seg></tuv>
+      <tuv lang="de-DE"><seg>Kasse</seg></tuv>
+    </tu>
+    <tu tuid="seg-1">
+      <tuv xml:lang="en-US"><seg>Cart</seg></tuv>
+      <tuv xml:lang="fr-FR"><seg>Panier</seg></tuv>
+    </tu>
+  </body>
+</tmx>

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/parse-tmx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/parse-tmx.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { isErr, isOk } from "@/lib/primitives/result/results";
+
+import { parseTmxDocument } from "./parse-tmx";
+import { documentToImportCandidates } from "./tmx-import";
+
+const fixtureDir = dirname(fileURLToPath(import.meta.url));
+
+function readFixture(name: string) {
+  return readFileSync(join(fixtureDir, "fixtures", name), "utf8");
+}
+
+describe("parseTmxDocument", () => {
+  it("preserves entities, inline codes, header srclang, notes, and context", () => {
+    const parsed = parseTmxDocument(readFixture("tmx-1.4-inline-codes.tmx"));
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value.header.srclang).toBe("en-US");
+    expect(parsed.value.totalUnits).toBe(1);
+    const unit = parsed.value.units[0];
+    expect(unit?.tuid).toBe("inline-1");
+    expect(unit?.notes).toEqual(["Keep the placeholder."]);
+    expect(unit?.properties).toEqual([{ type: "x-context", value: "homepage hero" }]);
+    expect(unit?.variants[0]?.segment).toBe('Hello <ph x="1"/> world & friends');
+    expect(unit?.variants[1]?.segment).toBe('Bonjour <ph x="1"/> le monde & les amis');
+  });
+
+  it("reads Phrase-style lang attributes and multilingual units", () => {
+    const parsed = parseTmxDocument(readFixture("tmx-phrase-like.tmx"));
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    const mapped = documentToImportCandidates(parsed.value);
+    const pairs = mapped.candidates.map((candidate) => `${candidate.sourceLocale}->${candidate.targetLocale}`);
+    expect(pairs).toEqual(["en-US->fr-FR", "en-US->de-DE", "en-US->fr-FR"]);
+    expect(mapped.candidates.filter((candidate) => candidate.isVariant)).toHaveLength(1);
+    expect(mapped.candidates[0]?.sourceText).toBe("Checkout");
+    expect(mapped.candidates[0]?.externalKey).toBe("tmx:seg-2:en-US:fr-FR");
+  });
+
+  it("decodes Crowdin-style escaped markup without flattening", () => {
+    const parsed = parseTmxDocument(readFixture("tmx-crowdin-like.tmx"));
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    const mapped = documentToImportCandidates(parsed.value);
+    expect(mapped.candidates[0]).toMatchObject({
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Checkout <now>",
+      targetText: "Commander & payer",
+    });
+  });
+
+  it("rejects DTD declarations", () => {
+    const parsed = parseTmxDocument(
+      `<?xml version="1.0"?><!DOCTYPE tmx [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><tmx version="1.4"><body/></tmx>`,
+    );
+    expect(isErr(parsed)).toBe(true);
+    if (!isErr(parsed)) return;
+    expect(parsed.error.code).toBe("doctype_forbidden");
+  });
+
+  it("rejects unsupported encodings", () => {
+    const parsed = parseTmxDocument(
+      `<?xml version="1.0" encoding="ISO-8859-1"?><tmx version="1.4"><body><tu><tuv xml:lang="en"><seg>A</seg></tuv><tuv xml:lang="fr"><seg>B</seg></tuv></tu></body></tmx>`,
+    );
+    expect(isErr(parsed)).toBe(true);
+    if (!isErr(parsed)) return;
+    expect(parsed.error.code).toBe("unsupported_encoding");
+  });
+
+  it("rejects malformed XML", () => {
+    const parsed = parseTmxDocument(`<tmx version="1.4"><body><tu>`);
+    expect(isErr(parsed)).toBe(true);
+    if (!isErr(parsed)) return;
+    expect(parsed.error.code).toBe("malformed_xml");
+  });
+
+  it("rejects files over the documented unit limit instead of truncating", () => {
+    const units = Array.from({ length: 4 }, (_, index) => {
+      return `<tu tuid="u${index}"><tuv xml:lang="en"><seg>S${index}</seg></tuv><tuv xml:lang="fr"><seg>T${index}</seg></tuv></tu>`;
+    }).join("");
+    const parsed = parseTmxDocument(
+      `<?xml version="1.0" encoding="UTF-8"?><tmx version="1.4"><header srclang="en" creationtool="t" creationtoolversion="1" segtype="sentence" o-tmf="t" adminlang="en" datatype="plaintext"/><body>${units}</body></tmx>`,
+      { maxUnits: 3 },
+    );
+    expect(isErr(parsed)).toBe(true);
+    if (!isErr(parsed)) return;
+    expect(parsed.error).toMatchObject({
+      code: "unit_limit_exceeded",
+      maxUnits: 3,
+      unitCount: 4,
+    });
+  });
+
+  it("skips oversized segments with a unit-level error", () => {
+    const huge = "x".repeat(20);
+    const parsed = parseTmxDocument(
+      `<tmx version="1.4"><header srclang="en" creationtool="t" creationtoolversion="1" segtype="sentence" o-tmf="t" adminlang="en" datatype="plaintext"/><body><tu tuid="big"><tuv xml:lang="en"><seg>${huge}</seg></tuv><tuv xml:lang="fr"><seg>ok</seg></tuv></tu></body></tmx>`,
+      { maxSegmentChars: 10 },
+    );
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+    expect(parsed.value.units).toEqual([]);
+    expect(parsed.value.issues).toEqual([
+      expect.objectContaining({ code: "oversized_segment", severity: "error", tuid: "big" }),
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/parse-tmx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/parse-tmx.test.ts
@@ -49,7 +49,9 @@ describe("parseTmxDocument", () => {
     if (!isOk(parsed)) return;
 
     const mapped = documentToImportCandidates(parsed.value);
-    const pairs = mapped.candidates.map((candidate) => `${candidate.sourceLocale}->${candidate.targetLocale}`);
+    const pairs = mapped.candidates.map(
+      (candidate) => `${candidate.sourceLocale}->${candidate.targetLocale}`,
+    );
     expect(pairs).toEqual(["en-US->fr-FR", "en-US->de-DE", "en-US->fr-FR"]);
     expect(mapped.candidates.filter((candidate) => candidate.isVariant)).toHaveLength(1);
     expect(mapped.candidates[0]?.sourceText).toBe("Checkout");

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/parse-tmx.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/parse-tmx.ts
@@ -1,0 +1,646 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+import {
+  TMX_DEFAULT_MAX_UNITS,
+  TMX_MAX_SEGMENT_CHARS,
+  TMX_SUPPORTED_ENCODINGS,
+  TMX_UNSUPPORTED_ELEMENTS,
+} from "./tmx-constants";
+import type {
+  TmxDocument,
+  TmxFatalError,
+  TmxHeader,
+  TmxIssue,
+  TmxProperty,
+  TmxUnit,
+  TmxVariant,
+} from "./tmx-types";
+
+const NAME_START = /[A-Za-z:_]/;
+const NAME_CHAR = /[A-Za-z0-9:_.-]/;
+
+type StartTag = {
+  name: string;
+  localName: string;
+  attrs: Record<string, string>;
+  selfClosing: boolean;
+};
+
+class XmlParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "XmlParseError";
+  }
+}
+
+class XmlReader {
+  readonly xml: string;
+  index = 0;
+
+  constructor(xml: string) {
+    this.xml = xml.charCodeAt(0) === 0xfeff ? xml.slice(1) : xml;
+  }
+
+  get remaining() {
+    return this.xml.length - this.index;
+  }
+
+  eof() {
+    return this.index >= this.xml.length;
+  }
+
+  peek() {
+    return this.xml[this.index] ?? "";
+  }
+
+  startsWith(value: string) {
+    return this.xml.startsWith(value, this.index);
+  }
+
+  startsWithInsensitive(value: string) {
+    return this.xml.slice(this.index, this.index + value.length).toLowerCase() === value.toLowerCase();
+  }
+
+  skipWhitespace() {
+    while (!this.eof() && /\s/.test(this.peek())) {
+      this.index += 1;
+    }
+  }
+
+  advance(count = 1) {
+    this.index += count;
+  }
+
+  expect(value: string) {
+    if (!this.startsWith(value)) {
+      throw new XmlParseError(`expected "${value}"`);
+    }
+    this.advance(value.length);
+  }
+
+  readUntil(needle: string) {
+    const start = this.index;
+    const found = this.xml.indexOf(needle, this.index);
+    if (found === -1) {
+      throw new XmlParseError(`unterminated "${needle}"`);
+    }
+    this.index = found + needle.length;
+    return this.xml.slice(start, found);
+  }
+
+  readName() {
+    if (!NAME_START.test(this.peek())) {
+      throw new XmlParseError("expected a name");
+    }
+    const start = this.index;
+    this.advance();
+    while (!this.eof() && NAME_CHAR.test(this.peek())) {
+      this.advance();
+    }
+    return this.xml.slice(start, this.index);
+  }
+
+  readDeclaration(): { version?: string; encoding?: string } {
+    this.expect("<?xml");
+    const body = this.readUntil("?>");
+    const version = /version\s*=\s*["']([^"']+)["']/i.exec(body)?.[1];
+    const encoding = /encoding\s*=\s*["']([^"']+)["']/i.exec(body)?.[1];
+    return { version, encoding };
+  }
+
+  skipProcessingInstruction() {
+    this.expect("<?");
+    this.readUntil("?>");
+  }
+
+  skipComment() {
+    this.expect("<!--");
+    this.readUntil("-->");
+  }
+
+  readCdata() {
+    this.expect("<![CDATA[");
+    return this.readUntil("]]>");
+  }
+
+  readDoctype() {
+    this.expect("<!");
+    return this.readUntil(">");
+  }
+
+  readQuotedValue() {
+    const quote = this.peek();
+    if (quote !== '"' && quote !== "'") {
+      throw new XmlParseError("expected a quoted attribute value");
+    }
+    this.advance();
+    const start = this.index;
+    const end = this.xml.indexOf(quote, this.index);
+    if (end === -1) {
+      throw new XmlParseError("unterminated attribute value");
+    }
+    this.index = end + 1;
+    return decodeXmlEntities(this.xml.slice(start, end));
+  }
+
+  readStartTag(): StartTag {
+    this.expect("<");
+    const name = this.readName();
+    const attrs: Record<string, string> = {};
+    this.skipWhitespace();
+    while (!this.eof() && this.peek() !== ">" && !this.startsWith("/>")) {
+      const attrName = this.readName();
+      this.skipWhitespace();
+      this.expect("=");
+      this.skipWhitespace();
+      attrs[attrName] = this.readQuotedValue();
+      this.skipWhitespace();
+    }
+    const selfClosing = this.startsWith("/>");
+    if (selfClosing) {
+      this.advance(2);
+    } else {
+      this.expect(">");
+    }
+    return {
+      name,
+      localName: localName(name),
+      attrs,
+      selfClosing,
+    };
+  }
+
+  readEndTag() {
+    this.expect("</");
+    const name = this.readName();
+    this.skipWhitespace();
+    this.expect(">");
+    return { name, localName: localName(name) };
+  }
+
+  readText() {
+    const start = this.index;
+    const next = this.xml.indexOf("<", this.index);
+    this.index = next === -1 ? this.xml.length : next;
+    return decodeXmlEntities(this.xml.slice(start, this.index));
+  }
+
+  skipElement(start: StartTag) {
+    if (start.selfClosing) {
+      return;
+    }
+    let depth = 1;
+    while (!this.eof() && depth > 0) {
+      if (this.startsWith("<!--")) {
+        this.skipComment();
+        continue;
+      }
+      if (this.startsWith("<![CDATA[")) {
+        this.readCdata();
+        continue;
+      }
+      if (this.startsWith("</")) {
+        this.readEndTag();
+        depth -= 1;
+        continue;
+      }
+      if (this.startsWith("<")) {
+        const child = this.readStartTag();
+        if (!child.selfClosing) {
+          depth += 1;
+        }
+        continue;
+      }
+      this.readText();
+    }
+    if (depth !== 0) {
+      throw new XmlParseError(`unclosed <${start.name}>`);
+    }
+  }
+}
+
+function localName(name: string) {
+  const separator = name.lastIndexOf(":");
+  return (separator === -1 ? name : name.slice(separator + 1)).toLowerCase();
+}
+
+function decodeXmlEntities(value: string) {
+  return value.replace(/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9._-]*);/g, (match, entity: string) => {
+    if (entity === "amp") return "&";
+    if (entity === "lt") return "<";
+    if (entity === "gt") return ">";
+    if (entity === "quot") return '"';
+    if (entity === "apos") return "'";
+    if (entity.startsWith("#x") || entity.startsWith("#X")) {
+      const codePoint = Number.parseInt(entity.slice(2), 16);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
+    }
+    if (entity.startsWith("#")) {
+      const codePoint = Number.parseInt(entity.slice(1), 10);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
+    }
+    return match;
+  });
+}
+
+function attr(attrs: Record<string, string>, name: string) {
+  if (attrs[name] !== undefined) {
+    return attrs[name];
+  }
+  const wanted = name.toLowerCase();
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key.toLowerCase() === wanted || localName(key) === wanted) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function languageAttr(attrs: Record<string, string>) {
+  return attr(attrs, "xml:lang") ?? attr(attrs, "lang");
+}
+
+function serializeStartTag(tag: StartTag) {
+  const attributes = Object.entries(tag.attrs)
+    .map(([name, value]) => ` ${name}="${escapeXmlAttr(value)}"`)
+    .join("");
+  return `<${tag.name}${attributes}${tag.selfClosing ? "/>" : ">"}`;
+}
+
+function escapeXmlAttr(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;");
+}
+
+function readElementText(reader: XmlReader, start: StartTag) {
+  if (start.selfClosing) {
+    return "";
+  }
+  let text = "";
+  while (!reader.eof()) {
+    if (reader.startsWith("<!--")) {
+      reader.skipComment();
+      continue;
+    }
+    if (reader.startsWith("<![CDATA[")) {
+      text += reader.readCdata();
+      continue;
+    }
+    if (reader.startsWith("</")) {
+      const end = reader.readEndTag();
+      if (end.localName !== start.localName) {
+        throw new XmlParseError(`expected </${start.name}>`);
+      }
+      return text;
+    }
+    if (reader.startsWith("<")) {
+      reader.skipElement(reader.readStartTag());
+      continue;
+    }
+    text += reader.readText();
+  }
+  throw new XmlParseError(`unclosed <${start.name}>`);
+}
+
+function readSegContent(reader: XmlReader, start: StartTag) {
+  if (start.selfClosing) {
+    return "";
+  }
+  let content = "";
+  let depth = 1;
+  while (!reader.eof() && depth > 0) {
+    if (reader.startsWith("<!--")) {
+      reader.skipComment();
+      continue;
+    }
+    if (reader.startsWith("<![CDATA[")) {
+      content += reader.readCdata();
+      continue;
+    }
+    if (reader.startsWith("</")) {
+      const end = reader.readEndTag();
+      depth -= 1;
+      if (depth > 0) {
+        content += `</${end.name}>`;
+      } else if (end.localName !== "seg") {
+        throw new XmlParseError("expected </seg>");
+      }
+      continue;
+    }
+    if (reader.startsWith("<")) {
+      const child = reader.readStartTag();
+      content += serializeStartTag(child);
+      if (!child.selfClosing) {
+        depth += 1;
+      }
+      continue;
+    }
+    content += reader.readText();
+  }
+  if (depth !== 0) {
+    throw new XmlParseError("unclosed <seg>");
+  }
+  return content;
+}
+
+function readPropertiesAndNotes(
+  reader: XmlReader,
+  start: StartTag,
+  onChild: (child: StartTag) => boolean,
+) {
+  const properties: TmxProperty[] = [];
+  const notes: string[] = [];
+  const skipped: string[] = [];
+  if (start.selfClosing) {
+    return { properties, notes, skipped };
+  }
+  while (!reader.eof()) {
+    reader.skipWhitespace();
+    if (reader.startsWith("<!--")) {
+      reader.skipComment();
+      continue;
+    }
+    if (reader.startsWith("<![CDATA[")) {
+      reader.readCdata();
+      continue;
+    }
+    if (reader.startsWith("</")) {
+      const end = reader.readEndTag();
+      if (end.localName !== start.localName) {
+        throw new XmlParseError(`expected </${start.name}>`);
+      }
+      return { properties, notes, skipped };
+    }
+    if (!reader.startsWith("<")) {
+      reader.readText();
+      continue;
+    }
+    const child = reader.readStartTag();
+    if (child.localName === "prop") {
+      const type = attr(child.attrs, "type")?.trim() ?? "";
+      properties.push({ type, value: readElementText(reader, child) });
+      continue;
+    }
+    if (child.localName === "note") {
+      notes.push(readElementText(reader, child));
+      continue;
+    }
+    if (onChild(child)) {
+      continue;
+    }
+    skipped.push(child.localName);
+    reader.skipElement(child);
+  }
+  throw new XmlParseError(`unclosed <${start.name}>`);
+}
+
+function parseHeader(reader: XmlReader, start: StartTag): TmxHeader {
+  const { properties, notes } = readPropertiesAndNotes(reader, start, () => false);
+  return {
+    srclang: attr(start.attrs, "srclang"),
+    adminlang: attr(start.attrs, "adminlang"),
+    creationtool: attr(start.attrs, "creationtool"),
+    creationtoolversion: attr(start.attrs, "creationtoolversion"),
+    segtype: attr(start.attrs, "segtype"),
+    oTmf: attr(start.attrs, "o-tmf"),
+    datatype: attr(start.attrs, "datatype"),
+    creationdate: attr(start.attrs, "creationdate"),
+    creationid: attr(start.attrs, "creationid"),
+    changedate: attr(start.attrs, "changedate"),
+    changeid: attr(start.attrs, "changeid"),
+    properties,
+    notes,
+  };
+}
+
+function parseVariant(reader: XmlReader, start: StartTag): TmxVariant {
+  let segment = "";
+  const { properties, notes } = readPropertiesAndNotes(reader, start, (child) => {
+    if (child.localName === "seg") {
+      segment = readSegContent(reader, child);
+      return true;
+    }
+    return false;
+  });
+  return {
+    language: languageAttr(start.attrs)?.trim() ?? "",
+    segment,
+    properties,
+    notes,
+    creationdate: attr(start.attrs, "creationdate"),
+    changedate: attr(start.attrs, "changedate"),
+    creationid: attr(start.attrs, "creationid"),
+    changeid: attr(start.attrs, "changeid"),
+  };
+}
+
+function parseUnit(reader: XmlReader, start: StartTag, unitIndex: number): TmxUnit {
+  const variants: TmxVariant[] = [];
+  const { properties, notes } = readPropertiesAndNotes(reader, start, (child) => {
+    if (child.localName === "tuv") {
+      variants.push(parseVariant(reader, child));
+      return true;
+    }
+    return false;
+  });
+  return {
+    unitIndex,
+    tuid: attr(start.attrs, "tuid")?.trim() || undefined,
+    srclang: attr(start.attrs, "srclang")?.trim() || undefined,
+    creationdate: attr(start.attrs, "creationdate"),
+    changedate: attr(start.attrs, "changedate"),
+    creationid: attr(start.attrs, "creationid"),
+    changeid: attr(start.attrs, "changeid"),
+    properties,
+    notes,
+    variants,
+  };
+}
+
+export type ParseTmxOptions = {
+  maxUnits?: number;
+  maxSegmentChars?: number;
+};
+
+export function parseTmxDocument(
+  xml: string,
+  options: ParseTmxOptions = {},
+): Result<TmxDocument, TmxFatalError> {
+  const maxUnits = options.maxUnits ?? TMX_DEFAULT_MAX_UNITS;
+  const maxSegmentChars = options.maxSegmentChars ?? TMX_MAX_SEGMENT_CHARS;
+  if (xml.length === 0) {
+    return err({ code: "empty_tmx", message: "TMX content is empty" });
+  }
+
+  const reader = new XmlReader(xml);
+  const issues: TmxIssue[] = [];
+  let encoding: string | undefined;
+  let version: string | undefined;
+  let header: TmxHeader = { properties: [], notes: [] };
+  const units: TmxUnit[] = [];
+  let totalUnits = 0;
+
+  try {
+    reader.skipWhitespace();
+    if (reader.startsWith("<?xml")) {
+      const declaration = reader.readDeclaration();
+      encoding = declaration.encoding;
+      if (encoding && !TMX_SUPPORTED_ENCODINGS.has(encoding.trim().toLowerCase())) {
+        return err({
+          code: "unsupported_encoding",
+          message: `Unsupported TMX encoding "${encoding}". Use UTF-8.`,
+        });
+      }
+    }
+
+    while (!reader.eof()) {
+      reader.skipWhitespace();
+      if (reader.eof()) {
+        break;
+      }
+      if (reader.startsWith("<!--")) {
+        reader.skipComment();
+        continue;
+      }
+      if (reader.startsWith("<?")) {
+        reader.skipProcessingInstruction();
+        continue;
+      }
+      if (reader.startsWithInsensitive("<!DOCTYPE") || reader.startsWith("<!ENTITY")) {
+        return err({
+          code: "doctype_forbidden",
+          message: "TMX documents may not include a DTD or entity declarations",
+        });
+      }
+      if (reader.startsWith("<!")) {
+        reader.readDoctype();
+        continue;
+      }
+      if (!reader.startsWith("<")) {
+        reader.readText();
+        continue;
+      }
+      const root = reader.readStartTag();
+      if (root.localName !== "tmx") {
+        throw new XmlParseError("root element must be <tmx>");
+      }
+      version = attr(root.attrs, "version");
+      if (version && !version.startsWith("1.")) {
+        issues.push({
+          severity: "warning",
+          code: "unsupported_tmx_version",
+          message: `TMX version "${version}" is not 1.4-compatible; parsing will continue`,
+        });
+      }
+      if (root.selfClosing) {
+        break;
+      }
+      while (!reader.eof()) {
+        reader.skipWhitespace();
+        if (reader.startsWith("<!--")) {
+          reader.skipComment();
+          continue;
+        }
+        if (reader.startsWith("</")) {
+          reader.readEndTag();
+          break;
+        }
+        if (!reader.startsWith("<")) {
+          reader.readText();
+          continue;
+        }
+        const child = reader.readStartTag();
+        if (child.localName === "header") {
+          header = parseHeader(reader, child);
+          continue;
+        }
+        if (child.localName === "body") {
+          if (child.selfClosing) {
+            continue;
+          }
+          while (!reader.eof()) {
+            reader.skipWhitespace();
+            if (reader.startsWith("<!--")) {
+              reader.skipComment();
+              continue;
+            }
+            if (reader.startsWith("</")) {
+              reader.readEndTag();
+              break;
+            }
+            if (!reader.startsWith("<")) {
+              reader.readText();
+              continue;
+            }
+            const unitStart = reader.readStartTag();
+            if (unitStart.localName !== "tu") {
+              if (TMX_UNSUPPORTED_ELEMENTS.includes(unitStart.localName as (typeof TMX_UNSUPPORTED_ELEMENTS)[number])) {
+                issues.push({
+                  severity: "warning",
+                  code: "unsupported_element",
+                  message: `<${unitStart.localName}> is not imported`,
+                });
+              }
+              reader.skipElement(unitStart);
+              continue;
+            }
+            totalUnits += 1;
+            if (totalUnits > maxUnits) {
+              return err({
+                code: "unit_limit_exceeded",
+                message: `TMX contains more than ${maxUnits} translation units. Split the file or raise the documented limit.`,
+                unitCount: totalUnits,
+                maxUnits,
+              });
+            }
+            const unit = parseUnit(reader, unitStart, totalUnits);
+            const oversized = unit.variants.some((variant) => variant.segment.length > maxSegmentChars);
+            if (oversized) {
+              issues.push({
+                severity: "error",
+                code: "oversized_segment",
+                message: `A segment exceeded the ${maxSegmentChars} character limit`,
+                unitIndex: unit.unitIndex,
+                tuid: unit.tuid,
+              });
+              continue;
+            }
+            units.push(unit);
+          }
+          continue;
+        }
+        reader.skipElement(child);
+      }
+    }
+  } catch (error) {
+    const message = error instanceof XmlParseError ? error.message : "Malformed TMX XML";
+    return err({ code: "malformed_xml", message: `Malformed TMX: ${message}` });
+  }
+
+  if (totalUnits === 0 && units.length === 0) {
+    return err({ code: "empty_tmx", message: "TMX contains no translation units" });
+  }
+
+  return ok({
+    version,
+    encoding,
+    header,
+    units,
+    issues,
+    totalUnits,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/parse-tmx.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/parse-tmx.ts
@@ -70,7 +70,9 @@ class XmlReader {
   }
 
   startsWithInsensitive(value: string) {
-    return this.xml.slice(this.index, this.index + value.length).toLowerCase() === value.toLowerCase();
+    return (
+      this.xml.slice(this.index, this.index + value.length).toLowerCase() === value.toLowerCase()
+    );
   }
 
   skipWhitespace() {
@@ -237,22 +239,25 @@ function localName(name: string) {
 }
 
 function decodeXmlEntities(value: string) {
-  return value.replace(/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9._-]*);/g, (match, entity: string) => {
-    if (entity === "amp") return "&";
-    if (entity === "lt") return "<";
-    if (entity === "gt") return ">";
-    if (entity === "quot") return '"';
-    if (entity === "apos") return "'";
-    if (entity.startsWith("#x") || entity.startsWith("#X")) {
-      const codePoint = Number.parseInt(entity.slice(2), 16);
-      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
-    }
-    if (entity.startsWith("#")) {
-      const codePoint = Number.parseInt(entity.slice(1), 10);
-      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
-    }
-    return match;
-  });
+  return value.replace(
+    /&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9._-]*);/g,
+    (match, entity: string) => {
+      if (entity === "amp") return "&";
+      if (entity === "lt") return "<";
+      if (entity === "gt") return ">";
+      if (entity === "quot") return '"';
+      if (entity === "apos") return "'";
+      if (entity.startsWith("#x") || entity.startsWith("#X")) {
+        const codePoint = Number.parseInt(entity.slice(2), 16);
+        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
+      }
+      if (entity.startsWith("#")) {
+        const codePoint = Number.parseInt(entity.slice(1), 10);
+        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
+      }
+      return match;
+    },
+  );
 }
 
 function attr(attrs: Record<string, string>, name: string) {
@@ -280,10 +285,7 @@ function serializeStartTag(tag: StartTag) {
 }
 
 function escapeXmlAttr(value: string) {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;");
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
 }
 
 function readElementText(reader: XmlReader, start: StartTag) {
@@ -588,7 +590,11 @@ export function parseTmxDocument(
             }
             const unitStart = reader.readStartTag();
             if (unitStart.localName !== "tu") {
-              if (TMX_UNSUPPORTED_ELEMENTS.includes(unitStart.localName as (typeof TMX_UNSUPPORTED_ELEMENTS)[number])) {
+              if (
+                TMX_UNSUPPORTED_ELEMENTS.includes(
+                  unitStart.localName as (typeof TMX_UNSUPPORTED_ELEMENTS)[number],
+                )
+              ) {
                 issues.push({
                   severity: "warning",
                   code: "unsupported_element",
@@ -608,7 +614,9 @@ export function parseTmxDocument(
               });
             }
             const unit = parseUnit(reader, unitStart, totalUnits);
-            const oversized = unit.variants.some((variant) => variant.segment.length > maxSegmentChars);
+            const oversized = unit.variants.some(
+              (variant) => variant.segment.length > maxSegmentChars,
+            );
             if (oversized) {
               issues.push({
                 severity: "error",

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.test.ts
@@ -31,7 +31,7 @@ function assertPhraseCompatible(tmx: string) {
 }
 
 function assertCrowdinCompatible(tmx: string) {
-  expect(tmx).toContain('<header ');
+  expect(tmx).toContain("<header ");
   expect(tmx).toContain('srclang="');
   expect(tmx).not.toContain("<!DOCTYPE");
   expect(tmx).toContain("&amp;");

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { isOk } from "@/lib/primitives/result/results";
+
+import { parseTmxDocument } from "./parse-tmx";
+import {
+  serializeMemoryEntriesTmx,
+  serializeSegContent,
+  serializeTmxDocument,
+} from "./serialize-tmx";
+import { documentToImportCandidates } from "./tmx-import";
+
+function assertPhraseCompatible(tmx: string) {
+  expect(tmx).toContain('<tmx version="1.4">');
+  expect(tmx).toContain("creationtool=");
+  expect(tmx).toContain("srclang=");
+  expect(tmx).toMatch(/<tu tuid="[^"]+"/);
+  expect(tmx).toMatch(/<tuv xml:lang="[^"]+"><seg>/);
+}
+
+function assertCrowdinCompatible(tmx: string) {
+  expect(tmx).toContain('<header ');
+  expect(tmx).toContain('srclang="');
+  expect(tmx).not.toContain("<!DOCTYPE");
+  expect(tmx).toContain("&amp;");
+  expect(tmx).toContain("&lt;now&gt;");
+}
+
+describe("serializeTmxDocument", () => {
+  it("keeps inline codes as XML and escapes text entities", () => {
+    expect(serializeSegContent('Hello <ph x="1"/> & friends')).toBe(
+      'Hello <ph x="1"/> &amp; friends',
+    );
+    expect(serializeSegContent("Checkout <now>")).toBe("Checkout &lt;now&gt;");
+  });
+
+  it("emits Phrase-compatible TMX 1.4 for multilingual units", () => {
+    const tmx = serializeTmxDocument({
+      header: { srclang: "en-US", creationtool: "Hyperlocalise" },
+      units: [
+        {
+          tuid: "seg-2",
+          creationdate: "20240101T010101Z",
+          variants: [
+            { language: "en-US", segment: "Checkout" },
+            { language: "fr-FR", segment: "Paiement" },
+            { language: "de-DE", segment: "Kasse" },
+          ],
+        },
+      ],
+    });
+    assertPhraseCompatible(tmx);
+    const parsed = parseTmxDocument(tmx);
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+    expect(documentToImportCandidates(parsed.value).candidates).toHaveLength(2);
+  });
+
+  it("emits Crowdin-compatible escaped text that re-imports", () => {
+    const tmx = serializeMemoryEntriesTmx([
+      {
+        sourceLocale: "en",
+        targetLocale: "fr",
+        sourceText: "Checkout <now>",
+        targetText: "Commander & payer",
+        tuid: "9",
+      },
+    ]);
+    assertCrowdinCompatible(tmx);
+    const parsed = parseTmxDocument(tmx);
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+    expect(documentToImportCandidates(parsed.value).candidates[0]).toMatchObject({
+      sourceText: "Checkout <now>",
+      targetText: "Commander & payer",
+    });
+  });
+
+  it("groups locale pairs that share a tuid into one unit", () => {
+    const tmx = serializeMemoryEntriesTmx([
+      {
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+        sourceText: "Cart",
+        targetText: "Panier",
+        tuid: "seg-1",
+      },
+      {
+        sourceLocale: "en-US",
+        targetLocale: "de-DE",
+        sourceText: "Cart",
+        targetText: "Warenkorb",
+        tuid: "seg-1",
+      },
+    ]);
+    expect(tmx.match(/<tu /g)).toHaveLength(1);
+    expect(tmx.match(/<tuv /g)).toHaveLength(3);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.test.ts
@@ -19,6 +19,9 @@ import {
   serializeMemoryEntriesTmx,
   serializeSegContent,
   serializeTmxDocument,
+  serializeTmxFooterXml,
+  serializeTmxHeaderXml,
+  serializeTmxUnitsXml,
 } from "./serialize-tmx";
 import { documentToImportCandidates } from "./tmx-import";
 
@@ -44,6 +47,12 @@ describe("serializeTmxDocument", () => {
       'Hello <ph x="1"/> &amp; friends',
     );
     expect(serializeSegContent("Checkout <now>")).toBe("Checkout &lt;now&gt;");
+  });
+
+  it("escapes incomplete or malformed inline tags instead of emitting them", () => {
+    expect(serializeSegContent("See <ph>")).toBe("See &lt;ph&gt;");
+    expect(serializeSegContent('<ph x="A&B"/>')).toBe('&lt;ph x="A&amp;B"/&gt;');
+    expect(serializeSegContent("<hi>A & B</hi>")).toBe("<hi>A &amp; B</hi>");
   });
 
   it("emits Phrase-compatible TMX 1.4 for multilingual units", () => {
@@ -86,6 +95,30 @@ describe("serializeTmxDocument", () => {
       sourceText: "Checkout <now>",
       targetText: "Commander & payer",
     });
+  });
+
+  it("joins streamed header, units, and footer into a complete document", () => {
+    const input = {
+      header: { srclang: "en", creationtool: "Hyperlocalise" },
+      units: [
+        {
+          tuid: "one",
+          variants: [
+            { language: "en", segment: "Hello" },
+            { language: "fr", segment: "Bonjour" },
+          ],
+        },
+      ],
+    };
+    expect(
+      [
+        serializeTmxHeaderXml(input.header),
+        serializeTmxUnitsXml(input.units),
+        serializeTmxFooterXml(),
+      ]
+        .filter((part) => part.length > 0)
+        .join("\n"),
+    ).toBe(serializeTmxDocument(input));
   });
 
   it("groups locale pairs that share a tuid into one unit", () => {

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { TMX_INLINE_ELEMENTS } from "./tmx-constants";
+import type { TmxExportEntry, TmxHeader, TmxProperty } from "./tmx-types";
+
+export function escapeXmlText(value: string) {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function escapeXmlAttr(value: string) {
+  return escapeXmlText(value).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+/**
+ * Serializes stored segment content for a `<seg>` element.
+ * Official TMX inline tags stay as XML. Everything else is escaped.
+ */
+export function serializeSegContent(content: string) {
+  let output = "";
+  let index = 0;
+  while (index < content.length) {
+    if (content[index] === "<") {
+      const inline = readInlineTag(content, index);
+      if (inline) {
+        output += inline.tag;
+        index = inline.end;
+        continue;
+      }
+    }
+    const nextTag = content.indexOf("<", index + 1);
+    const slice = nextTag === -1 ? content.slice(index) : content.slice(index, nextTag);
+    output += escapeXmlText(slice);
+    index = nextTag === -1 ? content.length : nextTag;
+  }
+  return output;
+}
+
+function readInlineTag(content: string, start: number): { tag: string; end: number } | null {
+  const remaining = content.slice(start);
+  const match = /^<\/?([A-Za-z:_][A-Za-z0-9:_.-]*)\b[^>]*>/.exec(remaining);
+  if (!match) {
+    return null;
+  }
+  const name = match[1]?.includes(":") ? match[1].slice(match[1].lastIndexOf(":") + 1) : match[1];
+  if (!name || !TMX_INLINE_ELEMENTS.has(name.toLowerCase())) {
+    return null;
+  }
+  return { tag: match[0], end: start + match[0].length };
+}
+
+function writeProps(properties: TmxProperty[] | undefined, indent: string) {
+  return (properties ?? [])
+    .filter((property) => property.type && property.value)
+    .map(
+      (property) =>
+        `${indent}<prop type="${escapeXmlAttr(property.type)}">${escapeXmlText(property.value)}</prop>`,
+    );
+}
+
+function writeNotes(notes: string[] | undefined, indent: string) {
+  return (notes ?? [])
+    .filter((note) => note.trim().length > 0)
+    .map((note) => `${indent}<note>${escapeXmlText(note)}</note>`);
+}
+
+type ExportTuv = {
+  language: string;
+  segment: string;
+};
+
+type ExportUnit = {
+  tuid?: string;
+  creationdate?: string;
+  changedate?: string;
+  creationid?: string;
+  changeid?: string;
+  properties?: TmxProperty[];
+  notes?: string[];
+  variants: ExportTuv[];
+};
+
+export type TmxSerializeInput = {
+  header?: Partial<TmxHeader>;
+  units: ExportUnit[];
+};
+
+export function serializeTmxDocument(input: TmxSerializeInput) {
+  const srclang = input.header?.srclang?.trim() || input.units[0]?.variants[0]?.language || "en";
+  const headerAttrs = [
+    `creationtool="${escapeXmlAttr(input.header?.creationtool ?? "Hyperlocalise")}"`,
+    `creationtoolversion="${escapeXmlAttr(input.header?.creationtoolversion ?? "1")}"`,
+    `segtype="${escapeXmlAttr(input.header?.segtype ?? "sentence")}"`,
+    `o-tmf="${escapeXmlAttr(input.header?.oTmf ?? "Hyperlocalise")}"`,
+    `adminlang="${escapeXmlAttr(input.header?.adminlang ?? "en")}"`,
+    `srclang="${escapeXmlAttr(srclang)}"`,
+    `datatype="${escapeXmlAttr(input.header?.datatype ?? "plaintext")}"`,
+  ];
+
+  const body = input.units
+    .map((unit) => {
+      const tuAttrs = [`tuid="${escapeXmlAttr(unit.tuid ?? "")}"`];
+      if (unit.creationdate) tuAttrs.push(`creationdate="${escapeXmlAttr(unit.creationdate)}"`);
+      if (unit.changedate) tuAttrs.push(`changedate="${escapeXmlAttr(unit.changedate)}"`);
+      if (unit.creationid) tuAttrs.push(`creationid="${escapeXmlAttr(unit.creationid)}"`);
+      if (unit.changeid) tuAttrs.push(`changeid="${escapeXmlAttr(unit.changeid)}"`);
+      const lines = [`  <tu ${tuAttrs.join(" ")}>`];
+      lines.push(...writeProps(unit.properties, "    "));
+      lines.push(...writeNotes(unit.notes, "    "));
+      for (const variant of unit.variants) {
+        lines.push(
+          `    <tuv xml:lang="${escapeXmlAttr(variant.language)}"><seg>${serializeSegContent(variant.segment)}</seg></tuv>`,
+        );
+      }
+      lines.push("  </tu>");
+      return lines.join("\n");
+    })
+    .join("\n");
+
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<tmx version="1.4">`,
+    `  <header ${headerAttrs.join(" ")}/>`,
+    `  <body>`,
+    body,
+    `  </body>`,
+    `</tmx>`,
+    ``,
+  ].join("\n");
+}
+
+function asString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function asStringArray(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function metadataProps(metadata: Record<string, unknown> | undefined): TmxProperty[] {
+  const tmx = metadata?.tmx;
+  if (!tmx || typeof tmx !== "object" || Array.isArray(tmx)) {
+    return [];
+  }
+  const props = (tmx as { props?: unknown }).props;
+  if (!props || typeof props !== "object" || Array.isArray(props)) {
+    return [];
+  }
+  return Object.entries(props).flatMap(([type, value]) => {
+    if (typeof value === "string") {
+      return [{ type, value }];
+    }
+    if (Array.isArray(value)) {
+      return value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => ({ type, value: item }));
+    }
+    return [];
+  });
+}
+
+export function groupEntriesForTmxExport(entries: readonly TmxExportEntry[]) {
+  const groups = new Map<string, ExportUnit>();
+  for (const [index, entry] of entries.entries()) {
+    const metadata = entry.metadata ?? {};
+    const tuid = entry.tuid ?? asString(metadata.tuid);
+    const groupKey = tuid
+      ? `tuid:${tuid}`
+      : `source:${entry.sourceLocale}\u0000${entry.sourceText}`;
+    const existing = groups.get(groupKey);
+    const sourceVariant = { language: entry.sourceLocale, segment: entry.sourceText };
+    const targetVariant = { language: entry.targetLocale, segment: entry.targetText };
+    if (!existing) {
+      groups.set(groupKey, {
+        tuid: tuid ?? `entry-${index + 1}`,
+        creationdate: asString(metadata.creationdate),
+        changedate: asString(metadata.changedate),
+        creationid: asString(metadata.creationid),
+        changeid: asString(metadata.changeid),
+        properties: metadataProps(metadata),
+        notes: asStringArray(metadata.notes),
+        variants: [sourceVariant, targetVariant],
+      });
+      continue;
+    }
+    const hasSource = existing.variants.some(
+      (variant) => variant.language === sourceVariant.language && variant.segment === sourceVariant.segment,
+    );
+    if (!hasSource) {
+      existing.variants.unshift(sourceVariant);
+    }
+    existing.variants.push(targetVariant);
+  }
+  return [...groups.values()];
+}
+
+export function serializeMemoryEntriesTmx(
+  entries: readonly TmxExportEntry[],
+  header?: Partial<TmxHeader>,
+) {
+  const units = groupEntriesForTmxExport(entries);
+  const srclang = header?.srclang ?? entries[0]?.sourceLocale ?? "en";
+  return serializeTmxDocument({
+    header: { ...header, srclang },
+    units,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.ts
@@ -30,9 +30,9 @@ export function serializeSegContent(content: string) {
   let index = 0;
   while (index < content.length) {
     if (content[index] === "<") {
-      const inline = readInlineTag(content, index);
+      const inline = readInlineMarkup(content, index);
       if (inline) {
-        output += inline.tag;
+        output += inline.xml;
         index = inline.end;
         continue;
       }
@@ -45,17 +45,156 @@ export function serializeSegContent(content: string) {
   return output;
 }
 
-function readInlineTag(content: string, start: number): { tag: string; end: number } | null {
-  const remaining = content.slice(start);
-  const match = /^<\/?([A-Za-z:_][A-Za-z0-9:_.-]*)\b[^>]*>/.exec(remaining);
-  if (!match) {
+const XML_NAME = /^[A-Za-z:_][A-Za-z0-9:_.-]*/;
+const XML_ENTITY = /^(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);/;
+
+type ParsedTag = {
+  name: string;
+  localName: string;
+  closing: boolean;
+  selfClosing: boolean;
+  raw: string;
+  end: number;
+};
+
+function localTagName(name: string) {
+  return name.includes(":") ? name.slice(name.lastIndexOf(":") + 1) : name;
+}
+
+function parseXmlTag(content: string, start: number): ParsedTag | null {
+  if (content[start] !== "<") {
     return null;
   }
-  const name = match[1]?.includes(":") ? match[1].slice(match[1].lastIndexOf(":") + 1) : match[1];
-  if (!name || !TMX_INLINE_ELEMENTS.has(name.toLowerCase())) {
+  let index = start + 1;
+  const closing = content[index] === "/";
+  if (closing) {
+    index += 1;
+  }
+  const nameMatch = XML_NAME.exec(content.slice(index));
+  if (!nameMatch?.[0]) {
     return null;
   }
-  return { tag: match[0], end: start + match[0].length };
+  const name = nameMatch[0];
+  index += name.length;
+  while (index < content.length) {
+    const char = content[index];
+    if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+      index += 1;
+      continue;
+    }
+    if (char === ">") {
+      return {
+        name,
+        localName: localTagName(name).toLowerCase(),
+        closing,
+        selfClosing: false,
+        raw: content.slice(start, index + 1),
+        end: index + 1,
+      };
+    }
+    if (char === "/" && content[index + 1] === ">") {
+      if (closing) {
+        return null;
+      }
+      return {
+        name,
+        localName: localTagName(name).toLowerCase(),
+        closing: false,
+        selfClosing: true,
+        raw: content.slice(start, index + 2),
+        end: index + 2,
+      };
+    }
+    const attrName = XML_NAME.exec(content.slice(index));
+    if (!attrName?.[0]) {
+      return null;
+    }
+    index += attrName[0].length;
+    while (
+      content[index] === " " ||
+      content[index] === "\t" ||
+      content[index] === "\n" ||
+      content[index] === "\r"
+    ) {
+      index += 1;
+    }
+    if (content[index] !== "=") {
+      return null;
+    }
+    index += 1;
+    while (
+      content[index] === " " ||
+      content[index] === "\t" ||
+      content[index] === "\n" ||
+      content[index] === "\r"
+    ) {
+      index += 1;
+    }
+    const quote = content[index];
+    if (quote !== '"' && quote !== "'") {
+      return null;
+    }
+    index += 1;
+    while (index < content.length && content[index] !== quote) {
+      if (content[index] === "<") {
+        return null;
+      }
+      if (content[index] === "&") {
+        const entity = XML_ENTITY.exec(content.slice(index + 1));
+        if (!entity?.[0]) {
+          return null;
+        }
+        index += 1 + entity[0].length;
+        continue;
+      }
+      index += 1;
+    }
+    if (content[index] !== quote) {
+      return null;
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function readInlineMarkup(content: string, start: number): { xml: string; end: number } | null {
+  const tag = parseXmlTag(content, start);
+  if (!tag || !TMX_INLINE_ELEMENTS.has(tag.localName)) {
+    return null;
+  }
+  if (tag.selfClosing || tag.closing) {
+    return { xml: tag.raw, end: tag.end };
+  }
+  let index = tag.end;
+  let depth = 1;
+  while (index < content.length) {
+    const nextOpen = content.indexOf("<", index);
+    if (nextOpen === -1) {
+      return null;
+    }
+    const next = parseXmlTag(content, nextOpen);
+    if (!next || next.localName !== tag.localName) {
+      index = nextOpen + 1;
+      continue;
+    }
+    if (!next.closing && !next.selfClosing) {
+      depth += 1;
+      index = next.end;
+      continue;
+    }
+    if (next.closing) {
+      depth -= 1;
+      if (depth === 0) {
+        const inner = content.slice(tag.end, nextOpen);
+        return {
+          xml: `${tag.raw}${serializeSegContent(inner)}${next.raw}`,
+          end: next.end,
+        };
+      }
+    }
+    index = next.end;
+  }
+  return null;
 }
 
 function writeProps(properties: TmxProperty[] | undefined, indent: string) {
@@ -94,19 +233,27 @@ export type TmxSerializeInput = {
   units: ExportUnit[];
 };
 
-export function serializeTmxDocument(input: TmxSerializeInput) {
-  const srclang = input.header?.srclang?.trim() || input.units[0]?.variants[0]?.language || "en";
+export function serializeTmxHeaderXml(header?: Partial<TmxHeader>, fallbackSrclang?: string) {
+  const srclang = header?.srclang?.trim() || fallbackSrclang || "en";
   const headerAttrs = [
-    `creationtool="${escapeXmlAttr(input.header?.creationtool ?? "Hyperlocalise")}"`,
-    `creationtoolversion="${escapeXmlAttr(input.header?.creationtoolversion ?? "1")}"`,
-    `segtype="${escapeXmlAttr(input.header?.segtype ?? "sentence")}"`,
-    `o-tmf="${escapeXmlAttr(input.header?.oTmf ?? "Hyperlocalise")}"`,
-    `adminlang="${escapeXmlAttr(input.header?.adminlang ?? "en")}"`,
+    `creationtool="${escapeXmlAttr(header?.creationtool ?? "Hyperlocalise")}"`,
+    `creationtoolversion="${escapeXmlAttr(header?.creationtoolversion ?? "1")}"`,
+    `segtype="${escapeXmlAttr(header?.segtype ?? "sentence")}"`,
+    `o-tmf="${escapeXmlAttr(header?.oTmf ?? "Hyperlocalise")}"`,
+    `adminlang="${escapeXmlAttr(header?.adminlang ?? "en")}"`,
     `srclang="${escapeXmlAttr(srclang)}"`,
-    `datatype="${escapeXmlAttr(input.header?.datatype ?? "plaintext")}"`,
+    `datatype="${escapeXmlAttr(header?.datatype ?? "plaintext")}"`,
   ];
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<tmx version="1.4">`,
+    `  <header ${headerAttrs.join(" ")}/>`,
+    `  <body>`,
+  ].join("\n");
+}
 
-  const body = input.units
+export function serializeTmxUnitsXml(units: readonly ExportUnit[]) {
+  return units
     .map((unit) => {
       const tuAttrs = [`tuid="${escapeXmlAttr(unit.tuid ?? "")}"`];
       if (unit.creationdate) tuAttrs.push(`creationdate="${escapeXmlAttr(unit.creationdate)}"`);
@@ -125,17 +272,21 @@ export function serializeTmxDocument(input: TmxSerializeInput) {
       return lines.join("\n");
     })
     .join("\n");
+}
 
+export function serializeTmxFooterXml() {
+  return `  </body>\n</tmx>\n`;
+}
+
+export function serializeTmxDocument(input: TmxSerializeInput) {
+  const body = serializeTmxUnitsXml(input.units);
   return [
-    `<?xml version="1.0" encoding="UTF-8"?>`,
-    `<tmx version="1.4">`,
-    `  <header ${headerAttrs.join(" ")}/>`,
-    `  <body>`,
+    serializeTmxHeaderXml(input.header, input.units[0]?.variants[0]?.language),
     body,
-    `  </body>`,
-    `</tmx>`,
-    ``,
-  ].join("\n");
+    serializeTmxFooterXml(),
+  ]
+    .filter((part) => part.length > 0)
+    .join("\n");
 }
 
 function asString(value: unknown) {

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/serialize-tmx.ts
@@ -196,7 +196,8 @@ export function groupEntriesForTmxExport(entries: readonly TmxExportEntry[]) {
       continue;
     }
     const hasSource = existing.variants.some(
-      (variant) => variant.language === sourceVariant.language && variant.segment === sourceVariant.segment,
+      (variant) =>
+        variant.language === sourceVariant.language && variant.segment === sourceVariant.segment,
     );
     if (!hasSource) {
       existing.variants.unshift(sourceVariant);

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.test.ts
@@ -15,6 +15,8 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   TMX_DEFAULT_BATCH_SIZE,
   TMX_DEFAULT_MAX_UNITS,
+  TMX_LOOKUP_BATCH_SIZE,
+  TMX_LOOKUP_CONCURRENCY,
   TMX_MAX_IMPORT_CONTENT_CHARS,
 } from "./tmx-constants";
 
@@ -23,5 +25,7 @@ describe("TMX import limits", () => {
     expect(TMX_DEFAULT_MAX_UNITS).toBe(1_000_000);
     expect(TMX_MAX_IMPORT_CONTENT_CHARS).toBe(100_000_000);
     expect(TMX_DEFAULT_BATCH_SIZE).toBe(500);
+    expect(TMX_LOOKUP_BATCH_SIZE).toBe(2_000);
+    expect(TMX_LOOKUP_CONCURRENCY).toBe(4);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  TMX_DEFAULT_BATCH_SIZE,
+  TMX_DEFAULT_MAX_UNITS,
+  TMX_MAX_IMPORT_CONTENT_CHARS,
+} from "./tmx-constants";
+
+describe("TMX import limits", () => {
+  it("allows million-unit memories and hundred-megabyte payloads", () => {
+    expect(TMX_DEFAULT_MAX_UNITS).toBe(1_000_000);
+    expect(TMX_MAX_IMPORT_CONTENT_CHARS).toBe(100_000_000);
+    expect(TMX_DEFAULT_BATCH_SIZE).toBe(500);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.ts
@@ -11,11 +11,18 @@
  * Version 2.0 or later.
  */
 
-/** Hard cap for translation units in one import. Larger files are rejected, never truncated. */
-export const TMX_DEFAULT_MAX_UNITS = 50_000;
+/**
+ * Hard cap for translation units in one import. Larger files are rejected, never truncated.
+ * Project and organisation TMs commonly reach hundreds of thousands of units; this leaves
+ * headroom without letting a single request allocate unbounded memory.
+ */
+export const TMX_DEFAULT_MAX_UNITS = 1_000_000;
+
+/** Maximum UTF-16 code units in the import request body (CSV or TMX). */
+export const TMX_MAX_IMPORT_CONTENT_CHARS = 100_000_000;
 
 /** Default number of entries written per database batch. */
-export const TMX_DEFAULT_BATCH_SIZE = 250;
+export const TMX_DEFAULT_BATCH_SIZE = 500;
 
 /** Matches the create-entry body limit so imported segments stay writable. */
 export const TMX_MAX_SEGMENT_CHARS = 100_000;

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.ts
@@ -37,7 +37,13 @@ export const TMX_MAX_PREVIEW_ENTRIES = 25;
 export const TMX_MAX_RESPONSE_ENTRIES = 100;
 
 /** Lookup batch size for existing external keys and source tuples. */
-export const TMX_LOOKUP_BATCH_SIZE = 100;
+export const TMX_LOOKUP_BATCH_SIZE = 2_000;
+
+/** Parallel lookup batches when resolving existing entries. */
+export const TMX_LOOKUP_CONCURRENCY = 4;
+
+/** Database page size while streaming a TMX export. */
+export const TMX_EXPORT_PAGE_SIZE = 500;
 
 export const TMX_INLINE_ELEMENTS = new Set(["bpt", "ept", "ph", "it", "hi", "sub", "ut"]);
 

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+/** Hard cap for translation units in one import. Larger files are rejected, never truncated. */
+export const TMX_DEFAULT_MAX_UNITS = 50_000;
+
+/** Default number of entries written per database batch. */
+export const TMX_DEFAULT_BATCH_SIZE = 250;
+
+/** Matches the create-entry body limit so imported segments stay writable. */
+export const TMX_MAX_SEGMENT_CHARS = 100_000;
+
+/** Cap issue rows returned in preview and final reports. */
+export const TMX_MAX_REPORT_ISSUES = 200;
+
+/** Candidate rows returned for import preview. */
+export const TMX_MAX_PREVIEW_ENTRIES = 25;
+
+/** Created entries echoed in the import JSON response. */
+export const TMX_MAX_RESPONSE_ENTRIES = 100;
+
+/** Lookup batch size for existing external keys and source tuples. */
+export const TMX_LOOKUP_BATCH_SIZE = 100;
+
+export const TMX_INLINE_ELEMENTS = new Set(["bpt", "ept", "ph", "it", "hi", "sub", "ut"]);
+
+export const TMX_SUPPORTED_ENCODINGS = new Set([
+  "utf-8",
+  "utf8",
+  "us-ascii",
+  "ascii",
+  "utf-16",
+  "utf-16le",
+  "utf-16be",
+]);
+
+export const TMX_CONTEXT_PROP_TYPES = new Set([
+  "context",
+  "x-context",
+  "x-context-string",
+  "x-context-pre",
+  "x-context-post",
+]);
+
+/**
+ * TMX 1.4 elements that Hyperlocalise does not import.
+ * They are skipped with a warning when present.
+ */
+export const TMX_UNSUPPORTED_ELEMENTS = [
+  "ude",
+  "map",
+  "r",
+  "alttrans",
+] as const;

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-constants.ts
@@ -56,9 +56,4 @@ export const TMX_CONTEXT_PROP_TYPES = new Set([
  * TMX 1.4 elements that Hyperlocalise does not import.
  * They are skipped with a warning when present.
  */
-export const TMX_UNSUPPORTED_ELEMENTS = [
-  "ude",
-  "map",
-  "r",
-  "alttrans",
-] as const;
+export const TMX_UNSUPPORTED_ELEMENTS = ["ude", "map", "r", "alttrans"] as const;

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-import.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-import.ts
@@ -118,10 +118,13 @@ function pickSourceVariant(
   headerSrclang: string | undefined,
   issues: TmxIssue[],
 ): TmxVariant | null {
-  const wanted = unit.srclang ?? (headerSrclang && headerSrclang !== "*all*" ? headerSrclang : undefined);
+  const wanted =
+    unit.srclang ?? (headerSrclang && headerSrclang !== "*all*" ? headerSrclang : undefined);
   if (wanted) {
     const exact = unit.variants.find(
-      (variant) => normalizeTmxLanguage(variant.language).toLowerCase() === normalizeTmxLanguage(wanted).toLowerCase(),
+      (variant) =>
+        normalizeTmxLanguage(variant.language).toLowerCase() ===
+        normalizeTmxLanguage(wanted).toLowerCase(),
     );
     if (exact) {
       return exact;
@@ -195,7 +198,8 @@ export function documentToImportCandidates(document: TmxDocument): {
     issues.push({
       severity: "warning",
       code: "missing_header_srclang",
-      message: "TMX header has no srclang; units without their own srclang use the first TUV as source",
+      message:
+        "TMX header has no srclang; units without their own srclang use the first TUV as source",
     });
   }
 
@@ -293,7 +297,10 @@ export function documentToImportCandidates(document: TmxDocument): {
   return { candidates, issues };
 }
 
-export function emptyImportReport(issues: TmxIssue[] = [], headerSrclang?: string): MemoryImportReport {
+export function emptyImportReport(
+  issues: TmxIssue[] = [],
+  headerSrclang?: string,
+): MemoryImportReport {
   return {
     totalRead: 0,
     created: 0,

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-import.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-import.ts
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { canonicalizeLocale } from "@/lib/i18n/locales";
+
+import { TMX_CONTEXT_PROP_TYPES, TMX_MAX_REPORT_ISSUES } from "./tmx-constants";
+import type {
+  MemoryImportCandidate,
+  MemoryImportReport,
+  TmxDocument,
+  TmxIssue,
+  TmxProperty,
+  TmxUnit,
+  TmxVariant,
+} from "./tmx-types";
+
+export function normalizeTmxLanguage(tag: string) {
+  const trimmed = tag.trim().replaceAll("_", "-");
+  return canonicalizeLocale(trimmed) ?? trimmed;
+}
+
+export function languagesMatch(left: string, right: string) {
+  const a = normalizeTmxLanguage(left).toLowerCase();
+  const b = normalizeTmxLanguage(right).toLowerCase();
+  if (!a || !b) {
+    return false;
+  }
+  if (a === b) {
+    return true;
+  }
+  const aPrimary = a.split("-")[0];
+  const bPrimary = b.split("-")[0];
+  return aPrimary === bPrimary && (a === aPrimary || b === bPrimary);
+}
+
+export function buildTmxExternalKey(
+  tuid: string | undefined,
+  sourceLocale: string,
+  targetLocale: string,
+) {
+  if (!tuid?.trim()) {
+    return null;
+  }
+  return `tmx:${tuid.trim()}:${sourceLocale}:${targetLocale}`;
+}
+
+function propertyValues(properties: TmxProperty[], type: string) {
+  return properties.filter((property) => property.type.toLowerCase() === type.toLowerCase());
+}
+
+function collectContext(properties: TmxProperty[]) {
+  const pre = propertyValues(properties, "x-context-pre")
+    .map((property) => property.value)
+    .join(" ");
+  const post = propertyValues(properties, "x-context-post")
+    .map((property) => property.value)
+    .join(" ");
+  const primary = properties
+    .filter((property) => TMX_CONTEXT_PROP_TYPES.has(property.type.toLowerCase()))
+    .filter(
+      (property) =>
+        property.type.toLowerCase() !== "x-context-pre" &&
+        property.type.toLowerCase() !== "x-context-post",
+    )
+    .map((property) => property.value)
+    .filter(Boolean);
+  const parts = [...primary];
+  if (pre) parts.push(pre);
+  if (post) parts.push(post);
+  return parts.join(" ").trim() || undefined;
+}
+
+function namespacedProps(properties: TmxProperty[]) {
+  const props: Record<string, string | string[]> = {};
+  for (const property of properties) {
+    if (!property.type) {
+      continue;
+    }
+    const existing = props[property.type];
+    if (existing === undefined) {
+      props[property.type] = property.value;
+      continue;
+    }
+    if (Array.isArray(existing)) {
+      existing.push(property.value);
+      continue;
+    }
+    props[property.type] = [existing, property.value];
+  }
+  return props;
+}
+
+function reviewStatusFromProps(properties: TmxProperty[]) {
+  const raw =
+    propertyValues(properties, "x-review-status")[0]?.value ??
+    propertyValues(properties, "review-status")[0]?.value;
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "approved" || normalized === "pending" || normalized === "rejected") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function pickSourceVariant(
+  unit: TmxUnit,
+  headerSrclang: string | undefined,
+  issues: TmxIssue[],
+): TmxVariant | null {
+  const wanted = unit.srclang ?? (headerSrclang && headerSrclang !== "*all*" ? headerSrclang : undefined);
+  if (wanted) {
+    const exact = unit.variants.find(
+      (variant) => normalizeTmxLanguage(variant.language).toLowerCase() === normalizeTmxLanguage(wanted).toLowerCase(),
+    );
+    if (exact) {
+      return exact;
+    }
+    const loose = unit.variants.find((variant) => languagesMatch(variant.language, wanted));
+    if (loose) {
+      issues.push({
+        severity: "warning",
+        code: "source_language_prefix_match",
+        message: `Source language "${wanted}" matched TUV "${loose.language}" by primary subtag`,
+        unitIndex: unit.unitIndex,
+        tuid: unit.tuid,
+      });
+      return loose;
+    }
+    issues.push({
+      severity: "error",
+      code: "source_tuv_missing",
+      message: `No TUV matched source language "${wanted}"`,
+      unitIndex: unit.unitIndex,
+      tuid: unit.tuid,
+    });
+    return null;
+  }
+  if (headerSrclang === "*all*") {
+    issues.push({
+      severity: "warning",
+      code: "srclang_all_uses_first_tuv",
+      message: "Header srclang is *all*; the first TUV is treated as the source",
+      unitIndex: unit.unitIndex,
+      tuid: unit.tuid,
+    });
+  }
+  return unit.variants[0] ?? null;
+}
+
+function buildMetadata(unit: TmxUnit, target: TmxVariant, sourceLanguage: string) {
+  const notes = [...unit.notes, ...target.notes].filter((note) => note.trim().length > 0);
+  const context = collectContext([...unit.properties, ...target.properties]);
+  const reviewStatus = reviewStatusFromProps([...unit.properties, ...target.properties]);
+  const props = namespacedProps([...unit.properties, ...target.properties]);
+  return {
+    ...(unit.tuid ? { tuid: unit.tuid } : {}),
+    ...(context ? { context } : {}),
+    ...(notes.length > 0 ? { notes } : {}),
+    ...(unit.creationdate ? { creationdate: unit.creationdate } : {}),
+    ...(unit.changedate ? { changedate: unit.changedate } : {}),
+    ...(unit.creationid ? { creationid: unit.creationid } : {}),
+    ...(unit.changeid ? { changeid: unit.changeid } : {}),
+    ...(reviewStatus ? { reviewStatus } : {}),
+    tmx: {
+      sourceLanguage,
+      props,
+      ...(target.creationdate ? { tuvCreationdate: target.creationdate } : {}),
+      ...(target.changedate ? { tuvChangedate: target.changedate } : {}),
+      ...(target.creationid ? { tuvCreationid: target.creationid } : {}),
+      ...(target.changeid ? { tuvChangeid: target.changeid } : {}),
+    },
+  };
+}
+
+export function documentToImportCandidates(document: TmxDocument): {
+  candidates: MemoryImportCandidate[];
+  issues: TmxIssue[];
+} {
+  const issues = [...document.issues];
+  const candidates: MemoryImportCandidate[] = [];
+  const headerSrclang = document.header.srclang?.trim();
+
+  if (!headerSrclang) {
+    issues.push({
+      severity: "warning",
+      code: "missing_header_srclang",
+      message: "TMX header has no srclang; units without their own srclang use the first TUV as source",
+    });
+  }
+
+  for (const unit of document.units) {
+    if (unit.variants.length === 0) {
+      issues.push({
+        severity: "error",
+        code: "empty_unit",
+        message: "Translation unit has no TUV elements",
+        unitIndex: unit.unitIndex,
+        tuid: unit.tuid,
+      });
+      continue;
+    }
+    const source = pickSourceVariant(unit, headerSrclang, issues);
+    if (!source) {
+      continue;
+    }
+    if (!source.language || !source.segment.trim()) {
+      issues.push({
+        severity: "error",
+        code: "empty_source_segment",
+        message: "Source TUV is missing a language or segment",
+        unitIndex: unit.unitIndex,
+        tuid: unit.tuid,
+      });
+      continue;
+    }
+
+    const targets = unit.variants.filter((variant) => variant !== source);
+    if (targets.length === 0) {
+      issues.push({
+        severity: "error",
+        code: "missing_target_tuv",
+        message: "Translation unit has no target TUV",
+        unitIndex: unit.unitIndex,
+        tuid: unit.tuid,
+      });
+      continue;
+    }
+
+    const seenTargetLanguages = new Set<string>();
+    let variantIndex = 0;
+    for (const target of targets) {
+      if (!target.language || !target.segment.trim()) {
+        issues.push({
+          severity: "error",
+          code: "empty_target_segment",
+          message: "Target TUV is missing a language or segment",
+          unitIndex: unit.unitIndex,
+          tuid: unit.tuid,
+        });
+        continue;
+      }
+      if (languagesMatch(source.language, target.language)) {
+        issues.push({
+          severity: "warning",
+          code: "same_language_variant_skipped",
+          message: `Skipped same-language target variant "${target.language}"`,
+          unitIndex: unit.unitIndex,
+          tuid: unit.tuid,
+        });
+        continue;
+      }
+      const languageKey = normalizeTmxLanguage(target.language).toLowerCase();
+      if (seenTargetLanguages.has(languageKey)) {
+        issues.push({
+          severity: "warning",
+          code: "duplicate_target_variant",
+          message: `Additional "${target.language}" variant in the same unit was skipped`,
+          unitIndex: unit.unitIndex,
+          tuid: unit.tuid,
+        });
+        continue;
+      }
+      seenTargetLanguages.add(languageKey);
+      const sourceLocale = normalizeTmxLanguage(source.language);
+      const targetLocale = normalizeTmxLanguage(target.language);
+      candidates.push({
+        sourceLocale,
+        targetLocale,
+        sourceText: source.segment,
+        targetText: target.segment,
+        matchScore: 100,
+        externalKey: buildTmxExternalKey(unit.tuid, sourceLocale, targetLocale),
+        metadata: buildMetadata(unit, target, sourceLocale),
+        unitIndex: unit.unitIndex,
+        tuid: unit.tuid,
+        isVariant: variantIndex > 0,
+      });
+      variantIndex += 1;
+    }
+  }
+
+  return { candidates, issues };
+}
+
+export function emptyImportReport(issues: TmxIssue[] = [], headerSrclang?: string): MemoryImportReport {
+  return {
+    totalRead: 0,
+    created: 0,
+    updated: 0,
+    variantCreated: 0,
+    skipped: 0,
+    warned: issues.filter((issue) => issue.severity === "warning").length,
+    failed: issues.filter((issue) => issue.severity === "error").length,
+    issues: issues.slice(0, TMX_MAX_REPORT_ISSUES),
+    headerSrclang,
+    truncatedIssues: issues.length > TMX_MAX_REPORT_ISSUES,
+  };
+}
+
+export function finalizeImportReport(
+  report: Omit<MemoryImportReport, "warned" | "failed" | "issues" | "truncatedIssues"> & {
+    issues: TmxIssue[];
+  },
+): MemoryImportReport {
+  return {
+    ...report,
+    warned: report.issues.filter((issue) => issue.severity === "warning").length,
+    failed: report.issues.filter((issue) => issue.severity === "error").length,
+    issues: report.issues.slice(0, TMX_MAX_REPORT_ISSUES),
+    truncatedIssues: report.issues.length > TMX_MAX_REPORT_ISSUES,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-roundtrip.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-roundtrip.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { isOk } from "@/lib/primitives/result/results";
+
+import { parseTmxDocument } from "./parse-tmx";
+import { serializeMemoryEntriesTmx } from "./serialize-tmx";
+import { documentToImportCandidates } from "./tmx-import";
+
+const fixtureDir = dirname(fileURLToPath(import.meta.url));
+
+function readFixture(name: string) {
+  return readFileSync(join(fixtureDir, "fixtures", name), "utf8");
+}
+
+function importThenExport(xml: string) {
+  const parsed = parseTmxDocument(xml);
+  expect(isOk(parsed)).toBe(true);
+  if (!isOk(parsed)) {
+    throw new Error("expected parse success");
+  }
+  const { candidates } = documentToImportCandidates(parsed.value);
+  const exported = serializeMemoryEntriesTmx(
+    candidates.map((candidate) => ({
+      sourceLocale: candidate.sourceLocale,
+      targetLocale: candidate.targetLocale,
+      sourceText: candidate.sourceText,
+      targetText: candidate.targetText,
+      tuid: candidate.tuid,
+      metadata: candidate.metadata,
+    })),
+    { srclang: parsed.value.header.srclang },
+  );
+  const reparsed = parseTmxDocument(exported);
+  expect(isOk(reparsed)).toBe(true);
+  if (!isOk(reparsed)) {
+    throw new Error("expected reparse success");
+  }
+  return {
+    original: candidates,
+    exported,
+    roundTripped: documentToImportCandidates(reparsed.value).candidates,
+  };
+}
+
+describe("TMX round-trip", () => {
+  it("round-trips inline codes and entities without content loss", () => {
+    const { original, exported, roundTripped } = importThenExport(
+      readFixture("tmx-1.4-inline-codes.tmx"),
+    );
+    expect(exported).toContain('<ph x="1"/>');
+    expect(exported).toContain("&amp;");
+    expect(roundTripped.map((candidate) => candidate.sourceText)).toEqual(
+      original.map((candidate) => candidate.sourceText),
+    );
+    expect(roundTripped.map((candidate) => candidate.targetText)).toEqual(
+      original.map((candidate) => candidate.targetText),
+    );
+    expect(roundTripped[0]?.metadata).toMatchObject({
+      tuid: "inline-1",
+      context: "homepage hero",
+      notes: ["Keep the placeholder."],
+    });
+  });
+
+  it("round-trips Phrase multilingual fixtures", () => {
+    const { original, roundTripped } = importThenExport(readFixture("tmx-phrase-like.tmx"));
+    expect(roundTripped).toHaveLength(original.length);
+    expect(roundTripped.map((candidate) => candidate.targetText).sort()).toEqual(
+      original.map((candidate) => candidate.targetText).sort(),
+    );
+  });
+
+  it("round-trips Crowdin entity fixtures", () => {
+    const { original, roundTripped } = importThenExport(readFixture("tmx-crowdin-like.tmx"));
+    expect(roundTripped[0]).toMatchObject({
+      sourceText: original[0]?.sourceText,
+      targetText: original[0]?.targetText,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-types.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/tmx/tmx-types.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export type TmxIssueSeverity = "warning" | "error";
+
+export type TmxIssue = {
+  severity: TmxIssueSeverity;
+  code: string;
+  message: string;
+  unitIndex?: number;
+  tuid?: string;
+};
+
+export type TmxFatalError = {
+  code:
+    | "malformed_xml"
+    | "unsupported_encoding"
+    | "doctype_forbidden"
+    | "unit_limit_exceeded"
+    | "empty_tmx"
+    | "oversized_content";
+  message: string;
+  unitCount?: number;
+  maxUnits?: number;
+};
+
+export type TmxProperty = {
+  type: string;
+  value: string;
+};
+
+export type TmxVariant = {
+  language: string;
+  segment: string;
+  properties: TmxProperty[];
+  notes: string[];
+  creationdate?: string;
+  changedate?: string;
+  creationid?: string;
+  changeid?: string;
+};
+
+export type TmxUnit = {
+  unitIndex: number;
+  tuid?: string;
+  srclang?: string;
+  creationdate?: string;
+  changedate?: string;
+  creationid?: string;
+  changeid?: string;
+  properties: TmxProperty[];
+  notes: string[];
+  variants: TmxVariant[];
+};
+
+export type TmxHeader = {
+  srclang?: string;
+  adminlang?: string;
+  creationtool?: string;
+  creationtoolversion?: string;
+  segtype?: string;
+  oTmf?: string;
+  datatype?: string;
+  creationdate?: string;
+  creationid?: string;
+  changedate?: string;
+  changeid?: string;
+  properties: TmxProperty[];
+  notes: string[];
+};
+
+export type TmxDocument = {
+  version?: string;
+  encoding?: string;
+  header: TmxHeader;
+  units: TmxUnit[];
+  issues: TmxIssue[];
+  totalUnits: number;
+};
+
+export type MemoryImportCandidate = {
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  targetText: string;
+  matchScore: number;
+  externalKey: string | null;
+  metadata: Record<string, unknown>;
+  unitIndex: number;
+  tuid?: string;
+  isVariant: boolean;
+};
+
+export type MemoryImportReport = {
+  totalRead: number;
+  created: number;
+  updated: number;
+  variantCreated: number;
+  skipped: number;
+  warned: number;
+  failed: number;
+  issues: TmxIssue[];
+  headerSrclang?: string;
+  truncatedIssues: boolean;
+};
+
+export type MemoryImportPreviewEntry = {
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  targetText: string;
+  externalKey: string | null;
+  tuid?: string;
+  action: "create" | "update" | "variant" | "skip";
+};
+
+export type TmxExportEntry = {
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  targetText: string;
+  tuid?: string;
+  metadata?: Record<string, unknown>;
+};

--- a/docs/adr/2026-08-28-tmx-import-export-design.md
+++ b/docs/adr/2026-08-28-tmx-import-export-design.md
@@ -31,7 +31,7 @@ Parse and write TMX 1.4 with a bounded XML reader. The import API accepts a dry 
 
 ### Limits
 
-The documented unit cap is 1,000,000 translation units per request. The import body may be up to 100,000,000 characters. Callers may pass a lower `maxUnits`. Files over either cap are rejected with an explicit error. They are never silently truncated. Writes use batches of 500 entries.
+The documented unit cap is 1,000,000 translation units per request. The import body may be up to 100,000,000 characters. Callers may pass a lower `maxUnits`. Files over either cap are rejected with an explicit error. They are never silently truncated. Writes use batches of 500 entries. Existing-entry lookups use batches of 2,000 keys with concurrency 4. Export streams TMX pages instead of buffering the full memory.
 
 Multi-gigabyte or multi-million-unit memories still need to be split. The current import path parses the request body in memory and writes in one API call. Async blob ingest is out of scope.
 

--- a/docs/adr/2026-08-28-tmx-import-export-design.md
+++ b/docs/adr/2026-08-28-tmx-import-export-design.md
@@ -1,0 +1,40 @@
+# TMX import and export
+
+## Context
+
+Native translation-memory import used regular expressions and assumed the first TUV was the source. That dropped inline codes, ignored header `srclang`, truncated after 5,000 units, and had no export path.
+
+## Decision
+
+Parse and write TMX 1.4 with a bounded XML reader. The import API accepts a dry run, returns a durable report, writes in batches, and upserts units that carry a stable `tuid`. Export downloads the full memory or a locale pair.
+
+### Supported
+
+- XML declaration encodings UTF-8, US-ASCII, and UTF-16 (payload is already Unicode)
+- Header `srclang` and per-unit `srclang`
+- `xml:lang` and TMX 1.1 `lang` on each TUV
+- Multiple target languages in one unit
+- Inline codes `bpt`, `ept`, `ph`, `it`, `hi`, `sub`, `ut`
+- Predefined and numeric character entities
+- `prop`, `note`, creation/change dates and ids
+- Context from `context`, `x-context`, `x-context-string`, `x-context-pre`, and `x-context-post`
+- Idempotent re-import when `tuid` is present (`externalKey` is `tmx:{tuid}:{source}:{target}`)
+
+### Intentionally unsupported
+
+- `ude` / `map` user-defined entities
+- `alttrans`
+- DTD and custom entity declarations (rejected to prevent XXE)
+- Non-UTF encodings such as ISO-8859-1 or Windows-1252
+- Same-language target variants in one unit (the extra TUV is skipped with a warning)
+- TBX and spreadsheet interchange
+
+### Limits
+
+The documented unit cap is 50,000 translation units per request. Callers may pass a lower `maxUnits`. Files over the cap are rejected with `unit_limit_exceeded`. They are never silently truncated. Writes use batches of 250 entries.
+
+Imported rows still require `memories:write` and keep the existing review-status default (`approved`) unless the file sets `x-review-status` or `review-status`.
+
+## Consequences
+
+CSV import shares the same report and dry-run contract. The TM detail page previews the report before writing and can download TMX.

--- a/docs/adr/2026-08-28-tmx-import-export-design.md
+++ b/docs/adr/2026-08-28-tmx-import-export-design.md
@@ -31,7 +31,9 @@ Parse and write TMX 1.4 with a bounded XML reader. The import API accepts a dry 
 
 ### Limits
 
-The documented unit cap is 50,000 translation units per request. Callers may pass a lower `maxUnits`. Files over the cap are rejected with `unit_limit_exceeded`. They are never silently truncated. Writes use batches of 250 entries.
+The documented unit cap is 1,000,000 translation units per request. The import body may be up to 100,000,000 characters. Callers may pass a lower `maxUnits`. Files over either cap are rejected with an explicit error. They are never silently truncated. Writes use batches of 500 entries.
+
+Multi-gigabyte or multi-million-unit memories still need to be split. The current import path parses the request body in memory and writes in one API call. Async blob ingest is out of scope.
 
 Imported rows still require `memories:write` and keep the existing review-status default (`approved`) unless the file sets `x-review-status` or `review-status`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Native TMX import no longer uses regular-expression extraction. A bounded XML reader parses TMX 1.4, keeps inline codes and entities, honors header `srclang` and TUV language tags, and expands multilingual units into locale pairs.

Import now supports a dry-run preview, returns a durable report (`totalRead`, `created`, `updated`, `variantCreated`, `skipped`, `warned`, `failed`, plus unit-level issues), writes in batches of 500, and upserts units that carry a stable `tuid`. Files over the documented **1,000,000-unit** or **100MB** caps are rejected instead of silently truncated. Existing-entry lookups use 2,000-key batches with concurrency 4. Export streams TMX pages instead of buffering the full memory.

Native memories can download TMX for the full TM or a filtered locale pair. Re-import of the exported file preserves segment text, including inline codes. Malformed inline markup is escaped so downloads stay well-formed. The import UI decodes UTF-16 by BOM. Review status from TMX is applied on both create and tuid update.

Unsupported TMX elements (`ude`, `map`, `alttrans`, DTD/entity declarations, non-UTF encodings, same-language target variants) are documented in `docs/adr/2026-08-28-tmx-import-export-design.md`.

## How to test

- `vp test src/lib/memory src/api/routes/memory` from `apps/hyperlocalise-web`
- `vp check --fix` from `apps/hyperlocalise-web`
- On a native TM detail page: choose a TMX file, review the preview, confirm import, then export TMX and re-import

## Checklist

- [x] I ran relevant checks locally (`vp test` for memory routes/library, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-633](https://linear.app/hyperlocalise/issue/HL-633/implement-standards-compliant-tmx-importexport-with-validation-reports)

<div><a href="https://cursor.com/agents/bc-743b6ecf-8b04-4e04-b213-8abb1358f0aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-743b6ecf-8b04-4e04-b213-8abb1358f0aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

