### PR TITLE
fix(agent-runtime): reject workspace path traversal in bash and repo tools

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -1764,10 +1764,7 @@ describe("createRunHyperlocaliseCliTool", () => {
       );
 
       const t = createRunHyperlocaliseCliTool(ctx);
-      const result = await t.execute!(
-        { subcommand: "check", flags: { config } },
-        toolCallInfo,
-      );
+      const result = await t.execute!({ subcommand: "check", flags: { config } }, toolCallInfo);
       expect(result).toMatchObject({
         success: false,
         error: expect.stringContaining("workspace"),

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -735,6 +735,15 @@ describe("createDetectRepoConfigTool", () => {
     expect(result).toMatchObject({ success: true, found: false });
   });
 
+  it("accepts ./ as the workspace root", async () => {
+    const ctx = createTestContext({
+      "/home/user/project/i18n.yml": "locales:\n  source: en\n",
+    });
+    const t = createDetectRepoConfigTool(ctx);
+    const result = await t.execute!({ path: "./" }, toolCallInfo);
+    expect(result).toMatchObject({ success: true, found: true, configPath: "i18n.yml" });
+  });
+
   it("finds i18n.yml", async () => {
     const yaml = `locales:
   source: en
@@ -889,6 +898,32 @@ describe("createRepoGitStateTool", () => {
       changedFiles: [],
     });
     expect((result as { commit: string }).commit).toHaveLength(40);
+  });
+
+  it("accepts ./ as the workspace root", async () => {
+    const ctx = createTestContext();
+    const dirs: string[] = [];
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        dirs.push(args[1] ?? "");
+        if (args[2] === "rev-parse" && args[3] === "--abbrev-ref") {
+          return { stdout: "main\n", stderr: "", exitCode: 0 };
+        }
+        if (args[2] === "rev-parse" && args[3] === "HEAD") {
+          return { stdout: "abc123def456789012345678901234567890abcd\n", stderr: "", exitCode: 0 };
+        }
+        if (args[2] === "status" && args[3] === "--porcelain") {
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    );
+
+    const t = createRepoGitStateTool(ctx);
+    const result = await t.execute!({ path: "./" }, toolCallInfo);
+    expect(result).toMatchObject({ success: true, branch: "main", isDirty: false });
+    expect(dirs).toContain(".");
+    expect(dirs).not.toContain("./");
   });
 
   it("dirty state", async () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -810,6 +810,40 @@ storage:
     expect(config?.buckets).toContain("app");
     expect(config?.storageAdapter).toBe("local");
   });
+
+  it.each(["/tmp/outside", "../outside", "foo/../../secret"])(
+    "rejects escaping path %s before exec",
+    async (path) => {
+      const ctx = createTestContext();
+      let invoked = false;
+      ctx.bash.registerCommand(
+        defineCommand("test", async () => {
+          invoked = true;
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      );
+      ctx.bash.registerCommand(
+        defineCommand("yq", async () => {
+          invoked = true;
+          return { stdout: "{}", stderr: "", exitCode: 0 };
+        }),
+      );
+      ctx.bash.registerCommand(
+        defineCommand("cat", async () => {
+          invoked = true;
+          return { stdout: "{}", stderr: "", exitCode: 0 };
+        }),
+      );
+
+      const t = createDetectRepoConfigTool(ctx);
+      const result = await t.execute!({ path }, toolCallInfo);
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.stringContaining("workspace"),
+      });
+      expect(invoked).toBe(false);
+    },
+  );
 });
 
 describe("createRepoGitStateTool", () => {
@@ -882,6 +916,28 @@ describe("createRepoGitStateTool", () => {
     });
     expect((result as { changedFiles: string[] }).changedFiles).toContain("dirty.txt");
   });
+
+  it.each(["/tmp", "../", "foo/../../outside"])(
+    "rejects escaping path %s before git exec",
+    async (path) => {
+      const ctx = createTestContext();
+      let invoked = false;
+      ctx.bash.registerCommand(
+        defineCommand("git", async () => {
+          invoked = true;
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      );
+
+      const t = createRepoGitStateTool(ctx);
+      const result = await t.execute!({ path }, toolCallInfo);
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.stringContaining("workspace"),
+      });
+      expect(invoked).toBe(false);
+    },
+  );
 });
 
 describe("createGitHistoryTool", () => {
@@ -1695,6 +1751,31 @@ describe("createRunHyperlocaliseCliTool", () => {
     expect(hlArgs).toEqual(["check", "--config=custom/i18n.yml"]);
   });
 
+  it.each(["foo/../../secret.yml", "/tmp/secret.yml", "../i18n.yml"])(
+    "rejects escaping --config %s without invoking hl",
+    async (config) => {
+      const ctx = createTestContext();
+      let invoked = false;
+      ctx.bash.registerCommand(
+        defineCommand("hl", async () => {
+          invoked = true;
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      );
+
+      const t = createRunHyperlocaliseCliTool(ctx);
+      const result = await t.execute!(
+        { subcommand: "check", flags: { config } },
+        toolCallInfo,
+      );
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.stringContaining("workspace"),
+      });
+      expect(invoked).toBe(false);
+    },
+  );
+
   it.each(["phrase", "crowdin", "lokalise"] as const)(
     "rejects provider/TMS actions for %s for now",
     async (provider) => {
@@ -1858,5 +1939,22 @@ describe("buildHlArgs", () => {
       ok: false,
       error: { code: "flag_value_contains_invalid_characters" },
     });
+  });
+
+  it.each(["foo/../../secret.yml", "/tmp/secret.yml", "../i18n.yml"])(
+    "rejects --config that escapes the workspace: %s",
+    (config) => {
+      expect(buildHlArgs({ subcommand: "check", flags: { config } })).toMatchObject({
+        ok: false,
+        error: { code: "flag_value_escapes_workspace", name: "config" },
+      });
+    },
+  );
+
+  it("normalizes a relative --config path", () => {
+    const result = buildHlArgs({ subcommand: "check", flags: { config: "./custom/i18n.yml" } });
+    expect(isOk(result)).toBe(true);
+    if (isErr(result)) throw new Error("expected valid hl args");
+    expect(result.value).toEqual(["check", "--config=custom/i18n.yml"]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
@@ -61,11 +61,25 @@ export function createDetectRepoConfigTool(ctx: RepoToolContext) {
       path: z.string().optional().describe("Directory to check. Defaults to repo root."),
     }),
     execute: async ({ path }) => {
-      const checkPath = path || ".";
+      const checkPathResult = requireWorkspacePath(path);
+      if (isErr(checkPathResult)) {
+        return {
+          success: false as const,
+          error: checkPathResult.error,
+        };
+      }
+      const checkPath = checkPathResult.value;
       const candidates = ["i18n.yml", "i18n.jsonc"];
 
       for (const name of candidates) {
-        const filePath = checkPath === "." ? name : `${checkPath}/${name}`;
+        const joined = checkPath === "." ? name : `${checkPath}/${name}`;
+        const filePath = normalizeWorkspacePath(joined);
+        if (!filePath) {
+          return {
+            success: false as const,
+            error: "Path must stay within the workspace.",
+          };
+        }
         const result = await ctx.bash.exec("test", { args: ["-f", filePath] });
         if (result.exitCode === 0) {
           const summary = await extractConfigSummary(ctx.bash, filePath, name);
@@ -136,7 +150,14 @@ export function createRepoGitStateTool(ctx: RepoToolContext) {
       path: z.string().optional().describe("Directory to inspect. Defaults to repo root."),
     }),
     execute: async ({ path }) => {
-      const dir = path || ".";
+      const dirResult = requireWorkspacePath(path);
+      if (isErr(dirResult)) {
+        return {
+          success: false,
+          error: dirResult.error,
+        };
+      }
+      const dir = dirResult.value;
 
       const branchResult = await ctx.bash.exec("git", {
         args: ["-C", dir, "rev-parse", "--abbrev-ref", "HEAD"],
@@ -1043,11 +1064,23 @@ export type RunHyperlocaliseCliOutput = {
 const HL_SUBCOMMANDS = ["check", "status", "extract"] as const;
 const HL_YAML_CONFIG_NAME = "i18n.yml";
 
+function isConfigFlagName(name: string): boolean {
+  return name.replace(/^-+/, "").toLowerCase() === "config";
+}
+
 function hasConfigFlag(flags?: Record<string, string>): boolean {
   if (!flags) {
     return false;
   }
-  return Object.keys(flags).some((key) => key.replace(/^-+/, "").toLowerCase() === "config");
+  return Object.keys(flags).some(isConfigFlagName);
+}
+
+function requireWorkspacePath(path: string | undefined): Result<string, string> {
+  const normalized = normalizeWorkspacePath(path || ".");
+  if (!normalized) {
+    return err("Path must stay within the workspace.");
+  }
+  return ok(normalized);
 }
 
 async function resolveDefaultHlYamlConfigPath(ctx: RepoToolContext): Promise<string | null> {
@@ -1156,7 +1189,8 @@ export type HyperlocaliseCliArgsError =
   | { code: "positional_arg_looks_like_flag"; value: string }
   | { code: "flag_not_allowed"; name: string }
   | { code: "flag_contains_invalid_characters"; name: string }
-  | { code: "flag_value_contains_invalid_characters" };
+  | { code: "flag_value_contains_invalid_characters" }
+  | { code: "flag_value_escapes_workspace"; name: string };
 
 export function formatHyperlocaliseCliArgsError(error: HyperlocaliseCliArgsError): string {
   switch (error.code) {
@@ -1170,6 +1204,8 @@ export function formatHyperlocaliseCliArgsError(error: HyperlocaliseCliArgsError
       return `Flag "${error.name}" contains invalid characters`;
     case "flag_value_contains_invalid_characters":
       return "Flag value contains invalid characters";
+    case "flag_value_escapes_workspace":
+      return `Flag "${error.name}" value must stay within the workspace.`;
   }
 }
 
@@ -1216,7 +1252,15 @@ export function buildHlArgs(input: {
     if (isErr(valueResult)) {
       return err(valueResult.error);
     }
-    args.push("--" + k + "=" + v);
+    let flagValue = v;
+    if (isConfigFlagName(k)) {
+      const normalizedConfig = normalizeWorkspacePath(v);
+      if (!normalizedConfig) {
+        return err({ code: "flag_value_escapes_workspace", name: k });
+      }
+      flagValue = normalizedConfig;
+    }
+    args.push("--" + k + "=" + flagValue);
   }
 
   return ok(args);

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
@@ -157,12 +157,14 @@ describe("isAllowedBashCommand", () => {
     expect(isAllowedBashCommand(command)).toBe(false);
   });
 
-  it.each(["find -L . -type f", "find -H . -type f", "find -LH . -type f", "find . -follow -type f"])(
-    "blocks find symlink-follow flag in %s",
-    (command) => {
-      expect(isAllowedBashCommand(command)).toBe(false);
-    },
-  );
+  it.each([
+    "find -L . -type f",
+    "find -H . -type f",
+    "find -LH . -type f",
+    "find . -follow -type f",
+  ])("blocks find symlink-follow flag in %s", (command) => {
+    expect(isAllowedBashCommand(command)).toBe(false);
+  });
 });
 
 describe("createBashTool", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
@@ -144,6 +144,25 @@ describe("isAllowedBashCommand", () => {
     expect(isAllowedBashCommand("git show HEAD")).toBe(true);
     expect(isAllowedBashCommand("git diff HEAD^ HEAD")).toBe(true);
   });
+
+  it.each([
+    "find ./../ -type f",
+    "ls ./../",
+    "ls foo/../../outside",
+    "find foo/bar/../../etc -type f",
+    "hl check --config foo/../../secret.yml",
+    "hl check --config ./../i18n.yml",
+    "find .\\..\\ -type f",
+  ])("blocks mid-path parent traversal in %s", (command) => {
+    expect(isAllowedBashCommand(command)).toBe(false);
+  });
+
+  it.each(["find -L . -type f", "find -H . -type f", "find -LH . -type f", "find . -follow -type f"])(
+    "blocks find symlink-follow flag in %s",
+    (command) => {
+      expect(isAllowedBashCommand(command)).toBe(false);
+    },
+  );
 });
 
 describe("createBashTool", () => {
@@ -296,5 +315,47 @@ describe("createBashTool", () => {
 
     const result = await tool.execute!({ command: "git status --short" }, toolCallInfo);
     expect(result).toMatchObject({ success: true, exitCode: 0 });
+  });
+
+  it("rejects mid-path parent traversal before execution", async () => {
+    const tool = createBashTool({
+      bash: {
+        exec: async () => {
+          throw new Error("bash.exec must not run for ./../ traversal");
+        },
+        readFile: async () => "",
+      },
+    });
+    const result = await tool.execute!({ command: "find ./../ -type f" }, toolCallInfo);
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("rejects space-separated hl --config traversal before execution", async () => {
+    const tool = createBashTool({
+      bash: {
+        exec: async () => {
+          throw new Error("bash.exec must not run for hl --config traversal");
+        },
+        readFile: async () => "",
+      },
+    });
+    const result = await tool.execute!(
+      { command: "hl check --config foo/../../secret.yml" },
+      toolCallInfo,
+    );
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("rejects find -L before execution", async () => {
+    const tool = createBashTool({
+      bash: {
+        exec: async () => {
+          throw new Error("bash.exec must not run for find -L");
+        },
+        readFile: async () => "",
+      },
+    });
+    const result = await tool.execute!({ command: "find -L . -type f" }, toolCallInfo);
+    expect(result).toMatchObject({ success: false });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
@@ -74,7 +74,35 @@ function attachedFlagValueEscapesWorkspace(token: string): boolean {
   if (!value) {
     return false;
   }
-  return value.startsWith("/") || value.split("/").includes("..");
+  return value.startsWith("/") || hasParentPathSegment(value);
+}
+
+/** Same rule as normalizeWorkspacePath: a `/`-separated `..` segment escapes the workspace. */
+function hasParentPathSegment(value: string): boolean {
+  return value.replace(/\\/g, "/").split("/").includes("..");
+}
+
+function tokenHasParentPathSegment(token: string): boolean {
+  if (hasParentPathSegment(token)) {
+    return true;
+  }
+  const separator = token.indexOf("=");
+  if (separator === -1) {
+    return false;
+  }
+  return hasParentPathSegment(unquoteFlagValue(token.slice(separator + 1)));
+}
+
+/** GNU find -L/-H/-follow walk symlinks out of the workspace. Do not treat git -L as the same. */
+function isDisallowedFindFollowFlag(token: string, bin: string): boolean {
+  if (bin !== "find" || !token.startsWith("-")) {
+    return false;
+  }
+  if (/^-[LH]+$/i.test(token)) {
+    return true;
+  }
+  const name = flagBasename(token);
+  return name === "l" || name === "h" || name === "follow";
 }
 
 function isDisallowedGitOutputFlag(token: string): boolean {
@@ -127,7 +155,13 @@ export function isAllowedBashCommand(command: string): boolean {
   if (tokens.some((token) => isDisallowedFlagToken(token, bin))) {
     return false;
   }
+  if (tokens.some((token) => isDisallowedFindFollowFlag(token, bin))) {
+    return false;
+  }
   if (tokens.some(attachedFlagValueEscapesWorkspace)) {
+    return false;
+  }
+  if (tokens.some(tokenHasParentPathSegment)) {
     return false;
   }
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.test.ts
@@ -37,6 +37,8 @@ describe("normalizeWorkspacePath", () => {
 
   it("rejects traversal and absolute paths", () => {
     expect(normalizeWorkspacePath("../secret")).toBeNull();
+    expect(normalizeWorkspacePath("foo/../../secret")).toBeNull();
+    expect(normalizeWorkspacePath("./../secret")).toBeNull();
     expect(normalizeWorkspacePath("/etc/passwd")).toBeNull();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.test.ts
@@ -33,6 +33,8 @@ describe("isGitMetadataPath", () => {
 describe("normalizeWorkspacePath", () => {
   it("keeps workspace-relative source paths", () => {
     expect(normalizeWorkspacePath("./src/app.tsx")).toBe("src/app.tsx");
+    expect(normalizeWorkspacePath(".")).toBe(".");
+    expect(normalizeWorkspacePath("./")).toBe(".");
   });
 
   it("rejects traversal and absolute paths", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/path.ts
@@ -14,7 +14,10 @@
  * Normalize a workspace-relative path. Returns null when the path escapes the repo root.
  */
 export function normalizeWorkspacePath(path: string): string | null {
-  const normalized = path.replace(/\\/g, "/").replace(/^\.\//, "").trim();
+  const withForwardSlashes = path.replace(/\\/g, "/").trim();
+  const stripped = withForwardSlashes.replace(/^\.\//, "");
+  // "./" strips to empty; keep it as the workspace root, same as ".".
+  const normalized = stripped === "" && withForwardSlashes === "./" ? "." : stripped;
   if (!normalized || normalized.startsWith("/") || normalized.split("/").includes("..")) {
     return null;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Closes two medium AppSec findings (tip a30eefc1) that let a steered read-only repository agent leave the clone without a planted symlink.

1. **Bash allowlist mid-path / `./../` traversal** (`bash.ts`)
   - After tokenization, reject any `/`-separated `..` segment (same rule as `normalizeWorkspacePath`). This blocks `find ./../ -type f`, `ls ./../`, and space-separated `hl check --config foo/../../…` (`--config=` was already blocked).
   - Deny GNU find `-L` / `-H` / clustered `-LH` and `-follow`, which walk symlinks out of the workspace. `git log -L` stays allowed.

2. **Unsanitized tool paths** (`repo-read-tools.ts`)
   - `detectRepoConfig` and `repoGitState` run `normalizeWorkspacePath` on the tool `path` before `test`/`yq`/`cat`/`git -C`.
   - `runHyperlocaliseCli` / `buildHlArgs` require a workspace-relative `--config` value and rewrite `./…` to the normalized path.

3. **Codex follow-up:** `normalizeWorkspacePath("./")` now returns `"."` so `detectRepoConfig` and `repoGitState` still accept the conventional root spelling.

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/lib/agent-runtime/tools/workspace/bash.test.ts src/lib/agent-runtime/tools/repo-read-tools.test.ts src/lib/agent-runtime/tools/workspace/path.test.ts
vp check --fix
```

- [x] `find ./../ -type f`, `ls ./../`, and `hl check --config foo/../../secret.yml` are denied before exec
- [x] `find -L` / `find -H` are denied; `git log HEAD..main` still allowed
- [x] `detectRepoConfig({ path: "/tmp/outside" })` and `repoGitState({ path: "/tmp" })` fail without invoking bash
- [x] `runHyperlocaliseCli` rejects `--config=foo/../../secret.yml` without invoking `hl`
- [x] `detectRepoConfig({ path: "./" })` and `repoGitState({ path: "./" })` treat `./` as the workspace root

## Checklist

- [x] I ran relevant checks locally (`vp test` on the changed files, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce599f46-910c-4710-97a5-e0c074db3e34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce599f46-910c-4710-97a5-e0c074db3e34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

