### PR TITLE
fix(spellcheck): keep the service up and transcode 8-bit dictionaries

### DIFF
--- a/apps/go-svc/internal/hunspell/BUILD.bazel
+++ b/apps/go-svc/internal/hunspell/BUILD.bazel
@@ -6,17 +6,27 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 # in hunspell.go for local setup instructions.
 go_library(
     name = "hunspell",
-    srcs = ["hunspell.go"],
+    srcs = [
+        "encoding.go",
+        "hunspell.go",
+    ],
     cgo = True,
     clinkopts = ["-lhunspell"],
     gotags = ["cgo_hunspell"],
     importpath = "github.com/hyperlocalise/hyperlocalise/apps/go-svc/internal/hunspell",
     visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_x_text//encoding",
+        "@org_golang_x_text//encoding/charmap",
+    ],
 )
 
 go_test(
     name = "hunspell_test",
-    srcs = ["hunspell_test.go"],
+    srcs = [
+        "encoding_test.go",
+        "hunspell_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":hunspell"],
     gotags = ["cgo_hunspell"],

--- a/apps/go-svc/internal/hunspell/encoding.go
+++ b/apps/go-svc/internal/hunspell/encoding.go
@@ -1,0 +1,230 @@
+package hunspell
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+)
+
+var (
+	errAffixEncodingUndeclared = errors.New("hunspell: affix file has no SET declaration")
+	errAffixEncodingNotUTF8    = errors.New("hunspell: affix file declares a non-UTF-8 encoding")
+)
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+func prepareUTF8Dictionary(affPath, dicPath string) (loadAff, loadDic string, cleanup func(), err error) {
+	cleanup = func() {}
+
+	affData, err := os.ReadFile(affPath)
+	if err != nil {
+		return "", "", cleanup, fmt.Errorf("hunspell: reading affix file encoding: %w", err)
+	}
+
+	declaredEncoding, declared, bom := parseAffEncoding(affData)
+	if !declared {
+		return "", "", cleanup, fmt.Errorf("%w: %q (Hunspell defaults undeclared dictionaries to ISO8859-1, not UTF-8)", errAffixEncodingUndeclared, affPath)
+	}
+
+	decoder, ok := decoderForHunspellEncoding(declaredEncoding)
+	if !ok {
+		return "", "", cleanup, fmt.Errorf("%w: %q declares %q, which cannot be transcoded to UTF-8", errAffixEncodingNotUTF8, affPath, declaredEncoding)
+	}
+
+	if decoder == nil && !bom {
+		return affPath, dicPath, cleanup, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "hunspell-utf8-")
+	if err != nil {
+		return "", "", cleanup, fmt.Errorf("hunspell: create utf-8 staging dir: %w", err)
+	}
+	cleanup = func() { _ = os.RemoveAll(tmpDir) }
+
+	loadAff = filepath.Join(tmpDir, filepath.Base(affPath))
+	if decoder == nil {
+		if err := os.WriteFile(loadAff, bytes.TrimPrefix(affData, utf8BOM), 0o600); err != nil {
+			cleanup()
+			return "", "", func() {}, fmt.Errorf("hunspell: write utf-8 affix file: %w", err)
+		}
+		return loadAff, dicPath, cleanup, nil
+	}
+
+	affUTF8, err := decoder.NewDecoder().Bytes(affData)
+	if err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("hunspell: transcode affix file %q from %s: %w", affPath, declaredEncoding, err)
+	}
+	affUTF8, err = rewriteSETToUTF8(affUTF8)
+	if err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("hunspell: rewrite affix SET in %q: %w", affPath, err)
+	}
+
+	dicData, err := os.ReadFile(dicPath)
+	if err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("hunspell: reading dictionary file: %w", err)
+	}
+	dicUTF8, err := decoder.NewDecoder().Bytes(dicData)
+	if err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("hunspell: transcode dictionary file %q from %s: %w", dicPath, declaredEncoding, err)
+	}
+
+	loadDic = filepath.Join(tmpDir, filepath.Base(dicPath))
+	if err := os.WriteFile(loadAff, affUTF8, 0o600); err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("hunspell: write utf-8 affix file: %w", err)
+	}
+	if err := os.WriteFile(loadDic, dicUTF8, 0o600); err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("hunspell: write utf-8 dictionary file: %w", err)
+	}
+
+	return loadAff, loadDic, cleanup, nil
+}
+
+func parseAffEncoding(affData []byte) (name string, declared, bom bool) {
+	if bytes.HasPrefix(affData, utf8BOM) {
+		bom = true
+		affData = affData[len(utf8BOM):]
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(affData))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 || fields[0] != "SET" {
+			continue
+		}
+		if len(fields) > 1 {
+			return fields[1], true, bom
+		}
+		return "", true, bom
+	}
+	return "", false, bom
+}
+
+func rewriteSETToUTF8(data []byte) ([]byte, error) {
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	rewritten := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if !rewritten && len(fields) > 0 && fields[0] == "SET" {
+			out.WriteString("SET UTF-8")
+			rewritten = true
+		} else {
+			out.WriteString(line)
+		}
+		out.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func canonicalHunspellEncoding(name string) string {
+	n := strings.ToUpper(strings.TrimSpace(name))
+	n = strings.ReplaceAll(n, "_", "-")
+	switch n {
+	case "UTF-8", "UTF8":
+		return "UTF-8"
+	case "ISO8859-1", "ISO-8859-1", "LATIN1", "LATIN-1":
+		return "ISO-8859-1"
+	case "ISO8859-2", "ISO-8859-2", "LATIN2", "LATIN-2":
+		return "ISO-8859-2"
+	case "ISO8859-3", "ISO-8859-3":
+		return "ISO-8859-3"
+	case "ISO8859-4", "ISO-8859-4":
+		return "ISO-8859-4"
+	case "ISO8859-5", "ISO-8859-5":
+		return "ISO-8859-5"
+	case "ISO8859-6", "ISO-8859-6":
+		return "ISO-8859-6"
+	case "ISO8859-7", "ISO-8859-7":
+		return "ISO-8859-7"
+	case "ISO8859-8", "ISO-8859-8":
+		return "ISO-8859-8"
+	case "ISO8859-9", "ISO-8859-9":
+		return "ISO-8859-9"
+	case "ISO8859-10", "ISO-8859-10":
+		return "ISO-8859-10"
+	case "ISO8859-13", "ISO-8859-13":
+		return "ISO-8859-13"
+	case "ISO8859-14", "ISO-8859-14":
+		return "ISO-8859-14"
+	case "ISO8859-15", "ISO-8859-15", "LATIN9", "LATIN-9":
+		return "ISO-8859-15"
+	case "ISO8859-16", "ISO-8859-16":
+		return "ISO-8859-16"
+	case "KOI8-R", "KOI8R":
+		return "KOI8-R"
+	case "KOI8-U", "KOI8U":
+		return "KOI8-U"
+	case "CP1250", "WINDOWS-1250", "MICROSOFT-CP1250":
+		return "WINDOWS-1250"
+	case "CP1251", "WINDOWS-1251", "MICROSOFT-CP1251":
+		return "WINDOWS-1251"
+	case "CP1252", "WINDOWS-1252", "MICROSOFT-CP1252":
+		return "WINDOWS-1252"
+	default:
+		return n
+	}
+}
+
+func decoderForHunspellEncoding(name string) (encoding.Encoding, bool) {
+	switch canonicalHunspellEncoding(name) {
+	case "UTF-8":
+		return nil, true
+	case "ISO-8859-1":
+		return charmap.ISO8859_1, true
+	case "ISO-8859-2":
+		return charmap.ISO8859_2, true
+	case "ISO-8859-3":
+		return charmap.ISO8859_3, true
+	case "ISO-8859-4":
+		return charmap.ISO8859_4, true
+	case "ISO-8859-5":
+		return charmap.ISO8859_5, true
+	case "ISO-8859-6":
+		return charmap.ISO8859_6, true
+	case "ISO-8859-7":
+		return charmap.ISO8859_7, true
+	case "ISO-8859-8":
+		return charmap.ISO8859_8, true
+	case "ISO-8859-9":
+		return charmap.ISO8859_9, true
+	case "ISO-8859-10":
+		return charmap.ISO8859_10, true
+	case "ISO-8859-13":
+		return charmap.ISO8859_13, true
+	case "ISO-8859-14":
+		return charmap.ISO8859_14, true
+	case "ISO-8859-15":
+		return charmap.ISO8859_15, true
+	case "ISO-8859-16":
+		return charmap.ISO8859_16, true
+	case "KOI8-R":
+		return charmap.KOI8R, true
+	case "KOI8-U":
+		return charmap.KOI8U, true
+	case "WINDOWS-1250":
+		return charmap.Windows1250, true
+	case "WINDOWS-1251":
+		return charmap.Windows1251, true
+	case "WINDOWS-1252":
+		return charmap.Windows1252, true
+	default:
+		return nil, false
+	}
+}

--- a/apps/go-svc/internal/hunspell/encoding_test.go
+++ b/apps/go-svc/internal/hunspell/encoding_test.go
@@ -1,0 +1,226 @@
+package hunspell
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseAffEncoding(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         []byte
+		wantName     string
+		wantDeclared bool
+		wantBOM      bool
+	}{
+		{name: "utf-8", data: []byte("SET UTF-8\n"), wantName: "UTF-8", wantDeclared: true},
+		{name: "utf-8 with bom", data: append(append([]byte{}, utf8BOM...), []byte("SET UTF-8\n")...), wantName: "UTF-8", wantDeclared: true, wantBOM: true},
+		{name: "iso8859-1 after comment", data: []byte("# comment\nSET ISO8859-1\n"), wantName: "ISO8859-1", wantDeclared: true},
+		{name: "missing", data: []byte("TRY abc\n"), wantDeclared: false},
+		{name: "set without value", data: []byte("SET\n"), wantDeclared: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotDeclared, gotBOM := parseAffEncoding(tt.data)
+			if gotName != tt.wantName || gotDeclared != tt.wantDeclared || gotBOM != tt.wantBOM {
+				t.Errorf("parseAffEncoding() = (%q, %v, %v), want (%q, %v, %v)", gotName, gotDeclared, gotBOM, tt.wantName, tt.wantDeclared, tt.wantBOM)
+			}
+		})
+	}
+}
+
+func TestRewriteSETToUTF8(t *testing.T) {
+	got, err := rewriteSETToUTF8([]byte("# keep\nSET ISO8859-1\nTRY abc\n"))
+	if err != nil {
+		t.Fatalf("rewriteSETToUTF8() error = %v, want nil", err)
+	}
+	want := "# keep\nSET UTF-8\nTRY abc\n"
+	if string(got) != want {
+		t.Errorf("rewriteSETToUTF8() = %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalHunspellEncoding(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "UTF-8", want: "UTF-8"},
+		{in: "utf8", want: "UTF-8"},
+		{in: "ISO8859-1", want: "ISO-8859-1"},
+		{in: "iso-8859-1", want: "ISO-8859-1"},
+		{in: "LATIN1", want: "ISO-8859-1"},
+		{in: "ISO8859-2", want: "ISO-8859-2"},
+		{in: "microsoft-cp1251", want: "WINDOWS-1251"},
+		{in: "EBCDIC", want: "EBCDIC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := canonicalHunspellEncoding(tt.in); got != tt.want {
+				t.Errorf("canonicalHunspellEncoding(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrepareUTF8Dictionary(t *testing.T) {
+	t.Run("utf-8 without bom uses original paths", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET UTF-8\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte("1\nhello\n"), 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		loadAff, loadDic, cleanup, err := prepareUTF8Dictionary(aff, dic)
+		if err != nil {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want nil", err)
+		}
+		t.Cleanup(cleanup)
+
+		if loadAff != aff || loadDic != dic {
+			t.Errorf("prepareUTF8Dictionary() paths = (%q, %q), want the original files", loadAff, loadDic)
+		}
+	})
+
+	t.Run("iso8859-1 latin-1 word becomes utf-8", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET ISO8859-1\nTRY abc\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte{'1', '\n', 'c', 'a', 'f', 0xE9, '\n'}, 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		loadAff, loadDic, cleanup, err := prepareUTF8Dictionary(aff, dic)
+		if err != nil {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want nil", err)
+		}
+		t.Cleanup(cleanup)
+
+		affOut, err := os.ReadFile(loadAff)
+		if err != nil {
+			t.Fatalf("read converted aff: %v", err)
+		}
+		if !bytes.HasPrefix(affOut, []byte("SET UTF-8\n")) {
+			t.Errorf("converted aff = %q, want SET UTF-8", affOut)
+		}
+
+		dicOut, err := os.ReadFile(loadDic)
+		if err != nil {
+			t.Fatalf("read converted dic: %v", err)
+		}
+		if !bytes.Contains(dicOut, []byte("café")) {
+			t.Errorf("converted dic = %q, want it to contain UTF-8 %q", dicOut, "café")
+		}
+		if bytes.Contains(dicOut, []byte{0xE9}) {
+			t.Errorf("converted dic still contains ISO8859-1 0xE9: %q", dicOut)
+		}
+	})
+
+	t.Run("iso8859-2 word becomes utf-8", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET ISO8859-2\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte{'1', '\n', 0xB3, '\n'}, 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		_, loadDic, cleanup, err := prepareUTF8Dictionary(aff, dic)
+		if err != nil {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want nil", err)
+		}
+		t.Cleanup(cleanup)
+
+		dicOut, err := os.ReadFile(loadDic)
+		if err != nil {
+			t.Fatalf("read converted dic: %v", err)
+		}
+		if !bytes.Contains(dicOut, []byte("ł")) {
+			t.Errorf("converted dic = %q, want it to contain UTF-8 %q", dicOut, "ł")
+		}
+	})
+
+	t.Run("utf-8 bom is stripped", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, append(append([]byte{}, utf8BOM...), []byte("SET UTF-8\nTRY abc\n")...), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte("1\nhello\n"), 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		loadAff, loadDic, cleanup, err := prepareUTF8Dictionary(aff, dic)
+		if err != nil {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want nil", err)
+		}
+		t.Cleanup(cleanup)
+
+		if loadDic != dic {
+			t.Errorf("dictionary path = %q, want original %q", loadDic, dic)
+		}
+		affOut, err := os.ReadFile(loadAff)
+		if err != nil {
+			t.Fatalf("read stripped aff: %v", err)
+		}
+		if bytes.HasPrefix(affOut, utf8BOM) {
+			t.Error("converted aff still starts with a UTF-8 BOM")
+		}
+		if !bytes.HasPrefix(affOut, []byte("SET UTF-8\n")) {
+			t.Errorf("stripped aff = %q, want SET UTF-8", affOut)
+		}
+	})
+
+	t.Run("unknown encoding is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET EBCDIC\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte("1\nhello\n"), 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		_, _, _, err := prepareUTF8Dictionary(aff, dic)
+		if !errors.Is(err, errAffixEncodingNotUTF8) {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want error wrapping errAffixEncodingNotUTF8", err)
+		}
+		if err != nil && !strings.Contains(err.Error(), "EBCDIC") {
+			t.Errorf("prepareUTF8Dictionary() error = %q, want it to mention the declared encoding", err.Error())
+		}
+	})
+
+	t.Run("missing SET is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("TRY abc\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte("1\nhello\n"), 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		_, _, _, err := prepareUTF8Dictionary(aff, dic)
+		if !errors.Is(err, errAffixEncodingUndeclared) {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want error wrapping errAffixEncodingUndeclared", err)
+		}
+	})
+}

--- a/apps/go-svc/internal/hunspell/hunspell.go
+++ b/apps/go-svc/internal/hunspell/hunspell.go
@@ -11,21 +11,14 @@ package hunspell
 import "C"
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"unsafe"
 )
 
 // ErrClosed is returned by Dictionary methods once Close has been called.
 var ErrClosed = errors.New("hunspell: dictionary is closed")
-
-var (
-	errAffixEncodingUndeclared = errors.New("hunspell: affix file has no SET declaration")
-	errAffixEncodingNotUTF8    = errors.New("hunspell: affix file declares a non-UTF-8 encoding")
-)
 
 const maxSuggestions = 5
 
@@ -35,8 +28,11 @@ type Dictionary struct {
 	closed bool
 }
 
-// New loads a UTF-8 Hunspell affix and dictionary pair.
-// Affix files without SET default to ISO8859-1 and are rejected.
+// New loads a Hunspell affix and dictionary pair for use with UTF-8 words.
+// Dictionaries that already declare UTF-8 are loaded as-is. Known 8-bit
+// encodings are transcoded to UTF-8 first so Go strings can be passed to
+// the C API. Affix files without SET, or with an unknown SET encoding, are
+// rejected because Hunspell defaults undeclared dictionaries to ISO8859-1.
 func New(affPath, dicPath string) (*Dictionary, error) {
 	if _, err := os.Stat(affPath); err != nil {
 		return nil, fmt.Errorf("hunspell: affix file: %w", err)
@@ -45,20 +41,15 @@ func New(affPath, dicPath string) (*Dictionary, error) {
 		return nil, fmt.Errorf("hunspell: dictionary file: %w", err)
 	}
 
-	encoding, declared, err := affEncoding(affPath)
+	loadAff, loadDic, cleanup, err := prepareUTF8Dictionary(affPath, dicPath)
 	if err != nil {
-		return nil, fmt.Errorf("hunspell: reading affix file encoding: %w", err)
+		return nil, err
 	}
-	if !declared {
-		return nil, fmt.Errorf("%w: %q (Hunspell defaults undeclared dictionaries to ISO8859-1, not UTF-8)", errAffixEncodingUndeclared, affPath)
-	}
-	if encoding != "UTF-8" {
-		return nil, fmt.Errorf("%w: %q declares %q, only UTF-8 dictionaries are supported", errAffixEncodingNotUTF8, affPath, encoding)
-	}
+	defer cleanup()
 
-	cAffPath := C.CString(affPath)
+	cAffPath := C.CString(loadAff)
 	defer C.free(unsafe.Pointer(cAffPath))
-	cDicPath := C.CString(dicPath)
+	cDicPath := C.CString(loadDic)
 	defer C.free(unsafe.Pointer(cDicPath))
 
 	handle := C.Hunspell_create(cAffPath, cDicPath)
@@ -67,26 +58,6 @@ func New(affPath, dicPath string) (*Dictionary, error) {
 	}
 
 	return &Dictionary{handle: handle}, nil
-}
-
-func affEncoding(affPath string) (encoding string, declared bool, err error) {
-	f, err := os.Open(affPath)
-	if err != nil {
-		return "", false, err
-	}
-	defer func() { _ = f.Close() }()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) > 0 && fields[0] == "SET" {
-			if len(fields) > 1 {
-				return fields[1], true, nil
-			}
-			return "", true, nil
-		}
-	}
-	return "", false, scanner.Err()
 }
 
 // Spell reports whether word is recognized by the loaded dictionary.

--- a/apps/go-svc/internal/hunspell/hunspell_test.go
+++ b/apps/go-svc/internal/hunspell/hunspell_test.go
@@ -60,9 +60,145 @@ func TestNew(t *testing.T) {
 	})
 }
 
-func TestNewRejectsNonUTF8Dictionaries(t *testing.T) {
-	t.Run("declared non-UTF-8 encoding", func(t *testing.T) {
-		_, err := New(nonUTF8Aff, nonUTF8Dic)
+func TestNewEncoding(t *testing.T) {
+	t.Run("ISO8859-1 ASCII dictionary loads", func(t *testing.T) {
+		d, err := New(nonUTF8Aff, nonUTF8Dic)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil (ISO8859-1 is transcoded to UTF-8)", err)
+		}
+		t.Cleanup(func() {
+			if err := d.Close(); err != nil {
+				t.Errorf("Close() error = %v, want nil", err)
+			}
+		})
+
+		got, err := d.Spell("hello")
+		if err != nil {
+			t.Fatalf("Spell() error = %v, want nil", err)
+		}
+		if !got {
+			t.Error(`Spell("hello") = false, want true after ISO8859-1 transcoding`)
+		}
+	})
+
+	t.Run("ISO8859-1 latin-1 word is queryable as UTF-8", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET ISO8859-1\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte{'1', '\n', 'c', 'a', 'f', 0xE9, '\n'}, 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		d, err := New(aff, dic)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil", err)
+		}
+		t.Cleanup(func() {
+			if err := d.Close(); err != nil {
+				t.Errorf("Close() error = %v, want nil", err)
+			}
+		})
+
+		got, err := d.Spell("café")
+		if err != nil {
+			t.Fatalf("Spell() error = %v, want nil", err)
+		}
+		if !got {
+			t.Error(`Spell("café") = false, want true: the ISO8859-1 byte 0xE9 must become UTF-8 before Hunspell_create`)
+		}
+	})
+
+	t.Run("ISO8859-2 word is queryable as UTF-8", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET ISO8859-2\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte{'1', '\n', 0xB3, '\n'}, 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		d, err := New(aff, dic)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil", err)
+		}
+		t.Cleanup(func() {
+			if err := d.Close(); err != nil {
+				t.Errorf("Close() error = %v, want nil", err)
+			}
+		})
+
+		got, err := d.Spell("ł")
+		if err != nil {
+			t.Fatalf("Spell() error = %v, want nil", err)
+		}
+		if !got {
+			t.Error(`Spell("ł") = false, want true after ISO8859-2 transcoding`)
+		}
+	})
+
+	t.Run("UTF-8 BOM is stripped so SET is recognized", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		valid, err := os.ReadFile(validAff)
+		if err != nil {
+			t.Fatalf("read valid aff: %v", err)
+		}
+		if err := os.WriteFile(aff, append(append([]byte{}, utf8BOM...), valid...), 0o600); err != nil {
+			t.Fatalf("write bom aff: %v", err)
+		}
+
+		d, err := New(aff, validDic)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil for a UTF-8 dictionary that starts with a BOM", err)
+		}
+		t.Cleanup(func() {
+			if err := d.Close(); err != nil {
+				t.Errorf("Close() error = %v, want nil", err)
+			}
+		})
+
+		got, err := d.Spell("hello")
+		if err != nil {
+			t.Fatalf("Spell() error = %v, want nil", err)
+		}
+		if !got {
+			t.Error(`Spell("hello") = false, want true after BOM stripping`)
+		}
+	})
+
+	t.Run("SET UTF8 alias is treated as UTF-8", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		if err := os.WriteFile(aff, []byte("SET UTF8\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+
+		d, err := New(aff, validDic)
+		if err != nil {
+			t.Fatalf("New() error = %v, want nil for SET UTF8", err)
+		}
+		if err := d.Close(); err != nil {
+			t.Errorf("Close() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("unknown encoding is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET EBCDIC\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte("1\nhello\n"), 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		_, err := New(aff, dic)
 		if !errors.Is(err, errAffixEncodingNotUTF8) {
 			t.Fatalf("New() error = %v, want error wrapping errAffixEncodingNotUTF8", err)
 		}

--- a/apps/go-svc/main.go
+++ b/apps/go-svc/main.go
@@ -50,7 +50,9 @@ func main() {
 
 	spellChecker, closeSpellChecker, err := newSpellChecker(dictDir)
 	if err != nil {
-		log.Fatalf("configure spell checker: %v", err)
+		log.Printf("configure spell checker: %v; continuing without spell check", err)
+		spellChecker = NoopSpellChecker{}
+		closeSpellChecker = func() error { return nil }
 	}
 
 	defer func() {

--- a/apps/go-svc/spellcheck_provider_cgo.go
+++ b/apps/go-svc/spellcheck_provider_cgo.go
@@ -27,15 +27,18 @@ type hunspellSpellChecker struct {
 
 var _ SpellChecker = (*hunspellSpellChecker)(nil)
 
-func newHunspellSpellChecker(dictDir string, registry *spellcheck.Registry) (*hunspellSpellChecker, error) {
+func newHunspellSpellChecker(dictDir string, registry *spellcheck.Registry) *hunspellSpellChecker {
 	locales := registry.SupportedLocales()
 	handles := make(map[string]*localeHandle, len(locales))
 
 	for _, locale := range locales {
 		files, err := registry.Resolve(locale)
 		if err != nil {
-			rollbackHandles(handles)
-			return nil, fmt.Errorf("spellcheck: resolve locale %q: %w", locale, err)
+			slog.Warn("spellcheck: dictionary resolve failed",
+				"locale", locale,
+				"error", err,
+			)
+			continue
 		}
 
 		affPath := filepath.Join(dictDir, files.AffFile)
@@ -49,20 +52,24 @@ func newHunspellSpellChecker(dictDir string, registry *spellcheck.Registry) (*hu
 				"dic_path", dicPath,
 				"error", err,
 			)
-			rollbackHandles(handles)
-			return nil, fmt.Errorf("spellcheck: load dictionary for locale %q: %w", locale, err)
+			continue
 		}
 
 		handles[locale] = &localeHandle{dict: dict}
 	}
 
-	return &hunspellSpellChecker{handles: handles}, nil
-}
-
-func rollbackHandles(handles map[string]*localeHandle) {
-	if err := closeHandles(handles); err != nil {
-		slog.Warn("spellcheck: error closing dictionaries during startup rollback", "error", err)
+	if len(handles) == 0 {
+		slog.Warn("spellcheck: no dictionaries loaded; spelling will be skipped for all locales")
+	} else if len(handles) < len(locales) {
+		slog.Warn("spellcheck: loaded a subset of dictionaries",
+			"loaded", len(handles),
+			"configured", len(locales),
+		)
+	} else {
+		slog.Info("spellcheck: dictionaries loaded", "loaded", len(handles))
 	}
+
+	return &hunspellSpellChecker{handles: handles}
 }
 
 func closeHandles(handles map[string]*localeHandle) error {
@@ -85,7 +92,7 @@ func (c *hunspellSpellChecker) Check(ctx context.Context, locale string, words [
 
 	handle, ok := c.handles[locale]
 	if !ok {
-		slog.Info("spellcheck: skipping check for unsupported locale",
+		slog.Info("spellcheck: skipping check for locale without a loaded dictionary",
 			"locale", locale,
 			"word_count", len(words),
 		)
@@ -126,12 +133,6 @@ func (c *hunspellSpellChecker) Close() error {
 }
 
 func newSpellChecker(dictDir string) (SpellChecker, func() error, error) {
-	registry := spellcheck.LoadRegistry()
-
-	checker, err := newHunspellSpellChecker(dictDir, registry)
-	if err != nil {
-		return nil, nil, err
-	}
-
+	checker := newHunspellSpellChecker(dictDir, spellcheck.LoadRegistry())
 	return checker, checker.Close, nil
 }

--- a/apps/go-svc/spellcheck_provider_cgo_test.go
+++ b/apps/go-svc/spellcheck_provider_cgo_test.go
@@ -27,10 +27,7 @@ func newTestHunspellChecker(t *testing.T, dictDir string, dictionaries map[strin
 	t.Helper()
 
 	registry := spellcheck.NewRegistry(dictionaries)
-	checker, err := newHunspellSpellChecker(dictDir, registry)
-	if err != nil {
-		t.Fatalf("newHunspellSpellChecker() error = %v, want nil", err)
-	}
+	checker := newHunspellSpellChecker(dictDir, registry)
 	t.Cleanup(func() {
 		if err := checker.Close(); err != nil {
 			t.Errorf("Close() error = %v, want nil", err)
@@ -127,6 +124,30 @@ func TestHunspellSpellCheckerCheckPropagatesContextCancellation(t *testing.T) {
 	}
 }
 
+func TestNewHunspellSpellCheckerPartialLoadFromFixtures(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureCopy(t, dir, "locale-ok", validDictDir)
+	writeFixtureCopy(t, dir, "locale-bad", noSetDictDir)
+
+	checker := newTestHunspellChecker(t, dir, map[string]spellcheck.DictionaryFiles{
+		"aa-AA": {AffFile: "locale-ok.aff", DicFile: "locale-ok.dic"},
+		"zz-ZZ": {AffFile: "locale-bad.aff", DicFile: "locale-bad.dic"},
+	})
+
+	got, err := checker.Check(context.Background(), "aa-AA", []string{"hello"})
+	if err != nil {
+		t.Fatalf("Check(aa-AA) error = %v, want nil", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Check(aa-AA, %q) = %+v, want no issues", "hello", got)
+	}
+
+	_, err = checker.Check(context.Background(), "zz-ZZ", []string{"hello"})
+	if !errors.Is(err, spellcheck.ErrUnsupportedLocale) {
+		t.Fatalf("Check(zz-ZZ) error = %v, want error wrapping spellcheck.ErrUnsupportedLocale", err)
+	}
+}
+
 func TestHunspellSpellCheckerChecksAreIsolatedPerLocale(t *testing.T) {
 	dir := t.TempDir()
 	writeFixtureCopy(t, dir, "locale-a", validDictDir)
@@ -154,23 +175,52 @@ func TestHunspellSpellCheckerChecksAreIsolatedPerLocale(t *testing.T) {
 	}
 }
 
-func TestNewHunspellSpellCheckerMissingDictionaryFile(t *testing.T) {
+func TestNewHunspellSpellCheckerSkipsMissingDictionaryFile(t *testing.T) {
 	registry := spellcheck.NewRegistry(map[string]spellcheck.DictionaryFiles{
 		"xx-YY": {AffFile: "does-not-exist.aff", DicFile: "does-not-exist.dic"},
 	})
 
-	_, err := newHunspellSpellChecker(t.TempDir(), registry)
-	if !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("newHunspellSpellChecker() error = %v, want error wrapping os.ErrNotExist", err)
+	checker := newHunspellSpellChecker(t.TempDir(), registry)
+	t.Cleanup(func() {
+		if err := checker.Close(); err != nil {
+			t.Errorf("Close() error = %v, want nil", err)
+		}
+	})
+
+	_, err := checker.Check(context.Background(), "xx-YY", []string{"hello"})
+	if !errors.Is(err, spellcheck.ErrUnsupportedLocale) {
+		t.Fatalf("Check() error = %v, want error wrapping spellcheck.ErrUnsupportedLocale for a locale whose files are missing", err)
 	}
 }
 
-func TestNewHunspellSpellCheckerInvalidDictionary(t *testing.T) {
+func TestNewHunspellSpellCheckerLoadsISO88591Dictionary(t *testing.T) {
+	checker := newTestHunspellChecker(t, nonUTF8DictDir, map[string]spellcheck.DictionaryFiles{
+		"de-DE": {AffFile: "test.aff", DicFile: "test.dic"},
+	})
+
+	got, err := checker.Check(context.Background(), "de-DE", []string{"hello"})
+	if err != nil {
+		t.Fatalf("Check() error = %v, want nil (ISO8859-1 dictionaries are transcoded to UTF-8)", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Check() = %+v, want no issues for a word present in the ISO8859-1 dictionary", got)
+	}
+}
+
+func TestNewHunspellSpellCheckerSkipsInvalidDictionary(t *testing.T) {
+	unknownDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(unknownDir, "test.aff"), []byte("SET EBCDIC\n"), 0o600); err != nil {
+		t.Fatalf("write unknown-encoding aff: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(unknownDir, "test.dic"), []byte("1\nhello\n"), 0o600); err != nil {
+		t.Fatalf("write unknown-encoding dic: %v", err)
+	}
+
 	tests := []struct {
 		name    string
 		dictDir string
 	}{
-		{name: "declared non-UTF-8 encoding", dictDir: nonUTF8DictDir},
+		{name: "unknown encoding", dictDir: unknownDir},
 		{name: "missing SET declaration", dictDir: noSetDictDir},
 	}
 
@@ -180,39 +230,32 @@ func TestNewHunspellSpellCheckerInvalidDictionary(t *testing.T) {
 				"xx-YY": {AffFile: "test.aff", DicFile: "test.dic"},
 			})
 
-			_, err := newHunspellSpellChecker(tt.dictDir, registry)
-			if err == nil {
-				t.Fatal("newHunspellSpellChecker() error = nil, want a clear startup error")
-			}
-			if !strings.Contains(err.Error(), "xx-YY") {
-				t.Errorf("newHunspellSpellChecker() error = %q, want it to mention the failing locale %q", err.Error(), "xx-YY")
+			checker := newHunspellSpellChecker(tt.dictDir, registry)
+			t.Cleanup(func() {
+				if err := checker.Close(); err != nil {
+					t.Errorf("Close() error = %v, want nil", err)
+				}
+			})
+
+			_, err := checker.Check(context.Background(), "xx-YY", []string{"hello"})
+			if !errors.Is(err, spellcheck.ErrUnsupportedLocale) {
+				t.Fatalf("Check() error = %v, want error wrapping spellcheck.ErrUnsupportedLocale for a locale whose dictionary failed to load", err)
 			}
 		})
 	}
 }
 
-func TestNewHunspellSpellCheckerClosesAlreadyOpenedHandlesOnFailure(t *testing.T) {
+func TestNewHunspellSpellCheckerKeepsLoadedLocalesWhenOneFails(t *testing.T) {
 	original := newHunspellDictionary
 	t.Cleanup(func() { newHunspellDictionary = original })
 
-	var (
-		mu     sync.Mutex
-		opened []*hunspell.Dictionary
-	)
 	syntheticErr := errors.New("synthetic dictionary load failure")
 
 	newHunspellDictionary = func(affPath, dicPath string) (*hunspell.Dictionary, error) {
 		if strings.Contains(affPath, "fail") {
 			return nil, syntheticErr
 		}
-		dict, err := original(affPath, dicPath)
-		if err != nil {
-			return nil, err
-		}
-		mu.Lock()
-		opened = append(opened, dict)
-		mu.Unlock()
-		return dict, nil
+		return original(affPath, dicPath)
 	}
 
 	registry := spellcheck.NewRegistry(map[string]spellcheck.DictionaryFiles{
@@ -221,18 +264,24 @@ func TestNewHunspellSpellCheckerClosesAlreadyOpenedHandlesOnFailure(t *testing.T
 		"cc-CC": {AffFile: "fail.aff", DicFile: "test.dic"},
 	})
 
-	_, err := newHunspellSpellChecker(validDictDir, registry)
-	if !errors.Is(err, syntheticErr) {
-		t.Fatalf("newHunspellSpellChecker() error = %v, want error wrapping the synthetic failure", err)
+	checker := newHunspellSpellChecker(validDictDir, registry)
+	t.Cleanup(func() {
+		if err := checker.Close(); err != nil {
+			t.Errorf("Close() error = %v, want nil", err)
+		}
+	})
+
+	got, err := checker.Check(context.Background(), "aa-AA", []string{"hello"})
+	if err != nil {
+		t.Fatalf("Check(aa-AA) error = %v, want nil (a later locale failure must not drop locales that already loaded)", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Check(aa-AA, %q) = %+v, want no issues", "hello", got)
 	}
 
-	if len(opened) != 2 {
-		t.Fatalf("opened %d dictionary handle(s) before the failure, want 2 (aa-AA, bb-BB)", len(opened))
-	}
-	for i, dict := range opened {
-		if _, err := dict.Spell("hello"); !errors.Is(err, hunspell.ErrClosed) {
-			t.Errorf("opened dictionary #%d: Spell() after newHunspellSpellChecker() failure error = %v, want hunspell.ErrClosed (newHunspellSpellChecker must close handles it already opened)", i, err)
-		}
+	_, err = checker.Check(context.Background(), "cc-CC", []string{"hello"})
+	if !errors.Is(err, spellcheck.ErrUnsupportedLocale) {
+		t.Fatalf("Check(cc-CC) error = %v, want error wrapping spellcheck.ErrUnsupportedLocale for the failed locale", err)
 	}
 }
 
@@ -242,10 +291,7 @@ func TestHunspellSpellCheckerCloseIsIdempotentAndClosesEveryHandle(t *testing.T)
 		"bb-BB": {AffFile: "test.aff", DicFile: "test.dic"},
 	})
 
-	checker, err := newHunspellSpellChecker(validDictDir, registry)
-	if err != nil {
-		t.Fatalf("newHunspellSpellChecker() error = %v, want nil", err)
-	}
+	checker := newHunspellSpellChecker(validDictDir, registry)
 
 	if err := checker.Close(); err != nil {
 		t.Fatalf("first Close() error = %v, want nil", err)
@@ -259,16 +305,26 @@ func TestHunspellSpellCheckerCloseIsIdempotentAndClosesEveryHandle(t *testing.T)
 	}
 }
 
-func TestNewSpellCheckerFailsFastWhenDictionariesAreMissing(t *testing.T) {
+func TestNewSpellCheckerStartsWhenDictionariesAreMissing(t *testing.T) {
 	checker, closeFn, err := newSpellChecker(t.TempDir())
-	if err == nil {
-		t.Fatal("newSpellChecker() error = nil, want an error because no real dictionaries exist in an empty directory")
+	if err != nil {
+		t.Fatalf("newSpellChecker() error = %v, want nil (missing dictionaries must not fail startup)", err)
 	}
-	if checker != nil {
-		t.Errorf("newSpellChecker() checker = %v, want nil on error", checker)
+	if checker == nil {
+		t.Fatal("newSpellChecker() checker = nil, want a checker that skips spelling")
 	}
-	if closeFn != nil {
-		t.Error("newSpellChecker() closeFn is non-nil, want nil on error")
+	if closeFn == nil {
+		t.Fatal("newSpellChecker() closeFn is nil, want a close function")
+	}
+	t.Cleanup(func() {
+		if err := closeFn(); err != nil {
+			t.Errorf("closeFn() error = %v, want nil", err)
+		}
+	})
+
+	_, err = checker.Check(context.Background(), "de-DE", []string{"Hallo"})
+	if !errors.Is(err, spellcheck.ErrUnsupportedLocale) {
+		t.Fatalf("Check() error = %v, want error wrapping spellcheck.ErrUnsupportedLocale when no dictionaries loaded", err)
 	}
 }
 

--- a/internal/i18n/spellcheck/DICTIONARIES.md
+++ b/internal/i18n/spellcheck/DICTIONARIES.md
@@ -17,6 +17,10 @@ that mapping is trusted (source, pinned version, licence, evidence).
   mapping is unsupported rather than silently pointed at a different
   regional variant or a generic/base-language dictionary.
 - Unsupported locales have no dictionary mapping at all.
+- The Hunspell wrapper speaks UTF-8 at the C API boundary. Dictionaries
+  that declare a known 8-bit encoding are transcoded to UTF-8 at load
+  time. A leading UTF-8 BOM is stripped so `SET` is still recognized.
+  Undeclared or unknown encodings are skipped.
 
 ## Supported locales (20)
 
@@ -76,13 +80,15 @@ These locales have **no** dictionary mapping.
 Future fallback support for `en-SG` and `fr-CA` (or a segmentation step for
 `th-TH`) may be considered in a later release.
 
-## API behavior for unsupported locales
+## API behavior for unsupported or unloaded locales
 
-When spelling is requested for a locale with no dictionary mapping, spelling
-is not executed for that request, and `spelling` is reported in the
-response's `skippedModes` list. This is a description of the intended
-contract, not new behavior implemented by this change: the API contract for
-an unavailable spell-check capability already reports `spelling` in
-`skippedModes` (see `ErrSpellCheckUnavailable` handling in
+When spelling is requested for a locale with no dictionary mapping, or
+whose dictionary failed to load at startup, spelling is not executed for
+that request, and `spelling` is reported in the response's `skippedModes`
+list. A single failed dictionary must not take the service down: other
+locales keep their loaded dictionaries, and the rest of segment validation
+continues. The API contract for an unavailable spell-check capability
+already reports `spelling` in `skippedModes` (see
+`ErrSpellCheckUnavailable` and `ErrUnsupportedLocale` handling in
 [`apps/go-svc/handler.go`](../../../apps/go-svc/handler.go) and
 [`apps/go-svc/spellcheck.go`](../../../apps/go-svc/spellcheck.go)).


### PR DESCRIPTION
## What changed

Spellcheck setup no longer takes the process down when one Hunspell dictionary fails to load. Failed locales are skipped (`skippedModes: ["spelling"]`); locales that loaded keep working.

The Hunspell wrapper still speaks UTF-8 at the C API boundary. Dictionaries that declare a known 8-bit encoding (`ISO8859-1`, `ISO8859-2`, and similar) are transcoded to UTF-8 at load time, and a leading UTF-8 BOM is stripped so `SET` is still recognized. That unblocks `de-DE` (`de_DE_frami`, ISO-8859-1) plus `id-ID`, `ms-MY`, `pl-PL`, and `hi-IN`. Unknown or undeclared encodings are still skipped.

## How to test

- [ ] `make fmt`, `make lint`, and `make test`
- [ ] `make check-build-go-svc-cgo` if `libhunspell` and `pkg-config` are available
- [ ] Start go-svc against `/usr/share/hunspell` (or `HUNSPELL_DICT_DIR`) and confirm a non-UTF-8 `de-DE` dictionary no longer fatals startup
- [ ] Request spelling for `de-DE` and confirm it is not skipped solely because of `SET ISO8859-1`
- [ ] Request spelling for a locale whose dictionary is missing or undeclared and confirm the response reports `spelling` in `skippedModes` while other validation continues

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)