### PR TITLE
feat(mcp): Add get_issue tool to the hosted MCP server

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -318,6 +318,65 @@ describe("MCP team-scoped access", () => {
     ]);
     expect(issuesBody.issues.map((issue) => issue.id)).not.toContain(betaIssue.id);
 
+    const accessibleIssueResponse = await callMcpTool(accessToken, "get_issue", {
+      projectId: alphaProjectBody.project.id,
+      issueId: alphaIssue.id,
+    });
+
+    expect(accessibleIssueResponse.status).toBe(200);
+
+    const accessibleIssueResponseBody = await accessibleIssueResponse.json();
+
+    expect(parseToolResultText(accessibleIssueResponseBody)).toMatchObject({
+      issue: {
+        id: alphaIssue.id,
+        title: "Accessible team issue",
+      },
+    });
+
+    const inaccessibleLookups = [
+      {
+        label: "missing issue",
+        projectId: alphaProjectBody.project.id,
+        issueId: "00000000-0000-4000-8000-000000000999",
+      },
+      {
+        label: "wrong project",
+        projectId: alphaProjectBody.project.id,
+        issueId: betaIssue.id,
+      },
+      {
+        label: "wrong team",
+        projectId: betaProjectBody.project.id,
+        issueId: betaIssue.id,
+      },
+      {
+        label: "wrong organization",
+        projectId: externalProject.id,
+        issueId: externalIssue.id,
+      },
+    ];
+
+    for (const lookup of inaccessibleLookups) {
+      const response = await callMcpTool(accessToken, "get_issue", {
+        projectId: lookup.projectId,
+        issueId: lookup.issueId,
+      });
+
+      expect(response.status, lookup.label).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(
+        (responseBody as { result?: { isError?: boolean } }).result?.isError,
+        lookup.label,
+      ).toBe(true);
+
+      expect(parseToolResultText(responseBody), lookup.label).toMatchObject({
+        error: "issue_not_found",
+      });
+    }
+
     expect(getDeniedResponse.status).toBe(200);
     const getDeniedBody = parseToolResultText(await getDeniedResponse.json()) as {
       project: { id: string } | null;

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -999,6 +999,45 @@ describe("mcpRoutes", () => {
         title: "Created through the MCP SDK",
       });
 
+      const getIssueResult = await client.callTool({
+        name: "get_issue",
+        arguments: {
+          projectId: stored.project.id,
+          issueId: createdIssue.id,
+        },
+      });
+
+      const getIssueContent = (
+        getIssueResult as {
+          content?: Array<{
+            type?: string;
+            text?: string;
+          }>;
+        }
+      ).content?.find((item) => item.type === "text");
+
+      if (!getIssueContent?.text) {
+        throw new Error("expected get_issue text content");
+      }
+
+      const getIssueOutput = JSON.parse(getIssueContent.text) as {
+        issue: {
+          id: string;
+          title: string;
+          description: string;
+          values: Record<string, unknown>;
+        };
+      };
+
+      expect(getIssueOutput.issue).toMatchObject({
+        id: createdIssue.id,
+        title: "Created through the MCP SDK",
+        description: "SDK integration coverage",
+        values: {
+          priority: "P1",
+        },
+      });
+
       const issuesResult = await client.callTool({
         name: "list_issues",
         arguments: {
@@ -1055,7 +1094,7 @@ describe("mcpRoutes", () => {
       });
 
       expect(result.content).toEqual(expect.any(Array));
-      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(6);
+      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(7);
       expect(requestMethods.filter((method) => method === "GET")).toHaveLength(1);
       expect(requestMethods.every((method) => method === "POST" || method === "GET")).toBe(true);
       expect(transportErrors).toEqual([]);
@@ -1352,6 +1391,57 @@ describe("mcpRoutes", () => {
     expect(text).toContain("invalid_issue_query");
   });
 
+  it("advertises the get_issue tool with UUID input validation", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "get_issue");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("issue");
+    expect(tool?.inputSchema?.required).toEqual(expect.arrayContaining(["projectId", "issueId"]));
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      issueId: {
+        type: "string",
+        format: "uuid",
+      },
+    });
+  });
+
   it("advertises the create_issue tool with a bounded input schema", async () => {
     const headers = await authenticatedMcpHeaders();
 
@@ -1469,6 +1559,182 @@ describe("mcpRoutes", () => {
         description: expect.stringContaining("retry key"),
       },
     });
+  });
+
+  it("rejects get_issue calls with a non-UUID issue ID", async () => {
+    const headers = await authenticatedMcpHeaders();
+    const getIssueSpy = vi.spyOn(IssueSheetService.prototype, "getIssue");
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "get_issue",
+            arguments: {
+              projectId: "project-id",
+              issueId: "not-a-uuid",
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+      expect(getIssueSpy).not.toHaveBeenCalled();
+    } finally {
+      getIssueSpy.mockRestore();
+    }
+  });
+
+  it("returns the complete accessible issue detail", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const service = new IssueSheetService();
+
+    const [translationKey] = await db
+      .insert(schema.projectTranslationKeys)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        projectId: stored.project.id,
+        key: "home.title",
+        sourceText: "Welcome",
+        normalizedSourceText: "Welcome",
+      })
+      .returning({
+        id: schema.projectTranslationKeys.id,
+      });
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    const created = await service.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Detailed MCP issue",
+        description: "Full issue description",
+        issueType: "translation_mistake",
+        status: "open",
+        targetLocale: "fr-FR",
+        sourcePath: "src/messages.json",
+        segmentId: "homepage.title",
+        priority: "P1",
+        translationKeyId: translationKey.id,
+      },
+    });
+
+    await service.setValue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      issueId: created.id,
+      body: {
+        columnKey: "owner_note",
+        value: "Needs linguistic review",
+      },
+    });
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "get_issue",
+          arguments: {
+            projectId: stored.project.id,
+            issueId: created.id,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+
+    const text = body.result?.content?.[0]?.text;
+    expect(text).toBeDefined();
+
+    const output = JSON.parse(text!) as {
+      issue: Record<string, unknown>;
+    };
+
+    expect(output.issue).toMatchObject({
+      id: created.id,
+      identifier: created.identifier,
+      title: "Detailed MCP issue",
+      description: "Full issue description",
+      issueType: "translation_mistake",
+      status: "open",
+      targetLocale: "fr-FR",
+      sourcePath: "src/messages.json",
+      segmentId: "homepage.title",
+      translationKeyId: translationKey.id,
+      linkedTranslationKey: {
+        id: translationKey.id,
+        key: "home.title",
+        sourceText: "Welcome",
+      },
+      assigneeUserId: null,
+      resolvedAt: null,
+      isWatching: true,
+      values: {
+        priority: "P1",
+        owner_note: "Needs linguistic review",
+      },
+      number: created.number,
+      reporter: created.reporter,
+      assignee: null,
+      linkedCommentId: null,
+      linkedAgentRunId: null,
+      linkKind: null,
+      linkLabel: null,
+      linkUrl: null,
+      externalRef: null,
+      templateKey: null,
+      createdAt: created.createdAt,
+      updatedAt: created.updatedAt,
+    });
+
+    expect(output.issue).not.toHaveProperty("key");
+    expect(output.issue).not.toHaveProperty("sourceText");
   });
 
   it.each([

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -992,6 +992,7 @@ describe("mcpRoutes", () => {
         id: string;
         projectId: string;
         title: string;
+        identifier: string;
       };
 
       expect(createdIssue).toMatchObject({
@@ -1003,7 +1004,7 @@ describe("mcpRoutes", () => {
         name: "get_issue",
         arguments: {
           projectId: stored.project.id,
-          issueId: createdIssue.id,
+          issueId: createdIssue.identifier,
         },
       });
 
@@ -1391,7 +1392,7 @@ describe("mcpRoutes", () => {
     expect(text).toContain("invalid_issue_query");
   });
 
-  it("advertises the get_issue tool with UUID input validation", async () => {
+  it("advertises the get_issue tool with issue identifier validation", async () => {
     const headers = await authenticatedMcpHeaders();
 
     const response = await app.request("http://localhost/mcp/sse", {
@@ -1437,7 +1438,6 @@ describe("mcpRoutes", () => {
       },
       issueId: {
         type: "string",
-        format: "uuid",
       },
     });
   });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -369,6 +369,16 @@ const mcpListIssuesInputSchema = z
     }
   });
 
+const mcpGetIssueInputSchema = z.object({
+  projectId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(128)
+    .describe("ID of the accessible Hyperlocalise project containing the issue."),
+  issueId: z.uuid().describe("UUID of the Hyperlocalise issue to retrieve."),
+});
+
 const issueSheetService = new IssueSheetService();
 const createIssueShape = issueSheetCreateIssueBodySchema.shape;
 
@@ -570,6 +580,58 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
           {
             type: "text",
             text: JSON.stringify(output),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "get_issue",
+    {
+      description: "Get the complete details of one accessible Hyperlocalise issue.",
+      inputSchema: mcpGetIssueInputSchema,
+    },
+    async ({ projectId, issueId }) => {
+      const [project] = await db
+        .select({ id: schema.projects.id })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("issue_not_found", "Issue not found");
+      }
+
+      const issue = await issueSheetService.getIssue({
+        organizationId: apiAuth.organization.localOrganizationId,
+        projectId: project.id,
+        issueId,
+        actorUserId: apiAuth.user.localUserId,
+      });
+
+      if (!issue) {
+        return mcpToolError("issue_not_found", "Issue not found");
+      }
+
+      const { key, sourceText, ...issueDetails } = issue;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              issue: {
+                ...issueDetails,
+                linkedTranslationKey: issue.translationKeyId
+                  ? {
+                      id: issue.translationKeyId,
+                      key,
+                      sourceText,
+                    }
+                  : null,
+              },
+            }),
           },
         ],
       };

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -27,6 +27,7 @@ import {
   organizationIssueService,
   type OrganizationIssueListItem,
 } from "@/lib/projects/issue-sheet/organization-issue-service";
+import { issueIdSchema } from "@/lib/projects/issue-identifier/project-issue-identifier";
 import { z } from "zod";
 
 import { apiAuthContextFromMcpAuth } from "@/api/auth/mcp-access";
@@ -376,7 +377,9 @@ const mcpGetIssueInputSchema = z.object({
     .min(1)
     .max(128)
     .describe("ID of the accessible Hyperlocalise project containing the issue."),
-  issueId: z.uuid().describe("UUID of the Hyperlocalise issue to retrieve."),
+  issueId: issueIdSchema.describe(
+    "Canonical issue identifier such as HL-123, or a legacy issue UUID.",
+  ),
 });
 
 const issueSheetService = new IssueSheetService();


### PR DESCRIPTION
## What changed

- Added the `get_issue` tool to the hosted MCP server.
- Added required `projectId` and UUID-validated `issueId` inputs.
- Reused `IssueSheetService.getIssue` to return the same core detail shape as the web issue route.
- Added full issue details, including custom values, reporter, assignee, timestamps, resolution state, and watch state.
- Exposed linked translation context under `linkedTranslationKey` so it cannot be mistaken for the issue identity.
- Enforced organization and team-scoped project access before loading an issue.
- Returned the same stable `issue_not_found` error for missing, wrong-project, wrong-team, and wrong-organization lookups.
- Added MCP SDK integration coverage for retrieving an issue after initialization.

## How to test

```bash
vp test src/api/routes/mcp/mcp.route.test.ts
vp test src/api/routes/mcp/mcp-team-access.test.ts

vp check \
  src/api/routes/mcp/mcp.route.ts \
  src/api/routes/mcp/mcp.route.test.ts \
  src/api/routes/mcp/mcp-team-access.test.ts

rm -rf .next
vp run build
```
## Checklist
- I ran relevant checks locally (vp check, relevant vp test suites, and vp run build)
- I updated tool descriptions and schema metadata where needed
- This PR is scoped and ready for review
