### PR TITLE
feat(sandbox-image): add hunspell and pinned dictionaries; ADR for CLI spell check

### DIFF
--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -5,12 +5,16 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - apps/sandbox-image/**
+      - apps/go-svc/build/fetch-dictionaries.sh
+      - internal/i18n/spellcheck/DICTIONARIES.md
       - .github/workflows/sandbox-image.yml
   push:
     branches:
       - main
     paths:
       - apps/sandbox-image/**
+      - apps/go-svc/build/fetch-dictionaries.sh
+      - internal/i18n/spellcheck/DICTIONARIES.md
       - .github/workflows/sandbox-image.yml
   workflow_dispatch:
 
@@ -100,7 +104,9 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          context: apps/sandbox-image
+          # Repository root: the dictionary stage stages files from
+          # internal/i18n/spellcheck and apps/go-svc/build.
+          context: .
           file: apps/sandbox-image/Dockerfile
           platforms: linux/amd64
           # PRs: build-only with a local tag (no registry auth).

--- a/apps/go-svc/build/fetch-dictionaries.sh
+++ b/apps/go-svc/build/fetch-dictionaries.sh
@@ -113,6 +113,23 @@ while IFS=$'\t' read -r bcp47 aff dic evidence_csv repo; do
     cp "$aff_src" "$STAGE_DICT/$aff"
     cp "$dic_src" "$STAGE_DICT/$dic"
 
+    # Hunspell reads the first .dic line as the word count and loads an empty
+    # word list when it cannot parse one, which silently flags every word in
+    # that locale. ms_MY ships "#30975"; drop a leading '#' when the rest is a
+    # bare integer, then require a numeric header so a future dictionary with a
+    # different malformed count fails the build instead of shipping empty.
+    header="$(head -n1 "$STAGE_DICT/$dic" | sed -e '1s/^\xEF\xBB\xBF//' | tr -d '\r')"
+    if [[ "$header" =~ ^#([0-9]+)$ ]]; then
+        echo "fetch-dictionaries: normalizing '$dic' word-count header '$header' -> '${BASH_REMATCH[1]}'"
+        sed -i '1s/^\(\xEF\xBB\xBF\)\{0,1\}#/\1/' "$STAGE_DICT/$dic"
+        header="${BASH_REMATCH[1]}"
+    fi
+    if ! [[ "$header" =~ ^[0-9]+$ ]]; then
+        echo "fetch-dictionaries: '$dic' has a non-numeric word-count header '$header'; Hunspell would load zero words for $bcp47" >&2
+        missing=$((missing + 1))
+        continue
+    fi
+
     license_dir="$STAGE_LICENSE/$bcp47"
     mkdir -p "$license_dir"
     IFS=',' read -ra evidence_files <<<"$evidence_csv"

--- a/apps/go-svc/build/fetch-dictionaries.sh
+++ b/apps/go-svc/build/fetch-dictionaries.sh
@@ -3,7 +3,52 @@
 # DICTIONARIES.md is the source of truth for supported locales and files.
 #
 # Usage: fetch-dictionaries.sh <repo-root> <dict-staging-dir> <licence-staging-dir>
+#        fetch-dictionaries.sh --normalize-header <dic-file>   (test helper)
 set -euo pipefail
+
+# Hunspell reads the first .dic line as the word count (atoi) and loads an
+# empty word list when it cannot parse one, which silently flags every word
+# in that locale. Strip a leading '#' and surrounding whitespace (ms_MY ships
+# "#30975"), rewrite the line to a bare integer, and fail when nothing
+# numeric remains. Matches parseDicWordCount in
+# apps/go-svc/internal/hunspell/encoding.go. The word list is never modified.
+normalize_dic_word_count_header() {
+    local file="$1"
+    local locale="${2:-}"
+    local header stripped digits
+    header="$(head -n1 "$file" | sed -e '1s/^\xEF\xBB\xBF//' | tr -d '\r')"
+    stripped="${header#"${header%%[![:space:]]*}"}"
+    stripped="${stripped#\#}"
+    stripped="${stripped#"${stripped%%[![:space:]]*}"}"
+    digits="$(printf '%s' "$stripped" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')"
+    if [ -z "$digits" ]; then
+        if [ -n "$locale" ]; then
+            echo "fetch-dictionaries: '$file' has a non-numeric word-count header '$header'; Hunspell would load zero words for $locale" >&2
+        else
+            echo "fetch-dictionaries: '$file' has a non-numeric word-count header '$header'; Hunspell would load zero words" >&2
+        fi
+        return 1
+    fi
+    if [ "$header" = "$digits" ]; then
+        return 0
+    fi
+    echo "fetch-dictionaries: normalizing '$(basename "$file")' word-count header '$header' -> '$digits'"
+    local tmp
+    tmp="$(mktemp)"
+    {
+        if [ "$(od -An -tx1 -N3 "$file" | tr -d ' \n')" = "efbbbf" ]; then
+            printf '\xEF\xBB\xBF'
+        fi
+        printf '%s\n' "$digits"
+        tail -n +2 "$file"
+    } >"$tmp"
+    mv "$tmp" "$file"
+}
+
+if [ "${1:-}" = "--normalize-header" ]; then
+    normalize_dic_word_count_header "${2:?dic file required}"
+    exit $?
+fi
 
 REPO_ROOT="${1:?repo root required}"
 STAGE_DICT="${2:?dictionary staging dir required}"
@@ -113,19 +158,7 @@ while IFS=$'\t' read -r bcp47 aff dic evidence_csv repo; do
     cp "$aff_src" "$STAGE_DICT/$aff"
     cp "$dic_src" "$STAGE_DICT/$dic"
 
-    # Hunspell reads the first .dic line as the word count and loads an empty
-    # word list when it cannot parse one, which silently flags every word in
-    # that locale. ms_MY ships "#30975"; drop a leading '#' when the rest is a
-    # bare integer, then require a numeric header so a future dictionary with a
-    # different malformed count fails the build instead of shipping empty.
-    header="$(head -n1 "$STAGE_DICT/$dic" | sed -e '1s/^\xEF\xBB\xBF//' | tr -d '\r')"
-    if [[ "$header" =~ ^#([0-9]+)$ ]]; then
-        echo "fetch-dictionaries: normalizing '$dic' word-count header '$header' -> '${BASH_REMATCH[1]}'"
-        sed -i '1s/^\(\xEF\xBB\xBF\)\{0,1\}#/\1/' "$STAGE_DICT/$dic"
-        header="${BASH_REMATCH[1]}"
-    fi
-    if ! [[ "$header" =~ ^[0-9]+$ ]]; then
-        echo "fetch-dictionaries: '$dic' has a non-numeric word-count header '$header'; Hunspell would load zero words for $bcp47" >&2
+    if ! normalize_dic_word_count_header "$STAGE_DICT/$dic" "$bcp47"; then
         missing=$((missing + 1))
         continue
     fi

--- a/apps/go-svc/build/fetch-dictionaries_test.sh
+++ b/apps/go-svc/build/fetch-dictionaries_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Exercises fetch-dictionaries.sh --normalize-header against the same cases
+# as parseDicWordCount in apps/go-svc/internal/hunspell/encoding.go.
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/fetch-dictionaries.sh"
+fail=0
+
+assert_header() {
+    local name="$1" input="$2" want="$3"
+    local dir file got
+    dir="$(mktemp -d)"
+    file="$dir/test.dic"
+    printf '%s' "$input" >"$file"
+    if ! bash "$SCRIPT" --normalize-header "$file" >/dev/null; then
+        echo "FAIL $name: normalize rejected a parseable header"
+        fail=$((fail + 1))
+        rm -rf "$dir"
+        return
+    fi
+    got="$(head -n1 "$file" | sed -e '1s/^\xEF\xBB\xBF//' | tr -d '\r')"
+    if [ "$got" != "$want" ]; then
+        echo "FAIL $name: header='$got' want='$want'"
+        fail=$((fail + 1))
+    else
+        echo "ok   $name"
+    fi
+    rm -rf "$dir"
+}
+
+assert_rejects() {
+    local name="$1" input="$2"
+    local dir file
+    dir="$(mktemp -d)"
+    file="$dir/test.dic"
+    printf '%s' "$input" >"$file"
+    if bash "$SCRIPT" --normalize-header "$file" >/dev/null 2>&1; then
+        echo "FAIL $name: expected reject"
+        fail=$((fail + 1))
+    else
+        echo "ok   $name"
+    fi
+    rm -rf "$dir"
+}
+
+assert_header already-numeric $'2\nhello\n' 2
+assert_header hash-prefix $'#2\nhello\n' 2
+assert_header hash-space $'# 30975\nhello\n' 30975
+assert_header trailing-comment $'12 extra\nhello\n' 12
+assert_rejects non-numeric $'notanumber\nhello\n'
+assert_rejects hash-words $'#words\nhello\n'
+
+# BOM + '#2' must keep the BOM and rewrite the count.
+bom_dir="$(mktemp -d)"
+printf '\xEF\xBB\xBF#2\nhello\n' >"$bom_dir/test.dic"
+bash "$SCRIPT" --normalize-header "$bom_dir/test.dic" >/dev/null
+if [ "$(od -An -tx1 -N3 "$bom_dir/test.dic" | tr -d ' \n')" != "efbbbf" ]; then
+    echo "FAIL bom-kept: missing UTF-8 BOM"
+    fail=$((fail + 1))
+else
+    got="$(tail -c +4 "$bom_dir/test.dic" | head -n1 | tr -d '\r')"
+    if [ "$got" != "2" ]; then
+        echo "FAIL bom-kept: header='$got' want='2'"
+        fail=$((fail + 1))
+    else
+        echo "ok   bom-kept"
+    fi
+fi
+rm -rf "$bom_dir"
+
+echo
+if [ "$fail" -ne 0 ]; then
+    echo "${fail} failed"
+    exit 1
+fi
+echo "all passed"

--- a/apps/go-svc/internal/hunspell/encoding.go
+++ b/apps/go-svc/internal/hunspell/encoding.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/charmap"
@@ -16,6 +18,7 @@ import (
 var (
 	errAffixEncodingUndeclared = errors.New("hunspell: affix file has no SET declaration")
 	errAffixEncodingNotUTF8    = errors.New("hunspell: affix file declares a non-UTF-8 encoding")
+	errDicWordCountHeader      = errors.New("hunspell: dictionary word-count header is not numeric")
 )
 
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
@@ -38,8 +41,46 @@ func prepareUTF8Dictionary(affPath, dicPath string) (loadAff, loadDic string, cl
 		return "", "", cleanup, fmt.Errorf("%w: %q declares %q, which cannot be transcoded to UTF-8", errAffixEncodingNotUTF8, affPath, declaredEncoding)
 	}
 
-	if decoder == nil && !bom {
-		return affPath, dicPath, cleanup, nil
+	dicData, err := os.ReadFile(dicPath)
+	if err != nil {
+		return "", "", cleanup, fmt.Errorf("hunspell: reading dictionary file: %w", err)
+	}
+
+	// UTF-8 dictionaries skip transcoding, so normalize the header on the
+	// original bytes. 8-bit dictionaries are transcoded first: the header is
+	// ASCII, and one rewrite then covers both encoding and the word-count line.
+	if decoder == nil {
+		var changed bool
+		dicData, changed, err = normalizeDicWordCountHeader(dicData)
+		if err != nil {
+			return "", "", cleanup, fmt.Errorf("%w: %q", err, dicPath)
+		}
+		if !bom && !changed {
+			return affPath, dicPath, cleanup, nil
+		}
+
+		tmpDir, err := os.MkdirTemp("", "hunspell-utf8-")
+		if err != nil {
+			return "", "", cleanup, fmt.Errorf("hunspell: create utf-8 staging dir: %w", err)
+		}
+		cleanup = func() { _ = os.RemoveAll(tmpDir) }
+
+		loadAff, loadDic = affPath, dicPath
+		if changed {
+			loadDic = filepath.Join(tmpDir, filepath.Base(dicPath))
+			if err := os.WriteFile(loadDic, dicData, 0o600); err != nil {
+				cleanup()
+				return "", "", func() {}, fmt.Errorf("hunspell: write utf-8 dictionary file: %w", err)
+			}
+		}
+		if bom {
+			loadAff = filepath.Join(tmpDir, filepath.Base(affPath))
+			if err := os.WriteFile(loadAff, bytes.TrimPrefix(affData, utf8BOM), 0o600); err != nil {
+				cleanup()
+				return "", "", func() {}, fmt.Errorf("hunspell: write utf-8 affix file: %w", err)
+			}
+		}
+		return loadAff, loadDic, cleanup, nil
 	}
 
 	tmpDir, err := os.MkdirTemp("", "hunspell-utf8-")
@@ -47,15 +88,8 @@ func prepareUTF8Dictionary(affPath, dicPath string) (loadAff, loadDic string, cl
 		return "", "", cleanup, fmt.Errorf("hunspell: create utf-8 staging dir: %w", err)
 	}
 	cleanup = func() { _ = os.RemoveAll(tmpDir) }
-
 	loadAff = filepath.Join(tmpDir, filepath.Base(affPath))
-	if decoder == nil {
-		if err := os.WriteFile(loadAff, bytes.TrimPrefix(affData, utf8BOM), 0o600); err != nil {
-			cleanup()
-			return "", "", func() {}, fmt.Errorf("hunspell: write utf-8 affix file: %w", err)
-		}
-		return loadAff, dicPath, cleanup, nil
-	}
+	loadDic = filepath.Join(tmpDir, filepath.Base(dicPath))
 
 	affUTF8, err := decoder.NewDecoder().Bytes(affData)
 	if err != nil {
@@ -68,18 +102,17 @@ func prepareUTF8Dictionary(affPath, dicPath string) (loadAff, loadDic string, cl
 		return "", "", func() {}, fmt.Errorf("hunspell: rewrite affix SET in %q: %w", affPath, err)
 	}
 
-	dicData, err := os.ReadFile(dicPath)
-	if err != nil {
-		cleanup()
-		return "", "", func() {}, fmt.Errorf("hunspell: reading dictionary file: %w", err)
-	}
 	dicUTF8, err := decoder.NewDecoder().Bytes(dicData)
 	if err != nil {
 		cleanup()
 		return "", "", func() {}, fmt.Errorf("hunspell: transcode dictionary file %q from %s: %w", dicPath, declaredEncoding, err)
 	}
+	dicUTF8, _, err = normalizeDicWordCountHeader(dicUTF8)
+	if err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("%w: %q", err, dicPath)
+	}
 
-	loadDic = filepath.Join(tmpDir, filepath.Base(dicPath))
 	if err := os.WriteFile(loadAff, affUTF8, 0o600); err != nil {
 		cleanup()
 		return "", "", func() {}, fmt.Errorf("hunspell: write utf-8 affix file: %w", err)
@@ -90,6 +123,64 @@ func prepareUTF8Dictionary(affPath, dicPath string) (loadAff, loadDic string, cl
 	}
 
 	return loadAff, loadDic, cleanup, nil
+}
+
+// parseDicWordCount reads the integer Hunspell would take from a .dic first
+// line. A leading '#' is ignored so dictionaries that ship "#30975" (ms_MY)
+// still load; Hunspell's atoi stops at '#' and would otherwise load zero words.
+func parseDicWordCount(line []byte) (int, bool) {
+	s := strings.TrimSpace(string(bytes.TrimSuffix(line, []byte{'\r'})))
+	s = strings.TrimLeft(s, "#")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	end := 0
+	for end < len(s) && unicode.IsDigit(rune(s[end])) {
+		end++
+	}
+	if end == 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[:end])
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// normalizeDicWordCountHeader rewrites the first .dic line to a bare integer
+// when Hunspell would fail to parse it. The word list is never modified.
+func normalizeDicWordCountHeader(dicData []byte) (normalized []byte, changed bool, err error) {
+	rest := dicData
+	hasBOM := bytes.HasPrefix(rest, utf8BOM)
+	if hasBOM {
+		rest = rest[len(utf8BOM):]
+	}
+
+	line, remainder, found := bytes.Cut(rest, []byte{'\n'})
+	count, ok := parseDicWordCount(line)
+	if !ok {
+		header := strings.TrimSuffix(string(line), "\r")
+		return nil, false, fmt.Errorf("%w %q; Hunspell would load zero words", errDicWordCountHeader, header)
+	}
+
+	canonical := strconv.Itoa(count)
+	current := strings.TrimSuffix(string(line), "\r")
+	if current == canonical {
+		return dicData, false, nil
+	}
+
+	var out bytes.Buffer
+	if hasBOM {
+		out.Write(utf8BOM)
+	}
+	out.WriteString(canonical)
+	if found {
+		out.WriteByte('\n')
+		out.Write(remainder)
+	}
+	return out.Bytes(), true, nil
 }
 
 func parseAffEncoding(affData []byte) (name string, declared, bom bool) {

--- a/apps/go-svc/internal/hunspell/encoding_test.go
+++ b/apps/go-svc/internal/hunspell/encoding_test.go
@@ -69,6 +69,86 @@ func TestCanonicalHunspellEncoding(t *testing.T) {
 	}
 }
 
+func TestParseDicWordCount(t *testing.T) {
+	tests := []struct {
+		line   string
+		want   int
+		wantOK bool
+	}{
+		{line: "30975", want: 30975, wantOK: true},
+		{line: "#30975", want: 30975, wantOK: true},
+		{line: "# 30975", want: 30975, wantOK: true},
+		{line: "  12  ", want: 12, wantOK: true},
+		{line: "12 extra", want: 12, wantOK: true},
+		{line: "12\r", want: 12, wantOK: true},
+		{line: "notanumber", wantOK: false},
+		{line: "#words", wantOK: false},
+		{line: "", wantOK: false},
+		{line: "#", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			got, ok := parseDicWordCount([]byte(tt.line))
+			if ok != tt.wantOK || got != tt.want {
+				t.Errorf("parseDicWordCount(%q) = (%d, %v), want (%d, %v)", tt.line, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestNormalizeDicWordCountHeader(t *testing.T) {
+	t.Run("already numeric is unchanged", func(t *testing.T) {
+		in := []byte("2\nhello\nworld\n")
+		got, changed, err := normalizeDicWordCountHeader(in)
+		if err != nil {
+			t.Fatalf("normalizeDicWordCountHeader() error = %v, want nil", err)
+		}
+		if changed {
+			t.Error("normalizeDicWordCountHeader() changed = true, want false")
+		}
+		if !bytes.Equal(got, in) {
+			t.Errorf("normalizeDicWordCountHeader() = %q, want original", got)
+		}
+	})
+
+	t.Run("hash-prefixed count is rewritten", func(t *testing.T) {
+		got, changed, err := normalizeDicWordCountHeader([]byte("#2\nhello\nworld\n"))
+		if err != nil {
+			t.Fatalf("normalizeDicWordCountHeader() error = %v, want nil", err)
+		}
+		if !changed {
+			t.Error("normalizeDicWordCountHeader() changed = false, want true")
+		}
+		want := []byte("2\nhello\nworld\n")
+		if !bytes.Equal(got, want) {
+			t.Errorf("normalizeDicWordCountHeader() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("hash-prefixed count with BOM is rewritten and BOM kept", func(t *testing.T) {
+		in := append(append([]byte{}, utf8BOM...), []byte("#2\nhello\n")...)
+		got, changed, err := normalizeDicWordCountHeader(in)
+		if err != nil {
+			t.Fatalf("normalizeDicWordCountHeader() error = %v, want nil", err)
+		}
+		if !changed {
+			t.Error("normalizeDicWordCountHeader() changed = false, want true")
+		}
+		want := append(append([]byte{}, utf8BOM...), []byte("2\nhello\n")...)
+		if !bytes.Equal(got, want) {
+			t.Errorf("normalizeDicWordCountHeader() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("non-numeric header is rejected", func(t *testing.T) {
+		_, _, err := normalizeDicWordCountHeader([]byte("notanumber\nhello\n"))
+		if !errors.Is(err, errDicWordCountHeader) {
+			t.Fatalf("normalizeDicWordCountHeader() error = %v, want error wrapping errDicWordCountHeader", err)
+		}
+	})
+}
+
 func TestPrepareUTF8Dictionary(t *testing.T) {
 	t.Run("utf-8 without bom uses original paths", func(t *testing.T) {
 		dir := t.TempDir()
@@ -89,6 +169,84 @@ func TestPrepareUTF8Dictionary(t *testing.T) {
 
 		if loadAff != aff || loadDic != dic {
 			t.Errorf("prepareUTF8Dictionary() paths = (%q, %q), want the original files", loadAff, loadDic)
+		}
+	})
+
+	t.Run("utf-8 hash-prefixed header is rewritten", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET UTF-8\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte("#2\nhello\nworld\n"), 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		loadAff, loadDic, cleanup, err := prepareUTF8Dictionary(aff, dic)
+		if err != nil {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want nil", err)
+		}
+		t.Cleanup(cleanup)
+
+		if loadAff != aff {
+			t.Errorf("affix path = %q, want original %q (UTF-8, no BOM)", loadAff, aff)
+		}
+		if loadDic == dic {
+			t.Error("dictionary path = original, want a rewritten temp file")
+		}
+		dicOut, err := os.ReadFile(loadDic)
+		if err != nil {
+			t.Fatalf("read rewritten dic: %v", err)
+		}
+		if want := []byte("2\nhello\nworld\n"); !bytes.Equal(dicOut, want) {
+			t.Errorf("rewritten dic = %q, want %q", dicOut, want)
+		}
+	})
+
+	t.Run("non-numeric header is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET UTF-8\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte("notanumber\nhello\n"), 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		_, _, _, err := prepareUTF8Dictionary(aff, dic)
+		if !errors.Is(err, errDicWordCountHeader) {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want error wrapping errDicWordCountHeader", err)
+		}
+	})
+
+	t.Run("iso8859-1 hash-prefixed header is rewritten after transcode", func(t *testing.T) {
+		dir := t.TempDir()
+		aff := filepath.Join(dir, "test.aff")
+		dic := filepath.Join(dir, "test.dic")
+		if err := os.WriteFile(aff, []byte("SET ISO8859-1\n"), 0o600); err != nil {
+			t.Fatalf("write aff: %v", err)
+		}
+		if err := os.WriteFile(dic, []byte{'#', '1', '\n', 'c', 'a', 'f', 0xE9, '\n'}, 0o600); err != nil {
+			t.Fatalf("write dic: %v", err)
+		}
+
+		_, loadDic, cleanup, err := prepareUTF8Dictionary(aff, dic)
+		if err != nil {
+			t.Fatalf("prepareUTF8Dictionary() error = %v, want nil", err)
+		}
+		t.Cleanup(cleanup)
+
+		dicOut, err := os.ReadFile(loadDic)
+		if err != nil {
+			t.Fatalf("read converted dic: %v", err)
+		}
+		if !bytes.HasPrefix(dicOut, []byte("1\n")) {
+			t.Errorf("converted dic header = %q, want 1", dicOut)
+		}
+		if !bytes.Contains(dicOut, []byte("café")) {
+			t.Errorf("converted dic = %q, want it to contain UTF-8 %q", dicOut, "café")
 		}
 	})
 

--- a/apps/go-svc/internal/hunspell/hunspell_test.go
+++ b/apps/go-svc/internal/hunspell/hunspell_test.go
@@ -212,12 +212,31 @@ func TestNewEncoding(t *testing.T) {
 	})
 }
 
-// Hunspell_create empirically tolerates malformed-but-readable dictionaries,
-// returning a non-NULL handle with no usable entries rather than failing.
-func TestNewToleratesMalformedDictionaryData(t *testing.T) {
-	d, err := New(malformedAff, malformedDic)
+func TestNewRejectsNonNumericWordCountHeader(t *testing.T) {
+	_, err := New(malformedAff, malformedDic)
+	if !errors.Is(err, errDicWordCountHeader) {
+		t.Fatalf("New() error = %v, want error wrapping errDicWordCountHeader (an unparseable count would load zero words)", err)
+	}
+}
+
+func TestNewNormalizesHashPrefixedWordCountHeader(t *testing.T) {
+	dir := t.TempDir()
+	aff := filepath.Join(dir, "test.aff")
+	dic := filepath.Join(dir, "test.dic")
+	valid, err := os.ReadFile(validAff)
 	if err != nil {
-		t.Fatalf("New() error = %v, want nil (Hunspell tolerates this input instead of failing construction)", err)
+		t.Fatalf("read valid aff: %v", err)
+	}
+	if err := os.WriteFile(aff, valid, 0o600); err != nil {
+		t.Fatalf("write aff: %v", err)
+	}
+	if err := os.WriteFile(dic, []byte("#2\nhello\napple\n"), 0o600); err != nil {
+		t.Fatalf("write dic: %v", err)
+	}
+
+	d, err := New(aff, dic)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil for a #prefixed word-count header", err)
 	}
 	t.Cleanup(func() {
 		if err := d.Close(); err != nil {
@@ -229,8 +248,8 @@ func TestNewToleratesMalformedDictionaryData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Spell() error = %v, want nil", err)
 	}
-	if got {
-		t.Errorf(`Spell("hello") = true, want false: a dictionary loaded from malformed data should have no usable entries`)
+	if !got {
+		t.Error(`Spell("hello") = false, want true after normalizing "#2" to "2"`)
 	}
 }
 

--- a/apps/go-svc/spellcheck_provider_cgo_test.go
+++ b/apps/go-svc/spellcheck_provider_cgo_test.go
@@ -166,12 +166,9 @@ func TestHunspellSpellCheckerChecksAreIsolatedPerLocale(t *testing.T) {
 		t.Errorf("Check(aa-AA, %q) = %+v, want no issues (word is in this locale's dictionary)", "hello", gotA)
 	}
 
-	gotB, err := checker.Check(context.Background(), "bb-BB", []string{"hello"})
-	if err != nil {
-		t.Fatalf("Check(bb-BB) error = %v, want nil", err)
-	}
-	if len(gotB) != 1 || gotB[0].Word != "hello" {
-		t.Errorf("Check(bb-BB, %q) = %+v, want a single issue for %q (malformed dictionary has no usable entries)", "hello", gotB, "hello")
+	_, err = checker.Check(context.Background(), "bb-BB", []string{"hello"})
+	if !errors.Is(err, spellcheck.ErrUnsupportedLocale) {
+		t.Fatalf("Check(bb-BB) error = %v, want error wrapping spellcheck.ErrUnsupportedLocale (malformed header must skip the locale, not flag every word)", err)
 	}
 }
 

--- a/apps/sandbox-image/Dockerfile
+++ b/apps/sandbox-image/Dockerfile
@@ -8,10 +8,33 @@
 # FROM vercel/sandbox/universal directly.
 #
 # Layout mirrors Vercel Sandbox conventions: ubuntu user, HOME=/vercel,
-# passwordless sudo. Adds Node 24, ripgrep, Volta, hl, and Playwright Chromium.
+# passwordless sudo. Adds Node 24, ripgrep, Volta, hl, Playwright Chromium, and
+# Hunspell with the pinned dictionary set.
+#
+# Build context is the repository root so the dictionary stage can reuse the
+# manifest and staging script that Dockerfile.vercel uses for go-svc.
 #
 # Build for linux/amd64 (Sandbox requirement), then push to Vercel Container
 # Registry. See README.md in this directory.
+
+# Stage the approved Hunspell dictionaries with the same script the go-svc
+# image runs, so both images carry byte-identical dictionaries for the locales
+# in internal/i18n/spellcheck/DICTIONARIES.md.
+FROM ubuntu:26.04 AS dictionaries
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gawk \
+        tar \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY internal/i18n/spellcheck/DICTIONARIES.md /repo/internal/i18n/spellcheck/DICTIONARIES.md
+COPY apps/go-svc/build/fetch-dictionaries.sh /repo/apps/go-svc/build/fetch-dictionaries.sh
+
+RUN bash /repo/apps/go-svc/build/fetch-dictionaries.sh /repo /dictionaries-staging/hunspell /dictionaries-staging/licenses
 
 FROM ubuntu:26.04
 
@@ -28,6 +51,9 @@ ARG PLAYWRIGHT_VERSION=1.61.1
 ARG VOLTA_VERSION=
 # Matches MANAGED_BROWSER_RUNTIME_DIR in capture-screenshot.ts (web wiring later).
 ARG BROWSER_RUNTIME_DIR=/tmp/hyperlocalise-browser-runtime
+# Hunspell's default search path; also exported as DICPATH so `hunspell -d en_US`
+# resolves without an absolute path.
+ARG HUNSPELL_DICT_DIR=/usr/share/hunspell
 
 # Sandbox user + sudo (from vercel/sandbox/ubuntu).
 RUN apt-get update \
@@ -36,6 +62,7 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
+        hunspell \
         libarchive-tools \
         libatomic1 \
         ripgrep \
@@ -83,6 +110,19 @@ RUN set -eux; \
     rm -rf "${TMP}"; \
     hl --help >/dev/null
 
+# Pinned dictionaries plus their licence evidence. The dictionaries are
+# GPL/LGPL/MPL licensed and redistributed in this image, so the licence files
+# must ship alongside them.
+COPY --from=dictionaries /dictionaries-staging/hunspell/ ${HUNSPELL_DICT_DIR}/
+COPY --from=dictionaries /dictionaries-staging/licenses/ /usr/share/doc/hunspell-dictionaries/
+
+# Fail the build if a dictionary is unreadable or loses its encoding: en_US
+# covers the ASCII path, de_DE_frami covers UTF-8 round-tripping.
+RUN set -eux; \
+    chmod -R a+rX "${HUNSPELL_DICT_DIR}" /usr/share/doc/hunspell-dictionaries; \
+    [ "$(printf 'hello\nhelo\n' | hunspell -d "${HUNSPELL_DICT_DIR}/en_US" -l)" = "helo" ]; \
+    [ "$(printf 'Stra\303\237e\nStrasze\n' | hunspell -d "${HUNSPELL_DICT_DIR}/de_DE_frami" -l)" = "Strasze" ]
+
 # Playwright Chromium + OS libs. Path must match MANAGED_BROWSER_RUNTIME_DIR
 # in capture-screenshot.ts so first screenshot skips npm/browser install.
 RUN set -eux; \
@@ -101,6 +141,7 @@ ENV HOME=/vercel
 ENV VOLTA_HOME=/vercel/.volta
 ENV PATH="/vercel/.volta/bin:/vercel/.global/pnpm/bin:/vercel/.global/npm/bin:${PATH}"
 ENV PLAYWRIGHT_BROWSERS_PATH=/tmp/hyperlocalise-browser-runtime/ms-playwright
+ENV DICPATH=/usr/share/hunspell
 USER ubuntu
 WORKDIR /vercel
 

--- a/apps/sandbox-image/Dockerfile
+++ b/apps/sandbox-image/Dockerfile
@@ -152,7 +152,9 @@ ENV HOME=/vercel
 ENV VOLTA_HOME=/vercel/.volta
 ENV PATH="/vercel/.volta/bin:/vercel/.global/pnpm/bin:/vercel/.global/npm/bin:${PATH}"
 ENV PLAYWRIGHT_BROWSERS_PATH=/tmp/hyperlocalise-browser-runtime/ms-playwright
-ENV DICPATH=/usr/share/hunspell
+# Must track HUNSPELL_DICT_DIR so `hunspell -d en_US` finds the pinned set
+# when the image is built with a non-default dictionary path.
+ENV DICPATH=${HUNSPELL_DICT_DIR}
 USER ubuntu
 WORKDIR /vercel
 

--- a/apps/sandbox-image/Dockerfile
+++ b/apps/sandbox-image/Dockerfile
@@ -36,6 +36,10 @@ COPY apps/go-svc/build/fetch-dictionaries.sh /repo/apps/go-svc/build/fetch-dicti
 
 RUN bash /repo/apps/go-svc/build/fetch-dictionaries.sh /repo /dictionaries-staging/hunspell /dictionaries-staging/licenses
 
+# Checksums of what was staged, so the runtime stage can prove the dictionaries
+# it ends up with are these and not a distro package's.
+RUN cd /dictionaries-staging/hunspell && sha256sum ./*.aff ./*.dic > /dictionaries-staging/SHA256SUMS
+
 FROM ubuntu:26.04
 
 USER root
@@ -113,13 +117,20 @@ RUN set -eux; \
 # Pinned dictionaries plus their licence evidence. The dictionaries are
 # GPL/LGPL/MPL licensed and redistributed in this image, so the licence files
 # must ship alongside them.
+#
+# This must stay after the apt install above: `hunspell` depends on
+# hunspell-en-us, which ships its own en_US into the same directory, and these
+# pinned files have to be the ones that survive.
 COPY --from=dictionaries /dictionaries-staging/hunspell/ ${HUNSPELL_DICT_DIR}/
 COPY --from=dictionaries /dictionaries-staging/licenses/ /usr/share/doc/hunspell-dictionaries/
+COPY --from=dictionaries /dictionaries-staging/SHA256SUMS /usr/share/doc/hunspell-dictionaries/SHA256SUMS
 
-# Fail the build if a dictionary is unreadable or loses its encoding: en_US
-# covers the ASCII path, de_DE_frami covers UTF-8 round-tripping.
+# Fail the build if the shipped dictionaries are not the staged ones (a distro
+# package winning the directory), if one is unreadable, or if a locale loses its
+# encoding: en_US covers the ASCII path, de_DE_frami UTF-8 round-tripping.
 RUN set -eux; \
     chmod -R a+rX "${HUNSPELL_DICT_DIR}" /usr/share/doc/hunspell-dictionaries; \
+    (cd "${HUNSPELL_DICT_DIR}" && sha256sum -c --quiet /usr/share/doc/hunspell-dictionaries/SHA256SUMS); \
     [ "$(printf 'hello\nhelo\n' | hunspell -d "${HUNSPELL_DICT_DIR}/en_US" -l)" = "helo" ]; \
     [ "$(printf 'Stra\303\237e\nStrasze\n' | hunspell -d "${HUNSPELL_DICT_DIR}/de_DE_frami" -l)" = "Strasze" ]
 

--- a/apps/sandbox-image/README.md
+++ b/apps/sandbox-image/README.md
@@ -26,9 +26,39 @@ passwordless sudo), with:
 | Volta | `/vercel/.volta` (`VOLTA_VERSION` optional pin) |
 | hyperlocalise CLI (`hl`) | pinned (`HYPERLOCALISE_VERSION`) |
 | Playwright + Chromium | pinned (`PLAYWRIGHT_VERSION`), under `/tmp/hyperlocalise-browser-runtime` |
+| Hunspell (`hunspell`) | apt |
+| Hunspell dictionaries (20 locales) | pinned by [`DICTIONARIES.md`](../../internal/i18n/spellcheck/DICTIONARIES.md), under `/usr/share/hunspell` |
 
 Keep those `ARG`s aligned with
 `apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts`.
+
+## Hunspell
+
+The build context is the **repository root** (not this directory) so a first
+stage can run [`apps/go-svc/build/fetch-dictionaries.sh`](../go-svc/build/fetch-dictionaries.sh) —
+the same script [`Dockerfile.vercel`](../../Dockerfile.vercel) uses for
+`go-svc`. Both images therefore carry byte-identical dictionaries for the
+locales in [`DICTIONARIES.md`](../../internal/i18n/spellcheck/DICTIONARIES.md),
+verified against pinned upstream commits and SHA-256 checksums.
+
+| Path | Contents |
+|------|----------|
+| `/usr/share/hunspell` | 20 `.aff`/`.dic` pairs; also exported as `DICPATH` so `hunspell -d en_US` works without an absolute path |
+| `/usr/share/doc/hunspell-dictionaries/<locale>` | licence evidence, required because the dictionaries are redistributed under GPL/LGPL/MPL terms |
+
+Dictionary basenames do **not** always follow the BCP 47 tag: `de-DE` maps to
+`de_DE_frami` and `fr-FR` to `fr`. Resolve them through
+`spellcheck.LoadRegistry()` rather than transforming the tag.
+
+Four dictionaries declare legacy 8-bit encodings (`de_DE_frami` and `id_ID`
+ISO8859-1, `ms_MY` ISO8859-1, `pl_PL` ISO8859-2). The `hunspell` binary
+transcodes these itself, so pass `-i UTF-8` and send UTF-8 words; no
+caller-side transcoding is needed. The CGO wrapper in
+[`apps/go-svc/internal/hunspell`](../go-svc/internal/hunspell) still needs its
+own transcoding because it talks to the C API directly.
+
+Rebuild and push the image when `DICTIONARIES.md` or `fetch-dictionaries.sh`
+changes; the workflow triggers on both paths.
 
 ## CI
 
@@ -88,13 +118,28 @@ repository shows **Ready** in the project Images dashboard.
 
 ## Local smoke test
 
+Build from the repository root, since the build context is the root:
+
 ```bash
-docker build --platform linux/amd64 -t hyperlocalise-sandbox:local .
+docker build --platform linux/amd64 \
+  -f apps/sandbox-image/Dockerfile -t hyperlocalise-sandbox:local .
+
 docker run --rm hyperlocalise-sandbox:local rg --version
 docker run --rm hyperlocalise-sandbox:local volta --version
 docker run --rm hyperlocalise-sandbox:local hl --help
 docker run --rm hyperlocalise-sandbox:local \
   node -e "require('/tmp/hyperlocalise-browser-runtime/node_modules/playwright'); console.log('ok')"
+```
+
+[`verify-hunspell.sh`](verify-hunspell.sh) checks every locale in the manifest:
+that the `.aff`/`.dic` pair is readable by the `ubuntu` user, that Hunspell
+reports it loaded, and that its word list is non-empty. The last check matters
+because Hunspell loads an **empty** word list — silently flagging every word —
+when it cannot parse the word-count header on the first `.dic` line.
+
+```bash
+docker run --rm -v "$PWD/apps/sandbox-image/verify-hunspell.sh:/verify.sh:ro" \
+  hyperlocalise-sandbox:local bash /verify.sh
 ```
 
 ## App cutover

--- a/apps/sandbox-image/README.md
+++ b/apps/sandbox-image/README.md
@@ -45,6 +45,14 @@ verified against pinned upstream commits and SHA-256 checksums.
 |------|----------|
 | `/usr/share/hunspell` | 20 `.aff`/`.dic` pairs; also exported as `DICPATH` so `hunspell -d en_US` works without an absolute path |
 | `/usr/share/doc/hunspell-dictionaries/<locale>` | licence evidence, required because the dictionaries are redistributed under GPL/LGPL/MPL terms |
+| `/usr/share/doc/hunspell-dictionaries/SHA256SUMS` | checksums of the staged dictionaries, asserted at build time |
+
+The apt `hunspell` package depends on `hunspell-en-us`, which ships its own
+`en_US` into `/usr/share/hunspell`. The pinned set has to win, which today it
+does only because the `COPY` runs after the apt install. Rather than rely on
+that ordering, the build verifies the shipped files against `SHA256SUMS` and
+fails if anything replaced them — so moving those steps breaks the build
+instead of silently swapping a dictionary.
 
 Dictionary basenames do **not** always follow the BCP 47 tag: `de-DE` maps to
 `de_DE_frami` and `fr-FR` to `fr`. Resolve them through

--- a/apps/sandbox-image/README.md
+++ b/apps/sandbox-image/README.md
@@ -43,7 +43,7 @@ verified against pinned upstream commits and SHA-256 checksums.
 
 | Path | Contents |
 |------|----------|
-| `/usr/share/hunspell` | 20 `.aff`/`.dic` pairs; also exported as `DICPATH` so `hunspell -d en_US` works without an absolute path |
+| `/usr/share/hunspell` (override with `HUNSPELL_DICT_DIR`) | 20 `.aff`/`.dic` pairs; `DICPATH` is set to the same path so `hunspell -d en_US` resolves without an absolute path |
 | `/usr/share/doc/hunspell-dictionaries/<locale>` | licence evidence, required because the dictionaries are redistributed under GPL/LGPL/MPL terms |
 | `/usr/share/doc/hunspell-dictionaries/SHA256SUMS` | checksums of the staged dictionaries, asserted at build time |
 
@@ -98,15 +98,19 @@ vcr.vercel.com/<VERCEL_TEAM_SLUG>/<VERCEL_PROJECT_SLUG>/hyperlocalise-sandbox:la
 
 ## Local build and push
 
-```bash
-cd apps/sandbox-image
+Build from the repository root. The dictionary stage copies
+`internal/i18n/spellcheck/DICTIONARIES.md` and
+`apps/go-svc/build/fetch-dictionaries.sh`, which are outside
+`apps/sandbox-image`.
 
+```bash
 # Authenticate Docker to VCR (OIDC, 12h credentials)
 vercel link   # if not already linked to hyperlocalise-web
 vercel vcr login docker
 
-# Build + push (recommended)
-vercel vcr build docker . hyperlocalise-sandbox:latest --push
+# Build + push (recommended). Flags after -- go to Docker.
+vercel vcr build docker . hyperlocalise-sandbox:latest --push \
+  -- --file apps/sandbox-image/Dockerfile
 ```
 
 Or with Docker Buildx:
@@ -116,6 +120,7 @@ IMAGE=vcr.vercel.com/<team-slug>/<project-slug>/hyperlocalise-sandbox:latest
 
 docker buildx build \
   --platform linux/amd64 \
+  --file apps/sandbox-image/Dockerfile \
   --output "type=image,name=${IMAGE},push=true,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true" \
   --push \
   .

--- a/apps/sandbox-image/verify-hunspell.sh
+++ b/apps/sandbox-image/verify-hunspell.sh
@@ -109,10 +109,23 @@ for entry in $LOCALES; do
     esac
 done
 
+DOC_DIR=/usr/share/doc/hunspell-dictionaries
+
 echo
 echo "=== licence evidence ==="
-echo "locales with licence files : $(find /usr/share/doc/hunspell-dictionaries -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)"
-echo "licence files total        : $(find /usr/share/doc/hunspell-dictionaries -type f 2>/dev/null | wc -l)"
+echo "locales with licence files : $(find "$DOC_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)"
+echo "licence files total        : $(find "$DOC_DIR" -mindepth 2 -type f 2>/dev/null | wc -l)"
+
+# The apt hunspell package depends on hunspell-en-us, which ships its own en_US
+# into DICT_DIR. Confirm the pinned files are the ones present.
+echo
+echo "=== dictionaries match the staged (pinned) set ==="
+if (cd "$DICT_DIR" && sha256sum -c --quiet "$DOC_DIR/SHA256SUMS"); then
+    echo "sha256sum -c: all $(wc -l < "$DOC_DIR/SHA256SUMS") files OK"
+else
+    echo "FAIL: shipped dictionaries do not match SHA256SUMS"
+    fail=$((fail + 1))
+fi
 
 echo
 echo "=== result: ${pass} locale(s) verified, ${fail} failed ==="

--- a/apps/sandbox-image/verify-hunspell.sh
+++ b/apps/sandbox-image/verify-hunspell.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Smoke-test the Hunspell layer of the sandbox image.
+#
+#   docker run --rm -v "$PWD/apps/sandbox-image/verify-hunspell.sh:/verify.sh:ro" \
+#     hyperlocalise-sandbox:local bash /verify.sh
+#
+# Checks, for every locale in internal/i18n/spellcheck/DICTIONARIES.md:
+#   1. the .aff/.dic pair is readable by the sandbox user,
+#   2. Hunspell reports the pair under "LOADED DICTIONARY",
+#   3. the word list is non-empty (a real word is accepted and nonsense is not),
+# where step 3 uses words sampled from the dictionary itself so the check works
+# for Latin, Devanagari and Hangul alike.
+set -uo pipefail
+
+DICT_DIR="${DICT_DIR:-/usr/share/hunspell}"
+
+# BCP 47 -> dictionary basename, mirroring internal/i18n/spellcheck/registry.go.
+LOCALES="
+de-DE:de_DE_frami
+en-AU:en_AU
+en-GB:en_GB
+en-US:en_US
+es-AR:es_AR
+es-ES:es_ES
+es-MX:es_MX
+fr-FR:fr
+hi-IN:hi_IN
+id-ID:id_ID
+it-IT:it_IT
+ko-KR:ko_KR
+ms-MY:ms_MY
+nl-NL:nl_NL
+pl-PL:pl_PL
+pt-BR:pt_BR
+pt-PT:pt_PT
+sv-SE:sv_SE
+tr-TR:tr_TR
+vi-VN:vi_VN
+"
+
+echo "=== environment ==="
+echo "user     : $(id -un) (uid $(id -u))"
+echo "hunspell : $(hunspell -vv 2>&1 | head -n1)"
+echo "DICPATH  : ${DICPATH:-<unset>}"
+echo "dict dir : ${DICT_DIR}"
+
+echo
+printf '%-8s %-16s %-10s %-8s %-9s %s\n' LOCALE DICTIONARY ENCODING STEMS LOADED "WORD LIST"
+
+pass=0
+fail=0
+for entry in $LOCALES; do
+    bcp47="${entry%%:*}"
+    dict="${entry##*:}"
+    aff="${DICT_DIR}/${dict}.aff"
+    dic="${DICT_DIR}/${dict}.dic"
+
+    if [ ! -r "$aff" ] || [ ! -r "$dic" ]; then
+        printf '%-8s %-16s %s\n' "$bcp47" "$dict" "FAIL: .aff/.dic not readable"
+        fail=$((fail + 1))
+        continue
+    fi
+
+    encoding="$(sed -e '1s/^\xEF\xBB\xBF//' "$aff" | grep -m1 -a '^SET' | tr -d '\r' | awk '{print $2}')"
+    header="$(head -n1 "$dic" | sed -e '1s/^\xEF\xBB\xBF//' | tr -d '\r')"
+
+    if hunspell -d "$dict" -D </dev/null 2>&1 | sed -n '/LOADED DICTIONARY/,$p' | grep -qF "$aff"; then
+        loaded="yes"
+    else
+        loaded="NO"
+    fi
+
+    # A word taken from the dictionary must be accepted, and a same-script
+    # nonsense word must be flagged. An empty word list -- Hunspell's silent
+    # failure mode when it cannot parse the .dic header -- fails both.
+    #
+    # Strip affix flags and morphology, keep stems of at least five characters
+    # so the nonsense word below cannot be a real word, and let Hunspell pick
+    # the first stem it accepts (bare stems may require an affix).
+    sample="$(awk 'NR > 1 {
+            sub(/\/.*$/, ""); sub(/\t.*$/, "");
+            gsub(/^[ \t]+|[ \t]+$/, "");
+            if ($0 != "" && $0 !~ /[ 0-9._-]/) print
+        }' "$dic" \
+        | grep -E '^.{5,}$' \
+        | hunspell -i UTF-8 -d "$dict" -G 2>/dev/null \
+        | head -n1)"
+
+    if [ -z "$sample" ]; then
+        wordlist="FAIL: empty word list"
+    else
+        # Repeat the final character; bash string ops are character-based under
+        # a UTF-8 locale, so this stays in-script for Hangul and Devanagari.
+        last="${sample: -1}"
+        nonsense="${sample}${last}${last}${last}${last}"
+        if [ -n "$(printf '%s\n' "$nonsense" | hunspell -i UTF-8 -d "$dict" -l 2>/dev/null)" ]; then
+            wordlist="ok (accepts ${sample}, flags ${nonsense})"
+        else
+            wordlist="FAIL: accepts ${nonsense}"
+        fi
+    fi
+
+    printf '%-8s %-16s %-10s %-8s %-9s %s\n' \
+        "$bcp47" "$dict" "$encoding" "$header" "$loaded" "$wordlist"
+
+    case "${loaded}|${wordlist}" in
+        yes\|ok*) pass=$((pass + 1)) ;;
+        *) fail=$((fail + 1)) ;;
+    esac
+done
+
+echo
+echo "=== licence evidence ==="
+echo "locales with licence files : $(find /usr/share/doc/hunspell-dictionaries -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)"
+echo "licence files total        : $(find /usr/share/doc/hunspell-dictionaries -type f 2>/dev/null | wc -l)"
+
+echo
+echo "=== result: ${pass} locale(s) verified, ${fail} failed ==="
+[ "$fail" -eq 0 ]

--- a/docs/adr/2026-08-28-cli-spellcheck-design.md
+++ b/docs/adr/2026-08-28-cli-spellcheck-design.md
@@ -1,0 +1,181 @@
+# CLI spell check
+
+## Date
+
+2026-08-28
+
+## Context
+
+`go-svc` spell checks segments with Hunspell through a CGO wrapper
+(`apps/go-svc/internal/hunspell`), behind the `cgo_hunspell` build tag. The
+shared package `internal/i18n/spellcheck` already contributes everything except
+the dictionary lookup itself: tokenization, markup and ICU stripping, entity
+decoding, and the locale-to-dictionary registry from
+[`DICTIONARIES.md`](../../internal/i18n/spellcheck/DICTIONARIES.md). All of it
+is CGO-free.
+
+`hl check` has nine check types and no spelling check. Adding one means giving
+the CLI a dictionary lookup, and the CLI has constraints `go-svc` does not:
+
+- `.goreleaser.yml` builds with `CGO_ENABLED=0` and cross-compiles
+  darwin/linux × amd64/arm64 from one host.
+- `hl check` reads local files only. It is expected to work offline and in CI
+  without credentials.
+- Release archives are single static binaries. The pinned dictionary set is
+  **84 MB** for 20 locales.
+
+Now that the sandbox image ships `hunspell` and the pinned dictionaries, the
+question is how the CLI should reach them.
+
+## Decision
+
+Shell out to the `hunspell` binary in pipe mode (`-a`), behind the same
+provider seam `go-svc` uses, and skip the spelling check when the binary or a
+dictionary is unavailable.
+
+| Concern | Choice |
+|---------|--------|
+| Lookup | `hunspell -a -i UTF-8 -d <dict>`, one long-lived process per locale |
+| Words | `spellcheck.Tokenize`, de-duplicated before checking |
+| Locale to dictionary | `spellcheck.LoadRegistry().Resolve` |
+| Dictionary location | `DICPATH`, else `/usr/share/hunspell`, else a `--dict-dir` flag |
+| Binary missing | Skip `spelling`, report it as skipped, exit 0 |
+| Suggestions | Cap at 5, matching `maxSuggestions` in the CGO wrapper |
+
+De-duplication is not an optimization detail; it is what makes this viable. See
+[Cost](#cost).
+
+### Why not the alternatives
+
+**Link libhunspell into the CLI (`cgo_hunspell`).** Rejected. It forces
+`CGO_ENABLED=1`, so the release matrix needs a cross toolchain and per-platform
+libhunspell for four targets, `go install` stops working, and every user needs
+libhunspell present. The CLI would gain a system dependency that only a
+minority of runs use.
+
+**Call `go-svc` over HTTP.** Rejected. `hl check` is offline and
+credential-free today. Routing one check through a network service adds auth,
+latency, and an availability dependency to a command that runs in pre-commit
+hooks and CI, and it would send source content off the machine.
+
+**Reimplement Hunspell in Go.** Rejected. Affix compression, compounding, and
+suggestion ranking are the hard parts, and no maintained Go implementation
+covers them. Results would diverge from `go-svc`, so the same segment could
+pass in the CAT editor and fail in CI.
+
+**Embed dictionaries in the binary.** Rejected. 84 MB against release archives
+currently a few MB. Dictionaries belong on disk, fetched by manifest.
+
+## Cost
+
+Measured with Hunspell 1.7.2 against the pinned dictionaries, driving pipe mode
+from a `CGO_ENABLED=0` Go binary:
+
+| Workload | Cost per word |
+|----------|---------------|
+| Correctly spelled word | ~2–3 µs (over 300,000 words/sec) |
+| Misspelled word, suggestions generated | ~5.7 ms (~175 words/sec) |
+
+Generating suggestions costs more than three orders of magnitude a plain
+lookup, and dominates everything else. The fixed cost of starting a checker is
+the other term, and it scales with dictionary size:
+
+| Dictionary | Spawn + load + first word |
+|------------|---------------------------|
+| `en_US` (50k stems) | 29 ms |
+| `de_DE_frami` (258k stems) | 56 ms |
+| `pl_PL` (349k stems) | 152 ms |
+| `pt_BR` (312k stems) | 274 ms |
+
+Three consequences:
+
+- **De-duplicate before checking.** Hunspell does not cache suggestions, so a
+  product name repeated 400 times costs 400 suggestion computations. `go-svc`
+  already does this in `uniqueWords`; the CLI must too. On a repeated corpus
+  de-duplication took a 13,200-word check from 6.6 s to 36 ms.
+- **Reuse one process per locale across all files.** At 274 ms for `pt_BR`, a
+  subprocess per file or per segment would cost more than the checking. Start
+  each locale's checker lazily on first use and keep it for the run.
+- **Do not micro-optimize the transport.** Pipelining writes ahead of reads
+  measured the same as lock-step (1,980 vs 2,000 words/sec), because the cost
+  is inside Hunspell, not the pipe.
+
+If suggestions ever become the bottleneck on a real repository, the next step is
+a detection pass with `hunspell -l` (no suggestions) and a second `-a` pass over
+only the flagged, de-duplicated words — not a different lookup engine.
+
+## Encoding
+
+Four pinned dictionaries declare legacy 8-bit encodings: `de_DE_frami` and
+`id_ID` and `ms_MY` (ISO8859-1), `pl_PL` (ISO8859-2). The `hunspell` binary
+reads `SET` and transcodes internally, so with `-i UTF-8` the CLI sends and
+receives UTF-8 and needs no transcoding layer. Verified against non-ASCII input
+for each: `Straße`, `Grüße`, `Fußgängerübergang` accepted and `Strasze` flagged
+for `de-DE`; `żółć`, `wąż`, `źdźbło` accepted for `pl-PL`.
+
+This is a real simplification over the CGO path, which must transcode itself
+because it passes Go strings to the C API (`apps/go-svc/internal/hunspell/encoding.go`).
+
+## Pipe protocol
+
+Pipe mode is line-oriented and needs care:
+
+- Skip the version banner on the first line of output.
+- Prefix every input line with `^` so a word starting with `*`, `&`, `@`, `#`,
+  `~`, `+`, or `-` is not read as a command.
+- One result block per input line, terminated by a blank line. `*` and `+` mean
+  accepted; `&` carries suggestions after `: `; `#` means rejected with none.
+- Hunspell applies its own tokenizer, so a single input word can produce
+  several result lines. Treat the word as misspelled if any line rejects it.
+
+## Availability
+
+| Environment | Hunspell | Dictionaries |
+|-------------|----------|--------------|
+| Sandbox image (`hyperlocalise-sandbox`) | baked in | `/usr/share/hunspell`, `DICPATH` set |
+| Managed image + bootstrap | not installed | absent |
+| Developer machine | `apt install hunspell` / `brew install hunspell` | opt-in fetch |
+| CI | runner-dependent | opt-in fetch |
+
+Only the sandbox image is ready today. Everywhere else the spelling check must
+skip rather than fail, mirroring the existing API contract where `go-svc`
+reports `spelling` in `skippedModes` (`ErrSpellCheckUnavailable`). A check that
+silently downgrades is acceptable; one that fails CI because a machine lacks a
+system package is not.
+
+For developer machines, dictionaries should be fetched on demand into a cache
+directory (`~/.cache/hyperlocalise/hunspell`) from the same manifest and pinned
+commits `fetch-dictionaries.sh` uses, so CLI and service results match. Baking
+84 MB into the release archive is not an option.
+
+## Shape
+
+Mirror the `go-svc` seam rather than inventing a second one:
+
+```
+internal/i18n/spellcheck/    tokenizer, registry, markup   (shared, exists)
+  hunspellexec/              pipe-mode driver              (new, CGO-free)
+apps/cli/cmd/check.go        "spelling" check type         (new)
+```
+
+`hunspellexec` is a sibling of the CGO wrapper, not a replacement: `go-svc`
+keeps linking libhunspell, where a long-lived server amortizes dictionary loads
+and avoids a subprocess per request. The CLI gets the subprocess driver. Both
+resolve dictionaries through the same registry, so a locale supported in one is
+supported in the other.
+
+The check reports `spelling` findings at **warning** severity, alongside
+`orphaned_key` and `same_as_source`. Spell checking translated marketing copy
+produces false positives on brand names and technical terms, so it must not
+fail CI by default. It is also not fixable by `--fix`: retranslating a segment
+because a product name is not in a dictionary would corrupt correct
+translations.
+
+## Out of scope
+
+- Implementing the check; this ADR settles the approach.
+- A custom or per-project word list. Needed before this is pleasant on real
+  repositories, but it is a separate design.
+- Grammar checking, and the locales `DICTIONARIES.md` lists as unsupported
+  (`ja-JP`, `zh-CN`, `zh-TW`, `th-TH`, `en-SG`, `fr-CA`, `tl-PH`).
+- Installing Hunspell during sandbox bootstrap for the managed image.

--- a/internal/i18n/spellcheck/DICTIONARIES.md
+++ b/internal/i18n/spellcheck/DICTIONARIES.md
@@ -23,10 +23,12 @@ that mapping is trusted (source, pinned version, licence, evidence).
   Undeclared or unknown encodings are skipped.
 - Hunspell reads the first line of a `.dic` as the word count and loads an
   **empty** word list when it cannot parse one, which silently reports every
-  word in that locale as misspelled. `fetch-dictionaries.sh` therefore drops a
-  leading `#` from that line when the remainder is a bare integer (`ms_MY`
-  ships `#30975`), and fails the build if any staged dictionary is left with a
-  non-numeric count. The word list itself is never modified.
+  word in that locale as misspelled. `fetch-dictionaries.sh` and the CGO
+  loader both strip a leading `#` and surrounding whitespace from that line
+  (`ms_MY` ships `#30975`) and rewrite it to a bare integer. A header with
+  no digits fails staging and, at runtime, fails `hunspell.New` so the
+  locale is skipped instead of flagging every word. The word list itself is
+  never modified.
 
 ## Supported locales (20)
 

--- a/internal/i18n/spellcheck/DICTIONARIES.md
+++ b/internal/i18n/spellcheck/DICTIONARIES.md
@@ -21,6 +21,12 @@ that mapping is trusted (source, pinned version, licence, evidence).
   that declare a known 8-bit encoding are transcoded to UTF-8 at load
   time. A leading UTF-8 BOM is stripped so `SET` is still recognized.
   Undeclared or unknown encodings are skipped.
+- Hunspell reads the first line of a `.dic` as the word count and loads an
+  **empty** word list when it cannot parse one, which silently reports every
+  word in that locale as misspelled. `fetch-dictionaries.sh` therefore drops a
+  leading `#` from that line when the remainder is a bare integer (`ms_MY`
+  ships `#30975`), and fails the build if any staged dictionary is left with a
+  non-numeric count. The word list itself is never modified.
 
 ## Supported locales (20)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Three things, in increasing order of scope.

**1. Sandbox image ships Hunspell and the 20 pinned dictionaries.** Agents running in the sandbox had no spell checker. The image now installs the `hunspell` binary and stages the locales from [`internal/i18n/spellcheck/DICTIONARIES.md`](../blob/main/internal/i18n/spellcheck/DICTIONARIES.md) using the same [`apps/go-svc/build/fetch-dictionaries.sh`](../blob/main/apps/go-svc/build/fetch-dictionaries.sh) script that `Dockerfile.vercel` runs for `go-svc`, so both images carry byte-identical dictionaries verified against pinned upstream commits and SHA-256 checksums.

The build context moves from `apps/sandbox-image` to the repository root so the new first stage can reach the manifest and the script. The existing root `.dockerignore` keeps the transferred context at **16.8 kB** in CI. Licence evidence ships to `/usr/share/doc/hunspell-dictionaries/` because the dictionaries are redistributed under GPL/LGPL/MPL terms. `DICPATH` is derived from `HUNSPELL_DICT_DIR` so `hunspell -d en_US` still resolves when the image is built with a non-default dictionary path.

Local push commands in the README now run from the repository root and pass `--file apps/sandbox-image/Dockerfile` (Codex review).

**2. Fixed a real spell-check bug this uncovered (affects `go-svc` today).** Hunspell reads the first line of a `.dic` as the word count and loads an **empty** word list when it cannot parse one — silently reporting every word in that locale as misspelled. `ms_MY` ships `#30975`.

The follow-up is now defense in depth, not only an image rewrite:

- `fetch-dictionaries.sh` strips a leading `#` and surrounding whitespace, rewrites the line to a bare integer (also handles `# 30975` and a trailing comment), and fails the build when no digits remain. A `--normalize-header` helper is covered by `fetch-dictionaries_test.sh`.
- `hunspell.New` applies the same rules at load time. A `#`-prefixed header now loads; a non-numeric header fails the load so the locale is **skipped** instead of flagging every word. That takes effect on the next `go-svc` deploy even if a raw upstream file is still on disk.

**3. ADR recommending how the CLI should spell check.** [`docs/adr/2026-08-28-cli-spellcheck-design.md`](../blob/cursor/sandbox-image-hunspell-c3a7/docs/adr/2026-08-28-cli-spellcheck-design.md) recommends shelling out to `hunspell -a` (pipe mode) behind the same provider seam `go-svc` uses, skipping the check when the binary or dictionary is missing. No implementation in this PR — the ADR settles the approach.

## How to test

```bash
# Build from the repository root (the build context is now the root).
docker build --platform linux/amd64 \
  -f apps/sandbox-image/Dockerfile -t hyperlocalise-sandbox:local .

docker run --rm hyperlocalise-sandbox:local printenv DICPATH
# /usr/share/hunspell

docker run --rm -v "$PWD/apps/sandbox-image/verify-hunspell.sh:/verify.sh:ro" \
  hyperlocalise-sandbox:local bash /verify.sh

bash apps/go-svc/build/fetch-dictionaries_test.sh
go test ./apps/go-svc/internal/hunspell/
CGO_ENABLED=1 go test -tags cgo_hunspell ./apps/go-svc/...
```

`verify-hunspell.sh` checks every locale: readable `.aff`/`.dic`, Hunspell reporting it loaded, a non-empty word list, and SHA-256 match against the staged set. Result: **20 verified, 0 failed**.

Other checks: `make fmt` (clean), `make lint` (0 issues), `go test ./...` (pass), `shellcheck` on both shell scripts (clean). `make test` fails only on the pre-existing `go: no such tool "covdata"` issue documented in `AGENTS.md`.

## Notes for review

- **apt `hunspell` depends on `hunspell-en-us`**, which ships its own `en_US` into `/usr/share/hunspell`. The pinned set wins because `COPY` runs after apt; `SHA256SUMS` makes a reorder fail the build.
- Four dictionaries declare legacy 8-bit encodings. The `hunspell` binary reads `SET` and transcodes internally (`-i UTF-8`). The CGO wrapper still transcodes itself.
- Dictionary basenames do not always follow the BCP 47 tag. Resolve through `spellcheck.LoadRegistry()`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04a9f-453e-7d36-b345-6f06d956c3a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04a9f-453e-7d36-b345-6f06d956c3a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

