### PR TITLE
fix(agent): block .git writes and harden git invocations

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/apply-patch.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/apply-patch.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
 
-import { normalizeWorkspacePath } from "./path";
+import { isGitMetadataPath, normalizeWorkspacePath } from "./path";
 import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
 import type { RepoToolContext } from "./types";
 
@@ -46,6 +46,7 @@ const GIT_INDEX_MODE = new RegExp(
 );
 
 const SPECIAL_GIT_PATH_ERROR = "Patch must not create or modify symbolic links or git submodules.";
+const GIT_METADATA_PATCH_ERROR = "Patch must not modify files under .git/.";
 
 /** Reject git symlink (120000) and submodule/gitlink (160000) modes before `git apply`. */
 export function disallowedGitFileModeError(patch: string): string | undefined {
@@ -129,6 +130,9 @@ function extractPatchPaths(patch: string): { paths: string[]; error?: string } {
       }
       continue;
     }
+    if (isGitMetadataPath(path)) {
+      return { paths: [], error: GIT_METADATA_PATCH_ERROR };
+    }
     paths.add(path);
   }
 
@@ -150,6 +154,7 @@ WHEN NOT TO USE:
 IMPORTANT:
 - The patch is validated with git apply --check before it is applied
 - Symbolic links and git submodules (modes 120000 and 160000) are rejected, including existing checkout targets
+- Paths under .git/ are rejected
 - This is a repository write action and may be denied by workspace policy`,
     inputSchema: applyPatchInputSchema,
     execute: async ({ patch }) => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { Bash, InMemoryFs } from "just-bash";
 
 import { createBashTool, isAllowedBashCommand } from "./bash";
+import { hardenGitArgs } from "./git-harden";
 import type { RepoToolContext } from "./types";
 
 const toolCallInfo = { toolCallId: "test-tool-call", messages: [], context: {} };
@@ -126,6 +127,23 @@ describe("isAllowedBashCommand", () => {
   ])("blocks attached absolute or parent path in %s", (command) => {
     expect(isAllowedBashCommand(command)).toBe(false);
   });
+
+  it.each([
+    "git show --textconv",
+    "git show HEAD --textconv",
+    "git diff --ext-diff",
+    "git diff HEAD --ext-diff",
+    `git show "--textconv"`,
+    "git log --textconv",
+    "git show --textconv=true",
+  ])("blocks git helper-program flag in %s", (command) => {
+    expect(isAllowedBashCommand(command)).toBe(false);
+  });
+
+  it("still allows ordinary git show and diff", () => {
+    expect(isAllowedBashCommand("git show HEAD")).toBe(true);
+    expect(isAllowedBashCommand("git diff HEAD^ HEAD")).toBe(true);
+  });
 });
 
 describe("createBashTool", () => {
@@ -190,7 +208,7 @@ describe("createBashTool", () => {
       bash: {
         exec: async (bin, options) => {
           expect(bin).toBe("git");
-          expect(options?.args).toEqual(["diff", "HEAD^", "HEAD"]);
+          expect(options?.args).toEqual(hardenGitArgs(["diff", "HEAD^", "HEAD"]));
           return { stdout: patch, stderr: "", exitCode: 1, env: {} };
         },
         readFile: async () => "",
@@ -212,7 +230,9 @@ describe("createBashTool", () => {
       bash: {
         exec: async (bin, options) => {
           expect(bin).toBe("git");
-          expect(options?.args).toEqual(["-C", "scribe-fe-v2", "diff", "HEAD^", "HEAD"]);
+          expect(options?.args).toEqual(
+            hardenGitArgs(["-C", "scribe-fe-v2", "diff", "HEAD^", "HEAD"]),
+          );
           return { stdout: patch, stderr: "", exitCode: 1, env: {} };
         },
         readFile: async () => "",
@@ -247,5 +267,34 @@ describe("createBashTool", () => {
       exitCode: 129,
       stdout: "usage: git diff [<options>]",
     });
+  });
+
+  it("rejects git show --textconv before execution", async () => {
+    const tool = createBashTool({
+      bash: {
+        exec: async () => {
+          throw new Error("bash.exec must not run for git --textconv");
+        },
+        readFile: async () => "",
+      },
+    });
+    const result = await tool.execute!({ command: "git show HEAD --textconv" }, toolCallInfo);
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("injects fsmonitor and diff.external disables on git status", async () => {
+    const tool = createBashTool({
+      bash: {
+        exec: async (bin, options) => {
+          expect(bin).toBe("git");
+          expect(options?.args).toEqual(hardenGitArgs(["status", "--short"]));
+          return { stdout: "", stderr: "", exitCode: 0, env: {} };
+        },
+        readFile: async () => "",
+      },
+    });
+
+    const result = await tool.execute!({ command: "git status --short" }, toolCallInfo);
+    expect(result).toMatchObject({ success: true, exitCode: 0 });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
@@ -17,6 +17,7 @@ import { flagBasename, HL_WRITE_FLAG_NAMES } from "@/lib/agent-runtime/tools/hl-
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import { isSuccessfulAllowlistedExit } from "./git-exit";
+import { hardenGitArgs } from "./git-harden";
 import { normalizeWorkspacePath } from "./path";
 import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
 import type { RepoToolContext } from "./types";
@@ -43,9 +44,10 @@ const DISALLOWED_FLAG_NAMES = new Set([
   ...HL_WRITE_FLAG_NAMES,
 ]);
 
-// git log/diff/show `--output`/`-o` writes a file. Keep these git-only:
+// git log/diff/show `--output`/`-o` writes a file. `--textconv` / `--ext-diff`
+// run helper programs from `.git/config`. Keep these git-only:
 // `find -o` is OR, and `hl status --output csv` is a format, not a path.
-const DISALLOWED_GIT_OUTPUT_FLAG_NAMES = new Set(["output", "o"]);
+const DISALLOWED_GIT_FLAG_NAMES = new Set(["output", "o", "textconv", "ext-diff"]);
 
 const ALLOWED_COMMAND_PATTERNS = [
   /^git\s+(status|log|diff|rev-parse|show)\b/i,
@@ -80,7 +82,7 @@ function isDisallowedGitOutputFlag(token: string): boolean {
     return false;
   }
   const name = flagBasename(token);
-  if (DISALLOWED_GIT_OUTPUT_FLAG_NAMES.has(name)) {
+  if (DISALLOWED_GIT_FLAG_NAMES.has(name)) {
     return true;
   }
   // git accepts `-ofile` as `-o` with an attached filename.
@@ -210,6 +212,9 @@ IMPORTANT:
           } else if (bin === "find" && args[0] !== workdir) {
             execArgs = [workdir, ...args];
           }
+        }
+        if (bin === "git") {
+          execArgs = hardenGitArgs(execArgs);
         }
 
         const result = await ctx.bash.exec(bin, { args: execArgs });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-exit.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-exit.test.ts
@@ -21,6 +21,14 @@ describe("git-exit", () => {
     expect(gitSubcommand(["-C", "repo", "--no-pager", "log"])).toBe("log");
   });
 
+  it("finds the subcommand after -c config overrides", () => {
+    expect(
+      gitSubcommand(["-c", "core.fsmonitor=", "-c", "diff.external=", "status", "--short"]),
+    ).toBe("status");
+    expect(gitSubcommand(["-C", "repo", "-c", "core.fsmonitor=", "diff"])).toBe("diff");
+    expect(gitSubcommand(["-ccore.fsmonitor=", "log"])).toBe("log");
+  });
+
   it("treats git diff exit 0 and 1 as success", () => {
     expect(
       isSuccessfulAllowlistedExit({

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-exit.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-exit.ts
@@ -11,26 +11,56 @@
  * Version 2.0 or later.
  */
 
+const GIT_VALUE_GLOBAL_FLAGS = new Set(["-C", "-c"]);
+const GIT_VALUE_LONG_GLOBAL_FLAGS = ["--git-dir", "--work-tree", "--namespace", "--config-env"];
+
+function skipGitGlobalFlag(token: string): number {
+  if (GIT_VALUE_GLOBAL_FLAGS.has(token)) {
+    return 1;
+  }
+  // git accepts `-ckey=value` as a single token.
+  if (token.startsWith("-c") && token.length > 2 && !token.startsWith("--")) {
+    return 0;
+  }
+  if (GIT_VALUE_LONG_GLOBAL_FLAGS.includes(token)) {
+    return 1;
+  }
+  if (GIT_VALUE_LONG_GLOBAL_FLAGS.some((flag) => token.startsWith(`${flag}=`))) {
+    return 0;
+  }
+  return -1;
+}
+
 /**
- * Git porcelain `diff` uses exit 1 to mean "differences found". That is success
- * for a read-only reviewer that needs the patch.
+ * Index of the git subcommand, skipping global options such as `-C` and `-c`.
+ * `-c core.fsmonitor=` must not be treated as the subcommand.
  */
-export function gitSubcommand(args: string[]): string | undefined {
+export function gitSubcommandIndex(args: string[]): number {
   for (let i = 0; i < args.length; i += 1) {
     const token = args[i];
     if (!token) {
       continue;
     }
-    if (token === "-C") {
-      i += 1;
+    const skipValues = skipGitGlobalFlag(token);
+    if (skipValues >= 0) {
+      i += skipValues;
       continue;
     }
     if (token.startsWith("-")) {
       continue;
     }
-    return token;
+    return i;
   }
-  return undefined;
+  return -1;
+}
+
+/**
+ * Git porcelain `diff` uses exit 1 to mean "differences found". That is success
+ * for a read-only reviewer that needs the patch.
+ */
+export function gitSubcommand(args: string[]): string | undefined {
+  const index = gitSubcommandIndex(args);
+  return index === -1 ? undefined : args[index];
 }
 
 export function isGitDiffCommand(args: string[]): boolean {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-harden.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-harden.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { gitSubcommand } from "./git-exit";
+import { hardenGitArgs } from "./git-harden";
+
+describe("hardenGitArgs", () => {
+  it("injects empty fsmonitor and diff.external overrides before status", () => {
+    expect(hardenGitArgs(["status", "--short"])).toEqual([
+      "-c",
+      "core.fsmonitor=",
+      "-c",
+      "core.fsmonitorHook=",
+      "-c",
+      "diff.external=",
+      "status",
+      "--short",
+    ]);
+  });
+
+  it("disables textconv and ext-diff on diff/show/log", () => {
+    expect(hardenGitArgs(["diff", "HEAD^", "HEAD"])).toEqual([
+      "-c",
+      "core.fsmonitor=",
+      "-c",
+      "core.fsmonitorHook=",
+      "-c",
+      "diff.external=",
+      "diff",
+      "--no-textconv",
+      "--no-ext-diff",
+      "HEAD^",
+      "HEAD",
+    ]);
+    expect(hardenGitArgs(["show", "HEAD:README.md"])).toEqual([
+      "-c",
+      "core.fsmonitor=",
+      "-c",
+      "core.fsmonitorHook=",
+      "-c",
+      "diff.external=",
+      "show",
+      "--no-textconv",
+      "--no-ext-diff",
+      "HEAD:README.md",
+    ]);
+  });
+
+  it("disables textconv on blame without passing --no-ext-diff", () => {
+    expect(hardenGitArgs(["blame", "--", "lang/en.json"])).toEqual([
+      "-c",
+      "core.fsmonitor=",
+      "-c",
+      "core.fsmonitorHook=",
+      "-c",
+      "diff.external=",
+      "blame",
+      "--no-textconv",
+      "--",
+      "lang/en.json",
+    ]);
+  });
+
+  it("keeps -C before the config overrides", () => {
+    expect(hardenGitArgs(["-C", "scribe-fe-v2", "status", "--porcelain"])).toEqual([
+      "-C",
+      "scribe-fe-v2",
+      "-c",
+      "core.fsmonitor=",
+      "-c",
+      "core.fsmonitorHook=",
+      "-c",
+      "diff.external=",
+      "status",
+      "--porcelain",
+    ]);
+  });
+
+  it("still reports diff as the subcommand after hardening", () => {
+    expect(gitSubcommand(hardenGitArgs(["-C", "repo", "diff", "HEAD"]))).toBe("diff");
+    expect(gitSubcommand(hardenGitArgs(["status"]))).toBe("status");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-harden.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-harden.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { gitSubcommandIndex } from "./git-exit";
+
+/**
+ * Empty `-c` overrides that disable helper programs from `.git/config`.
+ * `core.fsmonitor` runs on `git status`; `diff.external` runs on `git diff`.
+ */
+export const GIT_DISABLED_CONFIG_SETTINGS = [
+  "core.fsmonitor=",
+  "core.fsmonitorHook=",
+  "diff.external=",
+] as const;
+
+const NO_TEXTCONV_SUBCOMMANDS = new Set(["diff", "show", "log", "blame"]);
+const NO_EXT_DIFF_SUBCOMMANDS = new Set(["diff", "show", "log"]);
+
+export function gitSafeConfigArgs(): string[] {
+  return GIT_DISABLED_CONFIG_SETTINGS.flatMap((setting) => ["-c", setting]);
+}
+
+/**
+ * Force-disable fsmonitor, external diff, and textconv on a git argv.
+ * Preserves a leading `-C <dir>` so clone-root binding stays first.
+ */
+export function hardenGitArgs(args: string[]): string[] {
+  let prefix: string[] = [];
+  let rest = args;
+  if (args[0] === "-C" && typeof args[1] === "string") {
+    prefix = ["-C", args[1]];
+    rest = args.slice(2);
+  }
+
+  const withConfig = [...prefix, ...gitSafeConfigArgs(), ...rest];
+  const subIndex = gitSubcommandIndex(withConfig);
+  const subcommand = subIndex === -1 ? undefined : withConfig[subIndex];
+  if (!subcommand) {
+    return withConfig;
+  }
+
+  const extra: string[] = [];
+  if (NO_TEXTCONV_SUBCOMMANDS.has(subcommand)) {
+    extra.push("--no-textconv");
+  }
+  if (NO_EXT_DIFF_SUBCOMMANDS.has(subcommand)) {
+    extra.push("--no-ext-diff");
+  }
+  if (extra.length === 0) {
+    return withConfig;
+  }
+
+  return [...withConfig.slice(0, subIndex + 1), ...extra, ...withConfig.slice(subIndex + 1)];
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
@@ -12,8 +12,7 @@
  */
 export type { RepoToolContext } from "./types";
 export { redact, truncate, DEFAULT_MAX_OUTPUT_BYTES, DEFAULT_MAX_FILE_BYTES } from "./redact";
-export { isGitMetadataPath, normalizeWorkspacePath } from "./path";
-export { hardenGitArgs } from "./git-harden";
+export { normalizeWorkspacePath } from "./path";
 export { parseGrepLine, type GrepMatch } from "./parse-grep-line";
 export { createReadTool } from "./read";
 export { createGrepTool } from "./grep";

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
@@ -12,7 +12,8 @@
  */
 export type { RepoToolContext } from "./types";
 export { redact, truncate, DEFAULT_MAX_OUTPUT_BYTES, DEFAULT_MAX_FILE_BYTES } from "./redact";
-export { normalizeWorkspacePath } from "./path";
+export { isGitMetadataPath, normalizeWorkspacePath } from "./path";
+export { hardenGitArgs } from "./git-harden";
 export { parseGrepLine, type GrepMatch } from "./parse-grep-line";
 export { createReadTool } from "./read";
 export { createGrepTool } from "./grep";

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { isGitMetadataPath, normalizeWorkspacePath } from "./path";
+
+describe("isGitMetadataPath", () => {
+  it("rejects the git directory and files under it", () => {
+    expect(isGitMetadataPath(".git")).toBe(true);
+    expect(isGitMetadataPath(".git/config")).toBe(true);
+    expect(isGitMetadataPath("./.git/hooks/pre-commit")).toBe(true);
+    expect(isGitMetadataPath("vendor/lib/.git/config")).toBe(true);
+  });
+
+  it("allows ordinary git-dotfiles and source paths", () => {
+    expect(isGitMetadataPath(".gitignore")).toBe(false);
+    expect(isGitMetadataPath(".gitattributes")).toBe(false);
+    expect(isGitMetadataPath(".github/workflows/ci.yml")).toBe(false);
+    expect(isGitMetadataPath("src/app.tsx")).toBe(false);
+  });
+});
+
+describe("normalizeWorkspacePath", () => {
+  it("keeps workspace-relative source paths", () => {
+    expect(normalizeWorkspacePath("./src/app.tsx")).toBe("src/app.tsx");
+  });
+
+  it("rejects traversal and absolute paths", () => {
+    expect(normalizeWorkspacePath("../secret")).toBeNull();
+    expect(normalizeWorkspacePath("/etc/passwd")).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.ts
@@ -24,6 +24,17 @@ export function normalizeWorkspacePath(path: string): string | null {
   return normalized;
 }
 
+/**
+ * True when any path segment is `.git`.
+ * `.gitignore` / `.gitattributes` stay allowed; `.git/config` does not.
+ */
+export function isGitMetadataPath(path: string): boolean {
+  const normalized = path.replace(/\\/g, "/").replace(/^\.\//, "").trim();
+  return normalized.split("/").includes(".git");
+}
+
+export const GIT_METADATA_WRITE_ERROR = "Writes under .git/ are not allowed.";
+
 /** Prefix paths so shell tools like `find` treat them as relative paths, not flags. */
 export function toShellRelativePath(normalizedPath: string): string {
   if (normalizedPath === ".") {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.test.ts
@@ -75,6 +75,41 @@ describe("createWriteTool", () => {
     expect(writeWorkspaceFile).toHaveBeenCalledWith("src/mock.tsx", "export const value = 1;\n");
   });
 
+  it.each([".git/config", "./.git/hooks/pre-commit", "vendor/lib/.git/config", ".git"])(
+    "denies writes to git metadata path %s",
+    async (filePath) => {
+      const { repo, writeWorkspaceFile } = createRepoContext();
+      const write = createWriteTool(createWriteContext(), repo);
+
+      const result = await write.execute!(
+        {
+          filePath,
+          content: "[core]\nfsmonitor = sh ./payload\n",
+        },
+        toolCallInfo,
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        error: "Writes under .git/ are not allowed.",
+      });
+      expect(writeWorkspaceFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows writes to .gitignore", async () => {
+    const { repo, writeWorkspaceFile } = createRepoContext();
+    const write = createWriteTool(createWriteContext(), repo);
+
+    const result = await write.execute!(
+      { filePath: ".gitignore", content: "node_modules\n" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({ success: true, path: ".gitignore" });
+    expect(writeWorkspaceFile).toHaveBeenCalledWith(".gitignore", "node_modules\n");
+  });
+
   it("denies writes when repository write context is unavailable", async () => {
     const { repo, writeWorkspaceFile } = createRepoContext();
     const write = createWriteTool(
@@ -165,6 +200,32 @@ describe("createApplyPatchTool", () => {
     expect(result).toMatchObject({
       success: false,
       error: "Patch contains a path outside the workspace.",
+    });
+    expect(writeWorkspaceFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects patches that target .git/config", async () => {
+    const { repo, writeWorkspaceFile } = createRepoContext();
+    const applyPatch = createApplyPatchTool(createWriteContext(), repo);
+
+    const result = await applyPatch.execute!(
+      {
+        patch: [
+          "diff --git a/.git/config b/.git/config",
+          "--- a/.git/config",
+          "+++ b/.git/config",
+          "@@ -1 +1,2 @@",
+          " [core]",
+          "+	fsmonitor = sh ./payload",
+          "",
+        ].join("\n"),
+      },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Patch must not modify files under .git/.",
     });
     expect(writeWorkspaceFile).not.toHaveBeenCalled();
   });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.ts
@@ -16,7 +16,12 @@ import { z } from "zod";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
 
-import { normalizeWorkspacePath, toShellRelativePath } from "./path";
+import {
+  GIT_METADATA_WRITE_ERROR,
+  isGitMetadataPath,
+  normalizeWorkspacePath,
+  toShellRelativePath,
+} from "./path";
 import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
 import type { RepoToolContext } from "./types";
 
@@ -43,6 +48,7 @@ WHEN NOT TO USE:
 IMPORTANT:
 - This writes the complete file contents
 - Read existing files first before overwriting them
+- Paths under .git/ are rejected
 - This is a repository write action and may be denied by workspace policy`,
     inputSchema: writeInputSchema,
     execute: async ({ filePath, content }) => {
@@ -60,6 +66,9 @@ IMPORTANT:
       const path = normalizeWorkspacePath(filePath);
       if (!path) {
         return { success: false as const, error: "Path must stay within the workspace." };
+      }
+      if (isGitMetadataPath(path)) {
+        return { success: false as const, error: GIT_METADATA_WRITE_ERROR };
       }
 
       try {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-repo-bash.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-repo-bash.ts
@@ -10,8 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { getVercelSandboxWorkspace } from "@/lib/agent-runtime/workspaces/vercel-sandbox-runtime";
+import { hardenGitArgs } from "@/lib/agent-runtime/tools/workspace/git-harden";
+import {
+  GIT_METADATA_WRITE_ERROR,
+  isGitMetadataPath,
+} from "@/lib/agent-runtime/tools/workspace/path";
 import type { RepoToolContext } from "@/lib/agent-runtime/tools/workspace/types";
+import { getVercelSandboxWorkspace } from "@/lib/agent-runtime/workspaces/vercel-sandbox-runtime";
 
 /**
  * Minimal Bash adapter backed by a Vercel sandbox for repo read/search tools.
@@ -22,7 +27,8 @@ export function createSandboxRepoBash(sandboxId: string): RepoToolContext["bash"
   return {
     async exec(command, options) {
       const args = options?.args ?? [];
-      const result = await workspace.runCommand(command, args);
+      const execArgs = command === "git" ? hardenGitArgs(args) : args;
+      const result = await workspace.runCommand(command, execArgs);
       return {
         exitCode: result.exitCode,
         stdout: result.output,
@@ -34,6 +40,9 @@ export function createSandboxRepoBash(sandboxId: string): RepoToolContext["bash"
       return workspace.readFile(path);
     },
     async writeWorkspaceFile(path, content) {
+      if (isGitMetadataPath(path)) {
+        throw new Error(GIT_METADATA_WRITE_ERROR);
+      }
       await workspace.writeFile(path, content);
     },
   };

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
@@ -33,6 +33,7 @@ vi.mock("@vercel/sandbox", () => ({
 
 import {
   buildSandboxWriteFileScript,
+  SANDBOX_WRITE_GIT_METADATA_DENIED,
   SANDBOX_WRITE_OUTSIDE_WORKSPACE,
   SANDBOX_WRITE_SYMLINK_DENIED,
   VercelSandboxCommandError,
@@ -180,6 +181,25 @@ describe("VercelSandboxRuntime", () => {
       expect.arrayContaining(["-lc", expect.stringContaining("realpath -m")]),
     );
   });
+
+  it("maps git-metadata write denials from the sandbox guard", async () => {
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      exitCode: SANDBOX_WRITE_GIT_METADATA_DENIED,
+      output: async () => "",
+    });
+    sandboxMocks.get.mockResolvedValueOnce({
+      runCommand: sandboxMocks.runCommand,
+    });
+
+    const runtime = new VercelSandboxRuntime("sbx_123");
+    await expect(
+      runtime.writeFile(".git/config", "[core]\nfsmonitor=sh ./payload\n"),
+    ).rejects.toThrow("Writes under .git/ are not allowed.");
+    expect(sandboxMocks.runCommand).toHaveBeenCalledWith(
+      "bash",
+      expect.arrayContaining(["-lc", expect.stringContaining("realpath -m")]),
+    );
+  });
 });
 
 describe("buildSandboxWriteFileScript", () => {
@@ -244,5 +264,20 @@ describe("buildSandboxWriteFileScript", () => {
       exitCode: SANDBOX_WRITE_OUTSIDE_WORKSPACE,
     });
     await rm(outsideFile, { force: true });
+  });
+
+  it("refuses writes under .git while still allowing .gitignore", async () => {
+    const root = await createWorkspaceRoot();
+    await mkdir(join(root, ".git"), { recursive: true });
+
+    await expect(
+      runWriteGuard(root, ".git/config", "[core]\nfsmonitor=sh ./payload\n"),
+    ).resolves.toEqual({
+      exitCode: SANDBOX_WRITE_GIT_METADATA_DENIED,
+    });
+    await expect(runWriteGuard(root, ".gitignore", "node_modules\n")).resolves.toEqual({
+      exitCode: 0,
+    });
+    await expect(readFile(join(root, ".gitignore"), "utf8")).resolves.toBe("node_modules\n");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts
@@ -137,6 +137,7 @@ export const SANDBOX_WRITE_SYMLINK_DENIED = 42;
 export const SANDBOX_WRITE_PATH_INVALID = 43;
 export const SANDBOX_WRITE_OUTSIDE_WORKSPACE = 44;
 export const SANDBOX_WRITE_ROOT_UNAVAILABLE = 45;
+export const SANDBOX_WRITE_GIT_METADATA_DENIED = 46;
 
 function shellQuote(value: string) {
   return `'${value.replaceAll("'", "'\\''")}'`;
@@ -165,6 +166,10 @@ export function buildSandboxWriteFileScript(path: string, base64Content: string)
     'case "$resolved" in',
     `  "$root"|"$root"/*) ;;`,
     `  *) exit ${SANDBOX_WRITE_OUTSIDE_WORKSPACE} ;;`,
+    "esac",
+    // Deny `.git/config` and other git metadata. `*/.git/*` does not match `.gitignore`.
+    'case "/$resolved/" in',
+    `  */.git/*) exit ${SANDBOX_WRITE_GIT_METADATA_DENIED} ;;`,
     "esac",
     "remaining=$target",
     "current=.",
@@ -269,6 +274,9 @@ export class VercelSandboxRuntime implements WorkspaceRuntime {
     ]);
     if (result.exitCode === SANDBOX_WRITE_SYMLINK_DENIED) {
       throw new Error("Symlink writes are not allowed.");
+    }
+    if (result.exitCode === SANDBOX_WRITE_GIT_METADATA_DENIED) {
+      throw new Error("Writes under .git/ are not allowed.");
     }
     if (result.exitCode === SANDBOX_WRITE_OUTSIDE_WORKSPACE) {
       throw new Error("Path resolves outside the workspace.");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

An org member (or prompt injection) with a write-mode repository agent could write a payload script plus `.git/config`, then run allowlisted `git status` / `git show --textconv` / `git diff --ext-diff`. Git would execute `core.fsmonitor`, `diff.*.textconv`, or `diff.external` and bypass the read-only bash allowlist.

This change:

- Rejects write and applyPatch paths whose any segment is `.git` (`.gitignore` stays allowed)
- Rejects the same paths in the sandbox write adapter and write-file guard
- Injects `-c core.fsmonitor=` `-c core.fsmonitorHook=` `-c diff.external=` on every sandbox and bash-tool git invocation
- Adds `--no-textconv` / `--no-ext-diff` on commands that support them
- Rejects `--textconv` and `--ext-diff` before the bash tool runs
- Teaches `gitSubcommand` to skip `-c` values so hardened argv still classifies `diff` correctly

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/lib/agent-runtime/tools/workspace src/lib/agent-runtime/tools/repo-read-tools.test.ts src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
vp check --fix
vp test
```

Confirm:

- `write` of `.git/config` returns `Writes under .git/ are not allowed.`
- `applyPatch` targeting `.git/config` is rejected
- `git show --textconv` and `git diff --ext-diff` are not allowlisted
- `git status` / `git diff` exec args include the empty `-c` overrides

Verified locally: focused suite 244/244, full `vp test` 5410/5410, `vp check --fix` clean.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04a66-8e7e-73de-b189-8cae90f9a513?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04a66-8e7e-73de-b189-8cae90f9a513&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

