### PR TITLE
feat(cat): treat markdown and MDX as editable document files

### DIFF
--- a/apps/cli/cmd/entries.go
+++ b/apps/cli/cmd/entries.go
@@ -57,7 +57,7 @@ func newEntriesCmd() *cobra.Command {
 		&sourcePath,
 		"source",
 		"",
-		"source file used to align content-hashed keys for markdown/MDX targets",
+		"source file used to align markdown/MDX target documents onto source slot ids",
 	)
 	return cmd
 }
@@ -74,11 +74,16 @@ func readEntriesCommandOutput(path string, content []byte, sourcePath, locale st
 			if err != nil {
 				return nil, fmt.Errorf("read entries source %q: %w", sourcePath, err)
 			}
-			aligned := translationfileparser.AlignMarkdownTargetToSource(sourceContent, content, ext == ".mdx")
-			return translationfileparser.EncodeEntriesCommandOutput(
-				translationfileparser.IngestEntriesFromStringMap(aligned),
-			), nil
+			mdx := ext == ".mdx"
+			sourceDoc := translationfileparser.ParseMarkdownDocumentIR(sourceContent, mdx)
+			aligned := translationfileparser.AlignMarkdownTargetToSource(sourceContent, content, mdx)
+			return translationfileparser.EncodeDocumentEntriesCommandOutput(sourceDoc.WithBlockText(aligned)), nil
 		}
+	}
+
+	if translationfileparser.IsMarkdownDocumentExtension(path) {
+		doc := translationfileparser.ParseMarkdownDocumentIR(content, translationfileparser.IsMarkdownDocumentMDX(path))
+		return translationfileparser.EncodeDocumentEntriesCommandOutput(doc), nil
 	}
 
 	strategy := translationfileparser.NewDefaultStrategy()

--- a/apps/cli/cmd/entries_test.go
+++ b/apps/cli/cmd/entries_test.go
@@ -69,8 +69,10 @@ func TestEntriesCommandOutputsParsedEntries(t *testing.T) {
 	}
 
 	var payload map[string]string
-	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+	if decoded, err := decodeEntriesCommandStrings(out.Bytes()); err != nil {
 		t.Fatalf("decode output: %v", err)
+	} else {
+		payload = decoded
 	}
 	if payload["title"] != "Hello" || payload["nested.cta"] != "Click" {
 		t.Fatalf("unexpected payload: %+v", payload)
@@ -115,8 +117,10 @@ func TestEntriesCommandUsesLocaleForXCStrings(t *testing.T) {
 	}
 
 	var payload map[string]string
-	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+	if decoded, err := decodeEntriesCommandStrings(out.Bytes()); err != nil {
 		t.Fatalf("decode output: %v", err)
+	} else {
+		payload = decoded
 	}
 	if payload["hello"] != "Bonjour" {
 		t.Fatalf("expected French target locale value, got %+v", payload)
@@ -141,8 +145,10 @@ func TestEntriesCommandUsesLocaleForCSV(t *testing.T) {
 	}
 
 	var payload map[string]string
-	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+	if decoded, err := decodeEntriesCommandStrings(out.Bytes()); err != nil {
 		t.Fatalf("decode output: %v", err)
+	} else {
+		payload = decoded
 	}
 	if payload["hello"] != "Bonjour" {
 		t.Fatalf("expected French CSV column value, got %+v", payload)
@@ -167,8 +173,10 @@ func TestEntriesCommandParsesSubtitleCues(t *testing.T) {
 	}
 
 	var payload map[string]string
-	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+	if decoded, err := decodeEntriesCommandStrings(out.Bytes()); err != nil {
 		t.Fatalf("decode output: %v", err)
+	} else {
+		payload = decoded
 	}
 	if payload["srt.0001"] != "Hello" {
 		t.Fatalf("expected srt cue payload, got %+v", payload)
@@ -208,8 +216,10 @@ func TestEntriesCommandAlignsMarkdownTargetToSourceKeys(t *testing.T) {
 	}
 
 	var payload map[string]string
-	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+	if decoded, err := decodeEntriesCommandStrings(out.Bytes()); err != nil {
 		t.Fatalf("decode output: %v", err)
+	} else {
+		payload = decoded
 	}
 	if got := strings.TrimSpace(payload[introKey]); got != "Intro existant." {
 		t.Fatalf("expected intro mapped to source key %q, got %q (payload=%+v)", introKey, got, payload)
@@ -244,7 +254,7 @@ func TestEntriesCommandRejectsMismatchedMarkdownSourceExtension(t *testing.T) {
 	}
 }
 
-func TestEntriesCommandWithoutSourceRehashesMarkdownTarget(t *testing.T) {
+func TestEntriesCommandWithoutSourceUsesStructuralSlotKeys(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "guide.md")
 	targetPath := filepath.Join(dir, "guide-fr.md")
@@ -276,14 +286,13 @@ func TestEntriesCommandWithoutSourceRehashesMarkdownTarget(t *testing.T) {
 	}
 
 	var payload map[string]string
-	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+	if decoded, err := decodeEntriesCommandStrings(out.Bytes()); err != nil {
 		t.Fatalf("decode output: %v", err)
+	} else {
+		payload = decoded
 	}
-	if _, ok := payload[introKey]; ok {
-		t.Fatalf("expected bare entries on translated markdown not to keep source key %q, got %+v", introKey, payload)
-	}
-	if findEntriesTestKeyByValue(payload, "Intro existant.") == "" {
-		t.Fatalf("expected translated segment under a rehashed key, got %+v", payload)
+	if got := strings.TrimSpace(payload[introKey]); got != "Intro existant." {
+		t.Fatalf("expected target intro under source slot %q, got %q (payload=%+v)", introKey, got, payload)
 	}
 }
 
@@ -294,4 +303,30 @@ func findEntriesTestKeyByValue(entries map[string]string, want string) string {
 		}
 	}
 	return ""
+}
+
+func decodeEntriesCommandStrings(raw []byte) (map[string]string, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(payload))
+	for key, value := range payload {
+		if key == translationfileparser.DocumentEntriesMetaKey {
+			continue
+		}
+		var text string
+		if err := json.Unmarshal(value, &text); err == nil {
+			out[key] = text
+			continue
+		}
+		var record struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(value, &record); err != nil {
+			return nil, err
+		}
+		out[key] = record.Text
+	}
+	return out, nil
 }

--- a/apps/cli/cmd/sync_hyperlocalise.go
+++ b/apps/cli/cmd/sync_hyperlocalise.go
@@ -222,14 +222,13 @@ func runHyperlocalisePull(ctx context.Context, rt *hyperlocaliseSyncRuntime, o s
 					}
 					report.Downloaded++
 					continue
-				case !isHyperlocaliseNotFound(err):
-					report.Complete = false
-					return report, fmt.Errorf("download file variant for source %q locale %q: %w", plan.SourcePath, locale, err)
-				case !isHyperlocaliseDocumentFileFormat(plan.FileFormat):
+				case isHyperlocaliseNotFound(err):
 					report.Skipped++
 					continue
+				default:
+					report.Complete = false
+					return report, fmt.Errorf("download file variant for source %q locale %q: %w", plan.SourcePath, locale, err)
 				}
-				// Document variants are new; older markdown/MDX locales still live as translation rows.
 			}
 
 			content, err = rt.client.downloadTranslationExport(ctx, rt.projectID, plan.SourcePath, locale)

--- a/apps/cli/cmd/sync_hyperlocalise.go
+++ b/apps/cli/cmd/sync_hyperlocalise.go
@@ -214,20 +214,22 @@ func runHyperlocalisePull(ctx context.Context, rt *hyperlocaliseSyncRuntime, o s
 			var content []byte
 			if isHyperlocaliseWholeFileFormat(plan.FileFormat) {
 				content, err = rt.client.downloadFileVariant(ctx, rt.projectID, plan.SourcePath, locale)
-				if err != nil {
-					if isHyperlocaliseNotFound(err) {
-						report.Skipped++
-						continue
+				switch {
+				case err == nil:
+					if err := writeFileAtomic(resolvedTargetPath, content); err != nil {
+						report.Complete = false
+						return report, fmt.Errorf("write target file %q: %w", resolvedTargetPath, err)
 					}
+					report.Downloaded++
+					continue
+				case !isHyperlocaliseNotFound(err):
 					report.Complete = false
 					return report, fmt.Errorf("download file variant for source %q locale %q: %w", plan.SourcePath, locale, err)
+				case !isHyperlocaliseDocumentFileFormat(plan.FileFormat):
+					report.Skipped++
+					continue
 				}
-				if err := writeFileAtomic(resolvedTargetPath, content); err != nil {
-					report.Complete = false
-					return report, fmt.Errorf("write target file %q: %w", resolvedTargetPath, err)
-				}
-				report.Downloaded++
-				continue
+				// Document variants are new; older markdown/MDX locales still live as translation rows.
 			}
 
 			content, err = rt.client.downloadTranslationExport(ctx, rt.projectID, plan.SourcePath, locale)

--- a/apps/cli/cmd/sync_hyperlocalise.go
+++ b/apps/cli/cmd/sync_hyperlocalise.go
@@ -212,15 +212,15 @@ func runHyperlocalisePull(ctx context.Context, rt *hyperlocaliseSyncRuntime, o s
 			}
 
 			var content []byte
-			if isHyperlocaliseBinaryFileFormat(plan.FileFormat) {
-				content, err = rt.client.downloadImageVariant(ctx, rt.projectID, plan.SourcePath, locale)
+			if isHyperlocaliseWholeFileFormat(plan.FileFormat) {
+				content, err = rt.client.downloadFileVariant(ctx, rt.projectID, plan.SourcePath, locale)
 				if err != nil {
 					if isHyperlocaliseNotFound(err) {
 						report.Skipped++
 						continue
 					}
 					report.Complete = false
-					return report, fmt.Errorf("download binary variant for source %q locale %q: %w", plan.SourcePath, locale, err)
+					return report, fmt.Errorf("download file variant for source %q locale %q: %w", plan.SourcePath, locale, err)
 				}
 				if err := writeFileAtomic(resolvedTargetPath, content); err != nil {
 					report.Complete = false
@@ -500,8 +500,21 @@ func isHyperlocaliseOfficeFileFormat(format string) bool {
 	}
 }
 
+func isHyperlocaliseDocumentFileFormat(format string) bool {
+	switch format {
+	case "markdown", "mdx":
+		return true
+	default:
+		return false
+	}
+}
+
 func isHyperlocaliseBinaryFileFormat(format string) bool {
 	return isHyperlocaliseImageFileFormat(format) || isHyperlocaliseOfficeFileFormat(format)
+}
+
+func isHyperlocaliseWholeFileFormat(format string) bool {
+	return isHyperlocaliseBinaryFileFormat(format) || isHyperlocaliseDocumentFileFormat(format)
 }
 
 func sha256File(path string) (string, error) {
@@ -595,7 +608,7 @@ func (c *hyperlocaliseAPIClient) downloadTranslationExport(ctx context.Context, 
 	return content, nil
 }
 
-func (c *hyperlocaliseAPIClient) downloadImageVariant(ctx context.Context, projectID, sourcePath, locale string) ([]byte, error) {
+func (c *hyperlocaliseAPIClient) downloadFileVariant(ctx context.Context, projectID, sourcePath, locale string) ([]byte, error) {
 	query := url.Values{}
 	query.Set("sourcePath", sourcePath)
 	query.Set("locale", locale)
@@ -603,7 +616,7 @@ func (c *hyperlocaliseAPIClient) downloadImageVariant(ctx context.Context, proje
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
-		c.baseURL+"/v1/projects/"+url.PathEscape(projectID)+"/images/download?"+query.Encode(),
+		c.baseURL+"/v1/projects/"+url.PathEscape(projectID)+"/files/download?"+query.Encode(),
 		nil,
 	)
 	if err != nil {
@@ -627,7 +640,7 @@ func (c *hyperlocaliseAPIClient) downloadImageVariant(ctx context.Context, proje
 		return nil, err
 	}
 	if int64(len(content)) > hyperlocaliseMaxDownloadBytes {
-		return nil, fmt.Errorf("downloaded image variant exceeds maximum size of %d bytes", hyperlocaliseMaxDownloadBytes)
+		return nil, fmt.Errorf("downloaded file variant exceeds maximum size of %d bytes", hyperlocaliseMaxDownloadBytes)
 	}
 	return content, nil
 }

--- a/apps/cli/cmd/sync_hyperlocalise_test.go
+++ b/apps/cli/cmd/sync_hyperlocalise_test.go
@@ -267,6 +267,179 @@ func TestHyperlocalisePullWritesMarkdownVariantsDirectly(t *testing.T) {
 	}
 }
 
+func TestHyperlocalisePullReconstructsMarkdownWhenFileVariantMissing(t *testing.T) {
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	sourcePath := "docs/en/intro.md"
+	targetPath := "docs/fr/intro.md"
+	sourceContent := "# Hello\n\nWorld.\n"
+	writePullSourceFile(t, filepath.FromSlash(sourcePath), sourceContent)
+
+	strategy := translationfileparser.NewDefaultStrategy()
+	entries, err := strategy.Parse(sourcePath, []byte(sourceContent))
+	if err != nil {
+		t.Fatalf("parse markdown source: %v", err)
+	}
+	prefilled := make(map[string]string, len(entries))
+	for key, value := range entries {
+		prefilled[key] = strings.ReplaceAll(value, "World", "Monde")
+	}
+	prefilledJSON, err := json.Marshal(prefilled)
+	if err != nil {
+		t.Fatalf("marshal prefilled entries: %v", err)
+	}
+
+	var filesDownloadCount atomic.Int32
+	var translationDownloadCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download"):
+			filesDownloadCount.Add(1)
+			http.NotFound(w, r)
+			return
+		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download"):
+			translationDownloadCount.Add(1)
+			if got := r.URL.Query().Get("sourcePath"); got != sourcePath {
+				t.Fatalf("sourcePath = %q, want %q", got, sourcePath)
+			}
+			if got := r.URL.Query().Get("locale"); got != "fr" {
+				t.Fatalf("locale = %q, want fr", got)
+			}
+			_, _ = w.Write(prefilledJSON)
+			return
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	rt := &hyperlocaliseSyncRuntime{
+		cfg: &config.I18NConfig{
+			Locales: config.LocaleConfig{
+				Source:  "en",
+				Targets: []string{"fr"},
+			},
+			Buckets: map[string]config.BucketConfig{
+				"docs": {
+					Files: []config.BucketFileMapping{{
+						From: "docs/en/**/*.md",
+						To:   "docs/{{target}}/**/*.md",
+					}},
+				},
+			},
+		},
+		configRoot: dir,
+		projectID:  "project-1",
+		client: &hyperlocaliseAPIClient{
+			baseURL:    server.URL,
+			apiKey:     "test-key",
+			httpClient: server.Client(),
+		},
+	}
+
+	report, err := runHyperlocalisePull(context.Background(), rt, syncCommonOptions{})
+	if err != nil {
+		t.Fatalf("pull markdown fallback: %v", err)
+	}
+	if filesDownloadCount.Load() != 1 {
+		t.Fatalf("files/download count = %d, want 1", filesDownloadCount.Load())
+	}
+	if translationDownloadCount.Load() != 1 {
+		t.Fatalf("translations/download count = %d, want 1", translationDownloadCount.Load())
+	}
+	if report.Downloaded != 1 || report.Skipped != 0 {
+		t.Fatalf("report = %#v, want one reconstructed markdown file", report)
+	}
+
+	got, err := os.ReadFile(filepath.FromSlash(targetPath))
+	if err != nil {
+		t.Fatalf("read target markdown file: %v", err)
+	}
+	if strings.Contains(string(got), `"md.`) {
+		t.Fatalf("expected markdown output, got JSON-like content: %q", string(got))
+	}
+	if !strings.Contains(string(got), "Monde") {
+		t.Fatalf("target content = %q, want reconstructed translation", string(got))
+	}
+}
+
+func TestHyperlocalisePullSkipsMissingImageVariants(t *testing.T) {
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	sourcePath := "assets/en/banner.png"
+	writePullSourceFile(t, filepath.FromSlash(sourcePath), "source-png-bytes")
+
+	var translationDownloadCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download") {
+			http.NotFound(w, r)
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download") {
+			translationDownloadCount.Add(1)
+			http.NotFound(w, r)
+			return
+		}
+		t.Fatalf("unexpected path: %s", r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	rt := &hyperlocaliseSyncRuntime{
+		cfg: &config.I18NConfig{
+			Locales: config.LocaleConfig{
+				Source:  "en",
+				Targets: []string{"fr"},
+			},
+			Buckets: map[string]config.BucketConfig{
+				"images": {
+					Files: []config.BucketFileMapping{{
+						From: "assets/en/**/*.png",
+						To:   "assets/{{target}}/**/*.png",
+					}},
+				},
+			},
+		},
+		configRoot: dir,
+		projectID:  "project-1",
+		client: &hyperlocaliseAPIClient{
+			baseURL:    server.URL,
+			apiKey:     "test-key",
+			httpClient: server.Client(),
+		},
+	}
+
+	report, err := runHyperlocalisePull(context.Background(), rt, syncCommonOptions{})
+	if err != nil {
+		t.Fatalf("pull missing image variant: %v", err)
+	}
+	if translationDownloadCount.Load() != 0 {
+		t.Fatalf("translations/download count = %d, want 0 for missing image variants", translationDownloadCount.Load())
+	}
+	if report.Downloaded != 0 || report.Skipped != 1 {
+		t.Fatalf("report = %#v, want skipped missing image variant", report)
+	}
+}
+
 func TestHyperlocalisePushUploadsSourceFileMultipart(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/apps/cli/cmd/sync_hyperlocalise_test.go
+++ b/apps/cli/cmd/sync_hyperlocalise_test.go
@@ -67,7 +67,7 @@ func TestHyperlocalisePullWritesImageVariantsDirectly(t *testing.T) {
 	imageBytes := []byte("localized-png-bytes")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/images/download") {
+		if !strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download") {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		if got := r.URL.Query().Get("sourcePath"); got != sourcePath {
@@ -140,7 +140,7 @@ func TestHyperlocalisePullWritesOfficeVariantsDirectly(t *testing.T) {
 	officeBytes := []byte("localized-docx-bytes")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/images/download") {
+		if !strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download") {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		if got := r.URL.Query().Get("sourcePath"); got != sourcePath {
@@ -191,6 +191,79 @@ func TestHyperlocalisePullWritesOfficeVariantsDirectly(t *testing.T) {
 	}
 	if string(got) != string(officeBytes) {
 		t.Fatalf("target content = %q, want %q", string(got), string(officeBytes))
+	}
+}
+
+func TestHyperlocalisePullWritesMarkdownVariantsDirectly(t *testing.T) {
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	sourcePath := "docs/en/intro.md"
+	targetPath := "docs/fr/intro.md"
+	writePullSourceFile(t, filepath.FromSlash(sourcePath), "# Hello\n")
+	markdownBytes := []byte("# Bonjour\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download") {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("sourcePath"); got != sourcePath {
+			t.Fatalf("sourcePath = %q, want %q", got, sourcePath)
+		}
+		if got := r.URL.Query().Get("locale"); got != "fr" {
+			t.Fatalf("locale = %q, want fr", got)
+		}
+		_, _ = w.Write(markdownBytes)
+	}))
+	t.Cleanup(server.Close)
+
+	rt := &hyperlocaliseSyncRuntime{
+		cfg: &config.I18NConfig{
+			Locales: config.LocaleConfig{
+				Source:  "en",
+				Targets: []string{"fr"},
+			},
+			Buckets: map[string]config.BucketConfig{
+				"docs": {
+					Files: []config.BucketFileMapping{{
+						From: "docs/en/**/*.md",
+						To:   "docs/{{target}}/**/*.md",
+					}},
+				},
+			},
+		},
+		configRoot: dir,
+		projectID:  "project-1",
+		client: &hyperlocaliseAPIClient{
+			baseURL:    server.URL,
+			apiKey:     "test-key",
+			httpClient: server.Client(),
+		},
+	}
+
+	report, err := runHyperlocalisePull(context.Background(), rt, syncCommonOptions{})
+	if err != nil {
+		t.Fatalf("pull markdown variant: %v", err)
+	}
+	if report.Downloaded != 1 {
+		t.Fatalf("report = %#v, want one downloaded markdown file", report)
+	}
+
+	got, err := os.ReadFile(filepath.FromSlash(targetPath))
+	if err != nil {
+		t.Fatalf("read target markdown file: %v", err)
+	}
+	if string(got) != string(markdownBytes) {
+		t.Fatalf("target content = %q, want %q", string(got), string(markdownBytes))
 	}
 }
 
@@ -519,28 +592,6 @@ func TestHyperlocalisePullReconstructsNativeFormats(t *testing.T) {
 		assertNative  func(t *testing.T, content string)
 	}{
 		{
-			name:          "markdown",
-			sourceLocale:  "en-US",
-			targetLocale:  "de-DE",
-			sourcePath:    "_posts/en/hello.md",
-			targetPath:    "_posts/de-DE/hello.md",
-			fromPattern:   "_posts/en/**/*.md",
-			toPattern:     "_posts/{{target}}/**/*.md",
-			sourceContent: "# Hello\n\nWorld.\n",
-			translate: func(_, value string) string {
-				return strings.ReplaceAll(value, "World", "Welt")
-			},
-			assertNative: func(t *testing.T, content string) {
-				t.Helper()
-				if strings.Contains(content, `"md.`) {
-					t.Fatalf("target should be markdown, got JSON-like content: %q", content)
-				}
-				if !strings.Contains(content, "Welt") || !strings.HasPrefix(content, "# Hello") {
-					t.Fatalf("target content = %q, want translated markdown", content)
-				}
-			},
-		},
-		{
 			name:          "json",
 			sourceLocale:  "en",
 			targetLocale:  "fr",
@@ -730,28 +781,6 @@ func TestHyperlocalisePullReconstructsNativeFormats(t *testing.T) {
 				t.Helper()
 				if !strings.Contains(content, `"hello" = "Bonjour"`) {
 					t.Fatalf("target content = %q, want translated Apple strings entry", content)
-				}
-			},
-		},
-		{
-			name:          "mdx",
-			sourceLocale:  "en",
-			targetLocale:  "fr-FR",
-			sourcePath:    "docs/en/guide.mdx",
-			targetPath:    "docs/fr-FR/guide.mdx",
-			fromPattern:   "docs/en/**/*.mdx",
-			toPattern:     "docs/{{target}}/**/*.mdx",
-			sourceContent: "# Guide\n\nWelcome.\n",
-			translate: func(_, value string) string {
-				return strings.ReplaceAll(value, "Welcome", "Bienvenue")
-			},
-			assertNative: func(t *testing.T, content string) {
-				t.Helper()
-				if strings.Contains(content, `"md.`) {
-					t.Fatalf("target should be MDX, got JSON-like content: %q", content)
-				}
-				if !strings.Contains(content, "Bienvenue") || !strings.HasPrefix(content, "# Guide") {
-					t.Fatalf("target content = %q, want translated MDX", content)
 				}
 			},
 		},

--- a/apps/cli/cmd/sync_hyperlocalise_test.go
+++ b/apps/cli/cmd/sync_hyperlocalise_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -268,7 +267,7 @@ func TestHyperlocalisePullWritesMarkdownVariantsDirectly(t *testing.T) {
 	}
 }
 
-func TestHyperlocalisePullReconstructsMarkdownWhenFileVariantMissing(t *testing.T) {
+func TestHyperlocalisePullSkipsMarkdownWhenFileVariantMissing(t *testing.T) {
 	dir := t.TempDir()
 	wd, err := os.Getwd()
 	if err != nil {
@@ -283,47 +282,22 @@ func TestHyperlocalisePullReconstructsMarkdownWhenFileVariantMissing(t *testing.
 
 	sourcePath := "docs/en/intro.md"
 	targetPath := "docs/fr/intro.md"
-	sourceContent := "# Hello\n\nWorld.\n"
-	writePullSourceFile(t, filepath.FromSlash(sourcePath), sourceContent)
-
-	doc := translationfileparser.ParseMarkdownDocumentIR([]byte(sourceContent), false)
-	prefilled := make(map[string]string, len(doc.Blocks))
-	counts := make(map[string]int)
-	for _, block := range doc.Blocks {
-		n := counts[block.Fingerprint]
-		counts[block.Fingerprint] = n + 1
-		key := "md." + block.Fingerprint
-		if n > 0 {
-			key += "." + strconv.Itoa(n+1)
-		}
-		prefilled[key] = strings.ReplaceAll(block.Text, "World", "Monde")
-	}
-	prefilledJSON, err := json.Marshal(prefilled)
-	if err != nil {
-		t.Fatalf("marshal prefilled entries: %v", err)
-	}
+	writePullSourceFile(t, filepath.FromSlash(sourcePath), "# Hello\n\nWorld.\n")
 
 	var filesDownloadCount atomic.Int32
 	var translationDownloadCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download"):
+		if strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download") {
 			filesDownloadCount.Add(1)
 			http.NotFound(w, r)
 			return
-		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download"):
-			translationDownloadCount.Add(1)
-			if got := r.URL.Query().Get("sourcePath"); got != sourcePath {
-				t.Fatalf("sourcePath = %q, want %q", got, sourcePath)
-			}
-			if got := r.URL.Query().Get("locale"); got != "fr" {
-				t.Fatalf("locale = %q, want fr", got)
-			}
-			_, _ = w.Write(prefilledJSON)
-			return
-		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download") {
+			translationDownloadCount.Add(1)
+			t.Fatalf("unexpected translations/download for missing markdown variant")
+			return
+		}
+		t.Fatalf("unexpected path: %s", r.URL.Path)
 	}))
 	t.Cleanup(server.Close)
 
@@ -353,27 +327,19 @@ func TestHyperlocalisePullReconstructsMarkdownWhenFileVariantMissing(t *testing.
 
 	report, err := runHyperlocalisePull(context.Background(), rt, syncCommonOptions{})
 	if err != nil {
-		t.Fatalf("pull markdown fallback: %v", err)
+		t.Fatalf("pull missing markdown variant: %v", err)
 	}
 	if filesDownloadCount.Load() != 1 {
 		t.Fatalf("files/download count = %d, want 1", filesDownloadCount.Load())
 	}
-	if translationDownloadCount.Load() != 1 {
-		t.Fatalf("translations/download count = %d, want 1", translationDownloadCount.Load())
+	if translationDownloadCount.Load() != 0 {
+		t.Fatalf("translations/download count = %d, want 0", translationDownloadCount.Load())
 	}
-	if report.Downloaded != 1 || report.Skipped != 0 {
-		t.Fatalf("report = %#v, want one reconstructed markdown file", report)
+	if report.Downloaded != 0 || report.Skipped != 1 {
+		t.Fatalf("report = %#v, want skipped missing markdown variant", report)
 	}
-
-	got, err := os.ReadFile(filepath.FromSlash(targetPath))
-	if err != nil {
-		t.Fatalf("read target markdown file: %v", err)
-	}
-	if strings.Contains(string(got), `"md.`) {
-		t.Fatalf("expected markdown output, got JSON-like content: %q", string(got))
-	}
-	if !strings.Contains(string(got), "Monde") {
-		t.Fatalf("target content = %q, want reconstructed translation", string(got))
+	if _, err := os.Stat(filepath.FromSlash(targetPath)); !os.IsNotExist(err) {
+		t.Fatalf("stat target = %v, want not exist", err)
 	}
 }
 

--- a/apps/cli/cmd/sync_hyperlocalise_test.go
+++ b/apps/cli/cmd/sync_hyperlocalise_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -285,14 +286,17 @@ func TestHyperlocalisePullReconstructsMarkdownWhenFileVariantMissing(t *testing.
 	sourceContent := "# Hello\n\nWorld.\n"
 	writePullSourceFile(t, filepath.FromSlash(sourcePath), sourceContent)
 
-	strategy := translationfileparser.NewDefaultStrategy()
-	entries, err := strategy.Parse(sourcePath, []byte(sourceContent))
-	if err != nil {
-		t.Fatalf("parse markdown source: %v", err)
-	}
-	prefilled := make(map[string]string, len(entries))
-	for key, value := range entries {
-		prefilled[key] = strings.ReplaceAll(value, "World", "Monde")
+	doc := translationfileparser.ParseMarkdownDocumentIR([]byte(sourceContent), false)
+	prefilled := make(map[string]string, len(doc.Blocks))
+	counts := make(map[string]int)
+	for _, block := range doc.Blocks {
+		n := counts[block.Fingerprint]
+		counts[block.Fingerprint] = n + 1
+		key := "md." + block.Fingerprint
+		if n > 0 {
+			key += "." + strconv.Itoa(n+1)
+		}
+		prefilled[key] = strings.ReplaceAll(block.Text, "World", "Monde")
 	}
 	prefilledJSON, err := json.Marshal(prefilled)
 	if err != nil {

--- a/apps/cli/cmd/sync_test.go
+++ b/apps/cli/cmd/sync_test.go
@@ -149,6 +149,33 @@ func TestHyperlocaliseSyncRecognizesOfficeFiles(t *testing.T) {
 	}
 }
 
+func TestHyperlocaliseSyncRecognizesDocumentFiles(t *testing.T) {
+	cases := []struct {
+		path   string
+		format string
+	}{
+		{path: "docs/intro.md", format: "markdown"},
+		{path: "docs/page.mdx", format: "mdx"},
+	}
+	for _, tc := range cases {
+		if got := inferHyperlocaliseFileFormat(tc.path); got != tc.format {
+			t.Fatalf("inferHyperlocaliseFileFormat(%q) = %q, want %q", tc.path, got, tc.format)
+		}
+		if !isHyperlocaliseDocumentFileFormat(tc.format) {
+			t.Fatalf("isHyperlocaliseDocumentFileFormat(%q) = false, want true", tc.format)
+		}
+		if !isHyperlocaliseWholeFileFormat(tc.format) {
+			t.Fatalf("isHyperlocaliseWholeFileFormat(%q) = false, want true", tc.format)
+		}
+		if isHyperlocaliseBinaryFileFormat(tc.format) {
+			t.Fatalf("isHyperlocaliseBinaryFileFormat(%q) = true, want false", tc.format)
+		}
+	}
+	if isHyperlocaliseDocumentFileFormat("json") {
+		t.Fatalf("isHyperlocaliseDocumentFileFormat(json) = true, want false")
+	}
+}
+
 func TestHyperlocalisePullDownloadsTranslationExports(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "locales", "en.json")
@@ -353,11 +380,11 @@ func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
 		t.Fatalf("chdir project dir: %v", err)
 	}
 
-	sourcePath := "_posts/en/hello.md"
-	targetPattern := "_posts/{{target}}/hello.md"
-	targetPath := "_posts/de-DE/hello.md"
-	sourceMarkdown := "# Hello\n\nWorld.\n"
-	writePullSourceFile(t, sourcePath, sourceMarkdown)
+	sourcePath := "locales/en.json"
+	targetPattern := "locales/{{target}}.json"
+	targetPath := "locales/de-DE.json"
+	sourceJSON := `{"hello":"Hello"}`
+	writePullSourceFile(t, sourcePath, sourceJSON)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download") {
@@ -375,7 +402,7 @@ func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
 				Targets: []string{"de-DE"},
 			},
 			Buckets: map[string]config.BucketConfig{
-				"markdown": {
+				"json": {
 					Files: []config.BucketFileMapping{{
 						From: sourcePath,
 						To:   targetPattern,
@@ -405,10 +432,10 @@ func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
 		t.Fatalf("read target: %v", err)
 	}
 	if strings.Contains(string(content), `"md.`) || string(content) == "{}\n" {
-		t.Fatalf("target content = %q, want reconstructed markdown from source", string(content))
+		t.Fatalf("target content = %q, want reconstructed JSON from source", string(content))
 	}
-	if string(content) != sourceMarkdown {
-		t.Fatalf("target content = %q, want source markdown template %q", string(content), sourceMarkdown)
+	if !strings.Contains(string(content), `"hello"`) || !strings.Contains(string(content), `"Hello"`) {
+		t.Fatalf("target content = %q, want source JSON keys reconstructed", string(content))
 	}
 }
 
@@ -425,18 +452,18 @@ func TestHyperlocalisePullSkipsNativeExportWithoutLocalSource(t *testing.T) {
 		t.Fatalf("chdir project dir: %v", err)
 	}
 
-	sourcePath := "_posts/en/hello.md"
-	targetPattern := "_posts/{{target}}/hello.md"
-	targetPath := "_posts/de-DE/hello.md"
+	sourcePath := "locales/en.json"
+	targetPattern := "locales/{{target}}.json"
+	targetPath := "locales/de-DE.json"
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		t.Fatalf("mkdir target dir: %v", err)
 	}
-	existingContent := []byte("# Existing\n")
+	existingContent := []byte(`{"hello":"Existing"}`)
 	if err := os.WriteFile(targetPath, existingContent, 0o644); err != nil {
 		t.Fatalf("write existing target: %v", err)
 	}
 
-	exportBody := []byte("{\n  \"md.0.heading\": \"Bonjour\"\n}\n")
+	exportBody := []byte("{\n  \"hello\": \"Bonjour\"\n}\n")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download") {
 			_, _ = w.Write(exportBody)
@@ -453,7 +480,7 @@ func TestHyperlocalisePullSkipsNativeExportWithoutLocalSource(t *testing.T) {
 				Targets: []string{"de-DE"},
 			},
 			Buckets: map[string]config.BucketConfig{
-				"markdown": {
+				"json": {
 					Files: []config.BucketFileMapping{{
 						From: sourcePath,
 						To:   targetPattern,

--- a/apps/cli/cmd/sync_test.go
+++ b/apps/cli/cmd/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
@@ -367,7 +368,7 @@ func TestHyperlocalisePullFallsBackToExportWithoutLocalSource(t *testing.T) {
 	}
 }
 
-func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
+func TestHyperlocalisePullSkipsMarkdownWithoutStoredVariant(t *testing.T) {
 	dir := t.TempDir()
 	wd, err := os.Getwd()
 	if err != nil {
@@ -386,13 +387,17 @@ func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
 	sourceMarkdown := "# Hello\n\nWorld.\n"
 	writePullSourceFile(t, sourcePath, sourceMarkdown)
 
+	var filesDownloadCount atomic.Int32
+	var translationDownloadCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download"):
+			filesDownloadCount.Add(1)
 			http.NotFound(w, r)
 			return
 		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download"):
-			_, _ = w.Write([]byte("{}\n"))
+			translationDownloadCount.Add(1)
+			t.Fatalf("unexpected translations/download for missing markdown variant")
 			return
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -428,19 +433,17 @@ func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pull empty native export: %v", err)
 	}
-	if report.Downloaded != 1 {
-		t.Fatalf("report = %#v, want one downloaded export", report)
+	if filesDownloadCount.Load() != 1 {
+		t.Fatalf("files/download count = %d, want 1", filesDownloadCount.Load())
 	}
-
-	content, err := os.ReadFile(targetPath)
-	if err != nil {
-		t.Fatalf("read target: %v", err)
+	if translationDownloadCount.Load() != 0 {
+		t.Fatalf("translations/download count = %d, want 0", translationDownloadCount.Load())
 	}
-	if strings.Contains(string(content), `"md.`) || string(content) == "{}\n" {
-		t.Fatalf("target content = %q, want reconstructed markdown from source", string(content))
+	if report.Downloaded != 0 || report.Skipped != 1 {
+		t.Fatalf("report = %#v, want skipped missing markdown variant", report)
 	}
-	if string(content) != sourceMarkdown {
-		t.Fatalf("target content = %q, want source markdown template %q", string(content), sourceMarkdown)
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+		t.Fatalf("stat target = %v, want not exist", err)
 	}
 }
 

--- a/apps/cli/cmd/sync_test.go
+++ b/apps/cli/cmd/sync_test.go
@@ -380,18 +380,23 @@ func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
 		t.Fatalf("chdir project dir: %v", err)
 	}
 
-	sourcePath := "locales/en.json"
-	targetPattern := "locales/{{target}}.json"
-	targetPath := "locales/de-DE.json"
-	sourceJSON := `{"hello":"Hello"}`
-	writePullSourceFile(t, sourcePath, sourceJSON)
+	sourcePath := "_posts/en/hello.md"
+	targetPattern := "_posts/{{target}}/hello.md"
+	targetPath := "_posts/de-DE/hello.md"
+	sourceMarkdown := "# Hello\n\nWorld.\n"
+	writePullSourceFile(t, sourcePath, sourceMarkdown)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download") {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download"):
+			http.NotFound(w, r)
+			return
+		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download"):
 			_, _ = w.Write([]byte("{}\n"))
 			return
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		t.Fatalf("unexpected path: %s", r.URL.Path)
 	}))
 	defer server.Close()
 
@@ -402,7 +407,7 @@ func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
 				Targets: []string{"de-DE"},
 			},
 			Buckets: map[string]config.BucketConfig{
-				"json": {
+				"markdown": {
 					Files: []config.BucketFileMapping{{
 						From: sourcePath,
 						To:   targetPattern,
@@ -432,10 +437,10 @@ func TestHyperlocalisePullWritesEmptyNativeExportFromSource(t *testing.T) {
 		t.Fatalf("read target: %v", err)
 	}
 	if strings.Contains(string(content), `"md.`) || string(content) == "{}\n" {
-		t.Fatalf("target content = %q, want reconstructed JSON from source", string(content))
+		t.Fatalf("target content = %q, want reconstructed markdown from source", string(content))
 	}
-	if !strings.Contains(string(content), `"hello"`) || !strings.Contains(string(content), `"Hello"`) {
-		t.Fatalf("target content = %q, want source JSON keys reconstructed", string(content))
+	if string(content) != sourceMarkdown {
+		t.Fatalf("target content = %q, want source markdown template %q", string(content), sourceMarkdown)
 	}
 }
 
@@ -452,24 +457,29 @@ func TestHyperlocalisePullSkipsNativeExportWithoutLocalSource(t *testing.T) {
 		t.Fatalf("chdir project dir: %v", err)
 	}
 
-	sourcePath := "locales/en.json"
-	targetPattern := "locales/{{target}}.json"
-	targetPath := "locales/de-DE.json"
+	sourcePath := "_posts/en/hello.md"
+	targetPattern := "_posts/{{target}}/hello.md"
+	targetPath := "_posts/de-DE/hello.md"
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		t.Fatalf("mkdir target dir: %v", err)
 	}
-	existingContent := []byte(`{"hello":"Existing"}`)
+	existingContent := []byte("# Existing\n")
 	if err := os.WriteFile(targetPath, existingContent, 0o644); err != nil {
 		t.Fatalf("write existing target: %v", err)
 	}
 
-	exportBody := []byte("{\n  \"hello\": \"Bonjour\"\n}\n")
+	exportBody := []byte("{\n  \"md.0.heading\": \"Bonjour\"\n}\n")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download") {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/files/download"):
+			http.NotFound(w, r)
+			return
+		case strings.HasPrefix(r.URL.Path, "/v1/projects/project-1/translations/download"):
 			_, _ = w.Write(exportBody)
 			return
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		t.Fatalf("unexpected path: %s", r.URL.Path)
 	}))
 	defer server.Close()
 
@@ -480,7 +490,7 @@ func TestHyperlocalisePullSkipsNativeExportWithoutLocalSource(t *testing.T) {
 				Targets: []string{"de-DE"},
 			},
 			Buckets: map[string]config.BucketConfig{
-				"json": {
+				"markdown": {
 					Files: []config.BucketFileMapping{{
 						From: sourcePath,
 						To:   targetPattern,

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -248,10 +248,10 @@ import {
 } from "@/lib/translation/cat";
 import {
   inferSupportedFileTranslationFileFormat,
-  inferSupportedBinaryTranslationFileFormat,
   inferSupportedImageTranslationFileFormat,
   inferSupportedSourceUploadFormat,
   inferSupportedVideoTranslationFileFormat,
+  inferSupportedWholeFileTranslationFileFormat,
   looksLikeImageUrl,
   looksLikeVideoUrl,
 } from "@/lib/translation/file-formats";
@@ -2065,7 +2065,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         // File-backed segments may be locked under sourceFile.id or binary:/image:/video:
         // aliases. Expand aliases before the write so omitting or aliasing externalStringId
         // cannot bypass a lock (status already uses fileBackedCatSegmentIds).
-        const fileBackedSourceFile = inferSupportedBinaryTranslationFileFormat(body.sourcePath)
+        const fileBackedSourceFile = inferSupportedWholeFileTranslationFileFormat(body.sourcePath)
           ? await getRepositorySourceFileByPath({
               organizationId,
               projectId: params.projectId,
@@ -2073,7 +2073,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             })
           : null;
         const isFileBackedAsset = Boolean(
-          inferSupportedBinaryTranslationFileFormat(body.sourcePath),
+          inferSupportedWholeFileTranslationFileFormat(body.sourcePath),
         );
         const lockedImageResponse = await catSegmentLockedResponse(c, {
           organizationId,
@@ -2319,7 +2319,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const organizationId = c.var.auth.organization.localOrganizationId;
         const isFileBackedUpload =
           target.kind !== "provider" &&
-          Boolean(inferSupportedBinaryTranslationFileFormat(sourcePath));
+          Boolean(inferSupportedWholeFileTranslationFileFormat(sourcePath));
         const fileBackedUploadSourceFile = isFileBackedUpload
           ? await getRepositorySourceFileByPath({
               organizationId,
@@ -2518,7 +2518,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           );
         }
 
-        if (inferSupportedBinaryTranslationFileFormat(sourcePath)) {
+        if (inferSupportedWholeFileTranslationFileFormat(sourcePath)) {
           const sourceFile = fileBackedUploadSourceFile;
           if (!sourceFile) {
             return badRequestResponse(
@@ -2724,7 +2724,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           );
         }
 
-        if (inferSupportedBinaryTranslationFileFormat(body.sourcePath)) {
+        if (inferSupportedWholeFileTranslationFileFormat(body.sourcePath)) {
           const result = await updateImageVariantStatus({
             organizationId,
             projectId: params.projectId,

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -705,6 +705,7 @@ export const projectFileCatContentKindSchema = z.enum([
   "video_file",
   "video_url",
   "office_file",
+  "document",
 ]);
 
 export const projectFileCatTranslationSchema = z.object({

--- a/apps/hyperlocalise-web/src/api/routes/public-images/public-images.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-images/public-images.route.test.ts
@@ -83,6 +83,70 @@ describe("publicImageRoutes", () => {
     expect(Buffer.from(await response.arrayBuffer()).toString()).toBe("localized-image-bytes");
   });
 
+  it("downloads stored file variant bytes from files/download", async () => {
+    const { apiKey, project } = await createPublicApiFixture();
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ permissions: [...defaultApiKeyPermissions] })
+      .where(eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)));
+
+    const sourcePath = "docs/intro.md";
+    const markdownBytes = Buffer.from("# Bonjour\n");
+    const storedFile = await createStoredFile({
+      organizationId: project.organizationId,
+      projectId: project.id,
+      role: "output",
+      sourceKind: "job_output",
+      filename: "intro-fr.md",
+      contentType: "text/markdown",
+      content: markdownBytes,
+      adapter: fileStorageAdapter,
+    });
+
+    await db.insert(schema.projectImageVariants).values({
+      organizationId: project.organizationId,
+      projectId: project.id,
+      sourcePath,
+      targetLocale: "fr",
+      storedFileId: storedFile.id,
+      status: "approved",
+      provenance: "import",
+    });
+
+    const response = await client.api.v1.projects[":projectId"].files.download.$get(
+      {
+        param: { projectId: project.id },
+        query: { sourcePath, locale: "fr" },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/markdown");
+    expect(response.headers.get("content-disposition")).toContain("intro-fr.md");
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe("# Bonjour\n");
+  });
+
+  it("returns 404 when the file variant is missing", async () => {
+    const { apiKey, project } = await createPublicApiFixture();
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ permissions: [...defaultApiKeyPermissions] })
+      .where(eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)));
+
+    const response = await client.api.v1.projects[":projectId"].files.download.$get(
+      {
+        param: { projectId: project.id },
+        query: { sourcePath: "docs/missing.md", locale: "fr" },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body).toMatchObject({ error: "file_variant_not_found" });
+  });
+
   it("returns 404 when the image variant is missing", async () => {
     const { apiKey, project } = await createPublicApiFixture();
     await db

--- a/apps/hyperlocalise-web/src/api/routes/public-images/public-images.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-images/public-images.route.ts
@@ -30,6 +30,7 @@ import {
   publicImageProjectParamsSchema,
 } from "./public-images.schema";
 import {
+  fileVariantNotFoundResponse,
   imageVariantNotFoundResponse,
   invalidImagePayloadResponse,
   projectNotFoundResponse,
@@ -62,9 +63,109 @@ type CreatePublicImageRoutesOptions = {
   fileStorageAdapter?: FileStorageAdapter;
 };
 
+type ProjectFileVariantDownload = {
+  body: ReadableStream;
+  contentType: string;
+};
+
+async function loadProjectFileVariant(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  locale: string;
+  fileStorageAdapter?: FileStorageAdapter;
+}): Promise<ProjectFileVariantDownload | null> {
+  const [variant] = await db
+    .select({
+      storedFileId: schema.projectImageVariants.storedFileId,
+    })
+    .from(schema.projectImageVariants)
+    .where(
+      and(
+        eq(schema.projectImageVariants.organizationId, input.organizationId),
+        eq(schema.projectImageVariants.projectId, input.projectId),
+        eq(schema.projectImageVariants.sourcePath, input.sourcePath),
+        eq(schema.projectImageVariants.targetLocale, input.locale),
+      ),
+    )
+    .limit(1);
+
+  if (!variant?.storedFileId) {
+    return null;
+  }
+
+  const [file] = await db
+    .select({
+      storageKey: schema.storedFiles.storageKey,
+      contentType: schema.storedFiles.contentType,
+    })
+    .from(schema.storedFiles)
+    .where(
+      and(
+        eq(schema.storedFiles.id, variant.storedFileId),
+        eq(schema.storedFiles.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1);
+
+  if (!file) {
+    return null;
+  }
+
+  const adapter = input.fileStorageAdapter ?? getFileStorageAdapter();
+  const storedObject = await adapter.get({ keyOrUrl: file.storageKey });
+  if (!storedObject) {
+    return null;
+  }
+
+  return {
+    body: storedObject.body,
+    contentType: storedObject.contentType ?? file.contentType ?? "application/octet-stream",
+  };
+}
+
 export function createPublicImageRoutes(options: CreatePublicImageRoutesOptions = {}) {
   return new Hono<{ Variables: ApiKeyAuthVariables }>()
     .use("*", apiKeyAuthMiddleware)
+    .get(
+      "/:projectId/files/download",
+      requireApiKeyPermission("files:read"),
+      validateProjectParams,
+      validateDownloadQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query = c.req.valid("query");
+        const organizationId = c.var.auth.organization.localOrganizationId;
+
+        const project = await getAccessibleProjectForApiKey(
+          c.var.auth.teamAccess,
+          params.projectId,
+        );
+        if (!project) {
+          return projectNotFoundResponse(c);
+        }
+
+        const stored = await loadProjectFileVariant({
+          organizationId,
+          projectId: project.id,
+          sourcePath: query.sourcePath,
+          locale: query.locale,
+          fileStorageAdapter: options.fileStorageAdapter,
+        });
+        if (!stored) {
+          return fileVariantNotFoundResponse(c);
+        }
+
+        const filename = downloadFilename(query.sourcePath, query.locale);
+        return c.body(stored.body, 200, {
+          "Content-Type": stored.contentType,
+          "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
+          "Content-Security-Policy": "default-src 'none'; sandbox;",
+          "X-Content-Type-Options": "nosniff",
+          "Cache-Control": "no-store",
+        });
+      },
+    )
     .get(
       "/:projectId/images/download",
       requireApiKeyPermission("files:read"),
@@ -83,55 +184,20 @@ export function createPublicImageRoutes(options: CreatePublicImageRoutesOptions 
           return projectNotFoundResponse(c);
         }
 
-        const [variant] = await db
-          .select({
-            storedFileId: schema.projectImageVariants.storedFileId,
-          })
-          .from(schema.projectImageVariants)
-          .where(
-            and(
-              eq(schema.projectImageVariants.organizationId, organizationId),
-              eq(schema.projectImageVariants.projectId, project.id),
-              eq(schema.projectImageVariants.sourcePath, query.sourcePath),
-              eq(schema.projectImageVariants.targetLocale, query.locale),
-            ),
-          )
-          .limit(1);
-
-        if (!variant?.storedFileId) {
-          return imageVariantNotFoundResponse(c);
-        }
-
-        const [file] = await db
-          .select({
-            storageKey: schema.storedFiles.storageKey,
-            filename: schema.storedFiles.filename,
-            contentType: schema.storedFiles.contentType,
-          })
-          .from(schema.storedFiles)
-          .where(
-            and(
-              eq(schema.storedFiles.id, variant.storedFileId),
-              eq(schema.storedFiles.organizationId, organizationId),
-            ),
-          )
-          .limit(1);
-
-        if (!file) {
-          return imageVariantNotFoundResponse(c);
-        }
-
-        const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
-        const storedObject = await adapter.get({ keyOrUrl: file.storageKey });
-        if (!storedObject) {
+        const stored = await loadProjectFileVariant({
+          organizationId,
+          projectId: project.id,
+          sourcePath: query.sourcePath,
+          locale: query.locale,
+          fileStorageAdapter: options.fileStorageAdapter,
+        });
+        if (!stored) {
           return imageVariantNotFoundResponse(c);
         }
 
         const filename = downloadFilename(query.sourcePath, query.locale);
-
-        return c.body(storedObject.body, 200, {
-          "Content-Type":
-            storedObject.contentType ?? file.contentType ?? "application/octet-stream",
+        return c.body(stored.body, 200, {
+          "Content-Type": stored.contentType,
           "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
           "Content-Security-Policy": "default-src 'none'; sandbox;",
           "X-Content-Type-Options": "nosniff",

--- a/apps/hyperlocalise-web/src/api/routes/public-images/public-images.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-images/public-images.shared.ts
@@ -20,6 +20,14 @@ export function projectNotFoundResponse(c: JsonContext) {
   return notFoundResponse(c, "project_not_found");
 }
 
+export function fileVariantNotFoundResponse(c: JsonContext) {
+  return notFoundResponse(
+    c,
+    "file_variant_not_found",
+    "No file is available for this source path and locale.",
+  );
+}
+
 export function imageVariantNotFoundResponse(c: JsonContext) {
   return notFoundResponse(
     c,

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-file-viewer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-file-viewer.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { CatTestProviders } from "@/components/cat/shared/cat-test-utils";
+
+import { CatDocumentFileViewerPane } from "./cat-document-file-viewer";
+
+vi.mock("@/components/markdown-editor/markdown-editor", () => ({
+  MarkdownEditor: ({ value }: { value: string }) => (
+    <textarea aria-label="Translated document" defaultValue={value} />
+  ),
+  MarkdownPreview: ({ value }: { value: string }) => <div>{value}</div>,
+}));
+
+function requestUrl(input: RequestInfo | URL) {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("CatDocumentFileViewerPane", () => {
+  it("seeds from source only when the target file is missing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = requestUrl(input);
+        if (url.includes("source.md")) {
+          return new Response("# Hello from source\n", { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const { rerender } = render(
+      <CatTestProviders>
+        <CatDocumentFileViewerPane
+          role="target"
+          filename="intro.md"
+          seedSrc="https://example.com/source.md"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Translated document")).toHaveValue("# Hello from source\n");
+    });
+
+    rerender(
+      <CatTestProviders>
+        <CatDocumentFileViewerPane
+          role="target"
+          src="https://example.com/target.md"
+          seedSrc="https://example.com/source.md"
+          filename="intro.md"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not load the translated file")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Translated document")).not.toBeInTheDocument();
+  });
+
+  it("keeps an empty successful target instead of seeding source", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = requestUrl(input);
+        if (url.includes("target.md")) {
+          return new Response("", { status: 200 });
+        }
+        return new Response("# Source body\n", { status: 200 });
+      }),
+    );
+
+    render(
+      <CatTestProviders>
+        <CatDocumentFileViewerPane
+          role="target"
+          src="https://example.com/target.md"
+          seedSrc="https://example.com/source.md"
+          filename="intro.md"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Translated document")).toHaveValue("");
+    });
+    expect(screen.queryByDisplayValue("# Source body")).not.toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-file-viewer.tsx
@@ -30,15 +30,21 @@ import { Label } from "@/components/ui/label";
 
 export const CAT_DOCUMENT_FILE_UPLOAD_ACCEPT = ".md,.markdown,.mdx";
 
-async function loadDocumentText(src: string | null | undefined) {
+type LoadedDocument = { status: "missing" } | { status: "ok"; text: string } | { status: "error" };
+
+async function loadDocumentText(src: string | null | undefined): Promise<LoadedDocument> {
   if (!src) {
-    return "";
+    return { status: "missing" };
   }
-  const response = await fetch(src);
-  if (!response.ok) {
-    throw new Error(`document_fetch_${response.status}`);
+  try {
+    const response = await fetch(src);
+    if (!response.ok) {
+      return { status: "error" };
+    }
+    return { status: "ok", text: await response.text() };
+  } catch {
+    return { status: "error" };
   }
-  return response.text();
 }
 
 export function CatDocumentFileViewerPane({
@@ -76,21 +82,28 @@ export function CatDocumentFileViewerPane({
     setIsFetching(true);
     void (async () => {
       try {
-        let loaded = "";
-        try {
-          loaded = await loadDocumentText(src);
-        } catch {
-          loaded = "";
-        }
-        if (!loaded && role === "target") {
-          try {
-            loaded = await loadDocumentText(seedSrc);
-          } catch {
-            loaded = "";
-          }
-        }
+        const primary = await loadDocumentText(src);
         if (cancelled) {
           return;
+        }
+        if (primary.status === "error") {
+          setError(
+            role === "source"
+              ? intl.formatMessage(catFileViewMessages.sourceEmpty)
+              : intl.formatMessage(catFileViewMessages.documentLoadFailed),
+          );
+          return;
+        }
+
+        let loaded = primary.status === "ok" ? primary.text : "";
+        if (primary.status === "missing" && role === "target") {
+          const seed = await loadDocumentText(seedSrc);
+          if (cancelled) {
+            return;
+          }
+          if (seed.status === "ok") {
+            loaded = seed.text;
+          }
         }
         if (!loaded && role === "source") {
           setError(intl.formatMessage(catFileViewMessages.sourceEmpty));

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-file-viewer.tsx
@@ -65,6 +65,7 @@ export function CatDocumentFileViewerPane({
   const [fields, setFields] = useState<CatDocumentFrontmatterField[]>([]);
   const [body, setBody] = useState("");
   const [hasFrontmatter, setHasFrontmatter] = useState(false);
+  const [rawFrontmatter, setRawFrontmatter] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isFetching, setIsFetching] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -99,6 +100,7 @@ export function CatDocumentFileViewerPane({
         setFields(split.fields);
         setBody(split.body);
         setHasFrontmatter(split.hasFrontmatter);
+        setRawFrontmatter(split.rawFrontmatter);
       } catch {
         if (!cancelled) {
           setError(
@@ -129,7 +131,7 @@ export function CatDocumentFileViewerPane({
     }
     setIsSaving(true);
     try {
-      const text = joinCatDocument({ fields, body, hasFrontmatter });
+      const text = joinCatDocument({ fields, body, hasFrontmatter, rawFrontmatter });
       const file = new File([text], filename, { type: "text/markdown" });
       await onSave(file);
     } finally {

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-file-viewer.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FloppyDiskIcon, Loading03Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import {
+  joinCatDocument,
+  splitCatDocument,
+  type CatDocumentFrontmatterField,
+} from "@/components/cat/file-view/cat-document-frontmatter";
+import { catFileViewMessages } from "@/components/cat/file-view/cat-file-view.messages";
+import { MarkdownEditor, MarkdownPreview } from "@/components/markdown-editor/markdown-editor";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export const CAT_DOCUMENT_FILE_UPLOAD_ACCEPT = ".md,.markdown,.mdx";
+
+async function loadDocumentText(src: string | null | undefined) {
+  if (!src) {
+    return "";
+  }
+  const response = await fetch(src);
+  if (!response.ok) {
+    throw new Error(`document_fetch_${response.status}`);
+  }
+  return response.text();
+}
+
+export function CatDocumentFileViewerPane({
+  role,
+  src,
+  seedSrc,
+  filename,
+  isLoading,
+  canEdit = true,
+  isBusy = false,
+  onSave,
+}: {
+  role: "source" | "target";
+  src?: string | null;
+  seedSrc?: string | null;
+  filename: string;
+  isLoading?: boolean;
+  canEdit?: boolean;
+  isBusy?: boolean;
+  onSave?: (file: File) => void | Promise<void>;
+}) {
+  const intl = useIntl();
+  const readOnly = role === "source" || !canEdit;
+  const [fields, setFields] = useState<CatDocumentFrontmatterField[]>([]);
+  const [body, setBody] = useState("");
+  const [hasFrontmatter, setHasFrontmatter] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isFetching, setIsFetching] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    setIsFetching(true);
+    void (async () => {
+      try {
+        let loaded = "";
+        try {
+          loaded = await loadDocumentText(src);
+        } catch {
+          loaded = "";
+        }
+        if (!loaded && role === "target") {
+          try {
+            loaded = await loadDocumentText(seedSrc);
+          } catch {
+            loaded = "";
+          }
+        }
+        if (cancelled) {
+          return;
+        }
+        if (!loaded && role === "source") {
+          setError(intl.formatMessage(catFileViewMessages.sourceEmpty));
+          return;
+        }
+        const split = splitCatDocument(loaded);
+        setFields(split.fields);
+        setBody(split.body);
+        setHasFrontmatter(split.hasFrontmatter);
+      } catch {
+        if (!cancelled) {
+          setError(
+            role === "source"
+              ? intl.formatMessage(catFileViewMessages.sourceEmpty)
+              : intl.formatMessage(catFileViewMessages.targetEmpty),
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsFetching(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [intl, role, seedSrc, src]);
+
+  const emptyLabel =
+    role === "source"
+      ? intl.formatMessage(catFileViewMessages.sourceEmpty)
+      : intl.formatMessage(catFileViewMessages.targetEmpty);
+
+  async function handleSave() {
+    if (!onSave || readOnly) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const text = joinCatDocument({ fields, body, hasFrontmatter });
+      const file = new File([text], filename, { type: "text/markdown" });
+      await onSave(file);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const showSpinner = isLoading || isFetching;
+
+  return (
+    <div className="flex min-h-56 flex-col gap-3 rounded-lg border border-border bg-background p-3">
+      {showSpinner ? (
+        <div className="flex min-h-56 items-center justify-center text-muted-foreground">
+          <HugeiconsIcon icon={Loading03Icon} className="size-5 animate-spin" aria-hidden />
+        </div>
+      ) : error ? (
+        <div className="flex min-h-56 items-center justify-center px-4 text-center text-sm text-muted-foreground">
+          {error}
+        </div>
+      ) : !src && role === "source" ? (
+        <div className="flex min-h-56 items-center justify-center px-4 text-center text-sm text-muted-foreground">
+          {emptyLabel}
+        </div>
+      ) : (
+        <>
+          {hasFrontmatter ? (
+            <div className="space-y-2">
+              <h4 className="text-xs font-medium text-muted-foreground">
+                <FormattedMessage {...catFileViewMessages.documentFrontmatter} />
+              </h4>
+              <div className="grid gap-2">
+                {fields.map((field, index) => (
+                  <div key={`${field.key}-${index}`} className="grid gap-1">
+                    <Label htmlFor={`cat-document-field-${role}-${field.key}`} className="text-xs">
+                      {field.key}
+                    </Label>
+                    <Input
+                      id={`cat-document-field-${role}-${field.key}`}
+                      value={field.value}
+                      disabled={readOnly}
+                      onChange={(event) => {
+                        const value = event.currentTarget.value;
+                        setFields((current) =>
+                          current.map((entry, entryIndex) =>
+                            entryIndex === index ? { ...entry, value } : entry,
+                          ),
+                        );
+                      }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex min-h-0 flex-1 flex-col gap-2">
+            {hasFrontmatter ? (
+              <h4 className="text-xs font-medium text-muted-foreground">
+                <FormattedMessage {...catFileViewMessages.documentBody} />
+              </h4>
+            ) : null}
+            {readOnly ? (
+              <MarkdownPreview value={body} className="min-h-[16rem]" emptyMessage={emptyLabel} />
+            ) : (
+              <MarkdownEditor
+                value={body}
+                onChange={setBody}
+                className="min-h-[16rem]"
+                ariaLabel={intl.formatMessage(catFileViewMessages.documentEditorAria)}
+              />
+            )}
+          </div>
+
+          {onSave && !readOnly ? (
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={isBusy || isSaving}
+                onClick={() => void handleSave()}
+              >
+                {isBusy || isSaving ? (
+                  <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin" aria-hidden />
+                ) : (
+                  <HugeiconsIcon icon={FloppyDiskIcon} className="size-3" aria-hidden />
+                )}
+                <FormattedMessage {...catFileViewMessages.saveEdits} />
+              </Button>
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
@@ -153,9 +153,7 @@ draft: "true"
   it("decodes escaped newlines in double-quoted YAML scalars", () => {
     const rawFrontmatter = `title: "Line\\nOne"`;
     const split = splitCatDocument(`---\n${rawFrontmatter}\n---\n\n# Hello\n`);
-    expect(split.fields).toEqual([
-      { key: "title", value: "Line\nOne", rawValue: '"Line\\nOne"' },
-    ]);
+    expect(split.fields).toEqual([{ key: "title", value: "Line\nOne", rawValue: '"Line\\nOne"' }]);
     expect(
       joinCatDocument({
         hasFrontmatter: true,
@@ -188,9 +186,7 @@ title: "Line\\nTwo"
   it("unescapes doubled single quotes in YAML scalars", () => {
     const rawFrontmatter = `title: 'It''s fine'`;
     const split = splitCatDocument(`---\n${rawFrontmatter}\n---\n\n# Hello\n`);
-    expect(split.fields).toEqual([
-      { key: "title", value: "It's fine", rawValue: "'It''s fine'" },
-    ]);
+    expect(split.fields).toEqual([{ key: "title", value: "It's fine", rawValue: "'It''s fine'" }]);
     expect(
       joinCatDocument({
         hasFrontmatter: true,

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
@@ -149,4 +149,59 @@ draft: "true"
 # Hello
 `);
   });
+
+  it("decodes escaped newlines in double-quoted YAML scalars", () => {
+    const rawFrontmatter = `title: "Line\\nOne"`;
+    const split = splitCatDocument(`---\n${rawFrontmatter}\n---\n\n# Hello\n`);
+    expect(split.fields).toEqual([
+      { key: "title", value: "Line\nOne", rawValue: '"Line\\nOne"' },
+    ]);
+    expect(
+      joinCatDocument({
+        hasFrontmatter: true,
+        fields: split.fields,
+        body: "# Hello\n",
+        rawFrontmatter: split.rawFrontmatter,
+      }),
+    ).toBe(`---
+title: "Line\\nOne"
+---
+# Hello
+`);
+  });
+
+  it("rewrites an edited multiline YAML scalar with JSON-style escapes", () => {
+    expect(
+      joinCatDocument({
+        hasFrontmatter: true,
+        fields: [{ key: "title", value: "Line\nTwo", rawValue: '"Line\\nOne"' }],
+        body: "# Hello\n",
+        rawFrontmatter: `title: "Line\\nOne"`,
+      }),
+    ).toBe(`---
+title: "Line\\nTwo"
+---
+# Hello
+`);
+  });
+
+  it("unescapes doubled single quotes in YAML scalars", () => {
+    const rawFrontmatter = `title: 'It''s fine'`;
+    const split = splitCatDocument(`---\n${rawFrontmatter}\n---\n\n# Hello\n`);
+    expect(split.fields).toEqual([
+      { key: "title", value: "It's fine", rawValue: "'It''s fine'" },
+    ]);
+    expect(
+      joinCatDocument({
+        hasFrontmatter: true,
+        fields: split.fields,
+        body: "# Hello\n",
+        rawFrontmatter: split.rawFrontmatter,
+      }),
+    ).toBe(`---
+title: 'It''s fine'
+---
+# Hello
+`);
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
@@ -20,19 +20,45 @@ describe("splitCatDocument", () => {
       fields: [],
       body: "# Hello\n\nBody.\n",
       hasFrontmatter: false,
+      rawFrontmatter: "",
     });
   });
 
   it("extracts scalar frontmatter fields and leaves the body for TipTap", () => {
-    expect(
-      splitCatDocument("---\ntitle: Docs\ndescription: Intro page\n---\n\n# Hello\n"),
-    ).toEqual({
-      fields: [
-        { key: "title", value: "Docs" },
-        { key: "description", value: "Intro page" },
-      ],
+    expect(splitCatDocument("---\ntitle: Docs\ndescription: Intro page\n---\n\n# Hello\n")).toEqual(
+      {
+        fields: [
+          { key: "title", value: "Docs" },
+          { key: "description", value: "Intro page" },
+        ],
+        body: "\n# Hello\n",
+        hasFrontmatter: true,
+        rawFrontmatter: "title: Docs\ndescription: Intro page",
+      },
+    );
+  });
+
+  it("keeps nested YAML, lists, and comments out of editable fields", () => {
+    const text = `---
+title: Docs
+# keep this comment
+tags:
+  - one
+  - two
+authors:
+  - name: Ada
+description: |
+  Multi-line
+---
+
+# Hello
+`;
+    expect(splitCatDocument(text)).toEqual({
+      fields: [{ key: "title", value: "Docs" }],
       body: "\n# Hello\n",
       hasFrontmatter: true,
+      rawFrontmatter:
+        "title: Docs\n# keep this comment\ntags:\n  - one\n  - two\nauthors:\n  - name: Ada\ndescription: |\n  Multi-line",
     });
   });
 });
@@ -56,5 +82,37 @@ describe("joinCatDocument", () => {
         body: "# Hello\n",
       }),
     ).toBe("# Hello\n");
+  });
+
+  it("patches scalar fields without dropping nested YAML or comments", () => {
+    const rawFrontmatter = `title: Docs
+# keep this comment
+tags:
+  - one
+  - two
+authors:
+  - name: Ada
+description: |
+  Multi-line`;
+    expect(
+      joinCatDocument({
+        hasFrontmatter: true,
+        fields: [{ key: "title", value: "Guides" }],
+        body: "# Hello\n",
+        rawFrontmatter,
+      }),
+    ).toBe(`---
+title: Guides
+# keep this comment
+tags:
+  - one
+  - two
+authors:
+  - name: Ada
+description: |
+  Multi-line
+---
+# Hello
+`);
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { joinCatDocument, splitCatDocument } from "./cat-document-frontmatter";
+
+describe("splitCatDocument", () => {
+  it("returns the full text as body when there is no frontmatter", () => {
+    expect(splitCatDocument("# Hello\n\nBody.\n")).toEqual({
+      fields: [],
+      body: "# Hello\n\nBody.\n",
+      hasFrontmatter: false,
+    });
+  });
+
+  it("extracts scalar frontmatter fields and leaves the body for TipTap", () => {
+    expect(
+      splitCatDocument("---\ntitle: Docs\ndescription: Intro page\n---\n\n# Hello\n"),
+    ).toEqual({
+      fields: [
+        { key: "title", value: "Docs" },
+        { key: "description", value: "Intro page" },
+      ],
+      body: "\n# Hello\n",
+      hasFrontmatter: true,
+    });
+  });
+});
+
+describe("joinCatDocument", () => {
+  it("reconstructs a markdown file from fields and body", () => {
+    expect(
+      joinCatDocument({
+        hasFrontmatter: true,
+        fields: [{ key: "title", value: "Docs" }],
+        body: "# Hello\n",
+      }),
+    ).toBe("---\ntitle: Docs\n---\n# Hello\n");
+  });
+
+  it("leaves body-only documents unchanged", () => {
+    expect(
+      joinCatDocument({
+        hasFrontmatter: false,
+        fields: [],
+        body: "# Hello\n",
+      }),
+    ).toBe("# Hello\n");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.test.ts
@@ -28,8 +28,8 @@ describe("splitCatDocument", () => {
     expect(splitCatDocument("---\ntitle: Docs\ndescription: Intro page\n---\n\n# Hello\n")).toEqual(
       {
         fields: [
-          { key: "title", value: "Docs" },
-          { key: "description", value: "Intro page" },
+          { key: "title", value: "Docs", rawValue: "Docs" },
+          { key: "description", value: "Intro page", rawValue: "Intro page" },
         ],
         body: "\n# Hello\n",
         hasFrontmatter: true,
@@ -54,7 +54,7 @@ description: |
 # Hello
 `;
     expect(splitCatDocument(text)).toEqual({
-      fields: [{ key: "title", value: "Docs" }],
+      fields: [{ key: "title", value: "Docs", rawValue: "Docs" }],
       body: "\n# Hello\n",
       hasFrontmatter: true,
       rawFrontmatter:
@@ -111,6 +111,40 @@ authors:
   - name: Ada
 description: |
   Multi-line
+---
+# Hello
+`);
+  });
+
+  it("keeps original quoting for untouched scalars", () => {
+    const rawFrontmatter = `title: "true"
+code: "001"`;
+    const split = splitCatDocument(`---\n${rawFrontmatter}\n---\n\n# Hello\n`);
+    expect(
+      joinCatDocument({
+        hasFrontmatter: true,
+        fields: split.fields,
+        body: "# Hello\n",
+        rawFrontmatter: split.rawFrontmatter,
+      }),
+    ).toBe(`---
+title: "true"
+code: "001"
+---
+# Hello
+`);
+  });
+
+  it("quotes edited values that would change YAML type", () => {
+    expect(
+      joinCatDocument({
+        hasFrontmatter: true,
+        fields: [{ key: "draft", value: "true", rawValue: "false" }],
+        body: "# Hello\n",
+        rawFrontmatter: "draft: false",
+      }),
+    ).toBe(`---
+draft: "true"
 ---
 # Hello
 `);

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.ts
@@ -130,13 +130,31 @@ function patchRawFrontmatter(raw: string, fields: CatDocumentFrontmatterField[])
     .join("\n");
 }
 
+function unescapeDoubleQuotedYaml(inner: string) {
+  return inner
+    .replaceAll("\\\\", "\u0000")
+    .replaceAll("\\n", "\n")
+    .replaceAll("\\t", "\t")
+    .replaceAll("\\r", "\r")
+    .replaceAll('\\"', '"')
+    .replaceAll("\u0000", "\\");
+}
+
 function unquoteYamlScalar(value: string) {
   const trimmed = value.trim();
-  if (
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
-    return trimmed.slice(1, -1);
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed === "string") {
+        return parsed;
+      }
+    } catch {
+      // YAML double-quoted scalars are JSON-like; fall back to common escapes.
+    }
+    return unescapeDoubleQuotedYaml(trimmed.slice(1, -1));
+  }
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replaceAll("''", "'");
   }
   return trimmed;
 }
@@ -145,7 +163,7 @@ function quoteYamlScalar(value: string) {
   if (
     value === "" ||
     value !== value.trim() ||
-    /[:#{}[\],&*?|<>=!%@`]/.test(value) ||
+    /[\n\r\t:#{}[\],&*?|<>=!%@`]/.test(value) ||
     isYamlAmbiguousScalar(value)
   ) {
     return JSON.stringify(value);

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+const SIMPLE_FIELD_PATTERN = /^([A-Za-z0-9_-]+):\s*(.*)$/;
+
+export type CatDocumentFrontmatterField = {
+  key: string;
+  value: string;
+};
+
+export type SplitCatDocument = {
+  fields: CatDocumentFrontmatterField[];
+  body: string;
+  hasFrontmatter: boolean;
+};
+
+export function splitCatDocument(text: string): SplitCatDocument {
+  const match = FRONTMATTER_PATTERN.exec(text);
+  if (!match) {
+    return { fields: [], body: text, hasFrontmatter: false };
+  }
+
+  const raw = match[1] ?? "";
+  const fields: CatDocumentFrontmatterField[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    const field = SIMPLE_FIELD_PATTERN.exec(line);
+    if (!field) {
+      continue;
+    }
+    fields.push({ key: field[1] ?? "", value: unquoteYamlScalar(field[2] ?? "") });
+  }
+
+  return {
+    fields,
+    body: text.slice(match[0].length),
+    hasFrontmatter: true,
+  };
+}
+
+export function joinCatDocument(input: {
+  fields: CatDocumentFrontmatterField[];
+  body: string;
+  hasFrontmatter: boolean;
+}): string {
+  const body = input.body.replace(/^\n+/, "");
+  if (!input.hasFrontmatter) {
+    return input.body;
+  }
+
+  const yaml = input.fields
+    .filter((field) => field.key.trim().length > 0)
+    .map((field) => `${field.key}: ${quoteYamlScalar(field.value)}`)
+    .join("\n");
+
+  if (!yaml) {
+    return `---\n---\n${body}`;
+  }
+
+  return `---\n${yaml}\n---\n${body}`;
+}
+
+function unquoteYamlScalar(value: string) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function quoteYamlScalar(value: string) {
+  if (value === "" || /[:#{}[\],&*?|<>=!%@`]/.test(value) || value !== value.trim()) {
+    return JSON.stringify(value);
+  }
+  return value;
+}

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.ts
@@ -17,6 +17,7 @@ const SIMPLE_FIELD_PATTERN = /^([A-Za-z0-9_-]+):\s*(.*)$/;
 export type CatDocumentFrontmatterField = {
   key: string;
   value: string;
+  rawValue?: string;
 };
 
 export type SplitCatDocument = {
@@ -87,7 +88,7 @@ function parseEditableScalarLine(line: string): CatDocumentFrontmatterField | nu
   if (!isPlainYamlScalar(rawValue)) {
     return null;
   }
-  return { key: field[1] ?? "", value: unquoteYamlScalar(rawValue) };
+  return { key: field[1] ?? "", value: unquoteYamlScalar(rawValue), rawValue };
 }
 
 function isPlainYamlScalar(value: string) {
@@ -111,16 +112,20 @@ function patchRawFrontmatter(raw: string, fields: CatDocumentFrontmatterField[])
   const valuesByKey = new Map(
     fields
       .filter((field) => field.key.trim().length > 0)
-      .map((field) => [field.key, field.value] as const),
+      .map((field) => [field.key, field] as const),
   );
   return raw
     .split(/\r?\n/)
     .map((line) => {
       const field = parseEditableScalarLine(line);
-      if (!field || !valuesByKey.has(field.key)) {
+      const next = field ? valuesByKey.get(field.key) : undefined;
+      if (!field || !next) {
         return line;
       }
-      return `${field.key}: ${quoteYamlScalar(valuesByKey.get(field.key) ?? "")}`;
+      if (next.value === field.value) {
+        return line;
+      }
+      return `${field.key}: ${quoteYamlScalar(next.value)}`;
     })
     .join("\n");
 }
@@ -137,8 +142,23 @@ function unquoteYamlScalar(value: string) {
 }
 
 function quoteYamlScalar(value: string) {
-  if (value === "" || /[:#{}[\],&*?|<>=!%@`]/.test(value) || value !== value.trim()) {
+  if (
+    value === "" ||
+    value !== value.trim() ||
+    /[:#{}[\],&*?|<>=!%@`]/.test(value) ||
+    isYamlAmbiguousScalar(value)
+  ) {
     return JSON.stringify(value);
   }
   return value;
+}
+
+function isYamlAmbiguousScalar(value: string) {
+  if (/^(?:true|false|null|yes|no|on|off|~)$/i.test(value)) {
+    return true;
+  }
+  if (/^-?0\d/.test(value)) {
+    return true;
+  }
+  return /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(value);
 }

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-document-frontmatter.ts
@@ -23,31 +23,30 @@ export type SplitCatDocument = {
   fields: CatDocumentFrontmatterField[];
   body: string;
   hasFrontmatter: boolean;
+  rawFrontmatter: string;
 };
 
 export function splitCatDocument(text: string): SplitCatDocument {
   const match = FRONTMATTER_PATTERN.exec(text);
   if (!match) {
-    return { fields: [], body: text, hasFrontmatter: false };
+    return { fields: [], body: text, hasFrontmatter: false, rawFrontmatter: "" };
   }
 
-  const raw = match[1] ?? "";
+  const rawFrontmatter = match[1] ?? "";
   const fields: CatDocumentFrontmatterField[] = [];
-  for (const line of raw.split(/\r?\n/)) {
-    if (!line.trim()) {
-      continue;
-    }
-    const field = SIMPLE_FIELD_PATTERN.exec(line);
+  for (const line of rawFrontmatter.split(/\r?\n/)) {
+    const field = parseEditableScalarLine(line);
     if (!field) {
       continue;
     }
-    fields.push({ key: field[1] ?? "", value: unquoteYamlScalar(field[2] ?? "") });
+    fields.push(field);
   }
 
   return {
     fields,
     body: text.slice(match[0].length),
     hasFrontmatter: true,
+    rawFrontmatter,
   };
 }
 
@@ -55,22 +54,75 @@ export function joinCatDocument(input: {
   fields: CatDocumentFrontmatterField[];
   body: string;
   hasFrontmatter: boolean;
+  rawFrontmatter?: string;
 }): string {
   const body = input.body.replace(/^\n+/, "");
   if (!input.hasFrontmatter) {
     return input.body;
   }
 
-  const yaml = input.fields
-    .filter((field) => field.key.trim().length > 0)
-    .map((field) => `${field.key}: ${quoteYamlScalar(field.value)}`)
-    .join("\n");
+  const yaml = input.rawFrontmatter
+    ? patchRawFrontmatter(input.rawFrontmatter, input.fields)
+    : input.fields
+        .filter((field) => field.key.trim().length > 0)
+        .map((field) => `${field.key}: ${quoteYamlScalar(field.value)}`)
+        .join("\n");
 
   if (!yaml) {
     return `---\n---\n${body}`;
   }
 
   return `---\n${yaml}\n---\n${body}`;
+}
+
+function parseEditableScalarLine(line: string): CatDocumentFrontmatterField | null {
+  if (/^\s/.test(line)) {
+    return null;
+  }
+  const field = SIMPLE_FIELD_PATTERN.exec(line);
+  if (!field) {
+    return null;
+  }
+  const rawValue = (field[2] ?? "").trim();
+  if (!isPlainYamlScalar(rawValue)) {
+    return null;
+  }
+  return { key: field[1] ?? "", value: unquoteYamlScalar(rawValue) };
+}
+
+function isPlainYamlScalar(value: string) {
+  if (!value) {
+    return false;
+  }
+  if (
+    value.startsWith("|") ||
+    value.startsWith(">") ||
+    value.startsWith("[") ||
+    value.startsWith("{") ||
+    value.startsWith("&") ||
+    value.startsWith("*")
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function patchRawFrontmatter(raw: string, fields: CatDocumentFrontmatterField[]) {
+  const valuesByKey = new Map(
+    fields
+      .filter((field) => field.key.trim().length > 0)
+      .map((field) => [field.key, field.value] as const),
+  );
+  return raw
+    .split(/\r?\n/)
+    .map((line) => {
+      const field = parseEditableScalarLine(line);
+      if (!field || !valuesByKey.has(field.key)) {
+        return line;
+      }
+      return `${field.key}: ${quoteYamlScalar(valuesByKey.get(field.key) ?? "")}`;
+    })
+    .join("\n");
 }
 
 function unquoteYamlScalar(value: string) {

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
@@ -40,7 +40,10 @@ import { cn } from "@/lib/primitives/cn";
 import { catFileViewMessages } from "./cat-file-view.messages";
 import { CAT_IMAGE_FILE_UPLOAD_ACCEPT, CatImageFileViewerPane } from "./cat-image-file-viewer";
 import { CAT_VIDEO_FILE_UPLOAD_ACCEPT, CatVideoFileViewerPane } from "./cat-video-file-viewer";
-import { CAT_DOCUMENT_FILE_UPLOAD_ACCEPT, CatDocumentFileViewerPane } from "./cat-document-file-viewer";
+import {
+  CAT_DOCUMENT_FILE_UPLOAD_ACCEPT,
+  CatDocumentFileViewerPane,
+} from "./cat-document-file-viewer";
 import { catOfficeUploadAccept } from "./cat-office-mime";
 import type { CatOfficeKind } from "./cat-office-convert";
 

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
@@ -40,6 +40,7 @@ import { cn } from "@/lib/primitives/cn";
 import { catFileViewMessages } from "./cat-file-view.messages";
 import { CAT_IMAGE_FILE_UPLOAD_ACCEPT, CatImageFileViewerPane } from "./cat-image-file-viewer";
 import { CAT_VIDEO_FILE_UPLOAD_ACCEPT, CatVideoFileViewerPane } from "./cat-video-file-viewer";
+import { CAT_DOCUMENT_FILE_UPLOAD_ACCEPT, CatDocumentFileViewerPane } from "./cat-document-file-viewer";
 import { catOfficeUploadAccept } from "./cat-office-mime";
 import type { CatOfficeKind } from "./cat-office-convert";
 
@@ -109,14 +110,18 @@ export function CatFileViewPanel({
       ? CAT_IMAGE_FILE_UPLOAD_ACCEPT
       : viewerId === "video"
         ? CAT_VIDEO_FILE_UPLOAD_ACCEPT
-        : catOfficeUploadAccept(viewerId);
+        : viewerId === "markdown"
+          ? CAT_DOCUMENT_FILE_UPLOAD_ACCEPT
+          : catOfficeUploadAccept(viewerId);
   const displayName = segment.sourcePath || filename || segment.key;
   const officeKind = isOfficeViewerId(viewerId) ? viewerId : null;
   const isMediaViewer = viewerId === "image" || viewerId === "video";
+  const isDocumentViewer = viewerId === "markdown";
 
-  const sourceSrc = isMediaViewer || officeKind ? (segment.sourceAssetUrl ?? null) : null;
+  const sourceSrc =
+    isMediaViewer || officeKind || isDocumentViewer ? (segment.sourceAssetUrl ?? null) : null;
   const targetSrc =
-    isMediaViewer || officeKind
+    isMediaViewer || officeKind || isDocumentViewer
       ? (segment.targetAssetUrl ??
         (/^https?:\/\//i.test(segment.targetText) ? segment.targetText : null))
       : null;
@@ -251,6 +256,17 @@ export function CatFileViewPanel({
                 isBusy={isImageBusy}
                 onSave={onUpload}
               />
+            ) : isDocumentViewer ? (
+              <CatDocumentFileViewerPane
+                role="target"
+                src={targetSrc}
+                seedSrc={sourceSrc}
+                filename={displayName}
+                isLoading={isSegmentTargetLoading}
+                canEdit={canEdit}
+                isBusy={isImageBusy}
+                onSave={onUpload}
+              />
             ) : (
               <UnsupportedPreview />
             )}
@@ -271,6 +287,13 @@ export function CatFileViewPanel({
             ) : officeKind ? (
               <CatOfficeFileViewerPane
                 kind={officeKind}
+                role="source"
+                src={sourceSrc}
+                filename={displayName}
+                canEdit={false}
+              />
+            ) : isDocumentViewer ? (
+              <CatDocumentFileViewerPane
                 role="source"
                 src={sourceSrc}
                 filename={displayName}

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
@@ -62,17 +62,17 @@ export const catFileViewMessages = defineMessages({
   },
   documentFrontmatter: {
     defaultMessage: "Frontmatter",
-    id: "catDocFmHd",
+    id: "8Y86+IM3Ps",
     description: "Heading for YAML frontmatter fields in the CAT document editor",
   },
   documentBody: {
     defaultMessage: "Body",
-    id: "catDocBdHd",
+    id: "90JdQQe9zz",
     description: "Heading for the Markdown/MDX body editor in CAT document view",
   },
   documentEditorAria: {
     defaultMessage: "Translated document",
-    id: "catDocEdAr",
+    id: "ztZNSXlXOQ",
     description: "Accessible label for the TipTap document editor in CAT File view",
   },
   imageSourceAlt: {

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
@@ -60,6 +60,11 @@ export const catFileViewMessages = defineMessages({
     id: "3wxYCVb3wu",
     description: "Empty state when the CAT File view target preview has no file",
   },
+  documentLoadFailed: {
+    defaultMessage: "Could not load the translated file",
+    id: "GYiDdOqYU0",
+    description: "Error when CAT document viewer fails to fetch an existing target file",
+  },
   documentFrontmatter: {
     defaultMessage: "Frontmatter",
     id: "8Y86+IM3Ps",

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
@@ -60,6 +60,21 @@ export const catFileViewMessages = defineMessages({
     id: "3wxYCVb3wu",
     description: "Empty state when the CAT File view target preview has no file",
   },
+  documentFrontmatter: {
+    defaultMessage: "Frontmatter",
+    id: "catDocFmHd",
+    description: "Heading for YAML frontmatter fields in the CAT document editor",
+  },
+  documentBody: {
+    defaultMessage: "Body",
+    id: "catDocBdHd",
+    description: "Heading for the Markdown/MDX body editor in CAT document view",
+  },
+  documentEditorAria: {
+    defaultMessage: "Translated document",
+    id: "catDocEdAr",
+    description: "Accessible label for the TipTap document editor in CAT File view",
+  },
   imageSourceAlt: {
     defaultMessage: "Source image",
     id: "86pJK6MuXF",

--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issue-translation-key.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issue-translation-key.test.ts
@@ -60,6 +60,13 @@ describe("resolveCatLinkedIssueTranslationKeyId", () => {
         contentKind: "office_file",
       }),
     ).toBeNull();
+    expect(
+      resolveCatLinkedIssueTranslationKeyId({
+        isNativeProject: true,
+        segmentId: "source-file-1",
+        contentKind: "document",
+      }),
+    ).toBeNull();
   });
 
   it("returns null for provider-backed projects", () => {

--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issue-translation-key.ts
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-linked-issue-translation-key.ts
@@ -18,6 +18,7 @@ const FILE_BACKED_CONTENT_KINDS = new Set<NonNullable<CatSegment["contentKind"]>
   "image_file",
   "video_file",
   "office_file",
+  "document",
 ]);
 
 export function isFileBackedCatSegment(contentKind: CatSegment["contentKind"]) {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -373,7 +373,8 @@ export function ProjectFileCatWorkspace({
       if (
         segment?.contentKind === "image_file" ||
         segment?.contentKind === "video_file" ||
-        segment?.contentKind === "office_file"
+        segment?.contentKind === "office_file" ||
+        segment?.contentKind === "document"
       ) {
         const response = await apiClient.api.orgs[":organizationSlug"].projects[
           ":projectId"

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -18,7 +18,8 @@ export type CatContentKind =
   | "image_url"
   | "video_file"
   | "video_url"
-  | "office_file";
+  | "office_file"
+  | "document";
 
 export type CatSegmentStatus = "pending" | "needs_review" | "reviewed" | "skipped";
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.test.ts
@@ -104,6 +104,24 @@ describe("cat-file-view-capabilities", () => {
     ).toBe("office");
   });
 
+  it("defaults markdown and mdx to file view with the document editor", () => {
+    expect(resolveCatFileViewCapabilities({ sourcePath: "docs/intro.md" })).toEqual({
+      family: "document",
+      availableViews: ["file"],
+      defaultView: "file",
+      viewerId: "markdown",
+    });
+    expect(resolveCatFileViewCapabilities({ sourcePath: "docs/page.mdx" }).viewerId).toBe(
+      "markdown",
+    );
+    expect(
+      resolveCatFileViewCapabilities({
+        sourcePath: "CAT_ALL_FILES",
+        contentKind: "document",
+      }).family,
+    ).toBe("document");
+  });
+
   it("clamps disallowed modes to the family default", () => {
     const text = resolveCatFileViewCapabilities({ sourcePath: "a.json" });
     expect(clampCatWorkspaceViewMode("file", text)).toBe("comfortable");

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.ts
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import {
+  inferSupportedDocumentTranslationFileFormat,
   inferSupportedImageTranslationFileFormat,
   inferSupportedOfficeTranslationFileFormat,
   inferSupportedVideoTranslationFileFormat,
@@ -19,9 +20,9 @@ import {
 import type { CatContentKind } from "@/components/cat/shared/types";
 import type { CatWorkspaceViewMode } from "./cat-workspace-view-mode";
 
-export type CatFileViewFamily = "image" | "video" | "text" | "office";
+export type CatFileViewFamily = "image" | "video" | "text" | "office" | "document";
 
-export type CatFileViewerId = "image" | "video" | "docx" | "xlsx" | "pptx";
+export type CatFileViewerId = "image" | "video" | "docx" | "xlsx" | "pptx" | "markdown";
 
 export type CatFileViewCapabilities = {
   family: CatFileViewFamily;
@@ -41,6 +42,7 @@ const IMAGE_VIEWS = [
 ] as const satisfies readonly CatWorkspaceViewMode[];
 const VIDEO_VIEWS = IMAGE_VIEWS;
 const OFFICE_VIEWS = ["file"] as const satisfies readonly CatWorkspaceViewMode[];
+const DOCUMENT_VIEWS = ["file"] as const satisfies readonly CatWorkspaceViewMode[];
 
 function extensionOf(sourcePath: string): string | null {
   const basename = sourcePath.split(/[\\/]/).pop() ?? sourcePath;
@@ -99,6 +101,15 @@ export function resolveCatFileViewCapabilities(input: {
       availableViews: OFFICE_VIEWS,
       defaultView: "file",
       viewerId: officeViewerIdForExtension(extension) ?? "docx",
+    };
+  }
+
+  if (contentKind === "document" || inferSupportedDocumentTranslationFileFormat(sourcePath)) {
+    return {
+      family: "document",
+      availableViews: DOCUMENT_VIEWS,
+      defaultView: "file",
+      viewerId: "markdown",
     };
   }
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
@@ -103,6 +103,7 @@ export class CatReviewController {
             segment.contentKind === "image_file" ||
             segment.contentKind === "video_file" ||
             segment.contentKind === "office_file" ||
+            segment.contentKind === "document" ||
             segment.contentKind === "image_url" ||
             segment.contentKind === "video_url"
           ) {

--- a/apps/hyperlocalise-web/src/lib/projects/cat/external-cat-string-overlay-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/external-cat-string-overlay-service.ts
@@ -143,7 +143,14 @@ export async function getExternalCatStringOverlay(input: {
 export function enrichExternalCatSegmentImageFields<
   T extends {
     sourceText: string;
-    contentKind?: "text" | "image_file" | "image_url" | "video_file" | "video_url" | "office_file";
+    contentKind?:
+      | "text"
+      | "image_file"
+      | "image_url"
+      | "video_file"
+      | "video_url"
+      | "office_file"
+      | "document";
     sourceAssetUrl?: string | null;
     looksLikeImageUrl?: boolean;
   },
@@ -166,7 +173,14 @@ export function enrichExternalCatSegmentImageFields<
 export function enrichExternalCatTranslationImageFields<
   T extends {
     text: string;
-    contentKind?: "text" | "image_file" | "image_url" | "video_file" | "video_url" | "office_file";
+    contentKind?:
+      | "text"
+      | "image_file"
+      | "image_url"
+      | "video_file"
+      | "video_url"
+      | "office_file"
+      | "document";
     targetAssetUrl?: string | null;
   },
 >(translation: T, overlay?: ExternalCatStringOverlay | null): T {
@@ -200,7 +214,8 @@ export async function enrichExternalCatFileImageFields<
         | "image_url"
         | "video_file"
         | "video_url"
-        | "office_file";
+        | "office_file"
+        | "document";
       sourceAssetUrl?: string | null;
       looksLikeImageUrl?: boolean;
     }>;

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
@@ -391,6 +391,38 @@ describe("NativeCatService.getCatFile", () => {
     });
   });
 
+  it("returns a synthetic document segment for markdown sources", async () => {
+    getLatestRepositorySourceFileVersion.mockResolvedValue({
+      storedFileId: "stored_source_md",
+    });
+    getImageVariant.mockResolvedValue({
+      id: "variant_md",
+      storedFileId: "stored_target_md",
+      status: "needs_review",
+    });
+
+    const result = await service.getCatFile({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "docs/intro.md",
+      targetLocale: "fr",
+      canEditTranslations: true,
+      organizationSlug: "acme",
+    });
+
+    expect(listKeysForFile).not.toHaveBeenCalled();
+    expect(result?.segments).toHaveLength(1);
+    expect(result?.segments[0]).toMatchObject({
+      externalStringId: "file_1",
+      key: "docs/intro.md",
+      sourceText: "docs/intro.md",
+      contentKind: "document",
+      sourceAssetUrl: "/api/orgs/acme/projects/project_1/assets/stored_source_md",
+      targetAssetUrl: "/api/orgs/acme/projects/project_1/assets/stored_target_md",
+      imageVariantId: "variant_md",
+    });
+  });
+
   it("marks image URL keys with contentKind and looksLikeImageUrl", async () => {
     listKeysForFile.mockResolvedValue([
       {

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -537,7 +537,10 @@ export class NativeCatService extends ProjectServiceBase {
       truncated: false,
       segments: [
         {
-          externalStringId: documentFileExternalStringId(input.sourceFileId, input.input.sourcePath),
+          externalStringId: documentFileExternalStringId(
+            input.sourceFileId,
+            input.input.sourcePath,
+          ),
           key: input.input.sourcePath,
           sourceText: input.input.sourcePath,
           context: null,

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -44,10 +44,11 @@ import {
 import { ProjectServiceBase } from "@/lib/projects/project-service-base";
 import { ProjectTranslationService } from "@/lib/projects/translations/project-translation-service";
 import {
-  inferSupportedBinaryTranslationFileFormat,
+  inferSupportedDocumentTranslationFileFormat,
   inferSupportedImageTranslationFileFormat,
   inferSupportedOfficeTranslationFileFormat,
   inferSupportedVideoTranslationFileFormat,
+  inferSupportedWholeFileTranslationFileFormat,
   looksLikeImageUrl,
   looksLikeVideoUrl,
 } from "@/lib/translation/file-formats";
@@ -83,6 +84,10 @@ function videoFileExternalStringId(sourceFileId: string, sourcePath: string) {
 }
 
 function officeFileExternalStringId(sourceFileId: string, sourcePath: string) {
+  return binaryFileExternalStringId(sourceFileId, sourcePath);
+}
+
+function documentFileExternalStringId(sourceFileId: string, sourcePath: string) {
   return binaryFileExternalStringId(sourceFileId, sourcePath);
 }
 
@@ -201,6 +206,13 @@ export class NativeCatService extends ProjectServiceBase {
 
     if (inferSupportedOfficeTranslationFileFormat(input.sourcePath)) {
       return this.buildOfficeCatFileResponse({
+        input,
+        sourceFileId: sourceFile.id,
+      });
+    }
+
+    if (inferSupportedDocumentTranslationFileFormat(input.sourcePath)) {
+      return this.buildDocumentCatFileResponse({
         input,
         sourceFileId: sourceFile.id,
       });
@@ -464,6 +476,73 @@ export class NativeCatService extends ProjectServiceBase {
           context: null,
           type: null,
           contentKind: "office_file",
+          sourceAssetUrl,
+          targetAssetUrl,
+          imageVariantId: variant?.id ?? null,
+        },
+      ],
+    };
+  }
+
+  private async buildDocumentCatFileResponse(input: {
+    input: {
+      organizationId: string;
+      projectId: string;
+      sourcePath: string;
+      targetLocale: string;
+      canEditTranslations: boolean;
+      organizationSlug: string;
+    };
+    sourceFileId: string;
+  }): Promise<ProjectFileCatQueueFile> {
+    const [latestVersion, variant] = await Promise.all([
+      getLatestRepositorySourceFileVersion({
+        organizationId: input.input.organizationId,
+        projectId: input.input.projectId,
+        sourcePath: input.input.sourcePath,
+        db: this.database,
+      }),
+      getImageVariant({
+        organizationId: input.input.organizationId,
+        projectId: input.input.projectId,
+        sourcePath: input.input.sourcePath,
+        targetLocale: input.input.targetLocale,
+        db: this.database,
+      }),
+    ]);
+
+    const sourceStoredFileId = latestVersion?.storedFileId ?? null;
+    const targetStoredFileId = variant?.storedFileId ?? null;
+    const sourceAssetUrl = sourceStoredFileId
+      ? projectImageAssetPath({
+          organizationSlug: input.input.organizationSlug,
+          projectId: input.input.projectId,
+          fileId: sourceStoredFileId,
+        })
+      : null;
+    const targetAssetUrl = targetStoredFileId
+      ? projectImageAssetPath({
+          organizationSlug: input.input.organizationSlug,
+          projectId: input.input.projectId,
+          fileId: targetStoredFileId,
+        })
+      : null;
+
+    return {
+      sourcePath: input.input.sourcePath,
+      filename: filenameFromSourcePath(input.input.sourcePath),
+      provider: null,
+      targetLocale: input.input.targetLocale,
+      canEditTranslations: input.input.canEditTranslations,
+      truncated: false,
+      segments: [
+        {
+          externalStringId: documentFileExternalStringId(input.sourceFileId, input.input.sourcePath),
+          key: input.input.sourcePath,
+          sourceText: input.input.sourcePath,
+          context: null,
+          type: null,
+          contentKind: "document",
           sourceAssetUrl,
           targetAssetUrl,
           imageVariantId: variant?.id ?? null,
@@ -851,7 +930,7 @@ export class NativeCatService extends ProjectServiceBase {
   }): Promise<ProjectFileCatTranslation | null | "not_found"> {
     if (
       !isCatAllFilesSourcePath(input.sourcePath) &&
-      inferSupportedBinaryTranslationFileFormat(input.sourcePath)
+      inferSupportedWholeFileTranslationFileFormat(input.sourcePath)
     ) {
       const sourceFile = await this.translations.getRepositorySourceFileByPath({
         organizationId: input.organizationId,
@@ -865,11 +944,14 @@ export class NativeCatService extends ProjectServiceBase {
 
       const isVideo = Boolean(inferSupportedVideoTranslationFileFormat(input.sourcePath));
       const isOffice = Boolean(inferSupportedOfficeTranslationFileFormat(input.sourcePath));
+      const isDocument = Boolean(inferSupportedDocumentTranslationFileFormat(input.sourcePath));
       const contentKind = isVideo
         ? ("video_file" as const)
         : isOffice
           ? ("office_file" as const)
-          : ("image_file" as const);
+          : isDocument
+            ? ("document" as const)
+            : ("image_file" as const);
       const expectedIds = new Set(fileBackedCatSegmentIds(sourceFile.id, input.sourcePath));
       if (!expectedIds.has(input.externalStringId)) {
         return "not_found";
@@ -971,7 +1053,7 @@ export class NativeCatService extends ProjectServiceBase {
   }): Promise<ProjectFileCatComment[]> {
     if (
       !isCatAllFilesSourcePath(input.sourcePath) &&
-      inferSupportedBinaryTranslationFileFormat(input.sourcePath)
+      inferSupportedWholeFileTranslationFileFormat(input.sourcePath)
     ) {
       return [];
     }

--- a/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.test.ts
@@ -34,6 +34,17 @@ describe("parseHlEntriesJson", () => {
       /must be a string or object/,
     );
   });
+
+  it("skips the reserved document envelope", () => {
+    expect(
+      parseHlEntriesJson({
+        "md.Heading[0]": { text: "Title", fingerprint: "abc", path: "Heading[0]", kind: "body" },
+        __hl_document: { format: "markdown", parts: [] },
+      }),
+    ).toEqual({
+      "md.Heading[0]": { text: "Title", fingerprint: "abc", path: "Heading[0]", kind: "body" },
+    });
+  });
 });
 
 describe("entriesFromHlOutput", () => {

--- a/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/hl-entries.ts
@@ -20,6 +20,12 @@ export type HlEntryRecord = {
 
 export type HlEntriesPayload = Record<string, string | HlEntryRecord>;
 
+export const HL_DOCUMENT_ENTRIES_META_KEY = "__hl_document";
+
+function isReservedHlEntriesKey(key: string) {
+  return key === HL_DOCUMENT_ENTRIES_META_KEY || key.startsWith("__hl_");
+}
+
 function isHlEntryRecord(value: unknown): value is HlEntryRecord {
   if (!value || typeof value !== "object" || !("text" in value)) {
     return false;
@@ -31,6 +37,9 @@ function isHlEntryRecord(value: unknown): value is HlEntryRecord {
 export function hlEntriesPayloadToStringMap(payload: HlEntriesPayload): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(payload)) {
+    if (isReservedHlEntriesKey(key)) {
+      continue;
+    }
     out[key] = typeof value === "string" ? value : value.text;
   }
   return out;
@@ -38,6 +47,7 @@ export function hlEntriesPayloadToStringMap(payload: HlEntriesPayload): Record<s
 
 export function entriesFromHlOutput(payload: HlEntriesPayload): ProjectSourceStringEntry[] {
   return Object.entries(payload)
+    .filter(([key]) => !isReservedHlEntriesKey(key))
     .map(([key, value]) => {
       const text = typeof value === "string" ? value : value.text;
       const maxLength =
@@ -67,6 +77,9 @@ export function parseHlEntriesJson(raw: unknown): HlEntriesPayload {
   for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
     if (typeof value === "string") {
       payload[key] = value;
+      continue;
+    }
+    if (isReservedHlEntriesKey(key)) {
       continue;
     }
     if (isHlEntryRecord(value)) {

--- a/apps/hyperlocalise-web/src/lib/projects/files/image-variant-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/image-variant-service.ts
@@ -407,6 +407,8 @@ export async function replaceImageVariantBytes(input: {
   externalTmsFileId?: string | null;
   createdByUserId?: string | null;
   force?: boolean;
+  provenance?: (typeof schema.projectImageVariants.$inferSelect)["provenance"];
+  sourceJobId?: string | null;
 }): Promise<Result<typeof schema.projectImageVariants.$inferSelect, ImageVariantError>> {
   const existing = await getImageVariant(input);
   if (existing?.status === "approved" && !input.force) {
@@ -443,7 +445,8 @@ export async function replaceImageVariantBytes(input: {
     .set({
       storedFileId: stored.id,
       status: "needs_review",
-      provenance: "manual",
+      provenance: input.provenance ?? "manual",
+      sourceJobId: input.sourceJobId ?? null,
       reviewedByUserId: null,
       reviewedAt: null,
       updatedAt: new Date(),

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.test.ts
@@ -21,10 +21,13 @@ import {
   inferSupportedSourceUploadFormat,
   inferSupportedTranslationFileFormat,
   isBinaryTranslationFileFormat,
+  inferSupportedDocumentTranslationFileFormat,
+  isDocumentTranslationFileFormat,
   isImageTranslationFileFormat,
   isOfficeTranslationFileFormat,
   isSupportedSourceUploadFormat,
   isVideoTranslationFileFormat,
+  isWholeFileTranslationFileFormat,
   looksLikeImageUrl,
   looksLikeVideoUrl,
 } from "./file-formats";
@@ -107,6 +110,19 @@ describe("translation file formats", () => {
     expect(isBinaryTranslationFileFormat("xlsx")).toBe(true);
     expect(isBinaryTranslationFileFormat("png")).toBe(true);
     expect(isBinaryTranslationFileFormat("json")).toBe(false);
+  });
+
+  it("treats markdown and mdx as whole-file documents, not binary", () => {
+    expect(inferSupportedDocumentTranslationFileFormat("readme.md")).toBe("markdown");
+    expect(inferSupportedDocumentTranslationFileFormat("page.mdx")).toBe("mdx");
+    expect(isDocumentTranslationFileFormat("markdown")).toBe(true);
+    expect(isDocumentTranslationFileFormat("mdx")).toBe(true);
+    expect(isDocumentTranslationFileFormat("json")).toBe(false);
+    expect(isWholeFileTranslationFileFormat("markdown")).toBe(true);
+    expect(isWholeFileTranslationFileFormat("mdx")).toBe(true);
+    expect(isWholeFileTranslationFileFormat("json")).toBe(false);
+    expect(isBinaryTranslationFileFormat("markdown")).toBe(false);
+    expect(isBinaryTranslationFileFormat("mdx")).toBe(false);
   });
 
   it("builds a source-upload accept list including office and images", () => {

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
@@ -146,6 +146,31 @@ export function isBinaryTranslationFileFormat(
   );
 }
 
+export const supportedDocumentTranslationFileFormats = ["markdown", "mdx"] as const;
+
+export type SupportedDocumentTranslationFileFormat =
+  (typeof supportedDocumentTranslationFileFormats)[number];
+
+/** Markdown/MDX documents stored and edited as whole files, not CAT string keys. */
+export function isDocumentTranslationFileFormat(
+  format: SupportedTranslationFileFormat,
+): format is SupportedDocumentTranslationFileFormat {
+  return supportedDocumentTranslationFileFormats.includes(
+    format as SupportedDocumentTranslationFileFormat,
+  );
+}
+
+/** Formats whose CAT/download unit is the stored file (binary assets + documents). */
+export function isWholeFileTranslationFileFormat(
+  format: SupportedTranslationFileFormat,
+): format is
+  | SupportedImageTranslationFileFormat
+  | SupportedVideoTranslationFileFormat
+  | SupportedOfficeTranslationFileFormat
+  | SupportedDocumentTranslationFileFormat {
+  return isBinaryTranslationFileFormat(format) || isDocumentTranslationFileFormat(format);
+}
+
 export function isSupportedFileTranslationFileFormat(
   format: SupportedTranslationFileFormat,
 ): format is SupportedFileTranslationFileFormat {
@@ -227,6 +252,33 @@ export function inferSupportedBinaryTranslationFileFormat(
   | null {
   const format = inferSupportedTranslationFileFormat(filename);
   if (!format || !isBinaryTranslationFileFormat(format)) {
+    return null;
+  }
+
+  return format;
+}
+
+export function inferSupportedDocumentTranslationFileFormat(
+  filename: string,
+): SupportedDocumentTranslationFileFormat | null {
+  const format = inferSupportedTranslationFileFormat(filename);
+  if (!format || !isDocumentTranslationFileFormat(format)) {
+    return null;
+  }
+
+  return format;
+}
+
+export function inferSupportedWholeFileTranslationFileFormat(
+  filename: string,
+):
+  | SupportedImageTranslationFileFormat
+  | SupportedVideoTranslationFileFormat
+  | SupportedOfficeTranslationFileFormat
+  | SupportedDocumentTranslationFileFormat
+  | null {
+  const format = inferSupportedTranslationFileFormat(filename);
+  if (!format || !isWholeFileTranslationFileFormat(format)) {
     return null;
   }
 

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -19,6 +19,7 @@ import {
   inferSupportedFileTranslationFileFormat,
   isImageTranslationFileFormat,
   isOfficeTranslationFileFormat,
+  isDocumentTranslationFileFormat,
   isVideoTranslationFileFormat,
   isSupportedFileTranslationFileFormat,
   type SupportedTranslationFileFormat,
@@ -37,6 +38,7 @@ import {
   localizeImageVariantForJobStep,
   localizeVideoVariantForJobStep,
   persistFileProjectTranslationsStep,
+  persistDocumentVariantBytesStep,
   persistFileTranslationMemoryEntriesStep,
   reuseFileTranslationMemoryEntriesStep,
   storeOutputFileStep,
@@ -960,16 +962,22 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             sourceEntries,
             targetEntries,
           });
-          await persistFileProjectTranslationsStep({
-            organizationId,
-            projectId: claim.job.projectId,
-            jobId: claim.job.id,
-            sourcePath: repositorySourcePath,
-            sourceLocale: parsedInput.sourceLocale,
-            targetLocale,
-            sourceEntries,
-            targetEntries,
-          });
+          if (
+            !isDocumentTranslationFileFormat(
+              parsedInput.fileFormat as SupportedTranslationFileFormat,
+            )
+          ) {
+            await persistFileProjectTranslationsStep({
+              organizationId,
+              projectId: claim.job.projectId,
+              jobId: claim.job.id,
+              sourcePath: repositorySourcePath,
+              sourceLocale: parsedInput.sourceLocale,
+              targetLocale,
+              sourceEntries,
+              targetEntries,
+            });
+          }
         } catch (error) {
           console.warn("[file-translation-workflow] incremental translation persistence failed", {
             jobId: claim.job.id,
@@ -1420,6 +1428,22 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         content: translatedContent,
       });
 
+      if (
+        isDocumentTranslationFileFormat(parsedInput.fileFormat as SupportedTranslationFileFormat) &&
+        repositorySourcePath
+      ) {
+        await persistDocumentVariantBytesStep({
+          organizationId,
+          projectId: claim.job.projectId,
+          sourcePath: repositorySourcePath,
+          targetLocale,
+          content: translatedContent,
+          contentType: sourceFile.contentType,
+          filename: outputFilename,
+          sourceJobId: claim.job.id,
+        });
+      }
+
       if (sourceEntries && repositorySourcePath) {
         try {
           const targetEntries = await extractEntriesStep(sandboxId, outputFilename, {
@@ -1435,16 +1459,22 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             sourceEntries,
             targetEntries,
           });
-          await persistFileProjectTranslationsStep({
-            organizationId,
-            projectId: claim.job.projectId,
-            jobId: claim.job.id,
-            sourcePath: repositorySourcePath,
-            sourceLocale: parsedInput.sourceLocale,
-            targetLocale,
-            sourceEntries,
-            targetEntries,
-          });
+          if (
+            !isDocumentTranslationFileFormat(
+              parsedInput.fileFormat as SupportedTranslationFileFormat,
+            )
+          ) {
+            await persistFileProjectTranslationsStep({
+              organizationId,
+              projectId: claim.job.projectId,
+              jobId: claim.job.id,
+              sourcePath: repositorySourcePath,
+              sourceLocale: parsedInput.sourceLocale,
+              targetLocale,
+              sourceEntries,
+              targetEntries,
+            });
+          }
         } catch (error) {
           console.warn("[file-translation-workflow] target TM persistence failed", {
             jobId: claim.job.id,

--- a/apps/hyperlocalise-web/src/workflows/source-file-ingest.ts
+++ b/apps/hyperlocalise-web/src/workflows/source-file-ingest.ts
@@ -15,6 +15,7 @@ import { getWorkflowMetadata } from "workflow";
 import {
   inferSupportedTranslationFileFormat,
   isBinaryTranslationFileFormat,
+  isDocumentTranslationFileFormat,
   isImageTranslationFileFormat,
   isVideoTranslationFileFormat,
 } from "@/lib/translation/file-formats";
@@ -86,7 +87,11 @@ export async function sourceFileIngestWorkflow(event: SourceFileIngestEventData)
     }
 
     const inferredFormat = inferSupportedTranslationFileFormat(event.sourcePath);
-    if (inferredFormat && isBinaryTranslationFileFormat(inferredFormat)) {
+    if (
+      inferredFormat &&
+      (isBinaryTranslationFileFormat(inferredFormat) ||
+        isDocumentTranslationFileFormat(inferredFormat))
+    ) {
       const targetLocales = await getProjectTargetLocalesStep({
         organizationId: event.organizationId,
         projectId: event.projectId,
@@ -107,7 +112,10 @@ export async function sourceFileIngestWorkflow(event: SourceFileIngestEventData)
           repositorySourceFileId,
           targetLocales,
         });
-      } else if (isImageTranslationFileFormat(inferredFormat)) {
+      } else if (
+        isImageTranslationFileFormat(inferredFormat) ||
+        isDocumentTranslationFileFormat(inferredFormat)
+      ) {
         await ensureImageVariantsForSourceFileStep({
           organizationId: event.organizationId,
           projectId: event.projectId,

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job-document.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job-document.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { getImageVariantMock, replaceImageVariantBytesMock } = vi.hoisted(() => ({
+  getImageVariantMock: vi.fn(),
+  replaceImageVariantBytesMock: vi.fn(),
+}));
+
+vi.mock("@/lib/projects/files/image-variant-service", () => ({
+  getImageVariant: getImageVariantMock,
+  replaceImageVariantBytes: replaceImageVariantBytesMock,
+}));
+
+import { persistDocumentVariantBytesStep } from "@/workflows/steps/translation-job";
+
+describe("persistDocumentVariantBytesStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reuses an approved locale document instead of failing the whole job", async () => {
+    replaceImageVariantBytesMock.mockResolvedValue({
+      ok: false,
+      error: { code: "approved_locked" },
+    });
+    const existing = {
+      storedFileId: "file_approved_fr",
+      status: "approved",
+    };
+    getImageVariantMock.mockResolvedValue(existing);
+
+    await expect(
+      persistDocumentVariantBytesStep({
+        organizationId: "org_1",
+        projectId: "project_1",
+        sourcePath: "docs/guide.md",
+        targetLocale: "fr-FR",
+        content: Buffer.from("# Bonjour\n", "utf8"),
+        contentType: "text/markdown",
+        filename: "guide.md",
+        sourceJobId: "job_1",
+      }),
+    ).resolves.toEqual(existing);
+  });
+
+  it("throws when an approved locale has no stored document to reuse", async () => {
+    replaceImageVariantBytesMock.mockResolvedValue({
+      ok: false,
+      error: { code: "approved_locked" },
+    });
+    getImageVariantMock.mockResolvedValue(null);
+
+    await expect(
+      persistDocumentVariantBytesStep({
+        organizationId: "org_1",
+        projectId: "project_1",
+        sourcePath: "docs/guide.md",
+        targetLocale: "fr-FR",
+        content: Buffer.from("# Bonjour\n", "utf8"),
+        contentType: "text/markdown",
+        filename: "guide.md",
+        sourceJobId: "job_1",
+      }),
+    ).rejects.toThrow("failed to persist document variant: approved_locked");
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -423,7 +423,8 @@ export async function persistDocumentVariantBytesStep(input: {
   sourceJobId?: string | null;
 }) {
   "use step";
-  const { replaceImageVariantBytes } = await import("@/lib/projects/files/image-variant-service");
+  const { getImageVariant, replaceImageVariantBytes } =
+    await import("@/lib/projects/files/image-variant-service");
   const result = await replaceImageVariantBytes({
     organizationId: input.organizationId,
     projectId: input.projectId,
@@ -437,6 +438,17 @@ export async function persistDocumentVariantBytesStep(input: {
     provenance: "translation_job",
   });
   if (!result.ok) {
+    if (result.error.code === "approved_locked") {
+      const existing = await getImageVariant({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourcePath: input.sourcePath,
+        targetLocale: input.targetLocale,
+      });
+      if (existing?.storedFileId) {
+        return existing;
+      }
+    }
     throw new Error(`failed to persist document variant: ${result.error.code}`);
   }
   return result.value;

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -411,6 +411,37 @@ export async function persistFileProjectTranslationsStep(input: {
   return persistFileJobTranslations(input);
 }
 
+export async function persistDocumentVariantBytesStep(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  content: Buffer;
+  contentType: string;
+  filename: string;
+  repositorySourceFileId?: string | null;
+  sourceJobId?: string | null;
+}) {
+  "use step";
+  const { replaceImageVariantBytes } = await import("@/lib/projects/files/image-variant-service");
+  const result = await replaceImageVariantBytes({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+    targetLocale: input.targetLocale,
+    content: input.content,
+    contentType: input.contentType,
+    filename: input.filename,
+    repositorySourceFileId: input.repositorySourceFileId,
+    sourceJobId: input.sourceJobId,
+    provenance: "translation_job",
+  });
+  if (!result.ok) {
+    throw new Error(`failed to persist document variant: ${result.error.code}`);
+  }
+  return result.value;
+}
+
 export async function completeFileTranslationJobStep(input: {
   jobId: string;
   projectId: string;

--- a/internal/i18n/translationfileparser/document_ir.go
+++ b/internal/i18n/translationfileparser/document_ir.go
@@ -45,8 +45,8 @@ type DocumentBlock struct {
 
 // ParsedDocument is the public markdown/MDX document IR.
 type ParsedDocument struct {
-	Format DocumentFormat `json:"format"`
-	Parts  []DocumentPart `json:"parts"`
+	Format DocumentFormat  `json:"format"`
+	Parts  []DocumentPart  `json:"parts"`
 	Blocks []DocumentBlock `json:"blocks"`
 }
 

--- a/internal/i18n/translationfileparser/document_ir.go
+++ b/internal/i18n/translationfileparser/document_ir.go
@@ -2,8 +2,6 @@ package translationfileparser
 
 import (
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 )
 
@@ -26,8 +24,6 @@ const (
 	DocumentBlockKindBody  DocumentBlockKind = "body"
 	DocumentBlockKindField DocumentBlockKind = "field"
 )
-
-var markdownLegacyHashKeyPattern = regexp.MustCompile(`^md\.[0-9a-f]{16}(?:\.\d+)?$`)
 
 // DocumentPart is one reconstructed document region: frozen literal or a translatable block.
 type DocumentPart struct {
@@ -64,69 +60,6 @@ func IsMarkdownDocumentExtension(path string) bool {
 // IsMarkdownDocumentMDX reports whether path should use the MDX adapter.
 func IsMarkdownDocumentMDX(path string) bool {
 	return strings.ToLower(filepath.Ext(strings.TrimSpace(path))) == ".mdx"
-}
-
-// IsLegacyMarkdownHashKey reports whether key is a pre-slot content-hash identity.
-func IsLegacyMarkdownHashKey(key string) bool {
-	return markdownLegacyHashKeyPattern.MatchString(strings.TrimSpace(key))
-}
-
-// RemapLegacyMarkdownPrefill rewrites pre-slot `md.<16-hex>` translation keys onto
-// the current structural slot ids for source. Keys that are already slot ids stay as-is.
-func RemapLegacyMarkdownPrefill(source []byte, mdx bool, prefilled map[string]string) map[string]string {
-	if len(prefilled) == 0 {
-		return prefilled
-	}
-	hasLegacy := false
-	for key := range prefilled {
-		if IsLegacyMarkdownHashKey(key) {
-			hasLegacy = true
-			break
-		}
-	}
-	if !hasLegacy {
-		return prefilled
-	}
-
-	doc := ParseMarkdownDocumentIR(source, mdx)
-	idsByFingerprint := make(map[string][]string, len(doc.Blocks))
-	for _, block := range doc.Blocks {
-		if block.Fingerprint == "" {
-			continue
-		}
-		idsByFingerprint[block.Fingerprint] = append(idsByFingerprint[block.Fingerprint], block.ID)
-	}
-
-	out := make(map[string]string, len(prefilled))
-	for key, value := range prefilled {
-		if !IsLegacyMarkdownHashKey(key) {
-			out[key] = value
-			continue
-		}
-		fingerprint, index := splitLegacyMarkdownHashKey(key)
-		ids := idsByFingerprint[fingerprint]
-		if index >= 0 && index < len(ids) {
-			out[ids[index]] = value
-			continue
-		}
-		out[key] = value
-	}
-	return out
-}
-
-func splitLegacyMarkdownHashKey(key string) (string, int) {
-	rest := strings.TrimPrefix(strings.TrimSpace(key), "md.")
-	if len(rest) == 16 {
-		return rest, 0
-	}
-	if len(rest) > 17 && rest[16] == '.' {
-		n, err := strconv.Atoi(rest[17:])
-		if err != nil || n < 2 {
-			return rest[:16], 0
-		}
-		return rest[:16], n - 1
-	}
-	return rest, 0
 }
 
 // ParseMarkdownDocumentIR parses markdown or MDX into a document IR with stable slot ids.

--- a/internal/i18n/translationfileparser/document_ir.go
+++ b/internal/i18n/translationfileparser/document_ir.go
@@ -3,6 +3,7 @@ package translationfileparser
 import (
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -68,6 +69,64 @@ func IsMarkdownDocumentMDX(path string) bool {
 // IsLegacyMarkdownHashKey reports whether key is a pre-slot content-hash identity.
 func IsLegacyMarkdownHashKey(key string) bool {
 	return markdownLegacyHashKeyPattern.MatchString(strings.TrimSpace(key))
+}
+
+// RemapLegacyMarkdownPrefill rewrites pre-slot `md.<16-hex>` translation keys onto
+// the current structural slot ids for source. Keys that are already slot ids stay as-is.
+func RemapLegacyMarkdownPrefill(source []byte, mdx bool, prefilled map[string]string) map[string]string {
+	if len(prefilled) == 0 {
+		return prefilled
+	}
+	hasLegacy := false
+	for key := range prefilled {
+		if IsLegacyMarkdownHashKey(key) {
+			hasLegacy = true
+			break
+		}
+	}
+	if !hasLegacy {
+		return prefilled
+	}
+
+	doc := ParseMarkdownDocumentIR(source, mdx)
+	idsByFingerprint := make(map[string][]string, len(doc.Blocks))
+	for _, block := range doc.Blocks {
+		if block.Fingerprint == "" {
+			continue
+		}
+		idsByFingerprint[block.Fingerprint] = append(idsByFingerprint[block.Fingerprint], block.ID)
+	}
+
+	out := make(map[string]string, len(prefilled))
+	for key, value := range prefilled {
+		if !IsLegacyMarkdownHashKey(key) {
+			out[key] = value
+			continue
+		}
+		fingerprint, index := splitLegacyMarkdownHashKey(key)
+		ids := idsByFingerprint[fingerprint]
+		if index >= 0 && index < len(ids) {
+			out[ids[index]] = value
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func splitLegacyMarkdownHashKey(key string) (string, int) {
+	rest := strings.TrimPrefix(strings.TrimSpace(key), "md.")
+	if len(rest) == 16 {
+		return rest, 0
+	}
+	if len(rest) > 17 && rest[16] == '.' {
+		n, err := strconv.Atoi(rest[17:])
+		if err != nil || n < 2 {
+			return rest[:16], 0
+		}
+		return rest[:16], n - 1
+	}
+	return rest, 0
 }
 
 // ParseMarkdownDocumentIR parses markdown or MDX into a document IR with stable slot ids.

--- a/internal/i18n/translationfileparser/document_ir.go
+++ b/internal/i18n/translationfileparser/document_ir.go
@@ -1,0 +1,207 @@
+package translationfileparser
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// DocumentEntriesMetaKey is the reserved `hl entries` key for document structure.
+// Cloud ingest skips it as a translation key and stores it as file metadata.
+const DocumentEntriesMetaKey = "__hl_document"
+
+// DocumentFormat names a document adapter.
+type DocumentFormat string
+
+const (
+	DocumentFormatMarkdown DocumentFormat = "markdown"
+	DocumentFormatMDX      DocumentFormat = "mdx"
+)
+
+// DocumentBlockKind distinguishes CMS fields (frontmatter) from body blocks.
+type DocumentBlockKind string
+
+const (
+	DocumentBlockKindBody  DocumentBlockKind = "body"
+	DocumentBlockKindField DocumentBlockKind = "field"
+)
+
+var markdownLegacyHashKeyPattern = regexp.MustCompile(`^md\.[0-9a-f]{16}(?:\.\d+)?$`)
+
+// DocumentPart is one reconstructed document region: frozen literal or a translatable block.
+type DocumentPart struct {
+	Literal string `json:"literal,omitempty"`
+	BlockID string `json:"blockId,omitempty"`
+}
+
+// DocumentBlock is a translatable slot with stable structural identity and a content fingerprint.
+type DocumentBlock struct {
+	ID          string            `json:"id"`
+	Path        string            `json:"path"`
+	Fingerprint string            `json:"fingerprint"`
+	Kind        DocumentBlockKind `json:"kind"`
+	Text        string            `json:"text"`
+}
+
+// ParsedDocument is the public markdown/MDX document IR.
+type ParsedDocument struct {
+	Format DocumentFormat `json:"format"`
+	Parts  []DocumentPart `json:"parts"`
+	Blocks []DocumentBlock `json:"blocks"`
+}
+
+// IsMarkdownDocumentExtension reports whether path is a markdown or MDX document.
+func IsMarkdownDocumentExtension(path string) bool {
+	switch strings.ToLower(filepath.Ext(strings.TrimSpace(path))) {
+	case ".md", ".mdx", ".markdown", ".mdown", ".mkdn", ".mdwn", ".mkd":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsMarkdownDocumentMDX reports whether path should use the MDX adapter.
+func IsMarkdownDocumentMDX(path string) bool {
+	return strings.ToLower(filepath.Ext(strings.TrimSpace(path))) == ".mdx"
+}
+
+// IsLegacyMarkdownHashKey reports whether key is a pre-slot content-hash identity.
+func IsLegacyMarkdownHashKey(key string) bool {
+	return markdownLegacyHashKeyPattern.MatchString(strings.TrimSpace(key))
+}
+
+// ParseMarkdownDocumentIR parses markdown or MDX into a document IR with stable slot ids.
+func ParseMarkdownDocumentIR(content []byte, mdx bool) ParsedDocument {
+	doc, _ := parseMarkdownDocument(stripBOM(content), mdx)
+	return parsedDocumentFromMarkdown(doc, mdx)
+}
+
+func parsedDocumentFromMarkdown(doc markdownDocument, mdx bool) ParsedDocument {
+	format := DocumentFormatMarkdown
+	if mdx {
+		format = DocumentFormatMDX
+	}
+
+	out := ParsedDocument{
+		Format: format,
+		Parts:  make([]DocumentPart, 0, len(doc.parts)),
+		Blocks: make([]DocumentBlock, 0),
+	}
+	for _, part := range doc.parts {
+		if part.key == "" {
+			if part.literal == "" {
+				continue
+			}
+			out.Parts = append(out.Parts, DocumentPart{Literal: part.literal})
+			continue
+		}
+		kind := DocumentBlockKind(part.kind)
+		if kind == "" {
+			kind = markdownBlockKindForPath(part.path)
+		}
+		fingerprint := part.fingerprint
+		if fingerprint == "" {
+			fingerprint = markdownContentFingerprint(part.source)
+		}
+		block := DocumentBlock{
+			ID:          part.key,
+			Path:        part.path,
+			Fingerprint: fingerprint,
+			Kind:        kind,
+			Text:        part.source,
+		}
+		out.Blocks = append(out.Blocks, block)
+		out.Parts = append(out.Parts, DocumentPart{BlockID: part.key})
+	}
+	return out
+}
+
+func (d ParsedDocument) ingestEntries() map[string]IngestEntry {
+	if len(d.Blocks) == 0 {
+		return nil
+	}
+	out := make(map[string]IngestEntry, len(d.Blocks))
+	for _, block := range d.Blocks {
+		out[block.ID] = IngestEntry{
+			Text:        block.Text,
+			Fingerprint: block.Fingerprint,
+			Path:        block.Path,
+			Kind:        string(block.Kind),
+			Format:      string(d.Format),
+		}
+	}
+	return out
+}
+
+func (d ParsedDocument) WithBlockText(values map[string]string) ParsedDocument {
+	if len(values) == 0 {
+		return d
+	}
+	blocks := make([]DocumentBlock, len(d.Blocks))
+	copy(blocks, d.Blocks)
+	for i, block := range blocks {
+		if text, ok := values[block.ID]; ok {
+			blocks[i].Text = text
+		}
+	}
+	d.Blocks = blocks
+	return d
+}
+
+// EncodeDocumentEntriesCommandOutput emits `hl entries` JSON for a document:
+// block records plus the reserved document envelope.
+func EncodeDocumentEntriesCommandOutput(doc ParsedDocument) map[string]EntriesCommandOutputValue {
+	out := EncodeEntriesCommandOutput(doc.ingestEntries())
+	if out == nil {
+		out = map[string]EntriesCommandOutputValue{}
+	}
+	out[DocumentEntriesMetaKey] = map[string]any{
+		"format": doc.Format,
+		"parts":  doc.Parts,
+	}
+	return out
+}
+
+// AlignMarkdownSourceRevisions maps previous slot ids onto the current parse by
+// fingerprint first, then identical source text. Used when source structure shifts.
+func AlignMarkdownSourceRevisions(previous, current []byte, mdx bool) map[string]string {
+	prevDoc := ParseMarkdownDocumentIR(previous, mdx)
+	currDoc := ParseMarkdownDocumentIR(current, mdx)
+	return alignDocumentBlocksByFingerprint(prevDoc.Blocks, currDoc.Blocks)
+}
+
+func alignDocumentBlocksByFingerprint(previous, current []DocumentBlock) map[string]string {
+	used := make([]bool, len(current))
+	aligned := make(map[string]string, len(previous))
+
+	indexByFingerprint := make(map[string][]int, len(current))
+	indexByText := make(map[string][]int, len(current))
+	for i, block := range current {
+		if block.Fingerprint != "" {
+			indexByFingerprint[block.Fingerprint] = append(indexByFingerprint[block.Fingerprint], i)
+		}
+		indexByText[block.Text] = append(indexByText[block.Text], i)
+	}
+
+	take := func(indexes []int) (DocumentBlock, bool) {
+		for _, idx := range indexes {
+			if used[idx] {
+				continue
+			}
+			used[idx] = true
+			return current[idx], true
+		}
+		return DocumentBlock{}, false
+	}
+
+	for _, block := range previous {
+		if next, ok := take(indexByFingerprint[block.Fingerprint]); ok {
+			aligned[block.ID] = next.ID
+			continue
+		}
+		if next, ok := take(indexByText[block.Text]); ok {
+			aligned[block.ID] = next.ID
+		}
+	}
+	return aligned
+}

--- a/internal/i18n/translationfileparser/document_ir_test.go
+++ b/internal/i18n/translationfileparser/document_ir_test.go
@@ -1,0 +1,117 @@
+package translationfileparser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseMarkdownDocumentIRUsesStableSlotKeysAcrossWordingEdits(t *testing.T) {
+	t.Parallel()
+
+	original := ParseMarkdownDocumentIR([]byte("# Hello world\n\nFirst paragraph.\n"), false)
+	edited := ParseMarkdownDocumentIR([]byte("# Hello there\n\nFirst paragraph changed.\n"), false)
+
+	if len(original.Blocks) != 2 || len(edited.Blocks) != 2 {
+		t.Fatalf("blocks original=%d edited=%d, want 2", len(original.Blocks), len(edited.Blocks))
+	}
+	if original.Blocks[0].ID != edited.Blocks[0].ID {
+		t.Fatalf("heading slot changed: %q vs %q", original.Blocks[0].ID, edited.Blocks[0].ID)
+	}
+	if original.Blocks[1].ID != edited.Blocks[1].ID {
+		t.Fatalf("paragraph slot changed: %q vs %q", original.Blocks[1].ID, edited.Blocks[1].ID)
+	}
+	if original.Blocks[0].Fingerprint == edited.Blocks[0].Fingerprint {
+		t.Fatalf("expected heading fingerprint to change after wording edit")
+	}
+	if !strings.HasPrefix(original.Blocks[0].ID, "md.") {
+		t.Fatalf("slot id = %q, want md. prefix", original.Blocks[0].ID)
+	}
+}
+
+func TestParseMarkdownDocumentIRFrontmatterIsFieldKind(t *testing.T) {
+	t.Parallel()
+
+	doc := ParseMarkdownDocumentIR([]byte("---\ntitle: Docs\n---\n\nBody copy.\n"), false)
+	if len(doc.Blocks) < 2 {
+		t.Fatalf("expected frontmatter and body blocks, got %d", len(doc.Blocks))
+	}
+
+	var sawField bool
+	for _, block := range doc.Blocks {
+		if block.Kind == DocumentBlockKindField {
+			sawField = true
+			if block.Path != "frontmatter/title" {
+				t.Fatalf("field path = %q, want frontmatter/title", block.Path)
+			}
+			if block.Text != "Docs" {
+				t.Fatalf("field text = %q, want Docs", block.Text)
+			}
+		}
+	}
+	if !sawField {
+		t.Fatalf("expected a frontmatter field block, got %+v", doc.Blocks)
+	}
+}
+
+func TestAlignMarkdownSourceRevisionsMapsMovedCopyByFingerprint(t *testing.T) {
+	t.Parallel()
+
+	previous := []byte("Alpha\n\nBeta\n")
+	current := []byte("Intro\n\nAlpha\n\nBeta\n")
+	aligned := AlignMarkdownSourceRevisions(previous, current, false)
+
+	prev := ParseMarkdownDocumentIR(previous, false)
+	curr := ParseMarkdownDocumentIR(current, false)
+
+	alphaPrev := findDocumentBlockByText(prev, "Alpha")
+	alphaCurr := findDocumentBlockByText(curr, "Alpha")
+	betaPrev := findDocumentBlockByText(prev, "Beta")
+	betaCurr := findDocumentBlockByText(curr, "Beta")
+	if alphaPrev.ID == "" || betaPrev.ID == "" {
+		t.Fatalf("missing previous blocks")
+	}
+	if aligned[alphaPrev.ID] != alphaCurr.ID {
+		t.Fatalf("alpha aligned to %q, want %q", aligned[alphaPrev.ID], alphaCurr.ID)
+	}
+	if aligned[betaPrev.ID] != betaCurr.ID {
+		t.Fatalf("beta aligned to %q, want %q", aligned[betaPrev.ID], betaCurr.ID)
+	}
+}
+
+func TestEncodeDocumentEntriesCommandOutputIncludesEnvelope(t *testing.T) {
+	t.Parallel()
+
+	doc := ParseMarkdownDocumentIR([]byte("# Title\n"), false)
+	encoded := EncodeDocumentEntriesCommandOutput(doc)
+	raw, ok := encoded[DocumentEntriesMetaKey]
+	if !ok {
+		t.Fatalf("missing %s envelope", DocumentEntriesMetaKey)
+	}
+	meta, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("envelope type %T", raw)
+	}
+	if meta["format"] != DocumentFormatMarkdown {
+		t.Fatalf("format = %v, want markdown", meta["format"])
+	}
+}
+
+func TestIsLegacyMarkdownHashKey(t *testing.T) {
+	t.Parallel()
+
+	if !IsLegacyMarkdownHashKey("md.0123456789abcdef") {
+		t.Fatalf("expected hash key to be legacy")
+	}
+	if IsLegacyMarkdownHashKey("md.Heading[0]") {
+		t.Fatalf("slot key should not be treated as a legacy hash")
+	}
+}
+
+func findDocumentBlockByText(doc ParsedDocument, text string) DocumentBlock {
+	for _, block := range doc.Blocks {
+		if block.Text == text {
+			return block
+		}
+	}
+	return DocumentBlock{}
+}

--- a/internal/i18n/translationfileparser/document_ir_test.go
+++ b/internal/i18n/translationfileparser/document_ir_test.go
@@ -1,7 +1,6 @@
 package translationfileparser
 
 import (
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -94,53 +93,6 @@ func TestEncodeDocumentEntriesCommandOutputIncludesEnvelope(t *testing.T) {
 	}
 	if meta["format"] != DocumentFormatMarkdown {
 		t.Fatalf("format = %v, want markdown", meta["format"])
-	}
-}
-
-func TestIsLegacyMarkdownHashKey(t *testing.T) {
-	t.Parallel()
-
-	if !IsLegacyMarkdownHashKey("md.0123456789abcdef") {
-		t.Fatalf("expected hash key to be legacy")
-	}
-	if IsLegacyMarkdownHashKey("md.Heading[0]") {
-		t.Fatalf("slot key should not be treated as a legacy hash")
-	}
-}
-
-func TestRemapLegacyMarkdownPrefillMapsHashKeysOntoSlots(t *testing.T) {
-	t.Parallel()
-
-	source := []byte("# Hello\n\nWorld.\n")
-	doc := ParseMarkdownDocumentIR(source, false)
-	if len(doc.Blocks) == 0 {
-		t.Fatalf("expected source blocks")
-	}
-
-	legacy := make(map[string]string, len(doc.Blocks))
-	want := make(map[string]string, len(doc.Blocks))
-	counts := make(map[string]int)
-	for _, block := range doc.Blocks {
-		n := counts[block.Fingerprint]
-		counts[block.Fingerprint] = n + 1
-		key := "md." + block.Fingerprint
-		if n > 0 {
-			key += "." + strconv.Itoa(n+1)
-		}
-		legacy[key] = "FR-" + block.Text
-		want[block.ID] = "FR-" + block.Text
-	}
-
-	got := RemapLegacyMarkdownPrefill(source, false, legacy)
-	for id, text := range want {
-		if got[id] != text {
-			t.Fatalf("remapped[%q] = %q, want %q (map=%v)", id, got[id], text, got)
-		}
-	}
-
-	marshaled := string(MarshalMarkdown(source, legacy, false))
-	if !strings.Contains(marshaled, "FR-World") {
-		t.Fatalf("marshaled = %q, want legacy hash keys applied", marshaled)
 	}
 }
 

--- a/internal/i18n/translationfileparser/document_ir_test.go
+++ b/internal/i18n/translationfileparser/document_ir_test.go
@@ -1,6 +1,7 @@
 package translationfileparser
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -104,6 +105,42 @@ func TestIsLegacyMarkdownHashKey(t *testing.T) {
 	}
 	if IsLegacyMarkdownHashKey("md.Heading[0]") {
 		t.Fatalf("slot key should not be treated as a legacy hash")
+	}
+}
+
+func TestRemapLegacyMarkdownPrefillMapsHashKeysOntoSlots(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("# Hello\n\nWorld.\n")
+	doc := ParseMarkdownDocumentIR(source, false)
+	if len(doc.Blocks) == 0 {
+		t.Fatalf("expected source blocks")
+	}
+
+	legacy := make(map[string]string, len(doc.Blocks))
+	want := make(map[string]string, len(doc.Blocks))
+	counts := make(map[string]int)
+	for _, block := range doc.Blocks {
+		n := counts[block.Fingerprint]
+		counts[block.Fingerprint] = n + 1
+		key := "md." + block.Fingerprint
+		if n > 0 {
+			key += "." + strconv.Itoa(n+1)
+		}
+		legacy[key] = "FR-" + block.Text
+		want[block.ID] = "FR-" + block.Text
+	}
+
+	got := RemapLegacyMarkdownPrefill(source, false, legacy)
+	for id, text := range want {
+		if got[id] != text {
+			t.Fatalf("remapped[%q] = %q, want %q (map=%v)", id, got[id], text, got)
+		}
+	}
+
+	marshaled := string(MarshalMarkdown(source, legacy, false))
+	if !strings.Contains(marshaled, "FR-World") {
+		t.Fatalf("marshaled = %q, want legacy hash keys applied", marshaled)
 	}
 }
 

--- a/internal/i18n/translationfileparser/entries_command_output.go
+++ b/internal/i18n/translationfileparser/entries_command_output.go
@@ -4,6 +4,36 @@ package translationfileparser
 // Keys without metadata stay plain strings for backward compatibility.
 type EntriesCommandOutputValue any
 
+func ingestEntryNeedsObject(entry IngestEntry) bool {
+	return entry.MaxLength > 0 ||
+		entry.Fingerprint != "" ||
+		entry.Path != "" ||
+		entry.Kind != "" ||
+		entry.Format != ""
+}
+
+func ingestEntryObject(entry IngestEntry) map[string]any {
+	payload := map[string]any{
+		"text": entry.Text,
+	}
+	if entry.MaxLength > 0 {
+		payload["maxLength"] = entry.MaxLength
+	}
+	if entry.Fingerprint != "" {
+		payload["fingerprint"] = entry.Fingerprint
+	}
+	if entry.Path != "" {
+		payload["path"] = entry.Path
+	}
+	if entry.Kind != "" {
+		payload["kind"] = entry.Kind
+	}
+	if entry.Format != "" {
+		payload["format"] = entry.Format
+	}
+	return payload
+}
+
 // EncodeEntriesCommandOutput renders ingest entries for `hl entries` JSON output.
 func EncodeEntriesCommandOutput(entries map[string]IngestEntry) map[string]EntriesCommandOutputValue {
 	if len(entries) == 0 {
@@ -12,11 +42,8 @@ func EncodeEntriesCommandOutput(entries map[string]IngestEntry) map[string]Entri
 
 	out := make(map[string]EntriesCommandOutputValue, len(entries))
 	for key, entry := range entries {
-		if entry.MaxLength > 0 {
-			out[key] = map[string]any{
-				"text":      entry.Text,
-				"maxLength": entry.MaxLength,
-			}
+		if ingestEntryNeedsObject(entry) {
+			out[key] = ingestEntryObject(entry)
 			continue
 		}
 		out[key] = entry.Text

--- a/internal/i18n/translationfileparser/entry_metadata.go
+++ b/internal/i18n/translationfileparser/entry_metadata.go
@@ -12,8 +12,12 @@ const maxIngestEntryLength = 100_000
 
 // IngestEntry is a parsed translation entry with optional import metadata.
 type IngestEntry struct {
-	Text      string
-	MaxLength int
+	Text        string
+	MaxLength   int
+	Fingerprint string
+	Path        string
+	Kind        string
+	Format      string
 }
 
 var maxLengthCommentPattern = regexp.MustCompile(`(?i)(?:max[\s._-]?length|character[\s._-]?limit|hl:max-length)\s*[:=]\s*(\d+)`)

--- a/internal/i18n/translationfileparser/markdown_md_parser.go
+++ b/internal/i18n/translationfileparser/markdown_md_parser.go
@@ -54,7 +54,7 @@ func parseMarkdownASTDocument(content []byte) (markdownDocument, map[string]stri
 
 	doc := markdownDocument{parts: make([]markdownPart, 0, len(candidates)*2+1)}
 	entries := map[string]string{}
-	hashOccurrences := map[string]int{}
+	pathOccurrences := map[string]int{}
 	cursor := 0
 
 	for _, candidate := range candidates {
@@ -80,7 +80,7 @@ func parseMarkdownASTDocument(content []byte) (markdownDocument, map[string]stri
 			yamlPlain:         candidate.yamlPlain,
 			sourceSyntaxCount: rawHTMLSyntaxStartCount(placeholdered),
 		}
-		part.key = markdownSegmentKey(part.source, hashOccurrences)
+		assignMarkdownKeyedPart(&part, pathOccurrences)
 		doc.parts = append(doc.parts, part)
 		entries[part.key] = part.source
 		cursor = candidate.stop

--- a/internal/i18n/translationfileparser/markdown_mdx_parser.go
+++ b/internal/i18n/translationfileparser/markdown_mdx_parser.go
@@ -27,14 +27,14 @@ func parseMarkdownMDXDocument(content []byte) (markdownDocument, map[string]stri
 func extractMDXDocument(root *mdxNode, source string) (markdownDocument, map[string]string) {
 	doc := markdownDocument{parts: make([]markdownPart, 0, len(root.Children)*2+1)}
 	entries := map[string]string{}
-	hashOccurrences := map[string]int{}
+	pathOccurrences := map[string]int{}
 	pathState := mdxPathState{textOrdinals: map[string]int{}}
 	parserState := markdownParseState{}
 	extractState := mdxExtractState{
 		source:          source,
 		doc:             &doc,
 		entries:         entries,
-		hashOccurrences: hashOccurrences,
+		pathOccurrences: pathOccurrences,
 		pathState:       &pathState,
 		parserState:     &parserState,
 	}
@@ -47,7 +47,7 @@ type mdxExtractState struct {
 	source          string
 	doc             *markdownDocument
 	entries         map[string]string
-	hashOccurrences map[string]int
+	pathOccurrences map[string]int
 	pathState       *mdxPathState
 	parserState     *markdownParseState
 	prevTrimmed     string
@@ -97,10 +97,9 @@ func (s *mdxExtractState) walk(node *mdxNode, stack []mdxContainer) {
 
 func (s *mdxExtractState) emitFrontmatterText(text string) {
 	appendKey := func(part markdownPart) {
-		key := markdownSegmentKey(part.source, s.hashOccurrences)
-		part.key = key
+		assignMarkdownKeyedPart(&part, s.pathOccurrences)
 		s.doc.parts = append(s.doc.parts, part)
-		s.entries[key] = part.source
+		s.entries[part.key] = part.source
 	}
 	// BOLT OPTIMIZATION: Avoid strings.SplitAfter(text, "\n") to reduce allocations.
 	for len(text) > 0 {
@@ -122,10 +121,9 @@ func (s *mdxExtractState) emitFrontmatterText(text string) {
 
 func (s *mdxExtractState) emitMarkdownText(text string, stack []mdxContainer) {
 	appendKey := func(part markdownPart) {
-		key := markdownSegmentKey(part.source, s.hashOccurrences)
-		part.key = key
+		assignMarkdownKeyedPart(&part, s.pathOccurrences)
 		s.doc.parts = append(s.doc.parts, part)
-		s.entries[key] = part.source
+		s.entries[part.key] = part.source
 	}
 	// BOLT OPTIMIZATION: Avoid strings.SplitAfter(text, "\n") to reduce allocations.
 	for len(text) > 0 {

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -20,6 +20,8 @@ type markdownPart struct {
 	source       string
 	placeholders map[string]string
 	path         string
+	fingerprint  string
+	kind         string
 	yamlPlain    bool
 	// BOLT OPTIMIZATION: precompute raw HTML syntax count to avoid redundant scans.
 	sourceSyntaxCount int
@@ -94,22 +96,36 @@ func (d markdownDocument) keyContexts() []markdownKeyContext {
 	return out
 }
 
-func markdownSegmentKey(segment string, occurrences map[string]int) string {
+func markdownContentFingerprint(segment string) string {
 	sum := sha256.Sum256([]byte(segment))
-	// BOLT OPTIMIZATION: Format the 16-hex-char digest into a stack buffer to bypass
-	// hex.EncodeToString heap allocations.
 	var hexBuf [16]byte
 	hex.Encode(hexBuf[:], sum[:8])
+	return string(hexBuf[:])
+}
 
-	count := occurrences[string(hexBuf[:])]
-	if count == 0 {
-		key := "md." + string(hexBuf[:])
-		// Store a sliced view of key into the map so map storage reuses key's string buffer.
-		occurrences[key[3:]] = 1
-		return key
+func markdownSlotKey(path string, occurrences map[string]int) string {
+	if path == "" {
+		path = "slot"
 	}
-	occurrences[string(hexBuf[:])] = count + 1
-	return "md." + string(hexBuf[:]) + "." + strconv.Itoa(count+1)
+	count := occurrences[path]
+	occurrences[path] = count + 1
+	if count == 0 {
+		return "md." + path
+	}
+	return "md." + path + "." + strconv.Itoa(count+1)
+}
+
+func assignMarkdownKeyedPart(part *markdownPart, occurrences map[string]int) {
+	part.fingerprint = markdownContentFingerprint(part.source)
+	part.key = markdownSlotKey(part.path, occurrences)
+	part.kind = string(markdownBlockKindForPath(part.path))
+}
+
+func markdownBlockKindForPath(path string) DocumentBlockKind {
+	if strings.HasPrefix(path, "frontmatter/") {
+		return DocumentBlockKindField
+	}
+	return DocumentBlockKindBody
 }
 
 func emitMarkdownLineParts(line string, doc *markdownDocument, appendKey func(markdownPart), state *markdownParseState, path string) {
@@ -674,7 +690,12 @@ func emitFrontmatterLineParts(line string, doc *markdownDocument, appendKey func
 			return
 		}
 		doc.parts = append(doc.parts, markdownPart{literal: body[:colon+1] + valuePart[:lead]})
-		appendKey(markdownPart{source: plainValue, yamlPlain: true, sourceSyntaxCount: rawHTMLSyntaxStartCount(plainValue)})
+		appendKey(markdownPart{
+			source:            plainValue,
+			path:              "frontmatter/" + key,
+			yamlPlain:         true,
+			sourceSyntaxCount: rawHTMLSyntaxStartCount(plainValue),
+		})
 		doc.parts = append(doc.parts, markdownPart{literal: newline})
 		return
 	}
@@ -692,7 +713,11 @@ func emitFrontmatterLineParts(line string, doc *markdownDocument, appendKey func
 	}
 
 	doc.parts = append(doc.parts, markdownPart{literal: body[:colon+1] + valuePart[:lead] + string(quote)})
-	appendKey(markdownPart{source: quotedText, sourceSyntaxCount: rawHTMLSyntaxStartCount(quotedText)})
+	appendKey(markdownPart{
+		source:            quotedText,
+		path:              "frontmatter/" + key,
+		sourceSyntaxCount: rawHTMLSyntaxStartCount(quotedText),
+	})
 	doc.parts = append(doc.parts, markdownPart{literal: valueRest[end:] + newline})
 }
 

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -1217,8 +1217,9 @@ func MarshalMarkdown(template []byte, values map[string]string, mdx bool) []byte
 }
 
 func MarshalMarkdownWithDiagnostics(template []byte, values map[string]string, mdx bool) ([]byte, MarkdownRenderDiagnostics) {
-	doc, _ := parseMarkdownDocument(stripBOM(template), mdx)
-	return doc.render(values)
+	stripped := stripBOM(template)
+	doc, _ := parseMarkdownDocument(stripped, mdx)
+	return doc.render(RemapLegacyMarkdownPrefill(stripped, mdx, values))
 }
 
 func isThematicBreak(s string) bool {
@@ -1317,7 +1318,9 @@ func MarshalMarkdownWithTargetFallback(sourceTemplate, targetTemplate []byte, va
 }
 
 func MarshalMarkdownWithTargetFallbackDiagnostics(sourceTemplate, targetTemplate []byte, values map[string]string, mdx bool) ([]byte, MarkdownRenderDiagnostics) {
-	sourceDoc, sourceEntries := parseMarkdownDocument(stripBOM(sourceTemplate), mdx)
+	strippedSource := stripBOM(sourceTemplate)
+	values = RemapLegacyMarkdownPrefill(strippedSource, mdx, values)
+	sourceDoc, sourceEntries := parseMarkdownDocument(strippedSource, mdx)
 	targetDoc, _ := parseMarkdownDocument(stripBOM(targetTemplate), mdx)
 	targetContexts := targetDoc.keyContexts()
 	targetPartUsed := make([]bool, len(targetDoc.parts))

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -1219,7 +1219,7 @@ func MarshalMarkdown(template []byte, values map[string]string, mdx bool) []byte
 func MarshalMarkdownWithDiagnostics(template []byte, values map[string]string, mdx bool) ([]byte, MarkdownRenderDiagnostics) {
 	stripped := stripBOM(template)
 	doc, _ := parseMarkdownDocument(stripped, mdx)
-	return doc.render(RemapLegacyMarkdownPrefill(stripped, mdx, values))
+	return doc.render(values)
 }
 
 func isThematicBreak(s string) bool {
@@ -1319,7 +1319,6 @@ func MarshalMarkdownWithTargetFallback(sourceTemplate, targetTemplate []byte, va
 
 func MarshalMarkdownWithTargetFallbackDiagnostics(sourceTemplate, targetTemplate []byte, values map[string]string, mdx bool) ([]byte, MarkdownRenderDiagnostics) {
 	strippedSource := stripBOM(sourceTemplate)
-	values = RemapLegacyMarkdownPrefill(strippedSource, mdx, values)
 	sourceDoc, sourceEntries := parseMarkdownDocument(strippedSource, mdx)
 	targetDoc, _ := parseMarkdownDocument(stripBOM(targetTemplate), mdx)
 	targetContexts := targetDoc.keyContexts()

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -104,7 +104,7 @@ func TestMarkdownParserParseSkipsRawHTMLBlocks(t *testing.T) {
 func TestMarkdownParserParseMdxKeepsComponentsAndAttributesOut(t *testing.T) {
 	template := []byte("---\ntitle: Mdx Page\n---\n\nimport Tabs from '@theme/Tabs'\n\n<Tabs defaultValue=\"first\">\n  <Tab value=\"first\" label=\"First tab\">\n    Here is a paragraph with <Badge text=\"New\" /> and [docs](https://mintlify.com).\n  </Tab>\n</Tabs>\n\n<CodeGroup>\n```bash\necho \"hi\"\n```\n</CodeGroup>\n\n> <Note icon=\"info\">Read me</Note>\n")
 
-	entries, err := (MarkdownParser{}).Parse(template)
+	entries, err := (MarkdownParser{MDX: true}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -739,7 +739,7 @@ func TestMarshalMarkdownLeavesUnclosedMultiBacktickSpanLiteral(t *testing.T) {
 
 func TestMarshalMarkdownMdxRoundTripPreservesComponentSyntax(t *testing.T) {
 	template := []byte("<Tabs defaultValue=\"cli\">\n<Tab value=\"cli\" label=\"CLI\">Run the command.</Tab>\n</Tabs>\n")
-	entries, err := (MarkdownParser{}).Parse(template)
+	entries, err := (MarkdownParser{MDX: true}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -1117,7 +1117,7 @@ func TestMarkdownParserParseMdxSkipsFencedCodeInsideJSXWrappers(t *testing.T) {
 func TestMarshalMarkdownMdxPreservesMalformedJSXRegionWhileTranslatingSafeProse(t *testing.T) {
 	template := []byte("Intro paragraph.\n\n<Card title=\"broken\"\n  Replace only safe prose outside malformed tag.\n\nOutro paragraph.\n")
 
-	entries, err := (MarkdownParser{}).Parse(template)
+	entries, err := (MarkdownParser{MDX: true}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -1139,7 +1139,7 @@ func TestMarshalMarkdownMdxPreservesMalformedJSXRegionWhileTranslatingSafeProse(
 func TestMarshalMarkdownMdxPreservesMalformedExpressionRegionWhileTranslatingSafeProse(t *testing.T) {
 	template := []byte("Intro paragraph.\n\nFallback route: {locale === \"vi-VN\" ? \"/vi-VN\" : \"/\"\n\nOutro paragraph.\n")
 
-	entries, err := (MarkdownParser{}).Parse(template)
+	entries, err := (MarkdownParser{MDX: true}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -1568,7 +1568,7 @@ func TestMarshalMarkdownWithTargetFallbackRepairsDanglingTableRowClosersFromTest
 }
 
 func TestMarkdownParserParseMdxFixtureQuickstartSkipsCodeGroupExports(t *testing.T) {
-	source := readFixture(t, "docs/getting-started/quickstart.mdx")
+	source := readFixture(t, "docs/cli/getting-started/quickstart.mdx")
 
 	entries, err := (MarkdownParser{MDX: true}).Parse(source)
 	if err != nil {
@@ -2001,7 +2001,7 @@ func TestAlignMarkdownTargetToSourceMdxDoesNotCrossMatchReorderedSameLineSibling
 func TestMarshalMarkdownMdxPreservesBytesOutsideTranslatedSpans(t *testing.T) {
 	template := []byte("import Tabs from '@theme/Tabs'\n\n<Tabs items={[\"cli\", \"api\"]}>\n  <Tab value=\"cli\">\n    Run the command.\n  </Tab>\n</Tabs>\n")
 
-	entries, err := (MarkdownParser{}).Parse(template)
+	entries, err := (MarkdownParser{MDX: true}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -104,7 +104,7 @@ func TestMarkdownParserParseSkipsRawHTMLBlocks(t *testing.T) {
 func TestMarkdownParserParseMdxKeepsComponentsAndAttributesOut(t *testing.T) {
 	template := []byte("---\ntitle: Mdx Page\n---\n\nimport Tabs from '@theme/Tabs'\n\n<Tabs defaultValue=\"first\">\n  <Tab value=\"first\" label=\"First tab\">\n    Here is a paragraph with <Badge text=\"New\" /> and [docs](https://mintlify.com).\n  </Tab>\n</Tabs>\n\n<CodeGroup>\n```bash\necho \"hi\"\n```\n</CodeGroup>\n\n> <Note icon=\"info\">Read me</Note>\n")
 
-	entries, err := (MarkdownParser{MDX: true}).Parse(template)
+	entries, err := (MarkdownParser{}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -739,7 +739,7 @@ func TestMarshalMarkdownLeavesUnclosedMultiBacktickSpanLiteral(t *testing.T) {
 
 func TestMarshalMarkdownMdxRoundTripPreservesComponentSyntax(t *testing.T) {
 	template := []byte("<Tabs defaultValue=\"cli\">\n<Tab value=\"cli\" label=\"CLI\">Run the command.</Tab>\n</Tabs>\n")
-	entries, err := (MarkdownParser{MDX: true}).Parse(template)
+	entries, err := (MarkdownParser{}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -833,28 +833,25 @@ func TestStrategyParsesMDX(t *testing.T) {
 	}
 }
 
-func TestMarkdownParserKeysAreStableAcrossInsertedSegments(t *testing.T) {
-	base := []byte("Alpha\nBeta\n")
-	withInsert := []byte("Intro\nAlpha\nBeta\n")
+func TestMarkdownParserFingerprintsAreStableAcrossInsertedSegments(t *testing.T) {
+	base := []byte("Alpha\n\nBeta\n")
+	withInsert := []byte("Intro\n\nAlpha\n\nBeta\n")
 
-	baseEntries, err := (MarkdownParser{}).Parse(base)
-	if err != nil {
-		t.Fatalf("parse base: %v", err)
-	}
-	insertedEntries, err := (MarkdownParser{}).Parse(withInsert)
-	if err != nil {
-		t.Fatalf("parse with insert: %v", err)
-	}
+	baseDoc := ParseMarkdownDocumentIR(base, false)
+	insertedDoc := ParseMarkdownDocumentIR(withInsert, false)
 
-	baseAlpha := findKeyByValue(baseEntries, "Alpha")
-	baseBeta := findKeyByValue(baseEntries, "Beta")
-	insertAlpha := findKeyByValue(insertedEntries, "Alpha")
-	insertBeta := findKeyByValue(insertedEntries, "Beta")
-	if baseAlpha == "" || baseBeta == "" || insertAlpha == "" || insertBeta == "" {
-		t.Fatalf("expected keys for shared segments")
+	baseAlpha := findDocumentBlockByText(baseDoc, "Alpha")
+	baseBeta := findDocumentBlockByText(baseDoc, "Beta")
+	insertAlpha := findDocumentBlockByText(insertedDoc, "Alpha")
+	insertBeta := findDocumentBlockByText(insertedDoc, "Beta")
+	if baseAlpha.ID == "" || baseBeta.ID == "" || insertAlpha.ID == "" || insertBeta.ID == "" {
+		t.Fatalf("expected blocks for shared segments")
 	}
-	if baseAlpha != insertAlpha || baseBeta != insertBeta {
-		t.Fatalf("expected stable hash keys, base=(%s,%s) inserted=(%s,%s)", baseAlpha, baseBeta, insertAlpha, insertBeta)
+	if baseAlpha.Fingerprint != insertAlpha.Fingerprint || baseBeta.Fingerprint != insertBeta.Fingerprint {
+		t.Fatalf("expected stable fingerprints, base=(%s,%s) inserted=(%s,%s)", baseAlpha.Fingerprint, baseBeta.Fingerprint, insertAlpha.Fingerprint, insertBeta.Fingerprint)
+	}
+	if baseAlpha.ID == insertAlpha.ID {
+		t.Fatalf("expected slot ids to shift after insert, both %s", baseAlpha.ID)
 	}
 }
 
@@ -1120,7 +1117,7 @@ func TestMarkdownParserParseMdxSkipsFencedCodeInsideJSXWrappers(t *testing.T) {
 func TestMarshalMarkdownMdxPreservesMalformedJSXRegionWhileTranslatingSafeProse(t *testing.T) {
 	template := []byte("Intro paragraph.\n\n<Card title=\"broken\"\n  Replace only safe prose outside malformed tag.\n\nOutro paragraph.\n")
 
-	entries, err := (MarkdownParser{MDX: true}).Parse(template)
+	entries, err := (MarkdownParser{}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -1142,7 +1139,7 @@ func TestMarshalMarkdownMdxPreservesMalformedJSXRegionWhileTranslatingSafeProse(
 func TestMarshalMarkdownMdxPreservesMalformedExpressionRegionWhileTranslatingSafeProse(t *testing.T) {
 	template := []byte("Intro paragraph.\n\nFallback route: {locale === \"vi-VN\" ? \"/vi-VN\" : \"/\"\n\nOutro paragraph.\n")
 
-	entries, err := (MarkdownParser{MDX: true}).Parse(template)
+	entries, err := (MarkdownParser{}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -1771,7 +1768,7 @@ func TestMarshalMarkdownFallsBackToSourceWhenPlaceholderTokensRemainUnrecoverabl
 func TestMarshalMarkdownWithDiagnosticsReportsUnrecoverablePlaceholderFallback(t *testing.T) {
 	template := []byte("Open [docs](https://example.com/source-docs) and inspect <Badge text=\"beta\" />.\n")
 
-	entries, err := (MarkdownParser{}).Parse(template)
+	entries, err := (MarkdownParser{MDX: true}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -1794,7 +1791,7 @@ func TestMarshalMarkdownWithDiagnosticsReportsUnrecoverablePlaceholderFallback(t
 func TestMarshalMarkdownFallsBackToSourceWhenMalformedTokenTargetsWrongPlaceholderIndex(t *testing.T) {
 	template := []byte("Open [docs](https://example.com/source-docs) and inspect <Badge text=\"beta\" />.\n")
 
-	entries, err := (MarkdownParser{}).Parse(template)
+	entries, err := (MarkdownParser{MDX: true}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -2004,7 +2001,7 @@ func TestAlignMarkdownTargetToSourceMdxDoesNotCrossMatchReorderedSameLineSibling
 func TestMarshalMarkdownMdxPreservesBytesOutsideTranslatedSpans(t *testing.T) {
 	template := []byte("import Tabs from '@theme/Tabs'\n\n<Tabs items={[\"cli\", \"api\"]}>\n  <Tab value=\"cli\">\n    Run the command.\n  </Tab>\n</Tabs>\n")
 
-	entries, err := (MarkdownParser{MDX: true}).Parse(template)
+	entries, err := (MarkdownParser{}).Parse(template)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/internal/i18n/translationfileparser/strategy.go
+++ b/internal/i18n/translationfileparser/strategy.go
@@ -160,6 +160,16 @@ func (s *Strategy) ParseIngestEntries(path string, content []byte, locale string
 		return nil, fmt.Errorf("translation file parser: file %q has no extension", path)
 	}
 
+	if IsMarkdownDocumentExtension(path) {
+		mdx := IsMarkdownDocumentMDX(path)
+		doc := ParseMarkdownDocumentIR(content, mdx)
+		entries := doc.ingestEntries()
+		if entries == nil {
+			entries = map[string]IngestEntry{}
+		}
+		return entries, nil
+	}
+
 	switch ext {
 	case ".strings":
 		parser, ok := s.parsersByExt[ext].(AppleStringsParser)


### PR DESCRIPTION
## What changed

Markdown and MDX are stored and edited as documents, not CAT string keys.

- Ingest skips `hl entries` key upserts for `.md` / `.mdx`; locale copies live as stored files (same variant table as images/Office).
- CAT File view uses the existing TipTap Markdown editor: frontmatter as fields, body as markdown, save writes the target file.
- AI generate still parses/marshals internally; editor save and sync pull do not reconstruct from keys.
- Sync pull downloads whole-file variants from `GET /v1/projects/:projectId/files/download`. `/images/download` remains as an alias.

## How to test

- [ ] `go test ./internal/i18n/translationfileparser ./apps/cli/cmd`
- [ ] `vp test` and `vp check --fix` in `apps/hyperlocalise-web` (document viewer, file-formats, public download route)
- [ ] Open a `.md` / `.mdx` file in CAT File view, edit body and frontmatter, save, and confirm the stored target file updates
- [ ] `hl sync pull` for a markdown/MDX mapping writes the downloaded file instead of reconstructing from export JSON

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)