### PR TITLE
fix(go-svc): accept the /api/go-svc prefix Vercel forwards unchanged

### DIFF
--- a/apps/go-svc/handler.go
+++ b/apps/go-svc/handler.go
@@ -40,10 +40,27 @@ func newHandler() *handler {
 	}
 }
 
+const publicPathPrefix = "/api/go-svc"
+
 func registerRoutes(mux *http.ServeMux, h *handler, verifier SessionVerifier) {
 	validate := authMiddleware(verifier)(http.HandlerFunc(h.validateSegment))
 	mux.HandleFunc("GET /health", h.health)
 	mux.Handle("POST /v1/validate/segment", validate)
+}
+
+// withOptionalPrefix serves next at both its native paths and under prefix.
+// Vercel Services forwards the public path unchanged, so production calls
+// arrive as /api/go-svc/v1/validate/segment while local and binding calls
+// use /v1/validate/segment.
+func withOptionalPrefix(prefix string, next http.Handler) http.Handler {
+	stripped := http.StripPrefix(prefix, next)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == prefix || strings.HasPrefix(r.URL.Path, prefix+"/") {
+			stripped.ServeHTTP(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (h *handler) checkSpelling(ctx context.Context, locale, text string) ([]SpellingIssue, error) {

--- a/apps/go-svc/handler_test.go
+++ b/apps/go-svc/handler_test.go
@@ -59,20 +59,24 @@ func TestRegisterRoutesServesStrippedPaths(t *testing.T) {
 	h := newHandler()
 	mux := http.NewServeMux()
 	registerRoutes(mux, h, mockSessionVerifier{claims: AuthClaims{UserID: "user_123"}})
+	handler := withOptionalPrefix(publicPathPrefix, mux)
 
-	healthRec := httptest.NewRecorder()
-	healthReq := httptest.NewRequest(http.MethodGet, "/health", nil)
-	mux.ServeHTTP(healthRec, healthReq)
-	require.Equal(t, http.StatusOK, healthRec.Code)
-	require.JSONEq(t, `{"status":"ok"}`, healthRec.Body.String())
+	for _, path := range []string{"/health", publicPathPrefix + "/health"} {
+		healthRec := httptest.NewRecorder()
+		healthReq := httptest.NewRequest(http.MethodGet, path, nil)
+		handler.ServeHTTP(healthRec, healthReq)
+		require.Equal(t, http.StatusOK, healthRec.Code, path)
+		require.JSONEq(t, `{"status":"ok"}`, healthRec.Body.String())
+	}
 
 	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json"}`
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/validate/segment", bytes.NewBufferString(payload))
-	req.AddCookie(&http.Cookie{Name: workOSSessionCookieName, Value: "test-session"})
-	mux.ServeHTTP(rec, req)
-
-	require.Equal(t, http.StatusOK, rec.Code)
+	for _, path := range []string{"/v1/validate/segment", publicPathPrefix + "/v1/validate/segment"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(payload))
+		req.AddCookie(&http.Cookie{Name: workOSSessionCookieName, Value: "test-session"})
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code, path)
+	}
 }
 
 func TestValidateSegmentSuccess(t *testing.T) {

--- a/apps/go-svc/main.go
+++ b/apps/go-svc/main.go
@@ -68,7 +68,7 @@ func main() {
 	registerRoutes(mux, h, verifier)
 
 	addr := ":" + port
-	server := newHTTPServer(addr, mux)
+	server := newHTTPServer(addr, withOptionalPrefix(publicPathPrefix, mux))
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/docs/adr/2026-07-05-cat-segment-validation-service-design.md
+++ b/docs/adr/2026-07-05-cat-segment-validation-service-design.md
@@ -7,10 +7,11 @@ Use the Go segment-validation service as the CAT editor's source of truth for fo
 ## Architecture
 
 The CAT client posts directly to `/api/go-svc/v1/validate/segment`. A
-Vercel Services rewrite sends that same-origin path to `go-svc`, which
-strips `/api/go-svc` before the Go mux sees the request. The browser's
-WorkOS session cookie authenticates it. Server-side callers should use
-the injected `GO_SVC_URL` binding instead of the public path.
+Vercel Services rewrite sends that same-origin path to `go-svc`. Vercel
+forwards the public path unchanged, so the service accepts both
+`/api/go-svc/...` and the unprefixed `/v1/...` paths used by local runs
+and the injected `GO_SVC_URL` binding. The browser's WorkOS session
+cookie authenticates public calls.
 
 Each request includes the source text, current target text, source path, and all supported QA modes. It includes `maxLength` only when the segment defines a positive limit.
 


### PR DESCRIPTION
## What changed

Vercel Services forwards `/api/go-svc/v1/validate/segment` to go-svc without stripping the prefix. The mux only registered `/v1/validate/segment`, so production returned Go's default `404 page not found`.

The service now serves both the public `/api/go-svc/...` paths and the unprefixed `/v1/...` and `/health` paths used locally and by the `GO_SVC_URL` binding.

## How to test

- [x] `make fmt`, `make lint`, and `make test`
- [ ] After deploy, `GET /api/go-svc/health` returns `200`
- [ ] After deploy, `POST /api/go-svc/v1/validate/segment` without a session cookie returns `401`, not `404`
- [ ] CAT editor segment validation posts succeed when signed in

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)