### PR TITLE
feat(api-key): add PAT audit events and safe operational logging

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key.test.ts
@@ -17,6 +17,7 @@ import { testClient } from "hono/testing";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
+import { apiKeyAuthLogContext, touchApiKeyLastUsedAt } from "@/api/auth/api-key";
 import { revokeOrganizationMembershipAccess } from "@/api/auth/workos-sync";
 import {
   cleanupPublicApiFixture,
@@ -281,5 +282,98 @@ describe("apiKeyAuthMiddleware", () => {
       .limit(1);
 
     expect(keyRecord?.revokedAt).not.toBeNull();
+  });
+
+  it("updates lastUsedAt after successful authentication without blocking failures", async () => {
+    const { apiKey, project } = await createPublicApiFixture();
+
+    const response = await createStringJob(apiKey, project.id);
+    expect(response.status).toBe(201);
+
+    await vi.waitFor(async () => {
+      const [keyRecord] = await db
+        .select({ lastUsedAt: schema.organizationApiKeys.lastUsedAt })
+        .from(schema.organizationApiKeys)
+        .where(
+          and(
+            eq(schema.organizationApiKeys.organizationId, project.organizationId),
+            eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)),
+          ),
+        )
+        .limit(1);
+
+      expect(keyRecord?.lastUsedAt).not.toBeNull();
+    });
+  });
+
+  it("does not update lastUsedAt for a rejected credential", async () => {
+    const { apiKey, project } = await createPublicApiFixture();
+
+    await db
+      .update(schema.organizationApiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(
+          eq(schema.organizationApiKeys.organizationId, project.organizationId),
+          eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)),
+        ),
+      );
+
+    const response = await createStringJob(apiKey, project.id);
+    expect(response.status).toBe(401);
+
+    const [keyRecord] = await db
+      .select({ lastUsedAt: schema.organizationApiKeys.lastUsedAt })
+      .from(schema.organizationApiKeys)
+      .where(
+        and(
+          eq(schema.organizationApiKeys.organizationId, project.organizationId),
+          eq(schema.organizationApiKeys.keyHash, hashApiKey(apiKey)),
+        ),
+      )
+      .limit(1);
+
+    expect(keyRecord?.lastUsedAt).toBeNull();
+  });
+});
+
+describe("apiKeyAuthLogContext", () => {
+  it("binds only opaque ids and the safe prefix", () => {
+    const context = apiKeyAuthLogContext({
+      id: "token_123",
+      organizationId: "org_123",
+      createdByUserId: "user_123",
+      keyPrefix: "hl_AbCd",
+    });
+
+    expect(context).toEqual({
+      auth: {
+        apiKeyId: "token_123",
+        localOrganizationId: "org_123",
+        localUserId: "user_123",
+        keyPrefix: "hl_AbCd",
+      },
+    });
+    expect(JSON.stringify(context)).not.toContain("@");
+    expect(JSON.stringify(context)).not.toContain("x-api-key");
+  });
+});
+
+describe("touchApiKeyLastUsedAt", () => {
+  it("swallows write failures so authentication is not delayed", async () => {
+    const updateSpy = vi.spyOn(db, "update").mockImplementation(
+      () =>
+        ({
+          set: () => ({
+            where: () => ({
+              execute: () => Promise.reject(new Error("hl_must_not_escape")),
+            }),
+          }),
+        }) as never,
+    );
+
+    expect(() => touchApiKeyLastUsedAt("token_123")).not.toThrow();
+    await Promise.resolve();
+    updateSpy.mockRestore();
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/api-key.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key.ts
@@ -39,6 +39,33 @@ function hashApiKey(key: string): string {
   return createHash("sha256").update(key).digest("hex");
 }
 
+export function apiKeyAuthLogContext(keyRecord: {
+  id: string;
+  organizationId: string;
+  createdByUserId: string | null;
+  keyPrefix: string;
+}) {
+  return {
+    auth: {
+      apiKeyId: keyRecord.id,
+      localOrganizationId: keyRecord.organizationId,
+      localUserId: keyRecord.createdByUserId,
+      keyPrefix: keyRecord.keyPrefix,
+    },
+  };
+}
+
+/**
+ * Best-effort usage telemetry. Failure must never delay or fail the request.
+ */
+export function touchApiKeyLastUsedAt(apiKeyId: string) {
+  db.update(schema.organizationApiKeys)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(schema.organizationApiKeys.id, apiKeyId))
+    .execute()
+    .catch(() => {});
+}
+
 export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVariables }>(
   async (c, next) => {
     const apiKey = c.req.header("x-api-key");
@@ -53,6 +80,7 @@ export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVari
       .select({
         id: schema.organizationApiKeys.id,
         organizationId: schema.organizationApiKeys.organizationId,
+        keyPrefix: schema.organizationApiKeys.keyPrefix,
         permissions: schema.organizationApiKeys.permissions,
         createdByUserId: schema.organizationApiKeys.createdByUserId,
         revokedAt: schema.organizationApiKeys.revokedAt,
@@ -87,12 +115,8 @@ export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVari
       );
     }
 
-    // Update lastUsedAt asynchronously — don't block the request.
-    db.update(schema.organizationApiKeys)
-      .set({ lastUsedAt: new Date() })
-      .where(eq(schema.organizationApiKeys.id, keyRecord.id))
-      .execute()
-      .catch(() => {});
+    // Usage telemetry is best-effort and must never delay the request.
+    touchApiKeyLastUsedAt(keyRecord.id);
 
     c.set("auth", {
       organization: {
@@ -104,12 +128,7 @@ export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVari
       },
       teamAccess,
     });
-    c.get("log").set({
-      auth: {
-        apiKeyId: keyRecord.id,
-        localOrganizationId: keyRecord.organizationId,
-      },
-    });
+    c.get("log").set(apiKeyAuthLogContext(keyRecord));
 
     await next();
   },

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
@@ -15,6 +15,7 @@ import "dotenv/config";
 import { randomUUID } from "node:crypto";
 
 import { eq } from "drizzle-orm";
+import { mockAudit } from "evlog";
 import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 
 import {
@@ -28,6 +29,11 @@ import {
 import { createAuthTestFixture } from "@/api/test-auth.fixture";
 import { clearReplacingWorkosMembershipSentinel } from "@/api/test-cleanup";
 import { db, schema } from "@/lib/database/client";
+import { generateApiKey, getApiKeyPrefix, hashApiKey } from "@/lib/security/api-keys";
+import {
+  ACCESS_TOKEN_AUDIT_ACTIONS,
+  ACCESS_TOKEN_REVOKE_REASONS,
+} from "@/lib/security/access-token-audit";
 import {
   INVITED_WORKOS_USER_ID_PREFIX,
   REPLACING_WORKOS_MEMBERSHIP_ID,
@@ -165,5 +171,49 @@ describe("revokeOrganizationMembershipAccess", () => {
       mcpSessionsDeleted: 0,
       apiKeysRevoked: 0,
     });
+  });
+
+  it("emits membership-removal audits for each revoked token", async () => {
+    const captured = mockAudit();
+    const identity = createWorkosIdentity();
+    const synced = await syncWorkosIdentity(db, identity);
+    const plainKey = generateApiKey();
+
+    const [apiKey] = await db
+      .insert(schema.organizationApiKeys)
+      .values({
+        organizationId: synced.organization.id,
+        name: "Leaving Member Key",
+        keyHash: hashApiKey(plainKey),
+        keyPrefix: getApiKeyPrefix(plainKey),
+        createdByUserId: synced.user.id,
+      })
+      .returning({
+        id: schema.organizationApiKeys.id,
+        keyPrefix: schema.organizationApiKeys.keyPrefix,
+      });
+
+    const result = await revokeOrganizationMembershipAccess(db, {
+      workosMembershipId: identity.membership.workosMembershipId,
+      workosOrganizationId: identity.organization.workosOrganizationId,
+      workosUserId: identity.user.workosUserId,
+      actor: { type: "system", id: "workos_webhook" },
+    });
+
+    expect(result.apiKeysRevoked).toBe(1);
+    const event = captured.assertAudit({
+      action: ACCESS_TOKEN_AUDIT_ACTIONS.revoked,
+      actor: { type: "system", id: "workos_webhook" },
+      target: { id: apiKey!.id },
+    });
+    expect(event.reason).toBe(ACCESS_TOKEN_REVOKE_REASONS.membershipRemoved);
+    expect(event.target).toMatchObject({
+      organizationId: synced.organization.id,
+      ownerUserId: synced.user.id,
+      keyPrefix: apiKey!.keyPrefix,
+    });
+    expect(JSON.stringify(event)).not.toContain(plainKey);
+    expect(JSON.stringify(event)).not.toContain(identity.user.email);
+    captured.restore();
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
@@ -17,6 +17,13 @@ import type { OrganizationMembershipRole } from "@/lib/database/types";
 
 import { db, type DatabaseClient } from "@/lib/database/client";
 import {
+  ACCESS_TOKEN_REVOKE_REASONS,
+  emitPatRevoked,
+  sessionAccessTokenActor,
+  systemAccessTokenActor,
+  type AccessTokenAuditLogger,
+} from "@/lib/security/access-token-audit";
+import {
   INVITED_WORKOS_USER_ID_PREFIX,
   isInvitedPlaceholderWorkosUserId,
   REPLACING_WORKOS_MEMBERSHIP_ID,
@@ -425,6 +432,11 @@ export type RevokeOrganizationMembershipAccessResult = {
   apiKeysRevoked: number;
 };
 
+export type MembershipRevocationActor = {
+  type: "user" | "system";
+  id: string;
+};
+
 async function resolveRevocationTarget(
   database: DatabaseClient,
   input: {
@@ -482,8 +494,10 @@ async function resolveRevocationTarget(
 async function revokeOrganizationApiKeysForUser(
   database: DatabaseClient,
   target: RevocationTarget,
+  actor: MembershipRevocationActor,
+  log?: AccessTokenAuditLogger,
 ): Promise<Pick<RevokeOrganizationMembershipAccessResult, "apiKeysRevoked">> {
-  const apiKeysRevoked = await database
+  const revokedKeys = await database
     .update(schema.organizationApiKeys)
     .set({ revokedAt: new Date() })
     .where(
@@ -492,10 +506,30 @@ async function revokeOrganizationApiKeysForUser(
         eq(schema.organizationApiKeys.createdByUserId, target.userId),
         isNull(schema.organizationApiKeys.revokedAt),
       ),
-    );
+    )
+    .returning({
+      id: schema.organizationApiKeys.id,
+      keyPrefix: schema.organizationApiKeys.keyPrefix,
+      organizationId: schema.organizationApiKeys.organizationId,
+      createdByUserId: schema.organizationApiKeys.createdByUserId,
+    });
+
+  const auditActor =
+    actor.type === "user" ? sessionAccessTokenActor(actor.id) : systemAccessTokenActor(actor.id);
+
+  for (const token of revokedKeys) {
+    emitPatRevoked(log, {
+      actor: auditActor,
+      ownerUserId: token.createdByUserId,
+      organizationId: token.organizationId,
+      tokenId: token.id,
+      keyPrefix: token.keyPrefix,
+      reason: ACCESS_TOKEN_REVOKE_REASONS.membershipRemoved,
+    });
+  }
 
   return {
-    apiKeysRevoked: Number(apiKeysRevoked.rowCount ?? 0),
+    apiKeysRevoked: revokedKeys.length,
   };
 }
 
@@ -537,6 +571,8 @@ async function deleteTeamMembershipsAndMcpSessions(
 async function revokeMembershipAccessForTarget(
   database: DatabaseClient,
   target: RevocationTarget,
+  actor: MembershipRevocationActor,
+  log?: AccessTokenAuditLogger,
 ): Promise<RevokeOrganizationMembershipAccessResult> {
   const organizationMembershipsDeleted = await database
     .delete(schema.organizationMemberships)
@@ -548,7 +584,7 @@ async function revokeMembershipAccessForTarget(
     );
 
   const dependentDeletes = await deleteTeamMembershipsAndMcpSessions(database, target);
-  const apiKeyRevocation = await revokeOrganizationApiKeysForUser(database, target);
+  const apiKeyRevocation = await revokeOrganizationApiKeysForUser(database, target, actor, log);
 
   return {
     organizationMembershipsDeleted: Number(organizationMembershipsDeleted.rowCount ?? 0),
@@ -567,9 +603,12 @@ export async function revokeOrganizationMembershipAccess(
     workosMembershipId?: string;
     workosOrganizationId?: string;
     workosUserId?: string;
+    actor?: MembershipRevocationActor;
+    log?: AccessTokenAuditLogger;
   },
 ): Promise<RevokeOrganizationMembershipAccessResult> {
   const target = await resolveRevocationTarget(database, input);
+  const actor = input.actor ?? { type: "system", id: "membership_reconcile" };
 
   if (!target) {
     return {
@@ -581,8 +620,10 @@ export async function revokeOrganizationMembershipAccess(
   }
 
   if (isRootDatabaseClient(database)) {
-    return database.transaction((tx) => revokeMembershipAccessForTarget(tx, target));
+    return database.transaction((tx) =>
+      revokeMembershipAccessForTarget(tx, target, actor, input.log),
+    );
   }
 
-  return revokeMembershipAccessForTarget(database, target);
+  return revokeMembershipAccessForTarget(database, target, actor, input.log);
 }

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
@@ -210,20 +210,26 @@ export function createApiKeyRoutes() {
         return c.body(null, 204);
       }
 
-      // `isNull` keeps the first revocation timestamp intact when two revokes race.
-      await db
+      // `isNull` keeps the first revocation timestamp intact when two revokes
+      // race. Only the update that actually changes the row may emit success.
+      const [revoked] = await db
         .update(schema.organizationApiKeys)
         .set({ revokedAt: new Date() })
-        .where(and(revocable, isNull(schema.organizationApiKeys.revokedAt)));
+        .where(and(revocable, isNull(schema.organizationApiKeys.revokedAt)))
+        .returning({
+          id: schema.organizationApiKeys.id,
+        });
 
-      emitPatRevoked(c.get("log"), {
-        actor: sessionAccessTokenActor(c.var.auth.user.localUserId),
-        ownerUserId: existing.createdByUserId,
-        organizationId: existing.organizationId,
-        tokenId: existing.id,
-        keyPrefix: existing.keyPrefix,
-        reason: ACCESS_TOKEN_REVOKE_REASONS.manual,
-      });
+      if (revoked) {
+        emitPatRevoked(c.get("log"), {
+          actor: sessionAccessTokenActor(c.var.auth.user.localUserId),
+          ownerUserId: existing.createdByUserId,
+          organizationId: existing.organizationId,
+          tokenId: existing.id,
+          keyPrefix: existing.keyPrefix,
+          reason: ACCESS_TOKEN_REVOKE_REASONS.manual,
+        });
+      }
 
       return c.body(null, 204);
     });

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
@@ -15,8 +15,15 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
-import { apiErrorResponse } from "@/api/response.schema";
+import { apiErrorResponse, internalErrorResponse } from "@/api/response.schema";
 import { db, schema } from "@/lib/database/client";
+import { isErr } from "@/lib/primitives/result/results";
+import {
+  ACCESS_TOKEN_REVOKE_REASONS,
+  emitPatCreated,
+  emitPatRevoked,
+  sessionAccessTokenActor,
+} from "@/lib/security/access-token-audit";
 import { generateApiKey, getApiKeyPrefix, hashApiKey } from "@/lib/security/api-keys";
 
 import { getGrantableApiKeyPermissions, getRefusedApiKeyPermissions } from "./api-key.permissions";
@@ -75,13 +82,14 @@ export function createApiKeyRoutes() {
           name: row.name,
           keyPrefix: row.keyPrefix,
           permissions: row.permissions,
-          lastUsedAt: row.lastUsedAt,
+          lastUsedAt: row.lastUsedAt?.toISOString() ?? null,
           // A token whose owner cannot be resolved is permanently unusable, so
           // it must never read as active. `updatedAt` is the fallback when
           // `revokedAt` was never written (legacy unowned rows, or a later
           // user deletion that nulls the owner).
-          revokedAt: owner ? row.revokedAt : (row.revokedAt ?? row.updatedAt),
-          createdAt: row.createdAt,
+          revokedAt:
+            (owner ? row.revokedAt : (row.revokedAt ?? row.updatedAt))?.toISOString() ?? null,
+          createdAt: row.createdAt.toISOString(),
           owner,
         };
       });
@@ -137,10 +145,37 @@ export function createApiKeyRoutes() {
           .limit(1),
       ]);
 
+      if (!apiKey) {
+        return internalErrorResponse(c, "internal_error", "The token could not be created");
+      }
+
+      const auditResult = emitPatCreated(c.get("log"), {
+        actor: sessionAccessTokenActor(c.var.auth.user.localUserId),
+        ownerUserId: c.var.auth.user.localUserId,
+        organizationId: c.var.auth.organization.localOrganizationId,
+        tokenId: apiKey.id,
+        keyPrefix: apiKey.keyPrefix,
+        permissions: apiKey.permissions,
+      });
+
+      if (isErr(auditResult)) {
+        await db
+          .update(schema.organizationApiKeys)
+          .set({ revokedAt: new Date() })
+          .where(eq(schema.organizationApiKeys.id, apiKey.id));
+
+        return internalErrorResponse(
+          c,
+          "access_token_audit_failed",
+          "The token could not be recorded safely and was not issued",
+        );
+      }
+
       return c.json(
         {
           apiKey: {
             ...apiKey,
+            createdAt: apiKey.createdAt.toISOString(),
             key: plainKey,
             owner: ownerRow ? toApiKeyOwner(ownerRow) : null,
           },
@@ -158,6 +193,9 @@ export function createApiKeyRoutes() {
       const [existing] = await db
         .select({
           id: schema.organizationApiKeys.id,
+          keyPrefix: schema.organizationApiKeys.keyPrefix,
+          createdByUserId: schema.organizationApiKeys.createdByUserId,
+          organizationId: schema.organizationApiKeys.organizationId,
           revokedAt: schema.organizationApiKeys.revokedAt,
         })
         .from(schema.organizationApiKeys)
@@ -177,6 +215,15 @@ export function createApiKeyRoutes() {
         .update(schema.organizationApiKeys)
         .set({ revokedAt: new Date() })
         .where(and(revocable, isNull(schema.organizationApiKeys.revokedAt)));
+
+      emitPatRevoked(c.get("log"), {
+        actor: sessionAccessTokenActor(c.var.auth.user.localUserId),
+        ownerUserId: existing.createdByUserId,
+        organizationId: existing.organizationId,
+        tokenId: existing.id,
+        keyPrefix: existing.keyPrefix,
+        reason: ACCESS_TOKEN_REVOKE_REASONS.manual,
+      });
 
       return c.body(null, 204);
     });

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.schema.test.ts
@@ -93,6 +93,14 @@ describe("apiKeySummarySchema", () => {
     expect(apiKeySummarySchema.safeParse(summaryFixture({ owner: null })).success).toBe(true);
   });
 
+  it("requires createdAt and a nullable lastUsedAt without the secret", () => {
+    expect(apiKeySummarySchema.parse(summaryFixture()).lastUsedAt).toBeNull();
+    expect(apiKeySummarySchema.parse(summaryFixture()).createdAt).toBe("2026-08-29T00:00:00.000Z");
+
+    const { lastUsedAt: _lastUsedAt, ...withoutLastUsedAt } = summaryFixture();
+    expect(apiKeySummarySchema.safeParse(withoutLastUsedAt).success).toBe(false);
+  });
+
   it("carries neither the secret nor its hash", () => {
     const parsed = apiKeySummarySchema.parse(
       summaryFixture({ key: "hl_secret", keyHash: "hash" }) as never,

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.schema.ts
@@ -43,7 +43,7 @@ export const apiKeySummarySchema = z.object({
   name: z.string(),
   keyPrefix: z.string(),
   permissions: z.array(apiKeyPermissionSchema),
-  lastUsedAt: z.string().nullable().optional(),
+  lastUsedAt: z.string().nullable(),
   revokedAt: z.string().nullable().optional(),
   createdAt: z.string(),
   // Null only for legacy rows with no resolvable owner. Such a token is

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
@@ -241,6 +241,48 @@ describe("apiKeyRoutes", () => {
     captured.restore();
   });
 
+  it("emits pat.revoked only for the revoke that updates the token", async () => {
+    const identity = createWorkosIdentity();
+    const createResponse = await createApiKeyViaApi(identity, { name: "Idempotent Revoke Audit" });
+    const created = (await createResponse.json()) as ApiKeyResponse;
+    const captured = mockAudit();
+
+    expect((await revokeApiKeyAs(identity, created.apiKey.id)).status).toBe(204);
+    expect((await revokeApiKeyAs(identity, created.apiKey.id)).status).toBe(204);
+
+    const revokedEvents = captured.events.filter(
+      (event) => event.action === ACCESS_TOKEN_AUDIT_ACTIONS.revoked,
+    );
+    expect(revokedEvents).toHaveLength(1);
+    expect(revokedEvents[0]).toMatchObject({
+      action: ACCESS_TOKEN_AUDIT_ACTIONS.revoked,
+      reason: ACCESS_TOKEN_REVOKE_REASONS.manual,
+      target: { id: created.apiKey.id },
+    });
+    captured.restore();
+  });
+
+  it("emits a single pat.revoked when two authorized revokes race", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const adminIdentity = createWorkosIdentityForOrganization(ownerIdentity.organization, "admin");
+    const createResponse = await createApiKeyViaApi(ownerIdentity, { name: "Raced Revoke Audit" });
+    const created = (await createResponse.json()) as ApiKeyResponse;
+    const captured = mockAudit();
+
+    const [first, second] = await Promise.all([
+      revokeApiKeyAs(ownerIdentity, created.apiKey.id),
+      revokeApiKeyAs(adminIdentity, created.apiKey.id),
+    ]);
+
+    expect(first.status).toBe(204);
+    expect(second.status).toBe(204);
+    expect(
+      captured.events.filter((event) => event.action === ACCESS_TOKEN_AUDIT_ACTIONS.revoked),
+    ).toHaveLength(1);
+    expect((await readApiKeyRow(created.apiKey.id))?.revokedAt).not.toBeNull();
+    captured.restore();
+  });
+
   it("lists the caller's own tokens with owner attribution", async () => {
     const identity = createWorkosIdentity();
 

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
@@ -15,6 +15,7 @@ import "dotenv/config";
 import { randomUUID } from "node:crypto";
 
 import { eq } from "drizzle-orm";
+import { mockAudit } from "evlog";
 import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
@@ -38,6 +39,12 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
 import { createApp } from "@/api/app";
 import type { WorkosAuthIdentity } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database/client";
+import { err } from "@/lib/primitives/result/results";
+import * as accessTokenAudit from "@/lib/security/access-token-audit";
+import {
+  ACCESS_TOKEN_AUDIT_ACTIONS,
+  ACCESS_TOKEN_REVOKE_REASONS,
+} from "@/lib/security/access-token-audit";
 import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 
 import { createApiKeyTestFixture } from "./api-key.fixture";
@@ -147,6 +154,91 @@ describe("apiKeyRoutes", () => {
       "permissions",
       "revokedAt",
     ]);
+    expect(listed?.createdAt).toEqual(expect.any(String));
+    expect(listed?.lastUsedAt).toBeNull();
+  });
+
+  it("emits a safe pat.created audit record", async () => {
+    const captured = mockAudit();
+    const identity = createWorkosIdentity();
+    const response = await createApiKeyViaApi(identity, { name: "Audited Key" });
+    const body = (await response.json()) as ApiKeyResponse;
+    const ownerUserId = await getLocalUserId(identity.user.workosUserId);
+
+    expect(response.status).toBe(201);
+    const event = captured.assertAudit({
+      action: ACCESS_TOKEN_AUDIT_ACTIONS.created,
+      actor: { type: "user", id: ownerUserId },
+      target: { id: body.apiKey.id },
+    });
+    expect(event.target).toMatchObject({
+      organizationId: await getLocalOrganizationId(identity.organization.workosOrganizationId),
+      ownerUserId,
+      keyPrefix: body.apiKey.keyPrefix,
+    });
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain(body.apiKey.key);
+    expect(serialized).not.toContain(identity.user.email);
+    expect(serialized).not.toContain("x-api-key");
+    captured.restore();
+  });
+
+  it("revokes the token and omits the secret when audit recording fails", async () => {
+    const identity = createWorkosIdentity();
+    const emitSpy = vi
+      .spyOn(accessTokenAudit, "emitPatCreated")
+      .mockReturnValueOnce(err({ code: "audit_emit_failed" }));
+
+    const response = await createApiKeyViaApi(identity, { name: "Unrecorded Key" });
+    const body = (await response.json()) as { error?: string; apiKey?: { key?: string } };
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("access_token_audit_failed");
+    expect(body.apiKey?.key).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain("hl_");
+
+    const rows = await db
+      .select({
+        name: schema.organizationApiKeys.name,
+        revokedAt: schema.organizationApiKeys.revokedAt,
+      })
+      .from(schema.organizationApiKeys)
+      .where(
+        eq(
+          schema.organizationApiKeys.organizationId,
+          await getLocalOrganizationId(identity.organization.workosOrganizationId),
+        ),
+      );
+    const created = rows.find((row) => row.name === "Unrecorded Key");
+    expect(created?.revokedAt).not.toBeNull();
+    emitSpy.mockRestore();
+  });
+
+  it("emits a manual pat.revoked audit record for the acting user", async () => {
+    const captured = mockAudit();
+    const ownerIdentity = createWorkosIdentity();
+    const adminIdentity = createWorkosIdentityForOrganization(ownerIdentity.organization, "admin");
+    const createResponse = await createApiKeyViaApi(ownerIdentity, { name: "Revoke Audit" });
+    const created = (await createResponse.json()) as ApiKeyResponse;
+
+    expect((await revokeApiKeyAs(adminIdentity, created.apiKey.id)).status).toBe(204);
+
+    const actorUserId = await getLocalUserId(adminIdentity.user.workosUserId);
+    const ownerUserId = await getLocalUserId(ownerIdentity.user.workosUserId);
+
+    const event = captured.assertAudit({
+      action: ACCESS_TOKEN_AUDIT_ACTIONS.revoked,
+      actor: { type: "user", id: actorUserId },
+      target: { id: created.apiKey.id },
+    });
+    expect(event.reason).toBe(ACCESS_TOKEN_REVOKE_REASONS.manual);
+    expect(event.target).toMatchObject({
+      ownerUserId,
+      keyPrefix: created.apiKey.keyPrefix,
+    });
+    expect(JSON.stringify(event)).not.toContain(created.apiKey.key);
+    expect(JSON.stringify(event)).not.toContain(ownerIdentity.user.email);
+    captured.restore();
   });
 
   it("lists the caller's own tokens with owner attribution", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -917,6 +917,8 @@ export function createMemberRoutes() {
           workosMembershipId: member.workosMembershipId ?? undefined,
           workosOrganizationId,
           workosUserId: member.workosUserId,
+          actor: { type: "user", id: c.var.auth.user.localUserId },
+          log: c.get("log"),
         });
 
         return { ok: true as const };

--- a/apps/hyperlocalise-web/src/api/routes/workos-webhook/workos-webhook.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workos-webhook/workos-webhook.route.test.ts
@@ -175,6 +175,7 @@ describe("workosWebhookRoutes", () => {
       workosMembershipId: "membership_123",
       workosOrganizationId: "org_123",
       workosUserId: "user_123",
+      actor: { type: "system", id: "workos_webhook" },
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/workos-webhook/workos-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workos-webhook/workos-webhook.route.ts
@@ -192,6 +192,7 @@ async function handleWorkosEvent(event: WorkosWebhookEvent): Promise<void> {
         workosMembershipId: readString(data, "id", "membership_id"),
         workosOrganizationId,
         workosUserId,
+        actor: { type: "system", id: "workos_webhook" },
       }),
     );
 
@@ -275,6 +276,7 @@ async function handleWorkosEvent(event: WorkosWebhookEvent): Promise<void> {
             workosMembershipId,
             workosOrganizationId,
             workosUserId,
+            actor: { type: "system", id: "workos_webhook" },
           }),
         );
         return;

--- a/apps/hyperlocalise-web/src/lib/log.redaction.test.ts
+++ b/apps/hyperlocalise-web/src/lib/log.redaction.test.ts
@@ -71,6 +71,23 @@ describe("Logger Redaction", () => {
     expect(event?.apiKeyId).toBe("3f1b7c2a-0000-4000-8000-000000000000");
   });
 
+  it("should redact owner emails and plaintext token fields", () => {
+    const logger = createLogger();
+
+    logger.info({
+      email: "owner@example.com",
+      owner: { email: "owner@example.com", userId: "user_123" },
+      plainKey: "hl_secret_value",
+    });
+
+    const [event] = drainedEvents;
+    const owner = event?.owner as Record<string, unknown>;
+    expect(event?.email).toBe("[REDACTED]");
+    expect(owner.email).toBe("[REDACTED]");
+    expect(owner.userId).toBe("user_123");
+    expect(event?.plainKey).toBe("[REDACTED]");
+  });
+
   it("should redact sensitive headers", () => {
     const logger = createLogger();
 

--- a/apps/hyperlocalise-web/src/lib/log.ts
+++ b/apps/hyperlocalise-web/src/lib/log.ts
@@ -27,6 +27,10 @@ const REDACTED = "[REDACTED]";
 export const REDACTION_PATHS = [
   "apiKey",
   "*.apiKey",
+  "email",
+  "*.email",
+  "plainKey",
+  "*.plainKey",
   "token",
   "*.token",
   "accessToken",

--- a/apps/hyperlocalise-web/src/lib/security/access-token-audit.test.ts
+++ b/apps/hyperlocalise-web/src/lib/security/access-token-audit.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { mockAudit } from "evlog";
+
+import { isErr, isOk } from "@/lib/primitives/result/results";
+
+import {
+  ACCESS_TOKEN_AUDIT_ACTIONS,
+  ACCESS_TOKEN_REVOKE_REASONS,
+  assertSafeAccessTokenAuditPayload,
+  emitPatCreated,
+  emitPatRevoked,
+  sessionAccessTokenActor,
+  systemAccessTokenActor,
+} from "./access-token-audit";
+
+const createdInput = {
+  actor: sessionAccessTokenActor("user_actor"),
+  ownerUserId: "user_owner",
+  organizationId: "org_123",
+  tokenId: "token_123",
+  keyPrefix: "hl_AbCd",
+  permissions: ["jobs:read", "files:read"],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("access-token audit payloads", () => {
+  it("records creation with actor, owner, token id, and safe prefix", () => {
+    const captured = mockAudit();
+
+    const result = emitPatCreated(undefined, createdInput);
+
+    expect(isOk(result)).toBe(true);
+    const event = captured.assertAudit({
+      action: ACCESS_TOKEN_AUDIT_ACTIONS.created,
+      actor: { type: "user", id: "user_actor" },
+      target: { id: "token_123" },
+    });
+    expect(event.target).toEqual({
+      type: "personal_access_token",
+      id: "token_123",
+      organizationId: "org_123",
+      ownerUserId: "user_owner",
+      keyPrefix: "hl_AbCd",
+      permissions: ["jobs:read", "files:read"],
+    });
+    expect(JSON.stringify(event)).not.toContain("hl_secret");
+    expect(JSON.stringify(event)).not.toContain("@example.com");
+    captured.restore();
+  });
+
+  it("records revocation with a reason and does not require an email", () => {
+    const captured = mockAudit();
+
+    const result = emitPatRevoked(undefined, {
+      actor: systemAccessTokenActor("workos_webhook"),
+      ownerUserId: "user_owner",
+      organizationId: "org_123",
+      tokenId: "token_123",
+      keyPrefix: "hl_AbCd",
+      reason: ACCESS_TOKEN_REVOKE_REASONS.membershipRemoved,
+    });
+
+    expect(isOk(result)).toBe(true);
+    const event = captured.assertAudit({
+      action: ACCESS_TOKEN_AUDIT_ACTIONS.revoked,
+      actor: { type: "system", id: "workos_webhook" },
+    });
+    expect(event.reason).toBe(ACCESS_TOKEN_REVOKE_REASONS.membershipRemoved);
+    expect(event.target).toMatchObject({
+      id: "token_123",
+      keyPrefix: "hl_AbCd",
+      ownerUserId: "user_owner",
+      organizationId: "org_123",
+    });
+    expect(event).not.toHaveProperty("email");
+    captured.restore();
+  });
+
+  it("rejects payloads that carry secrets, emails, or request bodies", () => {
+    expect(() =>
+      assertSafeAccessTokenAuditPayload({
+        action: ACCESS_TOKEN_AUDIT_ACTIONS.created,
+        actor: { type: "user", id: "user_actor", email: "owner@example.com" },
+        target: { type: "personal_access_token", id: "token_123" },
+      }),
+    ).toThrow("access_token_audit_payload_contains_forbidden_fields");
+
+    expect(() =>
+      assertSafeAccessTokenAuditPayload({
+        action: ACCESS_TOKEN_AUDIT_ACTIONS.created,
+        actor: { type: "user", id: "user_actor" },
+        target: {
+          type: "personal_access_token",
+          id: "token_123",
+          keyHash: "sha256-of-secret",
+        },
+      }),
+    ).toThrow("access_token_audit_payload_contains_forbidden_fields");
+  });
+
+  it("returns a typed failure when the audit sink throws and does not rethrow the secret", () => {
+    const result = emitPatCreated(
+      {
+        audit: () => {
+          throw new Error("hl_this_must_not_escape");
+        },
+      },
+      createdInput,
+    );
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error).toEqual({ code: "audit_emit_failed" });
+      expect(JSON.stringify(result.error)).not.toContain("hl_this_must_not_escape");
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/security/access-token-audit.ts
+++ b/apps/hyperlocalise-web/src/lib/security/access-token-audit.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { audit, defineAuditAction, type AuditActor, type AuditInput } from "evlog";
+
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+export const ACCESS_TOKEN_AUDIT_ACTIONS = {
+  created: "pat.created",
+  revoked: "pat.revoked",
+} as const;
+
+export const ACCESS_TOKEN_REVOKE_REASONS = {
+  manual: "manual",
+  membershipRemoved: "membership_removed",
+} as const;
+
+export type AccessTokenRevokeReason =
+  (typeof ACCESS_TOKEN_REVOKE_REASONS)[keyof typeof ACCESS_TOKEN_REVOKE_REASONS];
+
+export type AccessTokenAuditError = { code: "audit_emit_failed" };
+
+export type AccessTokenAuditLogger = {
+  audit: (input: AuditInput) => void;
+};
+
+type AccessTokenAuditActorInput = {
+  type: AuditActor["type"];
+  id: string;
+};
+
+type AccessTokenCreatedAuditInput = {
+  actor: AccessTokenAuditActorInput;
+  ownerUserId: string;
+  organizationId: string;
+  tokenId: string;
+  keyPrefix: string;
+  permissions: readonly string[];
+};
+
+type AccessTokenRevokedAuditInput = {
+  actor: AccessTokenAuditActorInput;
+  ownerUserId: string | null;
+  organizationId: string;
+  tokenId: string;
+  keyPrefix: string;
+  reason: AccessTokenRevokeReason;
+};
+
+export const patCreated = defineAuditAction(ACCESS_TOKEN_AUDIT_ACTIONS.created, {
+  target: "personal_access_token",
+  severity: "high",
+  description: "A personal access token or organization API key was created",
+});
+
+export const patRevoked = defineAuditAction(ACCESS_TOKEN_AUDIT_ACTIONS.revoked, {
+  target: "personal_access_token",
+  severity: "high",
+  requiresReason: true,
+  description: "A personal access token or organization API key was revoked",
+});
+
+const SAFE_TARGET_KEYS = new Set([
+  "type",
+  "id",
+  "organizationId",
+  "ownerUserId",
+  "keyPrefix",
+  "permissions",
+]);
+
+function toSafeActor(actor: AccessTokenAuditActorInput): AuditActor {
+  return {
+    type: actor.type,
+    id: actor.id,
+  };
+}
+
+function toSafeCreatedTarget(input: AccessTokenCreatedAuditInput) {
+  return {
+    type: "personal_access_token" as const,
+    id: input.tokenId,
+    organizationId: input.organizationId,
+    ownerUserId: input.ownerUserId,
+    keyPrefix: input.keyPrefix,
+    permissions: [...input.permissions],
+  };
+}
+
+function toSafeRevokedTarget(input: AccessTokenRevokedAuditInput) {
+  return {
+    type: "personal_access_token" as const,
+    id: input.tokenId,
+    organizationId: input.organizationId,
+    ownerUserId: input.ownerUserId,
+    keyPrefix: input.keyPrefix,
+  };
+}
+
+export function assertSafeAccessTokenAuditPayload(payload: AuditInput) {
+  const serialized = JSON.stringify(payload);
+  if (
+    serialized.includes("keyHash") ||
+    serialized.includes("key_hash") ||
+    serialized.includes("x-api-key") ||
+    serialized.includes("authorization") ||
+    /"email"\s*:/.test(serialized) ||
+    /"body"\s*:/.test(serialized) ||
+    /"requestBody"\s*:/.test(serialized)
+  ) {
+    throw new Error("access_token_audit_payload_contains_forbidden_fields");
+  }
+
+  if (payload.target) {
+    for (const key of Object.keys(payload.target)) {
+      if (!SAFE_TARGET_KEYS.has(key)) {
+        throw new Error("access_token_audit_payload_contains_forbidden_fields");
+      }
+    }
+  }
+}
+
+function emitAudit(
+  log: AccessTokenAuditLogger | undefined,
+  payload: AuditInput,
+): Result<void, AccessTokenAuditError> {
+  try {
+    assertSafeAccessTokenAuditPayload(payload);
+    if (log && typeof log.audit === "function") {
+      log.audit(payload);
+    } else {
+      audit(payload);
+    }
+    return ok(undefined);
+  } catch {
+    return err({ code: "audit_emit_failed" });
+  }
+}
+
+export function emitPatCreated(
+  log: AccessTokenAuditLogger | undefined,
+  input: AccessTokenCreatedAuditInput,
+): Result<void, AccessTokenAuditError> {
+  return emitAudit(
+    log,
+    patCreated({
+      actor: toSafeActor(input.actor),
+      target: toSafeCreatedTarget(input),
+      outcome: "success",
+    }),
+  );
+}
+
+export function emitPatRevoked(
+  log: AccessTokenAuditLogger | undefined,
+  input: AccessTokenRevokedAuditInput,
+): Result<void, AccessTokenAuditError> {
+  return emitAudit(
+    log,
+    patRevoked({
+      actor: toSafeActor(input.actor),
+      target: toSafeRevokedTarget(input),
+      outcome: "success",
+      reason: input.reason,
+    }),
+  );
+}
+
+export function sessionAccessTokenActor(userId: string): AccessTokenAuditActorInput {
+  return { type: "user", id: userId };
+}
+
+export function systemAccessTokenActor(id: string): AccessTokenAuditActorInput {
+  return { type: "system", id };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Closes HL-667. Personal access tokens and organization API keys now emit attributable `pat.created` and `pat.revoked` audit records through evlog, covering create, manual revoke, and membership-removal revoke.

Audit payloads include the acting user, owner, token ID, safe prefix, organization ID, timestamp, action, granted scopes on create, and a revoke reason of `manual` or `membership_removed`. They never include the raw secret, hash, `x-api-key`, email, or request body.

If create-time audit emission fails, the new token is revoked and the client gets `500 access_token_audit_failed` without the secret. Successful API-key authentication binds `apiKeyId`, owner `localUserId`, organization ID, and `keyPrefix` on the request log. `lastUsedAt` remains non-blocking. List responses always expose `createdAt` and nullable `lastUsedAt`.

Manual revoke uses `UPDATE … RETURNING` and emits `pat.revoked` only when that update changes the row, so a racing second DELETE does not record a revocation it did not perform.

Logger redaction now also covers `email` and `plainKey`.

## Merge

Rebased onto `main` after #2111. Conflicts in PAT auth middleware and tests now keep both fail-closed ownerless-token auth and the audit log/membership-removal coverage.

## How to test

- `vp test` in `apps/hyperlocalise-web`
- `vp check --fix` in `apps/hyperlocalise-web`
- Targeted coverage: create/revoke audit payloads, membership-removal audits, secret redaction, create-time audit failure, idempotent and racing revoke audits, `lastUsedAt` non-blocking updates, and auth log context

Verified after the merge: 55 targeted tests passed. `vp check --fix` reported no format, lint, or type errors.

[Merge conflict resolution test results](https://cursor.com/agents/bc-b2030358-523a-4c49-9a58-6e1c70dd4c08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmerge_conflict_resolution_tests.txt)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-667](https://linear.app/hyperlocalise/issue/HL-667/add-pat-audit-events-and-safe-operational-logging)

<div><a href="https://cursor.com/agents/bc-1bbc3870-44a5-4afa-ba01-3d6a83a5a465?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bbc3870-44a5-4afa-ba01-3d6a83a5a465&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

