### PR TITLE
feat(cat): send targetLocale and display spelling checks

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.test.tsx
@@ -187,6 +187,25 @@ describe("CatEditorPanel UI", () => {
     expect(screen.getByText("Translation exceeds 80 characters.")).toBeInTheDocument();
   });
 
+  it("renders spelling warnings for the active segment", () => {
+    renderEditorPanel({
+      formatChecks: [
+        {
+          id: "spelling",
+          label: "Spelling",
+          status: "warn",
+          message: "Possible misspelling: recieve.",
+          category: "spelling",
+          relatedTokens: ["recieve"],
+        },
+      ],
+    });
+
+    expect(screen.getByText("Spelling")).toBeInTheDocument();
+    expect(screen.getByText("Possible misspelling: recieve.")).toBeInTheDocument();
+    expect(screen.getByText("Check")).toBeInTheDocument();
+  });
+
   it("shows the segment key above the source heading", () => {
     renderEditorPanel();
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.test.ts
@@ -299,6 +299,35 @@ describe("fetchCatSegmentValidation", () => {
     });
   });
 
+  it("omits spelling for a non-BCP-47 locale so other checks still run", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ checks: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        sourcePath: "/messages/en.json",
+        targetLocale: "invalid_locale_format",
+        intl: testIntl,
+      },
+      fetcher,
+    );
+
+    const request = fetcher.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(request.body as string)).toEqual({
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      sourcePath: "/messages/en.json",
+      targetLocale: "invalid_locale_format",
+      modes: ["not_localized", "whitespace_only", "same_as_source"],
+    });
+  });
+
   it("omits spelling and targetLocale when the segment has no locale", async () => {
     const fetcher = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ checks: [] }), {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.test.ts
@@ -42,6 +42,7 @@ describe("fetchCatSegmentValidation", () => {
         sourceText: "Hello {name}",
         targetText: "Bonjour {name}",
         sourcePath: "/messages/en.json",
+        targetLocale: "fr-FR",
         maxLength: 40,
         intl: testIntl,
       },
@@ -70,7 +71,8 @@ describe("fetchCatSegmentValidation", () => {
           targetText: "Bonjour {name}",
           sourcePath: "/messages/en.json",
           maxLength: 40,
-          modes: ["not_localized", "whitespace_only", "same_as_source"],
+          targetLocale: "fr-FR",
+          modes: ["not_localized", "whitespace_only", "same_as_source", "spelling"],
         }),
       }),
     );
@@ -88,6 +90,7 @@ describe("fetchCatSegmentValidation", () => {
         sourceText: "Hello",
         targetText: "Bonjour",
         sourcePath: "/messages/en.json",
+        targetLocale: "fr-FR",
         intl: testIntl,
       },
       fetcher,
@@ -96,6 +99,231 @@ describe("fetchCatSegmentValidation", () => {
     expect(result).toEqual({
       ok: false,
       error: expect.objectContaining({ code: "invalid_response" }),
+    });
+  });
+
+  it("accepts spelling checks and optional skippedModes on the response", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          checks: [
+            {
+              id: "format-parity",
+              label: "Placeholders & ICU",
+              status: "pass",
+              message: "Target keeps the required placeholders and ICU structure.",
+              category: "placeholder",
+            },
+            {
+              id: "spelling",
+              label: "Spelling",
+              status: "warn",
+              message: "Possible misspelling: recieve.",
+              category: "spelling",
+              relatedTokens: ["recieve"],
+            },
+          ],
+          skippedModes: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await fetchCatSegmentValidation(
+      {
+        sourceText: "Please receive the update",
+        targetText: "Please recieve the update",
+        sourcePath: "/messages/en.json",
+        targetLocale: "en-US",
+        intl: testIntl,
+      },
+      fetcher,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: [
+        {
+          id: "format-parity",
+          label: "Placeholders & ICU",
+          status: "pass",
+          message: "Target keeps the required placeholders and ICU structure.",
+          category: "placeholder",
+        },
+        {
+          id: "spelling",
+          label: "Spelling",
+          status: "warn",
+          message: "Possible misspelling: recieve.",
+          category: "spelling",
+          relatedTokens: ["recieve"],
+        },
+      ],
+    });
+  });
+
+  it("parses mocked responses that omit spelling fields", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          checks: [
+            {
+              id: "format-parity",
+              label: "Format",
+              status: "pass",
+              message: "No placeholders or ICU blocks detected.",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        sourcePath: "/messages/en.json",
+        targetLocale: "fr-FR",
+        intl: testIntl,
+      },
+      fetcher,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: [
+        {
+          id: "format-parity",
+          label: "Format",
+          status: "pass",
+          message: "No placeholders or ICU blocks detected.",
+        },
+      ],
+    });
+  });
+
+  it("accepts skippedModes without treating a skipped spelling mode as a pass", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          checks: [
+            {
+              id: "format-parity",
+              label: "Format",
+              status: "pass",
+              message: "No placeholders or ICU blocks detected.",
+              category: "placeholder",
+            },
+          ],
+          skippedModes: ["spelling"],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello",
+        targetText: "こんにちは",
+        sourcePath: "/messages/en.json",
+        targetLocale: "ja-JP",
+        intl: testIntl,
+      },
+      fetcher,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: [
+        {
+          id: "format-parity",
+          label: "Format",
+          status: "pass",
+          message: "No placeholders or ICU blocks detected.",
+          category: "placeholder",
+        },
+      ],
+    });
+    expect(result.ok && result.value.some((check) => check.category === "spelling")).toBe(false);
+  });
+
+  it("does not surface a spelling pass when spelling was skipped", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          checks: [
+            {
+              id: "format-parity",
+              label: "Format",
+              status: "pass",
+              message: "No placeholders or ICU blocks detected.",
+              category: "placeholder",
+            },
+            {
+              id: "spelling",
+              label: "Spelling",
+              status: "pass",
+              message: "No spelling issues found.",
+              category: "spelling",
+            },
+          ],
+          skippedModes: ["spelling"],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello",
+        targetText: "こんにちは",
+        sourcePath: "/messages/en.json",
+        targetLocale: "ja-JP",
+        intl: testIntl,
+      },
+      fetcher,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: [
+        {
+          id: "format-parity",
+          label: "Format",
+          status: "pass",
+          message: "No placeholders or ICU blocks detected.",
+          category: "placeholder",
+        },
+      ],
+    });
+  });
+
+  it("omits spelling and targetLocale when the segment has no locale", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ checks: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        sourcePath: "/messages/en.json",
+        targetLocale: "   ",
+        intl: testIntl,
+      },
+      fetcher,
+    );
+
+    const request = fetcher.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(request.body as string)).toEqual({
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      sourcePath: "/messages/en.json",
+      modes: ["not_localized", "whitespace_only", "same_as_source"],
     });
   });
 
@@ -112,6 +340,7 @@ describe("fetchCatSegmentValidation", () => {
         sourceText: "Hello",
         targetText: "Bonjour",
         sourcePath: "/messages/en.json",
+        targetLocale: "fr-FR",
         intl: testIntl,
       },
       fetcher,
@@ -122,7 +351,8 @@ describe("fetchCatSegmentValidation", () => {
       sourceText: "Hello",
       targetText: "Bonjour",
       sourcePath: "/messages/en.json",
-      modes: ["not_localized", "whitespace_only", "same_as_source"],
+      targetLocale: "fr-FR",
+      modes: ["not_localized", "whitespace_only", "same_as_source", "spelling"],
     });
   });
 
@@ -139,6 +369,7 @@ describe("fetchCatSegmentValidation", () => {
         sourceText: "Hello",
         targetText: "Bonjour",
         sourcePath: "/messages/en.json",
+        targetLocale: "fr-FR",
         signal: abortController.signal,
         intl: testIntl,
       },

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.ts
@@ -53,6 +53,19 @@ export const CAT_SEGMENT_QA_MODES = [
   CAT_SEGMENT_SPELLING_MODE,
 ] as const;
 
+export function isBcp47LanguageTag(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    Intl.getCanonicalLocales(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const CAT_SEGMENT_VALIDATION_ENABLED = true;
 
 export type CatSegmentValidationError =
@@ -80,7 +93,8 @@ export async function fetchCatSegmentValidation(
     projectFileCatValidationMessages.requestFailed,
   );
   const targetLocale = input.targetLocale.trim();
-  const modes = targetLocale
+  const canRequestSpelling = isBcp47LanguageTag(targetLocale);
+  const modes = canRequestSpelling
     ? CAT_SEGMENT_QA_MODES
     : CAT_SEGMENT_QA_MODES.filter((mode) => mode !== CAT_SEGMENT_SPELLING_MODE);
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.ts
@@ -13,28 +13,45 @@
 import { z } from "zod";
 
 import type { CatFormatMessageIntl } from "@/components/cat/message-format/cat-message-format-i18n";
-import type { CatFormatCheck } from "@/components/cat/shared/types";
+import type { CatFormatCheck, CatFormatCheckCategory } from "@/components/cat/shared/types";
 import { readApiError } from "@/lib/api-error";
 import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import { projectFileCatValidationMessages } from "./project-file-cat-validation.messages";
+
+const CAT_FORMAT_CHECK_CATEGORIES = [
+  "length",
+  "placeholder",
+  "icu",
+  "syntax",
+  "terminology",
+  "glossary",
+  "qa",
+  "spelling",
+] as const satisfies readonly CatFormatCheckCategory[];
 
 const catFormatCheckSchema = z.object({
   id: z.string(),
   label: z.string(),
   status: z.enum(["pass", "warn", "fail"]),
   message: z.string(),
-  category: z
-    .enum(["length", "placeholder", "icu", "syntax", "terminology", "glossary", "qa"])
-    .optional(),
+  category: z.enum(CAT_FORMAT_CHECK_CATEGORIES).optional(),
   relatedTokens: z.array(z.string()).optional(),
 });
 
 const catSegmentValidationResponseSchema = z.object({
   checks: z.array(catFormatCheckSchema),
+  skippedModes: z.array(z.string()).optional(),
 });
 
-export const CAT_SEGMENT_QA_MODES = ["not_localized", "whitespace_only", "same_as_source"] as const;
+export const CAT_SEGMENT_SPELLING_MODE = "spelling" as const;
+
+export const CAT_SEGMENT_QA_MODES = [
+  "not_localized",
+  "whitespace_only",
+  "same_as_source",
+  CAT_SEGMENT_SPELLING_MODE,
+] as const;
 
 const CAT_SEGMENT_VALIDATION_ENABLED = true;
 
@@ -48,6 +65,7 @@ export async function fetchCatSegmentValidation(
     sourceText: string;
     targetText: string;
     sourcePath: string;
+    targetLocale: string;
     maxLength?: number;
     signal?: AbortSignal;
     intl: CatFormatMessageIntl;
@@ -61,6 +79,10 @@ export async function fetchCatSegmentValidation(
   const requestFailedMessage = input.intl.formatMessage(
     projectFileCatValidationMessages.requestFailed,
   );
+  const targetLocale = input.targetLocale.trim();
+  const modes = targetLocale
+    ? CAT_SEGMENT_QA_MODES
+    : CAT_SEGMENT_QA_MODES.filter((mode) => mode !== CAT_SEGMENT_SPELLING_MODE);
 
   const responseResult = await fromThrowableAsync(
     fetcher("/api/go-svc/v1/validate/segment", {
@@ -74,7 +96,8 @@ export async function fetchCatSegmentValidation(
         targetText: input.targetText,
         sourcePath: input.sourcePath,
         ...(input.maxLength != null && input.maxLength > 0 ? { maxLength: input.maxLength } : {}),
-        modes: CAT_SEGMENT_QA_MODES,
+        ...(targetLocale ? { targetLocale } : {}),
+        modes,
       }),
       signal: input.signal,
     }),
@@ -116,5 +139,10 @@ export async function fetchCatSegmentValidation(
     });
   }
 
-  return ok(parsed.data.checks);
+  const skippedModes = new Set(parsed.data.skippedModes ?? []);
+  const checks = parsed.data.checks.filter(
+    (check) => !(skippedModes.has(CAT_SEGMENT_SPELLING_MODE) && check.category === "spelling"),
+  );
+
+  return ok(checks);
 }

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -323,6 +323,7 @@ export function ProjectFileCatWorkspace({
         sourceText: segment.sourceText,
         targetText: value,
         sourcePath,
+        targetLocale: segment.targetLocale,
         maxLength: segment.maxLength,
         signal: options?.signal,
         intl,

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -28,6 +28,16 @@ export type CatRiskLevel = "low" | "medium" | "high" | "good";
 
 export type CatFormatCheckStatus = "pass" | "warn" | "fail";
 
+export type CatFormatCheckCategory =
+  | "length"
+  | "placeholder"
+  | "icu"
+  | "syntax"
+  | "terminology"
+  | "glossary"
+  | "qa"
+  | "spelling";
+
 export type CatSegmentCommentType = "comment" | "issue";
 
 export type CatIssueType =
@@ -133,7 +143,7 @@ export interface CatFormatCheck {
   label: string;
   status: CatFormatCheckStatus;
   message: string;
-  category?: "length" | "placeholder" | "icu" | "syntax" | "terminology" | "glossary" | "qa";
+  category?: CatFormatCheckCategory;
   relatedTokens?: string[];
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
@@ -313,6 +313,35 @@ describe("CatSideBySideRow", () => {
     expect(screen.getByRole("status", { name: /Checking format & QA/i })).toBeInTheDocument();
   });
 
+  it("shows a spelling warning icon and details for focused text rows", () => {
+    renderRow({
+      formatChecks: [
+        {
+          id: "format-parity",
+          label: "Placeholders & markup",
+          status: "pass",
+          message: "No placeholders required.",
+          category: "placeholder",
+        },
+        {
+          id: "spelling",
+          label: "Spelling",
+          status: "warn",
+          message: "Possible misspelling: recieve.",
+          category: "spelling",
+          relatedTokens: ["recieve"],
+        },
+      ],
+    });
+
+    const icon = screen.getByRole("img", { name: /Format & QA warning/i });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute("data-status", "warn");
+    expect(screen.getByText("Spelling")).toBeInTheDocument();
+    expect(screen.getByText("Possible misspelling: recieve.")).toBeInTheDocument();
+    expect(screen.queryByText("Placeholders & markup")).not.toBeInTheDocument();
+  });
+
   it("shows a format check warning icon and details for focused text rows", () => {
     renderRow({
       formatChecks: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The CAT workspace now requests locale-aware spelling validation from go-svc (`HL-603`).

- Pass the selected segment's `targetLocale` on `/api/go-svc/v1/validate/segment` instead of inferring a locale.
- Include `spelling` in the requested QA modes when a locale is present.
- Accept `category: "spelling"` and optional `skippedModes` on the response so older mocked payloads still parse.
- Drop spelling checks when `skippedModes` includes `spelling`, so an unsupported locale cannot show a false pass.
- Render spelling warnings through the existing Format & QA checks UI in the editor and side-by-side views.
- Leave `CAT_SEGMENT_VALIDATION_ENABLED` unchanged.

## How to test

From `apps/hyperlocalise-web`:

- `vp test` — 800 files / 5413 tests passed
- `vp check --fix` — format, lint, and typecheck passed

Focused coverage:

- Request payload includes the real `targetLocale` and `spelling` mode
- Responses without spelling fields still parse
- Skipped spelling does not produce a pass check
- Spelling warnings render in editor and side-by-side rows

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-603](https://linear.app/hyperlocalise/issue/HL-603/send-targetlocale-and-display-spelling-checks-in-the-cat-web-client)

<div><a href="https://cursor.com/agents/bc-b48f24b4-8346-4f44-9485-74289831c6fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b48f24b4-8346-4f44-9485-74289831c6fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

