### PR TITLE
fix(deploy): call go-svc over the internal service binding

### DIFF
--- a/apps/go-svc/handler.go
+++ b/apps/go-svc/handler.go
@@ -40,27 +40,10 @@ func newHandler() *handler {
 	}
 }
 
-const publicPathPrefix = "/api/go-svc"
-
 func registerRoutes(mux *http.ServeMux, h *handler, verifier SessionVerifier) {
 	validate := authMiddleware(verifier)(http.HandlerFunc(h.validateSegment))
 	mux.HandleFunc("GET /health", h.health)
 	mux.Handle("POST /v1/validate/segment", validate)
-}
-
-// withOptionalPrefix serves next at both its native paths and under prefix.
-// Vercel Services forwards the public path unchanged, so production calls
-// arrive as /api/go-svc/v1/validate/segment while local and binding calls
-// use /v1/validate/segment.
-func withOptionalPrefix(prefix string, next http.Handler) http.Handler {
-	stripped := http.StripPrefix(prefix, next)
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == prefix || strings.HasPrefix(r.URL.Path, prefix+"/") {
-			stripped.ServeHTTP(w, r)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
 }
 
 func (h *handler) checkSpelling(ctx context.Context, locale, text string) ([]SpellingIssue, error) {

--- a/apps/go-svc/handler_test.go
+++ b/apps/go-svc/handler_test.go
@@ -55,28 +55,41 @@ func TestValidateSegmentUnauthorized(t *testing.T) {
 	require.Equal(t, "unauthorized", body["error"])
 }
 
-func TestRegisterRoutesServesStrippedPaths(t *testing.T) {
+func TestRegisterRoutesServesNativePaths(t *testing.T) {
 	h := newHandler()
 	mux := http.NewServeMux()
 	registerRoutes(mux, h, mockSessionVerifier{claims: AuthClaims{UserID: "user_123"}})
-	handler := withOptionalPrefix(publicPathPrefix, mux)
 
-	for _, path := range []string{"/health", publicPathPrefix + "/health"} {
-		healthRec := httptest.NewRecorder()
-		healthReq := httptest.NewRequest(http.MethodGet, path, nil)
-		handler.ServeHTTP(healthRec, healthReq)
-		require.Equal(t, http.StatusOK, healthRec.Code, path)
-		require.JSONEq(t, `{"status":"ok"}`, healthRec.Body.String())
-	}
+	healthRec := httptest.NewRecorder()
+	healthReq := httptest.NewRequest(http.MethodGet, "/health", nil)
+	mux.ServeHTTP(healthRec, healthReq)
+	require.Equal(t, http.StatusOK, healthRec.Code)
+	require.JSONEq(t, `{"status":"ok"}`, healthRec.Body.String())
 
 	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json"}`
-	for _, path := range []string{"/v1/validate/segment", publicPathPrefix + "/v1/validate/segment"} {
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(payload))
-		req.AddCookie(&http.Cookie{Name: workOSSessionCookieName, Value: "test-session"})
-		handler.ServeHTTP(rec, req)
-		require.Equal(t, http.StatusOK, rec.Code, path)
-	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/validate/segment", bytes.NewBufferString(payload))
+	req.AddCookie(&http.Cookie{Name: workOSSessionCookieName, Value: "test-session"})
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRegisterRoutesRejectsPublicPrefix(t *testing.T) {
+	h := newHandler()
+	mux := http.NewServeMux()
+	registerRoutes(mux, h, mockSessionVerifier{claims: AuthClaims{UserID: "user_123"}})
+
+	healthRec := httptest.NewRecorder()
+	healthReq := httptest.NewRequest(http.MethodGet, "/api/go-svc/health", nil)
+	mux.ServeHTTP(healthRec, healthReq)
+	require.Equal(t, http.StatusNotFound, healthRec.Code)
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/go-svc/v1/validate/segment", bytes.NewBufferString(payload))
+	req.AddCookie(&http.Cookie{Name: workOSSessionCookieName, Value: "test-session"})
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestValidateSegmentSuccess(t *testing.T) {

--- a/apps/go-svc/main.go
+++ b/apps/go-svc/main.go
@@ -71,7 +71,7 @@ func main() {
 	registerRoutes(mux, h, verifier)
 
 	addr := ":" + port
-	server := newHTTPServer(addr, requestLogMiddleware(withOptionalPrefix(publicPathPrefix, mux)))
+	server := newHTTPServer(addr, requestLogMiddleware(mux))
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/apps/go-svc/request_log.go
+++ b/apps/go-svc/request_log.go
@@ -31,13 +31,9 @@ func requestID(r *http.Request) string {
 	return strings.TrimSpace(r.Header.Get("X-Request-Id"))
 }
 
-func isHealthPath(path string) bool {
-	return path == "/health" || path == publicPathPrefix+"/health"
-}
-
 func requestLogMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if isHealthPath(r.URL.Path) {
+		if r.URL.Path == "/health" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -32,6 +32,7 @@ import { createFigmaIntegrationRoutes } from "./routes/figma-integration/figma-i
 import { createCrowdinAppRoutes } from "./routes/crowdin-app/crowdin-app.route";
 import { createContentfulWebhookRoutes } from "./routes/contentful-webhook/contentful-webhook.route";
 import { createGithubWebhookRoutes } from "./routes/github-webhook/github-webhook.route";
+import { createGoSvcRoutes } from "./routes/go-svc/go-svc.route";
 import { healthRoutes } from "./routes/health";
 import { createPublicMediaRoutes } from "./routes/public-media/public-media.route";
 import { createResendWebhookRoutes } from "./routes/resend-webhook/resend-webhook.route";
@@ -128,6 +129,7 @@ export type AppType = typeof app;
 function createInternalRoutes() {
   return new Hono()
     .route("/health", healthRoutes)
+    .route("/go-svc", createGoSvcRoutes())
     .route(
       "/cron/github-repository-automation-dispatch",
       createGithubRepositoryAutomationDispatchRoutes(),

--- a/apps/hyperlocalise-web/src/api/routes/go-svc/go-svc.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/go-svc/go-svc.route.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createGoSvcRoutes, goSvcUpstreamPath, resolveGoSvcBaseUrl } from "./go-svc.route";
+
+function createApp(options: Parameters<typeof createGoSvcRoutes>[0] = {}) {
+  return new Hono().basePath("/api").route("/go-svc", createGoSvcRoutes(options));
+}
+
+describe("goSvcUpstreamPath", () => {
+  it("strips the public prefix and allows health and v1 paths", () => {
+    expect(goSvcUpstreamPath("/api/go-svc/v1/validate/segment")).toBe("/v1/validate/segment");
+    expect(goSvcUpstreamPath("/api/go-svc/health")).toBe("/health");
+    expect(goSvcUpstreamPath("/v1/validate/segment")).toBe("/v1/validate/segment");
+  });
+
+  it("rejects traversal and unknown paths", () => {
+    expect(goSvcUpstreamPath("/api/go-svc/../secret")).toBeNull();
+    expect(goSvcUpstreamPath("/api/go-svc/admin")).toBeNull();
+    expect(goSvcUpstreamPath("/api/go-svc/v2/validate/segment")).toBeNull();
+  });
+});
+
+describe("resolveGoSvcBaseUrl", () => {
+  it("uses an explicit override and strips a trailing slash", () => {
+    expect(resolveGoSvcBaseUrl("http://go-svc.test/")).toBe("http://go-svc.test");
+  });
+
+  it("treats a null override as missing", () => {
+    expect(resolveGoSvcBaseUrl(null)).toBeUndefined();
+  });
+});
+
+describe("createGoSvcRoutes", () => {
+  it("posts to the bound go-svc URL with cookies and the stripped path", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ checks: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Set-Cookie": "wos-session=refreshed" },
+      }),
+    );
+    const app = createApp({
+      baseUrl: "http://go-svc.test/",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await app.request("/api/go-svc/v1/validate/segment?debug=1", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: "wos-session=sealed",
+      },
+      body: JSON.stringify({ sourceText: "Hello", targetText: "Bonjour" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toBe("wos-session=refreshed");
+    await expect(response.json()).resolves.toEqual({ checks: [] });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [URL, RequestInit];
+    expect(url.href).toBe("http://go-svc.test/v1/validate/segment?debug=1");
+    expect(init.method).toBe("POST");
+    expect(new Headers(init.headers).get("cookie")).toBe("wos-session=sealed");
+    expect(new Headers(init.headers).has("host")).toBe(false);
+    expect(init.body).toBeTruthy();
+  });
+
+  it("returns 404 for paths outside health and v1", async () => {
+    const fetchImpl = vi.fn();
+    const app = createApp({
+      baseUrl: "http://go-svc.test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await app.request("/api/go-svc/admin");
+
+    expect(response.status).toBe(404);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when the binding URL is missing", async () => {
+    const fetchImpl = vi.fn();
+    const app = createApp({
+      baseUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await app.request("/api/go-svc/v1/validate/segment", { method: "POST" });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "go_svc_unavailable",
+      message: "Validation service is unavailable",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when the binding fetch fails", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("connection refused"));
+    const app = createApp({
+      baseUrl: "http://go-svc.test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await app.request("/api/go-svc/health");
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "go_svc_unavailable",
+      message: "Validation service is unavailable",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/go-svc/go-svc.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/go-svc/go-svc.route.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Context } from "hono";
+import { Hono } from "hono";
+
+import { notFoundHandler } from "@/api/errors";
+import { serviceUnavailableResponse, type JsonContext } from "@/api/response.schema";
+import { createLogger } from "@/lib/log";
+
+const logger = createLogger("go-svc-proxy");
+
+const PUBLIC_PREFIX = "/api/go-svc";
+const LOCAL_GO_SVC_URL = "http://127.0.0.1:8080";
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+]);
+
+type RequestInitWithDuplex = RequestInit & { duplex?: "half" };
+
+export type CreateGoSvcRoutesOptions = {
+  baseUrl?: string | null;
+  fetchImpl?: typeof fetch;
+};
+
+export function resolveGoSvcBaseUrl(override?: string | null): string | undefined {
+  if (override === null) {
+    return undefined;
+  }
+  if (override != null && override.trim() !== "") {
+    return stripTrailingSlash(override);
+  }
+
+  const fromEnv = process.env.GO_SVC_URL;
+  if (fromEnv) {
+    return stripTrailingSlash(fromEnv);
+  }
+  if (process.env.NODE_ENV === "development") {
+    return LOCAL_GO_SVC_URL;
+  }
+  return undefined;
+}
+
+export function goSvcUpstreamPath(pathname: string): string | null {
+  const stripped =
+    pathname === PUBLIC_PREFIX || pathname.startsWith(`${PUBLIC_PREFIX}/`)
+      ? pathname.slice(PUBLIC_PREFIX.length) || "/"
+      : pathname;
+
+  if (stripped.includes("..") || stripped.includes("//") || stripped.includes("\\")) {
+    return null;
+  }
+  if (stripped === "/health" || stripped.startsWith("/v1/")) {
+    return stripped;
+  }
+  return null;
+}
+
+export function createGoSvcRoutes(options: CreateGoSvcRoutesOptions = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const proxy = (c: Context) => proxyGoSvc(c, options, fetchImpl);
+
+  return new Hono().get("/health", proxy).all("/v1/:path{.+}", proxy);
+}
+
+async function proxyGoSvc(
+  c: Context,
+  options: CreateGoSvcRoutesOptions,
+  fetchImpl: typeof fetch,
+): Promise<Response> {
+  const upstreamPath = goSvcUpstreamPath(new URL(c.req.url).pathname);
+  if (upstreamPath == null) {
+    return notFoundHandler(c);
+  }
+
+  const baseUrl = resolveGoSvcBaseUrl(options.baseUrl);
+  if (baseUrl == null) {
+    logger.warn({ reason: "missing_go_svc_url" }, "go-svc binding URL is not configured");
+    return serviceUnavailableResponse(
+      c as unknown as JsonContext,
+      "go_svc_unavailable",
+      "Validation service is unavailable",
+    );
+  }
+
+  const incoming = c.req.raw;
+  const target = new URL(upstreamPath, `${baseUrl}/`);
+  target.search = new URL(incoming.url).search;
+
+  const headers = copyForwardedHeaders(incoming.headers);
+  const init: RequestInitWithDuplex = {
+    method: incoming.method,
+    headers,
+    redirect: "manual",
+    signal: incoming.signal,
+  };
+  if (incoming.body != null && incoming.method !== "GET" && incoming.method !== "HEAD") {
+    init.body = incoming.body;
+    init.duplex = "half";
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetchImpl(target, init);
+  } catch {
+    logger.warn({ reason: "fetch_failed" }, "go-svc binding request failed");
+    return serviceUnavailableResponse(
+      c as unknown as JsonContext,
+      "go_svc_unavailable",
+      "Validation service is unavailable",
+    );
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: copyResponseHeaders(upstream.headers),
+  });
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function copyForwardedHeaders(incoming: Headers): Headers {
+  const headers = new Headers();
+  for (const [key, value] of incoming.entries()) {
+    if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      continue;
+    }
+    headers.append(key, value);
+  }
+  return headers;
+}
+
+function copyResponseHeaders(incoming: Headers): Headers {
+  const headers = new Headers();
+  for (const [key, value] of incoming.entries()) {
+    const lower = key.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower) || lower === "content-encoding") {
+      continue;
+    }
+    headers.append(key, value);
+  }
+  return headers;
+}

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -242,6 +242,13 @@ export const env = createEnv({
      */
     CROWDIN_APP_FRAME_ANCESTORS: z.string().min(1).optional(),
 
+    /**
+     * Internal go-svc URL. Vercel injects this at runtime from the web → go_svc
+     * service binding. Do not set it in the dashboard. Unset locally unless
+     * go-svc is running; the proxy then falls back to http://127.0.0.1:8080.
+     */
+    GO_SVC_URL: z.url().optional(),
+
     /** Base URL for browser e2e tests. Defaults to http://localhost:3000. */
     E2E_BASE_URL: z.url().optional(),
   },
@@ -350,6 +357,7 @@ export const env = createEnv({
       process.env.CROWDIN_APP_EMBED_SESSION_SECRET ??
       (isTestEnv ? "test-crowdin-embed-session-secret-32chars" : undefined),
     CROWDIN_APP_FRAME_ANCESTORS: process.env.CROWDIN_APP_FRAME_ANCESTORS,
+    GO_SVC_URL: process.env.GO_SVC_URL,
     E2E_BASE_URL: process.env.E2E_BASE_URL,
     NEXT_PUBLIC_WAITLIST_URL:
       process.env.NEXT_PUBLIC_WAITLIST_URL ??

--- a/docs/adr/2026-07-05-cat-segment-validation-service-design.md
+++ b/docs/adr/2026-07-05-cat-segment-validation-service-design.md
@@ -8,8 +8,10 @@ Use the Go segment-validation service as the CAT editor's source of truth for fo
 
 The CAT client posts to `/api/go-svc/v1/validate/segment`. Next.js
 proxies that path to go-svc over the Vercel service binding
-(`GO_SVC_URL`). go-svc is not on the public rewrite table; only `web`
-is. The proxy forwards the WorkOS session cookie, and go-svc still
+(`GO_SVC_URL`). go-svc has no public rewrite, so it is unreachable
+from the internet. Next.js is a route-owning service, so it serves
+public traffic through its own route table instead of a catch-all
+rewrite. The proxy forwards the WorkOS session cookie, and go-svc still
 authenticates the call. Local development uses `http://127.0.0.1:8080`
 when `GO_SVC_URL` is unset.
 

--- a/docs/adr/2026-07-05-cat-segment-validation-service-design.md
+++ b/docs/adr/2026-07-05-cat-segment-validation-service-design.md
@@ -6,12 +6,12 @@ Use the Go segment-validation service as the CAT editor's source of truth for fo
 
 ## Architecture
 
-The CAT client posts directly to `/api/go-svc/v1/validate/segment`. A
-Vercel Services rewrite sends that same-origin path to `go-svc`. Vercel
-forwards the public path unchanged, so the service accepts both
-`/api/go-svc/...` and the unprefixed `/v1/...` paths used by local runs
-and the injected `GO_SVC_URL` binding. The browser's WorkOS session
-cookie authenticates public calls.
+The CAT client posts to `/api/go-svc/v1/validate/segment`. Next.js
+proxies that path to go-svc over the Vercel service binding
+(`GO_SVC_URL`). go-svc is not on the public rewrite table; only `web`
+is. The proxy forwards the WorkOS session cookie, and go-svc still
+authenticates the call. Local development uses `http://127.0.0.1:8080`
+when `GO_SVC_URL` is unset.
 
 Each request includes the source text, current target text, source path, and all supported QA modes. It includes `maxLength` only when the segment defines a positive limit.
 

--- a/vercel.json
+++ b/vercel.json
@@ -37,14 +37,6 @@
       "entrypoint": "Dockerfile.vercel"
     }
   },
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": {
-        "service": "web"
-      }
-    }
-  ],
   "crons": [
     {
       "path": "/api/cron/github-repository-automation-dispatch",

--- a/vercel.json
+++ b/vercel.json
@@ -34,28 +34,10 @@
     "go_svc": {
       "runtime": "container",
       "root": ".",
-      "entrypoint": "Dockerfile.vercel",
-      "routes": [
-        {
-          "src": "/api/go-svc/(.*)",
-          "transforms": [
-            {
-              "type": "request.path",
-              "op": "set",
-              "args": "/$1"
-            }
-          ]
-        }
-      ]
+      "entrypoint": "Dockerfile.vercel"
     }
   },
   "rewrites": [
-    {
-      "source": "/api/go-svc/(.*)",
-      "destination": {
-        "service": "go_svc"
-      }
-    },
     {
       "source": "/(.*)",
       "destination": {


### PR DESCRIPTION
## Summary
- Stop exposing go-svc through a public Vercel rewrite. Next.js now proxies `/api/go-svc` to the injected `GO_SVC_URL` binding and forwards the WorkOS session cookie.
- go-svc only serves native `/health` and `/v1/...` paths; the leftover `/api/go-svc` prefix shim is gone.
- CAT still posts to the same-origin `/api/go-svc/v1/validate/segment` URL.

## Test plan
- [ ] Confirm a CAT segment validation request hits Next.js, then go-svc over `GO_SVC_URL`, and returns checks while signed in
- [ ] Confirm an unauthenticated `/api/go-svc/v1/validate/segment` call still returns 401 from go-svc
- [ ] Confirm `/api/go-svc/health` succeeds locally when go-svc is on `:8080`
- [ ] Confirm public `/api/go-svc` no longer routes around Next.js (no direct container rewrite)
- [ ] Smoke a normal page load to confirm the web catch-all rewrite still serves Next.js


Made with [Cursor](https://cursor.com)