### PR TITLE
feat(go-svc): return bounded spelling warnings from segment validation

### DIFF
--- a/apps/go-svc/handler.go
+++ b/apps/go-svc/handler.go
@@ -93,30 +93,20 @@ func (h *handler) validateSegment(w http.ResponseWriter, r *http.Request) {
 
 	spellingRequested := requestsSpelling(req.Modes)
 
-	var skippedModes []string
+	var targetLocale string
 	if spellingRequested {
-		targetLocale, err := validateTargetLocale(req.TargetLocale)
+		var err error
+		targetLocale, err = validateTargetLocale(req.TargetLocale)
 		if err != nil {
 			writeBadRequest(w, err.Error())
 			return
 		}
-
-		switch _, err := h.checkSpelling(r.Context(), targetLocale, req.TargetText); {
-		case errors.Is(err, ErrSpellCheckUnavailable), errors.Is(err, spellcheck.ErrUnsupportedLocale):
-			skippedModes = append(skippedModes, QA_MODE_SPELLING)
-		case err != nil:
-			writeInternalError(w, "spell check failed")
-			return
-		}
 	}
 
-	checks := h.validate(segmentvalidate.Request{
-		SourceText: req.SourceText,
-		TargetText: req.TargetText,
-		SourcePath: req.SourcePath,
-		MaxLength:  req.MaxLength,
-		Modes:      req.Modes,
-	})
+	checks, skippedModes, err := h.composeSegmentValidation(r.Context(), req, targetLocale, spellingRequested)
+	if err != nil {
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -148,15 +138,6 @@ func writeBadRequest(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusBadRequest)
 	_ = json.NewEncoder(w).Encode(map[string]string{
 		"error":   "bad_request",
-		"message": message,
-	})
-}
-
-func writeInternalError(w http.ResponseWriter, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusInternalServerError)
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"error":   "internal_error",
 		"message": message,
 	})
 }

--- a/apps/go-svc/handler_test.go
+++ b/apps/go-svc/handler_test.go
@@ -293,7 +293,7 @@ func TestValidateSegmentSpellingSucceedsWithoutSkip(t *testing.T) {
 	require.Equal(t, "fr-FR", fake.receivedLocale)
 }
 
-func TestValidateSegmentSpellingDiscardsIssuesOnSuccess(t *testing.T) {
+func TestValidateSegmentSpellingSurfacesIssuesAsWarnings(t *testing.T) {
 	fake := &fakeSpellChecker{
 		issues: []SpellingIssue{{Word: "recieve", Suggestions: []string{"receive"}}},
 	}
@@ -308,13 +308,19 @@ func TestValidateSegmentSpellingDiscardsIssuesOnSuccess(t *testing.T) {
 
 	var resp validateSegmentResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Len(t, resp.Checks, 1, "spelling issues must not be surfaced as checks in this contract")
-	require.Empty(t, resp.SkippedModes, "a successful check must not be reported as skipped, even with issues found")
+	require.Len(t, resp.Checks, 2, "spelling issues must be surfaced as an additional warning check")
+	require.Equal(t, "format-parity", resp.Checks[0].ID)
+	spelling := resp.Checks[1]
+	require.Equal(t, QA_MODE_SPELLING, spelling.ID)
+	require.Equal(t, QA_MODE_SPELLING, spelling.Category)
+	require.Equal(t, segmentvalidate.StatusWarn, spelling.Status, "spelling issues are warnings, not failures")
+	require.Equal(t, []string{"recieve", "receive"}, spelling.RelatedTokens)
+	require.Empty(t, resp.SkippedModes, "a successful check must not be reported as skipped")
 	require.Equal(t, "fr-FR", fake.receivedLocale)
-	require.Equal(t, spellcheck.Tokenize(targetText), fake.receivedWords)
+	require.Equal(t, spellcheck.Tokenize(targetText), fake.receivedWords, "only target text reaches the provider")
 }
 
-func TestValidateSegmentSpellingUnexpectedProviderErrorReturns500(t *testing.T) {
+func TestValidateSegmentSpellingUnexpectedProviderErrorPreservesFormatChecks(t *testing.T) {
 	fake := &fakeSpellChecker{err: errors.New("provider exploded")}
 	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
 	mux := newAuthedValidateSegmentMux(h)
@@ -322,9 +328,65 @@ func TestValidateSegmentSpellingUnexpectedProviderErrorReturns500(t *testing.T) 
 	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
 	rec := postValidateSegment(mux, payload)
 
-	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code, "an unexpected provider error must not erase format/QA results")
 
-	var body map[string]string
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	require.Equal(t, "internal_error", body["error"])
+	var resp validateSegmentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Checks, 1)
+	require.Equal(t, "format-parity", resp.Checks[0].ID)
+	require.Equal(t, []string{QA_MODE_SPELLING}, resp.SkippedModes)
+}
+
+func TestValidateSegmentSpellingCancellationWritesNoResponse(t *testing.T) {
+	fake := &fakeSpellChecker{err: context.Canceled}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+	mux := newAuthedValidateSegmentMux(h)
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Zero(t, rec.Body.Len(), "a canceled request must not receive a success body")
+	require.Empty(t, rec.Header().Get("Content-Type"), "a canceled request must not receive a JSON response")
+}
+
+func TestValidateSegmentSpellingDeadlineExceededWritesNoResponse(t *testing.T) {
+	fake := &fakeSpellChecker{err: context.DeadlineExceeded}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+	mux := newAuthedValidateSegmentMux(h)
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Zero(t, rec.Body.Len(), "a timed-out request must not receive a success body")
+	require.Empty(t, rec.Header().Get("Content-Type"), "a timed-out request must not receive a JSON response")
+}
+
+func TestValidateSegmentSpellingCapsIssuesAndSuggestions(t *testing.T) {
+	issues := make([]SpellingIssue, 0, 7)
+	for i := 1; i <= 7; i++ {
+		issues = append(issues, SpellingIssue{
+			Word:        fmt.Sprintf("word%d", i),
+			Suggestions: []string{"s1", "s2", "s3", "s4", "s5"},
+		})
+	}
+	fake := &fakeSpellChecker{issues: issues}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+	mux := newAuthedValidateSegmentMux(h)
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp validateSegmentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Checks, 1+maxSpellingIssues, "must cap at 5 unique misspellings")
+
+	spellingChecks := resp.Checks[1:]
+	var gotWords []string
+	for _, check := range spellingChecks {
+		require.Len(t, check.RelatedTokens, 1+maxSpellingSuggestions, "must cap at 3 suggestions per word")
+		gotWords = append(gotWords, check.RelatedTokens[0])
+	}
+	require.Equal(t, []string{"word1", "word2", "word3", "word4", "word5"}, gotWords, "must preserve first-seen order")
 }

--- a/apps/go-svc/handler_test.go
+++ b/apps/go-svc/handler_test.go
@@ -311,7 +311,7 @@ func TestValidateSegmentSpellingSurfacesIssuesAsWarnings(t *testing.T) {
 	require.Len(t, resp.Checks, 2, "spelling issues must be surfaced as an additional warning check")
 	require.Equal(t, "format-parity", resp.Checks[0].ID)
 	spelling := resp.Checks[1]
-	require.Equal(t, QA_MODE_SPELLING, spelling.ID)
+	require.Equal(t, "spelling-recieve", spelling.ID, "each spelling warning needs a stable per-word ID so the frontend doesn't produce duplicate React keys")
 	require.Equal(t, QA_MODE_SPELLING, spelling.Category)
 	require.Equal(t, segmentvalidate.StatusWarn, spelling.Status, "spelling issues are warnings, not failures")
 	require.Equal(t, []string{"recieve", "receive"}, spelling.RelatedTokens)
@@ -384,8 +384,11 @@ func TestValidateSegmentSpellingCapsIssuesAndSuggestions(t *testing.T) {
 
 	spellingChecks := resp.Checks[1:]
 	var gotWords []string
+	seenIDs := make(map[string]bool, len(spellingChecks))
 	for _, check := range spellingChecks {
 		require.Len(t, check.RelatedTokens, 1+maxSpellingSuggestions, "must cap at 3 suggestions per word")
+		require.False(t, seenIDs[check.ID], "each spelling warning must have a unique ID to avoid duplicate React keys on the frontend")
+		seenIDs[check.ID] = true
 		gotWords = append(gotWords, check.RelatedTokens[0])
 	}
 	require.Equal(t, []string{"word1", "word2", "word3", "word4", "word5"}, gotWords, "must preserve first-seen order")

--- a/apps/go-svc/segment_validation.go
+++ b/apps/go-svc/segment_validation.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
+)
+
+// composeSegmentValidation adds optional spelling warnings to format/QA checks.
+// Spelling failures are non-fatal, except for context cancellation.
+func (h *handler) composeSegmentValidation(
+	ctx context.Context,
+	req validateSegmentRequest,
+	targetLocale string,
+	spellingRequested bool,
+) ([]segmentvalidate.Check, []string, error) {
+	checks := h.validate(segmentvalidate.Request{
+		SourceText: req.SourceText,
+		TargetText: req.TargetText,
+		SourcePath: req.SourcePath,
+		MaxLength:  req.MaxLength,
+		Modes:      req.Modes,
+	})
+
+	if !spellingRequested {
+		return checks, nil, nil
+	}
+
+	issues, err := h.checkSpelling(ctx, targetLocale, req.TargetText)
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return nil, nil, err
+	case errors.Is(err, ErrSpellCheckUnavailable), errors.Is(err, spellcheck.ErrUnsupportedLocale):
+		return checks, []string{QA_MODE_SPELLING}, nil
+	case err != nil:
+		slog.Warn("spellcheck: skipping spelling checks after unexpected provider error", "error", err)
+		return checks, []string{QA_MODE_SPELLING}, nil
+	default:
+		return append(checks, spellingWarningChecks(issues)...), nil, nil
+	}
+}

--- a/apps/go-svc/segment_validation_test.go
+++ b/apps/go-svc/segment_validation_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComposeSegmentValidationSpellingNotRequested(t *testing.T) {
+	fake := &fakeSpellChecker{}
+	h := &handler{
+		validate: func(req segmentvalidate.Request) []segmentvalidate.Check {
+			return []segmentvalidate.Check{{ID: "format-parity", Status: segmentvalidate.StatusPass}}
+		},
+		spellChecker: fake,
+	}
+
+	checks, skipped, err := h.composeSegmentValidation(context.Background(), validateSegmentRequest{}, "", false)
+
+	require.NoError(t, err)
+	require.Nil(t, skipped)
+	require.Len(t, checks, 1)
+	require.Nil(t, fake.receivedCtx, "spell checker must not be invoked when spelling is not requested")
+}
+
+func TestComposeSegmentValidationSkipsOnUnsupportedLocale(t *testing.T) {
+	fake := &fakeSpellChecker{err: fmt.Errorf("%w: %q", spellcheck.ErrUnsupportedLocale, "en-CA")}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	checks, skipped, err := h.composeSegmentValidation(context.Background(), req, "en-CA", true)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{QA_MODE_SPELLING}, skipped)
+	require.Len(t, checks, 1)
+	require.Equal(t, "format-parity", checks[0].ID)
+}
+
+func TestComposeSegmentValidationSkipsOnUnavailableProvider(t *testing.T) {
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: NoopSpellChecker{}}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	checks, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{QA_MODE_SPELLING}, skipped)
+	require.Len(t, checks, 1)
+	require.Equal(t, "format-parity", checks[0].ID)
+}
+
+func TestComposeSegmentValidationSkipsOnUnexpectedProviderError(t *testing.T) {
+	fake := &fakeSpellChecker{err: errors.New("provider exploded")}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	checks, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+
+	require.NoError(t, err, "an unexpected provider error must not fail the request")
+	require.Equal(t, []string{QA_MODE_SPELLING}, skipped)
+	require.Len(t, checks, 1)
+	require.Equal(t, "format-parity", checks[0].ID)
+}
+
+func TestComposeSegmentValidationPropagatesCancellation(t *testing.T) {
+	fake := &fakeSpellChecker{err: context.Canceled}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	checks, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, checks, "a canceled request must not silently succeed with format/QA checks")
+	require.Nil(t, skipped, "cancellation must not be reported as a skipped mode")
+}
+
+func TestComposeSegmentValidationPropagatesDeadlineExceeded(t *testing.T) {
+	fake := &fakeSpellChecker{err: context.DeadlineExceeded}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	checks, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, checks)
+	require.Nil(t, skipped)
+}
+
+func TestComposeSegmentValidationPropagatesContextToProvider(t *testing.T) {
+	fake := &fakeSpellChecker{}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	_, _, err := h.composeSegmentValidation(ctx, req, "fr-FR", true)
+
+	require.NoError(t, err)
+	require.Equal(t, "marker", fake.receivedCtx.Value(ctxKey{}))
+}
+
+func TestComposeSegmentValidationAppendsSpellingWarnings(t *testing.T) {
+	fake := &fakeSpellChecker{
+		issues: []SpellingIssue{{Word: "recieve", Suggestions: []string{"receive"}}},
+	}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{
+		SourceText: "Hello",
+		TargetText: "Please recieve the update",
+		SourcePath: "/messages/en.json",
+	}
+	checks, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+
+	require.NoError(t, err)
+	require.Empty(t, skipped)
+	require.Len(t, checks, 2)
+	require.Equal(t, "format-parity", checks[0].ID)
+	require.Equal(t, QA_MODE_SPELLING, checks[1].ID)
+	require.Equal(t, QA_MODE_SPELLING, checks[1].Category)
+	require.Equal(t, segmentvalidate.StatusWarn, checks[1].Status)
+	require.Equal(t, []string{"recieve", "receive"}, checks[1].RelatedTokens)
+}
+
+func TestComposeSegmentValidationRepeatedMisspellingProducesOneWarning(t *testing.T) {
+	fake := &fakeSpellChecker{
+		issues: []SpellingIssue{{Word: "recieve", Suggestions: []string{"receive"}}},
+	}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{
+		SourceText: "Hello",
+		TargetText: "Please recieve recieve recieve the update",
+		SourcePath: "/messages/en.json",
+	}
+	checks, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+
+	require.NoError(t, err)
+	require.Empty(t, skipped)
+
+	var recieveOccurrences int
+	for _, word := range fake.receivedWords {
+		if word == "recieve" {
+			recieveOccurrences++
+		}
+	}
+	require.Equal(t, 1, recieveOccurrences, "checkSpelling must dedupe before calling the provider")
+
+	var spellingChecks int
+	for _, check := range checks {
+		if check.Category == QA_MODE_SPELLING {
+			spellingChecks++
+		}
+	}
+	require.Equal(t, 1, spellingChecks)
+}

--- a/apps/go-svc/segment_validation_test.go
+++ b/apps/go-svc/segment_validation_test.go
@@ -121,7 +121,7 @@ func TestComposeSegmentValidationAppendsSpellingWarnings(t *testing.T) {
 	require.Empty(t, skipped)
 	require.Len(t, checks, 2)
 	require.Equal(t, "format-parity", checks[0].ID)
-	require.Equal(t, QA_MODE_SPELLING, checks[1].ID)
+	require.Equal(t, "spelling-recieve", checks[1].ID)
 	require.Equal(t, QA_MODE_SPELLING, checks[1].Category)
 	require.Equal(t, segmentvalidate.StatusWarn, checks[1].Status)
 	require.Equal(t, []string{"recieve", "receive"}, checks[1].RelatedTokens)

--- a/apps/go-svc/spellcheck_warnings.go
+++ b/apps/go-svc/spellcheck_warnings.go
@@ -29,7 +29,7 @@ func spellingWarningChecks(issues []SpellingIssue) []segmentvalidate.Check {
 		relatedTokens = append(relatedTokens, suggestions...)
 
 		checks = append(checks, segmentvalidate.Check{
-			ID:            QA_MODE_SPELLING,
+			ID:            spellingCheckID(issue.Word),
 			Label:         "Spelling",
 			Status:        segmentvalidate.StatusWarn,
 			Message:       spellingMessage(issue.Word, suggestions),
@@ -38,6 +38,10 @@ func spellingWarningChecks(issues []SpellingIssue) []segmentvalidate.Check {
 		})
 	}
 	return checks
+}
+
+func spellingCheckID(word string) string {
+	return QA_MODE_SPELLING + "-" + word
 }
 
 func spellingMessage(word string, suggestions []string) string {

--- a/apps/go-svc/spellcheck_warnings.go
+++ b/apps/go-svc/spellcheck_warnings.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+)
+
+const (
+	maxSpellingIssues      = 5
+	maxSpellingSuggestions = 3
+)
+
+func spellingWarningChecks(issues []SpellingIssue) []segmentvalidate.Check {
+	if len(issues) > maxSpellingIssues {
+		issues = issues[:maxSpellingIssues]
+	}
+
+	checks := make([]segmentvalidate.Check, 0, len(issues))
+	for _, issue := range issues {
+		suggestions := issue.Suggestions
+		if len(suggestions) > maxSpellingSuggestions {
+			suggestions = suggestions[:maxSpellingSuggestions]
+		}
+
+		relatedTokens := make([]string, 0, 1+len(suggestions))
+		relatedTokens = append(relatedTokens, issue.Word)
+		relatedTokens = append(relatedTokens, suggestions...)
+
+		checks = append(checks, segmentvalidate.Check{
+			ID:            QA_MODE_SPELLING,
+			Label:         "Spelling",
+			Status:        segmentvalidate.StatusWarn,
+			Message:       spellingMessage(issue.Word, suggestions),
+			Category:      QA_MODE_SPELLING,
+			RelatedTokens: relatedTokens,
+		})
+	}
+	return checks
+}
+
+func spellingMessage(word string, suggestions []string) string {
+	if len(suggestions) == 0 {
+		return fmt.Sprintf("%q may be misspelled.", word)
+	}
+	return fmt.Sprintf("%q may be misspelled. Suggestions: %s.", word, strings.Join(suggestions, ", "))
+}

--- a/apps/go-svc/spellcheck_warnings_test.go
+++ b/apps/go-svc/spellcheck_warnings_test.go
@@ -19,7 +19,7 @@ func TestSpellingWarningChecksFieldShape(t *testing.T) {
 
 	require.Len(t, checks, 1)
 	check := checks[0]
-	require.Equal(t, QA_MODE_SPELLING, check.ID)
+	require.Equal(t, "spelling-recieve", check.ID)
 	require.Equal(t, "Spelling", check.Label)
 	require.Equal(t, segmentvalidate.StatusWarn, check.Status)
 	require.Equal(t, QA_MODE_SPELLING, check.Category)
@@ -45,6 +45,23 @@ func TestSpellingWarningChecksCapsSuggestionsAtThree(t *testing.T) {
 
 	require.Len(t, checks, 1)
 	require.Equal(t, []string{"helo", "hello", "help", "held"}, checks[0].RelatedTokens)
+}
+
+func TestSpellingWarningChecksDistinctMisspellingsProduceDistinctStableIDs(t *testing.T) {
+	checks := spellingWarningChecks([]SpellingIssue{
+		{Word: "recieve", Suggestions: []string{"receive"}},
+		{Word: "teh", Suggestions: []string{"the"}},
+	})
+
+	require.Len(t, checks, 2)
+	require.Equal(t, "spelling-recieve", checks[0].ID)
+	require.Equal(t, "spelling-teh", checks[1].ID)
+	require.NotEqual(t, checks[0].ID, checks[1].ID, "the frontend keys rendered checks by ID; distinct misspellings must not collide")
+
+	require.Equal(t, QA_MODE_SPELLING, checks[0].Category)
+	require.Equal(t, QA_MODE_SPELLING, checks[1].Category)
+
+	require.Equal(t, checks[0].ID, spellingCheckID("recieve"))
 }
 
 func TestSpellingWarningChecksCapsIssuesAtFivePreservingOrder(t *testing.T) {

--- a/apps/go-svc/spellcheck_warnings_test.go
+++ b/apps/go-svc/spellcheck_warnings_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpellingWarningChecksNilAndEmpty(t *testing.T) {
+	require.Empty(t, spellingWarningChecks(nil))
+	require.Empty(t, spellingWarningChecks([]SpellingIssue{}))
+}
+
+func TestSpellingWarningChecksFieldShape(t *testing.T) {
+	checks := spellingWarningChecks([]SpellingIssue{
+		{Word: "recieve", Suggestions: []string{"receive", "relieve"}},
+	})
+
+	require.Len(t, checks, 1)
+	check := checks[0]
+	require.Equal(t, QA_MODE_SPELLING, check.ID)
+	require.Equal(t, "Spelling", check.Label)
+	require.Equal(t, segmentvalidate.StatusWarn, check.Status)
+	require.Equal(t, QA_MODE_SPELLING, check.Category)
+	require.Equal(t, []string{"recieve", "receive", "relieve"}, check.RelatedTokens)
+	require.Contains(t, check.Message, "recieve")
+	require.Contains(t, check.Message, "receive")
+}
+
+func TestSpellingWarningChecksZeroSuggestions(t *testing.T) {
+	checks := spellingWarningChecks([]SpellingIssue{
+		{Word: "xyzzy", Suggestions: nil},
+	})
+
+	require.Len(t, checks, 1)
+	require.Equal(t, []string{"xyzzy"}, checks[0].RelatedTokens)
+	require.NotContains(t, checks[0].Message, "Suggestions:")
+}
+
+func TestSpellingWarningChecksCapsSuggestionsAtThree(t *testing.T) {
+	checks := spellingWarningChecks([]SpellingIssue{
+		{Word: "helo", Suggestions: []string{"hello", "help", "held", "helot", "halo"}},
+	})
+
+	require.Len(t, checks, 1)
+	require.Equal(t, []string{"helo", "hello", "help", "held"}, checks[0].RelatedTokens)
+}
+
+func TestSpellingWarningChecksCapsIssuesAtFivePreservingOrder(t *testing.T) {
+	issues := []SpellingIssue{
+		{Word: "w1"}, {Word: "w2"}, {Word: "w3"}, {Word: "w4"},
+		{Word: "w5"}, {Word: "w6"}, {Word: "w7"},
+	}
+
+	checks := spellingWarningChecks(issues)
+
+	require.Len(t, checks, maxSpellingIssues)
+	var gotWords []string
+	for _, check := range checks {
+		gotWords = append(gotWords, check.RelatedTokens[0])
+	}
+	require.Equal(t, []string{"w1", "w2", "w3", "w4", "w5"}, gotWords)
+}
+
+func TestSpellingMessage(t *testing.T) {
+	require.Equal(t, `"foo" may be misspelled.`, spellingMessage("foo", nil))
+	require.Equal(t, `"foo" may be misspelled. Suggestions: bar, baz.`, spellingMessage("foo", []string{"bar", "baz"}))
+}

--- a/apps/go-svc/spellcheck_warnings_test.go
+++ b/apps/go-svc/spellcheck_warnings_test.go
@@ -49,8 +49,13 @@ func TestSpellingWarningChecksCapsSuggestionsAtThree(t *testing.T) {
 
 func TestSpellingWarningChecksCapsIssuesAtFivePreservingOrder(t *testing.T) {
 	issues := []SpellingIssue{
-		{Word: "w1"}, {Word: "w2"}, {Word: "w3"}, {Word: "w4"},
-		{Word: "w5"}, {Word: "w6"}, {Word: "w7"},
+		{Word: "w1"},
+		{Word: "w2"},
+		{Word: "w3"},
+		{Word: "w4"},
+		{Word: "w5"},
+		{Word: "w6"},
+		{Word: "w7"},
 	}
 
 	checks := spellingWarningChecks(issues)


### PR DESCRIPTION
## What changed

- Return spelling warnings from segment validation when `spelling` is requested.
- Check target text only and return up to 5 unique misspellings with up to 3 suggestions each.
- Preserve existing format/QA checks when spelling is unsupported or the provider fails.
- Propagate request cancellation instead of treating it as a skipped spelling mode.
- Add coverage for warning shape, bounds, ordering, deduplication, target-only checking, partial failure, and cancellation.

## How to test

- `go test ./apps/go-svc ./internal/i18n/segmentvalidate`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
