### PR TITLE
feat(web): add MCP connect-agent card to workspace overview

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/mcp.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/mcp.test.ts
@@ -114,7 +114,7 @@ describe("mcpBearerAuthMiddleware", () => {
       .set({ lifecycleStatus: "archived", archivedAt: new Date() })
       .where(eq(schema.organizations.id, auth.organization.localOrganizationId));
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       headers: {
         authorization: `Bearer ${accessToken}`,
       },
@@ -165,7 +165,7 @@ describe("mcpBearerAuthMiddleware", () => {
         ),
       );
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       headers: {
         authorization: `Bearer ${accessToken}`,
       },
@@ -218,7 +218,7 @@ describe("mcpBearerAuthMiddleware", () => {
         ),
       );
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       headers: {
         authorization: `Bearer ${accessToken}`,
       },

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -203,7 +203,7 @@ describe("mcpRoutes", () => {
   });
 
   it("returns an absolute OAuth metadata URI on bearer challenges", async () => {
-    const response = await app.request("http://localhost/mcp/sse");
+    const response = await app.request("http://localhost/mcp");
 
     expect(response.status).toBe(401);
     expect(response.headers.get("www-authenticate")).toBe(
@@ -212,7 +212,7 @@ describe("mcpRoutes", () => {
   });
 
   it("returns the protected-resource challenge for invalid bearer tokens", async () => {
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       headers: {
         authorization: "Bearer invalid-token",
       },
@@ -232,7 +232,7 @@ describe("mcpRoutes", () => {
     const metadata = OAuthProtectedResourceMetadataSchema.parse(await response.json());
 
     expect(metadata).toMatchObject({
-      resource: "http://localhost/mcp/sse",
+      resource: "http://localhost/mcp",
       authorization_servers: ["http://localhost"],
       scopes_supported: ["mcp"],
     });
@@ -274,7 +274,7 @@ describe("mcpRoutes", () => {
         revokedAt,
       });
 
-      const response = await app.request("http://localhost/mcp/sse", {
+      const response = await app.request("http://localhost/mcp", {
         headers: {
           authorization: `Bearer ${accessToken}`,
         },
@@ -408,7 +408,7 @@ describe("mcpRoutes", () => {
   });
 
   it("does not expose MCP through the API alias", async () => {
-    const response = await apiApp.request("http://localhost/api/mcp/sse");
+    const response = await apiApp.request("http://localhost/api/mcp");
 
     expect(response.status).toBe(404);
   });
@@ -722,7 +722,8 @@ describe("mcpRoutes", () => {
   });
 
   it.each([
-    ["canonical endpoint", "/mcp/sse"],
+    ["canonical endpoint", "/mcp"],
+    ["legacy streamable path", "/mcp/sse"],
     ["compatibility alias", "/mcp/message"],
   ])("returns 405 for an authenticated GET to the $0", async (_label, endpoint) => {
     const headers = await authenticatedMcpHeaders();
@@ -746,7 +747,7 @@ describe("mcpRoutes", () => {
     const closeSpy = vi.spyOn(McpServer.prototype, "close");
 
     try {
-      const response = await app.request("http://localhost/mcp/sse", {
+      const response = await app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,
@@ -774,7 +775,7 @@ describe("mcpRoutes", () => {
     const closeSpy = vi.spyOn(McpServer.prototype, "close");
 
     try {
-      const response = await app.request("http://localhost/mcp/sse", {
+      const response = await app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,
@@ -809,7 +810,7 @@ describe("mcpRoutes", () => {
     const headers = await authenticatedMcpHeaders();
 
     const postMcp = (message: unknown) =>
-      app.request("http://localhost/mcp/sse", {
+      app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,
@@ -888,33 +889,36 @@ describe("mcpRoutes", () => {
     });
   });
 
-  it("keeps /mcp/message as a POST compatibility alias", async () => {
-    const headers = await authenticatedMcpHeaders();
+  it.each(["/mcp/sse", "/mcp/message"])(
+    "keeps %s as a POST compatibility alias",
+    async (endpoint) => {
+      const headers = await authenticatedMcpHeaders();
 
-    const response = await app.request("http://localhost/mcp/message", {
-      method: "POST",
-      headers: {
-        ...headers,
-        accept: "application/json, text/event-stream",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
+      const response = await app.request(`http://localhost${endpoint}`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+          params: {},
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
         jsonrpc: "2.0",
         id: 1,
-        method: "tools/list",
-        params: {},
-      }),
-    });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      jsonrpc: "2.0",
-      id: 1,
-      result: {
-        tools: expect.any(Array),
-      },
-    });
-  });
+        result: {
+          tools: expect.any(Array),
+        },
+      });
+    },
+  );
 
   it("works with a real Streamable HTTP MCP client without GET reconnects or errors", async () => {
     const stored = await fixture.createStoredProjectFixture();
@@ -923,7 +927,7 @@ describe("mcpRoutes", () => {
     const requestMethods: string[] = [];
     const transportErrors: Error[] = [];
 
-    const transport = new StreamableHTTPClientTransport(new URL("http://localhost/mcp/sse"), {
+    const transport = new StreamableHTTPClientTransport(new URL("http://localhost/mcp"), {
       requestInit: {
         headers: {
           ...headers,
@@ -1107,7 +1111,7 @@ describe("mcpRoutes", () => {
   it("preserves MCP protocol-version validation for POST requests", async () => {
     const headers = await authenticatedMcpHeaders();
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       method: "POST",
       headers: {
         ...headers,
@@ -1129,7 +1133,7 @@ describe("mcpRoutes", () => {
   it("advertises the list_issues tool with a bounded input schema", async () => {
     const headers = await authenticatedMcpHeaders();
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       method: "POST",
       headers: {
         ...headers,
@@ -1250,7 +1254,7 @@ describe("mcpRoutes", () => {
     });
 
     try {
-      const response = await app.request("http://localhost/mcp/sse", {
+      const response = await app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,
@@ -1355,7 +1359,7 @@ describe("mcpRoutes", () => {
   ])("returns invalid_issue_query for %s", async (_label, args) => {
     const headers = await authenticatedMcpHeaders();
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       method: "POST",
       headers: {
         ...headers,
@@ -1395,7 +1399,7 @@ describe("mcpRoutes", () => {
   it("advertises the get_issue tool with issue identifier validation", async () => {
     const headers = await authenticatedMcpHeaders();
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       method: "POST",
       headers: {
         ...headers,
@@ -1445,7 +1449,7 @@ describe("mcpRoutes", () => {
   it("advertises the create_issue tool with a bounded input schema", async () => {
     const headers = await authenticatedMcpHeaders();
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       method: "POST",
       headers: {
         ...headers,
@@ -1566,7 +1570,7 @@ describe("mcpRoutes", () => {
     const getIssueSpy = vi.spyOn(IssueSheetService.prototype, "getIssue");
 
     try {
-      const response = await app.request("http://localhost/mcp/sse", {
+      const response = await app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,
@@ -1657,7 +1661,7 @@ describe("mcpRoutes", () => {
       },
     });
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       method: "POST",
       headers: {
         ...headers,
@@ -1787,7 +1791,7 @@ describe("mcpRoutes", () => {
     const createSpy = vi.spyOn(IssueSheetService.prototype, "createIssue");
 
     try {
-      const response = await app.request("http://localhost/mcp/sse", {
+      const response = await app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,
@@ -1866,7 +1870,7 @@ describe("mcpRoutes", () => {
     });
 
     try {
-      const response = await app.request("http://localhost/mcp/sse", {
+      const response = await app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,
@@ -1960,7 +1964,7 @@ describe("mcpRoutes", () => {
       },
     });
 
-    const response = await app.request("http://localhost/mcp/sse", {
+    const response = await app.request("http://localhost/mcp", {
       method: "POST",
       headers: {
         ...headers,
@@ -2020,7 +2024,7 @@ describe("mcpRoutes", () => {
     }
 
     const callCreateIssue = async (title: string) =>
-      app.request("http://localhost/mcp/sse", {
+      app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,
@@ -2142,7 +2146,7 @@ describe("mcpRoutes", () => {
       .mockRejectedValueOnce(new Error(serviceError));
 
     try {
-      const response = await app.request("http://localhost/mcp/sse", {
+      const response = await app.request("http://localhost/mcp", {
         method: "POST",
         headers: {
           ...headers,

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -284,7 +284,7 @@ export function getMcpProtectedResourceMetadata(origin: string, apiBasePath = "/
   const mcpBasePath = getMcpBasePath(apiBasePath);
 
   return {
-    resource: `${origin}${mcpBasePath}/sse`,
+    resource: `${origin}${mcpBasePath}`,
     authorization_servers: [origin],
     scopes_supported: ["mcp"],
     bearer_methods_supported: ["header"],
@@ -951,8 +951,9 @@ const validateRegisterBody = validator("json", (value, c) => {
 export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
   const apiBasePath = options.apiBasePath ?? "/api";
 
-  // `/mcp/sse` is the canonical Streamable HTTP endpoint advertised by
-  // protected-resource metadata. `/mcp/message` remains a compatibility alias.
+  // `/mcp` is the canonical Streamable HTTP endpoint advertised by
+  // protected-resource metadata. `/mcp/sse` and `/mcp/message` remain
+  // compatibility aliases.
   return new Hono<{ Variables: McpAuthVariables }>()
     .get("/.well-known/oauth-authorization-server", (c) =>
       c.json(getMcpAuthorizationServerMetadata(endpointOrigin(c), apiBasePath), 200),
@@ -960,6 +961,7 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
     .get("/.well-known/oauth-protected-resource", (c) =>
       c.json(getMcpProtectedResourceMetadata(endpointOrigin(c), apiBasePath), 200),
     )
+    .use("/mcp", mcpAuthEnabledMiddleware)
     .use("/mcp/*", mcpAuthEnabledMiddleware)
     .post(
       "/mcp/register",
@@ -1304,8 +1306,10 @@ export function createMcpRoutes(options: { apiBasePath?: string } = {}) {
         );
       },
     )
+    .use("/mcp", mcpBearerAuthMiddleware)
     .use("/mcp/sse", mcpBearerAuthMiddleware)
     .use("/mcp/message", mcpBearerAuthMiddleware)
+    .all("/mcp", async (c) => handleMcpTransport(c.req.raw, c.var.mcpAuth))
     .all("/mcp/sse", async (c) => handleMcpTransport(c.req.raw, c.var.mcpAuth))
     .all("/mcp/message", async (c) => handleMcpTransport(c.req.raw, c.var.mcpAuth));
 }

--- a/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/mcp/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/mcp/route.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export { GET } from "../route";

--- a/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/route.test.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/route.test.ts
@@ -15,7 +15,8 @@ import { discoverOAuthProtectedResourceMetadata } from "@modelcontextprotocol/sd
 import { describe, expect, it } from "vite-plus/test";
 
 import { GET } from "./route";
-import { GET as GET_PATH_AWARE } from "./mcp/sse/route";
+import { GET as GET_PATH_AWARE } from "./mcp/route";
+import { GET as GET_LEGACY_PATH_AWARE } from "./mcp/sse/route";
 
 describe("OAuth protected resource metadata route", () => {
   it("returns metadata for the hosted MCP endpoint", async () => {
@@ -28,7 +29,7 @@ describe("OAuth protected resource metadata route", () => {
     const metadata = OAuthProtectedResourceMetadataSchema.parse(await response.json());
 
     expect(metadata).toMatchObject({
-      resource: "https://www.hyperlocalise.com/mcp/sse",
+      resource: "https://www.hyperlocalise.com/mcp",
       authorization_servers: ["https://www.hyperlocalise.com"],
       scopes_supported: ["mcp"],
     });
@@ -36,6 +37,22 @@ describe("OAuth protected resource metadata route", () => {
 
   it("returns metadata from the endpoint-specific discovery URL", async () => {
     const response = GET_PATH_AWARE(
+      new Request("https://www.hyperlocalise.com/.well-known/oauth-protected-resource/mcp"),
+    );
+
+    expect(response.status).toBe(200);
+
+    const metadata = OAuthProtectedResourceMetadataSchema.parse(await response.json());
+
+    expect(metadata).toMatchObject({
+      resource: "https://www.hyperlocalise.com/mcp",
+      authorization_servers: ["https://www.hyperlocalise.com"],
+      scopes_supported: ["mcp"],
+    });
+  });
+
+  it("keeps the legacy /mcp/sse discovery URL", async () => {
+    const response = GET_LEGACY_PATH_AWARE(
       new Request("https://www.hyperlocalise.com/.well-known/oauth-protected-resource/mcp/sse"),
     );
 
@@ -44,7 +61,7 @@ describe("OAuth protected resource metadata route", () => {
     const metadata = OAuthProtectedResourceMetadataSchema.parse(await response.json());
 
     expect(metadata).toMatchObject({
-      resource: "https://www.hyperlocalise.com/mcp/sse",
+      resource: "https://www.hyperlocalise.com/mcp",
       authorization_servers: ["https://www.hyperlocalise.com"],
       scopes_supported: ["mcp"],
     });
@@ -54,13 +71,13 @@ describe("OAuth protected resource metadata route", () => {
     const requestedUrls: string[] = [];
 
     const metadata = await discoverOAuthProtectedResourceMetadata(
-      "https://www.hyperlocalise.com/mcp/sse",
+      "https://www.hyperlocalise.com/mcp",
       undefined,
       async (input, init) => {
         const request = new Request(input, init);
         requestedUrls.push(request.url);
 
-        if (new URL(request.url).pathname === "/.well-known/oauth-protected-resource/mcp/sse") {
+        if (new URL(request.url).pathname === "/.well-known/oauth-protected-resource/mcp") {
           return GET_PATH_AWARE(request);
         }
 
@@ -69,8 +86,8 @@ describe("OAuth protected resource metadata route", () => {
     );
 
     expect(requestedUrls).toEqual([
-      "https://www.hyperlocalise.com/.well-known/oauth-protected-resource/mcp/sse",
+      "https://www.hyperlocalise.com/.well-known/oauth-protected-resource/mcp",
     ]);
-    expect(metadata.resource).toBe("https://www.hyperlocalise.com/mcp/sse");
+    expect(metadata.resource).toBe("https://www.hyperlocalise.com/mcp");
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.messages.ts
@@ -1,0 +1,68 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const overviewConnectAgentCardMessages = defineMessages({
+  title: {
+    defaultMessage: "Connect your agent",
+    id: 'OY5+Uf7y9y',
+    description: "Overview card title for connecting an MCP client to the workspace",
+  },
+  description: {
+    defaultMessage: "Access your Hyperlocalise workspace from MCP clients.",
+    id: 'I3Xom21N//',
+    description: "Overview card description for the inbound MCP connection snippet",
+  },
+  setupGuide: {
+    defaultMessage: "Setup guide",
+    id: 'FJwHsDxO6W',
+    description: "Link to the selected MCP client's setup documentation",
+  },
+  clientClaude: {
+    defaultMessage: "Claude",
+    id: 'PHuY/CmjvV',
+    description: "MCP client tab label for Claude",
+  },
+  clientCodex: {
+    defaultMessage: "Codex",
+    id: 'G9IH7mtmIb',
+    description: "MCP client tab label for Codex",
+  },
+  clientCursor: {
+    defaultMessage: "Cursor",
+    id: 'kDHggb67Dc',
+    description: "MCP client tab label for Cursor",
+  },
+  snippetLabel: {
+    defaultMessage: "Install command for {client}",
+    id: 'pmeyEQny7X',
+    description: "Accessible label for the copyable MCP install snippet",
+  },
+  claudeNextStep: {
+    defaultMessage: "Then run {command} to authenticate.",
+    id: 'JvZ26UFlte',
+    description: "Next step after adding the Hyperlocalise MCP server in Claude",
+  },
+  codexNextStep: {
+    defaultMessage: "Then run {command} to authenticate.",
+    id: 'G8NgjmMOFE',
+    description: "Next step after adding the Hyperlocalise MCP server in Codex",
+  },
+  cursorNextStep: {
+    defaultMessage: "Add this to ~/.cursor/mcp.json, then open Settings → MCP and click Login.",
+    id: 'V9ow5L2f7M',
+    description: "Next step after copying the Hyperlocalise MCP config for Cursor",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.messages.ts
@@ -17,52 +17,52 @@ import { defineMessages } from "react-intl";
 export const overviewConnectAgentCardMessages = defineMessages({
   title: {
     defaultMessage: "Connect your agent",
-    id: 'OY5+Uf7y9y',
+    id: "OY5+Uf7y9y",
     description: "Overview card title for connecting an MCP client to the workspace",
   },
   description: {
     defaultMessage: "Access your Hyperlocalise workspace from MCP clients.",
-    id: 'I3Xom21N//',
+    id: "I3Xom21N//",
     description: "Overview card description for the inbound MCP connection snippet",
   },
   setupGuide: {
     defaultMessage: "Setup guide",
-    id: 'FJwHsDxO6W',
+    id: "FJwHsDxO6W",
     description: "Link to the selected MCP client's setup documentation",
   },
   clientClaude: {
     defaultMessage: "Claude",
-    id: 'PHuY/CmjvV',
+    id: "PHuY/CmjvV",
     description: "MCP client tab label for Claude",
   },
   clientCodex: {
     defaultMessage: "Codex",
-    id: 'G9IH7mtmIb',
+    id: "G9IH7mtmIb",
     description: "MCP client tab label for Codex",
   },
   clientCursor: {
     defaultMessage: "Cursor",
-    id: 'kDHggb67Dc',
+    id: "kDHggb67Dc",
     description: "MCP client tab label for Cursor",
   },
   snippetLabel: {
     defaultMessage: "Install command for {client}",
-    id: 'pmeyEQny7X',
+    id: "pmeyEQny7X",
     description: "Accessible label for the copyable MCP install snippet",
   },
   claudeNextStep: {
     defaultMessage: "Then run {command} to authenticate.",
-    id: 'JvZ26UFlte',
+    id: "JvZ26UFlte",
     description: "Next step after adding the Hyperlocalise MCP server in Claude",
   },
   codexNextStep: {
     defaultMessage: "Then run {command} to authenticate.",
-    id: 'G8NgjmMOFE',
+    id: "G8NgjmMOFE",
     description: "Next step after adding the Hyperlocalise MCP server in Codex",
   },
   cursorNextStep: {
     defaultMessage: "Add this to ~/.cursor/mcp.json, then open Settings → MCP and click Login.",
-    id: 'V9ow5L2f7M',
+    id: "V9ow5L2f7M",
     description: "Next step after copying the Hyperlocalise MCP config for Cursor",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.stories.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent } from "storybook/test";
+
+import { OverviewConnectAgentCard } from "./overview-connect-agent-card";
+
+const mcpUrl = "https://www.hyperlocalise.com/mcp/sse";
+
+const meta = {
+  title: "App/Overview/ConnectAgent",
+  component: OverviewConnectAgentCard,
+  args: {
+    mcpUrl,
+  },
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof OverviewConnectAgentCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Connect your agent" })).toBeInTheDocument();
+    await expect(canvas.getByRole("textbox", { name: "Install command for Claude" })).toHaveValue(
+      `claude mcp add -t http hyperlocalise ${mcpUrl}`,
+    );
+  },
+};
+
+export const Codex: Story = {
+  play: async ({ canvas }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Codex" }));
+    await expect(canvas.getByRole("textbox", { name: "Install command for Codex" })).toHaveValue(
+      `codex mcp add hyperlocalise --url ${mcpUrl}`,
+    );
+  },
+};
+
+export const Cursor: Story = {
+  play: async ({ canvas }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Cursor" }));
+    await expect(canvas.getByLabelText("Install command for Cursor")).toHaveTextContent(mcpUrl);
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.stories.tsx
@@ -15,7 +15,7 @@ import { expect, userEvent } from "storybook/test";
 
 import { OverviewConnectAgentCard } from "./overview-connect-agent-card";
 
-const mcpUrl = "https://www.hyperlocalise.com/mcp/sse";
+const mcpUrl = "https://www.hyperlocalise.com/mcp";
 
 const meta = {
   title: "App/Overview/ConnectAgent",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.test.tsx
@@ -21,7 +21,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 import { OverviewConnectAgentCard } from "./overview-connect-agent-card";
 
-const mcpUrl = "https://www.hyperlocalise.com/mcp/sse";
+const mcpUrl = "https://www.hyperlocalise.com/mcp";
 
 function renderCard() {
   return render(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+import { OverviewConnectAgentCard } from "./overview-connect-agent-card";
+
+const mcpUrl = "https://www.hyperlocalise.com/mcp/sse";
+
+function renderCard() {
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      <TooltipProvider>
+        <OverviewConnectAgentCard mcpUrl={mcpUrl} />
+      </TooltipProvider>
+    </IntlProvider>,
+  );
+}
+
+describe("OverviewConnectAgentCard", () => {
+  it("shows the Claude install command by default", () => {
+    renderCard();
+
+    expect(screen.getByRole("heading", { name: "Connect your agent" })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Install command for Claude" })).toHaveValue(
+      `claude mcp add -t http hyperlocalise ${mcpUrl}`,
+    );
+    expect(screen.getByText("/mcp")).toBeInTheDocument();
+  });
+
+  it("switches the snippet when another client is selected", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(screen.getByRole("tab", { name: "Codex" }));
+
+    expect(screen.getByRole("textbox", { name: "Install command for Codex" })).toHaveValue(
+      `codex mcp add hyperlocalise --url ${mcpUrl}`,
+    );
+    expect(screen.getByText("codex mcp login hyperlocalise")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Cursor" }));
+
+    expect(screen.getByLabelText("Install command for Cursor")).toHaveTextContent(
+      `"url": "${mcpUrl}"`,
+    );
+    expect(
+      screen.getByText("Add this to ~/.cursor/mcp.json, then open Settings → MCP and click Login."),
+    ).toBeInTheDocument();
+  });
+
+  it("copies the selected install snippet", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    renderCard();
+
+    await user.click(screen.getByRole("button", { name: "Copy" }));
+    expect(writeText).toHaveBeenCalledWith(`claude mcp add -t http hyperlocalise ${mcpUrl}`);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useState, useSyncExternalStore, type ReactNode } from "react";
+import { LinkSquare02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { siClaude, siCursor } from "simple-icons";
+
+import {
+  Snippet,
+  SnippetAddon,
+  SnippetCopyButton,
+  SnippetInput,
+  SnippetText,
+} from "@/components/ai-elements/snippet";
+import { Card, CardContent } from "@/components/ui/card";
+import { Kbd } from "@/components/ui/kbd";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import { SimpleBrandIcon } from "../../integrations/_components/simple-brand-icon";
+import {
+  buildHyperlocaliseMcpUrl,
+  buildMcpAgentSnippet,
+  mcpAgentClientIds,
+  mcpAgentSnippetUsesShellPrompt,
+  mcpClientSetupGuideUrls,
+  type McpAgentClient,
+} from "./overview-connect-agent";
+import { overviewConnectAgentCardMessages as messages } from "./overview-connect-agent-card.messages";
+
+const subscribeNoop = () => () => undefined;
+
+function useBrowserOrigin() {
+  return useSyncExternalStore(
+    subscribeNoop,
+    () => window.location.origin,
+    () => "",
+  );
+}
+
+function CodexBrandIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={cn("size-3.5", className)}
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+    </svg>
+  );
+}
+
+const CLIENT_TABS: readonly {
+  id: McpAgentClient;
+  label: typeof messages.clientClaude;
+  icon: ReactNode;
+}[] = [
+  {
+    id: "claude",
+    label: messages.clientClaude,
+    icon: <SimpleBrandIcon className="size-3.5" colored icon={siClaude} />,
+  },
+  {
+    id: "codex",
+    label: messages.clientCodex,
+    icon: <CodexBrandIcon />,
+  },
+  {
+    id: "cursor",
+    label: messages.clientCursor,
+    icon: <SimpleBrandIcon className="size-3.5" colored icon={siCursor} />,
+  },
+];
+
+function isMcpAgentClient(value: string): value is McpAgentClient {
+  return mcpAgentClientIds.includes(value as McpAgentClient);
+}
+
+function ClientNextStep({ client }: { client: McpAgentClient }) {
+  switch (client) {
+    case "claude":
+      return (
+        <FormattedMessage
+          {...messages.claudeNextStep}
+          values={{
+            command: <Kbd>/mcp</Kbd>,
+          }}
+        />
+      );
+    case "codex":
+      return (
+        <FormattedMessage
+          {...messages.codexNextStep}
+          values={{
+            command: <Kbd>codex mcp login hyperlocalise</Kbd>,
+          }}
+        />
+      );
+    case "cursor":
+      return <FormattedMessage {...messages.cursorNextStep} />;
+    default: {
+      const _exhaustive: never = client;
+      return _exhaustive;
+    }
+  }
+}
+
+export function OverviewConnectAgentCard({
+  mcpUrl: mcpUrlProp,
+  className,
+}: {
+  mcpUrl?: string;
+  className?: string;
+}) {
+  const intl = useIntl();
+  const origin = useBrowserOrigin();
+  const mcpUrl = mcpUrlProp ?? (origin ? buildHyperlocaliseMcpUrl(origin) : "");
+  const [client, setClient] = useState<McpAgentClient>("claude");
+  const snippet = mcpUrl ? buildMcpAgentSnippet(client, mcpUrl) : "";
+  const clientLabel = intl.formatMessage(
+    CLIENT_TABS.find((tab) => tab.id === client)?.label ?? messages.clientClaude,
+  );
+
+  return (
+    <Card className={cn("rounded-2xl border border-border bg-card py-0 ring-0", className)}>
+      <CardContent className="flex flex-col gap-4 px-6 py-6">
+        <Tabs
+          onValueChange={(value) => {
+            if (isMcpAgentClient(value)) {
+              setClient(value);
+            }
+          }}
+          value={client}
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="font-heading text-xl font-medium text-balance text-foreground">
+              <FormattedMessage {...messages.title} />
+            </h2>
+            <TabsList className="h-8 self-start rounded-full p-0.5 sm:self-auto">
+              {CLIENT_TABS.map((tab) => (
+                <TabsTrigger
+                  className="h-7 gap-1.5 rounded-full px-2.5 text-xs"
+                  key={tab.id}
+                  value={tab.id}
+                >
+                  {tab.icon}
+                  <FormattedMessage {...tab.label} />
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </div>
+        </Tabs>
+
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <TypographyP className="text-pretty text-sm text-muted-foreground">
+            <FormattedMessage {...messages.description} />
+          </TypographyP>
+          <a
+            className="inline-flex items-center gap-1 text-sm font-medium text-primary underline-offset-4 hover:underline"
+            href={mcpClientSetupGuideUrls[client]}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage {...messages.setupGuide} />
+            <HugeiconsIcon className="size-3.5" icon={LinkSquare02Icon} strokeWidth={1.8} />
+          </a>
+        </div>
+
+        <Snippet className={cn(client === "cursor" && "h-auto items-start")} code={snippet}>
+          {mcpAgentSnippetUsesShellPrompt(client) ? <SnippetText>$</SnippetText> : null}
+          {client === "cursor" ? (
+            <pre
+              aria-label={intl.formatMessage(messages.snippetLabel, {
+                client: clientLabel,
+              })}
+              className="min-w-0 flex-1 overflow-x-auto px-3 py-2.5 font-mono text-sm text-foreground"
+            >
+              {snippet}
+            </pre>
+          ) : (
+            <SnippetInput
+              aria-label={intl.formatMessage(messages.snippetLabel, {
+                client: clientLabel,
+              })}
+              onFocus={(event) => event.currentTarget.select()}
+            />
+          )}
+          <SnippetAddon align="inline-end">
+            <SnippetCopyButton />
+          </SnippetAddon>
+        </Snippet>
+
+        <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <ClientNextStep client={client} />
+        </TypographyP>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildHyperlocaliseMcpUrl,
+  buildMcpAgentSnippet,
+  mcpAgentSnippetUsesShellPrompt,
+} from "./overview-connect-agent";
+
+const mcpUrl = "https://www.hyperlocalise.com/mcp/sse";
+
+describe("overview connect agent helpers", () => {
+  it("builds the public streamable HTTP MCP URL", () => {
+    expect(buildHyperlocaliseMcpUrl("https://www.hyperlocalise.com")).toBe(mcpUrl);
+  });
+
+  it("builds the Claude install command", () => {
+    expect(buildMcpAgentSnippet("claude", mcpUrl)).toBe(
+      `claude mcp add -t http hyperlocalise ${mcpUrl}`,
+    );
+    expect(mcpAgentSnippetUsesShellPrompt("claude")).toBe(true);
+  });
+
+  it("builds the Codex install command", () => {
+    expect(buildMcpAgentSnippet("codex", mcpUrl)).toBe(
+      `codex mcp add hyperlocalise --url ${mcpUrl}`,
+    );
+  });
+
+  it("builds Cursor mcp.json for the remote server", () => {
+    expect(buildMcpAgentSnippet("cursor", mcpUrl)).toBe(`{
+  "mcpServers": {
+    "hyperlocalise": {
+      "url": "${mcpUrl}"
+    }
+  }
+}`);
+    expect(mcpAgentSnippetUsesShellPrompt("cursor")).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent.test.ts
@@ -18,7 +18,7 @@ import {
   mcpAgentSnippetUsesShellPrompt,
 } from "./overview-connect-agent";
 
-const mcpUrl = "https://www.hyperlocalise.com/mcp/sse";
+const mcpUrl = "https://www.hyperlocalise.com/mcp";
 
 describe("overview connect agent helpers", () => {
   it("builds the public streamable HTTP MCP URL", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent.ts
@@ -12,7 +12,7 @@
  */
 
 export const HYPERLOCALISE_MCP_SERVER_NAME = "hyperlocalise";
-export const HYPERLOCALISE_MCP_RESOURCE_PATH = "/mcp/sse";
+export const HYPERLOCALISE_MCP_RESOURCE_PATH = "/mcp";
 
 export const mcpAgentClientIds = ["claude", "codex", "cursor"] as const;
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const HYPERLOCALISE_MCP_SERVER_NAME = "hyperlocalise";
+export const HYPERLOCALISE_MCP_RESOURCE_PATH = "/mcp/sse";
+
+export const mcpAgentClientIds = ["claude", "codex", "cursor"] as const;
+
+export type McpAgentClient = (typeof mcpAgentClientIds)[number];
+
+export const mcpClientSetupGuideUrls = {
+  claude: "https://code.claude.com/docs/en/mcp-quickstart",
+  codex: "https://developers.openai.com/codex/mcp",
+  cursor: "https://cursor.com/docs/context/mcp",
+} as const satisfies Record<McpAgentClient, string>;
+
+export function buildHyperlocaliseMcpUrl(origin: string) {
+  return new URL(HYPERLOCALISE_MCP_RESOURCE_PATH, origin).toString();
+}
+
+export function buildMcpAgentSnippet(client: McpAgentClient, mcpUrl: string) {
+  switch (client) {
+    case "claude":
+      return `claude mcp add -t http ${HYPERLOCALISE_MCP_SERVER_NAME} ${mcpUrl}`;
+    case "codex":
+      return `codex mcp add ${HYPERLOCALISE_MCP_SERVER_NAME} --url ${mcpUrl}`;
+    case "cursor":
+      return JSON.stringify(
+        {
+          mcpServers: {
+            [HYPERLOCALISE_MCP_SERVER_NAME]: {
+              url: mcpUrl,
+            },
+          },
+        },
+        null,
+        2,
+      );
+    default: {
+      const _exhaustive: never = client;
+      return _exhaustive;
+    }
+  }
+}
+
+export function mcpAgentSnippetUsesShellPrompt(client: McpAgentClient) {
+  return client !== "cursor";
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
@@ -171,6 +171,7 @@ export const SlackConnectInvite: Story = {
 export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Overview" })).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "Connect your agent" })).toBeInTheDocument();
     await expect(canvas.getByText("My jobs")).toBeInTheDocument();
     await expect(canvas.getByText("Latest jobs")).toBeInTheDocument();
     await expect(canvas.getByText("Recent projects")).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -38,6 +38,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
+import { OverviewConnectAgentCard } from "../../_components/overview/overview-connect-agent-card";
 import { OverviewHeroCard } from "../../_components/overview/overview-hero-card";
 import { OverviewSectionHeader } from "../../_components/overview/overview-section-header";
 import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
@@ -911,6 +912,8 @@ export function DashboardPageView({
           </>
         )}
       </section>
+
+      <OverviewConnectAgentCard />
 
       <section className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
         <DashboardJobsPanel


### PR DESCRIPTION
## What changed

Add a Connect your agent card to the workspace Overview so teams can hook Claude, Codex, or Cursor up to Hyperlocalise MCP without leaving the dashboard.

The card switches install snippets and setup-guide links per client, and uses the workspace origin (`/mcp/sse`) in the live app.

## How to test

- [ ] Open Storybook `App / Overview / ConnectAgent` and confirm Claude, Codex, and Cursor snippets, copy, and setup-guide links
- [ ] Open Storybook `App / Dashboard / Page` Default and confirm the card sits between quick start and jobs
- [ ] In the app Overview, copy the Claude command and confirm it uses `{origin}/mcp/sse`
- [ ] Switch to Codex and Cursor and confirm the next-step copy updates

## Checklist

- [x] I ran relevant checks locally (`vp test` on the new card tests)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)