### PR TITLE
feat(cli): add Crowdin string list, file ops, and auto-translate

### DIFF
--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -286,13 +286,14 @@ func newCrowdinStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cfg = applyCrowdinBranchFlag(cfg, o.branch)
 			client, err := newCrowdinTranslationStatusReader(cfg)
 			if err != nil {
 				return err
 			}
 			rows, err := client.GetTranslationStatus(backgroundContext(), crowdinstorage.TranslationStatusRequest{
 				ProjectID: cfg.ProjectID,
-				Branch:    o.branch,
+				Branch:    cfg.Branch,
 				Languages: o.languages,
 			})
 			if err != nil {
@@ -823,6 +824,13 @@ func crowdinstorageRequestDownload(cfg storage.FileWorkflowConfig, languages []s
 
 func overrideCrowdinBranch(cfg storage.FileWorkflowConfig, branch string) storage.FileWorkflowConfig {
 	if trimmed := strings.TrimSpace(branch); trimmed != "" {
+		cfg.Branch = trimmed
+	}
+	return cfg
+}
+
+func applyCrowdinBranchFlag(cfg crowdinstorage.Config, flagBranch string) crowdinstorage.Config {
+	if trimmed := strings.TrimSpace(flagBranch); trimmed != "" {
 		cfg.Branch = trimmed
 	}
 	return cfg

--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -111,6 +111,20 @@ type crowdinGlossaryImporter interface {
 	ImportGlossaryFile(context.Context, int, string) (crowdinstorage.ImportResult, error)
 }
 
+type crowdinSourceStringLister interface {
+	ListProjectSourceStrings(context.Context, crowdinstorage.ListSourceStringsInput) ([]crowdinstorage.SourceStringRow, error)
+}
+
+type crowdinFileOpsClient interface {
+	UploadProjectFile(context.Context, string, string, string, string) (int, error)
+	DownloadProjectFile(context.Context, string, string, string, string) ([]byte, error)
+	DeleteProjectFile(context.Context, string, string, string) error
+}
+
+type crowdinAutoTranslator interface {
+	ApplyPreTranslationAndWait(context.Context, crowdinstorage.PreTranslationInput) (crowdinstorage.PreTranslationResult, error)
+}
+
 var newCrowdinTranslationStatusReader = func(cfg crowdinstorage.Config) (crowdinTranslationStatusReader, error) {
 	return crowdinstorage.NewHTTPClient(cfg)
 }
@@ -159,6 +173,18 @@ var newCrowdinGlossaryImporter = func(cfg crowdinstorage.Config) (crowdinGlossar
 	return crowdinstorage.NewHTTPClient(cfg)
 }
 
+var newCrowdinSourceStringLister = func(cfg crowdinstorage.Config) (crowdinSourceStringLister, error) {
+	return crowdinstorage.NewHTTPClient(cfg)
+}
+
+var newCrowdinFileOpsClient = func(cfg crowdinstorage.Config) (crowdinFileOpsClient, error) {
+	return crowdinstorage.NewHTTPClient(cfg)
+}
+
+var newCrowdinAutoTranslator = func(cfg crowdinstorage.Config) (crowdinAutoTranslator, error) {
+	return crowdinstorage.NewHTTPClient(cfg)
+}
+
 func newCrowdinCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "crowdin",
@@ -170,11 +196,13 @@ func newCrowdinCmd() *cobra.Command {
 	cmd.AddCommand(newCrowdinStatusCmd())
 	cmd.AddCommand(newCrowdinBranchCmd())
 	cmd.AddCommand(newCrowdinFileCmd())
+	cmd.AddCommand(newCrowdinStringCmd())
 	cmd.AddCommand(newCrowdinLanguageCmd())
 	cmd.AddCommand(newCrowdinUploadCmd())
 	cmd.AddCommand(newCrowdinDownloadCmd())
 	cmd.AddCommand(newCrowdinGlossaryCmd())
 	cmd.AddCommand(newCrowdinTranslationMemoryCmd())
+	cmd.AddCommand(newCrowdinAutoTranslateCmd())
 
 	return cmd
 }

--- a/apps/cli/cmd/crowdin_advanced.go
+++ b/apps/cli/cmd/crowdin_advanced.go
@@ -244,11 +244,15 @@ func newCrowdinAutoTranslateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			branch := cfg.Branch
+			if o.directoryID > 0 && !cmd.Flags().Changed("branch") {
+				branch = ""
+			}
 			in := crowdinstorage.PreTranslationInput{
 				ProjectID:         cfg.ProjectID,
 				Languages:         o.languages,
 				FilePath:          o.filePath,
-				Branch:            cfg.Branch,
+				Branch:            branch,
 				DirectoryID:       o.directoryID,
 				AutoApproveOption: o.autoApproveOption,
 			}

--- a/apps/cli/cmd/crowdin_advanced.go
+++ b/apps/cli/cmd/crowdin_advanced.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	crowdinstorage "github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/crowdin"
+	"github.com/spf13/cobra"
+)
+
+type crowdinStringListOptions struct {
+	configPath   string
+	identityPath string
+	branch       string
+	filePath     string
+	filter       string
+	output       string
+}
+
+type crowdinFileUploadOptions struct {
+	configPath   string
+	identityPath string
+	branch       string
+	dest         string
+}
+
+type crowdinFileDownloadOptions struct {
+	configPath   string
+	identityPath string
+	branch       string
+	dest         string
+	language     string
+	force        bool
+}
+
+type crowdinFileDeleteOptions struct {
+	configPath   string
+	identityPath string
+	branch       string
+}
+
+type crowdinAutoTranslateOptions struct {
+	configPath                    string
+	identityPath                  string
+	languages                     []string
+	filePath                      string
+	branch                        string
+	directoryID                   int
+	method                        string
+	autoApproveOption             string
+	duplicateTranslations         bool
+	skipApprovedTranslations      bool
+	translateUntranslatedOnly     bool
+	translateWithPerfectMatchOnly bool
+}
+
+func newCrowdinStringCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "string",
+		Short: "Crowdin source string commands",
+	}
+	cmd.AddCommand(newCrowdinStringListCmd())
+	return cmd
+}
+
+func newCrowdinStringListCmd() *cobra.Command {
+	o := crowdinStringListOptions{output: "text"}
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "list Crowdin source strings",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, _, err := crowdinstorage.LoadClientConfig(o.configPath, o.identityPath)
+			if err != nil {
+				return err
+			}
+			client, err := newCrowdinSourceStringLister(cfg)
+			if err != nil {
+				return err
+			}
+			rows, err := client.ListProjectSourceStrings(cmd.Context(), crowdinstorage.ListSourceStringsInput{
+				ProjectID: cfg.ProjectID,
+				Branch:    o.branch,
+				FilePath:  o.filePath,
+				Filter:    o.filter,
+			})
+			if err != nil {
+				return err
+			}
+			return writeCrowdinEncodedOutput(cmd.OutOrStdout(), o.output, func() error {
+				for _, row := range rows {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "id=%d identifier=%s text=%s context=%s\n", row.ID, row.Identifier, row.Text, row.Context); err != nil {
+						return err
+					}
+				}
+				return nil
+			}, rows)
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
+	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Crowdin branch name")
+	cmd.Flags().StringVar(&o.filePath, "file", "", "Crowdin file path to filter strings")
+	cmd.Flags().StringVar(&o.filter, "filter", "", "filter strings by identifier, text, or context")
+	cmd.Flags().StringVar(&o.output, "output", o.output, "output format: text or json")
+	return cmd
+}
+
+func newCrowdinFileUploadCmd() *cobra.Command {
+	o := crowdinFileUploadOptions{}
+	cmd := &cobra.Command{
+		Use:          "upload <file>",
+		Short:        "upload one local file to a Crowdin project path",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(o.dest) == "" {
+				return fmt.Errorf("crowdin file upload: --dest is required")
+			}
+			cfg, _, err := crowdinstorage.LoadClientConfig(o.configPath, o.identityPath)
+			if err != nil {
+				return err
+			}
+			client, err := newCrowdinFileOpsClient(cfg)
+			if err != nil {
+				return err
+			}
+			fileID, err := client.UploadProjectFile(cmd.Context(), cfg.ProjectID, o.branch, o.dest, args[0])
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "uploaded dest=%s file_id=%d\n", o.dest, fileID)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
+	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Crowdin branch name")
+	cmd.Flags().StringVar(&o.dest, "dest", "", "destination path in the Crowdin project")
+	return cmd
+}
+
+func newCrowdinFileDownloadCmd() *cobra.Command {
+	o := crowdinFileDownloadOptions{}
+	cmd := &cobra.Command{
+		Use:          "download <file>",
+		Short:        "download one Crowdin file by project path",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _, err := crowdinstorage.LoadClientConfig(o.configPath, o.identityPath)
+			if err != nil {
+				return err
+			}
+			client, err := newCrowdinFileOpsClient(cfg)
+			if err != nil {
+				return err
+			}
+			content, err := client.DownloadProjectFile(cmd.Context(), cfg.ProjectID, o.branch, args[0], o.language)
+			if err != nil {
+				return err
+			}
+			dest := strings.TrimSpace(o.dest)
+			if dest == "" || dest == "-" {
+				_, err := cmd.OutOrStdout().Write(content)
+				return err
+			}
+			if err := writeCrowdinFileDownload(dest, content, o.force); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "downloaded dest=%s bytes=%d\n", dest, len(content))
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
+	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Crowdin branch name")
+	cmd.Flags().StringVar(&o.dest, "dest", "", "local path to write; omit or use - for stdout")
+	cmd.Flags().StringVarP(&o.language, "language", "l", "", "download a translation file for this language")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing destination file")
+	return cmd
+}
+
+func newCrowdinFileDeleteCmd() *cobra.Command {
+	o := crowdinFileDeleteOptions{}
+	cmd := &cobra.Command{
+		Use:          "delete <file>",
+		Short:        "delete one Crowdin source file by project path",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _, err := crowdinstorage.LoadClientConfig(o.configPath, o.identityPath)
+			if err != nil {
+				return err
+			}
+			client, err := newCrowdinFileOpsClient(cfg)
+			if err != nil {
+				return err
+			}
+			if err := client.DeleteProjectFile(cmd.Context(), cfg.ProjectID, o.branch, args[0]); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "deleted path=%s\n", args[0])
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
+	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Crowdin branch name")
+	return cmd
+}
+
+func newCrowdinAutoTranslateCmd() *cobra.Command {
+	o := crowdinAutoTranslateOptions{
+		method:                    "tm",
+		translateUntranslatedOnly: true,
+	}
+	cmd := &cobra.Command{
+		Use:          "auto-translate",
+		Aliases:      []string{"pre-translate"},
+		Short:        "pre-translate Crowdin files via translation memory",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			method := strings.ToLower(strings.TrimSpace(o.method))
+			if method != "" && method != "tm" {
+				return fmt.Errorf("crowdin auto-translate: method %q is not supported in v1 (tm only)", o.method)
+			}
+			cfg, _, err := crowdinstorage.LoadClientConfig(o.configPath, o.identityPath)
+			if err != nil {
+				return err
+			}
+			client, err := newCrowdinAutoTranslator(cfg)
+			if err != nil {
+				return err
+			}
+			in := crowdinstorage.PreTranslationInput{
+				ProjectID:         cfg.ProjectID,
+				Languages:         o.languages,
+				FilePath:          o.filePath,
+				Branch:            o.branch,
+				DirectoryID:       o.directoryID,
+				AutoApproveOption: o.autoApproveOption,
+			}
+			if cmd.Flags().Changed("duplicate-translations") {
+				value := o.duplicateTranslations
+				in.DuplicateTranslations = &value
+			}
+			if cmd.Flags().Changed("skip-approved-translations") {
+				value := o.skipApprovedTranslations
+				in.SkipApprovedTranslations = &value
+			}
+			if cmd.Flags().Changed("translate-untranslated-only") {
+				value := o.translateUntranslatedOnly
+				in.TranslateUntranslatedOnly = &value
+			}
+			if cmd.Flags().Changed("translate-with-perfect-match-only") {
+				value := o.translateWithPerfectMatchOnly
+				in.TranslateWithPerfectMatchOnly = &value
+			}
+			result, err := client.ApplyPreTranslationAndWait(cmd.Context(), in)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "pre-translated status=%s progress=%d identifier=%s\n", result.Status, result.Progress, result.Identifier)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
+	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
+	cmd.Flags().StringSliceVarP(&o.languages, "language", "l", nil, "target language(s) to pre-translate")
+	cmd.Flags().StringVar(&o.filePath, "file", "", "Crowdin file path to pre-translate")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Crowdin branch name to pre-translate")
+	cmd.Flags().IntVar(&o.directoryID, "directory-id", 0, "Crowdin directory identifier to pre-translate")
+	cmd.Flags().StringVar(&o.method, "method", "tm", "pre-translation method (v1 supports tm only)")
+	cmd.Flags().StringVar(&o.autoApproveOption, "auto-approve-option", "", "TM auto-approve option")
+	cmd.Flags().BoolVar(&o.duplicateTranslations, "duplicate-translations", false, "add translations even if the same translation already exists")
+	cmd.Flags().BoolVar(&o.skipApprovedTranslations, "skip-approved-translations", false, "skip strings that already have an approved translation")
+	cmd.Flags().BoolVar(&o.translateUntranslatedOnly, "translate-untranslated-only", true, "pre-translate untranslated strings only")
+	cmd.Flags().BoolVar(&o.translateWithPerfectMatchOnly, "translate-with-perfect-match-only", false, "apply TM matches only when source and context are identical")
+	_ = cmd.MarkFlagRequired("language")
+	return cmd
+}
+
+func writeCrowdinFileDownload(path string, content []byte, force bool) error {
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("crowdin file download: output file %q is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("crowdin file download: output file %q already exists; use --force to overwrite", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("crowdin file download: stat output file %q: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("crowdin file download: mkdir output directory: %w", err)
+	}
+	return writeFileAtomic(path, content)
+}

--- a/apps/cli/cmd/crowdin_advanced.go
+++ b/apps/cli/cmd/crowdin_advanced.go
@@ -76,13 +76,14 @@ func newCrowdinStringListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cfg = applyCrowdinBranchFlag(cfg, o.branch)
 			client, err := newCrowdinSourceStringLister(cfg)
 			if err != nil {
 				return err
 			}
 			rows, err := client.ListProjectSourceStrings(cmd.Context(), crowdinstorage.ListSourceStringsInput{
 				ProjectID: cfg.ProjectID,
-				Branch:    o.branch,
+				Branch:    cfg.Branch,
 				FilePath:  o.filePath,
 				Filter:    o.filter,
 			})
@@ -123,11 +124,12 @@ func newCrowdinFileUploadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cfg = applyCrowdinBranchFlag(cfg, o.branch)
 			client, err := newCrowdinFileOpsClient(cfg)
 			if err != nil {
 				return err
 			}
-			fileID, err := client.UploadProjectFile(cmd.Context(), cfg.ProjectID, o.branch, o.dest, args[0])
+			fileID, err := client.UploadProjectFile(cmd.Context(), cfg.ProjectID, cfg.Branch, o.dest, args[0])
 			if err != nil {
 				return err
 			}
@@ -154,6 +156,7 @@ func newCrowdinFileDownloadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cfg = applyCrowdinBranchFlag(cfg, o.branch)
 			client, err := newCrowdinFileOpsClient(cfg)
 			if err != nil {
 				return err
@@ -162,7 +165,7 @@ func newCrowdinFileDownloadCmd() *cobra.Command {
 			if cmd.Flags().Changed("language") && language == "" {
 				return fmt.Errorf("crowdin file download: language is required")
 			}
-			content, err := client.DownloadProjectFile(cmd.Context(), cfg.ProjectID, o.branch, args[0], language)
+			content, err := client.DownloadProjectFile(cmd.Context(), cfg.ProjectID, cfg.Branch, args[0], language)
 			if err != nil {
 				return err
 			}
@@ -199,11 +202,12 @@ func newCrowdinFileDeleteCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cfg = applyCrowdinBranchFlag(cfg, o.branch)
 			client, err := newCrowdinFileOpsClient(cfg)
 			if err != nil {
 				return err
 			}
-			if err := client.DeleteProjectFile(cmd.Context(), cfg.ProjectID, o.branch, args[0]); err != nil {
+			if err := client.DeleteProjectFile(cmd.Context(), cfg.ProjectID, cfg.Branch, args[0]); err != nil {
 				return err
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "deleted path=%s\n", args[0])
@@ -235,6 +239,7 @@ func newCrowdinAutoTranslateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cfg = applyCrowdinBranchFlag(cfg, o.branch)
 			client, err := newCrowdinAutoTranslator(cfg)
 			if err != nil {
 				return err
@@ -243,7 +248,7 @@ func newCrowdinAutoTranslateCmd() *cobra.Command {
 				ProjectID:         cfg.ProjectID,
 				Languages:         o.languages,
 				FilePath:          o.filePath,
-				Branch:            o.branch,
+				Branch:            cfg.Branch,
 				DirectoryID:       o.directoryID,
 				AutoApproveOption: o.autoApproveOption,
 			}

--- a/apps/cli/cmd/crowdin_advanced.go
+++ b/apps/cli/cmd/crowdin_advanced.go
@@ -158,7 +158,11 @@ func newCrowdinFileDownloadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			content, err := client.DownloadProjectFile(cmd.Context(), cfg.ProjectID, o.branch, args[0], o.language)
+			language := strings.TrimSpace(o.language)
+			if cmd.Flags().Changed("language") && language == "" {
+				return fmt.Errorf("crowdin file download: language is required")
+			}
+			content, err := client.DownloadProjectFile(cmd.Context(), cfg.ProjectID, o.branch, args[0], language)
 			if err != nil {
 				return err
 			}

--- a/apps/cli/cmd/crowdin_list.go
+++ b/apps/cli/cmd/crowdin_list.go
@@ -186,11 +186,12 @@ func newCrowdinFileListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cfg = applyCrowdinBranchFlag(cfg, o.branch)
 			client, err := newCrowdinFileLister(cfg)
 			if err != nil {
 				return err
 			}
-			rows, err := client.ListProjectFiles(cmd.Context(), cfg.ProjectID, o.branch)
+			rows, err := client.ListProjectFiles(cmd.Context(), cfg.ProjectID, cfg.Branch)
 			if err != nil {
 				return err
 			}

--- a/apps/cli/cmd/crowdin_list.go
+++ b/apps/cli/cmd/crowdin_list.go
@@ -169,6 +169,9 @@ func newCrowdinFileCmd() *cobra.Command {
 		Short: "Crowdin source file commands",
 	}
 	cmd.AddCommand(newCrowdinFileListCmd())
+	cmd.AddCommand(newCrowdinFileUploadCmd())
+	cmd.AddCommand(newCrowdinFileDownloadCmd())
+	cmd.AddCommand(newCrowdinFileDeleteCmd())
 	return cmd
 }
 

--- a/apps/cli/cmd/crowdin_test.go
+++ b/apps/cli/cmd/crowdin_test.go
@@ -16,6 +16,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestApplyCrowdinBranchFlag(t *testing.T) {
+	cfg := crowdinstorage.Config{Branch: "feature/login"}
+	got := applyCrowdinBranchFlag(cfg, "")
+	if got.Branch != "feature/login" {
+		t.Fatalf("empty flag = %q, want feature/login", got.Branch)
+	}
+	got = applyCrowdinBranchFlag(cfg, "  hotfix  ")
+	if got.Branch != "hotfix" {
+		t.Fatalf("flag override = %q, want hotfix", got.Branch)
+	}
+}
+
 func TestCrowdinInitWritesTemplate(t *testing.T) {
 	t.Chdir(t.TempDir())
 

--- a/apps/cli/cmd/crowdin_wave_test.go
+++ b/apps/cli/cmd/crowdin_wave_test.go
@@ -270,6 +270,38 @@ func TestCrowdinAutoTranslateRejectsMT(t *testing.T) {
 	}
 }
 
+func TestCrowdinAutoTranslateRejectsBlankLanguage(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMinimalCrowdinConfig(t, dir)
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"crowdin", "auto-translate", "--language", " ", "--file", "messages.json"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "at least one language is required") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCrowdinFileDownloadRejectsBlankLanguage(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMinimalCrowdinConfig(t, dir)
+
+	old := newCrowdinFileOpsClient
+	t.Cleanup(func() { newCrowdinFileOpsClient = old })
+	newCrowdinFileOpsClient = func(crowdinstorage.Config) (crowdinFileOpsClient, error) {
+		return &fakeCrowdinFileOpsClient{content: []byte(`{"hello":"Hello"}`)}, nil
+	}
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"crowdin", "file", "download", "messages.json", "--language", " "})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "language is required") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestCrowdinGlossaryAndTMUpload(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/apps/cli/cmd/crowdin_wave_test.go
+++ b/apps/cli/cmd/crowdin_wave_test.go
@@ -226,6 +226,53 @@ func TestCrowdinFileUploadDownloadDelete(t *testing.T) {
 	}
 }
 
+func TestCrowdinFileUploadUsesYAMLBranchUnlessFlagOverrides(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMinimalCrowdinConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+branch: feature/login
+files:
+  - source: /src/messages.json
+    translation: /locales/%locale%/%original_file_name%
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+	inputPath := filepath.Join(dir, "local.json")
+	if err := os.WriteFile(inputPath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	old := newCrowdinFileOpsClient
+	t.Cleanup(func() { newCrowdinFileOpsClient = old })
+	client := &fakeCrowdinFileOpsClient{}
+	newCrowdinFileOpsClient = func(crowdinstorage.Config) (crowdinFileOpsClient, error) {
+		return client, nil
+	}
+
+	cmd := newRootCmd("")
+	cmd.SetOut(bytes.NewBuffer(nil))
+	cmd.SetArgs([]string{"crowdin", "file", "upload", inputPath, "--dest", "/messages.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("file upload: %v", err)
+	}
+	if client.branch != "feature/login" {
+		t.Fatalf("branch = %q, want feature/login", client.branch)
+	}
+
+	cmd = newRootCmd("")
+	cmd.SetOut(bytes.NewBuffer(nil))
+	cmd.SetArgs([]string{"crowdin", "file", "upload", inputPath, "--dest", "/messages.json", "--branch", "hotfix"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("file upload override: %v", err)
+	}
+	if client.branch != "hotfix" {
+		t.Fatalf("branch = %q, want hotfix", client.branch)
+	}
+}
+
 func TestCrowdinAutoTranslate(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -418,17 +465,21 @@ func (fakeCrowdinSourceStringLister) ListProjectSourceStrings(_ context.Context,
 
 type fakeCrowdinFileOpsClient struct {
 	content []byte
+	branch  string
 }
 
-func (f *fakeCrowdinFileOpsClient) UploadProjectFile(context.Context, string, string, string, string) (int, error) {
+func (f *fakeCrowdinFileOpsClient) UploadProjectFile(_ context.Context, _, branch, _, _ string) (int, error) {
+	f.branch = branch
 	return 17, nil
 }
 
-func (f *fakeCrowdinFileOpsClient) DownloadProjectFile(context.Context, string, string, string, string) ([]byte, error) {
+func (f *fakeCrowdinFileOpsClient) DownloadProjectFile(_ context.Context, _, branch, _, _ string) ([]byte, error) {
+	f.branch = branch
 	return f.content, nil
 }
 
-func (f *fakeCrowdinFileOpsClient) DeleteProjectFile(context.Context, string, string, string) error {
+func (f *fakeCrowdinFileOpsClient) DeleteProjectFile(_ context.Context, _, branch, _ string) error {
+	f.branch = branch
 	return nil
 }
 

--- a/apps/cli/cmd/crowdin_wave_test.go
+++ b/apps/cli/cmd/crowdin_wave_test.go
@@ -273,6 +273,52 @@ files:
 	}
 }
 
+func TestCrowdinAutoTranslateDirectoryIDIgnoresYAMLBranch(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMinimalCrowdinConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+branch: feature/login
+files:
+  - source: /src/messages.json
+    translation: /locales/%locale%/%original_file_name%
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+
+	old := newCrowdinAutoTranslator
+	t.Cleanup(func() { newCrowdinAutoTranslator = old })
+	client := &fakeCrowdinAutoTranslator{}
+	newCrowdinAutoTranslator = func(crowdinstorage.Config) (crowdinAutoTranslator, error) {
+		return client, nil
+	}
+
+	cmd := newRootCmd("")
+	cmd.SetOut(bytes.NewBuffer(nil))
+	cmd.SetArgs([]string{"crowdin", "auto-translate", "--language", "fr", "--directory-id", "9"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auto-translate directory: %v", err)
+	}
+	if client.in.DirectoryID != 9 {
+		t.Fatalf("directory id = %d, want 9", client.in.DirectoryID)
+	}
+	if client.in.Branch != "" {
+		t.Fatalf("branch = %q, want empty when --directory-id is the scope", client.in.Branch)
+	}
+
+	cmd = newRootCmd("")
+	cmd.SetOut(bytes.NewBuffer(nil))
+	cmd.SetArgs([]string{"crowdin", "auto-translate", "--language", "fr", "--file", "messages.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auto-translate file: %v", err)
+	}
+	if client.in.Branch != "feature/login" {
+		t.Fatalf("branch = %q, want feature/login for file resolve", client.in.Branch)
+	}
+}
+
 func TestCrowdinAutoTranslate(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -281,7 +327,7 @@ func TestCrowdinAutoTranslate(t *testing.T) {
 	old := newCrowdinAutoTranslator
 	t.Cleanup(func() { newCrowdinAutoTranslator = old })
 	newCrowdinAutoTranslator = func(crowdinstorage.Config) (crowdinAutoTranslator, error) {
-		return fakeCrowdinAutoTranslator{}, nil
+		return &fakeCrowdinAutoTranslator{}, nil
 	}
 
 	cmd := newRootCmd("")
@@ -483,8 +529,11 @@ func (f *fakeCrowdinFileOpsClient) DeleteProjectFile(_ context.Context, _, branc
 	return nil
 }
 
-type fakeCrowdinAutoTranslator struct{}
+type fakeCrowdinAutoTranslator struct {
+	in crowdinstorage.PreTranslationInput
+}
 
-func (fakeCrowdinAutoTranslator) ApplyPreTranslationAndWait(context.Context, crowdinstorage.PreTranslationInput) (crowdinstorage.PreTranslationResult, error) {
+func (f *fakeCrowdinAutoTranslator) ApplyPreTranslationAndWait(_ context.Context, in crowdinstorage.PreTranslationInput) (crowdinstorage.PreTranslationResult, error) {
+	f.in = in
 	return crowdinstorage.PreTranslationResult{Identifier: "pre-1", Status: "finished", Progress: 100}, nil
 }

--- a/apps/cli/cmd/crowdin_wave_test.go
+++ b/apps/cli/cmd/crowdin_wave_test.go
@@ -148,6 +148,128 @@ func TestCrowdinFileAndLanguageList(t *testing.T) {
 	}
 }
 
+func TestCrowdinStringList(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMinimalCrowdinConfig(t, dir)
+
+	old := newCrowdinSourceStringLister
+	t.Cleanup(func() { newCrowdinSourceStringLister = old })
+	newCrowdinSourceStringLister = func(crowdinstorage.Config) (crowdinSourceStringLister, error) {
+		return fakeCrowdinSourceStringLister{}, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "string", "list", "--file", "messages.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("string list: %v", err)
+	}
+	if got, want := out.String(), "id=9 identifier=hello text=Hello context=home\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestCrowdinFileUploadDownloadDelete(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMinimalCrowdinConfig(t, dir)
+	inputPath := filepath.Join(dir, "local.json")
+	if err := os.WriteFile(inputPath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	old := newCrowdinFileOpsClient
+	t.Cleanup(func() { newCrowdinFileOpsClient = old })
+	client := &fakeCrowdinFileOpsClient{content: []byte(`{"hello":"Hello"}`)}
+	newCrowdinFileOpsClient = func(crowdinstorage.Config) (crowdinFileOpsClient, error) {
+		return client, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "file", "upload", inputPath, "--dest", "/messages.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("file upload: %v", err)
+	}
+	if !strings.Contains(out.String(), "file_id=17") {
+		t.Fatalf("upload output = %q", out.String())
+	}
+
+	dest := filepath.Join(dir, "out.json")
+	cmd = newRootCmd("")
+	out = bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "file", "download", "messages.json", "--dest", dest})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("file download: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(got) != `{"hello":"Hello"}` {
+		t.Fatalf("downloaded = %q", got)
+	}
+
+	cmd = newRootCmd("")
+	out = bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "file", "delete", "messages.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("file delete: %v", err)
+	}
+	if got, want := out.String(), "deleted path=messages.json\n"; got != want {
+		t.Fatalf("delete output = %q, want %q", got, want)
+	}
+}
+
+func TestCrowdinAutoTranslate(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMinimalCrowdinConfig(t, dir)
+
+	old := newCrowdinAutoTranslator
+	t.Cleanup(func() { newCrowdinAutoTranslator = old })
+	newCrowdinAutoTranslator = func(crowdinstorage.Config) (crowdinAutoTranslator, error) {
+		return fakeCrowdinAutoTranslator{}, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "auto-translate", "--language", "fr", "--file", "messages.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auto-translate: %v", err)
+	}
+	if !strings.Contains(out.String(), "status=finished") {
+		t.Fatalf("output = %q", out.String())
+	}
+
+	cmd = newRootCmd("")
+	out = bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "pre-translate", "--language", "fr", "--branch", "feature/login"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("pre-translate alias: %v", err)
+	}
+}
+
+func TestCrowdinAutoTranslateRejectsMT(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMinimalCrowdinConfig(t, dir)
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"crowdin", "auto-translate", "--language", "fr", "--file", "messages.json", "--method", "mt"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "tm only") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestCrowdinGlossaryAndTMUpload(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -248,4 +370,38 @@ func (fakeCrowdinImporter) ImportTranslationMemoryFile(context.Context, int, str
 
 func (fakeCrowdinImporter) ImportGlossaryFile(context.Context, int, string) (crowdinstorage.ImportResult, error) {
 	return crowdinstorage.ImportResult{Identifier: "g-1", Status: "finished", Progress: 100}, nil
+}
+
+type fakeCrowdinSourceStringLister struct{}
+
+func (fakeCrowdinSourceStringLister) ListProjectSourceStrings(_ context.Context, _ crowdinstorage.ListSourceStringsInput) ([]crowdinstorage.SourceStringRow, error) {
+	return []crowdinstorage.SourceStringRow{{
+		ID:         9,
+		Identifier: "hello",
+		Text:       "Hello",
+		Context:    "home",
+		FileID:     17,
+	}}, nil
+}
+
+type fakeCrowdinFileOpsClient struct {
+	content []byte
+}
+
+func (f *fakeCrowdinFileOpsClient) UploadProjectFile(context.Context, string, string, string, string) (int, error) {
+	return 17, nil
+}
+
+func (f *fakeCrowdinFileOpsClient) DownloadProjectFile(context.Context, string, string, string, string) ([]byte, error) {
+	return f.content, nil
+}
+
+func (f *fakeCrowdinFileOpsClient) DeleteProjectFile(context.Context, string, string, string) error {
+	return nil
+}
+
+type fakeCrowdinAutoTranslator struct{}
+
+func (fakeCrowdinAutoTranslator) ApplyPreTranslationAndWait(context.Context, crowdinstorage.PreTranslationInput) (crowdinstorage.PreTranslationResult, error) {
+	return crowdinstorage.PreTranslationResult{Identifier: "pre-1", Status: "finished", Progress: 100}, nil
 }

--- a/docs/cli/commands/crowdin.mdx
+++ b/docs/cli/commands/crowdin.mdx
@@ -45,7 +45,7 @@ Use them when you want Crowdin-compatible file mode:
 - source download into `files[].source` or a single output file
 - translation download/export back into your repo
 - optional source download alongside translations with `download translations --include-sources`
-- branch-scoped upload and download with root `branch:` or `--branch`
+- branch-scoped commands with root `branch:` or `--branch` (the flag overrides YAML for that command)
 - translation and approval progress with `status`
 - branch list/add, file list, language list, and configured source/translation listing
 - path-based `file upload` / `file download` / `file delete` (distinct from batch `crowdin.yml` upload/download)

--- a/docs/cli/commands/crowdin.mdx
+++ b/docs/cli/commands/crowdin.mdx
@@ -14,7 +14,12 @@ hyperlocalise crowdin status [--config <path>] [--identity <path>] [--branch <na
 hyperlocalise crowdin branch list [--config <path>] [--identity <path>] [--output text|json]
 hyperlocalise crowdin branch add --name <name> [--config <path>] [--identity <path>]
 hyperlocalise crowdin file list [--config <path>] [--identity <path>] [--branch <name>] [--output text|json]
+hyperlocalise crowdin file upload <file> --dest <crowdin-path> [--config <path>] [--identity <path>] [--branch <name>]
+hyperlocalise crowdin file download <crowdin-path> [--dest <path>] [--language <id>] [--config <path>] [--identity <path>] [--branch <name>] [--force]
+hyperlocalise crowdin file delete <crowdin-path> [--config <path>] [--identity <path>] [--branch <name>]
+hyperlocalise crowdin string list [--config <path>] [--identity <path>] [--branch <name>] [--file <crowdin-path>] [--filter <text>] [--output text|json]
 hyperlocalise crowdin language list [--config <path>] [--identity <path>] [--all] [--output text|json]
+hyperlocalise crowdin auto-translate --language <id> [--file <crowdin-path> | --branch <name> | --directory-id <id>] [--method tm] [--config <path>] [--identity <path>]
 hyperlocalise crowdin upload sources [--config <path>] [--identity <path>] [--branch <name>]
 hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
 hyperlocalise crowdin download sources [--config <path>] [--identity <path>] [--branch <name>] [--file-id <id>] [--source <path>] [--output <path>] [--force]
@@ -43,6 +48,9 @@ Use them when you want Crowdin-compatible file mode:
 - branch-scoped upload and download with root `branch:` or `--branch`
 - translation and approval progress with `status`
 - branch list/add, file list, language list, and configured source/translation listing
+- path-based `file upload` / `file download` / `file delete` (distinct from batch `crowdin.yml` upload/download)
+- source string listing with `string list`
+- TM auto-translate (`auto-translate`, alias `pre-translate`)
 - glossary and translation-memory list, download, and upload
 - strict YAML decoding: only keys Crowdin documents and `hl` recognizes may appear in `crowdin.yml` (unknown keys still error)
 
@@ -84,7 +92,9 @@ This v1 file-mode implementation does not support:
 - screenshot, comment, task, distribution, or app commands
 - glossary CSV/TBX scheme mapping (upload accepts Crowdin-native TBX only)
 - TM CSV import (upload accepts Crowdin-native TMX only)
-- low-level `file upload` / `file download` / `file delete`, `string list`, or `pre-translate`
+- CroQL, labels, and directory filters on `string list`
+- MT/AI auto-translate (`--method mt` / `ai`)
+- niche `file upload` flags (`--xliff`, parser version, cleanup mode)
 - permissive "warn and ignore" compatibility mode
 - interactive Crowdin project bootstrap
 
@@ -200,3 +210,27 @@ hyperlocalise crowdin tm upload --tm-id 4 --input memory.tmx
 `glossary upload` accepts TBX only. The CSV from `glossary download` is a Hyperlocalise export format and is not import-compatible.
 
 `tm upload` accepts TMX only. The CSV from `tm download` is not import-compatible. Re-importing TMX produced by `tm download --format tmx` is best-effort.
+
+List source strings (not translated values):
+
+```bash
+hyperlocalise crowdin string list --file messages.json --filter hello
+```
+
+Upload, download, or delete one file by Crowdin project path. Paths are branch-relative; do not prefix them with the branch name.
+
+```bash
+hyperlocalise crowdin file upload ./src/messages.json --dest /messages.json
+hyperlocalise crowdin file download /messages.json --dest /tmp/messages.json --force
+hyperlocalise crowdin file download /messages.json --language fr --dest /tmp/messages.fr.json --force
+hyperlocalise crowdin file delete /messages.json --branch feature/login
+```
+
+`file download` without `--language` downloads the **source** file. Pass `--language` to build and download that file's translations. For a numeric file ID, keep using `download sources --file-id`.
+
+Pre-translate with translation memory (v1 is TM only). `pre-translate` is an alias of `auto-translate`. Provide exactly one of `--file`, `--branch`, or `--directory-id`. `--branch` may accompany `--file` to resolve a branch-relative path.
+
+```bash
+hyperlocalise crowdin auto-translate --language fr --file messages.json
+hyperlocalise crowdin pre-translate --language fr --branch feature/login
+```

--- a/docs/cli/commands/crowdin.mdx
+++ b/docs/cli/commands/crowdin.mdx
@@ -228,7 +228,7 @@ hyperlocalise crowdin file delete /messages.json --branch feature/login
 
 `file download` without `--language` downloads the **source** file. Pass `--language` to build and download that file's translations. For a numeric file ID, keep using `download sources --file-id`.
 
-Pre-translate with translation memory (v1 is TM only). `pre-translate` is an alias of `auto-translate`. Provide exactly one of `--file`, `--branch`, or `--directory-id`. `--branch` may accompany `--file` to resolve a branch-relative path.
+Pre-translate with translation memory (v1 is TM only). `pre-translate` is an alias of `auto-translate`. Provide exactly one of `--file`, `--branch`, or `--directory-id`. `--branch` may accompany `--file` to resolve a branch-relative path. Root `branch:` in `crowdin.yml` also scopes `--file` and branch-only runs; `--directory-id` ignores that config value unless you also pass `--branch`.
 
 ```bash
 hyperlocalise crowdin auto-translate --language fr --file messages.json

--- a/docs/cli/storage/crowdin.mdx
+++ b/docs/cli/storage/crowdin.mdx
@@ -132,7 +132,7 @@ When Crowdin includes source-language fallback values in that export, Hyperlocal
 
 Use `download sources` when you only need source files. It avoids translation export work and is the preferred command for source-only automation.
 
-Use root `branch:` in `crowdin.yml` or pass `--branch <name>` to upload and download files from a Crowdin branch. The flag overrides the config value for that command.
+Use root `branch:` in `crowdin.yml` or pass `--branch <name>` to scope file, string, status, and auto-translate commands to a Crowdin branch. The flag overrides the config value for that command. Path-based `file upload` / `file download` / `file delete` follow the same rule.
 
 Validation fails closed on unsupported Crowdin fields or commands.
 

--- a/docs/cli/storage/crowdin.mdx
+++ b/docs/cli/storage/crowdin.mdx
@@ -101,6 +101,10 @@ hyperlocalise crowdin config translations --language fr
 hyperlocalise crowdin status --language es
 hyperlocalise crowdin branch list
 hyperlocalise crowdin file list
+hyperlocalise crowdin file upload ./src/messages.json --dest /messages.json
+hyperlocalise crowdin file download /messages.json --dest /tmp/messages.json --force
+hyperlocalise crowdin string list --file messages.json
+hyperlocalise crowdin auto-translate --language fr --file messages.json
 hyperlocalise crowdin language list
 hyperlocalise crowdin upload sources
 hyperlocalise crowdin upload translations --language fr
@@ -114,6 +118,12 @@ hyperlocalise crowdin tm upload --tm-id 4 --input memory.tmx
 ```
 
 `download sources` writes Crowdin source files into `files[].source` paths from `crowdin.yml`, or into a single `--output` file when you pass `--file-id`.
+
+Low-level `file upload` / `file download` / `file delete` operate on one Crowdin project path. They do not expand `files[]` globs. Use them for a single file; use `upload sources` / `download translations` for the configured batch workflow.
+
+`string list` lists **source strings** from Crowdin (`SourceStrings.List`), not translated entries.
+
+`auto-translate` (alias `pre-translate`) runs TM pre-translation and waits until Crowdin reports `finished`. Machine translation and AI methods are not supported in this v1.
 
 `download translations --merge-approved` merges approved JSON object keys into existing local translation files and preserves local keys omitted from Crowdin's approved export.
 When Crowdin includes source-language fallback values in that export, Hyperlocalise skips values that still match the source JSON so previously translated local strings are preserved.

--- a/internal/i18n/storage/crowdin/adapter.go
+++ b/internal/i18n/storage/crowdin/adapter.go
@@ -23,6 +23,7 @@ type Config struct {
 	APIToken        string   `json:"-"`
 	APITokenEnv     string   `json:"apiTokenEnv,omitempty"`
 	APIBaseURL      string   `json:"apiBaseURL,omitempty"`
+	Branch          string   `json:"branch,omitempty"`
 	SourceLanguage  string   `json:"sourceLanguage,omitempty"`
 	TargetLanguages []string `json:"targetLanguages,omitempty"`
 	TimeoutSeconds  int      `json:"timeoutSeconds,omitempty"`

--- a/internal/i18n/storage/crowdin/discovery.go
+++ b/internal/i18n/storage/crowdin/discovery.go
@@ -76,6 +76,9 @@ func (c *HTTPClient) ListProjectFiles(ctx context.Context, projectID, branch str
 		if directory == nil || directory.ID <= 0 {
 			continue
 		}
+		if directory.BranchID != nil && *directory.BranchID > 0 {
+			continue
+		}
 		nested, err := c.listProjectFilesPaged(ctx, projectInt, &model.FileListOptions{
 			DirectoryID: directory.ID,
 			Recursion:   true,

--- a/internal/i18n/storage/crowdin/discovery.go
+++ b/internal/i18n/storage/crowdin/discovery.go
@@ -10,9 +10,10 @@ import (
 
 // ProjectFile is a source file in a Crowdin project.
 type ProjectFile struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
-	Path string `json:"path"`
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Path     string `json:"path"`
+	branchID int
 }
 
 // ProjectLanguage is a language available to the project or account.
@@ -64,6 +65,7 @@ func (c *HTTPClient) ListProjectFiles(ctx context.Context, projectID, branch str
 	if err != nil {
 		return nil, err
 	}
+	out = filterDefaultBranchFiles(out)
 	seen := make(map[int]struct{}, len(out))
 	for _, file := range out {
 		seen[file.ID] = struct{}{}
@@ -86,7 +88,7 @@ func (c *HTTPClient) ListProjectFiles(ctx context.Context, projectID, branch str
 		if err != nil {
 			return nil, err
 		}
-		for _, file := range nested {
+		for _, file := range filterDefaultBranchFiles(nested) {
 			if _, ok := seen[file.ID]; ok {
 				continue
 			}
@@ -117,7 +119,7 @@ func (c *HTTPClient) listProjectFilesPaged(ctx context.Context, projectID int, o
 			if file == nil {
 				continue
 			}
-			out = append(out, ProjectFile{ID: file.ID, Name: file.Name, Path: file.Path})
+			out = append(out, projectFileFromModel(file))
 		}
 		if len(files) < pageLimit {
 			break
@@ -125,6 +127,25 @@ func (c *HTTPClient) listProjectFilesPaged(ctx context.Context, projectID int, o
 		offset += pageLimit
 	}
 	return out, nil
+}
+
+func projectFileFromModel(file *model.File) ProjectFile {
+	out := ProjectFile{ID: file.ID, Name: file.Name, Path: file.Path}
+	if file.BranchID != nil {
+		out.branchID = *file.BranchID
+	}
+	return out
+}
+
+func filterDefaultBranchFiles(files []ProjectFile) []ProjectFile {
+	out := make([]ProjectFile, 0, len(files))
+	for _, file := range files {
+		if file.branchID > 0 {
+			continue
+		}
+		out = append(out, file)
+	}
+	return out
 }
 
 func (c *HTTPClient) listProjectDirectoriesPaged(ctx context.Context, projectID int, opts *model.DirectoryListOptions) ([]*model.Directory, error) {

--- a/internal/i18n/storage/crowdin/discovery_test.go
+++ b/internal/i18n/storage/crowdin/discovery_test.go
@@ -80,6 +80,43 @@ func TestListProjectFilesIncludesNestedDirectories(t *testing.T) {
 	}
 }
 
+func TestListProjectFilesSkipsBranchDirectories(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.RawQuery {
+		case "limit=500":
+			writeJSON(t, w, map[string]any{"data": []any{}})
+		case "directoryId=9&limit=500&recursion=true":
+			writeJSON(t, w, map[string]any{
+				"data": []any{
+					map[string]any{"data": map[string]any{"id": 18, "name": "nested.json", "path": "/src/nested.json"}},
+				},
+			})
+		default:
+			t.Fatalf("unexpected files query %q", r.URL.RawQuery)
+		}
+	})
+	mux.HandleFunc("/api/v2/projects/123/directories", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{"id": 9, "name": "src", "path": "/src"}},
+				map[string]any{"data": map[string]any{"id": 11, "name": "feature", "path": "/feature", "branchId": 42}},
+			},
+		})
+	})
+
+	got, err := client.ListProjectFiles(context.Background(), "123", "")
+	if err != nil {
+		t.Fatalf("list files: %v", err)
+	}
+	want := []ProjectFile{{ID: 18, Name: "nested.json", Path: "/src/nested.json"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("files = %#v, want %#v", got, want)
+	}
+}
+
 func TestListProjectFilesByBranch(t *testing.T) {
 	client, mux, teardown := newCrowdinHTTPClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/crowdin/discovery_test.go
+++ b/internal/i18n/storage/crowdin/discovery_test.go
@@ -117,6 +117,35 @@ func TestListProjectFilesSkipsBranchDirectories(t *testing.T) {
 	}
 }
 
+func TestListProjectFilesSkipsBranchRootFiles(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "limit=500" {
+			t.Fatalf("unexpected files query %q", r.URL.RawQuery)
+		}
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{"id": 17, "name": "messages.json", "path": "/messages.json"}},
+				map[string]any{"data": map[string]any{"id": 18, "name": "branch.json", "path": "/branch.json", "branchId": 42}},
+			},
+		})
+	})
+	mux.HandleFunc("/api/v2/projects/123/directories", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{"data": []any{}})
+	})
+
+	got, err := client.ListProjectFiles(context.Background(), "123", "")
+	if err != nil {
+		t.Fatalf("list files: %v", err)
+	}
+	want := []ProjectFile{{ID: 17, Name: "messages.json", Path: "/messages.json"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("files = %#v, want %#v", got, want)
+	}
+}
+
 func TestListProjectFilesByBranch(t *testing.T) {
 	client, mux, teardown := newCrowdinHTTPClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/crowdin/fileconfig.go
+++ b/internal/i18n/storage/crowdin/fileconfig.go
@@ -166,6 +166,7 @@ func LoadClientConfig(path, identityPath string) (Config, string, error) {
 		ProjectID:  projectID,
 		APIToken:   apiToken,
 		APIBaseURL: baseURL,
+		Branch:     strings.TrimSpace(projectCfg.Branch),
 	}, resolvedPath, nil
 }
 

--- a/internal/i18n/storage/crowdin/fileconfig_test.go
+++ b/internal/i18n/storage/crowdin/fileconfig_test.go
@@ -72,6 +72,31 @@ base_url: https://api.crowdin.test
 	if cfg.APIBaseURL != "https://api.crowdin.test" {
 		t.Fatalf("api base url = %q, want https://api.crowdin.test", cfg.APIBaseURL)
 	}
+	if cfg.Branch != "" {
+		t.Fatalf("branch = %q, want empty", cfg.Branch)
+	}
+}
+
+func TestLoadClientConfigReadsYAMLBranch(t *testing.T) {
+	t.Setenv(defaultProjectIDEnvName, "123")
+	t.Setenv(defaultAPITokenEnvName, "secret")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "crowdin.yml")
+	if err := os.WriteFile(configPath, []byte(`
+branch: feature/login
+base_url: https://api.crowdin.test
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := LoadClientConfig(configPath, "")
+	if err != nil {
+		t.Fatalf("load client config: %v", err)
+	}
+	if cfg.Branch != "feature/login" {
+		t.Fatalf("branch = %q, want feature/login", cfg.Branch)
+	}
 }
 
 func TestLoadFileWorkflowConfigRejectsUnsupportedPlaceholder(t *testing.T) {

--- a/internal/i18n/storage/crowdin/fileops.go
+++ b/internal/i18n/storage/crowdin/fileops.go
@@ -23,19 +23,30 @@ func (c *HTTPClient) ResolveProjectFile(ctx context.Context, projectID, branch, 
 	if err != nil {
 		return ProjectFile{}, err
 	}
-	matches := make([]ProjectFile, 0)
+	pathMatches := make([]ProjectFile, 0)
+	nameMatches := make([]ProjectFile, 0)
 	for _, file := range files {
-		if normalizeCrowdinPath(file.Path) == want || normalizeCrowdinPath(file.Name) == want {
-			matches = append(matches, file)
+		if normalizeCrowdinPath(file.Path) == want {
+			pathMatches = append(pathMatches, file)
+			continue
+		}
+		if normalizeCrowdinPath(file.Name) == want {
+			nameMatches = append(nameMatches, file)
 		}
 	}
-	if len(matches) == 0 {
-		return ProjectFile{}, fmt.Errorf("crowdin file %q not found", crowdinPath)
+	if len(pathMatches) == 1 {
+		return pathMatches[0], nil
 	}
-	if len(matches) > 1 {
+	if len(pathMatches) > 1 {
 		return ProjectFile{}, fmt.Errorf("crowdin file %q is ambiguous", crowdinPath)
 	}
-	return matches[0], nil
+	if len(nameMatches) == 1 {
+		return nameMatches[0], nil
+	}
+	if len(nameMatches) > 1 {
+		return ProjectFile{}, fmt.Errorf("crowdin file %q is ambiguous", crowdinPath)
+	}
+	return ProjectFile{}, fmt.Errorf("crowdin file %q not found", crowdinPath)
 }
 
 // UploadProjectFile adds or updates one source file at a Crowdin destination path.
@@ -81,7 +92,7 @@ func (c *HTTPClient) DownloadProjectFile(ctx context.Context, projectID, branch,
 	if err != nil {
 		return nil, err
 	}
-	if len(locales) == 0 {
+	if len(locales) == 0 || strings.TrimSpace(locales[0].LanguageID) == "" {
 		return nil, fmt.Errorf("crowdin file download: language %q not found", language)
 	}
 	payload, err := c.DownloadTranslationFile(ctx, projectID, file.ID, locales[0].LanguageID, storage.FileExportOptions{})

--- a/internal/i18n/storage/crowdin/fileops.go
+++ b/internal/i18n/storage/crowdin/fileops.go
@@ -1,0 +1,134 @@
+package crowdin
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
+)
+
+// ResolveProjectFile finds a Crowdin source file by branch-relative path.
+func (c *HTTPClient) ResolveProjectFile(ctx context.Context, projectID, branch, crowdinPath string) (ProjectFile, error) {
+	if c == nil || c.client == nil {
+		return ProjectFile{}, fmt.Errorf("crowdin file: client is nil")
+	}
+	want := normalizeCrowdinPath(crowdinPath)
+	if want == "" {
+		return ProjectFile{}, fmt.Errorf("crowdin file: path is required")
+	}
+	files, err := c.ListProjectFiles(ctx, projectID, branch)
+	if err != nil {
+		return ProjectFile{}, err
+	}
+	matches := make([]ProjectFile, 0)
+	for _, file := range files {
+		if normalizeCrowdinPath(file.Path) == want || normalizeCrowdinPath(file.Name) == want {
+			matches = append(matches, file)
+		}
+	}
+	if len(matches) == 0 {
+		return ProjectFile{}, fmt.Errorf("crowdin file %q not found", crowdinPath)
+	}
+	if len(matches) > 1 {
+		return ProjectFile{}, fmt.Errorf("crowdin file %q is ambiguous", crowdinPath)
+	}
+	return matches[0], nil
+}
+
+// UploadProjectFile adds or updates one source file at a Crowdin destination path.
+func (c *HTTPClient) UploadProjectFile(ctx context.Context, projectID, branch, dest, localPath string) (int, error) {
+	if c == nil || c.client == nil {
+		return 0, fmt.Errorf("crowdin file upload: client is nil")
+	}
+	if strings.TrimSpace(localPath) == "" {
+		return 0, fmt.Errorf("crowdin file upload: input path is required")
+	}
+	dir, name, err := splitCrowdinDest(dest)
+	if err != nil {
+		return 0, fmt.Errorf("crowdin file upload: %w", err)
+	}
+	branchID, err := c.ResolveBranch(ctx, projectID, branch)
+	if err != nil {
+		return 0, err
+	}
+	directoryID := 0
+	if dir != "" {
+		directoryID, err = c.EnsureDirectory(ctx, projectID, branchID, dir)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return c.UpsertSourceFile(ctx, projectID, branchID, directoryID, name, localPath, storage.FileGroupSpec{})
+}
+
+// DownloadProjectFile downloads a source file, or a translation file when language is set.
+func (c *HTTPClient) DownloadProjectFile(ctx context.Context, projectID, branch, crowdinPath, language string) ([]byte, error) {
+	if c == nil || c.client == nil {
+		return nil, fmt.Errorf("crowdin file download: client is nil")
+	}
+	file, err := c.ResolveProjectFile(ctx, projectID, branch, crowdinPath)
+	if err != nil {
+		return nil, err
+	}
+	language = strings.TrimSpace(language)
+	if language == "" {
+		return c.DownloadSourceFile(ctx, projectID, file.ID)
+	}
+	locales, err := c.ResolveLocales(ctx, projectID, []string{language})
+	if err != nil {
+		return nil, err
+	}
+	if len(locales) == 0 {
+		return nil, fmt.Errorf("crowdin file download: language %q not found", language)
+	}
+	payload, err := c.DownloadTranslationFile(ctx, projectID, file.ID, locales[0].LanguageID, storage.FileExportOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		return nil, fmt.Errorf("crowdin file download: empty translation for %q language %s", crowdinPath, locales[0].LanguageID)
+	}
+	return payload, nil
+}
+
+// DeleteProjectFile deletes a source file identified by Crowdin path.
+func (c *HTTPClient) DeleteProjectFile(ctx context.Context, projectID, branch, crowdinPath string) error {
+	if c == nil || c.client == nil {
+		return fmt.Errorf("crowdin file delete: client is nil")
+	}
+	file, err := c.ResolveProjectFile(ctx, projectID, branch, crowdinPath)
+	if err != nil {
+		return err
+	}
+	projectInt, err := parseProjectID(projectID)
+	if err != nil {
+		return fmt.Errorf("crowdin file delete: %w", err)
+	}
+	if _, err := c.client.SourceFiles.DeleteFile(ctx, projectInt, file.ID); err != nil {
+		return fmt.Errorf("delete crowdin file %d: %w", file.ID, err)
+	}
+	return nil
+}
+
+func normalizeCrowdinPath(value string) string {
+	return strings.Trim(strings.TrimSpace(filepath.ToSlash(value)), "/")
+}
+
+func splitCrowdinDest(dest string) (dir, name string, err error) {
+	normalized := normalizeCrowdinPath(dest)
+	if normalized == "" {
+		return "", "", fmt.Errorf("destination path is required")
+	}
+	name = path.Base(normalized)
+	if name == "" || name == "." || name == "/" {
+		return "", "", fmt.Errorf("destination path %q has no file name", dest)
+	}
+	dir = path.Dir(normalized)
+	if dir == "." {
+		dir = ""
+	}
+	return dir, name, nil
+}

--- a/internal/i18n/storage/crowdin/fileops_test.go
+++ b/internal/i18n/storage/crowdin/fileops_test.go
@@ -342,6 +342,20 @@ func TestApplyPreTranslationAndWaitFailed(t *testing.T) {
 	}
 }
 
+func TestApplyPreTranslationRejectsBlankLanguages(t *testing.T) {
+	client, _, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	_, err := client.ApplyPreTranslationAndWait(context.Background(), PreTranslationInput{
+		ProjectID: "123",
+		Languages: []string{" ", ""},
+		FilePath:  "messages.json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "at least one language is required") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestApplyPreTranslationRequiresScope(t *testing.T) {
 	client, _, teardown := newCrowdinHTTPClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/crowdin/fileops_test.go
+++ b/internal/i18n/storage/crowdin/fileops_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -89,6 +90,65 @@ func TestResolveProjectFileMatchesNormalizedPath(t *testing.T) {
 	}
 	if got.ID != 17 {
 		t.Fatalf("file = %#v", got)
+	}
+}
+
+func TestResolveProjectFilePrefersExactPathOverSharedName(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	stubProjectFiles(t, mux, []ProjectFile{
+		{ID: 17, Name: "messages.json", Path: "/messages.json"},
+		{ID: 18, Name: "messages.json", Path: "/src/messages.json"},
+	})
+
+	got, err := client.ResolveProjectFile(context.Background(), "123", "", "messages.json")
+	if err != nil {
+		t.Fatalf("resolve file: %v", err)
+	}
+	if got.ID != 17 {
+		t.Fatalf("file = %#v, want root messages.json", got)
+	}
+
+	got, err = client.ResolveProjectFile(context.Background(), "123", "", "/src/messages.json")
+	if err != nil {
+		t.Fatalf("resolve nested file: %v", err)
+	}
+	if got.ID != 18 {
+		t.Fatalf("file = %#v, want nested messages.json", got)
+	}
+}
+
+func TestResolveProjectFileNameFallbackIsUnique(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	stubProjectFiles(t, mux, []ProjectFile{
+		{ID: 18, Name: "messages.json", Path: "/src/messages.json"},
+		{ID: 19, Name: "other.json", Path: "/src/other.json"},
+	})
+
+	got, err := client.ResolveProjectFile(context.Background(), "123", "", "messages.json")
+	if err != nil {
+		t.Fatalf("resolve file: %v", err)
+	}
+	if got.ID != 18 {
+		t.Fatalf("file = %#v", got)
+	}
+}
+
+func TestResolveProjectFileAmbiguousName(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	stubProjectFiles(t, mux, []ProjectFile{
+		{ID: 17, Name: "messages.json", Path: "/en/messages.json"},
+		{ID: 18, Name: "messages.json", Path: "/fr/messages.json"},
+	})
+
+	_, err := client.ResolveProjectFile(context.Background(), "123", "", "messages.json")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/i18n/storage/crowdin/fileops_test.go
+++ b/internal/i18n/storage/crowdin/fileops_test.go
@@ -1,0 +1,339 @@
+package crowdin
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestListProjectSourceStrings(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/strings", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/strings?limit=500")
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{
+					"id":         9,
+					"identifier": "hello",
+					"text":       "Hello",
+					"context":    "home",
+					"fileId":     17,
+					"createdAt":  "2026-01-01T00:00:00Z",
+				}},
+			},
+		})
+	})
+
+	got, err := client.ListProjectSourceStrings(context.Background(), ListSourceStringsInput{ProjectID: "123"})
+	if err != nil {
+		t.Fatalf("list source strings: %v", err)
+	}
+	want := []SourceStringRow{{
+		ID:         9,
+		Identifier: "hello",
+		Text:       "Hello",
+		Context:    "home",
+		FileID:     17,
+		CreatedAt:  "2026-01-01T00:00:00Z",
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("strings = %#v, want %#v", got, want)
+	}
+}
+
+func TestListProjectSourceStringsFiltersByFilePath(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	stubProjectFiles(t, mux, []ProjectFile{{ID: 17, Name: "messages.json", Path: "/messages.json"}})
+	mux.HandleFunc("/api/v2/projects/123/strings", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/strings?fileId=17&filter=hello&limit=500")
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{
+					"id":         9,
+					"identifier": "hello",
+					"text":       "Hello",
+					"fileId":     17,
+				}},
+			},
+		})
+	})
+
+	got, err := client.ListProjectSourceStrings(context.Background(), ListSourceStringsInput{
+		ProjectID: "123",
+		FilePath:  "messages.json",
+		Filter:    "hello",
+	})
+	if err != nil {
+		t.Fatalf("list source strings: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != 9 {
+		t.Fatalf("strings = %#v", got)
+	}
+}
+
+func TestResolveProjectFileMatchesNormalizedPath(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	stubProjectFiles(t, mux, []ProjectFile{{ID: 17, Name: "messages.json", Path: "/src/messages.json"}})
+
+	got, err := client.ResolveProjectFile(context.Background(), "123", "", "src/messages.json")
+	if err != nil {
+		t.Fatalf("resolve file: %v", err)
+	}
+	if got.ID != 17 {
+		t.Fatalf("file = %#v", got)
+	}
+}
+
+func TestUploadProjectFileAddsSource(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	localPath := writeHTTPClientFixture(t, "messages.json", `{"hello":"Hello"}`)
+	mux.HandleFunc("/api/v2/storages", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("storage method = %s", r.Method)
+		}
+		writeJSON(t, w, map[string]any{"data": map[string]any{"id": 61, "fileName": "messages.json"}})
+	})
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.RequestURI {
+		case http.MethodGet + " /api/v2/projects/123/files?filter=messages.json&limit=500":
+			writeJSON(t, w, map[string]any{"data": []any{}})
+		case http.MethodPost + " /api/v2/projects/123/files":
+			assertJSONBody(t, r, map[string]any{
+				"storageId": float64(61),
+				"name":      "messages.json",
+			})
+			writeJSON(t, w, map[string]any{"data": map[string]any{"id": 17, "name": "messages.json"}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.RequestURI)
+		}
+	})
+
+	id, err := client.UploadProjectFile(context.Background(), "123", "", "messages.json", localPath)
+	if err != nil {
+		t.Fatalf("upload file: %v", err)
+	}
+	if id != 17 {
+		t.Fatalf("file id = %d", id)
+	}
+}
+
+func TestDownloadProjectFileByPath(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	stubProjectFiles(t, mux, []ProjectFile{{ID: 17, Name: "messages.json", Path: "/messages.json"}})
+	mux.HandleFunc("/api/v2/projects/123/files/17/download", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/files/17/download")
+		writeJSON(t, w, map[string]any{"data": map[string]any{"url": "https://api.crowdin.com/downloads/source-17.json"}})
+	})
+	mux.HandleFunc("/downloads/source-17.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hello":"Hello"}`))
+	})
+
+	payload, err := client.DownloadProjectFile(context.Background(), "123", "", "/messages.json", "")
+	if err != nil {
+		t.Fatalf("download file: %v", err)
+	}
+	if string(payload) != `{"hello":"Hello"}` {
+		t.Fatalf("payload = %q", payload)
+	}
+}
+
+func TestDeleteProjectFileByPath(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	stubProjectFiles(t, mux, []ProjectFile{{ID: 17, Name: "messages.json", Path: "/messages.json"}})
+	mux.HandleFunc("/api/v2/projects/123/files/17", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodDelete, "/api/v2/projects/123/files/17")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := client.DeleteProjectFile(context.Background(), "123", "", "messages.json"); err != nil {
+		t.Fatalf("delete file: %v", err)
+	}
+}
+
+func TestApplyPreTranslationAndWait(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	oldInterval := importPollInterval
+	importPollInterval = time.Millisecond
+	t.Cleanup(func() { importPollInterval = oldInterval })
+
+	stubProjectFiles(t, mux, []ProjectFile{{ID: 17, Name: "messages.json", Path: "/messages.json"}})
+	stubResolveFrench(t, mux)
+	mux.HandleFunc("/api/v2/projects/123/pre-translations", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/projects/123/pre-translations" {
+			return
+		}
+		assertRequest(t, r, http.MethodPost, "/api/v2/projects/123/pre-translations")
+		assertJSONBody(t, r, map[string]any{
+			"languageIds": []any{"fr"},
+			"fileIds":     []any{float64(17)},
+			"method":      "tm",
+		})
+		writeJSON(t, w, map[string]any{
+			"data": map[string]any{
+				"identifier": "pre-1",
+				"status":     "created",
+				"progress":   0,
+			},
+		})
+	})
+	mux.HandleFunc("/api/v2/projects/123/pre-translations/pre-1", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/pre-translations/pre-1")
+		writeJSON(t, w, map[string]any{
+			"data": map[string]any{
+				"identifier": "pre-1",
+				"status":     "finished",
+				"progress":   100,
+			},
+		})
+	})
+
+	result, err := client.ApplyPreTranslationAndWait(context.Background(), PreTranslationInput{
+		ProjectID: "123",
+		Languages: []string{"fr"},
+		FilePath:  "messages.json",
+	})
+	if err != nil {
+		t.Fatalf("auto-translate: %v", err)
+	}
+	if result.Identifier != "pre-1" || result.Status != "finished" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestApplyPreTranslationAndWaitFailed(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	oldInterval := importPollInterval
+	importPollInterval = time.Millisecond
+	t.Cleanup(func() { importPollInterval = oldInterval })
+
+	mux.HandleFunc("/api/v2/projects/123/branches", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/branches?limit=500&name=feature%2Flogin")
+		writeJSON(t, w, map[string]any{
+			"data": []any{map[string]any{"data": map[string]any{"id": 42, "name": "feature/login"}}},
+		})
+	})
+	stubResolveFrench(t, mux)
+	mux.HandleFunc("/api/v2/projects/123/pre-translations", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"data": map[string]any{"identifier": "pre-2", "status": "created", "progress": 0},
+		})
+	})
+	mux.HandleFunc("/api/v2/projects/123/pre-translations/pre-2", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"data": map[string]any{"identifier": "pre-2", "status": "failed", "progress": 40},
+		})
+	})
+
+	_, err := client.ApplyPreTranslationAndWait(context.Background(), PreTranslationInput{
+		ProjectID: "123",
+		Languages: []string{"fr"},
+		Branch:    "feature/login",
+	})
+	if err == nil || err.Error() != "pre-translation failed" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestApplyPreTranslationRequiresScope(t *testing.T) {
+	client, _, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	_, err := client.ApplyPreTranslationAndWait(context.Background(), PreTranslationInput{
+		ProjectID: "123",
+		Languages: []string{"fr"},
+	})
+	if err == nil {
+		t.Fatal("expected scope error")
+	}
+}
+
+func TestSplitCrowdinDest(t *testing.T) {
+	dir, name, err := splitCrowdinDest("/src/locales/messages.json")
+	if err != nil {
+		t.Fatalf("split dest: %v", err)
+	}
+	if dir != "src/locales" || name != "messages.json" {
+		t.Fatalf("dir=%q name=%q", dir, name)
+	}
+}
+
+func TestDownloadProjectFileTranslationLanguage(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	stubProjectFiles(t, mux, []ProjectFile{{ID: 17, Name: "messages.json", Path: "/messages.json"}})
+	stubResolveFrench(t, mux)
+	mux.HandleFunc("/api/v2/projects/123/translations/builds/files/17", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodPost, "/api/v2/projects/123/translations/builds/files/17")
+		assertJSONBody(t, r, map[string]any{"targetLanguageId": "fr"})
+		writeJSON(t, w, map[string]any{"data": map[string]any{"url": "https://api.crowdin.com/downloads/fr-17.json"}})
+	})
+	mux.HandleFunc("/downloads/fr-17.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hello":"Bonjour"}`))
+	})
+
+	payload, err := client.DownloadProjectFile(context.Background(), "123", "", "messages.json", "fr")
+	if err != nil {
+		t.Fatalf("download translation: %v", err)
+	}
+	if string(payload) != `{"hello":"Bonjour"}` {
+		t.Fatalf("payload = %q", payload)
+	}
+}
+
+func stubProjectFiles(t *testing.T, mux *http.ServeMux, files []ProjectFile) {
+	t.Helper()
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("files method = %s", r.Method)
+		}
+		rows := make([]any, 0, len(files))
+		for _, file := range files {
+			rows = append(rows, map[string]any{
+				"data": map[string]any{"id": file.ID, "name": file.Name, "path": file.Path},
+			})
+		}
+		writeJSON(t, w, map[string]any{"data": rows})
+	})
+	mux.HandleFunc("/api/v2/projects/123/directories", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{"data": []any{}})
+	})
+}
+
+func stubResolveFrench(t *testing.T, mux *http.ServeMux) {
+	t.Helper()
+	mux.HandleFunc("/api/v2/projects/123", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"data": map[string]any{
+				"id":                123,
+				"targetLanguageIds": []string{"fr"},
+				"targetLanguages":   []any{},
+			},
+		})
+	})
+	mux.HandleFunc("/api/v2/languages", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{"id": "fr", "name": "French", "locale": "fr-FR"}},
+			},
+		})
+	})
+}

--- a/internal/i18n/storage/crowdin/fileops_test.go
+++ b/internal/i18n/storage/crowdin/fileops_test.go
@@ -46,6 +46,36 @@ func TestListProjectSourceStrings(t *testing.T) {
 	}
 }
 
+func TestListProjectSourceStringsAcceptsPluralText(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/strings", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/strings?limit=500")
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{
+					"id":         9,
+					"identifier": "videos",
+					"text":       map[string]any{"one": "1 video", "other": "{count} videos"},
+					"fileId":     17,
+				}},
+			},
+		})
+	})
+
+	got, err := client.ListProjectSourceStrings(context.Background(), ListSourceStringsInput{ProjectID: "123"})
+	if err != nil {
+		t.Fatalf("list source strings: %v", err)
+	}
+	if len(got) != 1 || got[0].Identifier != "videos" {
+		t.Fatalf("strings = %#v", got)
+	}
+	if !strings.Contains(got[0].Text, `"one":"1 video"`) && !strings.Contains(got[0].Text, `"one": "1 video"`) {
+		t.Fatalf("plural text = %q", got[0].Text)
+	}
+}
+
 func TestListProjectSourceStringsFiltersByFilePath(t *testing.T) {
 	client, mux, teardown := newCrowdinHTTPClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/crowdin/http_client.go
+++ b/internal/i18n/storage/crowdin/http_client.go
@@ -868,7 +868,7 @@ func (c *HTTPClient) findDirectory(ctx context.Context, projectID, branchID, par
 		return nil, fmt.Errorf("list directories for %q: %w", name, err)
 	}
 	for _, directory := range directories {
-		if directory != nil && directory.Name == name {
+		if directory != nil && directory.Name == name && matchesRequestedBranch(directory.BranchID, branchID) {
 			return directory, nil
 		}
 	}
@@ -887,11 +887,18 @@ func (c *HTTPClient) findFile(ctx context.Context, projectID, branchID, director
 		return nil, fmt.Errorf("list files for %q: %w", name, err)
 	}
 	for _, file := range files {
-		if file != nil && file.Name == name {
+		if file != nil && file.Name == name && matchesRequestedBranch(file.BranchID, branchID) {
 			return file, nil
 		}
 	}
 	return nil, nil
+}
+
+func matchesRequestedBranch(entryBranchID *int, requestedBranchID int) bool {
+	if requestedBranchID > 0 {
+		return true
+	}
+	return entryBranchID == nil || *entryBranchID <= 0
 }
 
 func (c *HTTPClient) downloadURL(ctx context.Context, rawURL string) ([]byte, error) {

--- a/internal/i18n/storage/crowdin/http_client.go
+++ b/internal/i18n/storage/crowdin/http_client.go
@@ -739,7 +739,9 @@ func (c *HTTPClient) UpsertSourceFile(ctx context.Context, projectID string, bra
 	if err != nil {
 		return 0, fmt.Errorf("update source file %q: %w", name, err)
 	}
-	if excludedTargetLanguagesDiffer(file.ExcludeTargetLanguages, group.ExcludedTargetLanguages) {
+	// nil means "leave existing exclusions alone" (content-only upload).
+	// A non-nil slice, including empty, is an explicit file-mode update.
+	if group.ExcludedTargetLanguages != nil && excludedTargetLanguagesDiffer(file.ExcludeTargetLanguages, group.ExcludedTargetLanguages) {
 		file, _, err = c.client.SourceFiles.EditFile(ctx, projectInt, file.ID, []*model.UpdateRequest{{
 			Op:    model.OpReplace,
 			Path:  "/excludedTargetLanguages",

--- a/internal/i18n/storage/crowdin/http_client_test.go
+++ b/internal/i18n/storage/crowdin/http_client_test.go
@@ -483,6 +483,57 @@ func TestHTTPClientFindDirectoryAndFileUseBranchForRootLookups(t *testing.T) {
 	}
 }
 
+func TestHTTPClientFindFileSkipsBranchOwnedWhenUnscoped(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/files?filter=messages.json&limit=500")
+		_, _ = io.WriteString(w, `{"data":[{"data":{"id":18,"projectId":123,"branchId":42,"name":"messages.json"}},{"data":{"id":17,"projectId":123,"name":"messages.json"}}]}`)
+	})
+
+	fileID, err := client.FindFile(context.Background(), "123", 0, 0, "messages.json")
+	if err != nil {
+		t.Fatalf("find file: %v", err)
+	}
+	if fileID != 17 {
+		t.Fatalf("file id = %d, want default-branch 17", fileID)
+	}
+}
+
+func TestHTTPClientFindFileDoesNotReuseOnlyBranchOwnedMatch(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/files?filter=messages.json&limit=500")
+		_, _ = io.WriteString(w, `{"data":[{"data":{"id":18,"projectId":123,"branchId":42,"name":"messages.json"}}]}`)
+	})
+
+	_, err := client.FindFile(context.Background(), "123", 0, 0, "messages.json")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestHTTPClientFindDirectorySkipsBranchOwnedWhenUnscoped(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/directories", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/directories?filter=src&limit=500")
+		_, _ = io.WriteString(w, `{"data":[{"data":{"id":11,"projectId":123,"branchId":42,"name":"src"}},{"data":{"id":8,"projectId":123,"name":"src"}}]}`)
+	})
+
+	dirID, err := client.FindDirectory(context.Background(), "123", 0, "src")
+	if err != nil {
+		t.Fatalf("find directory: %v", err)
+	}
+	if dirID != 8 {
+		t.Fatalf("directory id = %d, want default-branch 8", dirID)
+	}
+}
+
 func TestHTTPClientUpsertSourceFileAddsRootFileToBranch(t *testing.T) {
 	client, mux, teardown := newCrowdinHTTPClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/crowdin/http_client_test.go
+++ b/internal/i18n/storage/crowdin/http_client_test.go
@@ -571,6 +571,41 @@ func TestHTTPClientUpsertSourceFileAddsRootFileToBranch(t *testing.T) {
 	}
 }
 
+func TestHTTPClientUpsertSourceFileSkipsExclusionPatchWhenUnspecified(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	localPath := writeHTTPClientFixture(t, "messages.json", `{"hello":"Hello"}`)
+
+	mux.HandleFunc("/api/v2/storages", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("storage method = %s, want POST", r.Method)
+		}
+		_, _ = io.WriteString(w, `{"data":{"id":61,"fileName":"messages.json"}}`)
+	})
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/files?filter=messages.json&limit=500")
+		_, _ = io.WriteString(w, `{"data":[{"data":{"id":17,"projectId":123,"name":"messages.json","excludedTargetLanguages":["fr"]}}]}`)
+	})
+	mux.HandleFunc("/api/v2/projects/123/files/17", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			t.Fatal("content-only upload should not patch excludedTargetLanguages")
+		}
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		_, _ = io.WriteString(w, `{"data":{"id":17,"projectId":123,"name":"messages.json","excludedTargetLanguages":["fr"]}}`)
+	})
+
+	id, err := client.UpsertSourceFile(context.Background(), "123", 0, 0, "messages.json", localPath, storage.FileGroupSpec{})
+	if err != nil {
+		t.Fatalf("upsert source file: %v", err)
+	}
+	if id != 17 {
+		t.Fatalf("file id = %d, want 17", id)
+	}
+}
+
 func TestHTTPClientDownloadSourceFileUsesDownloadLink(t *testing.T) {
 	client, mux, teardown := newCrowdinHTTPClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/crowdin/import.go
+++ b/internal/i18n/storage/crowdin/import.go
@@ -111,23 +111,36 @@ func (c *HTTPClient) pollImport(
 	progress int,
 	check func(context.Context) (string, string, int, error),
 ) (ImportResult, error) {
-	deadline := time.Now().Add(importPollTimeout)
+	return c.pollAsyncStatus(ctx, identifier, status, progress, importPollTimeout, "import", check)
+}
+
+func (c *HTTPClient) pollAsyncStatus(
+	ctx context.Context,
+	identifier, status string,
+	progress int,
+	timeout time.Duration,
+	op string,
+	check func(context.Context) (string, string, int, error),
+) (ImportResult, error) {
+	deadline := time.Now().Add(timeout)
 	for {
-		if err := importStatusError(status); err != nil {
-			return ImportResult{}, err
+		normalized := strings.ToLower(strings.TrimSpace(status))
+		switch normalized {
+		case "failed", "canceled", "cancelled", "error":
+			return ImportResult{}, fmt.Errorf("%s %s", op, normalized)
 		}
 		if importStatusFinished(status) {
 			return ImportResult{Identifier: identifier, Status: status, Progress: progress}, nil
 		}
 		if time.Now().After(deadline) {
-			return ImportResult{}, fmt.Errorf("import timed out with status %s", status)
+			return ImportResult{}, fmt.Errorf("%s timed out with status %s", op, status)
 		}
 		if err := waitForRetry(ctx, importPollInterval); err != nil {
 			return ImportResult{}, err
 		}
 		nextID, nextStatus, nextProgress, err := check(ctx)
 		if err != nil {
-			return ImportResult{}, fmt.Errorf("check import status: %w", err)
+			return ImportResult{}, fmt.Errorf("check %s status: %w", op, err)
 		}
 		if strings.TrimSpace(nextID) != "" {
 			identifier = nextID

--- a/internal/i18n/storage/crowdin/pretranslate.go
+++ b/internal/i18n/storage/crowdin/pretranslate.go
@@ -1,0 +1,120 @@
+package crowdin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
+)
+
+// PreTranslationInput starts a Crowdin TM pre-translation job.
+type PreTranslationInput struct {
+	ProjectID                     string
+	Languages                     []string
+	FilePath                      string
+	Branch                        string
+	DirectoryID                   int
+	AutoApproveOption             string
+	DuplicateTranslations         *bool
+	SkipApprovedTranslations      *bool
+	TranslateUntranslatedOnly     *bool
+	TranslateWithPerfectMatchOnly *bool
+}
+
+// PreTranslationResult summarizes a finished pre-translation job.
+type PreTranslationResult struct {
+	Identifier string `json:"identifier"`
+	Status     string `json:"status"`
+	Progress   int    `json:"progress"`
+}
+
+// ApplyPreTranslationAndWait starts TM pre-translation and polls until it finishes.
+func (c *HTTPClient) ApplyPreTranslationAndWait(ctx context.Context, in PreTranslationInput) (PreTranslationResult, error) {
+	if c == nil || c.client == nil {
+		return PreTranslationResult{}, fmt.Errorf("crowdin auto-translate: client is nil")
+	}
+	projectID, err := parseProjectID(in.ProjectID)
+	if err != nil {
+		return PreTranslationResult{}, fmt.Errorf("crowdin auto-translate: %w", err)
+	}
+	if len(in.Languages) == 0 {
+		return PreTranslationResult{}, fmt.Errorf("crowdin auto-translate: at least one language is required")
+	}
+
+	locales, err := c.ResolveLocales(ctx, in.ProjectID, in.Languages)
+	if err != nil {
+		return PreTranslationResult{}, err
+	}
+	languageIDs := make([]string, 0, len(locales))
+	for _, locale := range locales {
+		languageIDs = append(languageIDs, locale.LanguageID)
+	}
+
+	req := &model.PreTranslationRequest{
+		LanguageIDs:                   languageIDs,
+		Method:                        "tm",
+		AutoApproveOption:             strings.TrimSpace(in.AutoApproveOption),
+		DuplicateTranslations:         in.DuplicateTranslations,
+		SkipApprovedTranslations:      in.SkipApprovedTranslations,
+		TranslateUntranslatedOnly:     in.TranslateUntranslatedOnly,
+		TranslateWithPerfectMatchOnly: in.TranslateWithPerfectMatchOnly,
+	}
+
+	filePath := strings.TrimSpace(in.FilePath)
+	branch := strings.TrimSpace(in.Branch)
+	scopeCount := 0
+	if filePath != "" {
+		scopeCount++
+	}
+	if in.DirectoryID > 0 {
+		scopeCount++
+	}
+	if branch != "" && filePath == "" {
+		scopeCount++
+	}
+	if scopeCount != 1 {
+		return PreTranslationResult{}, fmt.Errorf("crowdin auto-translate: exactly one of --file, --branch, or --directory-id is required")
+	}
+
+	switch {
+	case filePath != "":
+		file, err := c.ResolveProjectFile(ctx, in.ProjectID, branch, filePath)
+		if err != nil {
+			return PreTranslationResult{}, err
+		}
+		req.FileIDs = []int{file.ID}
+	case in.DirectoryID > 0:
+		req.DirectoryIDs = []int{in.DirectoryID}
+	case branch != "":
+		branchID, err := c.ResolveBranch(ctx, in.ProjectID, branch)
+		if err != nil {
+			return PreTranslationResult{}, err
+		}
+		req.BranchIDs = []int{branchID}
+	default:
+		return PreTranslationResult{}, fmt.Errorf("crowdin auto-translate: exactly one of --file, --branch, or --directory-id is required")
+	}
+
+	started, _, err := c.client.Translations.ApplyPreTranslation(ctx, projectID, req)
+	if err != nil {
+		return PreTranslationResult{}, fmt.Errorf("apply pre-translation: %w", err)
+	}
+	if started == nil || strings.TrimSpace(started.Identifier) == "" {
+		return PreTranslationResult{}, fmt.Errorf("apply pre-translation: empty identifier")
+	}
+	result, err := c.pollAsyncStatus(ctx, started.Identifier, started.Status, started.Progress, importPollTimeout, "pre-translation", func(ctx context.Context) (string, string, int, error) {
+		status, _, err := c.client.Translations.PreTranslationStatus(ctx, projectID, started.Identifier)
+		if err != nil {
+			return "", "", 0, err
+		}
+		if status == nil {
+			return "", "", 0, fmt.Errorf("empty pre-translation status")
+		}
+		return status.Identifier, status.Status, status.Progress, nil
+	})
+	if err != nil {
+		return PreTranslationResult{}, err
+	}
+	return PreTranslationResult(result), nil
+}

--- a/internal/i18n/storage/crowdin/pretranslate.go
+++ b/internal/i18n/storage/crowdin/pretranslate.go
@@ -48,7 +48,12 @@ func (c *HTTPClient) ApplyPreTranslationAndWait(ctx context.Context, in PreTrans
 	}
 	languageIDs := make([]string, 0, len(locales))
 	for _, locale := range locales {
-		languageIDs = append(languageIDs, locale.LanguageID)
+		if id := strings.TrimSpace(locale.LanguageID); id != "" {
+			languageIDs = append(languageIDs, id)
+		}
+	}
+	if len(languageIDs) == 0 {
+		return PreTranslationResult{}, fmt.Errorf("crowdin auto-translate: at least one language is required")
 	}
 
 	req := &model.PreTranslationRequest{

--- a/internal/i18n/storage/crowdin/pretranslate.go
+++ b/internal/i18n/storage/crowdin/pretranslate.go
@@ -38,11 +38,24 @@ func (c *HTTPClient) ApplyPreTranslationAndWait(ctx context.Context, in PreTrans
 	if err != nil {
 		return PreTranslationResult{}, fmt.Errorf("crowdin auto-translate: %w", err)
 	}
-	if len(in.Languages) == 0 {
+	languages := make([]string, 0, len(in.Languages))
+	seen := make(map[string]struct{}, len(in.Languages))
+	for _, language := range in.Languages {
+		trimmed := strings.TrimSpace(language)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		languages = append(languages, trimmed)
+	}
+	if len(languages) == 0 {
 		return PreTranslationResult{}, fmt.Errorf("crowdin auto-translate: at least one language is required")
 	}
 
-	locales, err := c.ResolveLocales(ctx, in.ProjectID, in.Languages)
+	locales, err := c.ResolveLocales(ctx, in.ProjectID, languages)
 	if err != nil {
 		return PreTranslationResult{}, err
 	}

--- a/internal/i18n/storage/crowdin/source_strings.go
+++ b/internal/i18n/storage/crowdin/source_strings.go
@@ -1,0 +1,101 @@
+package crowdin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
+)
+
+// ListSourceStringsInput filters Crowdin source strings for CLI listing.
+type ListSourceStringsInput struct {
+	ProjectID string
+	Branch    string
+	FilePath  string
+	Filter    string
+}
+
+// SourceStringRow is a source string shown by `crowdin string list`.
+type SourceStringRow struct {
+	ID         int    `json:"id"`
+	Identifier string `json:"identifier"`
+	Text       string `json:"text"`
+	Context    string `json:"context,omitempty"`
+	FileID     int    `json:"fileId,omitempty"`
+	BranchID   int    `json:"branchId,omitempty"`
+	CreatedAt  string `json:"createdAt,omitempty"`
+	UpdatedAt  string `json:"updatedAt,omitempty"`
+}
+
+// ListProjectSourceStrings returns source strings, optionally scoped by branch, file path, or filter.
+func (c *HTTPClient) ListProjectSourceStrings(ctx context.Context, in ListSourceStringsInput) ([]SourceStringRow, error) {
+	if c == nil || c.client == nil {
+		return nil, fmt.Errorf("crowdin string list: client is nil")
+	}
+	projectID, err := parseProjectID(in.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("crowdin string list: %w", err)
+	}
+
+	opts := &model.SourceStringsListOptions{
+		Filter: strings.TrimSpace(in.Filter),
+	}
+	filePath := strings.TrimSpace(in.FilePath)
+	if filePath != "" {
+		file, err := c.ResolveProjectFile(ctx, in.ProjectID, in.Branch, filePath)
+		if err != nil {
+			return nil, err
+		}
+		opts.FileID = file.ID
+	} else if strings.TrimSpace(in.Branch) != "" {
+		branchID, err := c.ResolveBranch(ctx, in.ProjectID, in.Branch)
+		if err != nil {
+			return nil, err
+		}
+		opts.BranchID = branchID
+	}
+
+	out := make([]SourceStringRow, 0)
+	offset := 0
+	for {
+		pageOpts := *opts
+		pageOpts.ListOptions = model.ListOptions{
+			Limit:  pageLimit,
+			Offset: offset,
+		}
+		stringsList, _, err := c.client.SourceStrings.List(ctx, projectID, &pageOpts)
+		if err != nil {
+			return nil, fmt.Errorf("list crowdin source strings: %w", err)
+		}
+		for _, src := range stringsList {
+			if src == nil {
+				continue
+			}
+			row := SourceStringRow{
+				ID:         src.ID,
+				Identifier: src.Identifier,
+				Text:       src.Text,
+				Context:    src.Context,
+			}
+			if src.FileID != nil {
+				row.FileID = *src.FileID
+			}
+			if src.BranchID != nil {
+				row.BranchID = *src.BranchID
+			}
+			if src.CreatedAt != nil {
+				row.CreatedAt = *src.CreatedAt
+			}
+			if src.UpdatedAt != nil {
+				row.UpdatedAt = *src.UpdatedAt
+			}
+			out = append(out, row)
+		}
+		if len(stringsList) < pageLimit {
+			break
+		}
+		offset += pageLimit
+	}
+	return out, nil
+}

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"errors"
 	"net/url"
 	"strconv"
@@ -31,6 +32,34 @@ type SourceString struct {
 	FileID         *int    `json:"fileId,omitempty"`
 	DirectoryID    *int    `json:"directoryId,omitempty"`
 	Revision       *int    `json:"revision,omitempty"`
+}
+
+// UnmarshalJSON accepts Crowdin's string-or-plural-object `text` field.
+func (s *SourceString) UnmarshalJSON(data []byte) error {
+	type sourceStringJSON SourceString
+	aux := struct {
+		Text json.RawMessage `json:"text"`
+		*sourceStringJSON
+	}{sourceStringJSON: (*sourceStringJSON)(s)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	s.Text = decodeSourceStringText(aux.Text)
+	return nil
+}
+
+func decodeSourceStringText(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	if raw[0] == '"' {
+		var text string
+		if err := json.Unmarshal(raw, &text); err != nil {
+			return string(raw)
+		}
+		return text
+	}
+	return string(raw)
 }
 
 // SourceStringsGetResponse describes the response when getting


### PR DESCRIPTION
## Summary
- Add `crowdin string list` via Crowdin `SourceStrings.List` (source strings, not translated entries).
- Add path-based `crowdin file upload|download|delete` (distinct from batch `crowdin.yml` workflows and `download sources --file-id`).
- Add TM-only `crowdin auto-translate` (alias `pre-translate`) with async status polling. MT/AI is deferred.

Closes HL-673.

## Test plan
- [x] `go test ./internal/i18n/storage/crowdin` (httptest for string list, file resolve/upload/download/delete, TM pre-translate poll)
- [x] `go test ./apps/cli/cmd -run Crowdin`
- [x] `golangci-lint run ./internal/i18n/storage/crowdin/... ./apps/cli/cmd/...`
- [x] `go build ./apps/cli`
- [ ] Optional live smoke: `string list --file`, `file download` by path, small TM `auto-translate` on a test branch
