### PR TITLE
Harden PAT authorization and lifecycle behavior

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
+++ b/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
@@ -110,8 +110,8 @@ of the owner's role at creation. Regression coverage lives in
     whether a presented secret hashes to a stored row.
 22. **Archived organizations and unresolvable memberships fail closed.**
     Archived orgs answer `403 workspace_archived`. Missing users, inactive or
-    non-authoritative memberships, and stale WorkOS lookups answer `403
-    forbidden`. Fresh reconcile fallback stays allowed inside the TTL.
+    non-authoritative memberships, and stale WorkOS lookups answer 403
+    `forbidden`. Fresh reconcile fallback stays allowed inside the TTL.
 23. **Membership removal revokes the owner's tokens.**
     `revokeOrganizationMembershipAccess` sets `revoked_at` on every unrevoked
     PAT owned by that user in that organization, in the same transaction as

--- a/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
+++ b/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
@@ -92,6 +92,33 @@ full WorkOS identity model.
     a membership role, are skipped during reconcile/webhook sync, and resolve to
     no capabilities. See [`LOCALIZATION_ROLES.md`](./LOCALIZATION_ROLES.md).
 
+## Personal access tokens (`api-key.ts`)
+
+PATs reuse `organization_api_keys`. They act as the owner, never as a snapshot
+of the owner's role at creation. Regression coverage lives in
+`api-key.test.ts` and the public `/api/v1` route tests.
+
+19. **Live membership, not stored scopes.** Every authenticated request resolves
+    the owner's current organization membership, role, team access, and
+    capabilities through `resolveApiKeyTeamAccessContext`. Fail closed when
+    that access cannot be established.
+20. **Intersection only.** Effective access is token scopes ∩ the owner's
+    current capabilities. A role downgrade takes effect on the next request.
+    `api_keys:write` is a session management permission; it is not a token
+    scope and never grants broader runtime access.
+21. **Same 401 for unknown, revoked, and ownerless tokens.** Do not leak
+    whether a presented secret hashes to a stored row.
+22. **Archived organizations and unresolvable memberships fail closed.**
+    Archived orgs answer `403 workspace_archived`. Missing users, inactive or
+    non-authoritative memberships, and stale WorkOS lookups answer `403
+    forbidden`. Fresh reconcile fallback stays allowed inside the TTL.
+23. **Membership removal revokes the owner's tokens.**
+    `revokeOrganizationMembershipAccess` sets `revoked_at` on every unrevoked
+    PAT owned by that user in that organization, in the same transaction as
+    membership deletion.
+24. **`lastUsedAt` is non-blocking telemetry.** Write it only after
+    authentication succeeds. Never fail the request if the write fails.
+
 ## Future extension points
 
 When adding team-scoped roles or external contributor access:

--- a/apps/hyperlocalise-web/src/api/auth/api-key-access.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key-access.ts
@@ -23,6 +23,20 @@ import { db, schema } from "@/lib/database/client";
 import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
 import { resolveOrganizationMembershipAccessSource } from "@/lib/workos/membership-access";
 
+/**
+ * Rebuild the PAT owner's live organization membership, role, team scope, and
+ * capabilities. Fail closed when the owner, membership, or organization cannot
+ * be established as currently authorized:
+ *
+ * - ownerless token (`createdByUserId` null) or deleted user row
+ * - archived or missing organization
+ * - WorkOS lookup failed and the last reconcile is stale
+ * - no authoritative WorkOS membership (pending invite, replacing sentinel,
+ *   removed member, or inactive local row)
+ *
+ * A successful result is the access the owner would have interactively. Token
+ * scopes subtract from it in `requireApiKeyPermission`; they never add.
+ */
 export async function resolveApiKeyTeamAccessContext(input: {
   organizationId: string;
   createdByUserId: string | null;

--- a/apps/hyperlocalise-web/src/api/auth/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key.test.ts
@@ -17,6 +17,7 @@ import { testClient } from "hono/testing";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
+import { INVALID_OR_REVOKED_API_KEY_MESSAGE } from "@/api/auth/api-key";
 import { revokeOrganizationMembershipAccess } from "@/api/auth/workos-sync";
 import {
   cleanupPublicApiFixture,
@@ -281,5 +282,142 @@ describe("apiKeyAuthMiddleware", () => {
       .limit(1);
 
     expect(keyRecord?.revokedAt).not.toBeNull();
+  });
+
+  it("rejects unknown, revoked, and ownerless tokens with the same 401", async () => {
+    const { apiKey, apiKeyId, project } = await createPublicApiFixture();
+    const expected = {
+      error: "unauthorized",
+      message: INVALID_OR_REVOKED_API_KEY_MESSAGE,
+    };
+
+    const unknownResponse = await createStringJob("hl_unknown_token_does_not_exist", project.id);
+    expect(unknownResponse.status).toBe(401);
+    await expect(unknownResponse.json()).resolves.toMatchObject(expected);
+
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ revokedAt: new Date() })
+      .where(eq(schema.organizationApiKeys.id, apiKeyId));
+
+    const revokedResponse = await createStringJob(apiKey, project.id);
+    expect(revokedResponse.status).toBe(401);
+    await expect(revokedResponse.json()).resolves.toMatchObject(expected);
+
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ revokedAt: null, createdByUserId: null })
+      .where(eq(schema.organizationApiKeys.id, apiKeyId));
+
+    const ownerlessResponse = await createStringJob(apiKey, project.id);
+    expect(ownerlessResponse.status).toBe(401);
+    await expect(ownerlessResponse.json()).resolves.toMatchObject(expected);
+  });
+
+  it("rejects a token after its owner user row is removed", async () => {
+    const { apiKey, project, user } = await createPublicApiFixture();
+
+    await db.delete(schema.users).where(eq(schema.users.id, user.id));
+
+    const response = await createStringJob(apiKey, project.id);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "unauthorized",
+      message: INVALID_OR_REVOKED_API_KEY_MESSAGE,
+    });
+  });
+
+  it("denies jobs:write when the token scope does not include it", async () => {
+    const { apiKey, project } = await createPublicApiFixture({
+      permissions: ["jobs:read"],
+    });
+
+    const response = await createStringJob(apiKey, project.id);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
+
+  it("denies jobs:write when the owner's current role cannot back the scope", async () => {
+    const { apiKey, project } = await createPublicApiFixture({
+      permissions: ["jobs:read", "jobs:write"],
+      role: "member",
+    });
+
+    const response = await createStringJob(apiKey, project.id);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
+
+  it("applies a role downgrade on the next authenticated request", async () => {
+    const { apiKey, project, user } = await createPublicApiFixture({
+      permissions: ["jobs:read", "jobs:write"],
+      role: "admin",
+    });
+
+    const allowed = await createStringJob(apiKey, project.id);
+    expect(allowed.status).toBe(201);
+
+    await db
+      .update(schema.organizationMemberships)
+      .set({ role: "member" })
+      .where(
+        and(
+          eq(schema.organizationMemberships.organizationId, project.organizationId),
+          eq(schema.organizationMemberships.userId, user.id),
+        ),
+      );
+
+    const denied = await createStringJob(apiKey, project.id);
+    expect(denied.status).toBe(403);
+    await expect(denied.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
+
+  it("does not grant broader runtime access after the owner loses api_keys:write", async () => {
+    const { apiKey, project, user } = await createPublicApiFixture({
+      permissions: ["jobs:read", "jobs:write"],
+      role: "admin",
+    });
+
+    await db
+      .update(schema.organizationMemberships)
+      .set({ role: "translator" })
+      .where(
+        and(
+          eq(schema.organizationMemberships.organizationId, project.organizationId),
+          eq(schema.organizationMemberships.userId, user.id),
+        ),
+      );
+
+    const response = await createStringJob(apiKey, project.id);
+    expect(response.status).toBe(201);
+  });
+
+  it("updates lastUsedAt only after successful authentication", async () => {
+    const { apiKey, apiKeyId, project } = await createPublicApiFixture();
+
+    const rejected = await createStringJob("hl_unknown_token_does_not_exist", project.id);
+    expect(rejected.status).toBe(401);
+
+    const [untouched] = await db
+      .select({ lastUsedAt: schema.organizationApiKeys.lastUsedAt })
+      .from(schema.organizationApiKeys)
+      .where(eq(schema.organizationApiKeys.id, apiKeyId))
+      .limit(1);
+    expect(untouched?.lastUsedAt).toBeNull();
+
+    const allowed = await createStringJob(apiKey, project.id);
+    expect(allowed.status).toBe(201);
+
+    await vi.waitFor(async () => {
+      const [touched] = await db
+        .select({ lastUsedAt: schema.organizationApiKeys.lastUsedAt })
+        .from(schema.organizationApiKeys)
+        .where(eq(schema.organizationApiKeys.id, apiKeyId))
+        .limit(1);
+      expect(touched?.lastUsedAt).toBeInstanceOf(Date);
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key.test.ts
@@ -381,6 +381,27 @@ describe("apiKeyAuthMiddleware", () => {
       role: "admin",
     });
 
+    const [team] = await db
+      .insert(schema.teams)
+      .values({
+        organizationId: project.organizationId,
+        name: "Runtime Access Team",
+        slug: `runtime-access-${user.id.slice(0, 8)}`,
+      })
+      .returning();
+    expect(team).toBeDefined();
+
+    await db
+      .update(schema.projects)
+      .set({ teamId: team!.id })
+      .where(eq(schema.projects.id, project.id));
+
+    await db.insert(schema.teamMemberships).values({
+      teamId: team!.id,
+      userId: user.id,
+      role: "member",
+    });
+
     await db
       .update(schema.organizationMemberships)
       .set({ role: "translator" })

--- a/apps/hyperlocalise-web/src/api/auth/api-key.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key.ts
@@ -35,8 +35,19 @@ export type ApiKeyAuthVariables = EvlogVariables["Variables"] & {
   };
 };
 
+/** Shared 401 for unknown, revoked, and ownerless tokens. Do not distinguish them. */
+export const INVALID_OR_REVOKED_API_KEY_MESSAGE = "Invalid or revoked API key";
+
 function hashApiKey(key: string): string {
   return createHash("sha256").update(key).digest("hex");
+}
+
+function scheduleApiKeyLastUsedAtUpdate(apiKeyId: string) {
+  db.update(schema.organizationApiKeys)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(schema.organizationApiKeys.id, apiKeyId))
+    .execute()
+    .catch(() => {});
 }
 
 export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVariables }>(
@@ -66,8 +77,10 @@ export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVari
       .where(eq(schema.organizationApiKeys.keyHash, keyHash))
       .limit(1);
 
-    if (!keyRecord || keyRecord.revokedAt) {
-      return unauthorizedResponse(c, "unauthorized", "Invalid or revoked API key");
+    // Unknown, revoked, and ownerless tokens share one 401 so callers cannot
+    // probe whether a secret hashes to a stored row.
+    if (!keyRecord || keyRecord.revokedAt || !keyRecord.createdByUserId) {
+      return unauthorizedResponse(c, "unauthorized", INVALID_OR_REVOKED_API_KEY_MESSAGE);
     }
 
     if (keyRecord.lifecycleStatus !== "active") {
@@ -87,12 +100,9 @@ export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVari
       );
     }
 
-    // Update lastUsedAt asynchronously — don't block the request.
-    db.update(schema.organizationApiKeys)
-      .set({ lastUsedAt: new Date() })
-      .where(eq(schema.organizationApiKeys.id, keyRecord.id))
-      .execute()
-      .catch(() => {});
+    // Telemetry only. Never block the request, and never write on a rejected
+    // credential — lastUsedAt is set only after authentication succeeds.
+    scheduleApiKeyLastUsedAtUpdate(keyRecord.id);
 
     c.set("auth", {
       organization: {
@@ -108,6 +118,7 @@ export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVari
       auth: {
         apiKeyId: keyRecord.id,
         localOrganizationId: keyRecord.organizationId,
+        ownerUserId: keyRecord.createdByUserId,
       },
     });
 
@@ -115,6 +126,12 @@ export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVari
   },
 );
 
+/**
+ * Runtime gate for `/api/v1/*`. Effective access is the intersection of the
+ * token's stored scopes and the owner's current role. `api_keys:write` is a
+ * session management capability, not a token scope — it never grants broader
+ * public-API access here.
+ */
 export function requireApiKeyPermission(permission: string) {
   return createMiddleware<{ Variables: ApiKeyAuthVariables }>(async (c, next) => {
     const auth = c.get("auth");

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
@@ -33,7 +33,8 @@ import {
   REPLACING_WORKOS_MEMBERSHIP_ID,
 } from "@/lib/workos/constants";
 
-const { createWorkosIdentity, cleanup, trackWorkosUserId } = createAuthTestFixture();
+const { createWorkosIdentity, createWorkosIdentityForOrganization, cleanup, trackWorkosUserId } =
+  createAuthTestFixture();
 
 beforeAll(async () => {
   await db.$client.query("select 1");
@@ -165,5 +166,114 @@ describe("revokeOrganizationMembershipAccess", () => {
       mcpSessionsDeleted: 0,
       apiKeysRevoked: 0,
     });
+  });
+
+  it("revokes only the departing member's unrevoked personal access tokens", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const departingIdentity = createWorkosIdentityForOrganization(
+      ownerIdentity.organization,
+      "translator",
+    );
+
+    await syncWorkosIdentity(db, ownerIdentity);
+    await syncWorkosIdentity(db, departingIdentity);
+
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(
+        eq(
+          schema.organizations.workosOrganizationId,
+          ownerIdentity.organization.workosOrganizationId,
+        ),
+      )
+      .limit(1);
+
+    const [ownerUser] = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.workosUserId, ownerIdentity.user.workosUserId))
+      .limit(1);
+
+    const [departingUser] = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.workosUserId, departingIdentity.user.workosUserId))
+      .limit(1);
+
+    expect(organization).toBeDefined();
+    expect(ownerUser).toBeDefined();
+    expect(departingUser).toBeDefined();
+
+    const [ownerKey] = await db
+      .insert(schema.organizationApiKeys)
+      .values({
+        organizationId: organization!.id,
+        name: "Owner Token",
+        keyHash: `hash_owner_${randomUUID()}`,
+        keyPrefix: "hl_owner",
+        permissions: ["jobs:read"],
+        createdByUserId: ownerUser!.id,
+      })
+      .returning({ id: schema.organizationApiKeys.id });
+
+    const [departingKey] = await db
+      .insert(schema.organizationApiKeys)
+      .values({
+        organizationId: organization!.id,
+        name: "Departing Token",
+        keyHash: `hash_departing_${randomUUID()}`,
+        keyPrefix: "hl_depar",
+        permissions: ["jobs:read"],
+        createdByUserId: departingUser!.id,
+      })
+      .returning({ id: schema.organizationApiKeys.id });
+
+    const [alreadyRevokedKey] = await db
+      .insert(schema.organizationApiKeys)
+      .values({
+        organizationId: organization!.id,
+        name: "Already Revoked Token",
+        keyHash: `hash_revoked_${randomUUID()}`,
+        keyPrefix: "hl_revok",
+        permissions: ["jobs:read"],
+        createdByUserId: departingUser!.id,
+        revokedAt: new Date("2026-01-01T00:00:00.000Z"),
+      })
+      .returning({
+        id: schema.organizationApiKeys.id,
+        revokedAt: schema.organizationApiKeys.revokedAt,
+      });
+
+    const result = await revokeOrganizationMembershipAccess(db, {
+      workosMembershipId: departingIdentity.membership.workosMembershipId,
+      workosOrganizationId: ownerIdentity.organization.workosOrganizationId,
+      workosUserId: departingIdentity.user.workosUserId,
+    });
+
+    expect(result.organizationMembershipsDeleted).toBe(1);
+    expect(result.apiKeysRevoked).toBe(1);
+
+    const [ownerKeyAfter] = await db
+      .select({ revokedAt: schema.organizationApiKeys.revokedAt })
+      .from(schema.organizationApiKeys)
+      .where(eq(schema.organizationApiKeys.id, ownerKey!.id))
+      .limit(1);
+    const [departingKeyAfter] = await db
+      .select({ revokedAt: schema.organizationApiKeys.revokedAt })
+      .from(schema.organizationApiKeys)
+      .where(eq(schema.organizationApiKeys.id, departingKey!.id))
+      .limit(1);
+    const [alreadyRevokedAfter] = await db
+      .select({ revokedAt: schema.organizationApiKeys.revokedAt })
+      .from(schema.organizationApiKeys)
+      .where(eq(schema.organizationApiKeys.id, alreadyRevokedKey!.id))
+      .limit(1);
+
+    expect(ownerKeyAfter?.revokedAt).toBeNull();
+    expect(departingKeyAfter?.revokedAt).not.toBeNull();
+    expect(alreadyRevokedAfter?.revokedAt?.toISOString()).toBe(
+      alreadyRevokedKey!.revokedAt!.toISOString(),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
@@ -367,7 +367,8 @@ describe("apiKeyRoutes", () => {
       { param: { jobId: `job_${randomUUID()}` } },
       { headers: { "x-api-key": plainKey } },
     );
-    expect(authResponse.status).toBe(403);
+    expect(authResponse.status).toBe(401);
+    expect(await authResponse.json()).toMatchObject({ error: "unauthorized" });
   });
 
   it("keeps listing and authenticating a pre-existing key created outside the route", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.test.ts
@@ -25,6 +25,7 @@ import {
   createExternalTmsPublicApiFixture,
   createPublicApiFixture,
   cleanupPublicApiFixture,
+  hashApiKey,
 } from "./public-files.fixture";
 
 const uploadSourceFileMock = vi.hoisted(() => vi.fn());
@@ -318,5 +319,56 @@ describe("publicFileRoutes", () => {
     expect(response.status).toBe(201);
     const body = (await response.json()) as { file: { id: string } };
     expect(body.file.id).toMatch(/^file_/);
+  });
+
+  it("rejects source uploads without files:write", async () => {
+    const { apiKey, project } = await createPublicApiFixture();
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ permissions: ["jobs:read", "jobs:write", "files:read"] })
+      .where(eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)));
+
+    const response = await client.api.v1.files.$post(
+      {
+        form: {
+          projectId: project.id,
+          sourcePath: "content/en/home.md",
+          file: new File(["# Hello"], "home.md", { type: "text/markdown" }),
+        },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
+
+  it("rejects file downloads without files:read", async () => {
+    const { apiKey, project } = await createPublicApiFixture();
+    const uploadResponse = await client.api.v1.files.$post(
+      {
+        form: {
+          projectId: project.id,
+          sourcePath: "content/en/secret.md",
+          file: new File(["# Secret"], "secret.md", { type: "text/markdown" }),
+        },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+    expect(uploadResponse.status).toBe(201);
+    const uploadBody = (await uploadResponse.json()) as { file: { id: string } };
+
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ permissions: ["jobs:read", "jobs:write", "files:write"] })
+      .where(eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)));
+
+    const downloadResponse = await client.api.v1.files[":fileId"].download.$get(
+      { param: { fileId: uploadBody.file.id } },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(downloadResponse.status).toBe(403);
+    await expect(downloadResponse.json()).resolves.toMatchObject({ error: "forbidden" });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/public-images/public-images.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-images/public-images.route.test.ts
@@ -166,4 +166,23 @@ describe("publicImageRoutes", () => {
     const body = await response.json();
     expect(body).toMatchObject({ error: "image_variant_not_found" });
   });
+
+  it("rejects image downloads without files:read", async () => {
+    const { apiKey, project } = await createPublicApiFixture();
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ permissions: ["jobs:read", "jobs:write"] })
+      .where(eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)));
+
+    const response = await client.api.v1.projects[":projectId"].images.download.$get(
+      {
+        param: { projectId: project.id },
+        query: { sourcePath: "assets/banner.png", locale: "fr" },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.fixture.ts
@@ -14,6 +14,7 @@ import { createHash, randomUUID } from "node:crypto";
 
 import { eq } from "drizzle-orm";
 
+import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { db, schema } from "@/lib/database/client";
 import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/test-project-identifier";
 
@@ -24,7 +25,10 @@ export function hashApiKey(key: string) {
   return createHash("sha256").update(key).digest("hex");
 }
 
-export async function createPublicApiFixture() {
+export async function createPublicApiFixture(options?: {
+  permissions?: string[];
+  role?: OrganizationMembershipRole;
+}) {
   const suffix = randomUUID();
   const workosOrganizationId = `org_${suffix}`;
   const workosUserId = `user_${suffix}`;
@@ -53,7 +57,7 @@ export async function createPublicApiFixture() {
   await db.insert(schema.organizationMemberships).values({
     organizationId: organization.id,
     userId: user.id,
-    role: "admin",
+    role: options?.role ?? "admin",
     workosMembershipId: `om_${suffix}`,
   });
 
@@ -70,16 +74,23 @@ export async function createPublicApiFixture() {
     })
     .returning();
 
-  await db.insert(schema.organizationApiKeys).values({
-    organizationId: organization.id,
-    name: "Public API Test Key",
-    keyHash: hashApiKey(apiKey),
-    keyPrefix: apiKey.slice(0, 8),
-    permissions: ["jobs:read", "jobs:write"],
-    createdByUserId: user.id,
-  });
+  const [apiKeyRow] = await db
+    .insert(schema.organizationApiKeys)
+    .values({
+      organizationId: organization.id,
+      name: "Public API Test Key",
+      keyHash: hashApiKey(apiKey),
+      keyPrefix: apiKey.slice(0, 8),
+      permissions: options?.permissions ?? ["jobs:read", "jobs:write"],
+      createdByUserId: user.id,
+    })
+    .returning({ id: schema.organizationApiKeys.id });
 
-  return { apiKey, project };
+  if (!apiKeyRow) {
+    throw new Error("api key insert failed");
+  }
+
+  return { apiKey, apiKeyId: apiKeyRow.id, project, user };
 }
 
 export async function insertStoredSourceFile(params: {

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.fixture.ts
@@ -10,20 +10,19 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { eq } from "drizzle-orm";
 
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { db, schema } from "@/lib/database/client";
 import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/test-project-identifier";
+import { hashApiKey } from "@/lib/security/api-keys";
 
 const createdWorkosOrganizationIds = new Set<string>();
 const createdWorkosUserIds = new Set<string>();
 
-export function hashApiKey(key: string) {
-  return createHash("sha256").update(key).digest("hex");
-}
+export { hashApiKey };
 
 export async function createPublicApiFixture(options?: {
   permissions?: string[];

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.test.ts
@@ -476,4 +476,23 @@ describe("publicJobRoutes", () => {
       },
     ]);
   });
+
+  it("rejects job reads without jobs:read", async () => {
+    const { apiKey, project } = await createPublicApiFixture({
+      permissions: ["jobs:write"],
+    });
+
+    const response = await client.api.v1.jobs.latest.$get(
+      {
+        query: {
+          projectId: project.id,
+          sourcePath: "locales/en/source.xliff",
+        },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/public-translations/public-translations.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-translations/public-translations.route.test.ts
@@ -240,4 +240,23 @@ describe("publicTranslationRoutes", () => {
       farewell: "Goodbye",
     });
   });
+
+  it("rejects translation downloads without files:read", async () => {
+    const { apiKey, project } = await createPublicApiFixture();
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ permissions: ["jobs:read", "jobs:write"] })
+      .where(eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)));
+
+    const response = await client.api.v1.projects[":projectId"].translations.download.$get(
+      {
+        param: { projectId: project.id },
+        query: { sourcePath: "lang/en.json", locale: "fr" },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Closes HL-668. Personal access tokens now fail closed against the owner's current organization membership, role, team access, and capabilities.

- Unknown, revoked, and ownerless tokens share the same `401 unauthorized` so callers cannot probe whether a secret hashes to a stored row.
- Runtime access is the intersection of token scopes and the owner's live role. Losing `api_keys:write` removes management access only; it does not widen public-API access.
- A role downgrade takes effect on the next authenticated request.
- Membership removal still revokes that user's unrevoked tokens in the same transaction.
- `lastUsedAt` still updates asynchronously after successful authentication only.
- Auth invariants document the PAT fail-closed rules.

## CI follow-up

Two checks failed on the first head. Both are fixed on this revision:

- **Web Test/Build:** `api-key.test.ts` still expected `403` for a legacy ownerless token. Auth now returns the shared `401 unauthorized`.
- **CodeQL:** the public-jobs fixture introduced a local SHA-256 hasher. It now reuses `hashApiKey` from `@/lib/security/api-keys`.

## How to test

```
cd apps/hyperlocalise-web
vp test src/api/auth/api-key.test.ts src/api/auth/workos-sync.test.ts \
  src/api/routes/api-key/api-key.test.ts \
  src/api/routes/public-jobs/public-jobs.route.test.ts \
  src/api/routes/public-files/public-files.route.test.ts \
  src/api/routes/public-translations/public-translations.route.test.ts \
  src/api/routes/public-images/public-images.route.test.ts \
  src/api/routes/public-api-team-access.test.ts
vp check --fix
```

Verified locally after the CI fixes: 69 tests passed across the files above, including the previously failing ownerless-token case. `vp check --fix` reported no format, lint, or type errors.

[Local CI-fix test results](https://cursor.com/agents/bc-b2030358-523a-4c49-9a58-6e1c70dd4c08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_fix_local_tests.txt)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-668](https://linear.app/hyperlocalise/issue/HL-668/harden-pat-authorization-and-lifecycle-behavior)

<div><a href="https://cursor.com/agents/bc-b2030358-523a-4c49-9a58-6e1c70dd4c08?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2030358-523a-4c49-9a58-6e1c70dd4c08&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

