### PR TITLE
feat(figma): bind page jobs and show plugin progress

### DIFF
--- a/apps/figma-plugin/README.md
+++ b/apps/figma-plugin/README.md
@@ -40,8 +40,12 @@ vp run build
 2. **Choose a project** — extracted text uploads to this Hyperlocalise project.
 3. **Extract text** — reads the current selection, or the whole page if nothing is selected.
 4. **Create job** — uploads extracted segments as `figma/files/{fileKey}/pages/{pageId}.json`.
-5. **Generate** — enqueues the translation job and waits until it finishes.
-6. **Pull** — applies the selected locale back onto matching text nodes.
+5. **Generate** — enqueues the translation job. The plugin shows a page job card and polls while the job is queued or running; Close and the rest of the panel stay usable.
+6. **Pull** — applies the selected locale back onto matching text nodes. Jobs that need review are pullable when output files exist.
+
+Each page stores `{ projectId, jobId, sourcePath }` in page plugin data (`hyperlocalise:binding:v1`). On boot and page change, the plugin asks Hyperlocalise for the latest job for that Figma file and page. The server is the source of truth: a newer job overwrites the binding, and no job clears it. `lastJobId` in client storage is only a local pointer.
+
+**Open in Hyperlocalise** on the job card opens `/org/{slug}/projects/{projectId}/jobs/{jobId}`.
 
 ## WorkOS setup
 

--- a/apps/figma-plugin/src/app.test.tsx
+++ b/apps/figma-plugin/src/app.test.tsx
@@ -1,14 +1,171 @@
-import { render } from "@testing-library/react";
-import { describe, expect, it } from "vite-plus/test";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { App } from "./app";
+import type { FigmaPageJobBinding } from "./page-binding";
+import type { FigmaPageJob, PluginSettings, SandboxToUiMessage } from "./plugin-messages";
+
+const succeededJob: FigmaPageJob = {
+  jobId: "job_figma",
+  status: "succeeded",
+  projectId: "proj_1",
+  sourcePath: "figma/files/file-1/pages/page-1.json",
+  targetLocales: ["es"],
+  lastError: null,
+  translationsByLocale: { es: { "figma.segment.1:1.0": "Hola" } },
+};
+
+const signedInSettings: PluginSettings = {
+  appUrl: "https://app.hyperlocalise.com",
+  sealedSession: "sealed.session",
+  userEmail: "dev@example.com",
+  organizationSlug: "acme",
+  projectId: "proj_1",
+  sourceLocale: "en",
+  targetLocales: ["es"],
+  preserveFormatting: true,
+  lastJobId: null,
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+function postToUi(message: SandboxToUiMessage) {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data: { pluginMessage: message },
+    }),
+  );
+}
+
+function readyMessage(binding: FigmaPageJobBinding | null) {
+  postToUi({
+    type: "ready",
+    settings: signedInSettings,
+    file: {
+      fileKey: "file-1",
+      fileName: "Marketing",
+      pageId: "page-1",
+      pageName: "Home",
+    },
+    binding,
+  });
+}
 
 describe("Figma plugin UI", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
   it("renders OAuth sign-in before a session exists", () => {
     const result = render(<App />);
 
     expect(result.getByRole("button", { name: "Sign in with Hyperlocalise" })).toBeTruthy();
     expect(result.getByText("Hyperlocalise URL")).toBeTruthy();
     expect(result.queryByRole("button", { name: "Create job and generate" })).toBeNull();
+  });
+
+  it("hydrates the page job card and keeps Close enabled", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/integrations/figma/session")) {
+        return jsonResponse({
+          session: {
+            user: { email: "dev@example.com", localUserId: "user_1" },
+            organization: { slug: "acme", name: "Acme", id: "org_1" },
+            organizations: [{ slug: "acme", name: "Acme", id: "org_1" }],
+          },
+        });
+      }
+      if (url.includes("/api/integrations/figma/projects")) {
+        return jsonResponse({
+          projects: [{ id: "proj_1", name: "Marketing", sourceLocale: "en", targetLocales: ["es"] }],
+        });
+      }
+      if (url.includes("/api/integrations/figma/jobs/current")) {
+        return jsonResponse({ job: succeededJob });
+      }
+      return jsonResponse({ error: "not_found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = render(<App />);
+    readyMessage({
+      projectId: "proj_1",
+      jobId: "job_stale",
+      sourcePath: "figma/files/file-1/pages/page-1.json",
+    });
+
+    await waitFor(() => {
+      expect(result.getByLabelText("Page job")).toBeTruthy();
+    });
+
+    expect(result.getByText("Ready")).toBeTruthy();
+    expect(result.getByText("job_figma")).toBeTruthy();
+    expect(result.getByRole("link", { name: "Open in Hyperlocalise" }).getAttribute("href")).toBe(
+      "https://app.hyperlocalise.com/org/acme/projects/proj_1/jobs/job_figma",
+    );
+    expect((result.getByRole("button", { name: "Close" }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+    expect(
+      (result.getByRole("button", { name: "Pull translations into Figma" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes("jobs/current"))).toBe(
+      true,
+    );
+  });
+
+  it("hides the job card when the server has no job for the page", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/integrations/figma/session")) {
+        return jsonResponse({
+          session: {
+            user: { email: "dev@example.com", localUserId: "user_1" },
+            organization: { slug: "acme", name: "Acme", id: "org_1" },
+            organizations: [{ slug: "acme", name: "Acme", id: "org_1" }],
+          },
+        });
+      }
+      if (url.includes("/api/integrations/figma/projects")) {
+        return jsonResponse({
+          projects: [{ id: "proj_1", name: "Marketing", sourceLocale: "en", targetLocales: ["es"] }],
+        });
+      }
+      if (url.includes("/api/integrations/figma/jobs/current")) {
+        return jsonResponse({ job: null });
+      }
+      return jsonResponse({ error: "not_found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = render(<App />);
+    readyMessage({
+      projectId: "proj_1",
+      jobId: "job_stale",
+      sourcePath: "figma/files/file-1/pages/page-1.json",
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([input]) => String(input).includes("jobs/current"))).toBe(
+        true,
+      );
+    });
+
+    expect(result.queryByLabelText("Page job")).toBeNull();
+    expect(
+      (result.getByRole("button", { name: "Pull translations into Figma" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
   });
 });

--- a/apps/figma-plugin/src/app.test.tsx
+++ b/apps/figma-plugin/src/app.test.tsx
@@ -1,9 +1,19 @@
-import { render, waitFor } from "@testing-library/react";
+import { cleanup, render, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { App } from "./app";
 import type { FigmaPageJobBinding } from "./page-binding";
 import type { FigmaPageJob, PluginSettings, SandboxToUiMessage } from "./plugin-messages";
+
+function requestUrl(input: RequestInfo | URL) {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
 
 const succeededJob: FigmaPageJob = {
   jobId: "job_figma",
@@ -60,6 +70,7 @@ function readyMessage(binding: FigmaPageJobBinding | null) {
 
 describe("Figma plugin UI", () => {
   afterEach(() => {
+    cleanup();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -74,7 +85,7 @@ describe("Figma plugin UI", () => {
 
   it("hydrates the page job card and keeps Close enabled", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
+      const url = requestUrl(input);
       if (url.includes("/api/integrations/figma/session")) {
         return jsonResponse({
           session: {
@@ -86,7 +97,9 @@ describe("Figma plugin UI", () => {
       }
       if (url.includes("/api/integrations/figma/projects")) {
         return jsonResponse({
-          projects: [{ id: "proj_1", name: "Marketing", sourceLocale: "en", targetLocales: ["es"] }],
+          projects: [
+            { id: "proj_1", name: "Marketing", sourceLocale: "en", targetLocales: ["es"] },
+          ],
         });
       }
       if (url.includes("/api/integrations/figma/jobs/current")) {
@@ -103,12 +116,9 @@ describe("Figma plugin UI", () => {
       sourcePath: "figma/files/file-1/pages/page-1.json",
     });
 
-    await waitFor(() => {
-      expect(result.getByLabelText("Page job")).toBeTruthy();
-    });
-
-    expect(result.getByText("Ready")).toBeTruthy();
-    expect(result.getByText("job_figma")).toBeTruthy();
+    const card = await waitFor(() => result.getByLabelText("Page job"));
+    expect(within(card).getByText("Ready")).toBeTruthy();
+    expect(within(card).getByText("job_figma")).toBeTruthy();
     expect(result.getByRole("link", { name: "Open in Hyperlocalise" }).getAttribute("href")).toBe(
       "https://app.hyperlocalise.com/org/acme/projects/proj_1/jobs/job_figma",
     );
@@ -120,14 +130,14 @@ describe("Figma plugin UI", () => {
         .disabled,
     ).toBe(false);
 
-    expect(fetchMock.mock.calls.some(([input]) => String(input).includes("jobs/current"))).toBe(
+    expect(fetchMock.mock.calls.some(([input]) => requestUrl(input).includes("jobs/current"))).toBe(
       true,
     );
   });
 
   it("hides the job card when the server has no job for the page", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
+      const url = requestUrl(input);
       if (url.includes("/api/integrations/figma/session")) {
         return jsonResponse({
           session: {
@@ -139,7 +149,9 @@ describe("Figma plugin UI", () => {
       }
       if (url.includes("/api/integrations/figma/projects")) {
         return jsonResponse({
-          projects: [{ id: "proj_1", name: "Marketing", sourceLocale: "en", targetLocales: ["es"] }],
+          projects: [
+            { id: "proj_1", name: "Marketing", sourceLocale: "en", targetLocales: ["es"] },
+          ],
         });
       }
       if (url.includes("/api/integrations/figma/jobs/current")) {
@@ -157,12 +169,9 @@ describe("Figma plugin UI", () => {
     });
 
     await waitFor(() => {
-      expect(fetchMock.mock.calls.some(([input]) => String(input).includes("jobs/current"))).toBe(
-        true,
-      );
+      expect(result.getByText("dev@example.com")).toBeTruthy();
+      expect(result.queryByLabelText("Page job")).toBeNull();
     });
-
-    expect(result.queryByLabelText("Page job")).toBeNull();
     expect(
       (result.getByRole("button", { name: "Pull translations into Figma" }) as HTMLButtonElement)
         .disabled,

--- a/apps/figma-plugin/src/app.test.tsx
+++ b/apps/figma-plugin/src/app.test.tsx
@@ -46,6 +46,38 @@ function jsonResponse(body: unknown, status = 200) {
   );
 }
 
+function workspaceResponse(input: RequestInfo | URL) {
+  const url = requestUrl(input);
+  if (url.includes("/api/integrations/figma/session")) {
+    return jsonResponse({
+      session: {
+        user: { email: "dev@example.com", localUserId: "user_1" },
+        organization: { slug: "acme", name: "Acme", id: "org_1" },
+        organizations: [{ slug: "acme", name: "Acme", id: "org_1" }],
+      },
+    });
+  }
+  if (url.includes("/api/integrations/figma/projects")) {
+    return jsonResponse({
+      projects: [{ id: "proj_1", name: "Marketing", sourceLocale: "en", targetLocales: ["es"] }],
+    });
+  }
+  return null;
+}
+
+function pluginMessages(postMessage: { mock: { calls: unknown[][] } }) {
+  return postMessage.mock.calls.map(([payload]) => {
+    if (!payload || typeof payload !== "object" || !("pluginMessage" in payload)) {
+      return null;
+    }
+    return (
+      payload as {
+        pluginMessage: { type: string; pageId?: string; binding?: { jobId?: string } };
+      }
+    ).pluginMessage;
+  });
+}
+
 function postToUi(message: SandboxToUiMessage) {
   window.dispatchEvent(
     new MessageEvent("message", {
@@ -108,6 +140,7 @@ describe("Figma plugin UI", () => {
       return jsonResponse({ error: "not_found" }, 404);
     });
     vi.stubGlobal("fetch", fetchMock);
+    const postMessage = vi.spyOn(window.parent, "postMessage");
 
     const result = render(<App />);
     readyMessage({
@@ -133,6 +166,67 @@ describe("Figma plugin UI", () => {
     expect(fetchMock.mock.calls.some(([input]) => requestUrl(input).includes("jobs/current"))).toBe(
       true,
     );
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginMessage: expect.objectContaining({
+          type: "binding-set",
+          pageId: "page-1",
+          binding: expect.objectContaining({ jobId: "job_figma" }),
+        }),
+      }),
+      "*",
+    );
+  });
+
+  it("does not offer Generate or Pull for a failed page job", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("/api/integrations/figma/session")) {
+        return jsonResponse({
+          session: {
+            user: { email: "dev@example.com", localUserId: "user_1" },
+            organization: { slug: "acme", name: "Acme", id: "org_1" },
+            organizations: [{ slug: "acme", name: "Acme", id: "org_1" }],
+          },
+        });
+      }
+      if (url.includes("/api/integrations/figma/projects")) {
+        return jsonResponse({
+          projects: [
+            { id: "proj_1", name: "Marketing", sourceLocale: "en", targetLocales: ["es"] },
+          ],
+        });
+      }
+      if (url.includes("/api/integrations/figma/jobs/current")) {
+        return jsonResponse({
+          job: {
+            ...succeededJob,
+            status: "failed",
+            lastError: "provider_timeout",
+            translationsByLocale: {},
+          },
+        });
+      }
+      return jsonResponse({ error: "not_found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = render(<App />);
+    readyMessage({
+      projectId: "proj_1",
+      jobId: "job_stale",
+      sourcePath: "figma/files/file-1/pages/page-1.json",
+    });
+
+    const card = await waitFor(() => result.getByLabelText("Page job"));
+    expect(within(card).getByText("Failed")).toBeTruthy();
+    expect(
+      (result.getByRole("button", { name: "Generate job" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (result.getByRole("button", { name: "Pull translations into Figma" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
   });
 
   it("hides the job card when the server has no job for the page", async () => {
@@ -176,5 +270,216 @@ describe("Figma plugin UI", () => {
       (result.getByRole("button", { name: "Pull translations into Figma" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
+  });
+
+  it("disables Pull while another action is running", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      return workspaceResponse(input) ?? jsonResponse({ job: succeededJob });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = render(<App />);
+    readyMessage({
+      projectId: "proj_1",
+      jobId: "job_stale",
+      sourcePath: "figma/files/file-1/pages/page-1.json",
+    });
+
+    await waitFor(() => {
+      expect(
+        (result.getByRole("button", { name: "Pull translations into Figma" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+
+    result.getByRole("button", { name: "Extract text" }).click();
+
+    await waitFor(() => {
+      expect(
+        (result.getByRole("button", { name: "Pull translations into Figma" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
+    });
+  });
+
+  it("keeps pull results on the originating page after a page change", async () => {
+    let resolvePull: ((value: Response) => void) | undefined;
+    const pullResponse = new Promise<Response>((resolve) => {
+      resolvePull = resolve;
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      const workspace = workspaceResponse(input);
+      if (workspace) {
+        return workspace;
+      }
+      if (url.includes("/jobs/current")) {
+        if (url.includes("pageId=page-2")) {
+          return jsonResponse({ job: null });
+        }
+        return jsonResponse({ job: succeededJob });
+      }
+      if (url.includes("/translations")) {
+        return pullResponse;
+      }
+      return jsonResponse({ error: "not_found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const postMessage = vi.spyOn(window.parent, "postMessage");
+
+    const result = render(<App />);
+    readyMessage({
+      projectId: "proj_1",
+      jobId: "job_figma",
+      sourcePath: "figma/files/file-1/pages/page-1.json",
+    });
+
+    await waitFor(() => result.getByLabelText("Page job"));
+    result.getByRole("button", { name: "Pull translations into Figma" }).click();
+
+    await waitFor(() => {
+      expect(result.getByRole("button", { name: "Pulling…" })).toBeTruthy();
+    });
+
+    postToUi({
+      type: "page-changed",
+      file: {
+        fileKey: "file-1",
+        fileName: "Marketing",
+        pageId: "page-2",
+        pageName: "About",
+      },
+      binding: null,
+    });
+
+    const originatingBindingsBeforePull = pluginMessages(postMessage).filter(
+      (message) =>
+        message?.type === "binding-set" &&
+        message.pageId === "page-1" &&
+        message.binding?.jobId === "job_figma",
+    ).length;
+
+    resolvePull!(
+      await jsonResponse({
+        translations: succeededJob,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        pluginMessages(postMessage).filter(
+          (message) =>
+            message?.type === "binding-set" &&
+            message.pageId === "page-1" &&
+            message.binding?.jobId === "job_figma",
+        ).length,
+      ).toBeGreaterThan(originatingBindingsBeforePull);
+    });
+
+    expect(
+      pluginMessages(postMessage).some(
+        (message) => message?.type === "binding-set" && message.pageId === "page-2",
+      ),
+    ).toBe(false);
+    expect(pluginMessages(postMessage).some((message) => message?.type === "apply")).toBe(false);
+
+    await waitFor(() => {
+      expect(result.queryByLabelText("Page job")).toBeNull();
+    });
+  });
+
+  it("keeps a created job on the originating page after a page change", async () => {
+    let resolveCreate: ((value: Response) => void) | undefined;
+    const createResponse = new Promise<Response>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      const workspace = workspaceResponse(input);
+      if (workspace) {
+        return workspace;
+      }
+      if (url.includes("/jobs/current")) {
+        return jsonResponse({ job: null });
+      }
+      if (url.endsWith("/api/integrations/figma/jobs")) {
+        return createResponse;
+      }
+      return jsonResponse({ error: "not_found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const postMessage = vi.spyOn(window.parent, "postMessage");
+
+    const result = render(<App />);
+    readyMessage(null);
+
+    await waitFor(() => result.getByRole("button", { name: "Extract text" }));
+    result.getByRole("button", { name: "Extract text" }).click();
+    postToUi({
+      type: "extracted",
+      segments: [{ key: "figma.segment.1:1.0", nodeId: "1:1", regionIndex: 0, text: "Hello" }],
+      file: {
+        fileKey: "file-1",
+        fileName: "Marketing",
+        pageId: "page-1",
+        pageName: "Home",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        (result.getByRole("button", { name: "Create job only" }) as HTMLButtonElement).disabled,
+      ).toBe(false);
+    });
+
+    result.getByRole("button", { name: "Create job only" }).click();
+    await waitFor(() => {
+      expect(result.getByRole("button", { name: "Creating…" })).toBeTruthy();
+    });
+
+    postToUi({
+      type: "page-changed",
+      file: {
+        fileKey: "file-1",
+        fileName: "Marketing",
+        pageId: "page-2",
+        pageName: "About",
+      },
+      binding: null,
+    });
+
+    resolveCreate!(
+      await jsonResponse({
+        job: {
+          jobId: "job_created",
+          generated: false,
+          projectId: "proj_1",
+          sourcePath: "figma/files/file-1/pages/page-1.json",
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        pluginMessages(postMessage).some(
+          (message) =>
+            message?.type === "binding-set" &&
+            message.pageId === "page-1" &&
+            message.binding?.jobId === "job_created",
+        ),
+      ).toBe(true);
+    });
+
+    expect(
+      pluginMessages(postMessage).some(
+        (message) =>
+          message?.type === "binding-set" &&
+          message.pageId === "page-2" &&
+          message.binding?.jobId === "job_created",
+      ),
+    ).toBe(false);
+    await waitFor(() => {
+      expect(result.queryByText("job_created")).toBeNull();
+    });
   });
 });

--- a/apps/figma-plugin/src/app.tsx
+++ b/apps/figma-plugin/src/app.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   createFigmaJob,
@@ -147,6 +147,7 @@ export function App() {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [booted, setBooted] = useState(false);
+  const pageIdRef = useRef<string | null>(null);
 
   const signedIn = Boolean(settings.sealedSession);
   const selectedProject = projects.find((project) => project.id === settings.projectId);
@@ -161,36 +162,41 @@ export function App() {
     signedIn &&
     Boolean(settings.organizationSlug) &&
     Boolean(pageJob?.projectId || settings.projectId) &&
-    busy !== "pull" &&
+    busy == null &&
     pageJob != null &&
     (pageJob.status === "succeeded" || pageJob.status === "waiting_for_review");
   const canGeneratePageJob =
-    signedIn &&
-    pageJob != null &&
-    (pageJob.status === "queued" || pageJob.status === "failed") &&
-    busy == null;
+    signedIn && pageJob != null && pageJob.status === "queued" && busy == null;
 
   const persistSettings = (next: PluginSettings) => {
     setSettings(next);
     postPluginMessage({ type: "storage-set", settings: next });
   };
 
-  const persistBinding = (binding: FigmaPageJobBinding | null) => {
-    setPageBinding(binding);
+  const persistBinding = (binding: FigmaPageJobBinding | null, pageId: string) => {
+    if (pageIdRef.current === pageId) {
+      setPageBinding(binding);
+    }
     if (binding) {
-      postPluginMessage({ type: "binding-set", binding });
+      postPluginMessage({ type: "binding-set", binding, pageId });
     } else {
-      postPluginMessage({ type: "binding-clear" });
+      postPluginMessage({ type: "binding-clear", pageId });
     }
   };
 
-  const rememberPageJob = (job: FigmaPageJob) => {
+  const rememberPageJob = (job: FigmaPageJob, pageId: string) => {
+    persistBinding(
+      {
+        projectId: job.projectId,
+        jobId: job.jobId,
+        sourcePath: job.sourcePath,
+      },
+      pageId,
+    );
+    if (pageIdRef.current !== pageId) {
+      return;
+    }
     setPageJob(job);
-    persistBinding({
-      projectId: job.projectId,
-      jobId: job.jobId,
-      sourcePath: job.sourcePath,
-    });
     setSettings((current) => {
       const next = { ...current, lastJobId: job.jobId };
       postPluginMessage({ type: "storage-set", settings: next });
@@ -199,16 +205,22 @@ export function App() {
   };
 
   useEffect(() => {
+    pageIdRef.current = file?.pageId ?? null;
+  }, [file?.pageId]);
+
+  useEffect(() => {
     const handleMessage = (event: MessageEvent<{ pluginMessage?: SandboxToUiMessage }>) => {
       const payload = event.data.pluginMessage;
       if (payload?.type === "ready") {
         setSettings(mergeSettings(payload.settings));
         setFile(payload.file);
+        pageIdRef.current = payload.file.pageId;
         setPageBinding(payload.binding);
         setBooted(true);
       }
       if (payload?.type === "page-changed") {
         setFile(payload.file);
+        pageIdRef.current = payload.file.pageId;
         setPageBinding(payload.binding);
         setPageJob(null);
         setSegments([]);
@@ -303,30 +315,31 @@ export function App() {
     let cancelled = false;
 
     async function hydratePageJob() {
+      const originatedPageId = file!.pageId;
       try {
         const job = await fetchCurrentFigmaJob({
           appUrl: settings.appUrl,
           sealedSession: settings.sealedSession!,
           organizationSlug: settings.organizationSlug,
           fileKey: file!.fileKey,
-          pageId: file!.pageId,
+          pageId: originatedPageId,
           projectId: pageBinding?.projectId || settings.projectId || undefined,
         });
-        if (cancelled) {
-          return;
-        }
         if (job) {
-          rememberPageJob(job);
+          rememberPageJob(job, originatedPageId);
+          if (cancelled || pageIdRef.current !== originatedPageId) {
+            return;
+          }
           const locales = Object.keys(job.translationsByLocale);
           setApplyLocale((current) => current || locales[0] || job.targetLocales[0] || "");
           return;
         }
-        persistBinding(null);
-        setPageJob(null);
-      } catch (error) {
-        if (cancelled) {
+        persistBinding(null, originatedPageId);
+        if (cancelled || pageIdRef.current !== originatedPageId) {
           return;
         }
+        setPageJob(null);
+      } catch (error) {
         if (pageBinding?.jobId) {
           try {
             const job = await getFigmaJob({
@@ -335,15 +348,15 @@ export function App() {
               organizationSlug: settings.organizationSlug,
               jobId: pageBinding.jobId,
             });
-            if (!cancelled) {
-              rememberPageJob(job);
-            }
+            rememberPageJob(job, originatedPageId);
             return;
           } catch {
             // Keep the page binding and show the stored job id as a fallback.
           }
         }
-        setErrorMessage(error instanceof Error ? error.message : "Unable to load the page job.");
+        if (!cancelled && pageIdRef.current === originatedPageId) {
+          setErrorMessage(error instanceof Error ? error.message : "Unable to load the page job.");
+        }
       }
     }
 
@@ -360,6 +373,7 @@ export function App() {
 
     let cancelled = false;
     const jobId = pageJob.jobId;
+    const originatedPageId = pageIdRef.current;
 
     async function refreshJob() {
       try {
@@ -369,15 +383,21 @@ export function App() {
           organizationSlug: settings.organizationSlug,
           jobId,
         });
-        if (cancelled) {
+        if (cancelled || !originatedPageId) {
+          return;
+        }
+        persistBinding(
+          {
+            projectId: job.projectId,
+            jobId: job.jobId,
+            sourcePath: job.sourcePath,
+          },
+          originatedPageId,
+        );
+        if (pageIdRef.current !== originatedPageId) {
           return;
         }
         setPageJob(job);
-        persistBinding({
-          projectId: job.projectId,
-          jobId: job.jobId,
-          sourcePath: job.sourcePath,
-        });
         if (!isInFlightStatus(job.status)) {
           const locales = Object.keys(job.translationsByLocale);
           setApplyLocale((current) => current || locales[0] || job.targetLocales[0] || "");
@@ -390,7 +410,7 @@ export function App() {
           }
         }
       } catch (error) {
-        if (!cancelled) {
+        if (!cancelled && originatedPageId && pageIdRef.current === originatedPageId) {
           setErrorMessage(error instanceof Error ? error.message : "Unable to check job status.");
         }
       }
@@ -450,6 +470,7 @@ export function App() {
       );
       setSegments(result.segments);
       setFile(result.file);
+      pageIdRef.current = result.file.pageId;
       setStatusMessage(
         result.segments.length > 0
           ? `Extracted ${result.segments.length} text segment${result.segments.length === 1 ? "" : "s"} from ${result.file.pageName}.`
@@ -466,13 +487,14 @@ export function App() {
         throw new Error("Select a project to upload to.");
       }
 
+      const originatedPageId = file.pageId;
       const created = await createFigmaJob({
         appUrl: settings.appUrl,
         sealedSession: settings.sealedSession,
         organizationSlug: settings.organizationSlug,
         projectId: settings.projectId,
         fileKey: file.fileKey,
-        pageId: file.pageId,
+        pageId: originatedPageId,
         fileName: file.fileName,
         sourceLocale: settings.sourceLocale,
         targetLocales: settings.targetLocales,
@@ -485,7 +507,11 @@ export function App() {
           ...created,
           targetLocales: settings.targetLocales,
         }),
+        originatedPageId,
       );
+      if (pageIdRef.current !== originatedPageId) {
+        return;
+      }
       setStatusMessage(
         generate
           ? "Job created. Translating…"
@@ -499,12 +525,16 @@ export function App() {
         throw new Error("Create a job first.");
       }
 
+      const originatedPageId = pageIdRef.current;
       await generateFigmaJob({
         appUrl: settings.appUrl,
         sealedSession: settings.sealedSession,
         organizationSlug: settings.organizationSlug,
         jobId: pageJob.jobId,
       });
+      if (!originatedPageId || pageIdRef.current !== originatedPageId) {
+        return;
+      }
       setPageJob({ ...pageJob, status: "queued", lastError: null });
       setStatusMessage("Generating translations…");
     });
@@ -519,15 +549,19 @@ export function App() {
         throw new Error("Select a project to pull translations from.");
       }
 
+      const originatedPageId = file.pageId;
       const pulled = await pullFigmaTranslations({
         appUrl: settings.appUrl,
         sealedSession: settings.sealedSession,
         organizationSlug: settings.organizationSlug,
         projectId,
         fileKey: file.fileKey,
-        pageId: file.pageId,
+        pageId: originatedPageId,
       });
-      rememberPageJob(pulled);
+      rememberPageJob(pulled, originatedPageId);
+      if (pageIdRef.current !== originatedPageId) {
+        return;
+      }
       const locales = Object.keys(pulled.translationsByLocale);
       const locale = applyLocale || locales[0] || settings.targetLocales[0];
       if (!locale || !pulled.translationsByLocale[locale]) {

--- a/apps/figma-plugin/src/app.tsx
+++ b/apps/figma-plugin/src/app.tsx
@@ -46,6 +46,25 @@ const LOCALE_OPTIONS = [
 
 type BusyAction = "login" | "extract" | "create" | "generate" | "pull" | null;
 
+function HyperlocaliseJobLink({ href }: { href: string }) {
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+
+  return (
+    <a className="jobLink" href={parsed.href} target="_blank" rel="noopener noreferrer">
+      Open in Hyperlocalise
+    </a>
+  );
+}
+
 function postPluginMessage(message: UiToSandboxMessage) {
   parent.postMessage({ pluginMessage: message }, "*");
 }
@@ -712,11 +731,7 @@ export function App() {
               {pageJob.lastError && pageJob.status === "failed" ? (
                 <p className="error">{pageJob.lastError}</p>
               ) : null}
-              {jobHref ? (
-                <a className="jobLink" href={jobHref} target="_blank" rel="noreferrer">
-                  Open in Hyperlocalise
-                </a>
-              ) : null}
+              {jobHref ? <HyperlocaliseJobLink href={jobHref} /> : null}
             </section>
           ) : null}
 

--- a/apps/figma-plugin/src/app.tsx
+++ b/apps/figma-plugin/src/app.tsx
@@ -2,17 +2,21 @@ import { useEffect, useState } from "react";
 
 import {
   createFigmaJob,
+  fetchCurrentFigmaJob,
   fetchFigmaProjects,
   fetchFigmaSession,
+  FIGMA_JOB_POLL_INTERVAL_MS,
   generateFigmaJob,
+  getFigmaJob,
   HyperlocaliseClientError,
-  pollFigmaJob,
   pullFigmaTranslations,
   signInWithOAuth,
   type FigmaProject,
 } from "./hyperlocalise-client";
+import { buildFigmaJobUrl, type FigmaPageJobBinding } from "./page-binding";
 import type {
   FigmaFileInfo,
+  FigmaPageJob,
   FigmaSegment,
   PluginSettings,
   SandboxToUiMessage,
@@ -72,12 +76,53 @@ function requestFromSandbox<T extends SandboxToUiMessage["type"]>(
   });
 }
 
+function isInFlightStatus(status: FigmaPageJob["status"]) {
+  return status === "queued" || status === "running";
+}
+
+function jobStatusLabel(status: FigmaPageJob["status"]) {
+  switch (status) {
+    case "queued":
+      return "Queued";
+    case "running":
+      return "Translating";
+    case "waiting_for_review":
+      return "Needs review";
+    case "succeeded":
+      return "Ready";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+  }
+}
+
+function pageJobFromCreate(input: {
+  jobId: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocales: string[];
+  generated: boolean;
+}): FigmaPageJob {
+  return {
+    jobId: input.jobId,
+    status: input.generated ? "queued" : "queued",
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+    targetLocales: input.targetLocales,
+    lastError: null,
+    translationsByLocale: {},
+  };
+}
+
 export function App() {
   const [settings, setSettings] = useState<PluginSettings>(DEFAULT_SETTINGS);
   const [file, setFile] = useState<FigmaFileInfo | null>(null);
   const [projects, setProjects] = useState<FigmaProject[]>([]);
   const [organizations, setOrganizations] = useState<Array<{ slug: string; name: string }>>([]);
   const [segments, setSegments] = useState<FigmaSegment[]>([]);
+  const [pageBinding, setPageBinding] = useState<FigmaPageJobBinding | null>(null);
+  const [pageJob, setPageJob] = useState<FigmaPageJob | null>(null);
   const [applyLocale, setApplyLocale] = useState("");
   const [busy, setBusy] = useState<BusyAction>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -94,11 +139,44 @@ export function App() {
     segments.length > 0 &&
     busy == null;
   const canPull =
-    signedIn && Boolean(settings.organizationSlug) && Boolean(settings.projectId) && busy == null;
+    signedIn &&
+    Boolean(settings.organizationSlug) &&
+    Boolean(pageJob?.projectId || settings.projectId) &&
+    busy !== "pull" &&
+    pageJob != null &&
+    (pageJob.status === "succeeded" || pageJob.status === "waiting_for_review");
+  const canGeneratePageJob =
+    signedIn &&
+    pageJob != null &&
+    (pageJob.status === "queued" || pageJob.status === "failed") &&
+    busy == null;
 
   const persistSettings = (next: PluginSettings) => {
     setSettings(next);
     postPluginMessage({ type: "storage-set", settings: next });
+  };
+
+  const persistBinding = (binding: FigmaPageJobBinding | null) => {
+    setPageBinding(binding);
+    if (binding) {
+      postPluginMessage({ type: "binding-set", binding });
+    } else {
+      postPluginMessage({ type: "binding-clear" });
+    }
+  };
+
+  const rememberPageJob = (job: FigmaPageJob) => {
+    setPageJob(job);
+    persistBinding({
+      projectId: job.projectId,
+      jobId: job.jobId,
+      sourcePath: job.sourcePath,
+    });
+    setSettings((current) => {
+      const next = { ...current, lastJobId: job.jobId };
+      postPluginMessage({ type: "storage-set", settings: next });
+      return next;
+    });
   };
 
   useEffect(() => {
@@ -107,7 +185,15 @@ export function App() {
       if (payload?.type === "ready") {
         setSettings(mergeSettings(payload.settings));
         setFile(payload.file);
+        setPageBinding(payload.binding);
         setBooted(true);
+      }
+      if (payload?.type === "page-changed") {
+        setFile(payload.file);
+        setPageBinding(payload.binding);
+        setPageJob(null);
+        setSegments([]);
+        setStatusMessage(null);
       }
     };
 
@@ -190,6 +276,117 @@ export function App() {
     };
   }, [booted, settings.sealedSession, settings.organizationSlug]);
 
+  useEffect(() => {
+    if (!booted || !settings.sealedSession || !file || !settings.organizationSlug) {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function hydratePageJob() {
+      try {
+        const job = await fetchCurrentFigmaJob({
+          appUrl: settings.appUrl,
+          sealedSession: settings.sealedSession!,
+          organizationSlug: settings.organizationSlug,
+          fileKey: file!.fileKey,
+          pageId: file!.pageId,
+          projectId: pageBinding?.projectId || settings.projectId || undefined,
+        });
+        if (cancelled) {
+          return;
+        }
+        if (job) {
+          rememberPageJob(job);
+          const locales = Object.keys(job.translationsByLocale);
+          setApplyLocale((current) => current || locales[0] || job.targetLocales[0] || "");
+          return;
+        }
+        persistBinding(null);
+        setPageJob(null);
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        if (pageBinding?.jobId) {
+          try {
+            const job = await getFigmaJob({
+              appUrl: settings.appUrl,
+              sealedSession: settings.sealedSession!,
+              organizationSlug: settings.organizationSlug,
+              jobId: pageBinding.jobId,
+            });
+            if (!cancelled) {
+              rememberPageJob(job);
+            }
+            return;
+          } catch {
+            // Keep the page binding and show the stored job id as a fallback.
+          }
+        }
+        setErrorMessage(error instanceof Error ? error.message : "Unable to load the page job.");
+      }
+    }
+
+    void hydratePageJob();
+    return () => {
+      cancelled = true;
+    };
+  }, [booted, settings.sealedSession, settings.organizationSlug, file?.fileKey, file?.pageId]);
+
+  useEffect(() => {
+    if (!pageJob || !isInFlightStatus(pageJob.status) || !settings.sealedSession) {
+      return;
+    }
+
+    let cancelled = false;
+    const jobId = pageJob.jobId;
+
+    async function refreshJob() {
+      try {
+        const job = await getFigmaJob({
+          appUrl: settings.appUrl,
+          sealedSession: settings.sealedSession!,
+          organizationSlug: settings.organizationSlug,
+          jobId,
+        });
+        if (cancelled) {
+          return;
+        }
+        setPageJob(job);
+        persistBinding({
+          projectId: job.projectId,
+          jobId: job.jobId,
+          sourcePath: job.sourcePath,
+        });
+        if (!isInFlightStatus(job.status)) {
+          const locales = Object.keys(job.translationsByLocale);
+          setApplyLocale((current) => current || locales[0] || job.targetLocales[0] || "");
+          if (job.status === "succeeded") {
+            setStatusMessage("Translations are ready. Choose a locale and pull them into Figma.");
+          } else if (job.status === "waiting_for_review") {
+            setStatusMessage("Needs review. You can still pull the current translations.");
+          } else if (job.status === "failed") {
+            setErrorMessage(job.lastError || "Translation job failed.");
+          }
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setErrorMessage(error instanceof Error ? error.message : "Unable to check job status.");
+        }
+      }
+    }
+
+    void refreshJob();
+    const interval = window.setInterval(() => {
+      void refreshJob();
+    }, FIGMA_JOB_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [pageJob?.jobId, pageJob?.status, settings.sealedSession, settings.organizationSlug]);
+
   const runAction = async (action: Exclude<BusyAction, null>, work: () => Promise<void>) => {
     setBusy(action);
     setErrorMessage(null);
@@ -222,6 +419,7 @@ export function App() {
       lastJobId: null,
     });
     setProjects([]);
+    setPageJob(null);
     setStatusMessage("Signed out.");
   };
 
@@ -263,30 +461,22 @@ export function App() {
         segments,
       });
 
-      persistSettings({ ...settings, lastJobId: created.jobId });
+      rememberPageJob(
+        pageJobFromCreate({
+          ...created,
+          targetLocales: settings.targetLocales,
+        }),
+      );
       setStatusMessage(
         generate
-          ? "Job created. Generating translations…"
+          ? "Job created. Translating…"
           : `Job ${created.jobId} created. Generate translations when you are ready.`,
       );
-
-      if (generate) {
-        const completed = await pollFigmaJob({
-          appUrl: settings.appUrl,
-          sealedSession: settings.sealedSession,
-          organizationSlug: settings.organizationSlug,
-          jobId: created.jobId,
-        });
-        const locales =
-          completed.status === "succeeded" ? Object.keys(completed.translationsByLocale) : [];
-        setApplyLocale((current) => current || locales[0] || settings.targetLocales[0] || "");
-        setStatusMessage("Translations are ready. Choose a locale and pull them into Figma.");
-      }
     });
 
   const handleGenerateExisting = () =>
     runAction("generate", async () => {
-      if (!settings.sealedSession || !settings.lastJobId) {
+      if (!settings.sealedSession || !pageJob) {
         throw new Error("Create a job first.");
       }
 
@@ -294,18 +484,10 @@ export function App() {
         appUrl: settings.appUrl,
         sealedSession: settings.sealedSession,
         organizationSlug: settings.organizationSlug,
-        jobId: settings.lastJobId,
+        jobId: pageJob.jobId,
       });
-      const completed = await pollFigmaJob({
-        appUrl: settings.appUrl,
-        sealedSession: settings.sealedSession,
-        organizationSlug: settings.organizationSlug,
-        jobId: settings.lastJobId,
-      });
-      const locales =
-        completed.status === "succeeded" ? Object.keys(completed.translationsByLocale) : [];
-      setApplyLocale((current) => current || locales[0] || settings.targetLocales[0] || "");
-      setStatusMessage("Translations are ready. Choose a locale and pull them into Figma.");
+      setPageJob({ ...pageJob, status: "queued", lastError: null });
+      setStatusMessage("Generating translations…");
     });
 
   const handlePull = () =>
@@ -313,7 +495,8 @@ export function App() {
       if (!settings.sealedSession || !file) {
         throw new Error("Sign in first.");
       }
-      if (!settings.projectId) {
+      const projectId = pageJob?.projectId || settings.projectId;
+      if (!projectId) {
         throw new Error("Select a project to pull translations from.");
       }
 
@@ -321,10 +504,11 @@ export function App() {
         appUrl: settings.appUrl,
         sealedSession: settings.sealedSession,
         organizationSlug: settings.organizationSlug,
-        projectId: settings.projectId,
+        projectId,
         fileKey: file.fileKey,
         pageId: file.pageId,
       });
+      rememberPageJob(pulled);
       const locales = Object.keys(pulled.translationsByLocale);
       const locale = applyLocale || locales[0] || settings.targetLocales[0];
       if (!locale || !pulled.translationsByLocale[locale]) {
@@ -340,11 +524,20 @@ export function App() {
         },
         "applied",
       );
-      persistSettings({ ...settings, lastJobId: pulled.jobId ?? settings.lastJobId });
       setStatusMessage(
         `Applied ${applied.count} translated segment${applied.count === 1 ? "" : "s"} (${locale}).`,
       );
     });
+
+  const jobHref =
+    pageJob && settings.organizationSlug
+      ? buildFigmaJobUrl({
+          appUrl: settings.appUrl,
+          organizationSlug: settings.organizationSlug,
+          projectId: pageJob.projectId,
+          jobId: pageJob.jobId,
+        })
+      : null;
 
   return (
     <div className="container">
@@ -505,6 +698,26 @@ export function App() {
             {selectedProject ? ` · ${selectedProject.name}` : ""}
           </p>
 
+          {pageJob ? (
+            <section className="jobCard" aria-label="Page job">
+              <p className="jobCardStatus">
+                <span className={`jobBadge jobBadge-${pageJob.status}`}>
+                  {jobStatusLabel(pageJob.status)}
+                </span>
+                {isInFlightStatus(pageJob.status) ? <span className="jobPulse">Working…</span> : null}
+              </p>
+              <p className="jobCardId">{pageJob.jobId}</p>
+              {pageJob.lastError && pageJob.status === "failed" ? (
+                <p className="error">{pageJob.lastError}</p>
+              ) : null}
+              {jobHref ? (
+                <a className="jobLink" href={jobHref} target="_blank" rel="noreferrer">
+                  Open in Hyperlocalise
+                </a>
+              ) : null}
+            </section>
+          ) : null}
+
           <div className="actions">
             <button
               type="button"
@@ -521,7 +734,7 @@ export function App() {
               disabled={!canCreateJob}
               title={!settings.projectId ? "Select a project to upload to" : undefined}
             >
-              {busy === "generate" ? "Generating…" : "Create job and generate"}
+              {busy === "generate" ? "Creating…" : "Create job and generate"}
             </button>
             <button
               type="button"
@@ -536,9 +749,9 @@ export function App() {
               type="button"
               className="button"
               onClick={() => void handleGenerateExisting()}
-              disabled={!settings.lastJobId || busy != null}
+              disabled={!canGeneratePageJob}
             >
-              Generate last job
+              {busy === "generate" && pageJob ? "Generating…" : "Generate job"}
             </button>
           </div>
 
@@ -547,7 +760,7 @@ export function App() {
             <select
               value={applyLocale || settings.targetLocales[0] || ""}
               onChange={(event) => setApplyLocale(event.target.value)}
-              disabled={busy != null}
+              disabled={busy === "pull"}
             >
               {settings.targetLocales.map((locale) => (
                 <option key={locale} value={locale}>
@@ -573,12 +786,7 @@ export function App() {
       {errorMessage ? <p className="error">{errorMessage}</p> : null}
 
       <div className="footer">
-        <button
-          type="button"
-          className="button"
-          onClick={() => postPluginMessage({ type: "cancel" })}
-          disabled={busy != null}
-        >
+        <button type="button" className="button" onClick={() => postPluginMessage({ type: "cancel" })}>
           Close
         </button>
       </div>

--- a/apps/figma-plugin/src/app.tsx
+++ b/apps/figma-plugin/src/app.tsx
@@ -704,7 +704,9 @@ export function App() {
                 <span className={`jobBadge jobBadge-${pageJob.status}`}>
                   {jobStatusLabel(pageJob.status)}
                 </span>
-                {isInFlightStatus(pageJob.status) ? <span className="jobPulse">Working…</span> : null}
+                {isInFlightStatus(pageJob.status) ? (
+                  <span className="jobPulse">Working…</span>
+                ) : null}
               </p>
               <p className="jobCardId">{pageJob.jobId}</p>
               {pageJob.lastError && pageJob.status === "failed" ? (
@@ -786,7 +788,11 @@ export function App() {
       {errorMessage ? <p className="error">{errorMessage}</p> : null}
 
       <div className="footer">
-        <button type="button" className="button" onClick={() => postPluginMessage({ type: "cancel" })}>
+        <button
+          type="button"
+          className="button"
+          onClick={() => postPluginMessage({ type: "cancel" })}
+        >
           Close
         </button>
       </div>

--- a/apps/figma-plugin/src/code.ts
+++ b/apps/figma-plugin/src/code.ts
@@ -1,9 +1,19 @@
 import type { FigmaFileInfo, SandboxToUiMessage, UiToSandboxMessage } from "./plugin-messages";
 import { SETTINGS_STORAGE_KEY } from "./plugin-messages";
+import {
+  PAGE_BINDING_KEY,
+  parsePageJobBinding,
+  serializePageJobBinding,
+  type FigmaPageJobBinding,
+} from "./page-binding";
 import { createFigmaSegment } from "./segment-file";
 import { mergeSettings } from "./settings";
 
-figma.showUI(__html__, { themeColors: true, width: 360, height: 620 });
+figma.showUI(__html__, { themeColors: true, width: 360, height: 720 });
+
+figma.on("currentpagechange", () => {
+  postToUi({ type: "page-changed", file: currentFileInfo(), binding: readPageBinding() });
+});
 
 figma.ui.onmessage = async (msg: UiToSandboxMessage) => {
   try {
@@ -14,12 +24,22 @@ figma.ui.onmessage = async (msg: UiToSandboxMessage) => {
 
     if (msg.type === "boot") {
       const settings = mergeSettings(await figma.clientStorage.getAsync(SETTINGS_STORAGE_KEY));
-      postToUi({ type: "ready", settings, file: currentFileInfo() });
+      postToUi({ type: "ready", settings, file: currentFileInfo(), binding: readPageBinding() });
       return;
     }
 
     if (msg.type === "storage-set") {
       await figma.clientStorage.setAsync(SETTINGS_STORAGE_KEY, msg.settings);
+      return;
+    }
+
+    if (msg.type === "binding-set") {
+      writePageBinding(msg.binding);
+      return;
+    }
+
+    if (msg.type === "binding-clear") {
+      figma.currentPage.setPluginData(PAGE_BINDING_KEY, "");
       return;
     }
 
@@ -42,6 +62,14 @@ figma.ui.onmessage = async (msg: UiToSandboxMessage) => {
     });
   }
 };
+
+function readPageBinding(): FigmaPageJobBinding | null {
+  return parsePageJobBinding(figma.currentPage.getPluginData(PAGE_BINDING_KEY));
+}
+
+function writePageBinding(binding: FigmaPageJobBinding) {
+  figma.currentPage.setPluginData(PAGE_BINDING_KEY, serializePageJobBinding(binding));
+}
 
 function postToUi(message: SandboxToUiMessage) {
   figma.ui.postMessage(message);

--- a/apps/figma-plugin/src/code.ts
+++ b/apps/figma-plugin/src/code.ts
@@ -34,12 +34,15 @@ figma.ui.onmessage = async (msg: UiToSandboxMessage) => {
     }
 
     if (msg.type === "binding-set") {
-      writePageBinding(msg.binding);
+      await writePageBinding(msg.pageId, msg.binding);
       return;
     }
 
     if (msg.type === "binding-clear") {
-      figma.currentPage.setPluginData(PAGE_BINDING_KEY, "");
+      const page = await pageNode(msg.pageId);
+      if (page) {
+        page.setPluginData(PAGE_BINDING_KEY, "");
+      }
       return;
     }
 
@@ -67,8 +70,21 @@ function readPageBinding(): FigmaPageJobBinding | null {
   return parsePageJobBinding(figma.currentPage.getPluginData(PAGE_BINDING_KEY));
 }
 
-function writePageBinding(binding: FigmaPageJobBinding) {
-  figma.currentPage.setPluginData(PAGE_BINDING_KEY, serializePageJobBinding(binding));
+async function pageNode(pageId: string): Promise<PageNode | null> {
+  if (figma.currentPage.id === pageId) {
+    return figma.currentPage;
+  }
+
+  const node = await figma.getNodeByIdAsync(pageId);
+  return node?.type === "PAGE" ? node : null;
+}
+
+async function writePageBinding(pageId: string, binding: FigmaPageJobBinding) {
+  const page = await pageNode(pageId);
+  if (!page) {
+    return;
+  }
+  page.setPluginData(PAGE_BINDING_KEY, serializePageJobBinding(binding));
 }
 
 function postToUi(message: SandboxToUiMessage) {

--- a/apps/figma-plugin/src/hyperlocalise-client.test.ts
+++ b/apps/figma-plugin/src/hyperlocalise-client.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  fetchCurrentFigmaJob,
+  HyperlocaliseClientError,
+  pullFigmaTranslations,
+} from "./hyperlocalise-client";
+import type { FigmaPageJob } from "./plugin-messages";
+
+const pageJob: FigmaPageJob = {
+  jobId: "job_figma",
+  status: "waiting_for_review",
+  projectId: "proj_1",
+  sourcePath: "figma/files/file-1/pages/page-1.json",
+  targetLocales: ["es"],
+  lastError: null,
+  translationsByLocale: { es: { "figma.segment.1:1.0": "Hola" } },
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+describe("figma hyperlocalise client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("loads the current page job and omits an empty projectId", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        "https://app.hyperlocalise.com/api/integrations/figma/jobs/current?fileKey=file-1&pageId=page-1",
+      );
+      return jsonResponse({ job: pageJob });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchCurrentFigmaJob({
+        appUrl: "https://app.hyperlocalise.com",
+        sealedSession: "sealed.session",
+        organizationSlug: "acme",
+        fileKey: "file-1",
+        pageId: "page-1",
+      }),
+    ).resolves.toEqual(pageJob);
+  });
+
+  it("scopes the current page job when a project id is provided", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("projectId=proj_1");
+      return jsonResponse({ job: null });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchCurrentFigmaJob({
+        appUrl: "https://app.hyperlocalise.com",
+        sealedSession: "sealed.session",
+        organizationSlug: "acme",
+        fileKey: "file-1",
+        pageId: "page-1",
+        projectId: "proj_1",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("pulls waiting-for-review translations and rejects in-flight jobs", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ translations: pageJob }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      pullFigmaTranslations({
+        appUrl: "https://app.hyperlocalise.com",
+        sealedSession: "sealed.session",
+        organizationSlug: "acme",
+        projectId: "proj_1",
+        fileKey: "file-1",
+        pageId: "page-1",
+      }),
+    ).resolves.toMatchObject({ status: "waiting_for_review", jobId: "job_figma" });
+
+    fetchMock.mockImplementation(async () =>
+      jsonResponse({
+        translations: { ...pageJob, status: "running", translationsByLocale: {} },
+      }),
+    );
+
+    await expect(
+      pullFigmaTranslations({
+        appUrl: "https://app.hyperlocalise.com",
+        sealedSession: "sealed.session",
+        organizationSlug: "acme",
+        projectId: "proj_1",
+        fileKey: "file-1",
+        pageId: "page-1",
+      }),
+    ).rejects.toBeInstanceOf(HyperlocaliseClientError);
+  });
+});

--- a/apps/figma-plugin/src/hyperlocalise-client.test.ts
+++ b/apps/figma-plugin/src/hyperlocalise-client.test.ts
@@ -7,6 +7,16 @@ import {
 } from "./hyperlocalise-client";
 import type { FigmaPageJob } from "./plugin-messages";
 
+function requestUrl(input: RequestInfo | URL) {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
+
 const pageJob: FigmaPageJob = {
   jobId: "job_figma",
   status: "waiting_for_review",
@@ -34,7 +44,7 @@ describe("figma hyperlocalise client", () => {
 
   it("loads the current page job and omits an empty projectId", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      expect(String(input)).toBe(
+      expect(requestUrl(input)).toBe(
         "https://app.hyperlocalise.com/api/integrations/figma/jobs/current?fileKey=file-1&pageId=page-1",
       );
       return jsonResponse({ job: pageJob });
@@ -54,7 +64,7 @@ describe("figma hyperlocalise client", () => {
 
   it("scopes the current page job when a project id is provided", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      expect(String(input)).toContain("projectId=proj_1");
+      expect(requestUrl(input)).toContain("projectId=proj_1");
       return jsonResponse({ job: null });
     });
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/figma-plugin/src/hyperlocalise-client.ts
+++ b/apps/figma-plugin/src/hyperlocalise-client.ts
@@ -1,12 +1,10 @@
-import { FIGMA_OAUTH_MESSAGE_TYPE } from "./plugin-messages";
-import type { FigmaSegment } from "./plugin-messages";
+import { FIGMA_OAUTH_MESSAGE_TYPE, type FigmaPageJob, type FigmaSegment } from "./plugin-messages";
 import { createPkcePair } from "./pkce";
 import { normalizeAppUrl } from "./settings";
 
 const FIGMA_SESSION_HEADER = "X-Hyperlocalise-Figma-Session";
 const ORGANIZATION_SLUG_HEADER = "X-Hyperlocalise-Organization-Slug";
-const POLL_INTERVAL_MS = 1_500;
-const MAX_POLL_ATTEMPTS = 120;
+export const FIGMA_JOB_POLL_INTERVAL_MS = 1_500;
 
 export class HyperlocaliseClientError extends Error {
   readonly code: string;
@@ -31,13 +29,7 @@ export type FigmaProject = {
   targetLocales: string[];
 };
 
-export type FigmaJobStatus =
-  | { jobId: string; status: "queued" | "running" }
-  | {
-      jobId: string;
-      status: "succeeded";
-      translationsByLocale: Record<string, Record<string, string>>;
-    };
+export type FigmaJobStatus = FigmaPageJob;
 
 type ErrorPayload = { error?: string; message?: string };
 
@@ -234,7 +226,12 @@ export async function createFigmaJob(input: {
   targetLocales: string[];
   generate: boolean;
   segments: FigmaSegment[];
-}): Promise<{ jobId: string; generated: boolean }> {
+}): Promise<{
+  jobId: string;
+  generated: boolean;
+  projectId: string;
+  sourcePath: string;
+}> {
   const response = await fetch(apiUrl(input.appUrl, "/api/integrations/figma/jobs"), {
     method: "POST",
     headers: sessionHeaders(input),
@@ -251,10 +248,15 @@ export async function createFigmaJob(input: {
   });
   const payload = (await response.json().catch(() => null)) as
     | ({
-        job?: { jobId?: string; generated?: boolean };
+        job?: {
+          jobId?: string;
+          generated?: boolean;
+          projectId?: string;
+          sourcePath?: string;
+        };
       } & ErrorPayload)
     | null;
-  if (!response.ok || !payload?.job?.jobId) {
+  if (!response.ok || !payload?.job?.jobId || !payload.job.projectId || !payload.job.sourcePath) {
     throw new HyperlocaliseClientError(
       payload?.error ?? "figma_job_create_failed",
       payload?.message ?? "Unable to create a translation job.",
@@ -263,6 +265,8 @@ export async function createFigmaJob(input: {
   return {
     jobId: payload.job.jobId,
     generated: payload.job.generated ?? input.generate,
+    projectId: payload.job.projectId,
+    sourcePath: payload.job.sourcePath,
   };
 }
 
@@ -291,41 +295,66 @@ export async function generateFigmaJob(input: {
   }
 }
 
-export async function pollFigmaJob(input: {
+export async function getFigmaJob(input: {
   appUrl: string;
   sealedSession: string;
   organizationSlug: string;
   jobId: string;
 }): Promise<FigmaJobStatus> {
-  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt += 1) {
-    const response = await fetch(
-      apiUrl(input.appUrl, `/api/integrations/figma/jobs/${encodeURIComponent(input.jobId)}`),
-      { headers: sessionHeaders(input) },
+  const response = await fetch(
+    apiUrl(input.appUrl, `/api/integrations/figma/jobs/${encodeURIComponent(input.jobId)}`),
+    { headers: sessionHeaders(input) },
+  );
+  const payload = (await response.json().catch(() => null)) as
+    | ({
+        job?: FigmaJobStatus;
+      } & ErrorPayload)
+    | null;
+
+  if (!response.ok || !payload?.job?.jobId) {
+    throw new HyperlocaliseClientError(
+      payload?.error ?? "figma_job_poll_failed",
+      payload?.message ?? "Unable to check job status.",
     );
-    const payload = (await response.json().catch(() => null)) as
-      | ({
-          job?: FigmaJobStatus;
-        } & ErrorPayload)
-      | null;
-
-    if (!response.ok || !payload?.job) {
-      throw new HyperlocaliseClientError(
-        payload?.error ?? "figma_job_poll_failed",
-        payload?.message ?? "Unable to check job status.",
-      );
-    }
-
-    if (payload.job.status === "succeeded") {
-      return payload.job;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
 
-  throw new HyperlocaliseClientError(
-    "translation_job_timed_out",
-    "Translation is taking longer than expected. Pull again in a moment.",
+  return payload.job;
+}
+
+export async function fetchCurrentFigmaJob(input: {
+  appUrl: string;
+  sealedSession: string;
+  organizationSlug: string;
+  fileKey: string;
+  pageId: string;
+  projectId?: string;
+}): Promise<FigmaJobStatus | null> {
+  const params = new URLSearchParams({
+    fileKey: input.fileKey,
+    pageId: input.pageId,
+  });
+  if (input.projectId) {
+    params.set("projectId", input.projectId);
+  }
+
+  const response = await fetch(
+    apiUrl(input.appUrl, `/api/integrations/figma/jobs/current?${params.toString()}`),
+    { headers: sessionHeaders(input) },
   );
+  const payload = (await response.json().catch(() => null)) as
+    | ({
+        job?: FigmaJobStatus | null;
+      } & ErrorPayload)
+    | null;
+
+  if (!response.ok) {
+    throw new HyperlocaliseClientError(
+      payload?.error ?? "figma_current_job_failed",
+      payload?.message ?? "Unable to load the job for this page.",
+    );
+  }
+
+  return payload?.job ?? null;
 }
 
 export async function pullFigmaTranslations(input: {
@@ -335,10 +364,7 @@ export async function pullFigmaTranslations(input: {
   projectId: string;
   fileKey: string;
   pageId: string;
-}): Promise<{
-  jobId: string | null;
-  translationsByLocale: Record<string, Record<string, string>>;
-}> {
+}): Promise<FigmaJobStatus> {
   const response = await fetch(
     apiUrl(
       input.appUrl,
@@ -348,11 +374,7 @@ export async function pullFigmaTranslations(input: {
   );
   const payload = (await response.json().catch(() => null)) as
     | ({
-        translations?: {
-          jobId?: string | null;
-          status?: string;
-          translationsByLocale?: Record<string, Record<string, string>>;
-        };
+        translations?: Partial<FigmaJobStatus> & { status?: string; jobId?: string | null };
       } & ErrorPayload)
     | null;
 
@@ -363,15 +385,37 @@ export async function pullFigmaTranslations(input: {
     );
   }
 
-  if (payload.translations.status === "not_found") {
+  if (payload.translations.status === "not_found" || !payload.translations.jobId) {
     throw new HyperlocaliseClientError(
       "translations_not_found",
-      "No completed translations for this file yet. Create a job first.",
+      "No job for this page yet. Create a job first.",
+    );
+  }
+
+  if (
+    payload.translations.status === "queued" ||
+    payload.translations.status === "running"
+  ) {
+    throw new HyperlocaliseClientError(
+      "translations_not_ready",
+      "Translations are still running. Wait until the job is ready, then pull.",
+    );
+  }
+
+  if (!payload.translations.projectId || !payload.translations.sourcePath) {
+    throw new HyperlocaliseClientError(
+      "figma_translations_failed",
+      "Unable to pull translations.",
     );
   }
 
   return {
-    jobId: payload.translations.jobId ?? null,
+    jobId: payload.translations.jobId,
+    status: payload.translations.status as FigmaJobStatus["status"],
+    projectId: payload.translations.projectId,
+    sourcePath: payload.translations.sourcePath,
+    targetLocales: payload.translations.targetLocales ?? [],
+    lastError: payload.translations.lastError ?? null,
     translationsByLocale: payload.translations.translationsByLocale ?? {},
   };
 }

--- a/apps/figma-plugin/src/hyperlocalise-client.ts
+++ b/apps/figma-plugin/src/hyperlocalise-client.ts
@@ -374,7 +374,15 @@ export async function pullFigmaTranslations(input: {
   );
   const payload = (await response.json().catch(() => null)) as
     | ({
-        translations?: Partial<FigmaJobStatus> & { status?: string; jobId?: string | null };
+        translations?: {
+          jobId?: string | null;
+          status?: FigmaJobStatus["status"] | "not_found";
+          projectId?: string;
+          sourcePath?: string;
+          targetLocales?: string[];
+          lastError?: string | null;
+          translationsByLocale?: Record<string, Record<string, string>>;
+        };
       } & ErrorPayload)
     | null;
 
@@ -392,10 +400,7 @@ export async function pullFigmaTranslations(input: {
     );
   }
 
-  if (
-    payload.translations.status === "queued" ||
-    payload.translations.status === "running"
-  ) {
+  if (payload.translations.status === "queued" || payload.translations.status === "running") {
     throw new HyperlocaliseClientError(
       "translations_not_ready",
       "Translations are still running. Wait until the job is ready, then pull.",
@@ -403,10 +408,7 @@ export async function pullFigmaTranslations(input: {
   }
 
   if (!payload.translations.projectId || !payload.translations.sourcePath) {
-    throw new HyperlocaliseClientError(
-      "figma_translations_failed",
-      "Unable to pull translations.",
-    );
+    throw new HyperlocaliseClientError("figma_translations_failed", "Unable to pull translations.");
   }
 
   return {

--- a/apps/figma-plugin/src/page-binding.test.ts
+++ b/apps/figma-plugin/src/page-binding.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildFigmaJobUrl,
+  parsePageJobBinding,
+  serializePageJobBinding,
+} from "./page-binding";
+
+describe("page job binding", () => {
+  it("round-trips a valid binding", () => {
+    const binding = {
+      projectId: "proj_1",
+      jobId: "job_1",
+      sourcePath: "figma/files/abc/pages/12:34.json",
+    };
+    expect(parsePageJobBinding(serializePageJobBinding(binding))).toEqual(binding);
+  });
+
+  it("rejects missing fields and invalid JSON", () => {
+    expect(parsePageJobBinding(null)).toBeNull();
+    expect(parsePageJobBinding("{")).toBeNull();
+    expect(parsePageJobBinding(JSON.stringify({ projectId: "proj_1", jobId: "" }))).toBeNull();
+  });
+
+  it("builds a workspace job URL", () => {
+    expect(
+      buildFigmaJobUrl({
+        appUrl: "https://app.hyperlocalise.com/",
+        organizationSlug: "acme",
+        projectId: "proj_1",
+        jobId: "job_1",
+      }),
+    ).toBe("https://app.hyperlocalise.com/org/acme/projects/proj_1/jobs/job_1");
+  });
+});

--- a/apps/figma-plugin/src/page-binding.test.ts
+++ b/apps/figma-plugin/src/page-binding.test.ts
@@ -27,5 +27,25 @@ describe("page job binding", () => {
         jobId: "job_1",
       }),
     ).toBe("https://app.hyperlocalise.com/org/acme/projects/proj_1/jobs/job_1");
+    expect(
+      buildFigmaJobUrl({
+        appUrl: "http://localhost:3000",
+        organizationSlug: "acme",
+        projectId: "proj_1",
+        jobId: "job_1",
+      }),
+    ).toBe("http://localhost:3000/org/acme/projects/proj_1/jobs/job_1");
+  });
+
+  it("rejects non-http job URLs", () => {
+    const input = {
+      organizationSlug: "acme",
+      projectId: "proj_1",
+      jobId: "job_1",
+    };
+    expect(buildFigmaJobUrl({ ...input, appUrl: "javascript:alert(1)" })).toBeNull();
+    expect(buildFigmaJobUrl({ ...input, appUrl: "data:text/html,hi" })).toBeNull();
+    expect(buildFigmaJobUrl({ ...input, appUrl: "https://user:pass@evil.example" })).toBeNull();
+    expect(buildFigmaJobUrl({ ...input, appUrl: "not a url" })).toBeNull();
   });
 });

--- a/apps/figma-plugin/src/page-binding.test.ts
+++ b/apps/figma-plugin/src/page-binding.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  buildFigmaJobUrl,
-  parsePageJobBinding,
-  serializePageJobBinding,
-} from "./page-binding";
+import { buildFigmaJobUrl, parsePageJobBinding, serializePageJobBinding } from "./page-binding";
 
 describe("page job binding", () => {
   it("round-trips a valid binding", () => {

--- a/apps/figma-plugin/src/page-binding.ts
+++ b/apps/figma-plugin/src/page-binding.ts
@@ -21,7 +21,11 @@ export function parsePageJobBinding(value: string | null | undefined): FigmaPage
       return null;
     }
     const candidate = parsed as Record<string, unknown>;
-    if (!hasValue(candidate.projectId) || !hasValue(candidate.jobId) || !hasValue(candidate.sourcePath)) {
+    if (
+      !hasValue(candidate.projectId) ||
+      !hasValue(candidate.jobId) ||
+      !hasValue(candidate.sourcePath)
+    ) {
       return null;
     }
     return {

--- a/apps/figma-plugin/src/page-binding.ts
+++ b/apps/figma-plugin/src/page-binding.ts
@@ -46,12 +46,38 @@ export function serializePageJobBinding(binding: FigmaPageJobBinding): string {
   });
 }
 
+function parseHttpUrl(value: string): URL | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+
+  if (parsed.username || parsed.password) {
+    return null;
+  }
+
+  return parsed;
+}
+
 export function buildFigmaJobUrl(input: {
   appUrl: string;
   organizationSlug: string;
   projectId: string;
   jobId: string;
-}): string {
-  const origin = input.appUrl.replace(/\/+$/, "");
-  return `${origin}/org/${encodeURIComponent(input.organizationSlug)}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.jobId)}`;
+}): string | null {
+  const parsed = parseHttpUrl(input.appUrl);
+  if (!parsed) {
+    return null;
+  }
+
+  return new URL(
+    `/org/${encodeURIComponent(input.organizationSlug)}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.jobId)}`,
+    parsed.origin,
+  ).href;
 }

--- a/apps/figma-plugin/src/page-binding.ts
+++ b/apps/figma-plugin/src/page-binding.ts
@@ -1,0 +1,53 @@
+export const PAGE_BINDING_KEY = "hyperlocalise:binding:v1";
+
+export type FigmaPageJobBinding = {
+  projectId: string;
+  jobId: string;
+  sourcePath: string;
+};
+
+function hasValue(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function parsePageJobBinding(value: string | null | undefined): FigmaPageJobBinding | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    const candidate = parsed as Record<string, unknown>;
+    if (!hasValue(candidate.projectId) || !hasValue(candidate.jobId) || !hasValue(candidate.sourcePath)) {
+      return null;
+    }
+    return {
+      projectId: candidate.projectId.trim(),
+      jobId: candidate.jobId.trim(),
+      sourcePath: candidate.sourcePath.trim(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function serializePageJobBinding(binding: FigmaPageJobBinding): string {
+  return JSON.stringify({
+    projectId: binding.projectId,
+    jobId: binding.jobId,
+    sourcePath: binding.sourcePath,
+  });
+}
+
+export function buildFigmaJobUrl(input: {
+  appUrl: string;
+  organizationSlug: string;
+  projectId: string;
+  jobId: string;
+}): string {
+  const origin = input.appUrl.replace(/\/+$/, "");
+  return `${origin}/org/${encodeURIComponent(input.organizationSlug)}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.jobId)}`;
+}

--- a/apps/figma-plugin/src/plugin-messages.ts
+++ b/apps/figma-plugin/src/plugin-messages.ts
@@ -1,3 +1,5 @@
+import type { FigmaPageJobBinding } from "./page-binding";
+
 export type FigmaSegment = {
   key: string;
   nodeId: string;
@@ -24,15 +26,28 @@ export type PluginSettings = {
   lastJobId: string | null;
 };
 
+export type FigmaPageJob = {
+  jobId: string;
+  status: "queued" | "running" | "waiting_for_review" | "succeeded" | "failed" | "cancelled";
+  projectId: string;
+  sourcePath: string;
+  targetLocales: string[];
+  lastError: string | null;
+  translationsByLocale: Record<string, Record<string, string>>;
+};
+
 export type UiToSandboxMessage =
   | { type: "boot" }
   | { type: "storage-set"; settings: PluginSettings }
+  | { type: "binding-set"; binding: FigmaPageJobBinding }
+  | { type: "binding-clear" }
   | { type: "extract"; preserveFormatting: boolean }
   | { type: "apply"; translations: Record<string, string>; preserveFormatting: boolean }
   | { type: "cancel" };
 
 export type SandboxToUiMessage =
-  | { type: "ready"; settings: PluginSettings; file: FigmaFileInfo }
+  | { type: "ready"; settings: PluginSettings; file: FigmaFileInfo; binding: FigmaPageJobBinding | null }
+  | { type: "page-changed"; file: FigmaFileInfo; binding: FigmaPageJobBinding | null }
   | { type: "extracted"; segments: FigmaSegment[]; file: FigmaFileInfo }
   | { type: "applied"; count: number }
   | { type: "error"; message: string };

--- a/apps/figma-plugin/src/plugin-messages.ts
+++ b/apps/figma-plugin/src/plugin-messages.ts
@@ -39,8 +39,8 @@ export type FigmaPageJob = {
 export type UiToSandboxMessage =
   | { type: "boot" }
   | { type: "storage-set"; settings: PluginSettings }
-  | { type: "binding-set"; binding: FigmaPageJobBinding }
-  | { type: "binding-clear" }
+  | { type: "binding-set"; binding: FigmaPageJobBinding; pageId: string }
+  | { type: "binding-clear"; pageId: string }
   | { type: "extract"; preserveFormatting: boolean }
   | { type: "apply"; translations: Record<string, string>; preserveFormatting: boolean }
   | { type: "cancel" };

--- a/apps/figma-plugin/src/plugin-messages.ts
+++ b/apps/figma-plugin/src/plugin-messages.ts
@@ -46,7 +46,12 @@ export type UiToSandboxMessage =
   | { type: "cancel" };
 
 export type SandboxToUiMessage =
-  | { type: "ready"; settings: PluginSettings; file: FigmaFileInfo; binding: FigmaPageJobBinding | null }
+  | {
+      type: "ready";
+      settings: PluginSettings;
+      file: FigmaFileInfo;
+      binding: FigmaPageJobBinding | null;
+    }
   | { type: "page-changed"; file: FigmaFileInfo; binding: FigmaPageJobBinding | null }
   | { type: "extracted"; segments: FigmaSegment[]; file: FigmaFileInfo }
   | { type: "applied"; count: number }

--- a/apps/figma-plugin/src/ui.css
+++ b/apps/figma-plugin/src/ui.css
@@ -117,3 +117,76 @@
   display: flex;
   justify-content: flex-end;
 }
+
+.jobCard {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--figma-color-border, #e5e5e5);
+  border-radius: 8px;
+  background: var(--figma-color-bg-secondary, #f5f5f5);
+}
+
+.jobCardStatus {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+
+.jobCardId {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--figma-color-text-secondary, #6b6b6b);
+  word-break: break-all;
+}
+
+.jobBadge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.jobBadge-queued,
+.jobBadge-running {
+  background: var(--figma-color-bg-brand-tertiary, #e5f4ff);
+  color: var(--figma-color-text-brand, #007be5);
+}
+
+.jobBadge-succeeded {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.jobBadge-waiting_for_review {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.jobBadge-failed {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.jobBadge-cancelled {
+  background: var(--figma-color-bg-hover, #ececec);
+  color: var(--figma-color-text-secondary, #6b6b6b);
+}
+
+.jobPulse {
+  color: var(--figma-color-text-secondary, #6b6b6b);
+}
+
+.jobLink {
+  color: var(--figma-color-text-brand, #0d99ff);
+  text-decoration: none;
+}
+
+.jobLink:hover {
+  text-decoration: underline;
+}

--- a/apps/hyperlocalise-web/src/api/routes/figma-integration/figma-integration.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/figma-integration/figma-integration.route.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 const mocks = vi.hoisted(() => ({
   startFigmaLocalizationMock: vi.fn(),
   getFigmaLocalizationStatusMock: vi.fn(),
+  getCurrentFigmaPageJobMock: vi.fn(),
   generateFigmaLocalizationMock: vi.fn(),
   pullLatestFigmaTranslationsMock: vi.fn(),
   listOrganizationProjectsMock: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
 vi.mock("@/lib/figma/localize-file", () => ({
   startFigmaLocalization: mocks.startFigmaLocalizationMock,
   getFigmaLocalizationStatus: mocks.getFigmaLocalizationStatusMock,
+  getCurrentFigmaPageJob: mocks.getCurrentFigmaPageJobMock,
   generateFigmaLocalization: mocks.generateFigmaLocalizationMock,
   pullLatestFigmaTranslations: mocks.pullLatestFigmaTranslationsMock,
 }));
@@ -305,6 +307,8 @@ describe("figmaIntegrationRoutes", () => {
     mocks.startFigmaLocalizationMock.mockResolvedValue({
       jobId: "job_figma",
       generated: true,
+      projectId: "proj_1",
+      sourcePath: "figma/files/fileKey123/pages/12:34.json",
     });
 
     const response = await client.api.integrations.figma.jobs.$post(
@@ -331,7 +335,12 @@ describe("figmaIntegrationRoutes", () => {
 
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual({
-      job: { jobId: "job_figma", generated: true },
+      job: {
+        jobId: "job_figma",
+        generated: true,
+        projectId: "proj_1",
+        sourcePath: "figma/files/fileKey123/pages/12:34.json",
+      },
     });
     expect(mocks.startFigmaLocalizationMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -349,12 +358,20 @@ describe("figmaIntegrationRoutes", () => {
     mocks.getFigmaLocalizationStatusMock.mockResolvedValue({
       jobId: "job_figma",
       status: "succeeded",
+      projectId: "proj_1",
+      sourcePath: "figma/files/fileKey123/pages/12:34.json",
+      targetLocales: ["es"],
+      lastError: null,
       translationsByLocale: { es: { "figma.segment.1:1.0": "Hola" } },
     });
     mocks.generateFigmaLocalizationMock.mockResolvedValue({ jobId: "job_figma" });
     mocks.pullLatestFigmaTranslationsMock.mockResolvedValue({
       jobId: "job_figma",
-      status: "succeeded",
+      status: "waiting_for_review",
+      projectId: "proj_1",
+      sourcePath: "figma/files/fileKey123/pages/12:34.json",
+      targetLocales: ["es"],
+      lastError: null,
       translationsByLocale: { es: { "figma.segment.1:1.0": "Hola" } },
     });
 
@@ -379,7 +396,7 @@ describe("figmaIntegrationRoutes", () => {
     );
     expect(pullResponse.status).toBe(200);
     await expect(pullResponse.json()).resolves.toMatchObject({
-      translations: { status: "succeeded" },
+      translations: { status: "waiting_for_review" },
     });
     expect(mocks.pullLatestFigmaTranslationsMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -388,5 +405,83 @@ describe("figmaIntegrationRoutes", () => {
         pageId: "12:34",
       }),
     );
+  });
+
+  it("returns the current page job for a Figma file and page", async () => {
+    mocks.authenticateSealedWorkosSessionMock.mockResolvedValue(verifiedSession);
+    mocks.resolveApiAuthContextFromSessionMock.mockResolvedValue(authContext);
+    mocks.getCurrentFigmaPageJobMock.mockResolvedValue({
+      job: {
+        jobId: "job_figma",
+        status: "queued",
+        projectId: "proj_1",
+        sourcePath: "figma/files/fileKey123/pages/12:34.json",
+        targetLocales: ["es"],
+        lastError: null,
+        translationsByLocale: {},
+      },
+    });
+
+    const response = await client.api.integrations.figma.jobs.current.$get(
+      { query: { projectId: "proj_1", fileKey: "fileKey123", pageId: "12:34" } },
+      sessionHeaders,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      job: { jobId: "job_figma", status: "queued" },
+    });
+    expect(mocks.getCurrentFigmaPageJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj_1",
+        fileKey: "fileKey123",
+        pageId: "12:34",
+      }),
+    );
+  });
+
+  it("looks up the current page job across the org when projectId is omitted", async () => {
+    mocks.authenticateSealedWorkosSessionMock.mockResolvedValue(verifiedSession);
+    mocks.resolveApiAuthContextFromSessionMock.mockResolvedValue(authContext);
+    mocks.getCurrentFigmaPageJobMock.mockResolvedValue({ job: null });
+
+    const response = await client.api.integrations.figma.jobs.current.$get(
+      { query: { fileKey: "fileKey123", pageId: "12:34" } },
+      sessionHeaders,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ job: null });
+    expect(mocks.getCurrentFigmaPageJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileKey: "fileKey123",
+        pageId: "12:34",
+      }),
+    );
+    expect(mocks.getCurrentFigmaPageJobMock.mock.calls[0]?.[0].projectId).toBeUndefined();
+  });
+
+  it("returns failed Figma jobs as a 200 status body", async () => {
+    mocks.authenticateSealedWorkosSessionMock.mockResolvedValue(verifiedSession);
+    mocks.resolveApiAuthContextFromSessionMock.mockResolvedValue(authContext);
+    mocks.getFigmaLocalizationStatusMock.mockResolvedValue({
+      jobId: "job_figma",
+      status: "failed",
+      projectId: "proj_1",
+      sourcePath: "figma/files/fileKey123/pages/12:34.json",
+      targetLocales: ["es"],
+      lastError: "provider_timeout",
+      translationsByLocale: {},
+    });
+
+    const response = await client.api.integrations.figma.jobs[":jobId"].$get(
+      { param: { jobId: "job_figma" } },
+      sessionHeaders,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      job: { status: "failed", lastError: "provider_timeout" },
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/figma-integration/figma-integration.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/figma-integration/figma-integration.route.ts
@@ -20,6 +20,7 @@ import type { AuthVariables } from "@/api/auth/workos";
 import { badRequestResponse, forbiddenResponse, notFoundResponse } from "@/api/response.schema";
 import {
   generateFigmaLocalization,
+  getCurrentFigmaPageJob,
   getFigmaLocalizationStatus,
   pullLatestFigmaTranslations,
   startFigmaLocalization,
@@ -30,6 +31,7 @@ import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 
 import {
   createFigmaJobBodySchema,
+  currentFigmaJobQuerySchema,
   figmaJobIdParamSchema,
   pullFigmaTranslationsQuerySchema,
 } from "./figma-integration.schema";
@@ -51,6 +53,19 @@ const validateJobIdParams = validator("param", (value, c) => {
   const parsed = figmaJobIdParamSchema.safeParse(value);
   if (!parsed.success) {
     return badRequestResponse(c, "invalid_figma_job_id", "Figma job id is invalid.");
+  }
+  return parsed.data;
+});
+
+const validateCurrentJobQuery = validator("query", (value, c) => {
+  const parsed = currentFigmaJobQuerySchema.safeParse(value);
+  if (!parsed.success) {
+    return badRequestResponse(
+      c,
+      "invalid_figma_current_job_query",
+      "Figma current job query is invalid.",
+      parsed.error.flatten(),
+    );
   }
   return parsed.data;
 });
@@ -185,6 +200,20 @@ export function createFigmaIntegrationRoutes(options: CreateFigmaIntegrationRout
           fileStorageAdapter: options.fileStorageAdapter,
         });
         return c.json({ job: result }, 201);
+      } catch (error) {
+        return localizeErrorResponse(c, error);
+      }
+    })
+    .get("/jobs/current", figmaSessionAuthMiddleware, validateCurrentJobQuery, async (c) => {
+      const query = c.req.valid("query");
+      try {
+        const result = await getCurrentFigmaPageJob({
+          auth: c.var.auth,
+          fileKey: query.fileKey,
+          pageId: query.pageId,
+          projectId: query.projectId,
+        });
+        return c.json(result, 200);
       } catch (error) {
         return localizeErrorResponse(c, error);
       }

--- a/apps/hyperlocalise-web/src/api/routes/figma-integration/figma-integration.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/figma-integration/figma-integration.schema.ts
@@ -12,7 +12,7 @@
  */
 import { z } from "zod";
 
-import { projectIdSchema } from "@/lib/projects/identity/project-id";
+import { projectIdSchema, optionalProjectIdSchema } from "@/lib/projects/identity/project-id";
 
 export const figmaSegmentSchema = z.object({
   key: z.string().min(1).max(256),
@@ -34,6 +34,12 @@ export const createFigmaJobBodySchema = z.object({
 
 export const figmaJobIdParamSchema = z.object({
   jobId: z.string().min(1).max(128),
+});
+
+export const currentFigmaJobQuerySchema = z.object({
+  projectId: optionalProjectIdSchema,
+  fileKey: z.string().min(1).max(128),
+  pageId: z.string().min(1).max(128),
 });
 
 export const pullFigmaTranslationsQuerySchema = z.object({

--- a/apps/hyperlocalise-web/src/lib/figma/localize-file.test.ts
+++ b/apps/hyperlocalise-web/src/lib/figma/localize-file.test.ts
@@ -116,9 +116,12 @@ describe("isFigmaIntegrationJob", () => {
     };
     expect(figmaJobMatchesPage(payload, { fileKey: "abc123", pageId: "12:34" })).toBe(true);
     expect(figmaJobMatchesPage(payload, { fileKey: "abc123", pageId: "99:00" })).toBe(false);
-    expect(figmaJobMatchesPage({ metadata: { integration: "canva" } }, { fileKey: "abc123", pageId: "12:34" })).toBe(
-      false,
-    );
+    expect(
+      figmaJobMatchesPage(
+        { metadata: { integration: "canva" } },
+        { fileKey: "abc123", pageId: "12:34" },
+      ),
+    ).toBe(false);
   });
 
   it("maps unknown statuses to queued and treats review as pullable", () => {

--- a/apps/hyperlocalise-web/src/lib/figma/localize-file.test.ts
+++ b/apps/hyperlocalise-web/src/lib/figma/localize-file.test.ts
@@ -12,7 +12,13 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { isFigmaIntegrationJob, publicJobOutputFiles } from "./localize-file";
+import {
+  figmaJobHasPullableTranslations,
+  figmaJobMatchesPage,
+  isFigmaIntegrationJob,
+  publicFigmaJobStatus,
+  publicJobOutputFiles,
+} from "./localize-file";
 
 describe("publicJobOutputFiles", () => {
   it("returns null for non file_result outcomes", () => {
@@ -98,6 +104,29 @@ describe("isFigmaIntegrationJob", () => {
         metadata: { integration: "figma-plugin" },
       }),
     ).toBe(true);
+  });
+
+  it("matches jobs to a Figma file and page", () => {
+    const payload = {
+      metadata: {
+        integration: "figma-plugin",
+        figmaFileKey: "abc123",
+        figmaPageId: "12:34",
+      },
+    };
+    expect(figmaJobMatchesPage(payload, { fileKey: "abc123", pageId: "12:34" })).toBe(true);
+    expect(figmaJobMatchesPage(payload, { fileKey: "abc123", pageId: "99:00" })).toBe(false);
+    expect(figmaJobMatchesPage({ metadata: { integration: "canva" } }, { fileKey: "abc123", pageId: "12:34" })).toBe(
+      false,
+    );
+  });
+
+  it("maps unknown statuses to queued and treats review as pullable", () => {
+    expect(publicFigmaJobStatus("running")).toBe("running");
+    expect(publicFigmaJobStatus("waiting_for_review")).toBe("waiting_for_review");
+    expect(publicFigmaJobStatus("mystery")).toBe("queued");
+    expect(figmaJobHasPullableTranslations("waiting_for_review")).toBe(true);
+    expect(figmaJobHasPullableTranslations("queued")).toBe(false);
   });
 
   it("rejects non-figma jobs and empty metadata", () => {

--- a/apps/hyperlocalise-web/src/lib/figma/localize-file.ts
+++ b/apps/hyperlocalise-web/src/lib/figma/localize-file.ts
@@ -12,7 +12,7 @@
  */
 import { createHash } from "node:crypto";
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { buildAccessibleJobsWhere, buildAccessibleProjectsWhere } from "@/api/auth/team-access";
@@ -39,8 +39,11 @@ import {
   segmentsToTranslationFile,
 } from "./segment-file";
 import type {
+  FigmaCurrentJobResult,
   FigmaDesignSegment,
+  FigmaJobStatusName,
   FigmaLocalizationStatus,
+  FigmaPageJob,
   StartFigmaLocalizationResult,
 } from "./types";
 
@@ -146,6 +149,115 @@ function readMetadataString(inputPayload: unknown, key: string): string | null {
 /** True when a translation job was created by the Figma plugin integration. */
 export function isFigmaIntegrationJob(inputPayload: unknown) {
   return readMetadataString(inputPayload, "integration") === "figma-plugin";
+}
+
+/** True when job metadata points at this Figma file and page. */
+export function figmaJobMatchesPage(
+  inputPayload: unknown,
+  input: { fileKey: string; pageId: string },
+) {
+  return (
+    isFigmaIntegrationJob(inputPayload) &&
+    readMetadataString(inputPayload, "figmaFileKey") === input.fileKey &&
+    readMetadataString(inputPayload, "figmaPageId") === input.pageId
+  );
+}
+
+const FIGMA_JOB_STATUSES = new Set<FigmaJobStatusName>([
+  "queued",
+  "running",
+  "waiting_for_review",
+  "succeeded",
+  "failed",
+  "cancelled",
+]);
+
+export function publicFigmaJobStatus(status: string): FigmaJobStatusName {
+  if (FIGMA_JOB_STATUSES.has(status as FigmaJobStatusName)) {
+    return status as FigmaJobStatusName;
+  }
+  return "queued";
+}
+
+export function figmaJobHasPullableTranslations(status: FigmaJobStatusName) {
+  return status === "succeeded" || status === "waiting_for_review";
+}
+
+function readJobTargetLocales(inputPayload: unknown): string[] {
+  if (!inputPayload || typeof inputPayload !== "object") {
+    return [];
+  }
+  const locales = (inputPayload as Record<string, unknown>).targetLocales;
+  if (!Array.isArray(locales)) {
+    return [];
+  }
+  return locales.filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+type FigmaJobSnapshot = {
+  id: string;
+  status: string;
+  projectId: string | null;
+  inputPayload: unknown;
+  lastError: string | null;
+  type: string | null;
+  outcomeKind: string | null;
+  outcomePayload: unknown;
+};
+
+function figmaJobSelectFields() {
+  return {
+    id: schema.jobs.id,
+    status: schema.jobs.status,
+    projectId: schema.jobs.projectId,
+    inputPayload: schema.jobs.inputPayload,
+    lastError: schema.jobs.lastError,
+    type: schema.translationJobDetails.type,
+    outcomeKind: schema.translationJobDetails.outcomeKind,
+    outcomePayload: schema.jobs.outcomePayload,
+  };
+}
+
+async function toFigmaPageJob(input: {
+  job: FigmaJobSnapshot;
+  organizationId: string;
+}): Promise<FigmaPageJob> {
+  const projectId = input.job.projectId;
+  if (!projectId) {
+    throw new Error("translation_job_missing_project");
+  }
+
+  const status = publicFigmaJobStatus(input.job.status);
+  const sourcePath =
+    readMetadataString(input.job.inputPayload, "sourcePath") ??
+    normalizeSourcePath(
+      buildFigmaSourcePath(
+        readMetadataString(input.job.inputPayload, "figmaFileKey") ?? "unknown",
+        readMetadataString(input.job.inputPayload, "figmaPageId") ?? "unknown",
+      ),
+    );
+
+  let translationsByLocale: Record<string, Record<string, string>> = {};
+  if (figmaJobHasPullableTranslations(status)) {
+    const outputFiles = publicJobOutputFiles(input.job) ?? [];
+    if (outputFiles.length > 0) {
+      translationsByLocale = await loadTranslationsByLocale({
+        organizationId: input.organizationId,
+        projectId,
+        outputFiles,
+      });
+    }
+  }
+
+  return {
+    jobId: input.job.id,
+    status,
+    projectId,
+    sourcePath,
+    targetLocales: readJobTargetLocales(input.job.inputPayload),
+    lastError: input.job.lastError,
+    translationsByLocale,
+  };
 }
 
 export async function getAccessibleFigmaProject(auth: ApiAuthContext, projectId: string) {
@@ -271,7 +383,12 @@ export async function startFigmaLocalization(input: {
     }
   }
 
-  return { jobId: created.jobId, generated: input.generate };
+  return {
+    jobId: created.jobId,
+    generated: input.generate,
+    projectId: project.id,
+    sourcePath,
+  };
 }
 
 export async function generateFigmaLocalization(input: {
@@ -305,16 +422,7 @@ async function getFigmaTranslationJobSnapshot(input: {
 }) {
   const accessibleJobsWhere = await buildAccessibleJobsWhere(input.auth);
   const [job] = await db
-    .select({
-      id: schema.jobs.id,
-      status: schema.jobs.status,
-      projectId: schema.jobs.projectId,
-      inputPayload: schema.jobs.inputPayload,
-      lastError: schema.jobs.lastError,
-      type: schema.translationJobDetails.type,
-      outcomeKind: schema.translationJobDetails.outcomeKind,
-      outcomePayload: schema.jobs.outcomePayload,
-    })
+    .select(figmaJobSelectFields())
     .from(schema.jobs)
     .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
     .where(
@@ -343,33 +451,71 @@ export async function getFigmaLocalizationStatus(input: {
     auth: input.auth,
   });
 
-  if (job.status === "succeeded") {
-    const projectId = job.projectId;
-    if (!projectId) {
-      throw new Error("translation_job_missing_project");
-    }
+  return toFigmaPageJob({
+    job,
+    organizationId: input.auth.organization.localOrganizationId,
+  });
+}
 
-    const outputFiles = publicJobOutputFiles(job) ?? [];
-    const translationsByLocale = await loadTranslationsByLocale({
-      organizationId: input.auth.organization.localOrganizationId,
-      projectId,
-      outputFiles,
-    });
+async function findLatestFigmaPageJob(input: {
+  auth: ApiAuthContext;
+  fileKey: string;
+  pageId: string;
+  projectId?: string;
+}): Promise<FigmaJobSnapshot | null> {
+  const organizationId = input.auth.organization.localOrganizationId;
+  const accessibleJobsWhere = await buildAccessibleJobsWhere(input.auth);
+  const conditions = [
+    eq(schema.jobs.organizationId, organizationId),
+    eq(schema.jobs.kind, "translation"),
+    accessibleJobsWhere,
+    sql`${schema.jobs.inputPayload}->'metadata'->>'integration' = 'figma-plugin'`,
+    sql`${schema.jobs.inputPayload}->'metadata'->>'figmaFileKey' = ${input.fileKey}`,
+    sql`${schema.jobs.inputPayload}->'metadata'->>'figmaPageId' = ${input.pageId}`,
+  ];
 
-    return {
-      jobId: job.id,
-      status: "succeeded",
-      translationsByLocale,
-    };
+  if (input.projectId) {
+    conditions.push(eq(schema.jobs.projectId, input.projectId));
   }
 
-  if (job.status === "failed" || job.status === "cancelled") {
-    throw new Error(job.lastError ?? "translation_job_failed");
+  const [job] = await db
+    .select(figmaJobSelectFields())
+    .from(schema.jobs)
+    .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+    .where(and(...conditions))
+    .orderBy(desc(schema.jobs.createdAt))
+    .limit(1);
+
+  if (!job || !figmaJobMatchesPage(job.inputPayload, input) || !job.projectId) {
+    return null;
+  }
+
+  return job;
+}
+
+export async function getCurrentFigmaPageJob(input: {
+  auth: ApiAuthContext;
+  fileKey: string;
+  pageId: string;
+  projectId?: string;
+}): Promise<FigmaCurrentJobResult> {
+  if (input.projectId) {
+    const project = await getAccessibleFigmaProject(input.auth, input.projectId);
+    if (!project) {
+      throw new Error("figma_project_not_found");
+    }
+  }
+
+  const job = await findLatestFigmaPageJob(input);
+  if (!job) {
+    return { job: null };
   }
 
   return {
-    jobId: job.id,
-    status: job.status === "running" ? "running" : "queued",
+    job: await toFigmaPageJob({
+      job,
+      organizationId: input.auth.organization.localOrganizationId,
+    }),
   };
 }
 
@@ -378,67 +524,24 @@ export async function pullLatestFigmaTranslations(input: {
   projectId: string;
   fileKey: string;
   pageId: string;
-}): Promise<
-  | { jobId: null; status: "not_found" }
-  | {
-      jobId: string;
-      status: "succeeded";
-      translationsByLocale: Record<string, Record<string, string>>;
-    }
-> {
+}): Promise<{ jobId: null; status: "not_found" } | FigmaPageJob> {
   const project = await getAccessibleFigmaProject(input.auth, input.projectId);
   if (!project) {
     throw new Error("figma_project_not_found");
   }
 
-  const organizationId = input.auth.organization.localOrganizationId;
-  const sourcePath = normalizeSourcePath(buildFigmaSourcePath(input.fileKey, input.pageId));
-  const accessibleJobsWhere = await buildAccessibleJobsWhere(input.auth);
-
-  const [job] = await db
-    .select({
-      id: schema.jobs.id,
-      projectId: schema.jobs.projectId,
-      type: schema.translationJobDetails.type,
-      outcomeKind: schema.translationJobDetails.outcomeKind,
-      outcomePayload: schema.jobs.outcomePayload,
-      inputPayload: schema.jobs.inputPayload,
-    })
-    .from(schema.repositorySourceFileVersions)
-    .innerJoin(
-      schema.translationJobDetails,
-      eq(schema.translationJobDetails.sourceFileVersionId, schema.repositorySourceFileVersions.id),
-    )
-    .innerJoin(schema.jobs, eq(schema.jobs.id, schema.translationJobDetails.jobId))
-    .where(
-      and(
-        eq(schema.repositorySourceFileVersions.organizationId, organizationId),
-        eq(schema.repositorySourceFileVersions.projectId, project.id),
-        eq(schema.repositorySourceFileVersions.sourcePath, sourcePath),
-        accessibleJobsWhere,
-        eq(schema.jobs.kind, "translation"),
-        eq(schema.jobs.status, "succeeded"),
-        eq(schema.translationJobDetails.type, "file"),
-        eq(schema.translationJobDetails.outcomeKind, "file_result"),
-      ),
-    )
-    .orderBy(desc(schema.repositorySourceFileVersions.createdAt), desc(schema.jobs.createdAt))
-    .limit(1);
-
-  if (!job || !isFigmaIntegrationJob(job.inputPayload) || !job.projectId) {
+  const job = await findLatestFigmaPageJob({
+    auth: input.auth,
+    fileKey: input.fileKey,
+    pageId: input.pageId,
+    projectId: project.id,
+  });
+  if (!job) {
     return { jobId: null, status: "not_found" };
   }
 
-  const outputFiles = publicJobOutputFiles(job) ?? [];
-  const translationsByLocale = await loadTranslationsByLocale({
-    organizationId,
-    projectId: job.projectId,
-    outputFiles,
+  return toFigmaPageJob({
+    job,
+    organizationId: input.auth.organization.localOrganizationId,
   });
-
-  return {
-    jobId: job.id,
-    status: "succeeded",
-    translationsByLocale,
-  };
 }

--- a/apps/hyperlocalise-web/src/lib/figma/types.ts
+++ b/apps/hyperlocalise-web/src/lib/figma/types.ts
@@ -17,18 +17,33 @@ export type FigmaDesignSegment = {
   text: string;
 };
 
+export type FigmaJobStatusName =
+  | "queued"
+  | "running"
+  | "waiting_for_review"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export type FigmaPageJob = {
+  jobId: string;
+  status: FigmaJobStatusName;
+  projectId: string;
+  sourcePath: string;
+  targetLocales: string[];
+  lastError: string | null;
+  translationsByLocale: Record<string, Record<string, string>>;
+};
+
 export type StartFigmaLocalizationResult = {
   jobId: string;
   generated: boolean;
+  projectId: string;
+  sourcePath: string;
 };
 
-export type FigmaLocalizationStatus =
-  | {
-      jobId: string;
-      status: "queued" | "running";
-    }
-  | {
-      jobId: string;
-      status: "succeeded";
-      translationsByLocale: Record<string, Record<string, string>>;
-    };
+export type FigmaLocalizationStatus = FigmaPageJob;
+
+export type FigmaCurrentJobResult = {
+  job: FigmaPageJob | null;
+};

--- a/docs/plans/2026-08-29-figma-page-job-binding-design.md
+++ b/docs/plans/2026-08-29-figma-page-job-binding-design.md
@@ -1,0 +1,35 @@
+# Figma page job binding
+
+Date: 2026-08-29
+
+## Decision
+
+Bind each Figma page to its latest Hyperlocalise job with plugin data on the page, and treat the server as source of truth.
+
+`figma.clientStorage.lastJobId` is not the identity. It is one pointer for the whole plugin on that client.
+
+## Binding
+
+On the current page node, `hyperlocalise:binding:v1` stores:
+
+```json
+{ "projectId": "proj_…", "jobId": "job_…", "sourcePath": "figma/files/…/pages/….json" }
+```
+
+Write it after create, generate, or pull. On boot and page change, read it, then confirm with:
+
+`GET /api/integrations/figma/jobs/current?fileKey&pageId&projectId?`
+
+The lookup matches `input_payload.metadata` (`integration=figma-plugin`, `figmaFileKey`, `figmaPageId`) and returns the latest job in any status. If `projectId` is omitted, search accessible projects in the org.
+
+If the server job differs, overwrite plugin data. If the server has no job, clear plugin data.
+
+## Status and pull
+
+`GET /jobs/:jobId` returns the real status: `queued`, `running`, `waiting_for_review`, `succeeded`, `failed`, `cancelled`. Failed jobs are a 200 body, not a thrown 502.
+
+Pull uses that latest page job. `waiting_for_review` is pullable when output files exist. Queued or running jobs are not.
+
+## Plugin UI
+
+A job card sits above the extract/create actions. Coarse phases only. Poll while `queued` or `running` without locking the rest of the panel. **Open in Hyperlocalise** links to `/org/{slug}/projects/{projectId}/jobs/{jobId}`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Bind each Figma page to its latest Hyperlocalise job, with the server as the source of truth.

- Page plugin data (`hyperlocalise:binding:v1`) stores `{ projectId, jobId, sourcePath }`.
- `GET /api/integrations/figma/jobs/current` looks up the latest Figma plugin job for a file and page (any status) via `input_payload.metadata`.
- Job status and pull return the real job state. Failed jobs are a 200 body. `waiting_for_review` is pullable when output files exist.
- The plugin hydrates that job on boot and page change, shows a job card above extract/create, polls while queued/running without locking the panel, and links to the job in Hyperlocalise.
- **Open in Hyperlocalise** only uses `http:`/`https:` URLs built with the URL API, so a typed Hyperlocalise origin cannot become `javascript:` XSS or an open redirect.
- Create and pull write the binding to the **originating** page id, not whichever page is current when the response arrives. If the user switches pages mid-request, the UI does not adopt or apply that job on the new page.
- Pull is disabled while any other action is running. Generate is only offered for queued jobs (failed jobs need a new Create).

## How to test

- `cd apps/figma-plugin && vp test && vp check --fix`
- `cd apps/hyperlocalise-web && vp test src/lib/figma/localize-file.test.ts src/api/routes/figma-integration/figma-integration.route.test.ts`
- In the Figma plugin: sign in, create a job, confirm the page job card and **Open in Hyperlocalise**. Close and reopen the plugin on the same page; the same job should hydrate. Switch pages; the card should follow that page’s latest job.
- Start Create or Pull, then switch pages before the request finishes. The old job should stay bound to the first page; the new page should not show or apply it.

## Checklist

- [x] I ran relevant checks locally (`vp test` / `vp check --fix` in the Figma plugin)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8a74753-18ce-42a9-9d1b-932eb2237d8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8a74753-18ce-42a9-9d1b-932eb2237d8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

