### PR TITLE
feat(mcp): add create_issue tool

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -14,7 +14,7 @@ import "dotenv/config";
 
 import { createHash } from "node:crypto";
 
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { createMcpTestApp } from "@/api/routes/mcp/mcp.fixture";
 import { createAuthorizationCode } from "@/api/auth/mcp";
@@ -323,5 +323,111 @@ describe("MCP team-scoped access", () => {
       project: { id: string } | null;
     };
     expect(getDeniedBody.project).toBeNull();
+
+    const createDeniedResponse = await callMcpTool(accessToken, "create_issue", {
+      projectId: alphaProjectBody.project.id,
+      title: "Member must not create this issue",
+      idempotencyKey: "member-denied",
+    });
+
+    expect(createDeniedResponse.status).toBe(200);
+
+    const createDeniedBody = parseToolResultText(await createDeniedResponse.json()) as {
+      error: string;
+    };
+
+    expect(createDeniedBody).toMatchObject({
+      error: "forbidden",
+    });
+
+    const deniedIssues = await db
+      .select({ id: schema.issueSheetIssues.id })
+      .from(schema.issueSheetIssues)
+      .where(
+        and(
+          eq(schema.issueSheetIssues.projectId, alphaProjectBody.project.id),
+          eq(schema.issueSheetIssues.externalRef, "mcp:member-denied"),
+        ),
+      );
+
+    expect(deniedIssues).toHaveLength(0);
+
+    await db
+      .update(schema.organizationMemberships)
+      .set({ role: "translator" })
+      .where(
+        and(
+          eq(
+            schema.organizationMemberships.organizationId,
+            memberAuth.organization.localOrganizationId,
+          ),
+          eq(schema.organizationMemberships.userId, memberAuth.user.localUserId),
+        ),
+      );
+
+    const createAllowedResponse = await callMcpTool(accessToken, "create_issue", {
+      projectId: alphaProjectBody.project.id,
+      title: "Translator can create in Team Alpha",
+      idempotencyKey: "translator-alpha",
+    });
+
+    expect(createAllowedResponse.status).toBe(200);
+
+    const createAllowedBody = parseToolResultText(await createAllowedResponse.json()) as {
+      id: string;
+      projectId: string;
+    };
+
+    expect(createAllowedBody).toMatchObject({
+      projectId: alphaProjectBody.project.id,
+    });
+
+    const crossTeamResponse = await callMcpTool(accessToken, "create_issue", {
+      projectId: betaProjectBody.project.id,
+      title: "Must not create in Team Beta",
+      idempotencyKey: "translator-beta",
+    });
+
+    expect(crossTeamResponse.status).toBe(200);
+
+    expect(parseToolResultText(await crossTeamResponse.json())).toMatchObject({
+      error: "project_not_found",
+    });
+
+    const crossOrganizationResponse = await callMcpTool(accessToken, "create_issue", {
+      projectId: externalProject.id,
+      title: "Must not create in another organization",
+      idempotencyKey: "translator-external",
+    });
+
+    expect(crossOrganizationResponse.status).toBe(200);
+
+    expect(parseToolResultText(await crossOrganizationResponse.json())).toMatchObject({
+      error: "project_not_found",
+    });
+
+    const createdMcpIssues = await db
+      .select({
+        projectId: schema.issueSheetIssues.projectId,
+        externalRef: schema.issueSheetIssues.externalRef,
+      })
+      .from(schema.issueSheetIssues)
+      .where(
+        and(
+          eq(schema.issueSheetIssues.organizationId, memberAuth.organization.localOrganizationId),
+          inArray(schema.issueSheetIssues.externalRef, [
+            "mcp:translator-alpha",
+            "mcp:translator-beta",
+            "mcp:translator-external",
+          ]),
+        ),
+      );
+
+    expect(createdMcpIssues).toEqual([
+      {
+        projectId: alphaProjectBody.project.id,
+        externalRef: "mcp:translator-alpha",
+      },
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -14,7 +14,7 @@ import "dotenv/config";
 
 import { createHash } from "node:crypto";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { OAuthProtectedResourceMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -22,6 +22,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
+import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 
 import {
   createAuthorizationCode,
@@ -121,8 +122,7 @@ async function refreshToken(refreshToken: string) {
   });
 }
 
-async function authenticatedMcpHeaders() {
-  const identity = fixture.createWorkosIdentity();
+async function authenticatedMcpHeaders(identity = fixture.createWorkosIdentity()) {
   const headers = await fixture.authHeadersFor(identity);
 
   const accessToken = generateMcpToken();
@@ -917,7 +917,8 @@ describe("mcpRoutes", () => {
   });
 
   it("works with a real Streamable HTTP MCP client without GET reconnects or errors", async () => {
-    const headers = await authenticatedMcpHeaders();
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
 
     const requestMethods: string[] = [];
     const transportErrors: Error[] = [];
@@ -963,10 +964,46 @@ describe("mcpRoutes", () => {
         },
       });
 
+      const createResult = await client.callTool({
+        name: "create_issue",
+        arguments: {
+          projectId: stored.project.id,
+          title: "Created through the MCP SDK",
+          description: "SDK integration coverage",
+          priority: "P1",
+          idempotencyKey: "sdk-create-read-back",
+        },
+      });
+
+      const createContent = (
+        createResult as {
+          content?: Array<{
+            type?: string;
+            text?: string;
+          }>;
+        }
+      ).content?.find((item) => item.type === "text");
+
+      if (!createContent?.text) {
+        throw new Error("expected create_issue text content");
+      }
+
+      const createdIssue = JSON.parse(createContent.text) as {
+        id: string;
+        projectId: string;
+        title: string;
+      };
+
+      expect(createdIssue).toMatchObject({
+        projectId: stored.project.id,
+        title: "Created through the MCP SDK",
+      });
+
       const issuesResult = await client.callTool({
         name: "list_issues",
         arguments: {
-          limit: 1,
+          projectId: stored.project.id,
+          limit: 10,
           offset: 0,
         },
       });
@@ -995,26 +1032,30 @@ describe("mcpRoutes", () => {
         issues: unknown[];
       };
 
-      expect(issuesOutput).toEqual({
-        total: 0,
+      expect(issuesOutput).toMatchObject({
+        total: 1,
         summary: {
-          total: 0,
-          open: 0,
-          inProgress: 0,
-          resolved: 0,
-          wontFix: 0,
+          total: 1,
+          open: 1,
         },
         pagination: {
-          limit: 1,
+          limit: 10,
           offset: 0,
           hasMore: false,
           nextOffset: null,
         },
-        issues: [],
+        issues: [
+          expect.objectContaining({
+            id: createdIssue.id,
+            projectId: stored.project.id,
+            title: "Created through the MCP SDK",
+            priority: "P1",
+          }),
+        ],
       });
 
       expect(result.content).toEqual(expect.any(Array));
-      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(5);
+      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(6);
       expect(requestMethods.filter((method) => method === "GET")).toHaveLength(1);
       expect(requestMethods.every((method) => method === "POST" || method === "GET")).toBe(true);
       expect(transportErrors).toEqual([]);
@@ -1309,5 +1350,490 @@ describe("mcpRoutes", () => {
     const text = body.result?.content?.[0]?.text;
     expect(text).toBeDefined();
     expect(text).toContain("invalid_issue_query");
+  });
+
+  it("advertises the create_issue tool with a bounded input schema", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "create_issue");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("issue");
+    expect(tool?.inputSchema?.required).toEqual(expect.arrayContaining(["projectId", "title"]));
+
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: expect.any(Object),
+      title: {
+        type: "string",
+        minLength: 1,
+        maxLength: 300,
+      },
+      description: {
+        type: "string",
+        maxLength: 20_000,
+      },
+      issueType: expect.any(Object),
+      status: expect.any(Object),
+      targetLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 32,
+      },
+      sourcePath: {
+        type: "string",
+        minLength: 1,
+        maxLength: 2048,
+      },
+      segmentId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 512,
+      },
+      translationKeyId: expect.any(Object),
+      assigneeUserId: expect.any(Object),
+      priority: expect.any(Object),
+      idempotencyKey: {
+        type: "string",
+        minLength: 1,
+        maxLength: 512,
+      },
+    });
+
+    expect(tool?.inputSchema?.properties).not.toHaveProperty("externalRef");
+
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        description: expect.stringContaining("accessible Hyperlocalise project"),
+      },
+      title: {
+        description: expect.stringContaining("issue title"),
+      },
+      description: {
+        description: expect.stringContaining("detailed issue description"),
+      },
+      issueType: {
+        description: expect.stringContaining("classification"),
+      },
+      status: {
+        description: expect.stringContaining("initial issue status"),
+      },
+      targetLocale: {
+        description: expect.stringContaining("target locale"),
+      },
+      sourcePath: {
+        description: expect.stringContaining("source file"),
+      },
+      segmentId: {
+        description: expect.stringContaining("segment identifier"),
+      },
+      translationKeyId: {
+        description: expect.stringContaining("translation key"),
+      },
+      assigneeUserId: {
+        description: expect.stringContaining("project member"),
+      },
+      priority: {
+        description: expect.stringContaining("priority"),
+      },
+      idempotencyKey: {
+        description: expect.stringContaining("retry key"),
+      },
+    });
+  });
+
+  it.each([
+    ["title length", { title: "x".repeat(301) }],
+    [
+      "description length",
+      {
+        title: "Valid title",
+        description: "x".repeat(20_001),
+      },
+    ],
+    [
+      "locale length",
+      {
+        title: "Valid title",
+        targetLocale: "x".repeat(33),
+      },
+    ],
+    [
+      "invalid priority",
+      {
+        title: "Valid title",
+        priority: "P3",
+      },
+    ],
+    [
+      "invalid assignee UUID",
+      {
+        title: "Valid title",
+        assigneeUserId: "not-a-uuid",
+      },
+    ],
+    [
+      "invalid translation key UUID",
+      {
+        title: "Valid title",
+        translationKeyId: "not-a-uuid",
+      },
+    ],
+    [
+      "idempotency key length",
+      {
+        title: "Valid title",
+        idempotencyKey: "x".repeat(513),
+      },
+    ],
+  ])("rejects create_issue input with invalid %s", async (_label, invalidInput) => {
+    const headers = await authenticatedMcpHeaders();
+
+    const createSpy = vi.spyOn(IssueSheetService.prototype, "createIssue");
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "create_issue",
+            arguments: {
+              projectId: "project-id",
+              ...invalidInput,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+      expect(createSpy).not.toHaveBeenCalled();
+    } finally {
+      createSpy.mockRestore();
+    }
+  });
+
+  it("creates an issue as the MCP-authenticated user", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const createSpy = vi.spyOn(IssueSheetService.prototype, "createIssue").mockResolvedValueOnce({
+      id: "issue-id",
+      identifier: "HL-123",
+      number: 123,
+      title: "Incorrect French translation",
+      description: "The CTA is mistranslated",
+      issueType: "translation_mistake",
+      status: "open",
+      targetLocale: "fr-FR",
+      sourcePath: "src/messages.json",
+      segmentId: null,
+      translationKeyId: null,
+      linkedCommentId: null,
+      linkedAgentRunId: null,
+      linkKind: "manual",
+      linkLabel: "MCP",
+      linkUrl: null,
+      externalRef: "mcp:request-123",
+      templateKey: null,
+      assigneeUserId: null,
+      reporter: "Thomas",
+      assignee: null,
+      key: null,
+      sourceText: null,
+      createdAt: "2026-08-31T00:00:00.000Z",
+      updatedAt: "2026-08-31T00:00:00.000Z",
+      resolvedAt: null,
+      values: {
+        priority: "P1",
+      },
+      isWatching: true,
+    });
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "create_issue",
+            arguments: {
+              projectId: stored.project.id,
+              title: "Incorrect French translation",
+              description: "The CTA is mistranslated",
+              issueType: "translation_mistake",
+              targetLocale: "fr-FR",
+              sourcePath: "src/messages.json",
+              priority: "P1",
+              idempotencyKey: "request-123",
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      expect(createSpy).toHaveBeenCalledWith({
+        organizationId: auth.organization.localOrganizationId,
+        projectId: stored.project.id,
+        actorUserId: auth.user.localUserId,
+        body: {
+          title: "Incorrect French translation",
+          description: "The CTA is mistranslated",
+          issueType: "translation_mistake",
+          targetLocale: "fr-FR",
+          sourcePath: "src/messages.json",
+          priority: "P1",
+          linkKind: "manual",
+          linkLabel: "MCP",
+          externalRef: "mcp:request-123",
+        },
+      });
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ type: string; text?: string }>;
+        };
+      };
+
+      expect(body.result?.isError).not.toBe(true);
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+      expect(JSON.parse(text!)).toMatchObject({
+        id: "issue-id",
+        projectId: stored.project.id,
+        title: "Incorrect French translation",
+        priority: "P1",
+      });
+    } finally {
+      createSpy.mockRestore();
+    }
+  });
+
+  it("reuses an issue for an equivalent retry and rejects a conflicting payload", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const callCreateIssue = async (title: string) =>
+      app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "create_issue",
+            arguments: {
+              projectId: stored.project.id,
+              title,
+              description: "Retry-safe description",
+              issueType: "general_question",
+              priority: "P1",
+              idempotencyKey: "retry-123",
+            },
+          },
+        }),
+      });
+
+    const readToolResult = async (response: Response) => {
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ type: string; text?: string }>;
+        };
+      };
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+
+      return {
+        isError: body.result?.isError === true,
+        output: JSON.parse(text!),
+      };
+    };
+
+    const first = await readToolResult(await callCreateIssue("Retry-safe issue"));
+
+    const retry = await readToolResult(await callCreateIssue("Retry-safe issue"));
+
+    expect(first.isError).toBe(false);
+    expect(retry.isError).toBe(false);
+    expect(retry.output.id).toBe(first.output.id);
+
+    const rows = await db
+      .select({ id: schema.issueSheetIssues.id })
+      .from(schema.issueSheetIssues)
+      .where(
+        and(
+          eq(schema.issueSheetIssues.projectId, stored.project.id),
+          eq(schema.issueSheetIssues.externalRef, "mcp:retry-123"),
+        ),
+      );
+
+    expect(rows).toHaveLength(1);
+
+    const [persistedIssue] = await db
+      .select({
+        reporterUserId: schema.issueSheetIssues.reporterUserId,
+      })
+      .from(schema.issueSheetIssues)
+      .where(eq(schema.issueSheetIssues.id, first.output.id))
+      .limit(1);
+
+    expect(persistedIssue).toEqual({
+      reporterUserId: auth.user.localUserId,
+    });
+
+    const createdActivities = await db
+      .select({
+        actorUserId: schema.issueSheetActivities.actorUserId,
+        type: schema.issueSheetActivities.type,
+      })
+      .from(schema.issueSheetActivities)
+      .where(
+        and(
+          eq(schema.issueSheetActivities.issueId, first.output.id),
+          eq(schema.issueSheetActivities.type, "issue_created"),
+        ),
+      );
+
+    expect(createdActivities).toEqual([
+      {
+        actorUserId: auth.user.localUserId,
+        type: "issue_created",
+      },
+    ]);
+
+    const conflict = await readToolResult(await callCreateIssue("Different retry payload"));
+
+    expect(conflict.isError).toBe(true);
+    expect(conflict.output).toMatchObject({
+      error: "issue_already_exists",
+    });
+  });
+
+  it.each([
+    ["assignee_not_assignable", "assignee_not_assignable"],
+    ["translation_key_not_found", "translation_key_not_found"],
+    ["duplicate external reference", "issue_already_exists"],
+  ])("maps create issue failure %s to %s", async (serviceError, expectedCode) => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const createSpy = vi
+      .spyOn(IssueSheetService.prototype, "createIssue")
+      .mockRejectedValueOnce(new Error(serviceError));
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "create_issue",
+            arguments: {
+              projectId: stored.project.id,
+              title: "Example issue",
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ type: string; text?: string }>;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+      expect(JSON.parse(text!)).toMatchObject({
+        error: expectedCode,
+      });
+    } finally {
+      createSpy.mockRestore();
+    }
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -1567,7 +1567,7 @@ describe("mcpRoutes", () => {
     }
 
     const createSpy = vi.spyOn(IssueSheetService.prototype, "createIssue").mockResolvedValueOnce({
-      id: "issue-id",
+      id: "00000000-0000-4000-8000-000000000123",
       identifier: "HL-123",
       number: 123,
       title: "Incorrect French translation",
@@ -1633,6 +1633,10 @@ describe("mcpRoutes", () => {
         organizationId: auth.organization.localOrganizationId,
         projectId: stored.project.id,
         actorUserId: auth.user.localUserId,
+        deduplicateLinkedIssues: false,
+        metadata: {
+          mcpCreateIssueFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
         body: {
           title: "Incorrect French translation",
           description: "The CTA is mistranslated",
@@ -1658,7 +1662,7 @@ describe("mcpRoutes", () => {
       const text = body.result?.content?.[0]?.text;
       expect(text).toBeDefined();
       expect(JSON.parse(text!)).toMatchObject({
-        id: "issue-id",
+        id: "00000000-0000-4000-8000-000000000123",
         projectId: stored.project.id,
         title: "Incorrect French translation",
         priority: "P1",
@@ -1666,6 +1670,78 @@ describe("mcpRoutes", () => {
     } finally {
       createSpy.mockRestore();
     }
+  });
+
+  it("does not deduplicate new MCP issues by segment and locale", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const service = new IssueSheetService();
+    const existing = await service.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Existing linked issue",
+        targetLocale: "fr-FR",
+        segmentId: "shared-segment",
+        linkKind: "manual",
+      },
+    });
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "create_issue",
+          arguments: {
+            projectId: stored.project.id,
+            title: "New MCP issue",
+            targetLocale: "fr-FR",
+            segmentId: "shared-segment",
+            idempotencyKey: "new-segment-issue",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const responseBody = (await response.json()) as {
+      result?: { content?: Array<{ text?: string }> };
+    };
+    const text = responseBody.result?.content?.[0]?.text;
+    expect(text).toBeDefined();
+
+    const created = JSON.parse(text!) as { id: string; title: string };
+    expect(created).toMatchObject({ title: "New MCP issue" });
+    expect(created.id).not.toBe(existing.id);
+
+    const rows = await db
+      .select({ id: schema.issueSheetIssues.id })
+      .from(schema.issueSheetIssues)
+      .where(
+        and(
+          eq(schema.issueSheetIssues.projectId, stored.project.id),
+          eq(schema.issueSheetIssues.segmentId, "shared-segment"),
+          eq(schema.issueSheetIssues.targetLocale, "fr-FR"),
+        ),
+      );
+
+    expect(rows).toHaveLength(2);
   });
 
   it("reuses an issue for an equivalent retry and rejects a conflicting payload", async () => {
@@ -1723,6 +1799,11 @@ describe("mcpRoutes", () => {
     };
 
     const first = await readToolResult(await callCreateIssue("Retry-safe issue"));
+
+    await db
+      .update(schema.issueSheetIssues)
+      .set({ title: "Edited after the original request", status: "in_progress" })
+      .where(eq(schema.issueSheetIssues.id, first.output.id));
 
     const retry = await readToolResult(await callCreateIssue("Retry-safe issue"));
 

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { and, desc, eq, gt, isNotNull, isNull } from "drizzle-orm";
 import { Hono } from "hono";
@@ -416,24 +416,25 @@ const mcpCreateIssueInputSchema = z.object({
 
 type McpCreateIssueInput = z.infer<typeof mcpCreateIssueInputSchema>;
 
-function isEquivalentMcpCreateIssue(
-  issue: Awaited<ReturnType<IssueSheetService["createIssue"]>>,
+const MCP_CREATE_ISSUE_FINGERPRINT_KEY = "mcpCreateIssueFingerprint";
+
+function mcpCreateIssueFingerprint(
   input: Omit<McpCreateIssueInput, "projectId" | "idempotencyKey">,
 ) {
-  const priority = typeof issue.values.priority === "string" ? issue.values.priority : null;
+  const canonicalPayload = {
+    title: input.title,
+    description: input.description ?? "",
+    issueType: input.issueType ?? "general_question",
+    status: input.status ?? "open",
+    targetLocale: input.targetLocale ?? null,
+    sourcePath: input.sourcePath ?? null,
+    segmentId: input.segmentId ?? null,
+    translationKeyId: input.translationKeyId ?? null,
+    assigneeUserId: input.assigneeUserId ?? null,
+    priority: input.priority ?? null,
+  };
 
-  return (
-    issue.title === input.title &&
-    issue.description === (input.description ?? "") &&
-    issue.issueType === (input.issueType ?? "general_question") &&
-    issue.status === (input.status ?? "open") &&
-    issue.targetLocale === (input.targetLocale ?? null) &&
-    issue.sourcePath === (input.sourcePath ?? null) &&
-    issue.segmentId === (input.segmentId ?? null) &&
-    issue.translationKeyId === (input.translationKeyId ?? null) &&
-    issue.assigneeUserId === (input.assigneeUserId ?? null) &&
-    priority === (input.priority ?? null)
-  );
+  return createHash("sha256").update(JSON.stringify(canonicalPayload)).digest("hex");
 }
 
 function mcpToolError(code: string, message: string) {
@@ -596,52 +597,105 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
         return mcpToolError("project_not_found", "Project not found or inaccessible");
       }
 
-      let issue: Awaited<ReturnType<IssueSheetService["createIssue"]>>;
+      let issue: Awaited<ReturnType<IssueSheetService["createIssue"]>> | null = null;
+      const externalRef = idempotencyKey ? `mcp:${idempotencyKey}` : undefined;
+      const fingerprint = idempotencyKey ? mcpCreateIssueFingerprint(body) : undefined;
 
-      try {
-        issue = await issueSheetService.createIssue({
-          organizationId: apiAuth.organization.localOrganizationId,
-          projectId,
-          actorUserId: apiAuth.user.localUserId,
-          body: {
-            ...body,
-            linkKind: "manual",
-            linkLabel: "MCP",
-            ...(idempotencyKey ? { externalRef: `mcp:${idempotencyKey}` } : {}),
-          },
-        });
-      } catch (error) {
-        if (error instanceof Error) {
-          if (error.message === "assignee_not_assignable") {
-            return mcpToolError(
-              "assignee_not_assignable",
-              "Assignee is not assignable to this project",
-            );
-          }
+      if (externalRef && fingerprint) {
+        const [existing] = await db
+          .select({
+            id: schema.issueSheetIssues.id,
+            metadata: schema.issueSheetIssues.metadata,
+          })
+          .from(schema.issueSheetIssues)
+          .where(
+            and(
+              eq(schema.issueSheetIssues.organizationId, apiAuth.organization.localOrganizationId),
+              eq(schema.issueSheetIssues.projectId, projectId),
+              eq(schema.issueSheetIssues.externalRef, externalRef),
+            ),
+          )
+          .limit(1);
 
-          if (error.message === "translation_key_not_found") {
-            return mcpToolError(
-              "translation_key_not_found",
-              "Translation key was not found in this project",
-            );
-          }
-
-          if (error.message.includes("duplicate")) {
+        if (existing) {
+          if (existing.metadata[MCP_CREATE_ISSUE_FINGERPRINT_KEY] !== fingerprint) {
             return mcpToolError(
               "issue_already_exists",
-              "An issue already exists for this reference",
+              "The idempotency key is already associated with a different issue payload",
             );
           }
-        }
 
-        throw error;
+          issue = await issueSheetService.getIssue({
+            organizationId: apiAuth.organization.localOrganizationId,
+            projectId,
+            issueId: existing.id,
+            actorUserId: apiAuth.user.localUserId,
+          });
+        }
       }
 
-      if (idempotencyKey && !isEquivalentMcpCreateIssue(issue, body)) {
-        return mcpToolError(
-          "issue_already_exists",
-          "The idempotency key is already associated with a different issue payload",
-        );
+      if (!issue) {
+        try {
+          issue = await issueSheetService.createIssue({
+            organizationId: apiAuth.organization.localOrganizationId,
+            projectId,
+            actorUserId: apiAuth.user.localUserId,
+            deduplicateLinkedIssues: false,
+            ...(fingerprint
+              ? { metadata: { [MCP_CREATE_ISSUE_FINGERPRINT_KEY]: fingerprint } }
+              : {}),
+            body: {
+              ...body,
+              linkKind: "manual",
+              linkLabel: "MCP",
+              ...(externalRef ? { externalRef } : {}),
+            },
+          });
+        } catch (error) {
+          if (error instanceof Error) {
+            if (error.message === "assignee_not_assignable") {
+              return mcpToolError(
+                "assignee_not_assignable",
+                "Assignee is not assignable to this project",
+              );
+            }
+
+            if (error.message === "translation_key_not_found") {
+              return mcpToolError(
+                "translation_key_not_found",
+                "Translation key was not found in this project",
+              );
+            }
+
+            if (error.message.includes("duplicate")) {
+              return mcpToolError(
+                "issue_already_exists",
+                "An issue already exists for this reference",
+              );
+            }
+          }
+
+          throw error;
+        }
+      }
+
+      if (!issue) {
+        throw new Error("issue_sheet_issue_load_failed");
+      }
+
+      if (fingerprint) {
+        const [persisted] = await db
+          .select({ metadata: schema.issueSheetIssues.metadata })
+          .from(schema.issueSheetIssues)
+          .where(eq(schema.issueSheetIssues.id, issue.id))
+          .limit(1);
+
+        if (persisted && persisted.metadata[MCP_CREATE_ISSUE_FINGERPRINT_KEY] !== fingerprint) {
+          return mcpToolError(
+            "issue_already_exists",
+            "The idempotency key is already associated with a different issue payload",
+          );
+        }
       }
 
       return {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -62,6 +62,9 @@ import { db, schema } from "@/lib/database/client";
 import { env } from "@/lib/env";
 import { resolveMcpClientMetadata } from "@/api/auth/mcp-client-metadata";
 import { isErr } from "@/lib/primitives/result/results";
+import { issueSheetCreateIssueBodySchema } from "@/api/routes/project/issue-sheet.schema";
+import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
+import { isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -366,6 +369,85 @@ const mcpListIssuesInputSchema = z
     }
   });
 
+const issueSheetService = new IssueSheetService();
+const createIssueShape = issueSheetCreateIssueBodySchema.shape;
+
+const mcpCreateIssueInputSchema = z.object({
+  projectId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(128)
+    .describe("ID of the accessible Hyperlocalise project in which to create the issue."),
+  title: createIssueShape.title.describe(
+    "Short issue title describing the problem or requested work.",
+  ),
+  description: createIssueShape.description.describe("Optional detailed issue description."),
+  issueType: createIssueShape.issueType.describe(
+    "Optional issue classification. Defaults to general_question.",
+  ),
+  status: createIssueShape.status.describe("Optional initial issue status. Defaults to open."),
+  targetLocale: createIssueShape.targetLocale.describe(
+    "Optional target locale associated with the issue.",
+  ),
+  sourcePath: createIssueShape.sourcePath.describe(
+    "Optional source file or content path associated with the issue.",
+  ),
+  segmentId: createIssueShape.segmentId.describe(
+    "Optional source segment identifier associated with the issue.",
+  ),
+  translationKeyId: createIssueShape.translationKeyId.describe(
+    "Optional UUID of a translation key in the target project.",
+  ),
+  assigneeUserId: createIssueShape.assigneeUserId.describe(
+    "Optional UUID of an assignable project member.",
+  ),
+  priority: createIssueShape.priority.describe("Optional issue priority: P0, P1, or P2."),
+  idempotencyKey: z
+    .string()
+    .trim()
+    .min(1)
+    .max(512)
+    .optional()
+    .describe(
+      "Caller-generated retry key. Reusing it with an equivalent payload returns the existing issue.",
+    ),
+});
+
+type McpCreateIssueInput = z.infer<typeof mcpCreateIssueInputSchema>;
+
+function isEquivalentMcpCreateIssue(
+  issue: Awaited<ReturnType<IssueSheetService["createIssue"]>>,
+  input: Omit<McpCreateIssueInput, "projectId" | "idempotencyKey">,
+) {
+  const priority = typeof issue.values.priority === "string" ? issue.values.priority : null;
+
+  return (
+    issue.title === input.title &&
+    issue.description === (input.description ?? "") &&
+    issue.issueType === (input.issueType ?? "general_question") &&
+    issue.status === (input.status ?? "open") &&
+    issue.targetLocale === (input.targetLocale ?? null) &&
+    issue.sourcePath === (input.sourcePath ?? null) &&
+    issue.segmentId === (input.segmentId ?? null) &&
+    issue.translationKeyId === (input.translationKeyId ?? null) &&
+    issue.assigneeUserId === (input.assigneeUserId ?? null) &&
+    priority === (input.priority ?? null)
+  );
+}
+
+function mcpToolError(code: string, message: string) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ error: code, message }),
+      },
+    ],
+    isError: true,
+  };
+}
+
 function compactMcpIssue(issue: OrganizationIssueListItem) {
   return {
     id: issue.id,
@@ -487,6 +569,103 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
           {
             type: "text",
             text: JSON.stringify(output),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "create_issue",
+    {
+      description: "Create one issue in an accessible Hyperlocalise project.",
+      inputSchema: mcpCreateIssueInputSchema,
+    },
+    async ({ projectId, idempotencyKey, ...body }) => {
+      if (!isWriteBackTranslationAllowed(apiAuth.membership.role)) {
+        return mcpToolError("forbidden", "Insufficient permissions to create issues");
+      }
+
+      const [project] = await db
+        .select({ id: schema.projects.id })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      let issue: Awaited<ReturnType<IssueSheetService["createIssue"]>>;
+
+      try {
+        issue = await issueSheetService.createIssue({
+          organizationId: apiAuth.organization.localOrganizationId,
+          projectId,
+          actorUserId: apiAuth.user.localUserId,
+          body: {
+            ...body,
+            linkKind: "manual",
+            linkLabel: "MCP",
+            ...(idempotencyKey ? { externalRef: `mcp:${idempotencyKey}` } : {}),
+          },
+        });
+      } catch (error) {
+        if (error instanceof Error) {
+          if (error.message === "assignee_not_assignable") {
+            return mcpToolError(
+              "assignee_not_assignable",
+              "Assignee is not assignable to this project",
+            );
+          }
+
+          if (error.message === "translation_key_not_found") {
+            return mcpToolError(
+              "translation_key_not_found",
+              "Translation key was not found in this project",
+            );
+          }
+
+          if (error.message.includes("duplicate")) {
+            return mcpToolError(
+              "issue_already_exists",
+              "An issue already exists for this reference",
+            );
+          }
+        }
+
+        throw error;
+      }
+
+      if (idempotencyKey && !isEquivalentMcpCreateIssue(issue, body)) {
+        return mcpToolError(
+          "issue_already_exists",
+          "The idempotency key is already associated with a different issue payload",
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              id: issue.id,
+              projectId,
+              identifier: issue.identifier,
+              title: issue.title,
+              description: issue.description,
+              issueType: issue.issueType,
+              status: issue.status,
+              priority: typeof issue.values.priority === "string" ? issue.values.priority : null,
+              targetLocale: issue.targetLocale,
+              sourcePath: issue.sourcePath,
+              segmentId: issue.segmentId,
+              translationKeyId: issue.translationKeyId,
+              assignee: issue.assignee,
+              assigneeUserId: issue.assigneeUserId,
+              createdAt: issue.createdAt,
+              updatedAt: issue.updatedAt,
+            }),
           },
         ],
       };

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -1264,6 +1264,8 @@ export class IssueSheetService {
     projectId: string;
     actorUserId: string;
     body: IssueSheetCreateIssueBody;
+    deduplicateLinkedIssues?: boolean;
+    metadata?: Record<string, unknown>;
   }): Promise<IssueSheetIssue> {
     await this.ensureStarterColumns(input);
     if (input.body.translationKeyId) {
@@ -1319,6 +1321,7 @@ export class IssueSheetService {
           linkUrl: input.body.linkUrl ?? null,
           externalRef: input.body.externalRef ?? null,
           templateKey: input.body.templateKey ?? null,
+          metadata: input.metadata ?? {},
           reporterUserId: input.actorUserId,
           assigneeUserId,
           resolvedAt:
@@ -2002,6 +2005,7 @@ export class IssueSheetService {
     projectId: string;
     actorUserId: string;
     body: IssueSheetCreateIssueBody;
+    deduplicateLinkedIssues?: boolean;
   }) {
     const baseConditions: SQL[] = [
       eq(schema.issueSheetIssues.organizationId, input.organizationId),
@@ -2016,6 +2020,10 @@ export class IssueSheetService {
       if (existingByExternalRef) {
         return existingByExternalRef;
       }
+    }
+
+    if (input.deduplicateLinkedIssues === false) {
+      return null;
     }
 
     const linkConditions: SQL[] = [];


### PR DESCRIPTION
## What changed

- Added the create_issue tool to the hosted MCP server.
- Reused the existing issue-sheet schema and IssueSheetService.
- Added bounded input fields for issue details, assignment, linkage, priority, and idempotency.
- Added MCP-namespaced idempotency keys to prevent duplicate issues and cross-integration collisions.
- Enforced organization, team, project, and write-capability access controls.
- Attributed created issues and activity history to the authenticated MCP user.
- Added stable errors for inaccessible projects, forbidden access, invalid assignees, missing translation keys, and conflicting retries.
- Added unit, access-control, idempotency, validation, and MCP SDK integration coverage.

## How to test

```
vp test src/api/routes/mcp/mcp.route.test.ts
vp test src/api/routes/mcp/mcp-team-access.test.ts

vp check \
  src/api/routes/mcp/mcp.route.ts \
  src/api/routes/mcp/mcp.route.test.ts \
  src/api/routes/mcp/mcp-team-access.test.ts

vp run build
```

## Checklist

- I ran relevant checks locally (vp check, relevant vp test suites, and vp run build)
- I updated tool descriptions and schema metadata where needed
- This PR is scoped and ready for review