### PR TITLE
feat(memory): restyle TM detail as a list page

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -2180,8 +2180,8 @@
     "description": "Marketing homepage testimonial quote"
   },
   "4JzoGkf5qD": {
-    "defaultMessage": "Import CSV or TMX",
-    "description": "Accessible label for the translation memory import file input"
+    "defaultMessage": "Import CSV or TMX file",
+    "description": "Accessible label for the hidden translation memory import file input"
   },
   "4LIUIf2s6l": {
     "defaultMessage": "Assignee",
@@ -2688,8 +2688,8 @@
     "description": "Fallback error when removing a project from a translation memory fails"
   },
   "6/dB+QQNUG": {
-    "defaultMessage": "Export TMX",
-    "description": "Button to open translation memory TMX export options"
+    "defaultMessage": "Export",
+    "description": "Button to open translation memory export options"
   },
   "6/jXIwGpnv": {
     "defaultMessage": "Loading Content Editor",
@@ -13351,6 +13351,10 @@
     "defaultMessage": "Shared guidance for agents and teams",
     "description": "Sidebar description for the Guideline navigation item"
   },
+  "dF9jC6xA5e": {
+    "defaultMessage": "Save an aligned source and target example to this memory.",
+    "description": "Description for the dialog that adds a translation memory entry"
+  },
   "dFDzTr1DKC": {
     "defaultMessage": "A localisation manager plans the quarter across four content streams",
     "description": "Scenario section title for the localisation-operations use case"
@@ -15891,6 +15895,10 @@
     "defaultMessage": "To {value}",
     "description": "Chip label for the modified-to filter"
   },
+  "kR7tW4hM2b": {
+    "defaultMessage": "Add entry",
+    "description": "Title for the dialog that adds a translation memory entry"
+  },
   "kRgGKX2G/s": {
     "defaultMessage": "Connect",
     "description": "Link label to connect an integration"
@@ -16839,6 +16847,10 @@
     "defaultMessage": "Source mistake",
     "description": "Issue type filter option for a source mistake"
   },
+  "nK8wQ2mR4t": {
+    "defaultMessage": "Import",
+    "description": "Button to import translation memory entries from a CSV or TMX file"
+  },
   "nLGLyaeThi": {
     "defaultMessage": "Locale",
     "description": "Label for issue target locale field"
@@ -17450,6 +17462,10 @@
   "pKzlTiRlHt": {
     "defaultMessage": "Members",
     "description": "Group label for assignable workspace members"
+  },
+  "pL3nS8vQ1c": {
+    "defaultMessage": "Cancel",
+    "description": "Button to close the add translation memory entry dialog"
   },
   "pM8pgX4u47": {
     "defaultMessage": "This removes the saved encrypted provider credentials. Reconnecting this provider will require entering the secret again.",
@@ -19706,6 +19722,10 @@
   "wGu07dv5qW": {
     "defaultMessage": "Project: {projectName}",
     "description": "Crowdin App inbox header showing the linked Hyperlocalise project"
+  },
+  "wH2uE5nY8s": {
+    "defaultMessage": "Projects",
+    "description": "Toolbar button that opens assigned projects for a translation memory"
   },
   "wHFmp4/+wj": {
     "defaultMessage": "Source file",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -56,6 +56,7 @@ export function TmEntryExplorer({
   canManageMemories = false,
   onDeleteEntry,
   isDeleting = false,
+  toolbarActions,
 }: {
   organizationSlug: string;
   memoryId: string;
@@ -64,6 +65,7 @@ export function TmEntryExplorer({
   canManageMemories?: boolean;
   onDeleteEntry?: (entryId: string) => void;
   isDeleting?: boolean;
+  toolbarActions?: ReactNode;
 }) {
   const intl = useIntl();
   const { state, searchDraft, setSearchDraft, updateState, clearFilters } =
@@ -226,6 +228,7 @@ export function TmEntryExplorer({
         onSearchDraftChange={setSearchDraft}
         onStateChange={updateState}
         onClearFilters={clearFilters}
+        actions={toolbarActions}
       />
 
       <div className="sr-only" role="status" aria-live="polite">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-toolbar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-list-toolbar.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Cancel01Icon, FilterIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -140,6 +140,7 @@ export function TmEntryListToolbar({
   onSearchDraftChange,
   onStateChange,
   onClearFilters,
+  actions,
 }: {
   state: TmEntryListUrlState;
   searchDraft: string;
@@ -147,6 +148,7 @@ export function TmEntryListToolbar({
   onSearchDraftChange: (value: string) => void;
   onStateChange: (patch: Partial<TmEntryListUrlState>) => void;
   onClearFilters: () => void;
+  actions?: ReactNode;
 }) {
   const intl = useIntl();
   const chips = getActiveTmEntryFilterChips(state);
@@ -407,6 +409,10 @@ export function TmEntryListToolbar({
             </SelectContent>
           </Select>
         </div>
+
+        {actions ? (
+          <div className="flex flex-wrap items-center gap-2 sm:ms-auto">{actions}</div>
+        ) : null}
       </div>
 
       {chips.length > 0 ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.messages.ts
@@ -15,10 +15,15 @@
 import { defineMessages } from "react-intl";
 
 export const tmImportExportPanelMessages = defineMessages({
+  import: {
+    defaultMessage: "Import",
+    id: "Z3fCUPrSEf",
+    description: "Button to import translation memory entries from a CSV or TMX file",
+  },
   importLabel: {
-    defaultMessage: "Import CSV or TMX",
-    id: "4JzoGkf5qD",
-    description: "Accessible label for the translation memory import file input",
+    defaultMessage: "Import CSV or TMX file",
+    id: "B1NsXVl3wA",
+    description: "Accessible label for the hidden translation memory import file input",
   },
   previewTitle: {
     defaultMessage: "Import preview",
@@ -57,9 +62,9 @@ export const tmImportExportPanelMessages = defineMessages({
     description: "Button to close the translation memory import report",
   },
   exportTmx: {
-    defaultMessage: "Export TMX",
-    id: "6/dB+QQNUG",
-    description: "Button to open translation memory TMX export options",
+    defaultMessage: "Export",
+    id: "wJpMrv20rr",
+    description: "Button to open translation memory export options",
   },
   exportTitle: {
     defaultMessage: "Export translation memory",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -27,7 +27,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
@@ -69,6 +68,7 @@ export function TmImportExportPanel({
   onImported: () => Promise<void> | void;
 }) {
   const intl = useIntl();
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
   const [preview, setPreview] = useState<MemoryImportResponse | null>(null);
   const [result, setResult] = useState<MemoryImportResponse | null>(null);
@@ -170,19 +170,31 @@ export function TmImportExportPanel({
   return (
     <div className="flex flex-wrap items-center gap-2">
       {canEdit ? (
-        <Input
-          type="file"
-          accept=".csv,.tmx,text/csv,application/xml,text/xml"
-          aria-label={intl.formatMessage(messages.importLabel)}
-          className="max-w-xs"
-          onChange={(event) => {
-            const file = event.target.files?.[0];
-            if (file) previewImport.mutate(file);
-            event.currentTarget.value = "";
-          }}
-        />
+        <>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,.tmx,text/csv,application/xml,text/xml"
+            aria-label={intl.formatMessage(messages.importLabel)}
+            className="sr-only"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) previewImport.mutate(file);
+              event.currentTarget.value = "";
+            }}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={previewImport.isPending}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <FormattedMessage {...messages.import} />
+          </Button>
+        </>
       ) : null}
-      <Button type="button" variant="outline" onClick={() => setExportOpen(true)}>
+      <Button type="button" variant="outline" size="sm" onClick={() => setExportOpen(true)}>
         <FormattedMessage {...messages.exportTmx} />
       </Button>
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.messages.ts
@@ -155,6 +155,26 @@ export const translationMemoryDetailPageContentMessages = defineMessages({
     id: "Zb2NG5FzSq",
     description: "Button to add a new translation memory entry",
   },
+  cancelAddEntry: {
+    defaultMessage: "Cancel",
+    id: "5jk6z2ASrH",
+    description: "Button to close the add translation memory entry dialog",
+  },
+  addEntryDialogTitle: {
+    defaultMessage: "Add entry",
+    id: "Y9WqHw/9nv",
+    description: "Title for the dialog that adds a translation memory entry",
+  },
+  addEntryDialogDescription: {
+    defaultMessage: "Save an aligned source and target example to this memory.",
+    id: "F9qtJj6l6D",
+    description: "Description for the dialog that adds a translation memory entry",
+  },
+  projectsToolbar: {
+    defaultMessage: "Projects",
+    id: "XiZ3CdNBSX",
+    description: "Toolbar button that opens assigned projects for a translation memory",
+  },
   cancelEdit: {
     defaultMessage: "Cancel edit",
     id: "Rlnuzntk1P",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -14,7 +14,7 @@
  */
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft01Icon, Database01Icon } from "@hugeicons/core-free-icons";
+import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -23,6 +23,14 @@ import { toast } from "sonner";
 import type { MemoryProjectRecord, MemoryRecord } from "@/api/routes/memory/memory.schema";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Field, FieldLabel } from "@/components/ui/field";
 import {
   Select,
@@ -70,6 +78,8 @@ export function TranslationMemoryDetailPageContent({
   const queryClient = useQueryClient();
   const [entryForm, setEntryForm] = useState<EntryForm>(emptyEntryForm);
   const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [addEntryOpen, setAddEntryOpen] = useState(false);
+  const [projectsOpen, setProjectsOpen] = useState(false);
 
   const memoryQuery = useQuery({
     queryKey: ["translation-memory", organizationSlug, memoryId],
@@ -147,6 +157,7 @@ export function TranslationMemoryDetailPageContent({
     onSuccess: async () => {
       await invalidateEntries();
       setEntryForm(emptyEntryForm);
+      setAddEntryOpen(false);
       toast.success(intl.formatMessage(messages.entryAdded));
     },
     onError: (error) => toast.error(error.message),
@@ -241,13 +252,9 @@ export function TranslationMemoryDetailPageContent({
         <FormattedMessage {...messages.backToList} />
       </Link>
 
-      <section className="flex flex-col gap-3">
+      <section className="flex flex-col gap-2">
         <div className="flex flex-wrap items-center gap-2">
-          <HugeiconsIcon
-            icon={Database01Icon}
-            className="size-5 text-muted-foreground"
-            strokeWidth={1.8}
-          />
+          <TypographyH1 className="font-sans text-2xl font-medium">{memory.name}</TypographyH1>
           <Badge variant="outline">
             {memory.source === "native" ? (
               <FormattedMessage {...messages.sourceWorkspace} />
@@ -256,32 +263,60 @@ export function TranslationMemoryDetailPageContent({
             )}
           </Badge>
         </div>
-        <TypographyH1 className="font-sans text-2xl font-medium">{memory.name}</TypographyH1>
-        <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
-          {memory.description || intl.formatMessage(messages.descriptionFallback)}
-        </TypographyP>
+        {memory.description ? (
+          <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            {memory.description}
+          </TypographyP>
+        ) : null}
       </section>
 
-      <section className="grid gap-4 rounded-lg border border-border p-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <TypographyP className="text-sm font-medium text-foreground">
-              <FormattedMessage {...messages.entriesTitle} />
-            </TypographyP>
-            <TypographyP className="text-xs text-muted-foreground">
-              <FormattedMessage {...messages.entriesDescription} />
-            </TypographyP>
-          </div>
-          <TmImportExportPanel
-            organizationSlug={organizationSlug}
-            memoryId={memoryId}
-            localeCoverage={memory.localeCoverage}
-            canEdit={canEdit}
-            onImported={invalidateEntries}
-          />
-        </div>
+      <TmEntryExplorer
+        organizationSlug={organizationSlug}
+        memoryId={memoryId}
+        localeCoverage={memory.localeCoverage}
+        canEdit={canEdit}
+        canManageMemories={canManageMemories}
+        isDeleting={deleteEntry.isPending}
+        onDeleteEntry={(entryId) => deleteEntry.mutate(entryId)}
+        toolbarActions={
+          <>
+            <Button type="button" variant="outline" size="sm" onClick={() => setProjectsOpen(true)}>
+              <FormattedMessage {...messages.projectsToolbar} />
+            </Button>
+            <TmImportExportPanel
+              organizationSlug={organizationSlug}
+              memoryId={memoryId}
+              localeCoverage={memory.localeCoverage}
+              canEdit={canEdit}
+              onImported={invalidateEntries}
+            />
+            {canEdit ? (
+              <Button type="button" size="sm" onClick={() => setAddEntryOpen(true)}>
+                <FormattedMessage {...messages.addEntry} />
+              </Button>
+            ) : null}
+          </>
+        }
+      />
 
-        {canEdit ? (
+      <Dialog
+        open={addEntryOpen}
+        onOpenChange={(open) => {
+          setAddEntryOpen(open);
+          if (!open) {
+            setEntryForm(emptyEntryForm);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...messages.addEntryDialogTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage {...messages.addEntryDialogDescription} />
+            </DialogDescription>
+          </DialogHeader>
           <div className="grid gap-3 md:grid-cols-2">
             <TmEntryLocaleField
               label={intl.formatMessage(messages.sourceLocaleLabel)}
@@ -333,101 +368,105 @@ export function TranslationMemoryDetailPageContent({
                 }
               />
             </Field>
-            <div className="flex gap-2 md:col-span-2">
-              <Button
-                type="button"
-                disabled={
-                  !entryForm.sourceText.trim() ||
-                  !entryForm.targetText.trim() ||
-                  !entryForm.sourceLocale.trim() ||
-                  !entryForm.targetLocale.trim() ||
-                  saveEntry.isPending
-                }
-                onClick={() => saveEntry.mutate(entryForm)}
-              >
-                <FormattedMessage {...messages.addEntry} />
-              </Button>
-            </div>
           </div>
-        ) : null}
-
-        <TmEntryExplorer
-          organizationSlug={organizationSlug}
-          memoryId={memoryId}
-          localeCoverage={memory.localeCoverage}
-          canEdit={canEdit}
-          canManageMemories={canManageMemories}
-          isDeleting={deleteEntry.isPending}
-          onDeleteEntry={(entryId) => deleteEntry.mutate(entryId)}
-        />
-      </section>
-
-      <section className="grid gap-4 rounded-lg border border-border p-4">
-        <div>
-          <TypographyP className="text-sm font-medium text-foreground">
-            <FormattedMessage {...messages.assignedProjectsTitle} />
-          </TypographyP>
-          <TypographyP className="text-xs text-muted-foreground">
-            <FormattedMessage {...messages.assignedProjectsDescription} />
-          </TypographyP>
-        </div>
-        {canEdit ? (
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <Select
-              value={selectedProjectId}
-              onValueChange={(value) => setSelectedProjectId(value ?? "")}
-            >
-              <SelectTrigger className="sm:max-w-sm">
-                <SelectValue placeholder={intl.formatMessage(messages.selectProjectPlaceholder)} />
-              </SelectTrigger>
-              <SelectContent>
-                {availableProjects.map((project) => (
-                  <SelectItem key={project.id} value={project.id}>
-                    {project.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <DialogFooter>
             <Button
               type="button"
-              disabled={!selectedProjectId || attachProject.isPending}
-              onClick={() => attachProject.mutate(selectedProjectId)}
+              variant="outline"
+              onClick={() => {
+                setAddEntryOpen(false);
+                setEntryForm(emptyEntryForm);
+              }}
             >
-              <FormattedMessage {...messages.assignToProject} />
+              <FormattedMessage {...messages.cancelAddEntry} />
             </Button>
-          </div>
-        ) : null}
-        <div className="grid gap-2">
-          {(attachedProjectsQuery.data ?? []).map((project) => (
-            <div
-              key={project.projectId}
-              className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-3 py-2"
+            <Button
+              type="button"
+              disabled={
+                !entryForm.sourceText.trim() ||
+                !entryForm.targetText.trim() ||
+                !entryForm.sourceLocale.trim() ||
+                !entryForm.targetLocale.trim() ||
+                saveEntry.isPending
+              }
+              onClick={() => saveEntry.mutate(entryForm)}
             >
-              <Link
-                href={`/org/${organizationSlug}/projects/${project.projectId}`}
-                className="text-sm font-medium text-foreground hover:underline"
+              <FormattedMessage {...messages.addEntry} />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={projectsOpen} onOpenChange={setProjectsOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...messages.assignedProjectsTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage {...messages.assignedProjectsDescription} />
+            </DialogDescription>
+          </DialogHeader>
+          {canEdit ? (
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Select
+                value={selectedProjectId || null}
+                onValueChange={(value) => setSelectedProjectId(value ?? "")}
               >
-                {project.projectName}
-              </Link>
-              {canEdit ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => detachProject.mutate(project.projectId)}
-                >
-                  <FormattedMessage {...messages.removeProject} />
-                </Button>
-              ) : null}
+                <SelectTrigger className="sm:max-w-sm">
+                  <SelectValue
+                    placeholder={intl.formatMessage(messages.selectProjectPlaceholder)}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableProjects.map((project) => (
+                    <SelectItem key={project.id} value={project.id} label={project.name}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                type="button"
+                disabled={!selectedProjectId || attachProject.isPending}
+                onClick={() => attachProject.mutate(selectedProjectId)}
+              >
+                <FormattedMessage {...messages.assignToProject} />
+              </Button>
             </div>
-          ))}
-          {attachedProjectsQuery.isSuccess && (attachedProjectsQuery.data ?? []).length === 0 ? (
-            <TypographyP className="text-sm text-muted-foreground">
-              <FormattedMessage {...messages.noProjectsAssigned} />
-            </TypographyP>
           ) : null}
-        </div>
-      </section>
+          <div className="grid gap-2">
+            {(attachedProjectsQuery.data ?? []).map((project) => (
+              <div
+                key={project.projectId}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-3 py-2"
+              >
+                <Link
+                  href={`/org/${organizationSlug}/projects/${project.projectId}`}
+                  className="text-sm font-medium text-foreground hover:underline"
+                >
+                  {project.projectName}
+                </Link>
+                {canEdit ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => detachProject.mutate(project.projectId)}
+                  >
+                    <FormattedMessage {...messages.removeProject} />
+                  </Button>
+                ) : null}
+              </div>
+            ))}
+            {attachedProjectsQuery.isSuccess && (attachedProjectsQuery.data ?? []).length === 0 ? (
+              <TypographyP className="text-sm text-muted-foreground">
+                <FormattedMessage {...messages.noProjectsAssigned} />
+              </TypographyP>
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
     </main>
   );
 }


### PR DESCRIPTION
## What changed

The translation memory detail page is now a list page: the entry list is the main surface, and add / assign / import / export live in the toolbar as dialogs instead of always-open forms.

- Slim header: back link, title + Workspace/Provider badge, description only when present
- Toolbar actions: Projects, Import, Export, Add entry
- Import uses a hidden file input (no native “Choose file” control)
- Assigned projects and add-entry forms open in dialogs; read-only users still see the project list

## How to test

- [ ] Open a native translation memory: header is title + badge, no database icon or fallback description
- [ ] Toolbar shows Search / Filters / sort, then Projects, Import, Export, and Add entry
- [ ] **Add entry** opens a dialog; Cancel closes it; a successful add closes and resets the form
- [ ] **Projects** lists assigned projects; Assign / Remove work; empty copy is “No projects assigned yet.”
- [ ] Read-only / provider memories: Projects is visible without assign controls; Add entry and Import are hidden
- [ ] **Import** opens a file picker (CSV/TMX) without a native file control; **Export** still opens the TMX options dialog
- [ ] Empty state remains “No entries yet” with actions in the toolbar
- [ ] In `apps/hyperlocalise-web`: `vp test` (TM component tests) and `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; TM component tests)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review