### PR TITLE
feat(memory): create a default TM for native projects

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -515,6 +515,10 @@
     "defaultMessage": "Should AcmePay stay untranslated in Spanish onboarding?",
     "description": "Inbox assistant glossary question in content ops mock"
   },
+  "/R/xwR7ZOR": {
+    "defaultMessage": "Project",
+    "description": "Label for the translation memory project filter"
+  },
   "/RotSbukS0": {
     "defaultMessage": "Unable to load projects",
     "description": "Error item when projects fail to load in the selector"
@@ -566,6 +570,10 @@
   "/WfsxTCk+E": {
     "defaultMessage": "Saving…",
     "description": "Status text while notification preferences are saving"
+  },
+  "/X++ueXvVD": {
+    "defaultMessage": "All projects",
+    "description": "Project filter option for all translation memories"
   },
   "/X6DitE9lx": {
     "defaultMessage": "All sync states",

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.test.ts
@@ -14,6 +14,7 @@ import "dotenv/config";
 
 import { randomUUID } from "node:crypto";
 
+import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
@@ -282,5 +283,52 @@ describe("memoryRoutes", () => {
     };
     expect(body.total).toBe(1);
     expect(body.memories).toEqual([expect.objectContaining({ id: matchingMemory.id })]);
+  });
+
+  it("removes project attachments when deleting a translation memory", async () => {
+    const { identity, organization, user, memory } = await fixture.createStoredMemoryFixture();
+    const team = await ensureDefaultWorkspaceTeam(organization.id);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({
+        id: `project_${randomUUID()}`,
+        identifier: uniqueTestProjectIdentifier(),
+        organizationId: organization.id,
+        teamId: team.id,
+        createdByUserId: user.id,
+        name: "Attached",
+        description: "",
+        translationContext: "",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .returning();
+
+    await db.insert(schema.projectMemories).values({
+      organizationId: organization.id,
+      projectId: project.id,
+      memoryId: memory.id,
+      priority: 0,
+    });
+
+    const headers = await fixture.authHeadersFor(identity);
+    const response = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].$delete(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: memory.id,
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(204);
+    const attachments = await db
+      .select({ memoryId: schema.projectMemories.memoryId })
+      .from(schema.projectMemories)
+      .where(eq(schema.projectMemories.memoryId, memory.id));
+    expect(attachments).toEqual([]);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.test.ts
@@ -12,6 +12,8 @@
  */
 import "dotenv/config";
 
+import { randomUUID } from "node:crypto";
+
 import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
@@ -35,7 +37,9 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
 import { createApp } from "@/api/app";
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
-import { db } from "@/lib/database/client";
+import { db, schema } from "@/lib/database/client";
+import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/test-project-identifier";
+import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
 import { createMemoryTestFixture } from "./memory.fixture";
 
@@ -195,5 +199,88 @@ describe("memoryRoutes", () => {
       source: "memory",
     });
     trackSpy.mockRestore();
+  });
+
+  it("filters translation memories by attached project", async () => {
+    const { identity, organization, user } = await fixture.createLocalWorkosIdentity();
+    const team = await ensureDefaultWorkspaceTeam(organization.id);
+    const [firstProject, secondProject] = await db
+      .insert(schema.projects)
+      .values([
+        {
+          id: `project_${randomUUID()}`,
+          identifier: uniqueTestProjectIdentifier(),
+          organizationId: organization.id,
+          teamId: team.id,
+          createdByUserId: user.id,
+          name: "First",
+          description: "",
+          translationContext: "",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+        {
+          id: `project_${randomUUID()}`,
+          identifier: uniqueTestProjectIdentifier(),
+          organizationId: organization.id,
+          teamId: team.id,
+          createdByUserId: user.id,
+          name: "Second",
+          description: "",
+          translationContext: "",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+      ])
+      .returning();
+    const [matchingMemory, otherMemory] = await db
+      .insert(schema.memories)
+      .values([
+        {
+          organizationId: organization.id,
+          createdByUserId: user.id,
+          name: "Matching TM",
+          description: "",
+        },
+        {
+          organizationId: organization.id,
+          createdByUserId: user.id,
+          name: "Other TM",
+          description: "",
+        },
+      ])
+      .returning();
+
+    await db.insert(schema.projectMemories).values([
+      {
+        organizationId: organization.id,
+        projectId: firstProject.id,
+        memoryId: matchingMemory.id,
+        priority: 0,
+      },
+      {
+        organizationId: organization.id,
+        projectId: secondProject.id,
+        memoryId: otherMemory.id,
+        priority: 0,
+      },
+    ]);
+
+    const headers = await fixture.authHeadersFor(identity);
+    const response = await client.api.orgs[":organizationSlug"]["translation-memories"].$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { limit: "50", offset: "0", projectId: firstProject.id },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      total: number;
+      memories: Array<{ id: string; name: string }>;
+    };
+    expect(body.total).toBe(1);
+    expect(body.memories).toEqual([expect.objectContaining({ id: matchingMemory.id })]);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -12,7 +12,7 @@
  */
 import { randomUUID } from "node:crypto";
 
-import { and, count, desc, eq } from "drizzle-orm";
+import { and, count, desc, eq, inArray } from "drizzle-orm";
 
 import {
   buildAccessibleProjectsWhere,
@@ -106,7 +106,26 @@ const memoryStore: MemoryStore = {
   async list(auth, query) {
     const limit = query?.limit ?? 50;
     const offset = query?.offset ?? 0;
-    const where = await buildProjectLinkedMemoryWhere(auth);
+    const projectId = query?.projectId;
+    if (projectId && !(await getOwnedProject(auth, projectId))) {
+      return { memories: [], total: 0 };
+    }
+
+    const accessWhere = await buildProjectLinkedMemoryWhere(auth);
+    const projectMemoryIds = projectId
+      ? db
+          .select({ memoryId: schema.projectMemories.memoryId })
+          .from(schema.projectMemories)
+          .where(
+            and(
+              eq(schema.projectMemories.projectId, projectId),
+              eq(schema.projectMemories.organizationId, auth.organization.localOrganizationId),
+            ),
+          )
+      : null;
+    const where = projectMemoryIds
+      ? and(accessWhere, inArray(schema.memories.id, projectMemoryIds))
+      : accessWhere;
 
     const [memories, totalRow] = await Promise.all([
       db

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -170,12 +170,21 @@ const memoryStore: MemoryStore = {
     return memory ?? null;
   },
   async delete(auth, memoryId) {
-    const deletedMemories = await db
-      .delete(schema.memories)
-      .where(await ownedMemoryWhere(auth, memoryId))
-      .returning({ id: schema.memories.id });
+    const memoryWhere = await ownedMemoryWhere(auth, memoryId);
+    return db.transaction(async (tx) => {
+      const deletedMemories = await tx
+        .delete(schema.memories)
+        .where(memoryWhere)
+        .returning({ id: schema.memories.id });
 
-    return deletedMemories.length > 0;
+      if (deletedMemories.length === 0) {
+        return false;
+      }
+
+      await tx.delete(schema.projectMemories).where(eq(schema.projectMemories.memoryId, memoryId));
+
+      return true;
+    });
   },
 };
 

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
@@ -35,6 +35,7 @@ export const listMemoryQuerySchema = z
   .object({
     limit: z.coerce.number().int().min(1).max(100).default(50),
     offset: z.coerce.number().int().min(0).default(0),
+    projectId: projectIdSchema.optional(),
   })
   .optional();
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.test.ts
@@ -854,6 +854,51 @@ describe("project identifier uniqueness", () => {
   });
 });
 
+describe("native project default translation memory", () => {
+  it("creates and attaches a default translation memory", async () => {
+    const admin = projectFixture.createWorkosIdentityWithRole("admin");
+    const headers = await projectFixture.authHeadersFor(admin);
+    const organizationSlug = admin.organization.slug ?? "missing-slug";
+    const team = await ensureDefaultWorkspaceTeam(
+      globalThis.__testApiAuthContext!.organization.localOrganizationId,
+    );
+
+    const projectResponse = await client.api.orgs[":organizationSlug"].projects.$post(
+      {
+        param: { organizationSlug },
+        json: {
+          name: "Default TM Project",
+          teamId: team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["es-ES"],
+        },
+      },
+      { headers },
+    );
+
+    expect(projectResponse.status).toBe(201);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+
+    const attachments = await db
+      .select({
+        memoryId: schema.projectMemories.memoryId,
+        priority: schema.projectMemories.priority,
+      })
+      .from(schema.projectMemories)
+      .where(eq(schema.projectMemories.projectId, project.id));
+    expect(attachments).toEqual([expect.objectContaining({ priority: 0 })]);
+
+    const [memory] = await db
+      .select({ name: schema.memories.name, source: schema.memories.source })
+      .from(schema.memories)
+      .where(eq(schema.memories.id, attachments[0]!.memoryId));
+    expect(memory).toMatchObject({
+      name: "Default TM Project",
+      source: "native",
+    });
+  });
+});
+
 describe("project source locale updates", () => {
   it("rejects changing source locale when attached glossaries use a different locale", async () => {
     const admin = projectFixture.createWorkosIdentityWithRole("admin");

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -46,6 +46,7 @@ import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
 import { isReleaseContentEditorAllFilesEnabled } from "@/lib/flags/release-flags";
 import { createLogger } from "@/lib/log";
+import { ensureDefaultNativeProjectMemory } from "@/lib/memory/ensure-default-native-project-memory";
 import {
   insertWithAllocatedProjectIdentifier,
   isProjectIdentifierTaken,
@@ -368,8 +369,8 @@ const projectStore: ProjectStore = {
       organizationId: auth.organization.localOrganizationId,
       name: payload.name,
       database,
-      insert: (identifier, attemptDb) =>
-        attemptDb
+      insert: async (identifier, attemptDb) => {
+        const created = await attemptDb
           .insert(schema.projects)
           .values({
             id: `project_${randomUUID()}`,
@@ -384,7 +385,19 @@ const projectStore: ProjectStore = {
             sourceLocale: payload.sourceLocale,
             targetLocales: payload.targetLocales,
           })
-          .returning(),
+          .returning();
+        const createdProject = created[0];
+        if (createdProject) {
+          await ensureDefaultNativeProjectMemory({
+            organizationId: auth.organization.localOrganizationId,
+            projectId: createdProject.id,
+            projectName: createdProject.name,
+            createdByUserId: auth.user.localUserId,
+            database: attemptDb,
+          });
+        }
+        return created;
+      },
     });
 
     // Creators without teams:write only see projects on teams they belong to.

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.stories.tsx
@@ -42,6 +42,13 @@ const meta = {
   component: AutomationDetailPageContent,
   parameters: {
     layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/acme/automations/${githubAutomation.id}`,
+        query: {},
+      },
+    },
   },
   args: {
     organizationSlug: "acme",
@@ -58,6 +65,7 @@ export const GithubTriggerHidesRun: Story = {
       handlers: createAutomationDetailMswHandlers(githubAutomation),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/automations/${githubAutomation.id}`,
       },
@@ -80,6 +88,7 @@ export const DeleteConfirmsRemoval: Story = {
       handlers: createAutomationDetailMswHandlers(githubAutomation),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/automations/${githubAutomation.id}`,
       },
@@ -109,6 +118,7 @@ export const ScheduledTriggerShowsRun: Story = {
       handlers: createAutomationDetailMswHandlers(scheduledAutomation),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/automations/${scheduledAutomation.id}`,
       },
@@ -130,6 +140,7 @@ export const ManualTriggerShowsRun: Story = {
       handlers: createAutomationDetailMswHandlers(manualAutomation),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/automations/${manualAutomation.id}`,
       },
@@ -151,6 +162,7 @@ export const SaveEnablesAfterFormChange: Story = {
       handlers: createAutomationDetailMswHandlers(scheduledAutomation),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/automations/${scheduledAutomation.id}`,
       },
@@ -178,6 +190,7 @@ export const SavePendingDisablesDelete: Story = {
       }),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/automations/${scheduledAutomation.id}`,
       },
@@ -205,6 +218,7 @@ export const DeletePendingDisablesSave: Story = {
       }),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/automations/${scheduledAutomation.id}`,
       },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -23,6 +23,13 @@ const meta = {
   component: AutomationsPageView,
   parameters: {
     layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/org/acme/automations",
+        query: {},
+      },
+    },
   },
   args: {
     organizationSlug: "acme",
@@ -151,6 +158,15 @@ export const ProjectScoped: Story = {
   args: {
     projectId: "project-1",
     automations: automationsFixture.filter((automation) => automation.projectId === "project-1"),
+  },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/org/acme/projects/project-1/automations",
+        query: {},
+      },
+    },
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Automations" })).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -47,9 +47,6 @@ import {
 } from "./automations-page-view-model";
 import { GithubAutoReviewCard } from "./github-auto-review-card";
 
-const TEMPLATE_FILTER_TABS_CLASS =
-  "h-auto flex-none rounded-full border-transparent px-3 py-1.5 text-muted-foreground shadow-none after:hidden hover:text-foreground data-active:bg-accent data-active:text-foreground dark:data-active:border-transparent dark:data-active:bg-accent";
-
 const AUTOMATION_LIST_GRID_CLASS =
   "grid min-w-[52rem] grid-cols-[minmax(0,1.5fr)_minmax(0,0.8fr)_minmax(0,0.55fr)_minmax(0,0.8fr)_minmax(0,0.45fr)] gap-4";
 
@@ -350,16 +347,9 @@ export function AutomationsPageView({
           }
           className="gap-5"
         >
-          <TabsList
-            variant="line"
-            className="h-auto w-full flex-wrap justify-start gap-1 bg-transparent p-0"
-          >
+          <TabsList>
             {templateCategoryTabs.map((category) => (
-              <TabsTrigger
-                key={category.id}
-                value={category.id}
-                className={TEMPLATE_FILTER_TABS_CLASS}
-              >
+              <TabsTrigger key={category.id} value={category.id}>
                 <FormattedMessage {...TEMPLATE_CATEGORY_MESSAGES[category.id]} />
               </TabsTrigger>
             ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -90,6 +90,7 @@ const meta = {
       handlers: automationEditorMswHandlers,
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: "/org/acme/automations/new",
       },
@@ -239,6 +240,7 @@ export const CreateValidationErrors: Story = {
 export const DetailDefault: Story = {
   parameters: {
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: "/org/acme/automations/11111111-1111-4111-8111-111111111111",
       },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -87,12 +87,6 @@ import { tmsUserConnectCtaQueryKey } from "../../_hooks/use-tms-user-connect-cta
 
 const api = createApiClient();
 
-const INTEGRATION_CATEGORY_FILTER_TABS_CLASS =
-  "h-auto flex-none rounded-full border-transparent px-3 py-1.5 text-muted-foreground shadow-none after:hidden hover:text-foreground data-active:bg-accent data-active:text-foreground dark:data-active:border-transparent dark:data-active:bg-accent";
-
-const INTEGRATION_CATEGORY_TABS_LIST_CLASS =
-  "flex h-auto min-h-0 w-full flex-wrap items-start justify-start gap-x-1 gap-y-2 bg-transparent p-0 group-data-horizontal/tabs:h-auto";
-
 const INTEGRATION_CATEGORY_IDS = [
   "source-control",
   "collaboration",
@@ -952,16 +946,12 @@ export function IntegrationsPageContent({
           onValueChange={(value) => setCategoryFilter(value as IntegrationCategoryFilter)}
           className="gap-5"
         >
-          <TabsList variant="line" className={INTEGRATION_CATEGORY_TABS_LIST_CLASS}>
-            <TabsTrigger value="all" className={INTEGRATION_CATEGORY_FILTER_TABS_CLASS}>
+          <TabsList>
+            <TabsTrigger value="all">
               <FormattedMessage {...integrationsPageContentMessages.categoryFilterAll} />
             </TabsTrigger>
             {visibleCategoryIds.map((categoryId) => (
-              <TabsTrigger
-                key={categoryId}
-                value={categoryId}
-                className={INTEGRATION_CATEGORY_FILTER_TABS_CLASS}
-              >
+              <TabsTrigger key={categoryId} value={categoryId}>
                 <FormattedMessage {...INTEGRATION_CATEGORY_MESSAGES[categoryId]} />
               </TabsTrigger>
             ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -138,6 +138,7 @@ export function TranslationMemoriesPageContent({
   const [createForm, setCreateForm] = useState<MemoryCreateForm>(() => createEmptyMemoryForm());
   const [createErrors, setCreateErrors] = useState<{ name?: string }>({});
   const [selectedExternalProjectId, setSelectedExternalProjectId] = useState("");
+  const [projectFilter, setProjectFilter] = useState("all");
   const { data: activeTmsProvider } = useActiveTmsProvider(organizationSlug);
   const useLiveProviderMemories = Boolean(activeTmsProvider);
   const allowCreateMemories = canCreateMemories && !useLiveProviderMemories;
@@ -190,6 +191,7 @@ export function TranslationMemoriesPageContent({
       ...memoriesQueryKey(organizationSlug, page),
       useLiveProviderMemories ? "live" : "native",
       selectedExternalProjectId,
+      projectFilter,
     ],
     enabled: !useLiveProviderMemories || Boolean(selectedExternalProjectId),
     queryFn: async () => {
@@ -230,6 +232,7 @@ export function TranslationMemoriesPageContent({
         query: {
           limit: String(MEMORIES_PAGE_SIZE),
           offset: String((page - 1) * MEMORIES_PAGE_SIZE),
+          ...(projectFilter !== "all" ? { projectId: projectFilter } : {}),
         },
       });
 
@@ -308,6 +311,14 @@ export function TranslationMemoriesPageContent({
   const pageStart = memoryTotal === 0 ? 0 : (page - 1) * MEMORIES_PAGE_SIZE + 1;
   const pageEnd = Math.min(page * MEMORIES_PAGE_SIZE, memoryTotal);
 
+  const filterProjects = useMemo(
+    () =>
+      (projectsQuery.data ?? [])
+        .map((project) => ({ id: project.id, name: project.name }))
+        .toSorted((left, right) => left.name.localeCompare(right.name)),
+    [projectsQuery.data],
+  );
+
   const providerKinds = useMemo(() => {
     const kinds = new Set<string>();
     for (const memory of memories) {
@@ -343,10 +354,12 @@ export function TranslationMemoriesPageContent({
     providerFilter,
     syncFilter,
     selectedExternalProjectId,
+    projectFilter,
   ]);
 
   useEffect(() => {
     setSelectedExternalProjectId("");
+    setProjectFilter("all");
   }, [organizationSlug, useLiveProviderMemories]);
 
   useEffect(() => {
@@ -393,18 +406,26 @@ export function TranslationMemoriesPageContent({
       onSearchQueryChange={setSearchQuery}
       sourceFilter={sourceFilter}
       onSourceFilterChange={setSourceFilter}
+      projectFilter={projectFilter}
+      onProjectFilterChange={setProjectFilter}
+      projects={filterProjects}
       providerFilter={providerFilter}
       onProviderFilterChange={setProviderFilter}
       syncFilter={syncFilter}
       onSyncFilterChange={setSyncFilter}
       providerKinds={providerKinds}
       hasExternalMemories={hasExternalMemories}
-      hasMemories={memories.length > 0}
-      activeFilterCount={activeFilterCount}
+      hasMemories={memories.length > 0 || (projectFilter !== "all" && memoryTotal === 0)}
+      activeFilterCount={activeFilterCount + (projectFilter === "all" ? 0 : 1)}
       showNoFilterMatches={
-        memoriesQuery.isSuccess && memories.length > 0 && filteredMemories.length === 0
+        memoriesQuery.isSuccess &&
+        ((memories.length > 0 && filteredMemories.length === 0) ||
+          (projectFilter !== "all" && memoryTotal === 0))
       }
-      onClearFilters={clearFilters}
+      onClearFilters={() => {
+        clearFilters();
+        setProjectFilter("all");
+      }}
       page={page}
       totalPages={totalPages}
       pageStart={pageStart}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.messages.ts
@@ -71,6 +71,16 @@ export const translationMemoriesPageViewMessages = defineMessages({
     id: "pT9uAzxhrd",
     description: "Source filter option for provider translation memories",
   },
+  projectLabel: {
+    defaultMessage: "Project",
+    id: "/R/xwR7ZOR",
+    description: "Label for the translation memory project filter",
+  },
+  projectAll: {
+    defaultMessage: "All projects",
+    id: "/X++ueXvVD",
+    description: "Project filter option for all translation memories",
+  },
   providerLabel: {
     defaultMessage: "Provider",
     id: "1GUuDck/5O",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.stories.tsx
@@ -42,6 +42,12 @@ const meta = {
     onSearchQueryChange: fn(),
     sourceFilter: "all",
     onSourceFilterChange: fn(),
+    projectFilter: "all",
+    onProjectFilterChange: fn(),
+    projects: [
+      { id: "project-marketing", name: "Marketing Site" },
+      { id: "project-docs", name: "Docs" },
+    ],
     providerFilter: "all",
     onProviderFilterChange: fn(),
     syncFilter: "all",
@@ -73,6 +79,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Translation Memories" })).toBeInTheDocument();
+    await expect(canvas.getByText("All projects")).toBeInTheDocument();
     await expect(canvas.getByText("Product UI")).toBeInTheDocument();
     await expect(canvas.getByText("Phrase TM")).toBeInTheDocument();
     await expect(canvas.getByText("Crowdin Memory")).toBeInTheDocument();
@@ -83,6 +90,7 @@ export const Loading: Story = {
   args: {
     memories: [],
     memoryTotal: 0,
+    projects: [],
     isLoading: true,
     isSuccess: false,
     pageStart: 0,
@@ -100,6 +108,7 @@ export const Empty: Story = {
   args: {
     memories: [],
     memoryTotal: 0,
+    projects: [],
     pageStart: 0,
     pageEnd: 0,
     providerKinds: [],

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
@@ -76,6 +76,9 @@ export function TranslationMemoriesPageView({
   onSearchQueryChange,
   sourceFilter,
   onSourceFilterChange,
+  projectFilter,
+  onProjectFilterChange,
+  projects,
   providerFilter,
   onProviderFilterChange,
   syncFilter,
@@ -115,6 +118,9 @@ export function TranslationMemoriesPageView({
   onSearchQueryChange: (value: string) => void;
   sourceFilter: string;
   onSourceFilterChange: (value: string) => void;
+  projectFilter: string;
+  onProjectFilterChange: (value: string) => void;
+  projects: readonly { id: string; name: string }[];
   providerFilter: string;
   onProviderFilterChange: (value: string) => void;
   syncFilter: string;
@@ -171,6 +177,11 @@ export function TranslationMemoriesPageView({
 
   const memoriesQuery = { isLoading, isError, isSuccess, error };
   const allProvidersLabel = intl.formatMessage(translationMemoriesPageViewMessages.providerAll);
+  const allProjectsLabel = intl.formatMessage(translationMemoriesPageViewMessages.projectAll);
+  const selectedProjectName =
+    projectFilter === "all"
+      ? allProjectsLabel
+      : (projects.find((project) => project.id === projectFilter)?.name ?? allProjectsLabel);
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
@@ -204,7 +215,7 @@ export function TranslationMemoriesPageView({
         </div>
       ) : null}
 
-      {isSuccess && hasMemories ? (
+      {isSuccess && (hasMemories || projects.length > 0) ? (
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
           <WorkspaceFilterField
             label={intl.formatMessage(translationMemoriesPageViewMessages.searchLabel)}
@@ -252,6 +263,31 @@ export function TranslationMemoriesPageView({
               </SelectContent>
             </Select>
           </WorkspaceFilterField>
+          {!useLiveProviderMemories && projects.length > 0 ? (
+            <WorkspaceFilterField
+              label={intl.formatMessage(translationMemoriesPageViewMessages.projectLabel)}
+              className="w-full sm:w-52"
+            >
+              <Select
+                value={projectFilter}
+                onValueChange={(value) => onProjectFilterChange(value ?? "all")}
+              >
+                <SelectTrigger className={workspaceFilterTriggerClassName}>
+                  <SelectValue>{selectedProjectName}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all" label={allProjectsLabel}>
+                    {allProjectsLabel}
+                  </SelectItem>
+                  {projects.map((project) => (
+                    <SelectItem key={project.id} value={project.id} label={project.name}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </WorkspaceFilterField>
+          ) : null}
 
           {hasExternalMemories && sourceFilter !== "native" ? (
             <WorkspaceFilterField

--- a/apps/hyperlocalise-web/src/lib/linked-domains/claims.ts
+++ b/apps/hyperlocalise-web/src/lib/linked-domains/claims.ts
@@ -21,6 +21,7 @@ import type {
 } from "@/lib/database/schema/linked-domains";
 import { isValidDomainSlug } from "@/lib/localisation-audit/domain-slug";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import { ensureDefaultNativeProjectMemory } from "@/lib/memory/ensure-default-native-project-memory";
 import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
 import { buildLinkedDomainChallenges, mintLinkedDomainVerificationToken } from "./challenges";
@@ -474,6 +475,13 @@ export async function verifyAndClaimLinkedDomain(input: {
         if (!project) {
           throw new Error("project_create_failed");
         }
+        await ensureDefaultNativeProjectMemory({
+          organizationId: input.organizationId,
+          projectId: project.id,
+          projectName: project.name,
+          createdByUserId: input.userId,
+          database: tx,
+        });
         projectId = project.id;
       } else if (projectId) {
         const [existingProject] = await tx

--- a/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.test.ts
@@ -122,4 +122,29 @@ describe("ensureDefaultNativeProjectMemory", () => {
     expect(memoryIds).toEqual([]);
     expect(await listAttachedProjectMemoryIds(project.id)).toEqual([]);
   });
+
+  it("recreates a default memory when attachments point at deleted memories", async () => {
+    const { organization, user, project } = await fixture.createStoredProjectFixture();
+    const danglingMemoryId = randomUUID();
+
+    await db.insert(schema.projectMemories).values({
+      organizationId: organization.id,
+      projectId: project.id,
+      memoryId: danglingMemoryId,
+      priority: 0,
+    });
+
+    expect(await listAttachedProjectMemoryIds(project.id)).toEqual([]);
+
+    const memoryIds = await ensureDefaultNativeProjectMemory({
+      organizationId: organization.id,
+      projectId: project.id,
+      projectName: project.name,
+      createdByUserId: user.id,
+    });
+
+    expect(memoryIds).toHaveLength(1);
+    expect(memoryIds[0]).not.toBe(danglingMemoryId);
+    expect(await listAttachedProjectMemoryIds(project.id)).toEqual(memoryIds);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+
+import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
+import { db, schema } from "@/lib/database/client";
+import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/test-project-identifier";
+import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
+
+import {
+  defaultNativeProjectMemoryName,
+  ensureDefaultNativeProjectMemory,
+  ensureDefaultNativeProjectMemoryForProject,
+  listAttachedProjectMemoryIds,
+} from "./ensure-default-native-project-memory";
+
+const fixture = createProjectTestFixture();
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  await fixture.cleanup();
+});
+
+describe("defaultNativeProjectMemoryName", () => {
+  it("uses the project name and falls back when blank", () => {
+    expect(defaultNativeProjectMemoryName("Marketing Site")).toBe("Marketing Site");
+    expect(defaultNativeProjectMemoryName("   ")).toBe("Translation memory");
+    expect(defaultNativeProjectMemoryName("a".repeat(250))).toHaveLength(200);
+  });
+});
+
+describe("ensureDefaultNativeProjectMemory", () => {
+  it("creates and attaches a default memory for a native project with none", async () => {
+    const { organization, user, project } = await fixture.createStoredProjectFixture();
+
+    const memoryIds = await ensureDefaultNativeProjectMemory({
+      organizationId: organization.id,
+      projectId: project.id,
+      projectName: project.name,
+      createdByUserId: user.id,
+    });
+
+    expect(memoryIds).toHaveLength(1);
+    expect(await listAttachedProjectMemoryIds(project.id)).toEqual(memoryIds);
+
+    const [memory] = await db
+      .select({ name: schema.memories.name, source: schema.memories.source })
+      .from(schema.memories)
+      .where(eq(schema.memories.id, memoryIds[0]!));
+
+    expect(memory).toMatchObject({
+      name: "Docs",
+      source: "native",
+    });
+  });
+
+  it("returns existing attachments without creating another memory", async () => {
+    const { organization, user, project } = await fixture.createStoredProjectFixture();
+
+    const first = await ensureDefaultNativeProjectMemory({
+      organizationId: organization.id,
+      projectId: project.id,
+      projectName: project.name,
+      createdByUserId: user.id,
+    });
+    const second = await ensureDefaultNativeProjectMemory({
+      organizationId: organization.id,
+      projectId: project.id,
+      projectName: project.name,
+      createdByUserId: user.id,
+    });
+
+    expect(second).toEqual(first);
+
+    const memories = await db
+      .select({ id: schema.memories.id })
+      .from(schema.memories)
+      .where(eq(schema.memories.organizationId, organization.id));
+    expect(memories).toHaveLength(1);
+  });
+
+  it("does not create a native memory for an external TMS project", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity();
+    const team = await ensureDefaultWorkspaceTeam(organization.id);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({
+        id: `project_${randomUUID()}`,
+        identifier: uniqueTestProjectIdentifier(),
+        organizationId: organization.id,
+        teamId: team.id,
+        createdByUserId: user.id,
+        name: "Crowdin Project",
+        description: "",
+        translationContext: "",
+        source: "external_tms",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .returning();
+
+    const memoryIds = await ensureDefaultNativeProjectMemoryForProject(project.id);
+
+    expect(memoryIds).toEqual([]);
+    expect(await listAttachedProjectMemoryIds(project.id)).toEqual([]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.ts
@@ -35,6 +35,7 @@ export async function listAttachedProjectMemoryIds(
   const attached = await database
     .select({ memoryId: schema.projectMemories.memoryId })
     .from(schema.projectMemories)
+    .innerJoin(schema.memories, eq(schema.memories.id, schema.projectMemories.memoryId))
     .where(eq(schema.projectMemories.projectId, projectId));
 
   return attached.map((row) => row.memoryId);

--- a/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { eq } from "drizzle-orm";
+
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
+import { db, schema, type DatabaseClient } from "@/lib/database/client";
+
+const DEFAULT_MEMORY_NAME = "Translation memory";
+const MAX_MEMORY_NAME_LENGTH = 200;
+
+export function defaultNativeProjectMemoryName(projectName: string): string {
+  const name = projectName.trim();
+  if (name.length === 0) {
+    return DEFAULT_MEMORY_NAME;
+  }
+
+  return name.slice(0, MAX_MEMORY_NAME_LENGTH);
+}
+
+export async function listAttachedProjectMemoryIds(
+  projectId: string,
+  database: DatabaseClient = db,
+): Promise<string[]> {
+  const attached = await database
+    .select({ memoryId: schema.projectMemories.memoryId })
+    .from(schema.projectMemories)
+    .where(eq(schema.projectMemories.projectId, projectId));
+
+  return attached.map((row) => row.memoryId);
+}
+
+export async function ensureDefaultNativeProjectMemory(input: {
+  organizationId: string;
+  projectId: string;
+  projectName: string;
+  createdByUserId?: string | null;
+  database?: DatabaseClient;
+}): Promise<string[]> {
+  const database = input.database ?? db;
+  const existing = await listAttachedProjectMemoryIds(input.projectId, database);
+  if (existing.length > 0) {
+    return existing;
+  }
+
+  return database.transaction(async (tx) => {
+    const [project] = await tx
+      .select({
+        id: schema.projects.id,
+        source: schema.projects.source,
+      })
+      .from(schema.projects)
+      .where(eq(schema.projects.id, input.projectId))
+      .for("update")
+      .limit(1);
+
+    if (!project || project.source !== "native") {
+      return listAttachedProjectMemoryIds(input.projectId, tx);
+    }
+
+    const attached = await listAttachedProjectMemoryIds(input.projectId, tx);
+    if (attached.length > 0) {
+      return attached;
+    }
+
+    const [memory] = await tx
+      .insert(schema.memories)
+      .values({
+        organizationId: input.organizationId,
+        createdByUserId: input.createdByUserId ?? null,
+        name: defaultNativeProjectMemoryName(input.projectName),
+        description: "",
+        source: "native",
+      })
+      .returning({ id: schema.memories.id });
+
+    if (!memory) {
+      return [];
+    }
+
+    await tx.insert(schema.projectMemories).values({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      memoryId: memory.id,
+      priority: 0,
+    });
+
+    serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.memoryCreated, {
+      status: "created",
+      source: "project",
+    });
+
+    return [memory.id];
+  });
+}
+
+export async function ensureDefaultNativeProjectMemoryForProject(
+  projectId: string,
+  database: DatabaseClient = db,
+): Promise<string[]> {
+  const [project] = await database
+    .select({
+      id: schema.projects.id,
+      organizationId: schema.projects.organizationId,
+      name: schema.projects.name,
+      source: schema.projects.source,
+      createdByUserId: schema.projects.createdByUserId,
+    })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, projectId))
+    .limit(1);
+
+  if (!project || project.source !== "native") {
+    return listAttachedProjectMemoryIds(projectId, database);
+  }
+
+  return ensureDefaultNativeProjectMemory({
+    organizationId: project.organizationId,
+    projectId: project.id,
+    projectName: project.name,
+    createdByUserId: project.createdByUserId,
+    database,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/tools/memory-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/memory-tools.ts
@@ -167,6 +167,10 @@ export function createDeleteTranslationMemoryTool(ctx: ToolContext) {
         return { success: false, error: `Translation memory ${memoryId} not found.` };
       }
 
+      await ctx.db
+        .delete(schema.projectMemories)
+        .where(eq(schema.projectMemories.memoryId, memoryId));
+
       return { success: true, deletedId: deleted[0].id };
     },
   });

--- a/apps/hyperlocalise-web/src/lib/translation/file-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-memory.ts
@@ -14,7 +14,10 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 
 import { db, schema } from "@/lib/database/client";
-import { ensureDefaultNativeProjectMemoryForProject } from "@/lib/memory/ensure-default-native-project-memory";
+import {
+  ensureDefaultNativeProjectMemoryForProject,
+  listAttachedProjectMemoryIds,
+} from "@/lib/memory/ensure-default-native-project-memory";
 import { incrementMemoryEntryVersionSql } from "@/lib/memory/memory-entry-lifecycle";
 import { listHiddenProjectTranslationKeysForSourcePath } from "@/lib/projects/translations/project-translation-service";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
@@ -58,11 +61,7 @@ export class FileTranslationMemoryStore {
       return {} as Record<string, string>;
     }
 
-    const attached = await db
-      .select({ memoryId: schema.projectMemories.memoryId })
-      .from(schema.projectMemories)
-      .where(eq(schema.projectMemories.projectId, input.projectId));
-    const memoryIds = attached.map((x) => x.memoryId);
+    const memoryIds = await listAttachedProjectMemoryIds(input.projectId);
     if (memoryIds.length === 0) {
       return {} as Record<string, string>;
     }
@@ -163,11 +162,7 @@ export class FileTranslationMemoryStore {
       return;
     }
 
-    const attached = await db
-      .select({ memoryId: schema.projectMemories.memoryId })
-      .from(schema.projectMemories)
-      .where(eq(schema.projectMemories.projectId, input.projectId));
-    let memoryIds = attached.map((x) => x.memoryId);
+    let memoryIds = await listAttachedProjectMemoryIds(input.projectId);
     if (memoryIds.length === 0) {
       memoryIds = await ensureDefaultNativeProjectMemoryForProject(input.projectId);
     }

--- a/apps/hyperlocalise-web/src/lib/translation/file-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-memory.ts
@@ -14,6 +14,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 
 import { db, schema } from "@/lib/database/client";
+import { ensureDefaultNativeProjectMemoryForProject } from "@/lib/memory/ensure-default-native-project-memory";
 import { incrementMemoryEntryVersionSql } from "@/lib/memory/memory-entry-lifecycle";
 import { listHiddenProjectTranslationKeysForSourcePath } from "@/lib/projects/translations/project-translation-service";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
@@ -166,7 +167,10 @@ export class FileTranslationMemoryStore {
       .select({ memoryId: schema.projectMemories.memoryId })
       .from(schema.projectMemories)
       .where(eq(schema.projectMemories.projectId, input.projectId));
-    const memoryIds = attached.map((x) => x.memoryId);
+    let memoryIds = attached.map((x) => x.memoryId);
+    if (memoryIds.length === 0) {
+      memoryIds = await ensureDefaultNativeProjectMemoryForProject(input.projectId);
+    }
     if (memoryIds.length === 0) {
       return;
     }

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
@@ -36,6 +36,7 @@ type ReusableMemoryEntryRow = {
 const {
   andMock,
   eqMock,
+  ensureDefaultMemoryIdsMock,
   inArrayMock,
   insertMock,
   listHiddenKeysMock,
@@ -57,10 +58,12 @@ const {
   const fromMock = vi.fn(() => ({ where: whereMock }));
   const selectMock = vi.fn(() => ({ from: fromMock }));
   const listHiddenKeysMock = vi.fn(async () => [] as string[]);
+  const ensureDefaultMemoryIdsMock = vi.fn(async () => [] as string[]);
 
   return {
     andMock: vi.fn((...conditions: unknown[]) => ["and", conditions]),
     eqMock: vi.fn((field: string, value: unknown) => ["eq", field, value]),
+    ensureDefaultMemoryIdsMock,
     inArrayMock: vi.fn((field: string, values: unknown[]) => ["inArray", field, values]),
     insertMock,
     listHiddenKeysMock,
@@ -81,6 +84,10 @@ vi.mock("drizzle-orm", () => ({
 
 vi.mock("@/lib/projects/translations/project-translation-service", () => ({
   listHiddenProjectTranslationKeysForSourcePath: listHiddenKeysMock,
+}));
+
+vi.mock("@/lib/memory/ensure-default-native-project-memory", () => ({
+  ensureDefaultNativeProjectMemoryForProject: ensureDefaultMemoryIdsMock,
 }));
 
 vi.mock("@/lib/database/client", () => ({
@@ -213,6 +220,26 @@ describe("persistFileTranslationMemoryEntries", () => {
     const [values] = valuesMock.mock.calls[0];
     expect(values.map((value) => value.metadata.segmentKey)).toEqual(["greeting", "greeting"]);
     expect(values.every((value) => value.targetText === "Bonjour")).toBe(true);
+  });
+
+  it("creates a default native memory when the project has none attached", async () => {
+    whereMock.mockResolvedValueOnce([]);
+    ensureDefaultMemoryIdsMock.mockResolvedValueOnce(["memory_created"]);
+
+    await persistFileTranslationMemoryEntries({
+      jobId: "job_1",
+      projectId: "project_1",
+      sourceEntries: { greeting: "Hello" },
+      sourceFileHash: "hash_1",
+      sourceLocale: "en",
+      sourcePath: "locales/en.json",
+      targetEntries: { greeting: "Bonjour" },
+      targetLocale: "fr",
+    });
+
+    expect(ensureDefaultMemoryIdsMock).toHaveBeenCalledWith("project_1");
+    const [values] = valuesMock.mock.calls[0];
+    expect(values.map((value) => value.memoryId)).toEqual(["memory_created"]);
   });
 
   it("does not write memory entries when every source key is hidden", async () => {

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
@@ -37,6 +37,7 @@ const {
   andMock,
   eqMock,
   ensureDefaultMemoryIdsMock,
+  listAttachedMemoryIdsMock,
   inArrayMock,
   insertMock,
   listHiddenKeysMock,
@@ -59,11 +60,13 @@ const {
   const selectMock = vi.fn(() => ({ from: fromMock }));
   const listHiddenKeysMock = vi.fn(async () => [] as string[]);
   const ensureDefaultMemoryIdsMock = vi.fn(async () => [] as string[]);
+  const listAttachedMemoryIdsMock = vi.fn(async () => ["memory_1", "memory_2"]);
 
   return {
     andMock: vi.fn((...conditions: unknown[]) => ["and", conditions]),
     eqMock: vi.fn((field: string, value: unknown) => ["eq", field, value]),
     ensureDefaultMemoryIdsMock,
+    listAttachedMemoryIdsMock,
     inArrayMock: vi.fn((field: string, values: unknown[]) => ["inArray", field, values]),
     insertMock,
     listHiddenKeysMock,
@@ -88,6 +91,7 @@ vi.mock("@/lib/projects/translations/project-translation-service", () => ({
 
 vi.mock("@/lib/memory/ensure-default-native-project-memory", () => ({
   ensureDefaultNativeProjectMemoryForProject: ensureDefaultMemoryIdsMock,
+  listAttachedProjectMemoryIds: listAttachedMemoryIdsMock,
 }));
 
 vi.mock("@/lib/database/client", () => ({
@@ -124,6 +128,7 @@ describe("persistFileTranslationMemoryEntries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listHiddenKeysMock.mockResolvedValue([]);
+    listAttachedMemoryIdsMock.mockResolvedValue(["memory_1", "memory_2"]);
   });
 
   it("dedupes duplicate normalized sources before batch upsert", async () => {
@@ -223,7 +228,7 @@ describe("persistFileTranslationMemoryEntries", () => {
   });
 
   it("creates a default native memory when the project has none attached", async () => {
-    whereMock.mockResolvedValueOnce([]);
+    listAttachedMemoryIdsMock.mockResolvedValueOnce([]);
     ensureDefaultMemoryIdsMock.mockResolvedValueOnce(["memory_created"]);
 
     await persistFileTranslationMemoryEntries({
@@ -263,10 +268,12 @@ describe("persistFileTranslationMemoryEntries", () => {
 describe("reuseFileTranslationMemoryEntries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    listAttachedMemoryIdsMock.mockResolvedValue(["memory_1", "memory_2"]);
   });
 
   it("excludes non-approved memory entries from reuse lookup", async () => {
-    whereMock.mockResolvedValueOnce([{ memoryId: "memory_1" }]).mockResolvedValueOnce([]);
+    listAttachedMemoryIdsMock.mockResolvedValueOnce(["memory_1"]);
+    whereMock.mockResolvedValueOnce([]);
 
     await reuseFileTranslationMemoryEntries({
       projectId: "project_1",
@@ -285,9 +292,7 @@ describe("reuseFileTranslationMemoryEntries", () => {
   });
 
   it("scopes reusable memory entry lookup to the project's attached memories", async () => {
-    whereMock
-      .mockResolvedValueOnce([{ memoryId: "memory_1" }, { memoryId: "memory_2" }])
-      .mockResolvedValueOnce([]);
+    whereMock.mockResolvedValueOnce([]);
 
     await reuseFileTranslationMemoryEntries({
       projectId: "project_1",
@@ -308,30 +313,28 @@ describe("reuseFileTranslationMemoryEntries", () => {
   });
 
   it("reuses only rows that match the target locale, segment key, and source hash", async () => {
-    whereMock
-      .mockResolvedValueOnce([{ memoryId: "memory_1" }, { memoryId: "memory_2" }])
-      .mockResolvedValueOnce([
-        {
-          memoryId: "memory_1",
-          metadata: {
-            segmentKey: "first",
-            sourceTextHash: createHash("sha256").update("Hello", "utf8").digest("hex"),
-          },
-          normalizedSourceText: "hello",
-          targetLocale: "fr",
-          targetText: "Bonjour",
+    whereMock.mockResolvedValueOnce([
+      {
+        memoryId: "memory_1",
+        metadata: {
+          segmentKey: "first",
+          sourceTextHash: createHash("sha256").update("Hello", "utf8").digest("hex"),
         },
-        {
-          memoryId: "memory_2",
-          metadata: {
-            segmentKey: "first",
-            sourceTextHash: createHash("sha256").update("Hello", "utf8").digest("hex"),
-          },
-          normalizedSourceText: "hello",
-          targetLocale: "de",
-          targetText: "Hallo",
+        normalizedSourceText: "hello",
+        targetLocale: "fr",
+        targetText: "Bonjour",
+      },
+      {
+        memoryId: "memory_2",
+        metadata: {
+          segmentKey: "first",
+          sourceTextHash: createHash("sha256").update("Hello", "utf8").digest("hex"),
         },
-      ]);
+        normalizedSourceText: "hello",
+        targetLocale: "de",
+        targetText: "Hallo",
+      },
+    ]);
 
     const result = await reuseFileTranslationMemoryEntries({
       projectId: "project_1",


### PR DESCRIPTION
## What changed

Native file jobs only write into memories already attached via `project_memories`, so translating never created a visible TM. New native projects now get a project-named default memory attached at priority 0. Legacy native projects with no attach get the same on the next file-job persist. The Translation Memories list can filter by project.

Crowdin, Phrase, Smartling, and Lokalise projects are unchanged. Historical project translations are not backfilled.

## How to test

- [ ] Create a native project and confirm a TM named after it appears on Translation Memories
- [ ] Filter Translation Memories by that project and see only its attached memory
- [ ] Run a file translation job on a legacy native project with no TM attach; a default TM should appear and receive that job's pairs
- [ ] Confirm provider-backed projects do not get a native default TM
- Targeted tests: `vp test src/lib/memory/ensure-default-native-project-memory.test.ts src/lib/translation/file-translation-memory.test.ts src/api/routes/memory/memory.route.test.ts src/api/routes/project/project.route.test.ts`
- `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test` for the changed routes/helpers, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)