### PR TITLE
feat(jobs): use one create-job composer for native and provider projects

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -17164,8 +17164,8 @@
     "description": "Dashboard panel description for live TMS jobs"
   },
   "nqQ9RngvcW": {
-    "defaultMessage": "Create Crowdin tasks with files, locales, and assignees.",
-    "description": "Create job dialog description for Crowdin provider projects"
+    "defaultMessage": "Create a job with context, files, locales, and assignees.",
+    "description": "Create job dialog accessible description"
   },
   "nqV2qZ+dzM": {
     "defaultMessage": "File and string translation jobs, batch localization, and translation subagents.",

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -560,15 +560,24 @@ describe("project job create", () => {
     );
 
     expect(response.status).toBe(201);
-    const body = (await response.json()) as { job: { id: string; kind: string } };
+    const body = (await response.json()) as {
+      job: { id: string; kind: string; status: string };
+    };
     expect(body.job.kind).toBe("proofread");
+    expect(body.job.status).toBe("waiting_for_review");
+    expect(enqueueJob).not.toHaveBeenCalled();
     const [job] = await db
-      .select({ kind: schema.jobs.kind, inputPayload: schema.jobs.inputPayload })
+      .select({
+        kind: schema.jobs.kind,
+        status: schema.jobs.status,
+        inputPayload: schema.jobs.inputPayload,
+      })
       .from(schema.jobs)
       .where(eq(schema.jobs.id, body.job.id))
       .limit(1);
 
     expect(job?.kind).toBe("proofread");
+    expect(job?.status).toBe("waiting_for_review");
     expect(job?.inputPayload).toMatchObject({
       metadata: {
         title: "Proofread homepage",

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -524,6 +524,58 @@ describe("project job create", () => {
       },
     });
   });
+
+  it("stores description and proofread kind on native create", async () => {
+    const { identity, organization, project } = await createFixture.createStoredProjectFixture();
+    const headers = await createFixture.authHeadersFor(identity);
+    const sourceFile = await insertStoredSourceFile({
+      organizationId: organization.id,
+      projectId: project.id,
+      filename: "messages.json",
+      contentType: "application/json",
+    });
+
+    const response = await createClient.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          type: "file",
+          title: "Proofread homepage",
+          description: "Check product names stay untranslated.",
+          kind: "proofread",
+          fileInput: {
+            sourceFileId: sourceFile.id,
+            fileFormat: "json",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { job: { id: string; kind: string } };
+    expect(body.job.kind).toBe("proofread");
+    const [job] = await db
+      .select({ kind: schema.jobs.kind, inputPayload: schema.jobs.inputPayload })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.id, body.job.id))
+      .limit(1);
+
+    expect(job?.kind).toBe("proofread");
+    expect(job?.inputPayload).toMatchObject({
+      metadata: {
+        title: "Proofread homepage",
+        description: "Check product names stay untranslated.",
+      },
+    });
+  });
 });
 
 describe("project job list triage", () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -593,7 +593,8 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
             .update(schema.jobs)
             .set({
               status: "failed",
-              lastError: error instanceof Error ? error.message : "translation job queue unavailable",
+              lastError:
+                error instanceof Error ? error.message : "translation job queue unavailable",
             })
             .where(and(eq(schema.jobs.projectId, params.projectId), eq(schema.jobs.id, job.id)));
 

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -508,15 +508,18 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       }
 
       const jobId = `job_${randomUUID()}`;
+      const isProofreadJob = jobKind === "proofread";
       let job;
       try {
         [job] = await db.transaction(async (tx) => {
-          const jobBudget = await assertOrganizationCanEnqueueTranslationJobInTransaction(
-            tx,
-            c.var.auth.organization.localOrganizationId,
-          );
-          if (isErr(jobBudget)) {
-            throw new OrganizationJobBudgetExceededError(jobBudget.error);
+          if (!isProofreadJob) {
+            const jobBudget = await assertOrganizationCanEnqueueTranslationJobInTransaction(
+              tx,
+              c.var.auth.organization.localOrganizationId,
+            );
+            if (isErr(jobBudget)) {
+              throw new OrganizationJobBudgetExceededError(jobBudget.error);
+            }
           }
 
           const sourceFileVersion =
@@ -539,7 +542,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
               ownerUserId,
               assigneeType: ownerUserId ? "user" : null,
               kind: jobKind,
-              status: "queued",
+              status: isProofreadJob ? "waiting_for_review" : "queued",
               inputPayload: enrichedInputPayload,
             })
             .returning();
@@ -553,17 +556,19 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
             })
             .returning();
 
-          const usageEventResult = await reserveUsageEvent({
-            db: tx,
-            organizationId: c.var.auth.organization.localOrganizationId,
-            featureId: usageFeatureIds.translationJobs,
-            operationKey: `job:${jobId}:translation_jobs`,
-            source: "translation_job_create",
-            jobId,
-            quantity: 1,
-          });
-          if (isErr(usageEventResult)) {
-            throw new Error(formatUsageControlError(usageEventResult.error));
+          if (!isProofreadJob) {
+            const usageEventResult = await reserveUsageEvent({
+              db: tx,
+              organizationId: c.var.auth.organization.localOrganizationId,
+              featureId: usageFeatureIds.translationJobs,
+              operationKey: `job:${jobId}:translation_jobs`,
+              source: "translation_job_create",
+              jobId,
+              quantity: 1,
+            });
+            if (isErr(usageEventResult)) {
+              throw new Error(formatUsageControlError(usageEventResult.error));
+            }
           }
 
           return [{ ...createdJob, type: details.type }];
@@ -575,23 +580,25 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
         throw error;
       }
 
-      try {
-        await options.jobQueue.enqueue({
-          kind: "translation",
-          jobId: job.id,
-          projectId: job.projectId ?? params.projectId,
-          type: job.type,
-        });
-      } catch (error) {
-        await db
-          .update(schema.jobs)
-          .set({
-            status: "failed",
-            lastError: error instanceof Error ? error.message : "translation job queue unavailable",
-          })
-          .where(and(eq(schema.jobs.projectId, params.projectId), eq(schema.jobs.id, job.id)));
+      if (!isProofreadJob) {
+        try {
+          await options.jobQueue.enqueue({
+            kind: "translation",
+            jobId: job.id,
+            projectId: job.projectId ?? params.projectId,
+            type: job.type,
+          });
+        } catch (error) {
+          await db
+            .update(schema.jobs)
+            .set({
+              status: "failed",
+              lastError: error instanceof Error ? error.message : "translation job queue unavailable",
+            })
+            .where(and(eq(schema.jobs.projectId, params.projectId), eq(schema.jobs.id, job.id)));
 
-        return serviceUnavailableResponse(c, "job_queue_unavailable", "Job queue is unavailable");
+          return serviceUnavailableResponse(c, "job_queue_unavailable", "Job queue is unavailable");
+        }
       }
 
       const createdJob = await getOwnedJob(params.projectId, job.id);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -414,16 +414,20 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       }
 
       const inputPayload = payload.type === "string" ? payload.stringInput : payload.fileInput;
-      let enrichedInputPayload =
-        payload.title && payload.title.trim().length > 0
-          ? {
-              ...inputPayload,
-              metadata: {
-                ...inputPayload.metadata,
-                title: payload.title.trim(),
-              },
-            }
-          : inputPayload;
+      const title = payload.title?.trim();
+      const description = payload.description?.trim();
+      const jobKind = payload.kind === "proofread" ? "proofread" : "translation";
+      let enrichedInputPayload = inputPayload;
+      if (title || description) {
+        enrichedInputPayload = {
+          ...inputPayload,
+          metadata: {
+            ...inputPayload.metadata,
+            ...(title ? { title } : {}),
+            ...(description ? { description } : {}),
+          },
+        };
+      }
 
       const localeValidation = validateJobLocalesAgainstProject(project, {
         sourceLocale: enrichedInputPayload.sourceLocale,
@@ -534,7 +538,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
               createdByUserId: c.var.auth.user.localUserId,
               ownerUserId,
               assigneeType: ownerUserId ? "user" : null,
-              kind: "translation",
+              kind: jobKind,
               status: "queued",
               inputPayload: enrichedInputPayload,
             })

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -57,18 +57,23 @@ export const fileTranslationJobInputSchema = z.object({
   metadata: metadataSchema,
 });
 
+const createJobSharedFields = {
+  ownerWorkosUserId: z.string().trim().min(1).max(256).optional(),
+  title: z.string().trim().min(1).max(256).optional(),
+  description: z.string().trim().max(2_048).optional(),
+  kind: z.enum(["translation", "proofread"]).optional(),
+};
+
 export const createJobBodySchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("string"),
     stringInput: stringTranslationJobInputSchema,
-    ownerWorkosUserId: z.string().trim().min(1).max(256).optional(),
-    title: z.string().trim().min(1).max(256).optional(),
+    ...createJobSharedFields,
   }),
   z.object({
     type: z.literal("file"),
     fileInput: fileTranslationJobInputSchema,
-    ownerWorkosUserId: z.string().trim().min(1).max(256).optional(),
-    title: z.string().trim().min(1).max(256).optional(),
+    ...createJobSharedFields,
   }),
 ]);
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-custom-column-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-custom-column-field.tsx
@@ -74,7 +74,7 @@ export function IssueCustomColumnField({
 
     return (
       <Select
-        value={currentValue || undefined}
+        value={currentValue || null}
         items={selectItems}
         onValueChange={(next) => {
           onChange(next ?? "");

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -976,7 +976,7 @@ export const IssueDetailPanel = forwardRef<
                   label={<FormattedMessage {...messages.fieldPriority} />}
                 >
                   <Select
-                    value={priority || undefined}
+                    value={priority || null}
                     items={priorityItems}
                     onValueChange={(value) => {
                       if (value) {
@@ -1240,7 +1240,7 @@ export const IssueDetailPanel = forwardRef<
 
               {showPriorityField ? (
                 <Select
-                  value={priority || undefined}
+                  value={priority || null}
                   items={priorityItems}
                   onValueChange={(value) => {
                     if (value) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-locale-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-locale-picker.tsx
@@ -168,7 +168,7 @@ export function IssueLocalePicker({
       ? ANY_LOCALE_VALUE
       : allowClear
         ? CLEAR_LOCALE_VALUE
-        : undefined;
+        : null;
   const hasChoices = options.length > 0 || allowAny || allowClear;
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-resource-shared.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-resource-shared.tsx
@@ -31,7 +31,7 @@ type WorkspacePageShellProps = ComponentProps<"main">;
 
 export function WorkspacePageShell({ children, className, ...props }: WorkspacePageShellProps) {
   return (
-    <main className={cn("mx-auto flex w-full max-w-6xl flex-col gap-6", className)} {...props}>
+    <main className={cn("flex w-full flex-col gap-6 p-4", className)} {...props}>
       {children}
     </main>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -511,7 +511,7 @@ function GithubRepositorySelect({
         <FormattedMessage {...workspaceAutomationFormMessages.repositoryLabel} />
       </Label>
       <Select
-        value={form.githubInstallationRepositoryId || undefined}
+        value={form.githubInstallationRepositoryId || null}
         onValueChange={(value) => {
           if (!value) {
             return;
@@ -533,7 +533,11 @@ function GithubRepositorySelect({
         </SelectTrigger>
         <SelectContent>
           {repositories.map((repository) => (
-            <SelectItem key={repository.id} value={repository.id}>
+            <SelectItem
+              key={repository.id}
+              value={repository.id}
+              label={formatRepositoryOptionLabel(intl, repository)}
+            >
               {formatRepositoryOptionLabel(intl, repository)}
             </SelectItem>
           ))}
@@ -1081,7 +1085,7 @@ function TriggerSettings({
             <div className="flex w-full min-w-0 flex-col gap-1.5">
               <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-2">
                 <Select
-                  value={form.githubInstallationRepositoryId || undefined}
+                  value={form.githubInstallationRepositoryId || null}
                   onValueChange={(value) => {
                     if (!value) {
                       return;
@@ -1108,7 +1112,11 @@ function TriggerSettings({
                   </SelectTrigger>
                   <SelectContent>
                     {repositories.map((repository) => (
-                      <SelectItem key={repository.id} value={repository.id}>
+                      <SelectItem
+                        key={repository.id}
+                        value={repository.id}
+                        label={formatRepositoryOptionLabel(intl, repository)}
+                      >
                         {formatRepositoryOptionLabel(intl, repository)}
                       </SelectItem>
                     ))}
@@ -2195,7 +2203,7 @@ function ToolsSettings({
                   <FormattedMessage {...workspaceAutomationFormMessages.connectionLabel} />
                 </Label>
                 <Select
-                  value={form.contentfulConnectionId || undefined}
+                  value={form.contentfulConnectionId || null}
                   disabled={disabled || !contentfulConnected}
                   onValueChange={(value) => {
                     if (!value) {
@@ -2221,7 +2229,18 @@ function ToolsSettings({
                   </SelectTrigger>
                   <SelectContent>
                     {contentfulConnections.map((connection) => (
-                      <SelectItem key={connection.id} value={connection.id}>
+                      <SelectItem
+                        key={connection.id}
+                        value={connection.id}
+                        label={
+                          connection.enabled
+                            ? connection.displayName
+                            : intl.formatMessage(
+                                workspaceAutomationFormMessages.connectionDisabledSuffix,
+                                { name: connection.displayName },
+                              )
+                        }
+                      >
                         {connection.enabled
                           ? connection.displayName
                           : intl.formatMessage(
@@ -2366,7 +2385,7 @@ function ToolsSettings({
                 <FormattedMessage {...workspaceAutomationFormMessages.selectProject} />
               </Label>
               <Select
-                value={form.crowdinProjectId || undefined}
+                value={form.crowdinProjectId || null}
                 disabled={disabled || !crowdinConnected}
                 onValueChange={(value) => {
                   if (!value) {
@@ -2385,7 +2404,7 @@ function ToolsSettings({
                 </SelectTrigger>
                 <SelectContent>
                   {crowdinProjects.map((project) => (
-                    <SelectItem key={project.id} value={project.id}>
+                    <SelectItem key={project.id} value={project.id} label={project.name}>
                       {project.name}
                     </SelectItem>
                   ))}
@@ -2557,7 +2576,7 @@ function ToolsSettings({
                 <FormattedMessage {...workspaceAutomationFormMessages.selectConnection} />
               </Label>
               <Select
-                value={form.mcpConnectionId || undefined}
+                value={form.mcpConnectionId || null}
                 disabled={disabled || !mcpConnected}
                 onValueChange={(value) => {
                   if (!value) {
@@ -2580,7 +2599,11 @@ function ToolsSettings({
                 </SelectTrigger>
                 <SelectContent>
                   {enabledMcpServerConnections.map((connection) => (
-                    <SelectItem key={connection.id} value={connection.id}>
+                    <SelectItem
+                      key={connection.id}
+                      value={connection.id}
+                      label={connection.displayName}
+                    >
                       {connection.displayName}
                     </SelectItem>
                   ))}
@@ -2619,7 +2642,7 @@ function ToolsSettings({
                 <FormattedMessage {...workspaceAutomationFormMessages.selectConnection} />
               </Label>
               <Select
-                value={form.semrushConnectionId || undefined}
+                value={form.semrushConnectionId || null}
                 disabled={disabled || !semrushConnected}
                 onValueChange={(value) => {
                   if (!value) {
@@ -2642,7 +2665,11 @@ function ToolsSettings({
                 </SelectTrigger>
                 <SelectContent>
                   {enabledSemrushConnections.map((connection) => (
-                    <SelectItem key={connection.id} value={connection.id}>
+                    <SelectItem
+                      key={connection.id}
+                      value={connection.id}
+                      label={connection.displayName}
+                    >
                       {connection.displayName}
                     </SelectItem>
                   ))}
@@ -2681,7 +2708,7 @@ function ToolsSettings({
                 <FormattedMessage {...workspaceAutomationFormMessages.selectConnection} />
               </Label>
               <Select
-                value={form.ahrefsConnectionId || undefined}
+                value={form.ahrefsConnectionId || null}
                 disabled={disabled || !ahrefsConnected}
                 onValueChange={(value) => {
                   if (!value) {
@@ -2704,7 +2731,11 @@ function ToolsSettings({
                 </SelectTrigger>
                 <SelectContent>
                   {enabledAhrefsConnections.map((connection) => (
-                    <SelectItem key={connection.id} value={connection.id}>
+                    <SelectItem
+                      key={connection.id}
+                      value={connection.id}
+                      label={connection.displayName}
+                    >
                       {connection.displayName}
                     </SelectItem>
                   ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -2337,7 +2337,7 @@ export function GlossaryDetailPageContent({
           {canManage && isNative ? (
             <div className="flex flex-col gap-2 sm:flex-row">
               <Select
-                value={selectedProjectId}
+                value={selectedProjectId || null}
                 onValueChange={(value) => setSelectedProjectId(value ?? "")}
               >
                 <SelectTrigger className="sm:max-w-sm">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/mcp-server-connection-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/mcp-server-connection-panel.tsx
@@ -310,10 +310,16 @@ export function McpServerConnectionPanel({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="http">
+                    <SelectItem
+                      value="http"
+                      label={intl.formatMessage(mcpServerConnectionPanelMessages.transportHttp)}
+                    >
                       <FormattedMessage {...mcpServerConnectionPanelMessages.transportHttp} />
                     </SelectItem>
-                    <SelectItem value="sse">
+                    <SelectItem
+                      value="sse"
+                      label={intl.formatMessage(mcpServerConnectionPanelMessages.transportSse)}
+                    >
                       <FormattedMessage {...mcpServerConnectionPanelMessages.transportSse} />
                     </SelectItem>
                   </SelectContent>
@@ -337,13 +343,22 @@ export function McpServerConnectionPanel({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="none">
+                    <SelectItem
+                      value="none"
+                      label={intl.formatMessage(mcpServerConnectionPanelMessages.authNone)}
+                    >
                       <FormattedMessage {...mcpServerConnectionPanelMessages.authNone} />
                     </SelectItem>
-                    <SelectItem value="bearer">
+                    <SelectItem
+                      value="bearer"
+                      label={intl.formatMessage(mcpServerConnectionPanelMessages.authBearer)}
+                    >
                       <FormattedMessage {...mcpServerConnectionPanelMessages.authBearer} />
                     </SelectItem>
-                    <SelectItem value="headers">
+                    <SelectItem
+                      value="headers"
+                      label={intl.formatMessage(mcpServerConnectionPanelMessages.authHeaders)}
+                    >
                       <FormattedMessage {...mcpServerConnectionPanelMessages.authHeaders} />
                     </SelectItem>
                   </SelectContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
@@ -127,7 +127,7 @@ function ProjectSelectField({
       <Label htmlFor={id}>{label}</Label>
       <p className="text-xs text-muted-foreground">{description}</p>
       <Select
-        value={value || undefined}
+        value={value || null}
         onValueChange={(nextValue) => {
           if (nextValue) {
             onChange(nextValue);
@@ -140,7 +140,7 @@ function ProjectSelectField({
         </SelectTrigger>
         <SelectContent>
           {projects.map((project) => (
-            <SelectItem key={project.id} value={project.id}>
+            <SelectItem key={project.id} value={project.id} label={project.name}>
               {project.name}
             </SelectItem>
           ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.tsx
@@ -116,7 +116,7 @@ export function IssuesProjectImportDialog({
             </p>
           ) : (
             <Select
-              value={selectedProjectId || undefined}
+              value={selectedProjectId || null}
               items={projectItems}
               onValueChange={(value) => setSelectedProjectId(value ?? "")}
             >

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
@@ -20,15 +20,10 @@ export const createJobDialogMessages = defineMessages({
     id: "yRg4x8kKbX",
     description: "Create job dialog title",
   },
-  descriptionProvider: {
-    defaultMessage: "Create Crowdin tasks with files, locales, and assignees.",
-    id: "nqQ9RngvcW",
-    description: "Create job dialog description for Crowdin provider projects",
-  },
-  descriptionNative: {
-    defaultMessage: "Create native translation jobs with files, locales, and an assignee.",
-    id: "UASZI6ojDa",
-    description: "Create job dialog description for native Hyperlocalise projects",
+  description: {
+    defaultMessage: "Create a job with context, files, locales, and assignees.",
+    id: "/e6ibZCuf5",
+    description: "Create job dialog accessible description",
   },
   titleLabel: {
     defaultMessage: "Title",
@@ -42,18 +37,18 @@ export const createJobDialogMessages = defineMessages({
   },
   taskTypeLabel: {
     defaultMessage: "Task type",
-    id: "CTLXW62s69",
-    description: "Label for the Crowdin task type select",
+    id: "AIsMxGkzgi",
+    description: "Label for the job task type select",
   },
   taskTypeTranslation: {
     defaultMessage: "Translation",
-    id: "2ghn1bUXd2",
-    description: "Crowdin task type option for translation",
+    id: "EYRqZtZx0G",
+    description: "Job task type option for translation",
   },
   taskTypeProofread: {
     defaultMessage: "Proofread",
-    id: "39i3huA7AM",
-    description: "Crowdin task type option for proofread",
+    id: "kV6HE87ScC",
+    description: "Job task type option for proofread",
   },
   descriptionLabel: {
     defaultMessage: "Description",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
@@ -11,11 +11,10 @@
  * Version 2.0 or later.
  */
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn } from "storybook/test";
 
 import { CreateJobDialog } from "./create-job-dialog";
 import {
-  createJobDialogCrowdinProjectId,
   createJobDialogMswHandlers,
   createJobDialogNativeProjectId,
   createJobDialogOrganizationSlug,
@@ -44,15 +43,15 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Native: Story = {
+export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("dialog", { name: "New job" })).toBeInTheDocument();
     await expect(canvas.getByLabelText("Title")).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Description")).toBeInTheDocument();
     await expect(canvas.queryByLabelText("Source locale")).not.toBeInTheDocument();
+    await expect(canvas.getByLabelText("Task type")).toHaveTextContent("Translation");
     await expect(canvas.getByLabelText("Target locales")).toHaveTextContent("All locales");
     await expect(canvas.getByLabelText("Assignee")).toHaveTextContent("Unassigned");
-    await expect(canvas.queryByLabelText("Task type")).not.toBeInTheDocument();
-    await expect(canvas.queryByLabelText("Description")).not.toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Create job" })).toBeInTheDocument();
 
     const files = await canvas.findByRole("group", { name: "Files" });
@@ -65,40 +64,5 @@ export const Native: Story = {
     await expect(
       canvas.queryByRole("checkbox", { name: "marketing/campaigns/spring.json" }),
     ).not.toBeInTheDocument();
-  },
-};
-
-export const Crowdin: Story = {
-  args: {
-    projectId: createJobDialogCrowdinProjectId,
-  },
-  play: async ({ canvas, canvasElement }) => {
-    const body = within(canvasElement.ownerDocument.body);
-    await expect(canvas.getByRole("dialog", { name: "New job" })).toBeInTheDocument();
-    await expect(canvas.getByLabelText("Title")).toBeInTheDocument();
-    await expect(canvas.getByLabelText("Description")).toBeInTheDocument();
-    await expect(canvas.getByLabelText("Task type")).toHaveTextContent("Translation");
-    await expect(canvas.getByLabelText("Target locales")).toHaveTextContent("All locales");
-    await expect(canvas.getByLabelText("Assignees")).toHaveTextContent("Unassigned");
-    await expect(canvas.queryByLabelText("Source locale")).not.toBeInTheDocument();
-
-    await expect(await canvas.findByRole("group", { name: "Files" })).toBeInTheDocument();
-    await expect(canvas.getByRole("checkbox", { name: "locales/home.json" })).not.toBeChecked();
-    await expect(canvas.getByRole("checkbox", { name: "locales/pricing.json" })).not.toBeChecked();
-    await expect(
-      canvas.queryByRole("checkbox", { name: "locales/emails/welcome.json" }),
-    ).not.toBeInTheDocument();
-
-    await userEvent.click(canvas.getByLabelText("Assignees"));
-    const mina = await body.findByRole("option", { name: /Mina Chen/ });
-    await expect(mina).toHaveAttribute("aria-checked", "false");
-    await expect(body.getByRole("option", { name: /Otto Berg/ })).toHaveAttribute(
-      "aria-checked",
-      "false",
-    );
-    await expect(body.getByRole("listbox", { name: "Assignees" })).toHaveAttribute(
-      "aria-multiselectable",
-      "true",
-    );
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
@@ -189,8 +189,8 @@ describe("CreateJobDialog", () => {
     expect(screen.queryByLabelText("Source locale")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Target locales")).toHaveTextContent("All locales");
     expect(screen.getByLabelText("Assignee")).toHaveTextContent("Unassigned");
-    expect(screen.queryByLabelText("Task type")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Task type")).toHaveTextContent("Translation");
+    expect(screen.getByLabelText("Description")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Create job" })).toBeDisabled();
 
     expect(await screen.findByRole("group", { name: "Files" })).toBeInTheDocument();
@@ -371,6 +371,10 @@ describe("CreateJobDialog", () => {
     renderDialog({ onOpenChange, onCreated });
 
     await user.type(screen.getByLabelText("Title"), "Release notes");
+    await user.type(screen.getByLabelText("Description"), "Ship JP and KO first.");
+    await user.click(screen.getByLabelText("Task type"));
+    const taskTypeList = await screen.findByRole("listbox");
+    await user.click(within(taskTypeList).getByRole("option", { name: "Proofread" }));
     await user.click(await screen.findByRole("checkbox", { name: "marketing/home.json" }));
     await user.click(screen.getByRole("button", { name: "Create job" }));
 
@@ -380,6 +384,8 @@ describe("CreateJobDialog", () => {
       json: {
         type: "file",
         title: "Release notes",
+        kind: "proofread",
+        description: "Ship JP and KO first.",
         fileInput: {
           sourceFileId: "file_home_json",
           fileFormat: "json",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -577,6 +577,7 @@ export function CreateJobDialog({
       );
       const ownerWorkosUserId = selectedAssignees[0];
       const createdIds: string[] = [];
+      const trimmedDescription = description.trim();
 
       for (const file of eligibleFiles) {
         const response = await apiClient.api.orgs[":organizationSlug"].projects[
@@ -586,6 +587,8 @@ export function CreateJobDialog({
           json: {
             type: "file",
             title: title.trim(),
+            kind,
+            ...(trimmedDescription ? { description: trimmedDescription } : {}),
             ...(ownerWorkosUserId ? { ownerWorkosUserId } : {}),
             fileInput: {
               sourceFileId: file.storedFileId!,
@@ -700,11 +703,7 @@ export function CreateJobDialog({
               <FormattedMessage {...createJobDialogMessages.title} />
             </DialogTitle>
             <DialogDescription className="sr-only">
-              {isProviderProject ? (
-                <FormattedMessage {...createJobDialogMessages.descriptionProvider} />
-              ) : (
-                <FormattedMessage {...createJobDialogMessages.descriptionNative} />
-              )}
+              <FormattedMessage {...createJobDialogMessages.description} />
             </DialogDescription>
           </DialogHeader>
 
@@ -722,18 +721,16 @@ export function CreateJobDialog({
               className="h-auto rounded-none border-0 bg-transparent px-0 py-1 text-base font-medium shadow-none focus-visible:ring-0 md:text-lg"
             />
 
-            {isProviderProject ? (
-              <MarkdownEditor
-                value={description}
-                onChange={setDescription}
-                disabled={createJob.isPending}
-                placeholder={intl.formatMessage(createJobDialogMessages.descriptionPlaceholder)}
-                ariaLabel={intl.formatMessage(createJobDialogMessages.descriptionLabel)}
-                chrome="minimal"
-                imageUpload={{ organizationSlug, projectId }}
-                className="min-h-28 bg-transparent px-0"
-              />
-            ) : null}
+            <MarkdownEditor
+              value={description}
+              onChange={setDescription}
+              disabled={createJob.isPending}
+              placeholder={intl.formatMessage(createJobDialogMessages.descriptionPlaceholder)}
+              ariaLabel={intl.formatMessage(createJobDialogMessages.descriptionLabel)}
+              chrome="default"
+              imageUpload={{ organizationSlug, projectId }}
+              className="min-h-28"
+            />
 
             <CreateJobFileTree
               files={fileOptions}
@@ -744,52 +741,50 @@ export function CreateJobDialog({
             />
 
             <div className="flex flex-wrap items-center gap-0.5 pt-1">
-              {isProviderProject ? (
-                <Select
-                  value={kind}
-                  items={kindItems}
-                  onValueChange={(value) => {
-                    if (value === "translation" || value === "proofread") {
-                      setKind(value);
-                    }
-                  }}
-                  disabled={createJob.isPending}
+              <Select
+                value={kind}
+                items={kindItems}
+                onValueChange={(value) => {
+                  if (value === "translation" || value === "proofread") {
+                    setKind(value);
+                  }
+                }}
+                disabled={createJob.isPending}
+              >
+                <SelectTrigger
+                  aria-label={intl.formatMessage(createJobDialogMessages.taskTypeLabel)}
+                  showIcon={false}
+                  className={propertyTriggerClassName}
                 >
-                  <SelectTrigger
-                    aria-label={intl.formatMessage(createJobDialogMessages.taskTypeLabel)}
-                    showIcon={false}
-                    className={propertyTriggerClassName}
-                  >
-                    <span className="flex items-center gap-1.5">
-                      <HugeiconsIcon
-                        icon={kind === "proofread" ? CheckListIcon : TranslateIcon}
-                        strokeWidth={1.8}
-                        className="size-3.5"
-                      />
-                      {intl.formatMessage(
-                        kind === "proofread"
-                          ? createJobDialogMessages.taskTypeProofread
-                          : createJobDialogMessages.taskTypeTranslation,
-                      )}
-                    </span>
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {kindItems.map((item) => (
-                        <SelectItem key={item.value} value={item.value} label={item.label}>
-                          <span className="flex items-center gap-2">
-                            <HugeiconsIcon
-                              icon={item.value === "proofread" ? CheckListIcon : TranslateIcon}
-                              strokeWidth={1.8}
-                            />
-                            {item.label}
-                          </span>
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              ) : null}
+                  <span className="flex items-center gap-1.5">
+                    <HugeiconsIcon
+                      icon={kind === "proofread" ? CheckListIcon : TranslateIcon}
+                      strokeWidth={1.8}
+                      className="size-3.5"
+                    />
+                    {intl.formatMessage(
+                      kind === "proofread"
+                        ? createJobDialogMessages.taskTypeProofread
+                        : createJobDialogMessages.taskTypeTranslation,
+                    )}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {kindItems.map((item) => (
+                      <SelectItem key={item.value} value={item.value} label={item.label}>
+                        <span className="flex items-center gap-2">
+                          <HugeiconsIcon
+                            icon={item.value === "proofread" ? CheckListIcon : TranslateIcon}
+                            strokeWidth={1.8}
+                          />
+                          {item.label}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
 
               <CreateJobPropertyPicker
                 icon={LanguageCircleIcon}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/content-editor-header-pickers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/content-editor-header-pickers.tsx
@@ -329,7 +329,7 @@ export function ContentEditorRepositorySelect({
 
   return (
     <Select
-      value={selectedRepositoryFullName ?? ""}
+      value={selectedRepositoryFullName || null}
       onValueChange={handleValueChange}
       disabled={repositoryFullNames.length <= 1}
     >
@@ -346,7 +346,11 @@ export function ContentEditorRepositorySelect({
       </SelectTrigger>
       <SelectContent>
         {repositoryFullNames.map((repositoryFullName) => (
-          <SelectItem key={repositoryFullName} value={repositoryFullName}>
+          <SelectItem
+            key={repositoryFullName}
+            value={repositoryFullName}
+            label={repositoryFullName}
+          >
             <GitHubMark className="size-4 text-muted-foreground" />
             {repositoryFullName}
           </SelectItem>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.tsx
@@ -870,7 +870,7 @@ export function IssueSheetCreateIssueDialog({
 
               {showProjectPicker ? (
                 <Select
-                  value={selectedProjectId || undefined}
+                  value={selectedProjectId || null}
                   items={projectItems}
                   onValueChange={(value) => {
                     setSelectedProjectId(value ?? "");

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-agent-run-diff-review-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-agent-run-diff-review-section.tsx
@@ -408,19 +408,25 @@ export function JobAgentRunDiffReviewSection({
 
       {reviewableRuns.length > 1 ? (
         <div className="mt-4 max-w-sm">
-          <Select value={selectedRun?.id ?? ""} onValueChange={(value) => setSelectedRunId(value)}>
+          <Select
+            value={selectedRun?.id || null}
+            onValueChange={(value) => setSelectedRunId(value)}
+          >
             <SelectTrigger>
               <SelectValue placeholder={intl.formatMessage(messages.selectAgentRunPlaceholder)} />
             </SelectTrigger>
             <SelectContent>
-              {reviewableRuns.map((run) => (
-                <SelectItem key={run.id} value={run.id}>
-                  {intl.formatMessage(messages.agentRunOption, {
-                    kind: run.kind.replaceAll("_", " "),
-                    createdAt: new Date(run.createdAt).toLocaleString(),
-                  })}
-                </SelectItem>
-              ))}
+              {reviewableRuns.map((run) => {
+                const label = intl.formatMessage(messages.agentRunOption, {
+                  kind: run.kind.replaceAll("_", " "),
+                  createdAt: new Date(run.createdAt).toLocaleString(),
+                });
+                return (
+                  <SelectItem key={run.id} value={run.id} label={label}>
+                    {label}
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
         </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-helpers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-helpers.tsx
@@ -49,7 +49,7 @@ function getInputPayloadStringArray(job: JobDetailRecord, key: string) {
 export function isNativeFileTranslationJob(job: JobDetailRecord) {
   return (
     !isProviderBackedJob(job) &&
-    job.kind === "translation" &&
+    (job.kind === "translation" || job.kind === "proofread") &&
     job.type === "file" &&
     Boolean(getInputPayloadString(job, "sourceFileId"))
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
@@ -78,7 +78,7 @@ export function ProjectSourceLocalePicker({
         <FormattedMessage {...projectLocalePickerMessages.sourceLocaleLabel} />
       </FieldLabel>
       <Select
-        value={value || undefined}
+        value={value || null}
         onValueChange={(next) => {
           if (next) {
             onChange(next);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
@@ -116,6 +116,7 @@ function RoleSelectItem({
   return (
     <SelectItem
       value={role}
+      label={getRoleLabel(role, intl)}
       className="items-start py-2 [&>:first-child]:w-full [&>:first-child]:min-w-0 [&>:first-child]:shrink [&>:first-child]:whitespace-normal"
     >
       <div className="flex min-w-0 flex-col gap-0.5 text-start">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.tsx
@@ -113,7 +113,7 @@ export function AddTeamMemberDialog({
                   <FormattedMessage {...addTeamMemberDialogMessages.memberLabel} />
                 </FieldLabel>
                 <Select
-                  value={workosUserId}
+                  value={workosUserId || null}
                   onValueChange={(value) => {
                     if (value) {
                       setWorkosUserId(value);
@@ -132,7 +132,11 @@ export function AddTeamMemberDialog({
                   </SelectTrigger>
                   <SelectContent>
                     {assignableMembers.map((member) => (
-                      <SelectItem key={member.workosUserId} value={member.workosUserId}>
+                      <SelectItem
+                        key={member.workosUserId}
+                        value={member.workosUserId}
+                        label={member.email}
+                      >
                         {member.email}
                       </SelectItem>
                     ))}
@@ -154,7 +158,11 @@ export function AddTeamMemberDialog({
                   </SelectTrigger>
                   <SelectContent>
                     {teamRoles.map((teamRole) => (
-                      <SelectItem key={teamRole} value={teamRole}>
+                      <SelectItem
+                        key={teamRole}
+                        value={teamRole}
+                        label={getTeamRoleLabel(teamRole, intl)}
+                      >
                         {getTeamRoleLabel(teamRole, intl)}
                       </SelectItem>
                     ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
@@ -375,10 +375,10 @@ export function TeamDetailPageView({
                             <SelectValue>{getTeamRoleLabel(member.role, intl)}</SelectValue>
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="manager">
+                            <SelectItem value="manager" label={getTeamRoleLabel("manager", intl)}>
                               {getTeamRoleLabel("manager", intl)}
                             </SelectItem>
-                            <SelectItem value="member">
+                            <SelectItem value="member" label={getTeamRoleLabel("member", intl)}>
                               {getTeamRoleLabel("member", intl)}
                             </SelectItem>
                           </SelectContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content-msw-handlers.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { delay, http, HttpResponse } from "msw";
+
+import type {
+  MemoryEntryDetailResponse,
+  MemoryEntryRecord,
+  MemoryProjectRecord,
+  MemoryRecord,
+} from "@/api/routes/memory/memory.schema";
+import type { ProjectRecord } from "@/api/routes/project/project.schema";
+
+function createEntryDetail(entry: MemoryEntryRecord): MemoryEntryDetailResponse {
+  const emptyActor = {
+    userId: null,
+    displayName: null,
+    at: null,
+    source: "created" as const,
+  };
+
+  return {
+    memoryEntry: entry,
+    provenance: {
+      origin: entry.provenance,
+      provider: null,
+      importBatchId: entry.importBatchId,
+      context: typeof entry.metadata.context === "string" ? entry.metadata.context : null,
+      created: {
+        ...emptyActor,
+        userId: entry.createdByUserId,
+        at: entry.createdAt,
+        source: "created",
+      },
+      modified: { ...emptyActor, at: entry.updatedAt, source: "modified" },
+      reviewed: { ...emptyActor, source: "reviewed" },
+      imported: { ...emptyActor, source: "imported" },
+      providerSupplied: { ...emptyActor, source: "provider" },
+    },
+    variants: [],
+    auditEvents: [
+      {
+        id: `${entry.id}:created`,
+        eventType: "created",
+        actorKind: "user",
+        actorUserId: entry.createdByUserId,
+        actorDisplayName: null,
+        version: 1,
+        changedFields: [],
+        attributes: {},
+        occurredAt: entry.createdAt,
+      },
+    ],
+    capabilities: {
+      canEdit: entry.provenance !== "external_tms",
+      readOnlyReason: null,
+    },
+  };
+}
+
+export function createTranslationMemoryDetailMswHandlers({
+  memory,
+  entries,
+  attachedProjects = [],
+  projects = [],
+  memoryLoading = false,
+  memoryMissing = false,
+  entriesLoading = false,
+}: {
+  memory: MemoryRecord;
+  entries: MemoryEntryRecord[];
+  attachedProjects?: MemoryProjectRecord[];
+  projects?: Array<Pick<ProjectRecord, "id" | "name">>;
+  memoryLoading?: boolean;
+  memoryMissing?: boolean;
+  entriesLoading?: boolean;
+}) {
+  let currentEntries = [...entries];
+  let currentAttachedProjects = [...attachedProjects];
+
+  return [
+    http.get("/api/orgs/:organizationSlug/translation-memories/:memoryId", async () => {
+      if (memoryLoading) {
+        await delay("infinite");
+      }
+      if (memoryMissing) {
+        return HttpResponse.json({ error: "memory_not_found" }, { status: 404 });
+      }
+      return HttpResponse.json({ memory });
+    }),
+    http.get("/api/orgs/:organizationSlug/translation-memories/:memoryId/projects", () =>
+      HttpResponse.json({ projects: currentAttachedProjects }),
+    ),
+    http.post(
+      "/api/orgs/:organizationSlug/translation-memories/:memoryId/projects",
+      async ({ request }) => {
+        const body = (await request.json()) as { projectId: string };
+        const project = projects.find((item) => item.id === body.projectId);
+        if (project && !currentAttachedProjects.some((item) => item.projectId === project.id)) {
+          currentAttachedProjects = [
+            ...currentAttachedProjects,
+            {
+              projectId: project.id,
+              projectName: project.name,
+              priority: 0,
+              sourceLocale: "en-US",
+              targetLocales: ["fr-FR"],
+            },
+          ];
+        }
+        return HttpResponse.json({ projects: currentAttachedProjects });
+      },
+    ),
+    http.delete(
+      "/api/orgs/:organizationSlug/translation-memories/:memoryId/projects/:projectId",
+      ({ params }) => {
+        currentAttachedProjects = currentAttachedProjects.filter(
+          (project) => project.projectId !== String(params.projectId),
+        );
+        return new HttpResponse(null, { status: 204 });
+      },
+    ),
+    http.get("/api/orgs/:organizationSlug/projects", () =>
+      HttpResponse.json({
+        projects: projects.map((project) => ({
+          id: project.id,
+          name: project.name,
+        })),
+      }),
+    ),
+    http.get("/api/orgs/:organizationSlug/translation-memories/:memoryId/entries", async () => {
+      if (entriesLoading) {
+        await delay("infinite");
+      }
+      return HttpResponse.json({
+        memoryEntries: currentEntries,
+        nextCursor: null,
+        total: currentEntries.length,
+        pagination: {
+          limit: 50,
+          returned: currentEntries.length,
+          hasMore: false,
+        },
+      });
+    }),
+    http.get(
+      "/api/orgs/:organizationSlug/translation-memories/:memoryId/entries/:entryId",
+      ({ params }) => {
+        const entry = currentEntries.find((item) => item.id === String(params.entryId));
+        if (!entry) {
+          return HttpResponse.json({ error: "memory_entry_not_found" }, { status: 404 });
+        }
+        return HttpResponse.json(createEntryDetail(entry));
+      },
+    ),
+    http.post(
+      "/api/orgs/:organizationSlug/translation-memories/:memoryId/entries",
+      async ({ request }) => {
+        const body = (await request.json()) as {
+          sourceLocale: string;
+          targetLocale: string;
+          sourceText: string;
+          targetText: string;
+        };
+        const created: MemoryEntryRecord = {
+          id: crypto.randomUUID(),
+          memoryId: memory.id,
+          sourceLocale: body.sourceLocale,
+          targetLocale: body.targetLocale,
+          sourceText: body.sourceText,
+          targetText: body.targetText,
+          matchScore: 100,
+          provenance: "manual",
+          reviewStatus: "approved",
+          version: 1,
+          externalKey: null,
+          createdByUserId: null,
+          modifiedByUserId: null,
+          reviewedByUserId: null,
+          importBatchId: null,
+          metadata: {},
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          reviewedAt: null,
+        };
+        currentEntries = [created, ...currentEntries];
+        return HttpResponse.json({ memoryEntry: created }, { status: 201 });
+      },
+    ),
+    http.delete(
+      "/api/orgs/:organizationSlug/translation-memories/:memoryId/entries/:entryId",
+      ({ params }) => {
+        currentEntries = currentEntries.filter((entry) => entry.id !== String(params.entryId));
+        return new HttpResponse(null, { status: 204 });
+      },
+    ),
+  ];
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.stories.tsx
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import type {
+  MemoryEntryRecord,
+  MemoryProjectRecord,
+  MemoryRecord,
+} from "@/api/routes/memory/memory.schema";
+
+import { createTranslationMemoryDetailMswHandlers } from "./translation-memory-detail-page-content-msw-handlers";
+import { TranslationMemoryDetailPageContent } from "./translation-memory-detail-page-content";
+
+const fixedNow = "2026-06-07T12:00:00.000Z";
+const memoryId = "11111111-1111-4111-8111-111111111111";
+
+function createMemory(overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id: memoryId,
+    organizationId: "org-1",
+    createdByUserId: "user-1",
+    name: "Product UI",
+    description: "Core product translations",
+    status: "active",
+    source: "native",
+    externalProviderKind: null,
+    externalProjectId: null,
+    externalMemoryId: null,
+    localeCoverage: ["en-US", "fr-FR"],
+    segmentCount: 2,
+    syncState: null,
+    capabilityMode: null,
+    segmentCapabilities: {},
+    externalUrl: null,
+    lastSyncedAt: null,
+    lastSyncErrorAt: null,
+    lastSyncErrorMessage: null,
+    createdAt: fixedNow,
+    updatedAt: fixedNow,
+    ...overrides,
+  };
+}
+
+function createEntry(overrides: Partial<MemoryEntryRecord> = {}): MemoryEntryRecord {
+  return {
+    id: "33333333-3333-4333-8333-333333333333",
+    memoryId,
+    sourceLocale: "en-US",
+    targetLocale: "fr-FR",
+    sourceText: "Checkout",
+    targetText: "Paiement",
+    matchScore: 100,
+    provenance: "file_job",
+    reviewStatus: "approved",
+    version: 1,
+    externalKey: "job_1:fr-FR:checkout",
+    createdByUserId: "user-1",
+    modifiedByUserId: null,
+    reviewedByUserId: null,
+    importBatchId: null,
+    metadata: {},
+    createdAt: fixedNow,
+    updatedAt: fixedNow,
+    reviewedAt: null,
+    ...overrides,
+  };
+}
+
+const memoryFixture = createMemory();
+const providerMemoryFixture = createMemory({
+  id: "22222222-2222-4222-8222-222222222222",
+  name: "Phrase TM",
+  description: "Marketing translations",
+  source: "external_tms",
+  externalProviderKind: "phrase",
+  externalProjectId: "phrase-project-9",
+  externalMemoryId: "tm-42",
+  localeCoverage: ["en-US", "fr-FR", "de-DE"],
+  segmentCount: 50_000,
+  syncState: "synced",
+  capabilityMode: "live_search",
+});
+
+const entriesFixture: MemoryEntryRecord[] = [
+  createEntry(),
+  createEntry({
+    id: "44444444-4444-4444-8444-444444444444",
+    sourceText: "Save changes",
+    targetText: "Enregistrer les modifications",
+    provenance: "manual",
+    externalKey: null,
+  }),
+];
+
+const attachedProjectsFixture: MemoryProjectRecord[] = [
+  {
+    projectId: "project-marketing",
+    projectName: "Marketing Site",
+    priority: 0,
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR"],
+  },
+];
+
+const projectsFixture = [
+  { id: "project-marketing", name: "Marketing Site" },
+  { id: "project-docs", name: "Docs" },
+];
+
+const meta = {
+  title: "App/TranslationMemories/Detail",
+  component: TranslationMemoryDetailPageContent,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: "acme",
+    memoryId,
+    canManageMemories: true,
+  },
+} satisfies Meta<typeof TranslationMemoryDetailPageContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function createDetailStoryParameters(input: {
+  memory: MemoryRecord;
+  entries?: MemoryEntryRecord[];
+  attachedProjects?: MemoryProjectRecord[];
+  memoryLoading?: boolean;
+  memoryMissing?: boolean;
+  entriesLoading?: boolean;
+}) {
+  return {
+    msw: {
+      handlers: createTranslationMemoryDetailMswHandlers({
+        memory: input.memory,
+        entries: input.entries ?? entriesFixture,
+        attachedProjects: input.attachedProjects ?? attachedProjectsFixture,
+        projects: projectsFixture,
+        memoryLoading: input.memoryLoading,
+        memoryMissing: input.memoryMissing,
+        entriesLoading: input.entriesLoading,
+      }),
+    },
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/acme/translation-memories/${input.memory.id}`,
+      },
+    },
+  };
+}
+
+export const Default: Story = {
+  parameters: createDetailStoryParameters({ memory: memoryFixture }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByRole("heading", { name: "Product UI" })).toBeInTheDocument();
+    await expect(canvas.getByText("Workspace")).toBeInTheDocument();
+    await expect(canvas.getByText("Core product translations")).toBeInTheDocument();
+    await expect(canvas.getByText("Checkout")).toBeInTheDocument();
+    await expect(canvas.getByText("Paiement")).toBeInTheDocument();
+    await expect(canvas.getByText("Save changes")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Add entry" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Export TMX" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Marketing Site" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Assign to project" })).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    memoryId: "55555555-5555-4555-8555-555555555555",
+  },
+  parameters: createDetailStoryParameters({
+    memory: createMemory({
+      id: "55555555-5555-4555-8555-555555555555",
+      description: "",
+      segmentCount: 0,
+    }),
+    entries: [],
+    attachedProjects: [],
+  }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByRole("heading", { name: "Product UI" })).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Manage translation examples and assign this memory to projects."),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("No entries yet.")).toBeInTheDocument();
+    await expect(canvas.getByText("No projects assigned yet.")).toBeInTheDocument();
+  },
+};
+
+export const ProviderReadOnly: Story = {
+  args: {
+    memoryId: providerMemoryFixture.id,
+    canManageMemories: true,
+  },
+  parameters: createDetailStoryParameters({
+    memory: providerMemoryFixture,
+  }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByRole("heading", { name: "Phrase TM" })).toBeInTheDocument();
+    await expect(canvas.getByText("Provider")).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Add entry" })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("button", { name: "Assign to project" }),
+    ).not.toBeInTheDocument();
+    await expect(canvas.getByText("Checkout")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Export TMX" })).toBeInTheDocument();
+  },
+};
+
+export const ReadOnlyMember: Story = {
+  args: {
+    canManageMemories: false,
+  },
+  parameters: createDetailStoryParameters({ memory: memoryFixture }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByRole("heading", { name: "Product UI" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Add entry" })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("button", { name: "Assign to project" }),
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Marketing Site" })).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    memoryId: "66666666-6666-4666-8666-666666666666",
+  },
+  parameters: createDetailStoryParameters({
+    memory: createMemory({ id: "66666666-6666-4666-8666-666666666666" }),
+    memoryLoading: true,
+  }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByText("Loading memory...")).toBeInTheDocument();
+  },
+};
+
+export const LoadingEntries: Story = {
+  args: {
+    memoryId: "77777777-7777-4777-8777-777777777777",
+  },
+  parameters: createDetailStoryParameters({
+    memory: createMemory({ id: "77777777-7777-4777-8777-777777777777" }),
+    entriesLoading: true,
+  }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByRole("heading", { name: "Product UI" })).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Loading translation memory entries")).toBeInTheDocument();
+  },
+};
+
+export const NotFound: Story = {
+  args: {
+    memoryId: "88888888-8888-4888-8888-888888888888",
+  },
+  parameters: createDetailStoryParameters({
+    memory: createMemory({ id: "88888888-8888-4888-8888-888888888888" }),
+    memoryMissing: true,
+  }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByText("Translation memory not found.")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/lib/projects/job-content-editor-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/job-content-editor-routing.test.ts
@@ -58,6 +58,21 @@ describe("canOpenJobContentEditor", () => {
         }),
       ),
     ).toBe(true);
+    expect(
+      canOpenJobContentEditor(
+        createJob({
+          externalProviderKind: null,
+          externalTargetLocales: null,
+          id: "job_native_proofread",
+          kind: "proofread",
+          type: "file",
+          inputPayload: {
+            sourceFileId: "file_home_json",
+            targetLocales: ["fr-FR"],
+          },
+        }),
+      ),
+    ).toBe(true);
   });
 
   it("rejects native jobs without a source file id", () => {
@@ -145,6 +160,24 @@ describe("buildJobContentEditorHref", () => {
       ),
     ).toBe(
       "/org/acme/projects/project-1/jobs/job_native/strings?storedFileId=file_home_json&targetLocale=fr-FR&queueFilter=untranslated",
+    );
+    expect(
+      buildJobContentEditorHref(
+        "acme",
+        "project-1",
+        createJob({
+          externalProviderKind: null,
+          externalTargetLocales: null,
+          id: "job_native_proofread",
+          kind: "proofread",
+          inputPayload: {
+            sourceFileId: "file_home_json",
+            targetLocales: ["fr-FR"],
+          },
+        }),
+      ),
+    ).toBe(
+      "/org/acme/projects/project-1/jobs/job_native_proofread/strings?storedFileId=file_home_json&targetLocale=fr-FR&queueFilter=needs_review",
     );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/workspace-resource-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/workspace-resource-capabilities.test.ts
@@ -105,6 +105,18 @@ describe("canOpenNativeJobContentEditor", () => {
         },
       }),
     ).toBe(true);
+    expect(
+      canOpenNativeJobContentEditor({
+        id: "job_native_proofread",
+        kind: "proofread",
+        type: "file",
+        externalProviderKind: null,
+        inputPayload: {
+          sourceFileId: "file_home_json",
+          targetLocales: ["fr-FR"],
+        },
+      }),
+    ).toBe(true);
   });
 
   it("rejects provider jobs and non-file translation jobs", () => {

--- a/apps/hyperlocalise-web/src/lib/projects/workspace-resource-capabilities.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/workspace-resource-capabilities.ts
@@ -77,7 +77,7 @@ export function canOpenNativeJobContentEditor(job: {
     return false;
   }
 
-  if (job.kind !== "translation" || job.type !== "file") {
+  if ((job.kind !== "translation" && job.kind !== "proofread") || job.type !== "file") {
     return false;
   }
 


### PR DESCRIPTION
## What changed

Native and provider (Crowdin) projects now share one create-job dialog: context with the markdown toolbar, translation/proofread, and the same field layout. Native create accepts optional `description` (stored in job metadata) and `kind`. Empty Select values are passed as `null` so pickers do not fall through to the first item.

Also includes Storybook coverage for the translation-memory detail page.

## How to test

- [ ] Open Create job on a native project: confirm context editor shows the markdown toolbar, task type is visible, and a single assignee picker is shown
- [ ] Create a native job with a description and Proofread; confirm the job is created with that kind and the description is stored
- [ ] Open Create job on a Crowdin/provider project: confirm the same composer (title, context, kind, files, locales, multi-assignees)
- [ ] Confirm empty Select pickers (locale, project, team member, etc.) no longer auto-select the first item
- [ ] `vp test` in `apps/hyperlocalise-web` (dialog tests; job route tests need `DATABASE_URL`)
- [ ] `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)