### PR TITLE
feat(go-svc): validate CAT spellcheck integration end to end

### DIFF
--- a/apps/go-svc/segment_validation.go
+++ b/apps/go-svc/segment_validation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
@@ -29,16 +30,22 @@ func (h *handler) composeSegmentValidation(
 		return checks, nil, nil
 	}
 
+	startedAt := time.Now()
 	issues, err := h.checkSpelling(ctx, targetLocale, req.TargetText)
+	duration := time.Since(startedAt)
+
 	switch {
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return nil, nil, err
 	case errors.Is(err, ErrSpellCheckUnavailable), errors.Is(err, spellcheck.ErrUnsupportedLocale):
+		logSpellingObservability(duration, true, 0, 0)
 		return checks, []string{QA_MODE_SPELLING}, nil
 	case err != nil:
 		slog.Warn("spellcheck: skipping spelling checks after unexpected provider error", "error", err)
+		logSpellingObservability(duration, false, 1, 0)
 		return checks, []string{QA_MODE_SPELLING}, nil
 	default:
+		logSpellingObservability(duration, false, 0, len(issues))
 		return append(checks, spellingWarningChecks(issues)...), nil, nil
 	}
 }

--- a/apps/go-svc/server_integration_test.go
+++ b/apps/go-svc/server_integration_test.go
@@ -17,18 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This file proves production server assembly and lifecycle: the same
-// *http.Server construction main.go uses (newHTTPServer + registerRoutes +
-// requestLogMiddleware + withOptionalPrefix), listening on a real TCP
-// socket, handling concurrent requests, and shutting down gracefully. It
-// deliberately does not require the cgo_hunspell build tag or real
-// dictionaries — that is the job of the handler-to-Hunspell integration
-// tests, which exercise the spelling provider itself.
+// These tests exercise the production server assembly used by main.go over a
+// real TCP listener. Real Hunspell integration is covered separately by the
+// cgo_hunspell integration tests.
 
-// stubSpellChecker is a stateless SpellChecker safe for concurrent use
-// across goroutines (unlike fakeSpellChecker in spellcheck_test.go, which
-// records the last request into shared struct fields and is only meant for
-// single-goroutine unit tests).
+// stubSpellChecker is stateless and safe for concurrent tests, unlike the
+// stateful fakeSpellChecker used by single-goroutine unit tests.
 type stubSpellChecker struct{}
 
 func (stubSpellChecker) Check(_ context.Context, locale string, _ []string) ([]SpellingIssue, error) {

--- a/apps/go-svc/server_integration_test.go
+++ b/apps/go-svc/server_integration_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
+	"github.com/stretchr/testify/require"
+)
+
+// This file proves production server assembly and lifecycle: the same
+// *http.Server construction main.go uses (newHTTPServer + registerRoutes +
+// requestLogMiddleware + withOptionalPrefix), listening on a real TCP
+// socket, handling concurrent requests, and shutting down gracefully. It
+// deliberately does not require the cgo_hunspell build tag or real
+// dictionaries — that is the job of the handler-to-Hunspell integration
+// tests, which exercise the spelling provider itself.
+
+// stubSpellChecker is a stateless SpellChecker safe for concurrent use
+// across goroutines (unlike fakeSpellChecker in spellcheck_test.go, which
+// records the last request into shared struct fields and is only meant for
+// single-goroutine unit tests).
+type stubSpellChecker struct{}
+
+func (stubSpellChecker) Check(_ context.Context, locale string, _ []string) ([]SpellingIssue, error) {
+	switch locale {
+	case "fr-FR":
+		return []SpellingIssue{{Word: "recieve", Suggestions: []string{"receive"}}}, nil
+	case "en-CA":
+		return nil, fmt.Errorf("%w: %q", spellcheck.ErrUnsupportedLocale, locale)
+	default:
+		return nil, ErrSpellCheckUnavailable
+	}
+}
+
+type delayedSpellChecker struct {
+	delay    time.Duration
+	delegate SpellChecker
+}
+
+func (d delayedSpellChecker) Check(ctx context.Context, locale string, words []string) ([]SpellingIssue, error) {
+	select {
+	case <-time.After(d.delay):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return d.delegate.Check(ctx, locale, words)
+}
+
+func startTestServer(t *testing.T, h *handler) (baseURL string, server *http.Server) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	registerRoutes(mux, h, mockSessionVerifier{claims: AuthClaims{UserID: "user_123"}})
+	rootHandler := requestLogMiddleware(withOptionalPrefix(publicPathPrefix, mux))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := newHTTPServer(listener.Addr().String(), rootHandler)
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- srv.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		_ = srv.Close()
+		<-serveErrCh
+	})
+
+	return "http://" + listener.Addr().String(), srv
+}
+
+func postSegment(client *http.Client, baseURL, payload string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/validate/segment", strings.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: workOSSessionCookieName, Value: "test-session"})
+	return client.Do(req)
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+type concurrentValidationCase struct {
+	name        string
+	payload     string
+	wantStatus  int
+	wantSkipped []string
+}
+
+func TestServerConcurrentValidationRequests(t *testing.T) {
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: stubSpellChecker{}}
+	baseURL, _ := startTestServer(t, h)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	cases := []concurrentValidationCase{
+		{
+			name:       "supported locale returns spelling warning",
+			payload:    `{"sourceText":"Hello","targetText":"Please recieve the update","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:        "unsupported locale skips spelling but keeps format checks",
+			payload:     `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"en-CA"}`,
+			wantStatus:  http.StatusOK,
+			wantSkipped: []string{QA_MODE_SPELLING},
+		},
+		{
+			name:       "no modes requested runs only format checks",
+			payload:    `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json"}`,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	const requestsPerCase = 8
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(cases)*requestsPerCase)
+
+	for _, tc := range cases {
+		for i := 0; i < requestsPerCase; i++ {
+			wg.Add(1)
+			go func(tc concurrentValidationCase) {
+				defer wg.Done()
+
+				resp, err := postSegment(client, baseURL, tc.payload)
+				if err != nil {
+					errCh <- fmt.Errorf("%s: request error: %w", tc.name, err)
+					return
+				}
+				defer func() { _ = resp.Body.Close() }()
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					errCh <- fmt.Errorf("%s: read body: %w", tc.name, err)
+					return
+				}
+				if resp.StatusCode != tc.wantStatus {
+					errCh <- fmt.Errorf("%s: status = %d, want %d (body=%s)", tc.name, resp.StatusCode, tc.wantStatus, body)
+					return
+				}
+
+				var parsed validateSegmentResponse
+				if err := json.Unmarshal(body, &parsed); err != nil {
+					errCh <- fmt.Errorf("%s: decode: %w", tc.name, err)
+					return
+				}
+				if !sameStrings(parsed.SkippedModes, tc.wantSkipped) {
+					errCh <- fmt.Errorf("%s: skippedModes = %v, want %v", tc.name, parsed.SkippedModes, tc.wantSkipped)
+				}
+			}(tc)
+		}
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+func TestServerGracefulShutdownCompletesInFlightRequests(t *testing.T) {
+	h := &handler{
+		validate:     segmentvalidate.ValidateSegment,
+		spellChecker: delayedSpellChecker{delay: 200 * time.Millisecond, delegate: stubSpellChecker{}},
+	}
+	baseURL, srv := startTestServer(t, h)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	const payload = `{"sourceText":"Hello","targetText":"Please recieve the update","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
+
+	var wg sync.WaitGroup
+	var resp *http.Response
+	var reqErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, reqErr = postSegment(client, baseURL, payload)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, srv.Shutdown(shutdownCtx), "graceful shutdown must wait for the in-flight request instead of aborting it")
+
+	wg.Wait()
+	require.NoError(t, reqErr, "the in-flight request must complete successfully despite the shutdown")
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, err := client.Post(baseURL+"/v1/validate/segment", "application/json", strings.NewReader(`{}`))
+	require.Error(t, err, "the server must refuse new connections once shutdown has completed")
+}
+
+func TestServerRequestsNeverLogSegmentText(t *testing.T) {
+	buf := captureSlog(t)
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: stubSpellChecker{}}
+	baseURL, _ := startTestServer(t, h)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	const canary = "CANARY-SECRET-server-integration-8b31"
+	payload := fmt.Sprintf(
+		`{"sourceText":"Source %s","targetText":"Target %s","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`,
+		canary, canary,
+	)
+
+	resp, err := postSegment(client, baseURL, payload)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.NotContains(t, buf.String(), canary, "request and observability logs must never include segment text")
+	require.Contains(t, buf.String(), "spelling_duration_ms", "spelling observability fields must be present end-to-end for a real HTTP spelling request")
+}

--- a/apps/go-svc/spellcheck_integration_cgo_test.go
+++ b/apps/go-svc/spellcheck_integration_cgo_test.go
@@ -1,0 +1,267 @@
+//go:build cgo_hunspell
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the handler-to-real-Hunspell path over HTTP.
+// Lower-level Hunspell behaviour is covered by spellcheck_provider_cgo_test.go.
+
+const (
+	integrationLocaleEnUS = "en-US"
+	integrationLocaleEnGB = "en-GB"
+	integrationLocalePtBR = "pt-BR"
+	integrationLocalePtPT = "pt-PT"
+)
+
+func newIntegrationSpellChecker(t *testing.T) *hunspellSpellChecker {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeFixtureCopy(t, dir, "en-us", filepath.Join("testdata", "integration", "en-us"))
+	writeFixtureCopy(t, dir, "en-gb", filepath.Join("testdata", "integration", "en-gb"))
+	writeFixtureCopy(t, dir, "pt-br", filepath.Join("testdata", "integration", "pt-br"))
+	writeFixtureCopy(t, dir, "pt-pt", filepath.Join("testdata", "integration", "pt-pt"))
+
+	registry := spellcheck.NewRegistry(map[string]spellcheck.DictionaryFiles{
+		integrationLocaleEnUS: {AffFile: "en-us.aff", DicFile: "en-us.dic"},
+		integrationLocaleEnGB: {AffFile: "en-gb.aff", DicFile: "en-gb.dic"},
+		integrationLocalePtBR: {AffFile: "pt-br.aff", DicFile: "pt-br.dic"},
+		integrationLocalePtPT: {AffFile: "pt-pt.aff", DicFile: "pt-pt.dic"},
+	})
+
+	checker := newHunspellSpellChecker(dir, registry)
+	t.Cleanup(func() {
+		require.NoError(t, checker.Close())
+	})
+	return checker
+}
+
+func spellingChecksOf(checks []segmentvalidate.Check) []segmentvalidate.Check {
+	var out []segmentvalidate.Check
+	for _, c := range checks {
+		if c.Category == QA_MODE_SPELLING {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func postSegmentAndDecode(t *testing.T, client *http.Client, baseURL, payload string) validateSegmentResponse {
+	t.Helper()
+
+	resp, err := postSegment(client, baseURL, payload)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var parsed validateSegmentResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&parsed))
+	return parsed
+}
+
+func TestIntegrationSpellingAcrossLocaleFamiliesAndRegionalVariants(t *testing.T) {
+	checker := newIntegrationSpellChecker(t)
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: checker}
+	baseURL, _ := startTestServer(t, h)
+	client := &http.Client{}
+
+	tests := []struct {
+		name            string
+		locale          string
+		targetText      string
+		wantWarningWord string 
+		wantSuggestion  string 
+	}{
+		{name: "en-US accepts its own spelling", locale: integrationLocaleEnUS, targetText: "please update color"},
+		{
+			name:            "en-US flags the en-GB spelling",
+			locale:          integrationLocaleEnUS,
+			targetText:      "please update colour",
+			wantWarningWord: "colour",
+			wantSuggestion:  "color",
+		},
+		{name: "en-GB accepts its own spelling", locale: integrationLocaleEnGB, targetText: "please update colour"},
+		{
+			name:            "en-GB flags the en-US spelling (no regional fallback)",
+			locale:          integrationLocaleEnGB,
+			targetText:      "please update color",
+			wantWarningWord: "color",
+			wantSuggestion:  "colour",
+		},
+		{name: "pt-BR accepts its own spelling", locale: integrationLocalePtBR, targetText: "nome atualizar registro"},
+		{
+			name:            "pt-BR flags the pt-PT spelling",
+			locale:          integrationLocalePtBR,
+			targetText:      "nome atualizar registo",
+			wantWarningWord: "registo",
+			wantSuggestion:  "registro",
+		},
+		{name: "pt-PT accepts its own spelling", locale: integrationLocalePtPT, targetText: "nome atualizar registo"},
+		{
+			name:            "pt-PT flags the pt-BR spelling (no regional fallback)",
+			locale:          integrationLocalePtPT,
+			targetText:      "nome atualizar registro",
+			wantWarningWord: "registro",
+			wantSuggestion:  "registo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := fmt.Sprintf(
+				`{"sourceText":"Hello","targetText":%q,"sourcePath":"/messages/test.json","modes":["spelling"],"targetLocale":%q}`,
+				tt.targetText, tt.locale,
+			)
+			parsed := postSegmentAndDecode(t, client, baseURL, payload)
+			require.Empty(t, parsed.SkippedModes, "a fixture-supported locale must not report spelling as skipped")
+
+			spellingChecks := spellingChecksOf(parsed.Checks)
+			if tt.wantWarningWord == "" {
+				require.Empty(t, spellingChecks, "no spelling warnings expected for text using %s's own spelling", tt.locale)
+				return
+			}
+
+			require.Len(t, spellingChecks, 1)
+			require.Equal(t, segmentvalidate.StatusWarn, spellingChecks[0].Status)
+			require.Contains(t, spellingChecks[0].RelatedTokens, tt.wantWarningWord)
+			if tt.wantSuggestion != "" {
+				require.Contains(t, spellingChecks[0].RelatedTokens, tt.wantSuggestion)
+			}
+		})
+	}
+}
+
+func TestIntegrationPlaceholdersAndMarkupProduceNoFalsePositives(t *testing.T) {
+	checker := newIntegrationSpellChecker(t)
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: checker}
+	baseURL, _ := startTestServer(t, h)
+	client := &http.Client{}
+
+	const payload = `{"sourceText":"<b>hello</b> update {name} color","targetText":"<b>please</b> update {name} colour","sourcePath":"/messages/test.json","modes":["spelling"],"targetLocale":"en-US"}`
+	parsed := postSegmentAndDecode(t, client, baseURL, payload)
+	require.Empty(t, parsed.SkippedModes)
+
+	spellingChecks := spellingChecksOf(parsed.Checks)
+	require.Len(t, spellingChecks, 1, "the HTML tags and {name} placeholder must not be flagged, only the genuine misspelling")
+	require.Equal(t, segmentvalidate.StatusWarn, spellingChecks[0].Status)
+	require.Contains(t, spellingChecks[0].RelatedTokens, "colour")
+}
+
+func TestIntegrationUnsupportedLocaleSkipsSpellingButKeepsFormatChecks(t *testing.T) {
+	checker := newIntegrationSpellChecker(t)
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: checker}
+	baseURL, _ := startTestServer(t, h)
+	client := &http.Client{}
+
+	const payload = `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/test.json","modes":["spelling"],"targetLocale":"ja-JP"}`
+	parsed := postSegmentAndDecode(t, client, baseURL, payload)
+
+	require.Equal(t, []string{QA_MODE_SPELLING}, parsed.SkippedModes)
+	require.NotEmpty(t, parsed.Checks, "format/QA checks must still run for a locale with no spelling dictionary")
+	require.Empty(t, spellingChecksOf(parsed.Checks))
+}
+
+type localeConcurrencyCase struct {
+	locale          string
+	targetText      string
+	wantWarningWord string
+}
+
+func TestIntegrationConcurrentRequestsAcrossLocales(t *testing.T) {
+	checker := newIntegrationSpellChecker(t)
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: checker}
+	baseURL, _ := startTestServer(t, h)
+	client := &http.Client{}
+
+	cases := []localeConcurrencyCase{
+		{locale: integrationLocaleEnUS, targetText: "please update color"},
+		{locale: integrationLocaleEnUS, targetText: "please update colour", wantWarningWord: "colour"},
+		{locale: integrationLocaleEnGB, targetText: "please update colour"},
+		{locale: integrationLocaleEnGB, targetText: "please update color", wantWarningWord: "color"},
+		{locale: integrationLocalePtBR, targetText: "nome atualizar registro"},
+		{locale: integrationLocalePtBR, targetText: "nome atualizar registo", wantWarningWord: "registo"},
+		{locale: integrationLocalePtPT, targetText: "nome atualizar registo"},
+		{locale: integrationLocalePtPT, targetText: "nome atualizar registro", wantWarningWord: "registro"},
+	}
+
+	const repeats = 3
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(cases)*repeats)
+
+	for _, tc := range cases {
+		for i := 0; i < repeats; i++ {
+			wg.Add(1)
+			go func(tc localeConcurrencyCase) {
+				defer wg.Done()
+
+				payload := fmt.Sprintf(
+					`{"sourceText":"Hello","targetText":%q,"sourcePath":"/messages/test.json","modes":["spelling"],"targetLocale":%q}`,
+					tc.targetText, tc.locale,
+				)
+				resp, err := postSegment(client, baseURL, payload)
+				if err != nil {
+					errCh <- fmt.Errorf("%s/%s: request error: %w", tc.locale, tc.targetText, err)
+					return
+				}
+				defer func() { _ = resp.Body.Close() }()
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					errCh <- fmt.Errorf("%s/%s: read body: %w", tc.locale, tc.targetText, err)
+					return
+				}
+				if resp.StatusCode != http.StatusOK {
+					errCh <- fmt.Errorf("%s/%s: status = %d (body=%s)", tc.locale, tc.targetText, resp.StatusCode, body)
+					return
+				}
+
+				var parsed validateSegmentResponse
+				if err := json.Unmarshal(body, &parsed); err != nil {
+					errCh <- fmt.Errorf("%s/%s: decode: %w", tc.locale, tc.targetText, err)
+					return
+				}
+
+				spellingChecks := spellingChecksOf(parsed.Checks)
+				if tc.wantWarningWord == "" {
+					if len(spellingChecks) != 0 {
+						errCh <- fmt.Errorf("%s/%s: unexpected spelling warnings: %+v", tc.locale, tc.targetText, spellingChecks)
+					}
+					return
+				}
+				if len(spellingChecks) != 1 {
+					errCh <- fmt.Errorf("%s/%s: got %d spelling warnings, want 1", tc.locale, tc.targetText, len(spellingChecks))
+					return
+				}
+				found := false
+				for _, token := range spellingChecks[0].RelatedTokens {
+					if token == tc.wantWarningWord {
+						found = true
+						break
+					}
+				}
+				if !found {
+					errCh <- fmt.Errorf("%s/%s: expected warning for %q, got tokens %v", tc.locale, tc.targetText, tc.wantWarningWord, spellingChecks[0].RelatedTokens)
+				}
+			}(tc)
+		}
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}

--- a/apps/go-svc/spellcheck_integration_cgo_test.go
+++ b/apps/go-svc/spellcheck_integration_cgo_test.go
@@ -82,8 +82,8 @@ func TestIntegrationSpellingAcrossLocaleFamiliesAndRegionalVariants(t *testing.T
 		name            string
 		locale          string
 		targetText      string
-		wantWarningWord string 
-		wantSuggestion  string 
+		wantWarningWord string
+		wantSuggestion  string
 	}{
 		{name: "en-US accepts its own spelling", locale: integrationLocaleEnUS, targetText: "please update color"},
 		{

--- a/apps/go-svc/spellcheck_observability.go
+++ b/apps/go-svc/spellcheck_observability.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"log/slog"
+	"time"
+)
+
+func logSpellingObservability(duration time.Duration, localeSkipped bool, providerErrorCount, warningCount int) {
+	slog.Info("spellcheck: request completed",
+		"spelling_duration_ms", duration.Milliseconds(),
+		"spelling_locale_skipped", localeSkipped,
+		"spelling_provider_error_count", providerErrorCount,
+		"spelling_warning_count", warningCount,
+	)
+}

--- a/apps/go-svc/spellcheck_observability_test.go
+++ b/apps/go-svc/spellcheck_observability_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
+	"github.com/stretchr/testify/require"
+)
+
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return &buf
+}
+
+func findLogEntry(t *testing.T, buf *bytes.Buffer, message string) map[string]any {
+	t.Helper()
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		if entry["msg"] == message {
+			return entry
+		}
+	}
+	t.Fatalf("no log line with message %q found in: %s", message, buf.String())
+	return nil
+}
+
+const spellingObservabilityLogMessage = "spellcheck: request completed"
+
+func TestComposeSegmentValidationLogsSpellingObservabilityOnSuccess(t *testing.T) {
+	buf := captureSlog(t)
+	fake := &fakeSpellChecker{issues: []SpellingIssue{
+		{Word: "recieve", Suggestions: []string{"receive"}},
+		{Word: "wierd", Suggestions: []string{"weird"}},
+	}}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{
+		SourceText: "Hello",
+		TargetText: "Please recieve the wierd update",
+		SourcePath: "/messages/en.json",
+	}
+	_, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+	require.NoError(t, err)
+	require.Empty(t, skipped)
+
+	entry := findLogEntry(t, buf, spellingObservabilityLogMessage)
+	require.Contains(t, entry, "spelling_duration_ms")
+	require.Equal(t, false, entry["spelling_locale_skipped"])
+	require.Equal(t, float64(0), entry["spelling_provider_error_count"])
+	require.Equal(t, float64(2), entry["spelling_warning_count"])
+}
+
+func TestComposeSegmentValidationLogsSpellingObservabilityOnLocaleSkip(t *testing.T) {
+	buf := captureSlog(t)
+	fake := &fakeSpellChecker{err: fmt.Errorf("%w: %q", spellcheck.ErrUnsupportedLocale, "en-CA")}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	_, skipped, err := h.composeSegmentValidation(context.Background(), req, "en-CA", true)
+	require.NoError(t, err)
+	require.Equal(t, []string{QA_MODE_SPELLING}, skipped)
+
+	entry := findLogEntry(t, buf, spellingObservabilityLogMessage)
+	require.Contains(t, entry, "spelling_duration_ms")
+	require.Equal(t, true, entry["spelling_locale_skipped"])
+	require.Equal(t, float64(0), entry["spelling_provider_error_count"])
+	require.Equal(t, float64(0), entry["spelling_warning_count"])
+}
+
+func TestComposeSegmentValidationLogsSpellingObservabilityOnUnavailableProvider(t *testing.T) {
+	buf := captureSlog(t)
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: NoopSpellChecker{}}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	_, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+	require.NoError(t, err)
+	require.Equal(t, []string{QA_MODE_SPELLING}, skipped)
+
+	entry := findLogEntry(t, buf, spellingObservabilityLogMessage)
+	require.Equal(t, true, entry["spelling_locale_skipped"])
+	require.Equal(t, float64(0), entry["spelling_provider_error_count"])
+	require.Equal(t, float64(0), entry["spelling_warning_count"])
+}
+
+func TestComposeSegmentValidationLogsSpellingObservabilityOnProviderError(t *testing.T) {
+	buf := captureSlog(t)
+	fake := &fakeSpellChecker{err: errors.New("provider exploded")}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	_, skipped, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+	require.NoError(t, err)
+	require.Equal(t, []string{QA_MODE_SPELLING}, skipped)
+
+	entry := findLogEntry(t, buf, spellingObservabilityLogMessage)
+	require.Equal(t, false, entry["spelling_locale_skipped"])
+	require.Equal(t, float64(1), entry["spelling_provider_error_count"])
+	require.Equal(t, float64(0), entry["spelling_warning_count"])
+}
+
+func TestComposeSegmentValidationDoesNotLogSpellingObservabilityWhenNotRequested(t *testing.T) {
+	buf := captureSlog(t)
+	h := &handler{
+		validate: func(req segmentvalidate.Request) []segmentvalidate.Check {
+			return []segmentvalidate.Check{{ID: "format-parity", Status: segmentvalidate.StatusPass}}
+		},
+		spellChecker: &fakeSpellChecker{},
+	}
+
+	_, _, err := h.composeSegmentValidation(context.Background(), validateSegmentRequest{}, "", false)
+	require.NoError(t, err)
+	require.Empty(t, buf.String(), "no spelling observability should be logged when spelling was not requested")
+}
+
+func TestComposeSegmentValidationDoesNotLogSpellingObservabilityOnCancellation(t *testing.T) {
+	buf := captureSlog(t)
+	fake := &fakeSpellChecker{err: context.Canceled}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{SourceText: "Hello", TargetText: "Bonjour", SourcePath: "/messages/en.json"}
+	_, _, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, buf.String(), "a canceled spelling check has no completed outcome to report")
+}
+
+func TestComposeSegmentValidationSpellingObservabilityNeverLogsSegmentText(t *testing.T) {
+	buf := captureSlog(t)
+	const canary = "CANARY-SECRET-do-not-log-this-9f2c"
+	fake := &fakeSpellChecker{issues: []SpellingIssue{{Word: "recieve", Suggestions: []string{"receive"}}}}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+
+	req := validateSegmentRequest{
+		SourceText: "Source " + canary,
+		TargetText: "Target " + canary + " recieve",
+		SourcePath: "/messages/" + canary + ".json",
+	}
+	_, _, err := h.composeSegmentValidation(context.Background(), req, "fr-FR", true)
+	require.NoError(t, err)
+
+	require.NotContains(t, buf.String(), canary, "spelling observability logs must never include segment text")
+}

--- a/apps/go-svc/testdata/integration/en-gb/test.aff
+++ b/apps/go-svc/testdata/integration/en-gb/test.aff
@@ -1,0 +1,2 @@
+SET UTF-8
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'

--- a/apps/go-svc/testdata/integration/en-gb/test.dic
+++ b/apps/go-svc/testdata/integration/en-gb/test.dic
@@ -1,0 +1,4 @@
+3
+please
+update
+colour

--- a/apps/go-svc/testdata/integration/en-us/test.aff
+++ b/apps/go-svc/testdata/integration/en-us/test.aff
@@ -1,0 +1,2 @@
+SET UTF-8
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'

--- a/apps/go-svc/testdata/integration/en-us/test.dic
+++ b/apps/go-svc/testdata/integration/en-us/test.dic
@@ -1,0 +1,4 @@
+3
+please
+update
+color

--- a/apps/go-svc/testdata/integration/pt-br/test.aff
+++ b/apps/go-svc/testdata/integration/pt-br/test.aff
@@ -1,0 +1,2 @@
+SET UTF-8
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'

--- a/apps/go-svc/testdata/integration/pt-br/test.dic
+++ b/apps/go-svc/testdata/integration/pt-br/test.dic
@@ -1,0 +1,4 @@
+3
+nome
+atualizar
+registro

--- a/apps/go-svc/testdata/integration/pt-pt/test.aff
+++ b/apps/go-svc/testdata/integration/pt-pt/test.aff
@@ -1,0 +1,2 @@
+SET UTF-8
+TRY esianrtolcdugmphbyfvkwzESIANRTOLCDUGMPHBYFVKWZ'

--- a/apps/go-svc/testdata/integration/pt-pt/test.dic
+++ b/apps/go-svc/testdata/integration/pt-pt/test.dic
@@ -1,0 +1,4 @@
+3
+nome
+atualizar
+registo

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-validation.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-validation.ts
@@ -70,6 +70,8 @@ export function isBcp47LanguageTag(value: string): boolean {
 }
 
 const CAT_SEGMENT_VALIDATION_ENABLED = true;
+// Allows spelling to be disabled without disabling all segment validation.
+const CAT_SEGMENT_SPELLING_ENABLED = true;
 
 export type ContentEditorSegmentValidationError =
   | { code: "aborted" }
@@ -97,9 +99,10 @@ export async function fetchCatSegmentValidation(
   );
   const targetLocale = input.targetLocale.trim();
   const canRequestSpelling = isBcp47LanguageTag(targetLocale);
-  const modes = canRequestSpelling
-    ? CAT_SEGMENT_QA_MODES
-    : CAT_SEGMENT_QA_MODES.filter((mode) => mode !== CAT_SEGMENT_SPELLING_MODE);
+  const modes =
+    canRequestSpelling && CAT_SEGMENT_SPELLING_ENABLED
+      ? CAT_SEGMENT_QA_MODES
+      : CAT_SEGMENT_QA_MODES.filter((mode) => mode !== CAT_SEGMENT_SPELLING_MODE);
 
   const responseResult = await fromThrowableAsync(
     fetcher("/api/go-svc/v1/validate/segment", {

--- a/docs/adr/2026-09-01-cat-spellcheck-rollout-validation-design.md
+++ b/docs/adr/2026-09-01-cat-spellcheck-rollout-validation-design.md
@@ -1,0 +1,91 @@
+# CAT spellcheck rollout and rollback
+
+## Date
+
+2026-09-01
+
+## Context
+
+CAT already posts to `/api/go-svc/v1/validate/segment` for format, length, and
+QA checks. `go-svc` can also spell-check requested locales with Hunspell when
+built with `cgo_hunspell`. The `go_svc` container service and `/api/go-svc/*`
+rewrite are already in [`vercel.json`](../../vercel.json). This record is the
+rollout and rollback procedure for turning CAT spelling on and for turning it
+off independently of the rest of segment validation.
+
+Related: [CAT segment validation service
+integration](./2026-07-05-cat-segment-validation-service-design.md), [CLI spell
+check](./2026-08-28-cli-spellcheck-design.md).
+
+## Decision
+
+Keep spelling behind a web compile-time flag that is independent of all CAT
+segment validation. Rollback spelling first; disable all segment validation
+only if the problem is not spelling.
+
+### Rollout order
+
+This order is already in place. Follow it again only if a future change turns
+the flags off.
+
+1. Confirm `vercel.json` defines the `go_svc` container (`Dockerfile.vercel`)
+   and the `/api/go-svc/*` rewrite.
+2. Build and deploy that image (`make docker-build-go-svc`, then the usual
+   deploy).
+3. Confirm `GET /api/go-svc/health` returns `{"status":"ok"}`.
+4. Set both flags in
+   [`project-file-content-editor-validation.ts`](../../apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-validation.ts)
+   to `true` and deploy web:
+   - `CAT_SEGMENT_VALIDATION_ENABLED` — all CAT segment validation.
+   - `CAT_SEGMENT_SPELLING_ENABLED` — include `"spelling"` in `modes` when the
+     target locale is a BCP 47 tag.
+
+### Toggle
+
+`CAT_SEGMENT_SPELLING_ENABLED` is the supported deployment toggle for
+spelling. Set it to `false` and redeploy web. CAT keeps posting format and QA
+modes; it stops requesting spelling. `CAT_SEGMENT_VALIDATION_ENABLED` stays
+`true`.
+
+Do not treat an invalid `HUNSPELL_DICT_DIR`, a missing dictionary, or a
+non-`cgo_hunspell` build as a rollback switch. Those are existing
+provider-unavailable behaviours: the service still starts, format and QA checks
+still run, and the response lists `"spelling"` in `skippedModes`.
+
+### Rollback order
+
+1. Set `CAT_SEGMENT_SPELLING_ENABLED = false` and redeploy web. Spelling stops;
+   other segment checks continue.
+2. If the fault is not spelling, set `CAT_SEGMENT_VALIDATION_ENABLED = false`
+   and redeploy web. CAT stops calling go-svc for segment validation.
+
+### Observability
+
+Each completed spelling check emits one `spellcheck: request completed` log
+from `composeSegmentValidation`. Canceled or deadline-exceeded checks do not
+emit this completion log. Fields:
+
+| Field | Meaning |
+| --- | --- |
+| `spelling_duration_ms` | Time spent in `checkSpelling` |
+| `spelling_locale_skipped` | `true` when the locale has no dictionary or the provider is unavailable |
+| `spelling_provider_error_count` | `0` or `1`; unexpected provider errors |
+| `spelling_warning_count` | Spelling issues found before the per-response cap |
+
+The log takes only duration, booleans, and counts. The spelling log must not
+include source text, target text, extracted words, or the submitted source file
+path. The generic request log records HTTP method, route path, status,
+duration, and an optional request id.
+
+### Smoke test
+
+After deploy, as a signed-in user, `POST /api/go-svc/v1/validate/segment` with
+the `wos-session` cookie.
+
+- Supported locale (`en-US`): body includes `"modes":["spelling"]` and a
+  misspelling from the dictionary. Expect HTTP 200, a spelling warning in
+  `checks`, and no `"spelling"` in `skippedModes`.
+- Unsupported locale (`ja-JP`): expect HTTP 200, format/QA checks present, and
+  `"spelling"` in `skippedModes`.
+- Logs for that request contain `spelling_duration_ms` and do not contain the
+  segment text.


### PR DESCRIPTION
## What changed

- Added per-request spelling observability without logging segment content.
- Added production-shaped server tests for concurrency, graceful shutdown, and log hygiene.
- Added real Hunspell integration coverage across `en-US`/`en-GB` and `pt-BR`/`pt-PT`, including markup/placeholders and unsupported locales.
- Added an independent CAT spelling rollback toggle.
- Documented rollout, rollback, observability, and deployed smoke-test steps.

## How to test

- `make fmt`
- `make lint`
- `go test -race ./apps/go-svc/...`
- `make check-build-go-svc-cgo`
- `make docker-build-go-svc`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
