### PR TITLE
feat(cat): replace inline glossary create with picker and dialog

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -27,6 +27,7 @@ import { ensureRepositorySourceFile } from "@/lib/file-storage/records";
 import { ensureImageVariantsForSourceFile } from "@/lib/projects/files/image-variant-service";
 import { upsertProjectTranslationKeysFromEntries } from "@/lib/projects/translations/project-translation-service";
 import { TmsProviderLiveError } from "@/lib/providers/jobs/tms-provider-live";
+import { DEFAULT_WORKSPACE_TEAM_NAME } from "@/lib/teams/default-workspace-team";
 
 import { createProjectTestFixture } from "./project.fixture";
 import { createTeamTestFixture } from "../team/team.fixture";
@@ -3047,6 +3048,9 @@ describe("project file CAT routes", () => {
     expect(adminBody.catQueue.contributorTeams?.map((team) => team.name)).toEqual(
       expect.arrayContaining(["CAT Alpha", "CAT Beta"]),
     );
+    expect(adminBody.catQueue.contributorTeams?.map((team) => team.name)).not.toContain(
+      DEFAULT_WORKSPACE_TEAM_NAME,
+    );
 
     const translatorQueueResponse = await client.api.orgs[":organizationSlug"].projects[
       ":projectId"
@@ -3060,7 +3064,7 @@ describe("project file CAT routes", () => {
     expect(translatorQueueResponse.status).toBe(200);
     const translatorBody = (await translatorQueueResponse.json()) as ProjectFileCatQueueResponse;
     expect(translatorBody.catQueue.contributorTeams).toEqual([
-      { id: alphaTeam.id, name: "CAT Alpha" },
+      expect.objectContaining({ id: alphaTeam.id, name: "CAT Alpha" }),
     ]);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -916,6 +916,7 @@ async function withCatTeamGlossaryContext(
       catQueue.provider == null && isGlossaryContributorRole(auth.membership.role),
     ...(projectTeam?.teamId ? { projectTeamId: projectTeam.teamId } : {}),
     ...(projectTeam?.teamName ? { teamName: projectTeam.teamName } : {}),
+    ...(projectTeam?.teamSlug ? { projectTeamSlug: projectTeam.teamSlug } : {}),
   };
 }
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -786,12 +786,14 @@ export const projectFileCatResponseSchema = z.object({
         z.object({
           id: z.string(),
           name: z.string(),
+          slug: z.string(),
         }),
       )
       .optional(),
     projectTeamId: z.string().optional(),
     canContributeTeamGlossary: z.boolean().optional(),
     teamName: z.string().optional(),
+    projectTeamSlug: z.string().optional(),
     segments: z.array(projectFileCatSegmentSchema),
     pagination: projectFileCatPaginationSchema.optional(),
   }),

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-add-to-glossary.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-add-to-glossary.stories.tsx
@@ -65,6 +65,9 @@ export const Picker: Story = {
       "Product team terms",
     );
     await expect(canvas.getAllByRole("combobox").length).toBeGreaterThan(1);
+    await expect(canvas.getAllByRole("combobox", { name: "Status" })[0]).toHaveTextContent(
+      "Preferred",
+    );
     await expect(canvas.getByRole("button", { name: "Add concept" })).toBeEnabled();
     const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(canvas.getByRole("combobox", { name: "Team glossary" }));
@@ -116,13 +119,16 @@ export const CreateNew: Story = {
     const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(canvas.getByRole("combobox", { name: "Team glossary" }));
     await userEvent.click(await body.findByRole("option", { name: "Create new" }));
-    await expect(canvas.getByRole("textbox", { name: "Glossary name" })).toHaveValue(
+    const dialog = body.getByRole("dialog");
+    await expect(dialog).toBeInTheDocument();
+    await expect(within(dialog).getByRole("textbox", { name: "Glossary name" })).toHaveValue(
       "Shared with Product.",
     );
-    await expect(canvas.getByRole("button", { name: "Create" })).toBeEnabled();
-    await expect(canvas.queryByRole("button", { name: "Add concept" })).not.toBeInTheDocument();
-    await userEvent.click(canvas.getByRole("button", { name: "Cancel" }));
+    await expect(within(dialog).getByRole("button", { name: "Create" })).toBeEnabled();
+    await expect(canvas.getByRole("button", { name: "Add concept" })).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
     await expect(canvas.getByRole("combobox", { name: "Team glossary" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Add concept" })).toBeEnabled();
   },
 };
 
@@ -130,15 +136,17 @@ export const Empty: Story = {
   args: {
     teamGlossaries: [],
   },
-  play: async ({ canvas }) => {
+  play: async ({ canvas, canvasElement, userEvent }) => {
     await expect(canvas.getByRole("heading", { name: "Add concept" })).toBeInTheDocument();
     await expect(canvas.getByText("Shared with Product.")).toBeInTheDocument();
-    await expect(canvas.getByRole("textbox", { name: "Glossary name" })).toHaveValue(
-      "Shared with Product.",
+    await expect(canvas.getByRole("combobox", { name: "Team glossary" })).toHaveTextContent(
+      "Select team glossary",
     );
-    await expect(canvas.getByRole("button", { name: "Create" })).toBeEnabled();
-    await expect(canvas.queryByRole("button", { name: "Add concept" })).not.toBeInTheDocument();
-    await expect(canvas.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Add concept" })).toBeDisabled();
+    await expect(canvas.queryByRole("textbox", { name: "Glossary name" })).not.toBeInTheDocument();
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole("combobox", { name: "Team glossary" }));
+    await expect(await body.findByRole("option", { name: "Create new" })).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-add-to-glossary.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-add-to-glossary.stories.tsx
@@ -71,10 +71,10 @@ export const Picker: Story = {
     await expect(canvas.getByRole("button", { name: "Add concept" })).toBeEnabled();
     const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(canvas.getByRole("combobox", { name: "Team glossary" }));
+    await expect(await body.findByRole("option", { name: "Create new" })).toBeInTheDocument();
     await expect(
-      await body.findByRole("option", { name: "Marketing team terms" }),
+      body.queryByRole("option", { name: "Marketing team terms" }),
     ).not.toBeInTheDocument();
-    await expect(body.getByRole("option", { name: "Create new" })).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-add-to-glossary.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-add-to-glossary.tsx
@@ -330,9 +330,6 @@ export function CatAddToGlossary({
             checked={translatable}
             onCheckedChange={(checked) => setTranslatable(checked === true)}
             disabled={isBusy}
-            aria-label={intl.formatMessage(
-              catIntelligencePanelMessages.addToGlossaryTranslatableLabel,
-            )}
           />
           <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryTranslatableLabel} />
         </label>

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-add-to-glossary.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-add-to-glossary.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { useId, useMemo, useState } from "react";
-import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { Add01Icon, ArrowDown01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -32,16 +32,25 @@ import { cn } from "@/lib/primitives/cn";
 import { badgeVariants } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Field, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 
 import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messages";
@@ -52,6 +61,11 @@ import {
 } from "./cat-team-glossary";
 
 const CREATE_TEAM_GLOSSARY_VALUE = "__create__";
+
+const preferredGlossaryTermMetadataDraft: GlossaryTermMetadataDraft = {
+  ...emptyGlossaryTermMetadataDraft,
+  status: "preferred",
+};
 
 export type { CatTeamGlossaryOption };
 
@@ -111,23 +125,24 @@ export function CatAddToGlossary({
     ];
   }, [createdGlossaries, scopedTeamGlossaries, teamId]);
   const [selectedGlossaryId, setSelectedGlossaryId] = useState(glossaries[0]?.id ?? "");
-  const [isCreating, setIsCreating] = useState(glossaries.length === 0 && canCreate);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [newGlossaryName, setNewGlossaryName] = useState(defaultGlossaryName);
   const [primaryTerm, setPrimaryTerm] = useState(sourceTerm);
   const [definition, setDefinition] = useState("");
   const [translatable, setTranslatable] = useState(true);
   const [targetDraft, setTargetDraft] = useState(targetTerm);
   const [sourceMetadata, setSourceMetadata] = useState<GlossaryTermMetadataDraft>(
-    () => emptyGlossaryTermMetadataDraft,
+    () => preferredGlossaryTermMetadataDraft,
   );
   const [targetMetadata, setTargetMetadata] = useState<GlossaryTermMetadataDraft>(
-    () => emptyGlossaryTermMetadataDraft,
+    () => preferredGlossaryTermMetadataDraft,
   );
 
   const selectedGlossary =
     glossaries.find((glossary) => glossary.id === selectedGlossaryId) ?? glossaries[0];
   const canSubmit = Boolean(
-    canContribute && organizationSlug && selectedGlossary && primaryTerm.trim() && !isCreating,
+    canContribute && organizationSlug && selectedGlossary && primaryTerm.trim(),
   );
 
   const createGlossary = useMutation({
@@ -169,7 +184,7 @@ export function CatAddToGlossary({
         current.some((glossary) => glossary.id === created.id) ? current : [...current, created],
       );
       setSelectedGlossaryId(created.id);
-      setIsCreating(false);
+      setIsCreateDialogOpen(false);
       onTeamGlossaryCreated?.(created);
       toast.success(intl.formatMessage(catIntelligencePanelMessages.addToGlossaryCreateSuccess));
     },
@@ -245,12 +260,13 @@ export function CatAddToGlossary({
   const isBusy = addConcept.isPending || createGlossary.isPending;
   const glossaryName =
     selectedGlossary?.name ??
-    intl.formatMessage(catIntelligencePanelMessages.addToGlossaryCreateOption);
+    intl.formatMessage(catIntelligencePanelMessages.addToGlossaryPickerPlaceholder);
   const sharedWithTeamNote = formatCatSharedWithTeamGlossaryName(intl, teamName);
 
-  const startCreating = () => {
+  const openCreateDialog = () => {
+    setPickerOpen(false);
     setNewGlossaryName(defaultGlossaryName);
-    setIsCreating(true);
+    setIsCreateDialogOpen(true);
   };
 
   return (
@@ -321,111 +337,135 @@ export function CatAddToGlossary({
           <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryTranslatableLabel} />
         </label>
         <div className="flex items-center justify-between gap-3">
-          {isCreating ? (
-            <div className="flex min-w-0 flex-1 items-center gap-2">
-              <Field className="min-w-0 flex-1 gap-1.5">
-                <FieldLabel htmlFor={newGlossaryNameId} className="sr-only">
-                  <FormattedMessage
-                    {...catIntelligencePanelMessages.addToGlossaryCreateNameLabel}
-                  />
-                </FieldLabel>
-                <Input
-                  id={newGlossaryNameId}
-                  value={newGlossaryName}
-                  onChange={(event) => setNewGlossaryName(event.target.value)}
-                  disabled={isBusy}
-                  className="h-8"
-                  placeholder={defaultGlossaryName}
-                />
-              </Field>
-              <Button
-                type="button"
-                size="sm"
-                disabled={isBusy || !newGlossaryName.trim() || !canCreate}
-                onClick={() => createGlossary.mutate()}
-              >
-                <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryCreateAction} />
-              </Button>
-              {glossaries.length > 0 ? (
+          <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+            <PopoverTrigger
+              render={
                 <Button
                   type="button"
-                  size="sm"
-                  variant="ghost"
+                  variant="outline"
                   disabled={isBusy}
-                  onClick={() => setIsCreating(false)}
-                >
-                  <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryCreateCancel} />
-                </Button>
-              ) : null}
-            </div>
-          ) : (
-            <>
-              <Select
-                value={selectedGlossary?.id ?? ""}
-                onValueChange={(value) => {
-                  if (value === CREATE_TEAM_GLOSSARY_VALUE) {
-                    startCreating();
-                    return;
-                  }
-                  if (value) {
-                    setSelectedGlossaryId(value);
-                  }
-                }}
-                disabled={isBusy}
-              >
-                <SelectTrigger
-                  showIcon={false}
+                  role="combobox"
+                  aria-expanded={pickerOpen}
+                  aria-haspopup="listbox"
+                  aria-label={intl.formatMessage(
+                    catIntelligencePanelMessages.addToGlossaryPickerLabel,
+                  )}
                   className={cn(
                     badgeVariants({ variant: "outline" }),
                     "h-5 max-w-[min(100%,12rem)] cursor-pointer gap-1 px-2 py-0.5 text-xs font-medium",
                   )}
-                  aria-label={intl.formatMessage(
-                    catIntelligencePanelMessages.addToGlossaryPickerLabel,
+                />
+              }
+            >
+              <span className="min-w-0 truncate">{glossaryName}</span>
+              <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} className="size-3" />
+            </PopoverTrigger>
+            <PopoverContent
+              align="start"
+              side="top"
+              className="w-max min-w-[12rem] max-w-[min(22rem,calc(100vw-2rem))] gap-0 p-0"
+            >
+              <Command>
+                <CommandInput
+                  placeholder={intl.formatMessage(
+                    catIntelligencePanelMessages.addToGlossaryPickerSearchPlaceholder,
                   )}
+                />
+                <CommandList
+                  label={intl.formatMessage(catIntelligencePanelMessages.addToGlossaryPickerLabel)}
                 >
-                  <SelectValue className="min-w-0 flex-none truncate">{glossaryName}</SelectValue>
-                  <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} className="size-3" />
-                </SelectTrigger>
-                <SelectContent
-                  align="start"
-                  side="top"
-                  alignItemWithTrigger={false}
-                  className="w-max min-w-[12rem] max-w-[min(22rem,calc(100vw-2rem))]"
-                >
-                  {glossaries.map((glossary) => (
-                    <SelectItem key={glossary.id} value={glossary.id} label={glossary.name}>
-                      {glossary.name}
-                    </SelectItem>
-                  ))}
+                  <CommandEmpty>
+                    {intl.formatMessage(catIntelligencePanelMessages.addToGlossaryPickerEmpty)}
+                  </CommandEmpty>
+                  {glossaries.length > 0 ? (
+                    <CommandGroup>
+                      {glossaries.map((glossary) => (
+                        <CommandItem
+                          key={glossary.id}
+                          value={`${glossary.id} ${glossary.name}`}
+                          data-checked={selectedGlossary?.id === glossary.id || undefined}
+                          onSelect={() => {
+                            setSelectedGlossaryId(glossary.id);
+                            setPickerOpen(false);
+                          }}
+                        >
+                          {glossary.name}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  ) : null}
                   {canCreate ? (
                     <>
-                      {glossaries.length > 0 ? <SelectSeparator /> : null}
-                      <SelectItem
-                        value={CREATE_TEAM_GLOSSARY_VALUE}
-                        label={intl.formatMessage(
-                          catIntelligencePanelMessages.addToGlossaryCreateOption,
-                        )}
-                      >
-                        <FormattedMessage
-                          {...catIntelligencePanelMessages.addToGlossaryCreateOption}
-                        />
-                      </SelectItem>
+                      {glossaries.length > 0 ? <CommandSeparator /> : null}
+                      <CommandGroup>
+                        <CommandItem
+                          value={`${CREATE_TEAM_GLOSSARY_VALUE} ${intl.formatMessage(
+                            catIntelligencePanelMessages.addToGlossaryCreateOption,
+                          )}`}
+                          onSelect={openCreateDialog}
+                        >
+                          <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-4" />
+                          <FormattedMessage
+                            {...catIntelligencePanelMessages.addToGlossaryCreateOption}
+                          />
+                        </CommandItem>
+                      </CommandGroup>
                     </>
                   ) : null}
-                </SelectContent>
-              </Select>
-              <Button
-                type="button"
-                size="sm"
-                disabled={!canSubmit || isBusy}
-                onClick={() => addConcept.mutate()}
-              >
-                <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryAction} />
-              </Button>
-            </>
-          )}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!canSubmit || isBusy}
+            onClick={() => addConcept.mutate()}
+          >
+            <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryAction} />
+          </Button>
         </div>
       </div>
+      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryCreateDialogTitle} />
+            </DialogTitle>
+          </DialogHeader>
+          <FieldGroup>
+            <Field className="gap-1.5">
+              <FieldLabel htmlFor={newGlossaryNameId}>
+                <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryCreateNameLabel} />
+              </FieldLabel>
+              <Input
+                id={newGlossaryNameId}
+                value={newGlossaryName}
+                onChange={(event) => setNewGlossaryName(event.target.value)}
+                disabled={createGlossary.isPending}
+                placeholder={defaultGlossaryName}
+              />
+            </Field>
+          </FieldGroup>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={createGlossary.isPending}
+              onClick={() => setIsCreateDialogOpen(false)}
+            >
+              <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryCreateCancel} />
+            </Button>
+            <Button
+              type="button"
+              disabled={createGlossary.isPending || !newGlossaryName.trim() || !canCreate}
+              onClick={() => createGlossary.mutate()}
+            >
+              <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryCreateAction} />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
@@ -310,6 +310,9 @@ export const AddToTeamGlossary: Story = {
       "Product team terms",
     );
     await expect(canvas.getByRole("button", { name: "Add concept" })).toBeEnabled();
+    await expect(canvas.getAllByRole("combobox", { name: "Status" })[0]).toHaveTextContent(
+      "Preferred",
+    );
     const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(canvas.getByRole("combobox", { name: "Team glossary" }));
     await expect(
@@ -374,6 +377,9 @@ export const TeamSectionsWithOrgAndTeamMatches: Story = {
     await expect(canvas.getByRole("heading", { name: "Marketing", level: 3 })).toBeInTheDocument();
     await expect(canvas.getByText("Review")).toBeInTheDocument();
     await expect(canvas.getAllByRole("button", { name: "Add concept" })).toHaveLength(2);
+    await expect(
+      canvas.queryByText("Attach a team glossary to this project."),
+    ).not.toBeInTheDocument();
   },
 };
 
@@ -402,10 +408,46 @@ export const AddToTeamGlossaryEmpty: Story = {
       void expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
     });
     await expect(canvas.getByText("No matching terms for Product.")).toBeInTheDocument();
+    await expect(canvas.getByText("Attach a team glossary to this project.")).toBeInTheDocument();
     await userEvent.click(canvas.getByRole("button", { name: "Add concept" }));
-    await expect(canvas.getByRole("textbox", { name: "Glossary name" })).toHaveValue(
-      "Shared with Product.",
+    await expect(canvas.getByRole("combobox", { name: "Team glossary" })).toHaveTextContent(
+      "Select team glossary",
     );
-    await expect(canvas.getByRole("button", { name: "Create" })).toBeEnabled();
+    await expect(canvas.getByRole("button", { name: "Add concept" })).toBeDisabled();
+    await expect(canvas.getAllByRole("combobox", { name: "Status" })[0]).toHaveTextContent(
+      "Preferred",
+    );
+  },
+};
+
+export const LockedStringAddConcept: Story = {
+  args: {
+    sourceText: "Dashboard",
+    targetText: "Bảng điều khiển",
+    sourceLocale: "en",
+    targetLocale: "vi",
+    organizationSlug: "acme",
+    projectId: "project_1",
+    canContributeTeamGlossary: true,
+    isTranslationLocked: true,
+    onUseTmMatch: fn(),
+    teamName: "Product",
+    projectTeamId: teamProductId,
+    contributorTeams: [{ id: teamProductId, name: "Product" }],
+    teamGlossaries: [{ id: "glossary-team-1", name: "Product team terms", teamId: teamProductId }],
+  },
+  play: async ({ canvas, canvasElement }) => {
+    await waitFor(() => {
+      requestCatGlossaryGuidance();
+      void expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    });
+    const addButton = canvas.getByRole("button", { name: "Add concept" });
+    await expect(addButton).toBeDisabled();
+    await expect(canvas.queryByRole("button", { name: "Use" })).not.toBeInTheDocument();
+    await userEvent.hover(addButton.parentElement ?? addButton);
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      await body.findByText("This string is locked. Unlock it to add a concept."),
+    ).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
@@ -315,10 +315,10 @@ export const AddToTeamGlossary: Story = {
     );
     const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(canvas.getByRole("combobox", { name: "Team glossary" }));
+    await expect(await body.findByRole("option", { name: "Create new" })).toBeInTheDocument();
     await expect(
-      await body.findByRole("option", { name: "Marketing team terms" }),
+      body.queryByRole("option", { name: "Marketing team terms" }),
     ).not.toBeInTheDocument();
-    await expect(body.getByRole("option", { name: "Create new" })).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -40,6 +40,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
 
 import {
@@ -57,6 +58,7 @@ import { CatAddToGlossary } from "./cat-add-to-glossary";
 import { CatGlossaryConceptCard } from "./cat-glossary-concept-card";
 import {
   collectVisibleCatGlossaryConcepts,
+  filterCatTeamGlossariesForTeam,
   groupCatGlossaryConceptsByTeam,
   resolveCatContributorTeams,
   type CatContributorTeam,
@@ -115,6 +117,33 @@ function AgentContextSkeleton() {
         <Skeleton className="h-5 w-36 rounded-lg bg-skeleton" />
       </div>
     </div>
+  );
+}
+
+function AddConceptButton({
+  disabled,
+  disabledReason,
+  onClick,
+}: {
+  disabled: boolean;
+  disabledReason?: string;
+  onClick: () => void;
+}) {
+  const button = (
+    <Button type="button" size="sm" className="shrink-0" disabled={disabled} onClick={onClick}>
+      <FormattedMessage {...catIntelligencePanelMessages.addToGlossaryAction} />
+    </Button>
+  );
+
+  if (!disabled || !disabledReason) {
+    return button;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<span className="inline-flex" />}>{button}</TooltipTrigger>
+      <TooltipContent>{disabledReason}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -204,6 +233,7 @@ export function CatIntelligencePanel({
   teamGlossaries = [],
   canContributeTeamGlossary = false,
   teamName,
+  projectTeamSlug,
   isLookingUpContext = false,
   isConcordanceLoading = false,
   isVisualContextLoading = false,
@@ -212,6 +242,7 @@ export function CatIntelligencePanel({
   showMaxLengthEditor = false,
   isMaxLengthSaving = false,
   canEditTranslations = true,
+  isTranslationLocked = false,
   canLookupFreshContext = true,
   onRefreshContext,
   onUseTmMatch,
@@ -231,6 +262,7 @@ export function CatIntelligencePanel({
   teamGlossaries?: CatTeamGlossaryOption[];
   canContributeTeamGlossary?: boolean;
   teamName?: string;
+  projectTeamSlug?: string;
   isLookingUpContext?: boolean;
   isConcordanceLoading?: boolean;
   isVisualContextLoading?: boolean;
@@ -239,6 +271,7 @@ export function CatIntelligencePanel({
   showMaxLengthEditor?: boolean;
   isMaxLengthSaving?: boolean;
   canEditTranslations?: boolean;
+  isTranslationLocked?: boolean;
   canLookupFreshContext?: boolean;
   onRefreshContext?: () => void;
   onUseTmMatch?: (match: CatTranslationMemoryMatch) => void;
@@ -263,8 +296,9 @@ export function CatIntelligencePanel({
         contributorTeams,
         projectTeamId,
         projectTeamName: teamName,
+        projectTeamSlug,
       }),
-    [contributorTeams, projectTeamId, teamName],
+    [contributorTeams, projectTeamId, projectTeamSlug, teamName],
   );
   const teamGlossaryIds = useMemo(
     () => new Set(resolvedTeamGlossaries.map((glossary) => glossary.id)),
@@ -358,6 +392,12 @@ export function CatIntelligencePanel({
   }, [glossaryConceptKey, glossaryGuidanceStatus, isConcordanceLoading]);
 
   useEffect(() => {
+    if (isTranslationLocked) {
+      setAddingConceptTeamId(null);
+    }
+  }, [isTranslationLocked]);
+
+  useEffect(() => {
     function handleOpenGlossaryGuidance() {
       setIsGlossaryPanelOpen(true);
     }
@@ -413,8 +453,9 @@ export function CatIntelligencePanel({
     setIsGlossaryPanelOpen(false);
   }
 
-  const canAddConcept =
+  const canContributeConcept =
     canEditTranslations && Boolean(sourceLocale && targetLocale) && canContributeTeamGlossary;
+  const canOpenAddConcept = canContributeConcept && !isTranslationLocked;
   const hasTeamSections = orderedContributorTeams.length > 0;
   const showGlobalEmpty =
     !isConcordanceLoading && visibleGlossaryConcepts.length === 0 && !hasTeamSections;
@@ -446,7 +487,7 @@ export function CatIntelligencePanel({
               <div className={intelligenceMutedPanelClassName}>
                 <CatSegmentMaxLengthEditor
                   maxLength={intelligence.maxLength}
-                  canEdit={canEditTranslations && Boolean(onSetMaxLength)}
+                  canEdit={canEditTranslations && !isTranslationLocked && Boolean(onSetMaxLength)}
                   isSaving={isMaxLengthSaving}
                   onSave={onSetMaxLength ?? (async () => undefined)}
                 />
@@ -565,7 +606,11 @@ export function CatIntelligencePanel({
                     <TranslationMemoryRow
                       key={match.id}
                       match={match}
-                      onUse={canEditTranslations && onUseTmMatch ? handleUseTmMatch : undefined}
+                      onUse={
+                        canEditTranslations && !isTranslationLocked && onUseTmMatch
+                          ? handleUseTmMatch
+                          : undefined
+                      }
                     />
                   ))}
                 </ul>
@@ -615,7 +660,7 @@ export function CatIntelligencePanel({
           <ScrollArea className="min-h-0 flex-1">
             <div className="space-y-3 p-4">
               {addingConceptTeamId &&
-              canAddConcept &&
+              canOpenAddConcept &&
               addingConceptTeam &&
               sourceLocale &&
               targetLocale ? (
@@ -691,24 +736,39 @@ export function CatIntelligencePanel({
                         <div className="space-y-4">
                           {orderedContributorTeams.map((team) => {
                             const teamConcepts = conceptsByTeamId.get(team.id) ?? [];
+                            const hasAttachedGlossary =
+                              filterCatTeamGlossariesForTeam(resolvedTeamGlossaries, team.id)
+                                .length > 0;
 
                             return (
                               <section key={team.id} className="space-y-3">
-                                <div className="flex items-center justify-between gap-3">
-                                  <h3 className="text-sm font-medium text-foreground">
-                                    {team.name}
-                                  </h3>
-                                  {canAddConcept ? (
-                                    <Button
-                                      type="button"
-                                      size="sm"
-                                      className="shrink-0"
+                                <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+                                  <div className="min-w-0 flex-1">
+                                    {team.name ? (
+                                      <h3 className="text-sm font-medium text-foreground">
+                                        {team.name}
+                                      </h3>
+                                    ) : null}
+                                    {hasAttachedGlossary ? null : (
+                                      <p className="text-xs text-muted-foreground">
+                                        <FormattedMessage
+                                          {...catIntelligencePanelMessages.addToGlossaryEmpty}
+                                        />
+                                      </p>
+                                    )}
+                                  </div>
+                                  {canContributeConcept ? (
+                                    <AddConceptButton
+                                      disabled={isTranslationLocked}
+                                      disabledReason={
+                                        isTranslationLocked
+                                          ? intl.formatMessage(
+                                              catIntelligencePanelMessages.addToGlossaryLocked,
+                                            )
+                                          : undefined
+                                      }
                                       onClick={() => setAddingConceptTeamId(team.id)}
-                                    >
-                                      <FormattedMessage
-                                        {...catIntelligencePanelMessages.addToGlossaryAction}
-                                      />
-                                    </Button>
+                                    />
                                   ) : null}
                                 </div>
                                 {teamConcepts.length > 0 ? (
@@ -717,7 +777,7 @@ export function CatIntelligencePanel({
                                       <CatGlossaryConceptCard
                                         key={concept.id}
                                         concept={concept}
-                                        teamName={team.name}
+                                        teamName={team.name || undefined}
                                         expanded={expandedGlossaryConceptIds.has(concept.id)}
                                         onToggle={() => toggleGlossaryConcept(concept.id)}
                                       />
@@ -725,10 +785,16 @@ export function CatIntelligencePanel({
                                   </div>
                                 ) : (
                                   <p className="rounded-xl border border-border bg-muted/20 px-3 py-2.5 text-sm text-muted-foreground">
-                                    <FormattedMessage
-                                      {...catIntelligencePanelMessages.addToGlossaryTeamEmpty}
-                                      values={{ teamName: team.name }}
-                                    />
+                                    {team.name ? (
+                                      <FormattedMessage
+                                        {...catIntelligencePanelMessages.addToGlossaryTeamEmpty}
+                                        values={{ teamName: team.name }}
+                                      />
+                                    ) : (
+                                      <FormattedMessage
+                                        {...catIntelligencePanelMessages.addToGlossaryTeamEmptyUnnamed}
+                                      />
+                                    )}
                                   </p>
                                 )}
                               </section>

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   DEFAULT_WORKSPACE_TEAM_NAME,
   DEFAULT_WORKSPACE_TEAM_SLUG,
-} from "@/lib/teams/default-workspace-team";
+} from "@/lib/teams/default-workspace-team-constants";
 
 import {
   collectVisibleCatGlossaryConcepts,

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.test.ts
@@ -13,6 +13,11 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  DEFAULT_WORKSPACE_TEAM_NAME,
+  DEFAULT_WORKSPACE_TEAM_SLUG,
+} from "@/lib/teams/default-workspace-team";
+
+import {
   collectVisibleCatGlossaryConcepts,
   filterCatTeamGlossariesForTeam,
   groupCatGlossaryConceptsByTeam,
@@ -23,11 +28,11 @@ describe("resolveCatContributorTeams", () => {
   it("returns membership teams when present", () => {
     expect(
       resolveCatContributorTeams({
-        contributorTeams: [{ id: "team-a", name: "Alpha" }],
+        contributorTeams: [{ id: "team-a", name: "Alpha", slug: "alpha" }],
         projectTeamId: "team-b",
         projectTeamName: "Beta",
       }),
-    ).toEqual([{ id: "team-a", name: "Alpha" }]);
+    ).toEqual([{ id: "team-a", name: "Alpha", slug: "alpha" }]);
   });
 
   it("falls back to the project team when memberships are empty", () => {
@@ -36,8 +41,38 @@ describe("resolveCatContributorTeams", () => {
         contributorTeams: [],
         projectTeamId: "team-b",
         projectTeamName: "Beta",
+        projectTeamSlug: "beta",
       }),
-    ).toEqual([{ id: "team-b", name: "Beta" }]);
+    ).toEqual([{ id: "team-b", name: "Beta", slug: "beta" }]);
+  });
+
+  it("omits the default workspace team from contributor sections", () => {
+    expect(
+      resolveCatContributorTeams({
+        contributorTeams: [
+          {
+            id: "team-default",
+            name: DEFAULT_WORKSPACE_TEAM_NAME,
+            slug: DEFAULT_WORKSPACE_TEAM_SLUG,
+          },
+          { id: "team-a", name: "Alpha", slug: "alpha" },
+        ],
+        projectTeamId: "team-default",
+        projectTeamName: DEFAULT_WORKSPACE_TEAM_NAME,
+        projectTeamSlug: DEFAULT_WORKSPACE_TEAM_SLUG,
+      }),
+    ).toEqual([{ id: "team-a", name: "Alpha", slug: "alpha" }]);
+  });
+
+  it("keeps an unlabeled write target when only the default team remains", () => {
+    expect(
+      resolveCatContributorTeams({
+        contributorTeams: [],
+        projectTeamId: "team-default",
+        projectTeamName: DEFAULT_WORKSPACE_TEAM_NAME,
+        projectTeamSlug: DEFAULT_WORKSPACE_TEAM_SLUG,
+      }),
+    ).toEqual([{ id: "team-default", name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG }]);
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.test.ts
@@ -61,7 +61,37 @@ describe("resolveCatContributorTeams", () => {
         projectTeamName: DEFAULT_WORKSPACE_TEAM_NAME,
         projectTeamSlug: DEFAULT_WORKSPACE_TEAM_SLUG,
       }),
-    ).toEqual([{ id: "team-a", name: "Alpha", slug: "alpha" }]);
+    ).toEqual([
+      { id: "team-a", name: "Alpha", slug: "alpha" },
+      { id: "team-default", name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG },
+    ]);
+  });
+
+  it("appends an unlabeled default project team when the viewer belongs to other teams", () => {
+    expect(
+      resolveCatContributorTeams({
+        contributorTeams: [{ id: "team-a", name: "Alpha", slug: "alpha" }],
+        projectTeamId: "team-default",
+        projectTeamName: DEFAULT_WORKSPACE_TEAM_NAME,
+        projectTeamSlug: DEFAULT_WORKSPACE_TEAM_SLUG,
+      }),
+    ).toEqual([
+      { id: "team-a", name: "Alpha", slug: "alpha" },
+      { id: "team-default", name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG },
+    ]);
+  });
+
+  it("does not hide a team that only shares the default team name", () => {
+    expect(
+      resolveCatContributorTeams({
+        contributorTeams: [
+          { id: "team-marketing", name: DEFAULT_WORKSPACE_TEAM_NAME, slug: "marketing" },
+        ],
+        projectTeamId: "team-product",
+        projectTeamName: "Product",
+        projectTeamSlug: "product",
+      }),
+    ).toEqual([{ id: "team-marketing", name: DEFAULT_WORKSPACE_TEAM_NAME, slug: "marketing" }]);
   });
 
   it("keeps an unlabeled write target when only the default team remains", () => {
@@ -113,6 +143,29 @@ describe("groupCatGlossaryConceptsByTeam", () => {
     expect(orgConceptIds).toEqual(new Set(["org-concept"]));
     expect(conceptsByTeamId.get("team-a")).toEqual([concepts[1]]);
     expect(conceptsByTeamId.has("team-b")).toBe(false);
+  });
+
+  it("retains default-project glossary concepts when the unlabeled target is included", () => {
+    const { orgConceptIds, conceptsByTeamId } = groupCatGlossaryConceptsByTeam({
+      concepts: [
+        { id: "default-team-concept", glossaryId: "glossary-default" },
+        { id: "alpha-team-concept", glossaryId: "glossary-alpha" },
+      ],
+      teamGlossaryIds: new Set(["glossary-default", "glossary-alpha"]),
+      glossaryTeamById: new Map([
+        ["glossary-default", "team-default"],
+        ["glossary-alpha", "team-a"],
+      ]),
+      contributorTeamIds: new Set(["team-a", "team-default"]),
+    });
+
+    expect(orgConceptIds).toEqual(new Set());
+    expect(conceptsByTeamId.get("team-default")).toEqual([
+      { id: "default-team-concept", glossaryId: "glossary-default" },
+    ]);
+    expect(conceptsByTeamId.get("team-a")).toEqual([
+      { id: "alpha-team-concept", glossaryId: "glossary-alpha" },
+    ]);
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.ts
@@ -16,7 +16,7 @@ import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messag
 import {
   DEFAULT_WORKSPACE_TEAM_NAME,
   DEFAULT_WORKSPACE_TEAM_SLUG,
-} from "@/lib/teams/default-workspace-team";
+} from "@/lib/teams/default-workspace-team-constants";
 
 export type CatContributorTeam = {
   id: string;

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.ts
@@ -13,10 +13,7 @@
 import type { IntlShape } from "react-intl";
 
 import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messages";
-import {
-  DEFAULT_WORKSPACE_TEAM_NAME,
-  DEFAULT_WORKSPACE_TEAM_SLUG,
-} from "@/lib/teams/default-workspace-team-constants";
+import { DEFAULT_WORKSPACE_TEAM_SLUG } from "@/lib/teams/default-workspace-team-constants";
 
 export type CatContributorTeam = {
   id: string;
@@ -30,8 +27,12 @@ export type CatTeamGlossaryOption = {
   teamId: string;
 };
 
-export function isHiddenDefaultContributorTeam(team: { slug?: string; name: string }) {
-  return team.slug === DEFAULT_WORKSPACE_TEAM_SLUG || team.name === DEFAULT_WORKSPACE_TEAM_NAME;
+export function isHiddenDefaultContributorTeam(team: { slug?: string }) {
+  return team.slug === DEFAULT_WORKSPACE_TEAM_SLUG;
+}
+
+function unlabeledDefaultProjectTeam(projectTeamId: string): CatContributorTeam {
+  return { id: projectTeamId, name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG };
 }
 
 export function formatCatSharedWithTeamGlossaryName(intl: IntlShape, teamName: string) {
@@ -56,23 +57,34 @@ export function resolveCatContributorTeams({
   projectTeamSlug?: string;
 }): CatContributorTeam[] {
   const visibleTeams = contributorTeams.filter((team) => !isHiddenDefaultContributorTeam(team));
-  if (visibleTeams.length > 0) {
-    return visibleTeams;
+
+  if (visibleTeams.length === 0) {
+    if (
+      projectTeamId &&
+      projectTeamName &&
+      !isHiddenDefaultContributorTeam({ slug: projectTeamSlug })
+    ) {
+      return [{ id: projectTeamId, name: projectTeamName, slug: projectTeamSlug }];
+    }
+
+    if (projectTeamId) {
+      return [unlabeledDefaultProjectTeam(projectTeamId)];
+    }
+
+    return [];
   }
+
+  const teams = [...visibleTeams];
 
   if (
     projectTeamId &&
-    projectTeamName &&
-    !isHiddenDefaultContributorTeam({ name: projectTeamName, slug: projectTeamSlug })
+    projectTeamSlug === DEFAULT_WORKSPACE_TEAM_SLUG &&
+    !teams.some((team) => team.id === projectTeamId)
   ) {
-    return [{ id: projectTeamId, name: projectTeamName, slug: projectTeamSlug }];
+    teams.push(unlabeledDefaultProjectTeam(projectTeamId));
   }
 
-  if (projectTeamId) {
-    return [{ id: projectTeamId, name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG }];
-  }
-
-  return [];
+  return teams;
 }
 
 export function groupCatGlossaryConceptsByTeam<T extends { id: string; glossaryId: string }>({

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.ts
@@ -13,10 +13,15 @@
 import type { IntlShape } from "react-intl";
 
 import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messages";
+import {
+  DEFAULT_WORKSPACE_TEAM_NAME,
+  DEFAULT_WORKSPACE_TEAM_SLUG,
+} from "@/lib/teams/default-workspace-team";
 
 export type CatContributorTeam = {
   id: string;
   name: string;
+  slug?: string;
 };
 
 export type CatTeamGlossaryOption = {
@@ -25,7 +30,15 @@ export type CatTeamGlossaryOption = {
   teamId: string;
 };
 
+export function isHiddenDefaultContributorTeam(team: { slug?: string; name: string }) {
+  return team.slug === DEFAULT_WORKSPACE_TEAM_SLUG || team.name === DEFAULT_WORKSPACE_TEAM_NAME;
+}
+
 export function formatCatSharedWithTeamGlossaryName(intl: IntlShape, teamName: string) {
+  if (!teamName.trim()) {
+    return intl.formatMessage(catIntelligencePanelMessages.addToGlossaryNoteFallback);
+  }
+
   return intl.formatMessage(catIntelligencePanelMessages.addToGlossarySharedWithTeam, {
     teamName,
   });
@@ -35,17 +48,28 @@ export function resolveCatContributorTeams({
   contributorTeams,
   projectTeamId,
   projectTeamName,
+  projectTeamSlug,
 }: {
   contributorTeams: CatContributorTeam[];
   projectTeamId?: string;
   projectTeamName?: string;
+  projectTeamSlug?: string;
 }): CatContributorTeam[] {
-  if (contributorTeams.length > 0) {
-    return contributorTeams;
+  const visibleTeams = contributorTeams.filter((team) => !isHiddenDefaultContributorTeam(team));
+  if (visibleTeams.length > 0) {
+    return visibleTeams;
   }
 
-  if (projectTeamId && projectTeamName) {
-    return [{ id: projectTeamId, name: projectTeamName }];
+  if (
+    projectTeamId &&
+    projectTeamName &&
+    !isHiddenDefaultContributorTeam({ name: projectTeamName, slug: projectTeamSlug })
+  ) {
+    return [{ id: projectTeamId, name: projectTeamName, slug: projectTeamSlug }];
+  }
+
+  if (projectTeamId) {
+    return [{ id: projectTeamId, name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG }];
   }
 
   return [];

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.test.ts
@@ -94,6 +94,8 @@ describe("projectFileCatToWorkspaceState", () => {
       catFile({
         provider: null,
         teamName: "Product",
+        projectTeamSlug: "product",
+        contributorTeams: [{ id: "team-product", name: "Product", slug: "product" }],
         canContributeTeamGlossary: true,
       }),
       "en-US",
@@ -101,6 +103,10 @@ describe("projectFileCatToWorkspaceState", () => {
     );
 
     expect(state.fileContext.teamName).toBe("Product");
+    expect(state.fileContext.projectTeamSlug).toBe("product");
+    expect(state.fileContext.contributorTeams).toEqual([
+      { id: "team-product", name: "Product", slug: "product" },
+    ]);
     expect(state.fileContext.canContributeTeamGlossary).toBe(true);
   });
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
@@ -227,6 +227,7 @@ function fileContextFor(catFile: CatFile, sourceLocale: string): CatFileContext 
     ...(catFile.projectTeamId ? { projectTeamId: catFile.projectTeamId } : {}),
     canContributeTeamGlossary: Boolean(catFile.canContributeTeamGlossary) && providerKind == null,
     ...(catFile.teamName ? { teamName: catFile.teamName } : {}),
+    ...(catFile.projectTeamSlug ? { projectTeamSlug: catFile.projectTeamSlug } : {}),
   };
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -641,9 +641,9 @@ export const catIntelligencePanelMessages = defineMessages({
     description: "Button that creates a draft glossary concept from CAT",
   },
   addToGlossaryEmpty: {
-    defaultMessage: "Attach a team glossary to this project to add concepts from CAT.",
-    id: "sADsr3MvMv",
-    description: "Empty state when CAT has no attached team glossary to write to",
+    defaultMessage: "Attach a team glossary to this project.",
+    id: "InXVW1Cy4C",
+    description: "Hint next to Add concept when this team has no glossary attached to the project",
   },
   addToGlossarySuccess: {
     defaultMessage: "Concept added to the team glossary",
@@ -664,6 +664,36 @@ export const catIntelligencePanelMessages = defineMessages({
     defaultMessage: "No matching terms for {teamName}.",
     id: "sjTUZFh0+J",
     description: "Empty state when a team section has no matching glossary concepts",
+  },
+  addToGlossaryTeamEmptyUnnamed: {
+    defaultMessage: "No matching terms.",
+    id: "xozianrnAl",
+    description: "Empty state when an unlabeled team section has no matching glossary concepts",
+  },
+  addToGlossaryLocked: {
+    defaultMessage: "This string is locked. Unlock it to add a concept.",
+    id: "lYqWI3Hv5b",
+    description: "Tooltip on a disabled CAT Add concept button when the current string is locked",
+  },
+  addToGlossaryPickerPlaceholder: {
+    defaultMessage: "Select team glossary",
+    id: "gjz2sY/l+i",
+    description: "Placeholder on the CAT team glossary picker when none is selected",
+  },
+  addToGlossaryPickerSearchPlaceholder: {
+    defaultMessage: "Search team glossaries...",
+    id: "dZjmTiak7a",
+    description: "Search placeholder in the CAT team glossary picker",
+  },
+  addToGlossaryPickerEmpty: {
+    defaultMessage: "No team glossaries found.",
+    id: "bEDQLfblvP",
+    description: "Empty search result in the CAT team glossary picker",
+  },
+  addToGlossaryCreateDialogTitle: {
+    defaultMessage: "Create team glossary",
+    id: "TmRQa9i4X5",
+    description: "Title of the CAT dialog that creates a team glossary",
   },
   addToGlossaryCreateOption: {
     defaultMessage: "Create new",

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -93,10 +93,11 @@ export interface CatFileContext {
   canAddComments: boolean;
   truncated?: boolean;
   teamGlossaries?: { id: string; name: string; teamId: string }[];
-  contributorTeams?: { id: string; name: string }[];
+  contributorTeams?: { id: string; name: string; slug: string }[];
   projectTeamId?: string;
   canContributeTeamGlossary?: boolean;
   teamName?: string;
+  projectTeamSlug?: string;
 }
 
 export interface CatSegment {

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
@@ -168,6 +168,7 @@ export function CatSideBySideIntelligencePanel({
         Boolean(fileContext.canContributeTeamGlossary) && fileContext.providerKind == null
       }
       teamName={fileContext.teamName}
+      projectTeamSlug={fileContext.projectTeamSlug}
       isLookingUpContext={isLookingUpContext}
       isConcordanceLoading={isConcordanceLoading}
       isVisualContextLoading={isVisualContextLoading}
@@ -175,7 +176,8 @@ export function CatSideBySideIntelligencePanel({
       showVisualContext={showVisualContext}
       showMaxLengthEditor={showMaxLengthEditor}
       isMaxLengthSaving={isMaxLengthSaving}
-      canEditTranslations={canEditTranslations && !segment.isLocked}
+      canEditTranslations={canEditTranslations}
+      isTranslationLocked={Boolean(segment.isLocked)}
       canLookupFreshContext={canLookupFreshContext}
       onRefreshContext={onRefreshContext}
       onUseTmMatch={onUseTmMatch}

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-detail-panel.tsx
@@ -199,6 +199,7 @@ export function CatVisualEditorDetailPanel({
             showAgentContext={false}
             showVisualContext={false}
             canEditTranslations={canEditTranslations}
+            isTranslationLocked={Boolean(segment.isLocked)}
             canLookupFreshContext={false}
             onUseTmMatch={onUseTmMatch}
           />

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -623,6 +623,7 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
             Boolean(shell.fileContext.canContributeTeamGlossary) && isNativeProject
           }
           teamName={shell.fileContext.teamName}
+          projectTeamSlug={shell.fileContext.projectTeamSlug}
           isLookingUpContext={isLookingUpContext}
           isConcordanceLoading={isConcordanceLoading}
           isVisualContextLoading={isVisualContextLoading}
@@ -630,9 +631,8 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           showVisualContext={showVisualContext}
           showMaxLengthEditor={isNativeProject}
           isMaxLengthSaving={isMaxLengthSaving}
-          canEditTranslations={
-            shell.fileContext.canEditTranslations !== false && !editorSegment.isLocked
-          }
+          canEditTranslations={shell.fileContext.canEditTranslations !== false}
+          isTranslationLocked={Boolean(editorSegment.isLocked)}
           canLookupFreshContext={canLookupContext}
           onRefreshContext={() => review.onAskQuestion(editorSegment.id, { forceRefresh: true })}
           onUseTmMatch={(match) => editing.onUseTmMatch(editorSegment.id, match)}

--- a/apps/hyperlocalise-web/src/lib/glossary/attached-team-glossaries.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/attached-team-glossaries.ts
@@ -13,6 +13,7 @@
 import { and, eq, ne } from "drizzle-orm";
 
 import { db, schema, type DatabaseClient } from "@/lib/database";
+import { DEFAULT_WORKSPACE_TEAM_SLUG } from "@/lib/teams/default-workspace-team";
 
 export type AttachedTeamGlossary = {
   id: string;
@@ -23,11 +24,13 @@ export type AttachedTeamGlossary = {
 export type ContributorTeam = {
   id: string;
   name: string;
+  slug: string;
 };
 
 export type ProjectTeamContext = {
   teamId: string | null;
   teamName: string | null;
+  teamSlug: string | null;
 };
 
 export async function getProjectTeamContext(projectId: string): Promise<ProjectTeamContext | null> {
@@ -35,6 +38,7 @@ export async function getProjectTeamContext(projectId: string): Promise<ProjectT
     .select({
       teamId: schema.projects.teamId,
       teamName: schema.teams.name,
+      teamSlug: schema.teams.slug,
     })
     .from(schema.projects)
     .leftJoin(schema.teams, eq(schema.projects.teamId, schema.teams.id))
@@ -64,9 +68,15 @@ export async function listContributorTeams(
       .select({
         id: schema.teams.id,
         name: schema.teams.name,
+        slug: schema.teams.slug,
       })
       .from(schema.teams)
-      .where(eq(schema.teams.organizationId, organizationId))
+      .where(
+        and(
+          eq(schema.teams.organizationId, organizationId),
+          ne(schema.teams.slug, DEFAULT_WORKSPACE_TEAM_SLUG),
+        ),
+      )
       .orderBy(schema.teams.name);
   }
 
@@ -74,6 +84,7 @@ export async function listContributorTeams(
     .select({
       id: schema.teams.id,
       name: schema.teams.name,
+      slug: schema.teams.slug,
     })
     .from(schema.teamMemberships)
     .innerJoin(schema.teams, eq(schema.teamMemberships.teamId, schema.teams.id))
@@ -81,6 +92,7 @@ export async function listContributorTeams(
       and(
         eq(schema.teamMemberships.userId, userId),
         eq(schema.teams.organizationId, organizationId),
+        ne(schema.teams.slug, DEFAULT_WORKSPACE_TEAM_SLUG),
       ),
     )
     .orderBy(schema.teams.name);

--- a/apps/hyperlocalise-web/src/lib/teams/default-workspace-team-constants.ts
+++ b/apps/hyperlocalise-web/src/lib/teams/default-workspace-team-constants.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+export const DEFAULT_WORKSPACE_TEAM_SLUG = "default";
+export const DEFAULT_WORKSPACE_TEAM_NAME = "Default team";

--- a/apps/hyperlocalise-web/src/lib/teams/default-workspace-team.ts
+++ b/apps/hyperlocalise-web/src/lib/teams/default-workspace-team.ts
@@ -15,8 +15,12 @@ import { and, eq, isNull } from "drizzle-orm";
 import { db, schema, type DatabaseClient } from "@/lib/database";
 import type { TeamMembershipRole } from "@/lib/database/types";
 
-export const DEFAULT_WORKSPACE_TEAM_SLUG = "default";
-export const DEFAULT_WORKSPACE_TEAM_NAME = "Default team";
+import {
+  DEFAULT_WORKSPACE_TEAM_NAME,
+  DEFAULT_WORKSPACE_TEAM_SLUG,
+} from "./default-workspace-team-constants";
+
+export { DEFAULT_WORKSPACE_TEAM_NAME, DEFAULT_WORKSPACE_TEAM_SLUG };
 
 export async function ensureDefaultWorkspaceTeam(
   organizationId: string,


### PR DESCRIPTION
## What changed

CAT glossary guidance no longer uses the inline name field to create a team glossary. Translators pick an attached glossary from a searchable Command picker, and **Create new** opens a dialog so Add concept stays on screen.

Also:

- Hide the workspace **Default team** from CAT contributor sections (Teams settings is unchanged). If that is the only team, keep an unlabeled write target so Add concept still works.
- New CAT concepts default source and target term status to **Preferred**.
- When a team has no glossary attached to the project, show **Attach a team glossary to this project.** next to Add concept.
- On locked strings, Add concept stays visible but disabled, with a tooltip explaining how to unlock. TM Use and max-length editing stay blocked.

## How to test

- [ ] Open Glossary guidance on a project with attached team glossaries. Confirm the picker lists only that team's glossaries, **Create new** opens a dialog, and Cancel leaves Add concept visible.
- [ ] On a team with no attached glossary, confirm the attach hint appears, Add concept on the form is disabled until a glossary exists, and creating a glossary from the dialog enables it.
- [ ] Confirm **Default team** does not appear as a CAT contributor heading. Add concept still works when the project is on the default team.
- [ ] Open Add concept and confirm Status starts as **Preferred** for source and target terms.
- [ ] Lock the current string: Add concept is disabled with tooltip **This string is locked. Unlock it to add a concept.** TM **Use** is hidden.
- [x] `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix` in `apps/hyperlocalise-web`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)