### PR TITLE
feat(overview): limit Needs you now to last 7 days

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -530,30 +530,38 @@ describe("project job list triage", () => {
   it("filters Overview triage statuses and ranks review before failed before in-progress", async () => {
     const { identity, organization, project } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);
+    const now = Date.now();
+    const hoursAgo = (hours: number) => new Date(now - hours * 60 * 60 * 1000);
 
     const [queuedJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       status: "queued",
-      updatedAt: new Date("2026-08-01T12:00:00.000Z"),
+      updatedAt: hoursAgo(1),
     });
     const [failedJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       status: "failed",
-      updatedAt: new Date("2026-08-01T11:00:00.000Z"),
+      updatedAt: hoursAgo(2),
     });
     const [reviewJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       status: "waiting_for_review",
-      updatedAt: new Date("2026-08-01T10:00:00.000Z"),
+      updatedAt: hoursAgo(3),
     });
     const [succeededJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       status: "succeeded",
-      updatedAt: new Date("2026-08-01T13:00:00.000Z"),
+      updatedAt: hoursAgo(0.5),
+    });
+    const [staleReviewJob] = await insertNativeJob({
+      organizationId: organization.id,
+      projectId: project.id,
+      status: "waiting_for_review",
+      updatedAt: new Date(now - 8 * 24 * 60 * 60 * 1000),
     });
 
     const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$get(
@@ -575,6 +583,7 @@ describe("project job list triage", () => {
     expect(body.jobs.map((job) => job.id)).toEqual([reviewJob.id, failedJob.id, queuedJob.id]);
     expect(body.jobs.map((job) => job.status)).toEqual(["waiting_for_review", "failed", "queued"]);
     expect(body.jobs.some((job) => job.id === succeededJob.id)).toBe(false);
+    expect(body.jobs.some((job) => job.id === staleReviewJob.id)).toBe(false);
   });
 });
 
@@ -583,40 +592,49 @@ describe("workspace job list triage", () => {
     const { identity, organization, project, user } =
       await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);
+    const now = Date.now();
+    const hoursAgo = (hours: number) => new Date(now - hours * 60 * 60 * 1000);
 
     const [queuedJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       ownerUserId: user.id,
       status: "queued",
-      updatedAt: new Date("2026-08-01T12:00:00.000Z"),
+      updatedAt: hoursAgo(1),
     });
     const [failedJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       ownerUserId: user.id,
       status: "failed",
-      updatedAt: new Date("2026-08-01T11:00:00.000Z"),
+      updatedAt: hoursAgo(2),
     });
     const [reviewJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       ownerUserId: user.id,
       status: "waiting_for_review",
-      updatedAt: new Date("2026-08-01T10:00:00.000Z"),
+      updatedAt: hoursAgo(3),
     });
     const [succeededJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       ownerUserId: user.id,
       status: "succeeded",
-      updatedAt: new Date("2026-08-01T13:00:00.000Z"),
+      updatedAt: hoursAgo(0.5),
     });
     const [unownedReviewJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       status: "waiting_for_review",
-      updatedAt: new Date("2026-08-01T14:00:00.000Z"),
+      updatedAt: hoursAgo(0.25),
+    });
+    const [staleReviewJob] = await insertNativeJob({
+      organizationId: organization.id,
+      projectId: project.id,
+      ownerUserId: user.id,
+      status: "waiting_for_review",
+      updatedAt: new Date(now - 8 * 24 * 60 * 60 * 1000),
     });
 
     const response = await client.api.orgs[":organizationSlug"].jobs.$get(
@@ -639,6 +657,7 @@ describe("workspace job list triage", () => {
     expect(body.jobs.map((job) => job.status)).toEqual(["waiting_for_review", "failed", "queued"]);
     expect(body.jobs.some((job) => job.id === succeededJob.id)).toBe(false);
     expect(body.jobs.some((job) => job.id === unownedReviewJob.id)).toBe(false);
+    expect(body.jobs.some((job) => job.id === staleReviewJob.id)).toBe(false);
   });
 });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  isWithinOverviewTriageLookback,
+  overviewTriageLookbackCutoff,
+  overviewTriageLookbackDays,
+} from "./job.schema";
+
+describe("overview triage lookback", () => {
+  const now = new Date("2026-08-28T12:00:00.000Z");
+  const nowMs = now.getTime();
+
+  it("uses a 7-day window", () => {
+    expect(overviewTriageLookbackDays).toBe(7);
+    expect(overviewTriageLookbackCutoff(now).toISOString()).toBe("2026-08-21T12:00:00.000Z");
+  });
+
+  it("includes jobs updated at the cutoff and excludes older ones", () => {
+    expect(isWithinOverviewTriageLookback("2026-08-21T12:00:00.000Z", nowMs)).toBe(true);
+    expect(isWithinOverviewTriageLookback("2026-08-21T11:59:59.999Z", nowMs)).toBe(false);
+    expect(isWithinOverviewTriageLookback("not-a-date", nowMs)).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -100,12 +100,29 @@ export const overviewTriageJobStatusValues = [
   "running",
 ] as const;
 
+/** Overview "Needs you now" only includes jobs updated in this window. */
+export const overviewTriageLookbackDays = 7;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function overviewTriageLookbackCutoff(now: Date = new Date()): Date {
+  return new Date(now.getTime() - overviewTriageLookbackDays * MS_PER_DAY);
+}
+
+export function isWithinOverviewTriageLookback(
+  updatedAt: string,
+  nowMs: number = Date.now(),
+): boolean {
+  const updatedMs = Date.parse(updatedAt);
+  return !Number.isNaN(updatedMs) && nowMs - updatedMs <= overviewTriageLookbackDays * MS_PER_DAY;
+}
+
 export const jobListQuerySchema = z.object({
   kind: z.enum(schema.jobKindEnum.enumValues).optional(),
   type: z.enum(schema.translationJobTypeEnum.enumValues).optional(),
   status: z.enum(schema.jobStatusEnum.enumValues).optional(),
   open: z.coerce.boolean().optional(),
-  /** Prefer review/failed before other open jobs, then apply `limit`. */
+  /** Prefer review/failed before other open jobs, keep last 7 days, then apply `limit`. */
   triage: z.coerce.boolean().optional(),
   relationship: z.enum(["assigned", "created"]).optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-overview-jobs.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-overview-jobs.ts
@@ -49,8 +49,9 @@ export function useProjectOverviewJobsQuery(
         return selectOverviewTriageProjectJobs(jobs, PROJECT_OVERVIEW_TRIAGE_LIMIT) as ApiJob[];
       }
 
-      // Server orders by triage priority before applying the cap so older
-      // waiting_for_review / failed jobs are not displaced by newer queued work.
+      // Server keeps jobs updated in the last 7 days, then orders by triage
+      // priority before applying the cap so older waiting_for_review / failed
+      // jobs are not displaced by newer queued work.
       return (await fetchNativeProjectJobs(organizationSlug, projectId, {
         triage: true,
         limit: PROJECT_OVERVIEW_TRIAGE_LIMIT,

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.test.ts
@@ -202,6 +202,7 @@ describe("fetchProjectJobs", () => {
   });
 
   it("applies the triage cap after review-priority selection", () => {
+    const nowMs = Date.parse("2026-07-02T00:00:10.000Z");
     const jobs = [
       { id: "running-new", status: "running", updatedAt: "2026-07-02T00:00:10.000Z" },
       { id: "queued-new", status: "queued", updatedAt: "2026-07-02T00:00:09.000Z" },
@@ -216,12 +217,35 @@ describe("fetchProjectJobs", () => {
       { id: "failed-old", status: "failed", updatedAt: "2026-07-01T00:00:01.000Z" },
     ];
 
-    expect(selectOverviewTriageProjectJobs(jobs, 5).map((job) => job.id)).toEqual([
+    expect(selectOverviewTriageProjectJobs(jobs, 5, nowMs).map((job) => job.id)).toEqual([
       "review-old",
       "failed-old",
       "running-new",
       "queued-new",
       "running-2",
+    ]);
+  });
+
+  it("excludes triage jobs not updated in the last 7 days", () => {
+    const nowMs = Date.parse("2026-08-28T12:00:00.000Z");
+    const jobs = [
+      {
+        id: "recent-review",
+        status: "waiting_for_review",
+        updatedAt: "2026-08-27T12:00:00.000Z",
+      },
+      {
+        id: "stale-review",
+        status: "waiting_for_review",
+        updatedAt: "2026-08-20T12:00:00.000Z",
+      },
+      { id: "stale-failed", status: "failed", updatedAt: "2026-08-01T00:00:00.000Z" },
+      { id: "recent-queued", status: "queued", updatedAt: "2026-08-25T12:00:00.000Z" },
+    ];
+
+    expect(selectOverviewTriageProjectJobs(jobs, 5, nowMs).map((job) => job.id)).toEqual([
+      "recent-review",
+      "recent-queued",
     ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.ts
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import {
+  isWithinOverviewTriageLookback,
   jobsResponseSchema,
   openJobStatusValues,
   overviewTriageJobStatusValues,
@@ -95,14 +96,17 @@ export function filterOverviewTriageProjectJobs<T extends ProjectJobRecord>(
 }
 
 /**
- * Filters to triage statuses, ranks review → failed → in-progress, then caps.
- * Use before displaying the Overview Today queue (especially for TMS lists).
+ * Filters to triage statuses updated in the last 7 days, ranks review → failed
+ * → in-progress, then caps. Use before displaying the Overview Today queue
+ * (especially for TMS lists).
  */
 export function selectOverviewTriageProjectJobs<T extends ProjectJobRecord>(
   jobs: readonly T[],
   limit: number,
+  nowMs: number = Date.now(),
 ): T[] {
   return filterOverviewTriageProjectJobs(jobs)
+    .filter((job) => isWithinOverviewTriageLookback(job.updatedAt, nowMs))
     .toSorted((left, right) => {
       const rankDiff =
         overviewTriageStatusRank(left.status) - overviewTriageStatusRank(right.status);

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/organization-job-query-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/organization-job-query-service.ts
@@ -10,12 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, isNull, ne, or, sql } from "drizzle-orm";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
 import {
   openJobStatusValues,
   overviewTriageJobStatusValues,
+  overviewTriageLookbackCutoff,
 } from "@/api/routes/project/job.schema";
 import { buildAccessibleJobsWhere, buildOrganizationJobsListWhere } from "@/api/auth/team-access";
 import { db, schema } from "@/lib/database";
@@ -106,6 +107,7 @@ function jobListFilters(input: {
 
   if (input.triage) {
     filters.push(inArray(schema.jobs.status, [...overviewTriageJobStatusValues]));
+    filters.push(gte(schema.jobs.updatedAt, overviewTriageLookbackCutoff()));
   } else if (input.open) {
     filters.push(inArray(schema.jobs.status, [...openJobStatusValues]));
   } else if (input.status) {

--- a/docs/adr/2026-08-28-overview-triage-7-day-lookback-design.md
+++ b/docs/adr/2026-08-28-overview-triage-7-day-lookback-design.md
@@ -1,0 +1,24 @@
+# Overview triage: last 7 days only
+
+## Problem
+
+Project Overview **Needs you now** listed every triage-eligible job (review,
+failed, queued, running), including work that had not changed in weeks. The
+queue should stay a current action list, not a backlog.
+
+## Decision
+
+When `triage=true` (native Overview) or when selecting Overview jobs on the
+client (TMS), keep only jobs whose `updatedAt` is within the last 7 days.
+
+- Use `updatedAt`, not `createdAt`, so a job created earlier still appears if
+  it entered review or failed recently.
+- Apply the window before triage ranking and the existing cap of 5.
+- Leave the Jobs page and non-triage list queries unchanged.
+
+## Out of scope
+
+- Configurable lookback
+- Filtering by `createdAt`
+- Workspace dashboard UI changes (the shared `triage` query uses the same
+  window if callers pass `triage=true`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Project Overview **Needs you now** now only lists triage jobs updated in the last 7 days.

Native Overview uses `triage=true`, so the job list query drops rows whose `updatedAt` is older than seven days before ranking and applying the cap. TMS Overview uses the same window in `selectOverviewTriageProjectJobs`. Ranking is unchanged: review, then failed, then queued/running.

The Jobs page and other non-triage lists are unchanged.

## How to test

- Open a project Overview with a mix of recent and stale review/failed/queued jobs.
- Confirm **Needs you now** shows only jobs updated in the last 7 days.
- Confirm a job created earlier still appears if it was updated recently (for example, it entered review yesterday).
- Confirm the Jobs page still lists older open jobs.

```
cd apps/hyperlocalise-web
vp test src/api/routes/project/job.schema.test.ts src/lib/projects/jobs/fetch-project-jobs.test.ts src/api/routes/project/job.route.test.ts
vp check --fix
```

Local results: 15 unit tests and 14 route tests passed. `vp check --fix` reported no lint, format, or type errors.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27f5e318-f2fc-4218-bcd6-6f2f8fc6043c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27f5e318-f2fc-4218-bcd6-6f2f8fc6043c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

