### PR TITLE
fix(cat): simplify glossary guidance panel

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.fixture.ts
@@ -24,7 +24,7 @@ export const matchedGlossaryConceptFixture: CatGlossaryConcept = {
   sourceTerms: [
     {
       id: "reseller-en",
-      locale: "en",
+      locale: "en-US",
       text: "Reseller",
       status: "preferred",
       preferred: true,
@@ -33,14 +33,14 @@ export const matchedGlossaryConceptFixture: CatGlossaryConcept = {
   targetTerms: [
     {
       id: "reseller-vi-preferred",
-      locale: "vi",
+      locale: "vi-VN",
       text: "Đại lý",
       status: "preferred",
       preferred: true,
     },
     {
       id: "reseller-vi-alternate",
-      locale: "vi",
+      locale: "vi-VN",
       text: "Nhà bán lại",
       status: "not_recommended",
       forbidden: true,
@@ -103,5 +103,53 @@ export const primaryTermFallbackGlossaryConceptFixture: CatGlossaryConcept = {
   primaryTerm: "API",
   translatable: true,
   sourceTerms: [],
+  targetTerms: [],
+};
+
+export const amountWithViTargetFixture: CatGlossaryConcept = {
+  id: "concept-amount-vi",
+  glossaryId: "glossary-linguists",
+  glossaryName: "Internal Linguists",
+  glossaryUrl: "/org/acme/glossaries/glossary-linguists",
+  conceptUrl: "/org/acme/glossaries/glossary-linguists/concepts/concept-amount-vi",
+  primaryTerm: "Amount",
+  translatable: true,
+  sourceTerms: [
+    {
+      id: "amount-en",
+      locale: "en-US",
+      text: "Amount",
+      status: "preferred",
+      preferred: true,
+    },
+  ],
+  targetTerms: [
+    {
+      id: "amount-vi",
+      locale: "vi-VN",
+      text: "Số tiền",
+      status: "preferred",
+      preferred: true,
+    },
+  ],
+};
+
+export const amountSourceOnlyFixture: CatGlossaryConcept = {
+  id: "concept-amount-source-only",
+  glossaryId: "glossary-linguists",
+  glossaryName: "Internal Linguists",
+  glossaryUrl: "/org/acme/glossaries/glossary-linguists",
+  conceptUrl: "/org/acme/glossaries/glossary-linguists/concepts/concept-amount-source-only",
+  primaryTerm: "Amount",
+  translatable: true,
+  sourceTerms: [
+    {
+      id: "amount-en-only",
+      locale: "en-US",
+      text: "Amount",
+      status: "preferred",
+      preferred: true,
+    },
+  ],
   targetTerms: [],
 };

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.stories.tsx
@@ -80,6 +80,9 @@ export const MatchedConcept: Story = {
     await userEvent.click(canvas.getByRole("button", { name: "Show glossary concept details" }));
     await expect(canvas.getByText("Nhà bán lại")).toBeInTheDocument();
     await expect(canvas.getByText("Not recommended")).toBeInTheDocument();
+    await expect(canvas.getByText("en-US")).toBeInTheDocument();
+    await expect(canvas.getByText("vi-VN")).toBeInTheDocument();
+    await expect(canvas.queryByText("VI-VN")).not.toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-concept-card.tsx
@@ -20,6 +20,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { canonicalizeLocale } from "@/lib/i18n/locales";
 import { cn } from "@/lib/primitives/cn";
 
 import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messages";
@@ -145,9 +146,9 @@ function ConceptTermRow({
     <div className="flex min-h-9 items-center gap-2 rounded-lg bg-input/30 px-2.5 py-1.5">
       <Badge
         variant="outline"
-        className="h-5 shrink-0 rounded-md border-input bg-background/30 px-1.5 text-[10px] uppercase tracking-wide"
+        className="h-5 shrink-0 rounded-md border-input bg-background/30 px-1.5 text-[10px] tracking-wide"
       >
-        {term.locale}
+        {canonicalizeLocale(term.locale) ?? term.locale}
       </Badge>
       <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
         <p className="min-w-24 flex-1 break-words text-sm font-medium leading-tight text-foreground">

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-utils.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-utils.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import type { CatGlossaryConcept } from "@/components/cat/shared/types";
+
+import {
+  catGlossaryConceptHasTargetLocaleTerm,
+  isCatGlossaryConceptVisibleForTargetLocale,
+} from "./cat-glossary-utils";
+
+const translatableWithVi: Pick<CatGlossaryConcept, "translatable" | "targetTerms"> = {
+  translatable: true,
+  targetTerms: [{ id: "amount-vi", locale: "vi-VN", text: "Số tiền" }],
+};
+
+const translatableSourceOnly: Pick<CatGlossaryConcept, "translatable" | "targetTerms"> = {
+  translatable: true,
+  targetTerms: [],
+};
+
+const untranslatableConcept: Pick<CatGlossaryConcept, "translatable" | "targetTerms"> = {
+  translatable: false,
+  targetTerms: [],
+};
+
+describe("catGlossaryConceptHasTargetLocaleTerm", () => {
+  it("matches canonical target locales", () => {
+    expect(catGlossaryConceptHasTargetLocaleTerm(translatableWithVi, "vi-vn")).toBe(true);
+    expect(catGlossaryConceptHasTargetLocaleTerm(translatableWithVi, "ja-JP")).toBe(false);
+  });
+});
+
+describe("isCatGlossaryConceptVisibleForTargetLocale", () => {
+  it("shows translatable concepts only when a target-locale term exists", () => {
+    expect(isCatGlossaryConceptVisibleForTargetLocale(translatableWithVi, "vi-VN")).toBe(true);
+    expect(isCatGlossaryConceptVisibleForTargetLocale(translatableSourceOnly, "vi-VN")).toBe(false);
+  });
+
+  it("shows untranslatable concepts without a target term", () => {
+    expect(isCatGlossaryConceptVisibleForTargetLocale(untranslatableConcept, "vi-VN")).toBe(true);
+  });
+
+  it("shows all concepts when no target locale is set", () => {
+    expect(isCatGlossaryConceptVisibleForTargetLocale(translatableSourceOnly, undefined)).toBe(
+      true,
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-utils.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-glossary-utils.ts
@@ -10,6 +10,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import type { CatGlossaryConcept } from "@/components/cat/shared/types";
+import { canonicalizeLocale } from "@/lib/i18n/locales";
+
 export function applyGlossaryTermToTarget(
   segmentSourceText: string,
   currentTargetText: string,
@@ -32,4 +35,33 @@ export function applyGlossaryTermToTarget(
   }
 
   return term.target;
+}
+
+function canonicalLocaleOrSelf(locale: string) {
+  return canonicalizeLocale(locale) ?? locale;
+}
+
+export function catGlossaryConceptHasTargetLocaleTerm(
+  concept: Pick<CatGlossaryConcept, "targetTerms">,
+  targetLocale: string,
+) {
+  const canonicalTargetLocale = canonicalLocaleOrSelf(targetLocale);
+  return concept.targetTerms.some(
+    (term) => canonicalLocaleOrSelf(term.locale) === canonicalTargetLocale,
+  );
+}
+
+export function isCatGlossaryConceptVisibleForTargetLocale(
+  concept: Pick<CatGlossaryConcept, "translatable" | "targetTerms">,
+  targetLocale: string | undefined,
+) {
+  if (concept.translatable === false) {
+    return true;
+  }
+
+  if (!targetLocale?.trim()) {
+    return true;
+  }
+
+  return catGlossaryConceptHasTargetLocaleTerm(concept, targetLocale);
 }

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.stories.tsx
@@ -23,10 +23,15 @@ import {
   primaryTermFallbackGlossaryConceptFixture,
   sourceOnlyGlossaryConceptFixture,
   untranslatableGlossaryConceptFixture,
+  amountSourceOnlyFixture,
+  amountWithViTargetFixture,
 } from "./cat-glossary-concept-card.fixture";
+import { DEFAULT_WORKSPACE_TEAM_SLUG } from "@/lib/teams/default-workspace-team-constants";
 
 const teamProductId = "team-product";
 const teamMarketingId = "team-marketing";
+const teamLinguistsId = "team-linguists";
+const teamDefaultId = "team-default";
 
 const defaultTargetText = catSegmentsFixture[1]?.targetText ?? "";
 
@@ -195,17 +200,16 @@ const sourceOnlyConceptIntelligence: CatSegmentIntelligence = {
 export const SourceOnlyConcept: Story = {
   args: {
     intelligence: sourceOnlyConceptIntelligence,
+    targetLocale: "vi-VN",
+    sourceLocale: "en-US",
   },
   play: async ({ canvas }) => {
     await waitFor(() => {
       requestCatGlossaryGuidance();
       void expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
     });
-    await expect(canvas.getByText("Dashboard")).toBeInTheDocument();
-    await expect(canvas.getByText("Draft")).toBeInTheDocument();
-
-    await userEvent.click(canvas.getByRole("button", { name: "Show glossary concept details" }));
-    await expect(canvas.getAllByText("Dashboard")).toHaveLength(2);
+    await expect(canvas.getByText("No glossary matches")).toBeInTheDocument();
+    await expect(canvas.queryByText("Dashboard", { exact: true })).not.toBeInTheDocument();
   },
 };
 
@@ -215,14 +219,16 @@ export const PrimaryTermFallback: Story = {
       ...catIntelligenceFixture,
       glossaryConcepts: [primaryTermFallbackGlossaryConceptFixture],
     },
+    targetLocale: "vi-VN",
+    sourceLocale: "en-US",
   },
   play: async ({ canvas }) => {
     await waitFor(() => {
       requestCatGlossaryGuidance();
       void expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
     });
-    await expect(canvas.getByText("API")).toBeInTheDocument();
-    await expect(canvas.getByText("Draft")).toBeInTheDocument();
+    await expect(canvas.getByText("No glossary matches")).toBeInTheDocument();
+    await expect(canvas.queryByText("API", { exact: true })).not.toBeInTheDocument();
   },
 };
 
@@ -417,6 +423,67 @@ export const AddToTeamGlossaryEmpty: Story = {
     await expect(canvas.getAllByRole("combobox", { name: "Status" })[0]).toHaveTextContent(
       "Preferred",
     );
+  },
+};
+
+export const NamedTeamWithoutDefaultSection: Story = {
+  args: {
+    sourceText: "Amount",
+    targetText: "Số tiền",
+    sourceLocale: "en-US",
+    targetLocale: "vi-VN",
+    organizationSlug: "acme",
+    projectId: "project_1",
+    projectTeamId: teamDefaultId,
+    projectTeamSlug: DEFAULT_WORKSPACE_TEAM_SLUG,
+    contributorTeams: [{ id: teamLinguistsId, name: "Linguists" }],
+    teamGlossaries: [
+      { id: "glossary-linguists", name: "Internal Linguists", teamId: teamLinguistsId },
+    ],
+    intelligence: {
+      ...catIntelligenceFixture,
+      glossaryConcepts: [],
+      translationMemoryMatches: [],
+    },
+  },
+  play: async ({ canvas }) => {
+    await waitFor(() => {
+      requestCatGlossaryGuidance();
+      void expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    });
+    await expect(canvas.getByRole("heading", { name: "Linguists", level: 3 })).toBeInTheDocument();
+    await expect(
+      canvas.queryByText("Attach a team glossary to this project."),
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByText("No matching terms.", { exact: true })).not.toBeInTheDocument();
+  },
+};
+
+export const FiltersSourceOnlyDuplicateConcepts: Story = {
+  args: {
+    sourceText: "Amount",
+    targetText: "Số tiền",
+    sourceLocale: "en-US",
+    targetLocale: "vi-VN",
+    organizationSlug: "acme",
+    projectId: "project_1",
+    contributorTeams: [{ id: teamLinguistsId, name: "Linguists" }],
+    teamGlossaries: [
+      { id: "glossary-linguists", name: "Internal Linguists", teamId: teamLinguistsId },
+    ],
+    intelligence: {
+      ...catIntelligenceFixture,
+      glossaryConcepts: [amountWithViTargetFixture, amountSourceOnlyFixture],
+      translationMemoryMatches: [],
+    },
+  },
+  play: async ({ canvas }) => {
+    await waitFor(() => {
+      requestCatGlossaryGuidance();
+      void expect(canvas.getByRole("region", { name: "Glossary guidance" })).toBeInTheDocument();
+    });
+    await expect(canvas.getByText("Số tiền")).toBeInTheDocument();
+    await expect(canvas.getAllByText("Amount", { exact: true })).toHaveLength(1);
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -42,6 +42,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
+import { DEFAULT_WORKSPACE_TEAM_SLUG } from "@/lib/teams/default-workspace-team-constants";
 
 import {
   catEditorPanelMessages,
@@ -56,6 +57,7 @@ import type {
 import { normalizedCatGlossaryTermStatus } from "./cat-glossary-term-status";
 import { CatAddToGlossary } from "./cat-add-to-glossary";
 import { CatGlossaryConceptCard } from "./cat-glossary-concept-card";
+import { isCatGlossaryConceptVisibleForTargetLocale } from "./cat-glossary-utils";
 import {
   collectVisibleCatGlossaryConcepts,
   filterCatTeamGlossariesForTeam,
@@ -315,8 +317,18 @@ export function CatIntelligencePanel({
   const glossaryConcepts = useMemo(
     // Concept-only guidance. Legacy flat glossaryTerms (no glossaryConcepts) are intentionally
     // not synthesized here; concordance must return concept payloads for the panel to populate.
-    () => intelligence.glossaryConcepts ?? [],
-    [intelligence.glossaryConcepts],
+    () =>
+      (intelligence.glossaryConcepts ?? []).filter((concept) =>
+        isCatGlossaryConceptVisibleForTargetLocale(concept, targetLocale),
+      ),
+    [intelligence.glossaryConcepts, targetLocale],
+  );
+  const ungroupedTeamIds = useMemo(
+    () =>
+      projectTeamId && projectTeamSlug === DEFAULT_WORKSPACE_TEAM_SLUG
+        ? new Set([projectTeamId])
+        : new Set<string>(),
+    [projectTeamId, projectTeamSlug],
   );
   const { orgConceptIds, conceptsByTeamId } = useMemo(
     () =>
@@ -325,8 +337,9 @@ export function CatIntelligencePanel({
         teamGlossaryIds,
         glossaryTeamById,
         contributorTeamIds,
+        ungroupedTeamIds,
       }),
-    [contributorTeamIds, glossaryConcepts, glossaryTeamById, teamGlossaryIds],
+    [contributorTeamIds, glossaryConcepts, glossaryTeamById, teamGlossaryIds, ungroupedTeamIds],
   );
   const orgGlossaryConcepts = useMemo(
     () => glossaryConcepts.filter((concept) => orgConceptIds.has(concept.id)),
@@ -785,16 +798,10 @@ export function CatIntelligencePanel({
                                   </div>
                                 ) : (
                                   <p className="rounded-xl border border-border bg-muted/20 px-3 py-2.5 text-sm text-muted-foreground">
-                                    {team.name ? (
-                                      <FormattedMessage
-                                        {...catIntelligencePanelMessages.addToGlossaryTeamEmpty}
-                                        values={{ teamName: team.name }}
-                                      />
-                                    ) : (
-                                      <FormattedMessage
-                                        {...catIntelligencePanelMessages.addToGlossaryTeamEmptyUnnamed}
-                                      />
-                                    )}
+                                    <FormattedMessage
+                                      {...catIntelligencePanelMessages.addToGlossaryTeamEmpty}
+                                      values={{ teamName: team.name }}
+                                    />
                                   </p>
                                 )}
                               </section>

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.test.ts
@@ -61,13 +61,10 @@ describe("resolveCatContributorTeams", () => {
         projectTeamName: DEFAULT_WORKSPACE_TEAM_NAME,
         projectTeamSlug: DEFAULT_WORKSPACE_TEAM_SLUG,
       }),
-    ).toEqual([
-      { id: "team-a", name: "Alpha", slug: "alpha" },
-      { id: "team-default", name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG },
-    ]);
+    ).toEqual([{ id: "team-a", name: "Alpha", slug: "alpha" }]);
   });
 
-  it("appends an unlabeled default project team when the viewer belongs to other teams", () => {
+  it("does not append a default project team when the viewer belongs to other teams", () => {
     expect(
       resolveCatContributorTeams({
         contributorTeams: [{ id: "team-a", name: "Alpha", slug: "alpha" }],
@@ -75,10 +72,7 @@ describe("resolveCatContributorTeams", () => {
         projectTeamName: DEFAULT_WORKSPACE_TEAM_NAME,
         projectTeamSlug: DEFAULT_WORKSPACE_TEAM_SLUG,
       }),
-    ).toEqual([
-      { id: "team-a", name: "Alpha", slug: "alpha" },
-      { id: "team-default", name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG },
-    ]);
+    ).toEqual([{ id: "team-a", name: "Alpha", slug: "alpha" }]);
   });
 
   it("does not hide a team that only shares the default team name", () => {
@@ -94,7 +88,7 @@ describe("resolveCatContributorTeams", () => {
     ).toEqual([{ id: "team-marketing", name: DEFAULT_WORKSPACE_TEAM_NAME, slug: "marketing" }]);
   });
 
-  it("keeps an unlabeled write target when only the default team remains", () => {
+  it("returns no contributor sections when only the default team remains", () => {
     expect(
       resolveCatContributorTeams({
         contributorTeams: [],
@@ -102,7 +96,7 @@ describe("resolveCatContributorTeams", () => {
         projectTeamName: DEFAULT_WORKSPACE_TEAM_NAME,
         projectTeamSlug: DEFAULT_WORKSPACE_TEAM_SLUG,
       }),
-    ).toEqual([{ id: "team-default", name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG }]);
+    ).toEqual([]);
   });
 });
 
@@ -145,7 +139,7 @@ describe("groupCatGlossaryConceptsByTeam", () => {
     expect(conceptsByTeamId.has("team-b")).toBe(false);
   });
 
-  it("retains default-project glossary concepts when the unlabeled target is included", () => {
+  it("surfaces default-team glossary concepts as org concepts when ungrouped", () => {
     const { orgConceptIds, conceptsByTeamId } = groupCatGlossaryConceptsByTeam({
       concepts: [
         { id: "default-team-concept", glossaryId: "glossary-default" },
@@ -156,16 +150,15 @@ describe("groupCatGlossaryConceptsByTeam", () => {
         ["glossary-default", "team-default"],
         ["glossary-alpha", "team-a"],
       ]),
-      contributorTeamIds: new Set(["team-a", "team-default"]),
+      contributorTeamIds: new Set(["team-a"]),
+      ungroupedTeamIds: new Set(["team-default"]),
     });
 
-    expect(orgConceptIds).toEqual(new Set());
-    expect(conceptsByTeamId.get("team-default")).toEqual([
-      { id: "default-team-concept", glossaryId: "glossary-default" },
-    ]);
+    expect(orgConceptIds).toEqual(new Set(["default-team-concept"]));
     expect(conceptsByTeamId.get("team-a")).toEqual([
       { id: "alpha-team-concept", glossaryId: "glossary-alpha" },
     ]);
+    expect(conceptsByTeamId.has("team-default")).toBe(false);
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-team-glossary.ts
@@ -31,10 +31,6 @@ export function isHiddenDefaultContributorTeam(team: { slug?: string }) {
   return team.slug === DEFAULT_WORKSPACE_TEAM_SLUG;
 }
 
-function unlabeledDefaultProjectTeam(projectTeamId: string): CatContributorTeam {
-  return { id: projectTeamId, name: "", slug: DEFAULT_WORKSPACE_TEAM_SLUG };
-}
-
 export function formatCatSharedWithTeamGlossaryName(intl: IntlShape, teamName: string) {
   if (!teamName.trim()) {
     return intl.formatMessage(catIntelligencePanelMessages.addToGlossaryNoteFallback);
@@ -67,24 +63,10 @@ export function resolveCatContributorTeams({
       return [{ id: projectTeamId, name: projectTeamName, slug: projectTeamSlug }];
     }
 
-    if (projectTeamId) {
-      return [unlabeledDefaultProjectTeam(projectTeamId)];
-    }
-
     return [];
   }
 
-  const teams = [...visibleTeams];
-
-  if (
-    projectTeamId &&
-    projectTeamSlug === DEFAULT_WORKSPACE_TEAM_SLUG &&
-    !teams.some((team) => team.id === projectTeamId)
-  ) {
-    teams.push(unlabeledDefaultProjectTeam(projectTeamId));
-  }
-
-  return teams;
+  return visibleTeams;
 }
 
 export function groupCatGlossaryConceptsByTeam<T extends { id: string; glossaryId: string }>({
@@ -92,11 +74,13 @@ export function groupCatGlossaryConceptsByTeam<T extends { id: string; glossaryI
   teamGlossaryIds,
   glossaryTeamById,
   contributorTeamIds,
+  ungroupedTeamIds = new Set<string>(),
 }: {
   concepts: T[];
   teamGlossaryIds: Set<string>;
   glossaryTeamById: Map<string, string>;
   contributorTeamIds: Set<string>;
+  ungroupedTeamIds?: Set<string>;
 }) {
   const orgConceptIds = new Set<string>();
   const conceptsByTeamId = new Map<string, T[]>();
@@ -112,7 +96,16 @@ export function groupCatGlossaryConceptsByTeam<T extends { id: string; glossaryI
     }
 
     const teamId = glossaryTeamById.get(concept.glossaryId);
-    if (!teamId || !conceptsByTeamId.has(teamId)) {
+    if (!teamId) {
+      continue;
+    }
+
+    if (ungroupedTeamIds.has(teamId)) {
+      orgConceptIds.add(concept.id);
+      continue;
+    }
+
+    if (!conceptsByTeamId.has(teamId)) {
       continue;
     }
 

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -665,11 +665,6 @@ export const catIntelligencePanelMessages = defineMessages({
     id: "sjTUZFh0+J",
     description: "Empty state when a team section has no matching glossary concepts",
   },
-  addToGlossaryTeamEmptyUnnamed: {
-    defaultMessage: "No matching terms.",
-    id: "xozianrnAl",
-    description: "Empty state when an unlabeled team section has no matching glossary concepts",
-  },
   addToGlossaryLocked: {
     defaultMessage: "This string is locked. Unlock it to add a concept.",
     id: "lYqWI3Hv5b",


### PR DESCRIPTION
## What changed

- Removed the unlabeled Default team block from Glossary guidance; Add concept is only shown on named team sections (e.g. Linguists).
- Default-team glossary matches still appear as ungrouped cards under "Matched concepts from the project glossary".
- Hid translatable concepts that have no term in the current CAT target locale, so source-only duplicates (e.g. a second Amount card with only `en-US`) no longer appear.
- Locale badges now use BCP 47 formatting (`vi-VN`, `en-US`) instead of all-caps `VI-VN`.

## How to test

- Open Glossary guidance in CAT for a segment with a team glossary attached and confirm only named team sections render.
- With target locale `vi-VN`, verify concepts without a Vietnamese term are hidden while untranslatable concepts still show.
- Expand a concept card and confirm locale badges read `vi-VN` / `en-US`.
- `cd apps/hyperlocalise-web && vp test src/components/cat/intelligence/cat-team-glossary.test.ts src/components/cat/intelligence/cat-glossary-utils.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)