### PR TITLE
fix(web): unwrap proxied Requests before Hono clones them

### DIFF
--- a/apps/hyperlocalise-web/src/api/hono-vercel.ts
+++ b/apps/hyperlocalise-web/src/api/hono-vercel.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { handle as honoHandle } from "hono/vercel";
+
+import { toPlainRequest } from "./to-plain-request";
+
+/**
+ * Vercel/Next route adapter that unwraps proxied Requests before Hono.
+ *
+ * Hono `.route()` remounts with `new Request(url, request)` and `bodyLimit`
+ * clones with `new Request(raw, init)`. Both throw on Next.js-proxied
+ * Requests after the Vercel Services runtime change.
+ */
+export function handle(app: Parameters<typeof honoHandle>[0]) {
+  const handler = honoHandle(app);
+  return (request: Request) => handler(toPlainRequest(request));
+}

--- a/apps/hyperlocalise-web/src/api/to-plain-request.test.ts
+++ b/apps/hyperlocalise-web/src/api/to-plain-request.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+
+import { handle } from "./hono-vercel";
+import { toPlainRequest } from "./to-plain-request";
+
+function asNextLikeRequest(request: Request): Request {
+  return new Proxy(request, {
+    get(target, property) {
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+describe("toPlainRequest", () => {
+  it("rebuilds a Request that Hono can remount and bodyLimit can clone", async () => {
+    const app = new Hono().basePath("/api").route(
+      "/echo",
+      new Hono().post(
+        "/",
+        bodyLimit({
+          maxSize: 1024,
+          onError: (c) => c.json({ error: "too_large" }, 413),
+        }),
+        async (c) => c.json({ text: await c.req.text() }),
+      ),
+    );
+
+    const createChunkedPost = () =>
+      new Request("http://localhost/api/echo", {
+        method: "POST",
+        headers: { "transfer-encoding": "chunked" },
+        body: "hello",
+        duplex: "half",
+      } as RequestInit);
+
+    const proxied = asNextLikeRequest(createChunkedPost());
+    expect(() => new Request(proxied)).toThrow(/private member #state/);
+    const failed = await app.fetch(proxied);
+    expect(failed.status).toBe(500);
+
+    const handler = handle(app);
+    const response = await handler(asNextLikeRequest(createChunkedPost()));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ text: "hello" });
+  });
+
+  it("preserves method, url, headers, and body", async () => {
+    const request = new Request("http://localhost/api/items?q=1", {
+      method: "PUT",
+      headers: { "content-type": "text/plain", "x-test": "yes" },
+      body: "payload",
+    });
+
+    const plain = toPlainRequest(asNextLikeRequest(request));
+    expect(plain).not.toBe(request);
+    expect(plain.url).toBe("http://localhost/api/items?q=1");
+    expect(plain.method).toBe("PUT");
+    expect(plain.headers.get("x-test")).toBe("yes");
+    await expect(plain.text()).resolves.toBe("payload");
+  });
+});

--- a/apps/hyperlocalise-web/src/api/to-plain-request.ts
+++ b/apps/hyperlocalise-web/src/api/to-plain-request.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+type RequestInitWithDuplex = RequestInit & { duplex?: "half" };
+
+/**
+ * Rebuild a Request from public fields so Hono can remount and clone it.
+ *
+ * Next.js (and Vercel Services) may hand route handlers a Proxy or a Request
+ * from another undici copy. `new Request(thatRequest)` then throws
+ * `Cannot read private member #state` because the constructor reads a class
+ * private. Rebuild from URL + init instead.
+ */
+export function toPlainRequest(request: Request): Request {
+  const method = request.method;
+  const init: RequestInitWithDuplex = {
+    method,
+    headers: request.headers,
+    signal: request.signal,
+  };
+
+  if (request.body != null && method !== "GET" && method !== "HEAD") {
+    init.body = request.body;
+    init.duplex = "half";
+  }
+
+  return new Request(request.url, init);
+}

--- a/apps/hyperlocalise-web/src/app/api/[[...route]]/route.ts
+++ b/apps/hyperlocalise-web/src/app/api/[[...route]]/route.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { handle } from "hono/vercel";
+import { handle } from "@/api/hono-vercel";
 
 import { app } from "@/api/app";
 

--- a/apps/hyperlocalise-web/src/app/mcp/[[...route]]/route.ts
+++ b/apps/hyperlocalise-web/src/app/mcp/[[...route]]/route.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { handle } from "hono/vercel";
+import { handle } from "@/api/hono-vercel";
 
 import { createMcpRoutes } from "@/api/routes/mcp/mcp.route";
 


### PR DESCRIPTION
## What changed

After the Vercel Services rollout, Next.js hands `/api` and `/mcp` a proxied `Request`. Hono then clones it with `new Request(raw)`, which throws `Cannot read private member #state` and shows up as `Unhandled API error`.

The Vercel adapter now rebuilds a plain `Request` from the URL and public fields before Hono sees it, so remounts and `bodyLimit` succeed.

## How to test

- [x] `vp test src/api/to-plain-request.test.ts src/api/middleware/request-body-limit.test.ts src/api/security-headers.test.ts`
- [x] `vp check --fix` on the changed web files
- [ ] After deploy, POSTs to Hono routes that use `bodyLimit` (webhooks, project image upload, public jobs/files, MCP) no longer log `Cannot read private member #state`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)