### PR TITLE
Rename Issues feature to Board

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -559,7 +559,7 @@
     "defaultMessage": "Save",
     "description": "Save button for issue column edit dialogs"
   },
-  "/WFoDeqxe7": {
+  "bC8xP17A1P": {
     "defaultMessage": "Upload a spreadsheet export, map columns to board fields, preview the result, then import.",
     "description": "Description of the Issue Sheet CSV import dialog"
   },
@@ -731,7 +731,7 @@
     "defaultMessage": "Informal shortened name",
     "description": "Description for the short form term type"
   },
-  "04BDy8jZlJ": {
+  "CBibCD/p8E": {
     "defaultMessage": "Read board issues for the selected project during this automation.",
     "description": "Description for the List issues automation tool"
   },
@@ -2251,9 +2251,9 @@
     "defaultMessage": "Context-aware quality checks",
     "description": "Differentiator point 4 for the localisation-quality-monitoring use case"
   },
-  "4UoHK4nCgZ": {
+  "JRZrMUrfeM": {
     "defaultMessage": "Triage localization issues for this project.",
-    "description": "Short section description for the project Issue Sheet page"
+    "description": "Short section description for the project Board page"
   },
   "4UqkRDJW9u": {
     "defaultMessage": "Context auto-discovery",
@@ -3607,7 +3607,7 @@
     "defaultMessage": "{position} / {total}",
     "description": "Current segment index and total count in the compact CAT workspace header"
   },
-  "8Wv1MRwzXX": {
+  "yGs5M+8byg": {
     "defaultMessage": "Add a project-specific workflow column to the board.",
     "description": "Description of the dialog to add a custom Board column"
   },
@@ -3735,9 +3735,9 @@
     "defaultMessage": "Glossary created",
     "description": "Toast after a glossary is created successfully"
   },
-  "8qNqRTyyLK": {
+  "vqmXbSZwqU": {
     "defaultMessage": "Create an issue to track work on this string.",
-    "description": "Empty-state description when the CAT segment has no linked Issues"
+    "description": "Empty-state description when the CAT segment has no linked issues"
   },
   "8qa1pUW6eX": {
     "defaultMessage": "Account",
@@ -4275,7 +4275,7 @@
     "defaultMessage": "Related variants",
     "description": "Heading for related translation memory variants"
   },
-  "AF35eujXwK": {
+  "6haGvAy+HC": {
     "defaultMessage": "Added to Board",
     "description": "Toast confirmation after adding a CAT segment to the issue sheet"
   },
@@ -4711,7 +4711,7 @@
     "defaultMessage": "Alert on post-publish drift",
     "description": "Capability 6 title for the localisation-quality-monitoring use case"
   },
-  "BeXUx2ytXa": {
+  "R/mQHxnDLt": {
     "defaultMessage": "Board",
     "description": "Section title for the project Board page"
   },
@@ -5051,7 +5051,7 @@
     "defaultMessage": "TMS agnostic",
     "description": "Differentiator point 1 for the localisation-operations use case"
   },
-  "Cgi0SFaOp5": {
+  "4Bnw8oUCip": {
     "defaultMessage": "The board could not be loaded.",
     "description": "Error state when the workspace board fails to load"
   },
@@ -5179,7 +5179,7 @@
     "defaultMessage": "Format",
     "description": "Label above download format options in the CAT queue"
   },
-  "D2Iw7bGHIc": {
+  "igJunofoju": {
     "defaultMessage": "Board",
     "description": "Heading for the CAT segment Board section"
   },
@@ -5455,9 +5455,9 @@
     "defaultMessage": "Optional. You can attach projects from the glossary detail page later.",
     "description": "Help text explaining that glossary project attachment can happen later"
   },
-  "DeCrAOQFGT": {
+  "cAQmoTwBPJ": {
     "defaultMessage": "List issues",
-    "description": "Menu item and tool title for listing Issue Sheet issues"
+    "description": "Menu item and tool title for listing Board issues"
   },
   "DeRSeFizML": {
     "defaultMessage": "Unable to load Contentful metadata",
@@ -5859,9 +5859,9 @@
     "defaultMessage": "Track review coverage and approval status",
     "description": "Capability 4 title for the localisation-quality-monitoring use case"
   },
-  "Esr6tXDJJe": {
+  "JXB2wuhw1Z": {
     "defaultMessage": "No issues for this string",
-    "description": "Empty-state title when the CAT segment has no linked Issues"
+    "description": "Empty-state title when the CAT segment has no linked issues"
   },
   "EtLBqA9kAL": {
     "defaultMessage": "No related variants.",
@@ -6903,7 +6903,7 @@
     "defaultMessage": "Choose an organization from your account or contact support if this continues.",
     "description": "Access denied page guidance when the organization slug is missing"
   },
-  "IA5Kmwt4uK": {
+  "KCIvL0TJB4": {
     "defaultMessage": "Board",
     "description": "Button to open the Board for the current CAT segment"
   },
@@ -7387,9 +7387,9 @@
     "defaultMessage": "Workspaces",
     "description": "Label above the list of workspaces in the switch submenu"
   },
-  "JprxqupePC": {
+  "Hjj+QG5LDK": {
     "defaultMessage": "Request failed",
-    "description": "Generic fallback when a CAT Issues API request fails"
+    "description": "Generic fallback when a CAT Board API request fails"
   },
   "JqZe/Pxka2": {
     "defaultMessage": "Sample i18n.yml",
@@ -8331,7 +8331,7 @@
     "defaultMessage": "Pull request",
     "description": "Workflow step 1 label for the github-release-localisation use case"
   },
-  "MweQRnF9MU": {
+  "weTyi2vT5M": {
     "defaultMessage": "File board issues for the selected project from automation findings.",
     "description": "Description for the Create issue automation tool"
   },
@@ -9739,7 +9739,7 @@
     "defaultMessage": "Sampled {count} pages across technical, linguistic, contextual, and visual localisation credits.",
     "description": "Summary of how many pages a localisation audit sampled"
   },
-  "RQpMZIFSEX": {
+  "LGF0oZcJpk": {
     "defaultMessage": "Loading board...",
     "description": "Suspense fallback while Board content loads"
   },
@@ -9907,7 +9907,7 @@
     "defaultMessage": "Provider",
     "description": "Badge for a provider-managed glossary"
   },
-  "RtEbYHhw1P": {
+  "sJoNIftCZI": {
     "defaultMessage": "Board",
     "description": "App shell breadcrumb title for the workspace board page"
   },
@@ -10007,9 +10007,9 @@
     "defaultMessage": "Team",
     "description": "Eyebrow label above the team detail page title"
   },
-  "SGKONsO7tY": {
+  "3W0VCaMyWO": {
     "defaultMessage": "Create issue",
-    "description": "Menu item and tool title for creating Issue Sheet issues"
+    "description": "Menu item and tool title for creating Board issues"
   },
   "SGPPXTsltm": {
     "defaultMessage": "Message #launch-ops",
@@ -10287,7 +10287,7 @@
     "defaultMessage": "Connect Ahrefs with an MCP API key in Integrations before using this tool.",
     "description": "Description when no Ahrefs connection is available"
   },
-  "T7+otbWCxu": {
+  "6XlImduZ6L": {
     "defaultMessage": "Board is unavailable for this string.",
     "description": "Shown when the CAT segment cannot link to the Board (missing translation key)"
   },
@@ -11527,7 +11527,7 @@
     "defaultMessage": "API Keys",
     "description": "Settings hub row label for API keys"
   },
-  "X+GHkBiDyV": {
+  "wZsNKEWooe": {
     "defaultMessage": "Loading board...",
     "description": "Suspense fallback while workspace board content loads"
   },
@@ -13659,7 +13659,7 @@
     "defaultMessage": "Hyperlab",
     "description": "Built-in market experiments product name on the integrations page"
   },
-  "dj9zRisspO": {
+  "QSTiMWaXF/": {
     "defaultMessage": "The board could not be loaded.",
     "description": "Error state when Board rows fail to load"
   },
@@ -13735,7 +13735,7 @@
     "defaultMessage": "Included",
     "description": "Badge on Hyperlocalise Included model provider cards"
   },
-  "dyxy90ZIN1": {
+  "2Q9B8y1llx": {
     "defaultMessage": "Board",
     "description": "Sidebar nav label in marketing app shell mock"
   },
@@ -14043,7 +14043,7 @@
     "defaultMessage": "No target locale is available for this task.",
     "description": "Empty state when all-files CAT mode has no selectable target locale"
   },
-  "enrIL8oTbj": {
+  "r7gtZsn8Qh": {
     "defaultMessage": "Board",
     "description": "Project sidebar navigation item for the project board"
   },
@@ -14267,7 +14267,7 @@
     "defaultMessage": "External task ID",
     "description": "Secondary job property row label for external task ID"
   },
-  "fVOROtw+GW": {
+  "32+8NTo5Pl": {
     "defaultMessage": "Board",
     "description": "Submenu label grouping Board automation tools"
   },
@@ -14783,7 +14783,7 @@
     "defaultMessage": "User agent",
     "description": "Label for the localisation audit crawler user agent"
   },
-  "gyT9rFJB1u": {
+  "HrspdhKQl+": {
     "defaultMessage": "Open board",
     "description": "Accessible label for the Board button in the app shell footer"
   },
@@ -15087,7 +15087,7 @@
     "defaultMessage": "Try again",
     "description": "Button to retry rendering the chat dock panel"
   },
-  "hjub6GRZr4": {
+  "dKznjRBgya": {
     "defaultMessage": "Board",
     "description": "Label for the Board button in the app shell footer"
   },
@@ -15431,7 +15431,7 @@
     "defaultMessage": "Created",
     "description": "Created timestamp column in the concept table"
   },
-  "ipVFcJ8AtN": {
+  "l+RVkhyT2N": {
     "defaultMessage": "Create a project first, then import issues into its board.",
     "description": "Empty state when there are no projects to import issues into"
   },
@@ -15475,7 +15475,7 @@
     "defaultMessage": "Forbidden term \"{term}\" appears in the target translation.",
     "description": "CAT format check message when a forbidden glossary term appears in the target"
   },
-  "iwQ9dbHG3A": {
+  "dBZKwTIoEH": {
     "defaultMessage": "Failed to add to Board",
     "description": "Fallback error when creating an issue sheet row from CAT fails"
   },
@@ -15775,7 +15775,7 @@
     "defaultMessage": "Actions for {email}",
     "description": "Accessible label for a team member row actions menu"
   },
-  "jmazd5AXy4": {
+  "sslu9yZyVp": {
     "defaultMessage": "Board",
     "description": "App shell breadcrumb title for the project board page"
   },
@@ -15879,7 +15879,7 @@
     "defaultMessage": "Start a new audit",
     "description": "Button to start a fresh localisation audit after a domain block"
   },
-  "k3nR8wPqLm": {
+  "C5SPm8Zbbu": {
     "defaultMessage": "Board",
     "description": "Workspace board page title"
   },
@@ -16251,7 +16251,7 @@
     "defaultMessage": "Warnings",
     "description": "QA summary chip and filter option for warning severity"
   },
-  "kzAQTYATA+": {
+  "J8uRouTxFR": {
     "defaultMessage": "Choose whether Inbox updates for board issues are also delivered to your email.",
     "description": "Helper text under notification preferences on account settings"
   },
@@ -16647,7 +16647,7 @@
     "defaultMessage": "Fix first",
     "description": "Heading for the top findings to fix on a localisation audit result"
   },
-  "mL4jmlzo/F": {
+  "D1Wfd509ws": {
     "defaultMessage": "Choose which project should receive the imported board rows.",
     "description": "Description of the workspace issues CSV import project picker dialog"
   },
@@ -17095,7 +17095,7 @@
     "defaultMessage": "Copied OAuth callback URL",
     "description": "Aria label after copying the OAuth callback URL"
   },
-  "ncf9XHFPKV": {
+  "hYi0NizHJf": {
     "defaultMessage": "Board · this string",
     "description": "Title on the editor mock board overlay"
   },
@@ -17451,7 +17451,7 @@
     "defaultMessage": "Translation memory",
     "description": "Section heading for translation memory matches in the intelligence panel"
   },
-  "olmZvevw/Q": {
+  "XswXu+UFpy": {
     "defaultMessage": "Board",
     "description": "Sidebar navigation item for the workspace board"
   },
@@ -18143,7 +18143,7 @@
     "defaultMessage": "Czech (Czechia)",
     "description": "Display name for BCP-47 locale cs-CZ"
   },
-  "qyJpxYtcpE": {
+  "n/ryC/yPKS": {
     "defaultMessage": "Create or link issues for this string. Navigate to an issue to collaborate.",
     "description": "Dialog description for managing issues linked to a CAT string"
   },
@@ -18439,7 +18439,7 @@
     "defaultMessage": "Unable to send that message right now.",
     "description": "Toast when a public web chat message fails"
   },
-  "rugkgwDED8": {
+  "tX5h+jHyR2": {
     "defaultMessage": "Board · acme workspace",
     "description": "Board panel title in content ops mock"
   },
@@ -18515,7 +18515,7 @@
     "defaultMessage": "Request failed",
     "description": "Fallback error when the create issue API request fails"
   },
-  "s7TZoJvKum": {
+  "J2Tvcwc2sx": {
     "defaultMessage": "Open board, {count} open",
     "description": "Accessible label for the Board button when open issues are available"
   },
@@ -18571,7 +18571,7 @@
     "defaultMessage": "Domains",
     "description": "Sidebar navigation item for linked domains"
   },
-  "sHe4qCdT7b": {
+  "E8k6bvQHrX": {
     "defaultMessage": "Close board",
     "description": "Accessible label for closing the CAT Board panel"
   },
@@ -19023,9 +19023,9 @@
     "defaultMessage": "Provider link",
     "description": "Detail row label for the external provider URL"
   },
-  "thNgDb6rW2": {
+  "h5+KJI2d7A": {
     "defaultMessage": "Could not load issues.",
-    "description": "Error message when CAT segment Issues fail to load"
+    "description": "Error message when CAT segment board issues fail to load"
   },
   "tj9LSxTmXM": {
     "defaultMessage": "Console",
@@ -20803,7 +20803,7 @@
     "defaultMessage": "Choose a source file from the project files list to open it in the Content Editor.",
     "description": "Empty state when the Content Editor page is opened without a source file"
   },
-  "yqDgUgDi10": {
+  "08+4Nn7rgH": {
     "defaultMessage": "Acme · Board",
     "description": "Header breadcrumb in marketing app shell mock"
   },
@@ -21087,9 +21087,9 @@
     "defaultMessage": "Segment validation returned an invalid response.",
     "description": "Error when the CAT segment validation response fails schema validation"
   },
-  "zi+sjAi385": {
+  "46zk0LJShA": {
     "defaultMessage": "Triage open work across this workspace.",
-    "description": "Short description under the workspace Issues page title"
+    "description": "Short description under the workspace Board page title"
   },
   "zirutH7PO0": {
     "defaultMessage": "Created by me",

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -560,7 +560,7 @@
     "description": "Save button for issue column edit dialogs"
   },
   "/WFoDeqxe7": {
-    "defaultMessage": "Upload a spreadsheet export, map columns to Issue Sheet fields, preview the result, then import.",
+    "defaultMessage": "Upload a spreadsheet export, map columns to board fields, preview the result, then import.",
     "description": "Description of the Issue Sheet CSV import dialog"
   },
   "/WSX2GW1p1": {
@@ -732,7 +732,7 @@
     "description": "Description for the short form term type"
   },
   "04BDy8jZlJ": {
-    "defaultMessage": "Read Issue Sheet issues for the selected project during this automation.",
+    "defaultMessage": "Read board issues for the selected project during this automation.",
     "description": "Description for the List issues automation tool"
   },
   "04TH5FBW4Q": {
@@ -3608,8 +3608,8 @@
     "description": "Current segment index and total count in the compact CAT workspace header"
   },
   "8Wv1MRwzXX": {
-    "defaultMessage": "Add a project-specific workflow column to the Issue Sheet.",
-    "description": "Description of the dialog to add a custom Issue Sheet column"
+    "defaultMessage": "Add a project-specific workflow column to the board.",
+    "description": "Description of the dialog to add a custom Board column"
   },
   "8XNSkLVgbI": {
     "defaultMessage": "Failed to delete Ahrefs connection.",
@@ -4276,7 +4276,7 @@
     "description": "Heading for related translation memory variants"
   },
   "AF35eujXwK": {
-    "defaultMessage": "Added to Issue Sheet",
+    "defaultMessage": "Added to Board",
     "description": "Toast confirmation after adding a CAT segment to the issue sheet"
   },
   "AFid22/7fj": {
@@ -4712,8 +4712,8 @@
     "description": "Capability 6 title for the localisation-quality-monitoring use case"
   },
   "BeXUx2ytXa": {
-    "defaultMessage": "Issues",
-    "description": "Section title for the project Issue Sheet page"
+    "defaultMessage": "Board",
+    "description": "Section title for the project Board page"
   },
   "Bel9GZJcDc": {
     "defaultMessage": "Allow memory updates",
@@ -5052,8 +5052,8 @@
     "description": "Differentiator point 1 for the localisation-operations use case"
   },
   "Cgi0SFaOp5": {
-    "defaultMessage": "Issues could not be loaded.",
-    "description": "Error state when workspace issues fail to load"
+    "defaultMessage": "The board could not be loaded.",
+    "description": "Error state when the workspace board fails to load"
   },
   "ChA2eL6U9Z": {
     "defaultMessage": "Localisation updates the product glossary after a rebrand. Hyperlocalise scans product strings, marketing landing pages, and help center articles for terminology that no longer matches, runs regression evals against approved baselines, routes flagged strings to reviewers, blocks TMS sync for locales that fail the threshold, and continues monitoring published content for drift over the following two weeks.",
@@ -5180,8 +5180,8 @@
     "description": "Label above download format options in the CAT queue"
   },
   "D2Iw7bGHIc": {
-    "defaultMessage": "Issues",
-    "description": "Heading for the CAT segment Issues section"
+    "defaultMessage": "Board",
+    "description": "Heading for the CAT segment Board section"
   },
   "D2ZrcxejKr": {
     "defaultMessage": "MCP servers",
@@ -6904,8 +6904,8 @@
     "description": "Access denied page guidance when the organization slug is missing"
   },
   "IA5Kmwt4uK": {
-    "defaultMessage": "Issues",
-    "description": "Button to open linked Issues for the current CAT segment"
+    "defaultMessage": "Board",
+    "description": "Button to open the Board for the current CAT segment"
   },
   "IC06cS9nUd": {
     "defaultMessage": "Agent fixing",
@@ -8332,7 +8332,7 @@
     "description": "Workflow step 1 label for the github-release-localisation use case"
   },
   "MweQRnF9MU": {
-    "defaultMessage": "File Issue Sheet issues for the selected project from automation findings.",
+    "defaultMessage": "File board issues for the selected project from automation findings.",
     "description": "Description for the Create issue automation tool"
   },
   "MwxM6cb/1r": {
@@ -9740,8 +9740,8 @@
     "description": "Summary of how many pages a localisation audit sampled"
   },
   "RQpMZIFSEX": {
-    "defaultMessage": "Loading Issue Sheet...",
-    "description": "Suspense fallback while Issue Sheet content loads"
+    "defaultMessage": "Loading board...",
+    "description": "Suspense fallback while Board content loads"
   },
   "RS4pbTA1Mq": {
     "defaultMessage": "Character limit",
@@ -9908,8 +9908,8 @@
     "description": "Badge for a provider-managed glossary"
   },
   "RtEbYHhw1P": {
-    "defaultMessage": "Issues",
-    "description": "App shell breadcrumb title for the issues page"
+    "defaultMessage": "Board",
+    "description": "App shell breadcrumb title for the workspace board page"
   },
   "RtU7kH2epq": {
     "defaultMessage": "Select a project",
@@ -10288,8 +10288,8 @@
     "description": "Description when no Ahrefs connection is available"
   },
   "T7+otbWCxu": {
-    "defaultMessage": "Issues are unavailable for this string.",
-    "description": "Shown when the CAT segment cannot link to Issues (missing translation key)"
+    "defaultMessage": "Board is unavailable for this string.",
+    "description": "Shown when the CAT segment cannot link to the Board (missing translation key)"
   },
   "T7ocGbiped": {
     "defaultMessage": "Last delivery: No deliveries yet",
@@ -11528,8 +11528,8 @@
     "description": "Settings hub row label for API keys"
   },
   "X+GHkBiDyV": {
-    "defaultMessage": "Loading issues...",
-    "description": "Suspense fallback while workspace issues content loads"
+    "defaultMessage": "Loading board...",
+    "description": "Suspense fallback while workspace board content loads"
   },
   "X/5lAUS4wm": {
     "defaultMessage": "/100",
@@ -13660,8 +13660,8 @@
     "description": "Built-in market experiments product name on the integrations page"
   },
   "dj9zRisspO": {
-    "defaultMessage": "Issues could not be loaded.",
-    "description": "Error state when Issue Sheet rows fail to load"
+    "defaultMessage": "The board could not be loaded.",
+    "description": "Error state when Board rows fail to load"
   },
   "djWAPr32N4": {
     "defaultMessage": "Cancel",
@@ -13736,7 +13736,7 @@
     "description": "Badge on Hyperlocalise Included model provider cards"
   },
   "dyxy90ZIN1": {
-    "defaultMessage": "Issues",
+    "defaultMessage": "Board",
     "description": "Sidebar nav label in marketing app shell mock"
   },
   "e+CeFvSaNg": {
@@ -14044,8 +14044,8 @@
     "description": "Empty state when all-files CAT mode has no selectable target locale"
   },
   "enrIL8oTbj": {
-    "defaultMessage": "Issues",
-    "description": "Project sidebar navigation item for the project issue sheet"
+    "defaultMessage": "Board",
+    "description": "Project sidebar navigation item for the project board"
   },
   "eogv8qHzO7": {
     "defaultMessage": "Direct and familiar French SaaS CTA phrasing.",
@@ -14268,8 +14268,8 @@
     "description": "Secondary job property row label for external task ID"
   },
   "fVOROtw+GW": {
-    "defaultMessage": "Issues",
-    "description": "Submenu label grouping Issues automation tools"
+    "defaultMessage": "Board",
+    "description": "Submenu label grouping Board automation tools"
   },
   "fWWcDn9s5p": {
     "defaultMessage": "Startups",
@@ -14784,8 +14784,8 @@
     "description": "Label for the localisation audit crawler user agent"
   },
   "gyT9rFJB1u": {
-    "defaultMessage": "Open issues",
-    "description": "Accessible label for the Issues button in the app shell footer"
+    "defaultMessage": "Open board",
+    "description": "Accessible label for the Board button in the app shell footer"
   },
   "gyVhBvCqLP": {
     "defaultMessage": "Add sources",
@@ -15088,8 +15088,8 @@
     "description": "Button to retry rendering the chat dock panel"
   },
   "hjub6GRZr4": {
-    "defaultMessage": "Issues",
-    "description": "Label for the Issues button in the app shell footer"
+    "defaultMessage": "Board",
+    "description": "Label for the Board button in the app shell footer"
   },
   "hmabVdb4tH": {
     "defaultMessage": "Glossary",
@@ -15432,7 +15432,7 @@
     "description": "Created timestamp column in the concept table"
   },
   "ipVFcJ8AtN": {
-    "defaultMessage": "Create a project first, then import issues into its Issue Sheet.",
+    "defaultMessage": "Create a project first, then import issues into its board.",
     "description": "Empty state when there are no projects to import issues into"
   },
   "irDjU9PSS4": {
@@ -15476,7 +15476,7 @@
     "description": "CAT format check message when a forbidden glossary term appears in the target"
   },
   "iwQ9dbHG3A": {
-    "defaultMessage": "Failed to add to Issue Sheet",
+    "defaultMessage": "Failed to add to Board",
     "description": "Fallback error when creating an issue sheet row from CAT fails"
   },
   "iyeC0lBvav": {
@@ -15776,8 +15776,8 @@
     "description": "Accessible label for a team member row actions menu"
   },
   "jmazd5AXy4": {
-    "defaultMessage": "Issues",
-    "description": "App shell breadcrumb title for the issue sheet page"
+    "defaultMessage": "Board",
+    "description": "App shell breadcrumb title for the project board page"
   },
   "jn5bLV1i0/": {
     "defaultMessage": "Jetzt starten",
@@ -15878,6 +15878,10 @@
   "k3eu1T7STw": {
     "defaultMessage": "Start a new audit",
     "description": "Button to start a fresh localisation audit after a domain block"
+  },
+  "k3nR8wPqLm": {
+    "defaultMessage": "Board",
+    "description": "Workspace board page title"
   },
   "k4KpJNxaEK": {
     "defaultMessage": "Web chat",
@@ -16248,7 +16252,7 @@
     "description": "QA summary chip and filter option for warning severity"
   },
   "kzAQTYATA+": {
-    "defaultMessage": "Choose whether Issue Sheet Inbox updates are also delivered to your email.",
+    "defaultMessage": "Choose whether Inbox updates for board issues are also delivered to your email.",
     "description": "Helper text under notification preferences on account settings"
   },
   "l+wMmn4Krw": {
@@ -16644,7 +16648,7 @@
     "description": "Heading for the top findings to fix on a localisation audit result"
   },
   "mL4jmlzo/F": {
-    "defaultMessage": "Choose which project should receive the imported Issue Sheet rows.",
+    "defaultMessage": "Choose which project should receive the imported board rows.",
     "description": "Description of the workspace issues CSV import project picker dialog"
   },
   "mMp/zOre+X": {
@@ -17092,8 +17096,8 @@
     "description": "Aria label after copying the OAuth callback URL"
   },
   "ncf9XHFPKV": {
-    "defaultMessage": "Issues · this string",
-    "description": "Title on the editor mock issues overlay"
+    "defaultMessage": "Board · this string",
+    "description": "Title on the editor mock board overlay"
   },
   "ndyP1whnV+": {
     "defaultMessage": "If your site uses a firewall, CDN, bot check, or login wall, allow this user agent to access public pages so we can complete the audit.",
@@ -17448,8 +17452,8 @@
     "description": "Section heading for translation memory matches in the intelligence panel"
   },
   "olmZvevw/Q": {
-    "defaultMessage": "Issues",
-    "description": "Sidebar navigation item for workspace issues"
+    "defaultMessage": "Board",
+    "description": "Sidebar navigation item for the workspace board"
   },
   "omP7hSnBIw": {
     "defaultMessage": "Format {format}",
@@ -18140,7 +18144,7 @@
     "description": "Display name for BCP-47 locale cs-CZ"
   },
   "qyJpxYtcpE": {
-    "defaultMessage": "Create or link Issues for this string. Navigate to an issue to collaborate.",
+    "defaultMessage": "Create or link issues for this string. Navigate to an issue to collaborate.",
     "description": "Dialog description for managing issues linked to a CAT string"
   },
   "qySc0NPK9C": {
@@ -18436,8 +18440,8 @@
     "description": "Toast when a public web chat message fails"
   },
   "rugkgwDED8": {
-    "defaultMessage": "Issues · acme workspace",
-    "description": "Issues panel title in content ops mock"
+    "defaultMessage": "Board · acme workspace",
+    "description": "Board panel title in content ops mock"
   },
   "rw4HCHelCR": {
     "defaultMessage": "Translate in chat",
@@ -18512,8 +18516,8 @@
     "description": "Fallback error when the create issue API request fails"
   },
   "s7TZoJvKum": {
-    "defaultMessage": "Open issues, {count} open",
-    "description": "Accessible label for the Issues button when open issues are available"
+    "defaultMessage": "Open board, {count} open",
+    "description": "Accessible label for the Board button when open issues are available"
   },
   "s8Aqn1fSU6": {
     "defaultMessage": "Live projects fetched from {providerName}.",
@@ -18568,8 +18572,8 @@
     "description": "Sidebar navigation item for linked domains"
   },
   "sHe4qCdT7b": {
-    "defaultMessage": "Close issues",
-    "description": "Accessible label for closing the CAT Issues panel"
+    "defaultMessage": "Close board",
+    "description": "Accessible label for closing the CAT Board panel"
   },
   "sHrPdefvvp": {
     "defaultMessage": "Search microphones...",
@@ -20800,7 +20804,7 @@
     "description": "Empty state when the Content Editor page is opened without a source file"
   },
   "yqDgUgDi10": {
-    "defaultMessage": "Acme · Issues",
+    "defaultMessage": "Acme · Board",
     "description": "Header breadcrumb in marketing app shell mock"
   },
   "ysf+RB1d04": {

--- a/apps/hyperlocalise-web/src/agents/README.md
+++ b/apps/hyperlocalise-web/src/agents/README.md
@@ -30,7 +30,7 @@ Each package uses Eve-inspired slots under `agent/`:
 
 - **Plan**: deterministic tool order from `toolConfig` and `executorAgent` skill metadata
 - **Execution**: `ToolLoopAgent` with `prepareStep` forcing each planned tool
-- **Tools**: GitHub workflows, Contentful translation, Issue Sheet list/create,
+- **Tools**: GitHub workflows, Contentful translation, Board list/create,
   Slack, and email notifications
 
 Child executors remain specialized packages (`contentful`, `github-repository`) but are invoked as orchestrator tools rather than separate dispatch branches.

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
@@ -43,7 +43,7 @@ const createIssueInputSchema = z.object({
     .array(createIssueItemSchema)
     .max(20)
     .describe(
-      "Issues to create on the project Issue Sheet. Pass an empty array when nothing should be filed this run.",
+      "Issues to create on the project board. Pass an empty array when nothing should be filed this run.",
     ),
 });
 
@@ -79,7 +79,7 @@ async function persistCreateIssueOutput(
 export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
   return defineAgentTool({
     description:
-      "Create Hyperlocalise Issue Sheet issues for the automation project. Pass an empty issues array when there is nothing actionable to file.",
+      "Create Hyperlocalise Board issues for the automation project. Pass an empty issues array when there is nothing actionable to file.",
     inputSchema: createIssueInputSchema,
     execute: async ({ issues }) => {
       const createConfig = session.automation.toolConfig.createIssue;

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
@@ -65,7 +65,7 @@ function compactIssue(issue: {
 export function createListIssuesTool(session: WorkspaceOrchestratorSession) {
   return defineAgentTool({
     description:
-      "List Hyperlocalise Issue Sheet issues for the automation project. Use filters to triage open work before creating or notifying.",
+      "List Hyperlocalise Board issues for the automation project. Use filters to triage open work before creating or notifying.",
     inputSchema: listIssuesInputSchema,
     execute: async (input) => {
       const listConfig = session.automation.toolConfig.listIssues;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -311,9 +311,9 @@ export const workspaceAutomationFormMessages = defineMessages({
     description: "Submenu label grouping native TMS job automation tools",
   },
   issuesToolsMenu: {
-    defaultMessage: "Issues",
+    defaultMessage: "Board",
     id: "fVOROtw+GW",
-    description: "Submenu label grouping Issues automation tools",
+    description: "Submenu label grouping Board automation tools",
   },
   memories: {
     defaultMessage: "Use workspace guideline",
@@ -410,20 +410,20 @@ export const workspaceAutomationFormMessages = defineMessages({
   listIssues: {
     defaultMessage: "List issues",
     id: "DeCrAOQFGT",
-    description: "Menu item and tool title for listing Issue Sheet issues",
+    description: "Menu item and tool title for listing Board issues",
   },
   listIssuesDescription: {
-    defaultMessage: "Read Issue Sheet issues for the selected project during this automation.",
+    defaultMessage: "Read board issues for the selected project during this automation.",
     id: "04BDy8jZlJ",
     description: "Description for the List issues automation tool",
   },
   createIssue: {
     defaultMessage: "Create issue",
     id: "SGKONsO7tY",
-    description: "Menu item and tool title for creating Issue Sheet issues",
+    description: "Menu item and tool title for creating Board issues",
   },
   createIssueDescription: {
-    defaultMessage: "File Issue Sheet issues for the selected project from automation findings.",
+    defaultMessage: "File board issues for the selected project from automation findings.",
     id: "MweQRnF9MU",
     description: "Description for the Create issue automation tool",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -312,7 +312,7 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   issuesToolsMenu: {
     defaultMessage: "Board",
-    id: "fVOROtw+GW",
+    id: "32+8NTo5Pl",
     description: "Submenu label grouping Board automation tools",
   },
   memories: {
@@ -409,22 +409,22 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   listIssues: {
     defaultMessage: "List issues",
-    id: "DeCrAOQFGT",
+    id: "cAQmoTwBPJ",
     description: "Menu item and tool title for listing Board issues",
   },
   listIssuesDescription: {
     defaultMessage: "Read board issues for the selected project during this automation.",
-    id: "04BDy8jZlJ",
+    id: "CBibCD/p8E",
     description: "Description for the List issues automation tool",
   },
   createIssue: {
     defaultMessage: "Create issue",
-    id: "SGKONsO7tY",
+    id: "3W0VCaMyWO",
     description: "Menu item and tool title for creating Board issues",
   },
   createIssueDescription: {
     defaultMessage: "File board issues for the selected project from automation findings.",
-    id: "MweQRnF9MU",
+    id: "weTyi2vT5M",
     description: "Description for the Create issue automation tool",
   },
   removeListIssues: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.messages.ts
@@ -15,15 +15,20 @@
 import { defineMessages } from "react-intl";
 
 export const issuesPageViewMessages = defineMessages({
+  pageTitle: {
+    defaultMessage: "Board",
+    id: "k3nR8wPqLm",
+    description: "Workspace board page title",
+  },
   pageDescription: {
     defaultMessage: "Triage open work across this workspace.",
     id: "zi+sjAi385",
-    description: "Short description under the workspace Issues page title",
+    description: "Short description under the workspace Board page title",
   },
   loadError: {
-    defaultMessage: "Issues could not be loaded.",
+    defaultMessage: "The board could not be loaded.",
     id: "Cgi0SFaOp5",
-    description: "Error state when workspace issues fail to load",
+    description: "Error state when the workspace board fails to load",
   },
   empty: {
     defaultMessage: "No issues match this view.",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.messages.ts
@@ -17,17 +17,17 @@ import { defineMessages } from "react-intl";
 export const issuesPageViewMessages = defineMessages({
   pageTitle: {
     defaultMessage: "Board",
-    id: "k3nR8wPqLm",
+    id: "C5SPm8Zbbu",
     description: "Workspace board page title",
   },
   pageDescription: {
     defaultMessage: "Triage open work across this workspace.",
-    id: "zi+sjAi385",
+    id: "46zk0LJShA",
     description: "Short description under the workspace Board page title",
   },
   loadError: {
     defaultMessage: "The board could not be loaded.",
-    id: "Cgi0SFaOp5",
+    id: "4Bnw8oUCip",
     description: "Error state when the workspace board fails to load",
   },
   empty: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
@@ -22,7 +22,7 @@ import {
 import { IssuesPageView } from "./issues-page-view";
 
 const meta = {
-  title: "App/Issues/Page",
+  title: "App/Board/Page",
   component: IssuesPageView,
   parameters: {
     layout: "fullscreen",
@@ -46,7 +46,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getByRole("heading", { name: "Issues" })).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "Board" })).toBeInTheDocument();
     await expect(canvas.getByText("Source string needs context")).toBeInTheDocument();
     await expect(canvas.getByText("Website localization")).toBeInTheDocument();
     await expect(canvas.getByText("Open")).toBeInTheDocument();
@@ -63,7 +63,7 @@ export const Loading: Story = {
     isLoading: true,
   },
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getByRole("heading", { name: "Issues" })).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "Board" })).toBeInTheDocument();
     await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(
       0,
     );
@@ -93,7 +93,7 @@ export const Error: Story = {
     isError: true,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Issues could not be loaded.")).toBeInTheDocument();
+    await expect(canvas.getByText("The board could not be loaded.")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -98,7 +98,7 @@ export function IssuesPageView({
       <PageHeader
         icon={Copy01Icon}
         label="Workspace"
-        title="Issues"
+        title={intl.formatMessage(issuesPageViewMessages.pageTitle)}
         description={intl.formatMessage(issuesPageViewMessages.pageDescription)}
         actions={actions}
       />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.messages.ts
@@ -22,12 +22,12 @@ export const issuesProjectImportDialogMessages = defineMessages({
   },
   description: {
     defaultMessage: "Choose which project should receive the imported board rows.",
-    id: "mL4jmlzo/F",
+    id: "D1Wfd509ws",
     description: "Description of the workspace issues CSV import project picker dialog",
   },
   emptyProjects: {
     defaultMessage: "Create a project first, then import issues into its board.",
-    id: "ipVFcJ8AtN",
+    id: "l+RVkhyT2N",
     description: "Empty state when there are no projects to import issues into",
   },
   cancel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.messages.ts
@@ -21,12 +21,12 @@ export const issuesProjectImportDialogMessages = defineMessages({
     description: "Title of the workspace issues CSV import project picker dialog",
   },
   description: {
-    defaultMessage: "Choose which project should receive the imported Issue Sheet rows.",
+    defaultMessage: "Choose which project should receive the imported board rows.",
     id: "mL4jmlzo/F",
     description: "Description of the workspace issues CSV import project picker dialog",
   },
   emptyProjects: {
-    defaultMessage: "Create a project first, then import issues into its Issue Sheet.",
+    defaultMessage: "Create a project first, then import issues into its board.",
     id: "ipVFcJ8AtN",
     description: "Empty state when there are no projects to import issues into",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
@@ -36,7 +36,7 @@ export default async function IssuesPage({
         <TypographyP className="text-sm text-muted-foreground">
           {intl.formatMessage({
             defaultMessage: "Loading board...",
-            id: "X+GHkBiDyV",
+            id: "wZsNKEWooe",
             description: "Suspense fallback while workspace board content loads",
           })}
         </TypographyP>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
@@ -35,9 +35,9 @@ export default async function IssuesPage({
       fallback={
         <TypographyP className="text-sm text-muted-foreground">
           {intl.formatMessage({
-            defaultMessage: "Loading issues...",
+            defaultMessage: "Loading board...",
             id: "X+GHkBiDyV",
-            description: "Suspense fallback while workspace issues content loads",
+            description: "Suspense fallback while workspace board content loads",
           })}
         </TypographyP>
       }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.messages.ts
@@ -23,7 +23,7 @@ export const issueSheetImportDialogMessages = defineMessages({
   description: {
     defaultMessage:
       "Upload a spreadsheet export, map columns to board fields, preview the result, then import.",
-    id: "/WFoDeqxe7",
+    id: "bC8xP17A1P",
     description: "Description of the Issue Sheet CSV import dialog",
   },
   chooseCsvFile: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.messages.ts
@@ -22,7 +22,7 @@ export const issueSheetImportDialogMessages = defineMessages({
   },
   description: {
     defaultMessage:
-      "Upload a spreadsheet export, map columns to Issue Sheet fields, preview the result, then import.",
+      "Upload a spreadsheet export, map columns to board fields, preview the result, then import.",
     id: "/WFoDeqxe7",
     description: "Description of the Issue Sheet CSV import dialog",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
@@ -16,14 +16,14 @@ import { defineMessages } from "react-intl";
 
 export const issueSheetPageContentMessages = defineMessages({
   sectionTitle: {
-    defaultMessage: "Issues",
+    defaultMessage: "Board",
     id: "BeXUx2ytXa",
-    description: "Section title for the project Issue Sheet page",
+    description: "Section title for the project Board page",
   },
   sectionDescription: {
     defaultMessage: "Triage localization issues for this project.",
     id: "4UoHK4nCgZ",
-    description: "Short section description for the project Issue Sheet page",
+    description: "Short section description for the project Board page",
   },
   importCsv: {
     defaultMessage: "Import CSV",
@@ -101,9 +101,9 @@ export const issueSheetPageContentMessages = defineMessages({
     description: "Loading state shown while Issue Sheet rows are fetching",
   },
   loadIssuesError: {
-    defaultMessage: "Issues could not be loaded.",
+    defaultMessage: "The board could not be loaded.",
     id: "dj9zRisspO",
-    description: "Error state when Issue Sheet rows fail to load",
+    description: "Error state when Board rows fail to load",
   },
   emptyTitle: {
     defaultMessage: "No issues in this view.",
@@ -157,9 +157,9 @@ export const issueSheetPageContentMessages = defineMessages({
     description: "Title of the dialog to add a custom Issue Sheet column",
   },
   addColumnDescription: {
-    defaultMessage: "Add a project-specific workflow column to the Issue Sheet.",
+    defaultMessage: "Add a project-specific workflow column to the board.",
     id: "8Wv1MRwzXX",
-    description: "Description of the dialog to add a custom Issue Sheet column",
+    description: "Description of the dialog to add a custom Board column",
   },
   columnIconLabel: {
     defaultMessage: "Icon",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
@@ -17,12 +17,12 @@ import { defineMessages } from "react-intl";
 export const issueSheetPageContentMessages = defineMessages({
   sectionTitle: {
     defaultMessage: "Board",
-    id: "BeXUx2ytXa",
+    id: "R/mQHxnDLt",
     description: "Section title for the project Board page",
   },
   sectionDescription: {
     defaultMessage: "Triage localization issues for this project.",
-    id: "4UoHK4nCgZ",
+    id: "JRZrMUrfeM",
     description: "Short section description for the project Board page",
   },
   importCsv: {
@@ -102,7 +102,7 @@ export const issueSheetPageContentMessages = defineMessages({
   },
   loadIssuesError: {
     defaultMessage: "The board could not be loaded.",
-    id: "dj9zRisspO",
+    id: "QSTiMWaXF/",
     description: "Error state when Board rows fail to load",
   },
   emptyTitle: {
@@ -158,7 +158,7 @@ export const issueSheetPageContentMessages = defineMessages({
   },
   addColumnDescription: {
     defaultMessage: "Add a project-specific workflow column to the board.",
-    id: "8Wv1MRwzXX",
+    id: "yGs5M+8byg",
     description: "Description of the dialog to add a custom Board column",
   },
   columnIconLabel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
@@ -23,7 +23,7 @@ import { issueSheetOrganizationSlug, issueSheetProjectId } from "./issue-sheet.f
 import { IssueSheetPageContent } from "./issue-sheet-page-content";
 
 const meta = {
-  title: "App/Issues/Sheet",
+  title: "App/Board/Project",
   component: IssueSheetPageContent,
   parameters: {
     layout: "fullscreen",
@@ -49,7 +49,7 @@ export const Default: Story = {
     },
   },
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getByText("Issues")).toBeInTheDocument();
+    await expect(canvas.getByText("Board")).toBeInTheDocument();
     await expect(canvas.getByText("Source string needs context")).toBeInTheDocument();
     await expect(canvas.getByText("Open")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Issue" })).toBeInTheDocument();
@@ -69,7 +69,7 @@ export const Loading: Story = {
     },
   },
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getByText("Issues")).toBeInTheDocument();
+    await expect(canvas.getByText("Board")).toBeInTheDocument();
     await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(
       0,
     );
@@ -97,8 +97,8 @@ export const Error: Story = {
     },
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Issues")).toBeInTheDocument();
-    await expect(canvas.getByText("Issues could not be loaded.")).toBeInTheDocument();
+    await expect(canvas.getByText("Board")).toBeInTheDocument();
+    await expect(canvas.getByText("The board could not be loaded.")).toBeInTheDocument();
     await expect(canvas.queryByText("No issues in this view.")).not.toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
@@ -36,7 +36,7 @@ export default async function IssueSheetPage({
         <TypographyP className="text-sm text-muted-foreground">
           {intl.formatMessage({
             defaultMessage: "Loading board...",
-            id: "RQpMZIFSEX",
+            id: "LGF0oZcJpk",
             description: "Suspense fallback while Board content loads",
           })}
         </TypographyP>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
@@ -35,9 +35,9 @@ export default async function IssueSheetPage({
       fallback={
         <TypographyP className="text-sm text-muted-foreground">
           {intl.formatMessage({
-            defaultMessage: "Loading Issue Sheet...",
+            defaultMessage: "Loading board...",
             id: "RQpMZIFSEX",
-            description: "Suspense fallback while Issue Sheet content loads",
+            description: "Suspense fallback while Board content loads",
           })}
         </TypographyP>
       }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.messages.ts
@@ -21,8 +21,9 @@ export const notificationPreferencesFormMessages = defineMessages({
     description: "Section heading for notification preferences on account settings",
   },
   sectionDescription: {
-    defaultMessage: "Choose whether Inbox updates for board issues are also delivered to your email.",
-    id: "kzAQTYATA+",
+    defaultMessage:
+      "Choose whether Inbox updates for board issues are also delivered to your email.",
+    id: "J8uRouTxFR",
     description: "Helper text under notification preferences on account settings",
   },
   emailEnabledLabel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.messages.ts
@@ -21,7 +21,7 @@ export const notificationPreferencesFormMessages = defineMessages({
     description: "Section heading for notification preferences on account settings",
   },
   sectionDescription: {
-    defaultMessage: "Choose whether Issue Sheet Inbox updates are also delivered to your email.",
+    defaultMessage: "Choose whether Inbox updates for board issues are also delivered to your email.",
     id: "kzAQTYATA+",
     description: "Helper text under notification preferences on account settings",
   },

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -37,19 +37,19 @@ export const appShellFooterMessages = defineMessages({
     description: "Label for the glossary guidance button in the app shell footer",
   },
   issueGuidanceAriaLabel: {
-    defaultMessage: "Open issues",
+    defaultMessage: "Open board",
     id: "gyT9rFJB1u",
-    description: "Accessible label for the Issues button in the app shell footer",
+    description: "Accessible label for the Board button in the app shell footer",
   },
   issueGuidanceAvailableAriaLabel: {
-    defaultMessage: "Open issues, {count} open",
+    defaultMessage: "Open board, {count} open",
     id: "s7TZoJvKum",
-    description: "Accessible label for the Issues button when open issues are available",
+    description: "Accessible label for the Board button when open issues are available",
   },
   issueGuidanceLabel: {
-    defaultMessage: "Issues",
+    defaultMessage: "Board",
     id: "hjub6GRZr4",
-    description: "Label for the Issues button in the app shell footer",
+    description: "Label for the Board button in the app shell footer",
   },
   supportLabel: {
     defaultMessage: "Support",

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -38,17 +38,17 @@ export const appShellFooterMessages = defineMessages({
   },
   issueGuidanceAriaLabel: {
     defaultMessage: "Open board",
-    id: "gyT9rFJB1u",
+    id: "HrspdhKQl+",
     description: "Accessible label for the Board button in the app shell footer",
   },
   issueGuidanceAvailableAriaLabel: {
     defaultMessage: "Open board, {count} open",
-    id: "s7TZoJvKum",
+    id: "J2Tvcwc2sx",
     description: "Accessible label for the Board button when open issues are available",
   },
   issueGuidanceLabel: {
     defaultMessage: "Board",
-    id: "hjub6GRZr4",
+    id: "dKznjRBgya",
     description: "Label for the Board button in the app shell footer",
   },
   supportLabel: {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
@@ -115,7 +115,7 @@ export const SupportOnly: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("link", { name: "Email support" })).toBeInTheDocument();
     await expect(canvas.queryByRole("button", { name: "New request" })).not.toBeInTheDocument();
-    await expect(canvas.queryByText("Issues")).not.toBeInTheDocument();
+    await expect(canvas.queryByText("Board")).not.toBeInTheDocument();
   },
 };
 
@@ -140,7 +140,7 @@ export const GuidanceAvailable: Story = {
     const glossaryButton = canvas.getByRole("button", {
       name: "Glossary guidance, concept matches available",
     });
-    const issuesButton = canvas.getByRole("button", { name: "Open issues, 2 open" });
+    const issuesButton = canvas.getByRole("button", { name: "Open board, 2 open" });
 
     await expect(glossaryButton).toBeInTheDocument();
     await expect(issuesButton).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -170,8 +170,8 @@ describe("AppShellFooter", () => {
 
     renderFooter({ showPlan: false, showIssueGuidance: true });
 
-    const issues = screen.getByRole("button", { name: "Open issues, 2 open" });
-    expect(issues).toHaveTextContent("Issues");
+    const issues = screen.getByRole("button", { name: "Open board, 2 open" });
+    expect(issues).toHaveTextContent("Board");
     expect(issues).toHaveTextContent("2");
 
     try {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -30,7 +30,7 @@ describe("getAppShellTitle", () => {
     ["/org/acme/projects/proj_1/jobs", "Jobs"],
     ["/org/acme/projects/proj_1/automations", "Automations"],
     ["/org/acme/projects/proj_1/knowledge", "Guideline"],
-    ["/org/acme/projects/proj_1/issue-sheet", "Issues"],
+    ["/org/acme/projects/proj_1/issue-sheet", "Board"],
     ["/org/acme/projects/proj_1/strings", "Content Editor"],
     ["/org/acme/projects/proj_1/agent-runs", "Agent Runs"],
     ["/org/acme/projects/proj_1/activity", "Activity"],
@@ -156,11 +156,11 @@ describe("getAppShellBreadcrumbs", () => {
     ).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
-      { label: "Issues" },
+      { label: "Board" },
     ]);
   });
 
-  it("links Issues when viewing a permanent issue detail URL", () => {
+  it("links Board when viewing a permanent issue detail URL", () => {
     expect(
       getAppShellBreadcrumbs(
         "/org/acme/projects/proj_1/issue-sheet/11111111-1111-4111-8111-111111111111",
@@ -170,7 +170,7 @@ describe("getAppShellBreadcrumbs", () => {
     ).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
-      { label: "Issues", href: "/org/acme/projects/proj_1/issue-sheet" },
+      { label: "Board", href: "/org/acme/projects/proj_1/issue-sheet" },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -221,13 +221,13 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
     case "issues":
       return intl.formatMessage({
         defaultMessage: "Board",
-        id: "RtEbYHhw1P",
+        id: "sJoNIftCZI",
         description: "App shell breadcrumb title for the workspace board page",
       });
     case "issue-sheet":
       return intl.formatMessage({
         defaultMessage: "Board",
-        id: "jmazd5AXy4",
+        id: "sslu9yZyVp",
         description: "App shell breadcrumb title for the project board page",
       });
     case "jobs":

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -220,15 +220,15 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
       });
     case "issues":
       return intl.formatMessage({
-        defaultMessage: "Issues",
+        defaultMessage: "Board",
         id: "RtEbYHhw1P",
-        description: "App shell breadcrumb title for the issues page",
+        description: "App shell breadcrumb title for the workspace board page",
       });
     case "issue-sheet":
       return intl.formatMessage({
-        defaultMessage: "Issues",
+        defaultMessage: "Board",
         id: "jmazd5AXy4",
-        description: "App shell breadcrumb title for the issue sheet page",
+        description: "App shell breadcrumb title for the project board page",
       });
     case "jobs":
       return intl.formatMessage({

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -197,7 +197,7 @@ describe("path builders", () => {
     expect(byLabel.get("AI Engine")?.href).toBe("/org/acme/ai-engine");
     expect(byLabel.get("Automations")?.featureFlagKey).toBe(WORKSPACE_AUTOMATIONS_FLAG);
     expect(byLabel.get("Guideline")?.featureFlagKey).toBe(WORKSPACE_KNOWLEDGE_FLAG);
-    expect(byLabel.get("Issues")?.featureFlagKey).toBeUndefined();
+    expect(byLabel.get("Board")?.featureFlagKey).toBeUndefined();
     expect(byLabel.get("Domains")?.featureFlagKey).toBe(WORKSPACE_DOMAINS_FLAG);
 
     expect(groups.map((group) => group.label)).toEqual([undefined, "Agents", "Workspace"]);
@@ -209,7 +209,7 @@ describe("path builders", () => {
     expect(groups[0]?.items.map((item) => item.label)).toEqual([
       "Inbox",
       "My Jobs",
-      "Issues",
+      "Board",
       "Overview",
     ]);
   });
@@ -222,12 +222,12 @@ describe("path builders", () => {
       ["Files", "/org/acme/projects/proj_1/files"],
       ["Content Editor", "/org/acme/projects/proj_1/strings"],
       ["Jobs", "/org/acme/projects/proj_1/jobs"],
-      ["Issues", "/org/acme/projects/proj_1/issue-sheet"],
+      ["Board", "/org/acme/projects/proj_1/issue-sheet"],
       ["Automations", "/org/acme/projects/proj_1/automations"],
       ["Guideline", "/org/acme/projects/proj_1/knowledge"],
       ["Settings", "/org/acme/projects/proj_1/settings"],
     ]);
-    expect(items.find((item) => item.label === "Issues")?.featureFlagKey).toBeUndefined();
+    expect(items.find((item) => item.label === "Board")?.featureFlagKey).toBeUndefined();
     expect(items.find((item) => item.label === "Automations")?.featureFlagKey).toBe(
       WORKSPACE_AUTOMATIONS_FLAG,
     );

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -125,9 +125,9 @@ export function buildGlobalNavigationGroups(
         },
         {
           label: intl.formatMessage({
-            defaultMessage: "Issues",
+            defaultMessage: "Board",
             id: "olmZvevw/Q",
-            description: "Sidebar navigation item for workspace issues",
+            description: "Sidebar navigation item for the workspace board",
           }),
           href: org("issues"),
           icon: Copy01Icon,
@@ -357,9 +357,9 @@ export function buildProjectNavigationItems(
     },
     {
       label: intl.formatMessage({
-        defaultMessage: "Issues",
+        defaultMessage: "Board",
         id: "enrIL8oTbj",
-        description: "Project sidebar navigation item for the project issue sheet",
+        description: "Project sidebar navigation item for the project board",
       }),
       href: project("issue-sheet"),
       icon: Copy01Icon,

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -126,7 +126,7 @@ export function buildGlobalNavigationGroups(
         {
           label: intl.formatMessage({
             defaultMessage: "Board",
-            id: "olmZvevw/Q",
+            id: "XswXu+UFpy",
             description: "Sidebar navigation item for the workspace board",
           }),
           href: org("issues"),
@@ -358,7 +358,7 @@ export function buildProjectNavigationItems(
     {
       label: intl.formatMessage({
         defaultMessage: "Board",
-        id: "enrIL8oTbj",
+        id: "r7gtZsn8Qh",
         description: "Project sidebar navigation item for the project board",
       }),
       href: project("issue-sheet"),

--- a/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.stories.tsx
@@ -175,7 +175,7 @@ export const WithCommentsAndIssues: Story = {
     await expect(canvas.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
     await expect(canvas.getAllByText("Issue")).toHaveLength(3);
 
-    const issueSheetButton = canvas.getByRole("button", { name: "Issues" });
+    const issueSheetButton = canvas.getByRole("button", { name: "Board" });
     await expect(issueSheetButton).toBeInTheDocument();
     await userEvent.click(issueSheetButton);
     await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
@@ -220,7 +220,7 @@ export const CommentOnly: Story = {
     const canvas = within(canvasElement);
     await expect(canvas.queryByRole("tab", { name: "Issue" })).not.toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Add comment" })).toBeInTheDocument();
-    await expect(canvas.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
   },
 };
 
@@ -233,7 +233,7 @@ export const IssueSheetCtaWithExistingIssues: Story = {
   },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
-    const issueSheetButton = canvas.getByRole("button", { name: "Issues" });
+    const issueSheetButton = canvas.getByRole("button", { name: "Board" });
 
     await expect(issueSheetButton).toBeInTheDocument();
     await expect(issueSheetButton).toBeEnabled();
@@ -251,12 +251,12 @@ export const IssueSheetCtaOnIssueTab: Story = {
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole("tab", { name: "Issue" }));
-    await waitFor(() => expect(canvas.getByRole("button", { name: "Issues" })).toBeInTheDocument());
+    await waitFor(() => expect(canvas.getByRole("button", { name: "Board" })).toBeInTheDocument());
 
-    await userEvent.click(canvas.getByRole("button", { name: "Issues" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Board" }));
     await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
   },
 };
@@ -275,7 +275,7 @@ export const IssueSheetCtaHiddenOnCommentTab: Story = {
       "data-state",
       "active",
     );
-    await expect(canvas.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
   },
 };
 
@@ -290,7 +290,7 @@ export const IssueSheetCtaDisabledWhilePosting: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.getByRole("button", { name: "Issues" })).toBeDisabled();
+    await expect(canvas.getByRole("button", { name: "Board" })).toBeDisabled();
   },
 };
 
@@ -305,7 +305,7 @@ export const RaiseIssueInteraction: Story = {
     await userEvent.click(canvas.getByRole("tab", { name: "Issue" }));
     await waitFor(() => expect(canvas.getByText("Issue type")).toBeInTheDocument());
     await expect(canvas.getByText("General question")).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Issues" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Board" })).toBeInTheDocument();
 
     const input = canvas.getByPlaceholderText("Add a comment...");
     await userEvent.type(input, "Wrong tone for ja-JP.");
@@ -316,7 +316,7 @@ export const RaiseIssueInteraction: Story = {
     await expect(canvas.getByText("1")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
 
-    await userEvent.click(canvas.getByRole("button", { name: "Issues" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Board" }));
     await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
   },
 };

--- a/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.test.tsx
@@ -61,7 +61,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.getByRole("button", { name: "Issues" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Board" })).toBeInTheDocument();
   });
 
   it("shows the Issue Sheet CTA when the Issue tab is selected", async () => {
@@ -71,11 +71,11 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Issue" }));
 
-    expect(screen.getByRole("button", { name: "Issues" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Board" })).toBeInTheDocument();
   });
 
   it("hides the Issue Sheet CTA on the Comment tab when there are no issue comments", () => {
@@ -86,7 +86,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
   });
 
   it("hides the Issue Sheet CTA when no handler is provided", () => {
@@ -96,7 +96,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       }),
     });
 
-    expect(screen.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
   });
 
   it("hides the Issue Sheet CTA when issue comments are unsupported", () => {
@@ -108,7 +108,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Issue" })).not.toBeInTheDocument();
   });
 
@@ -123,7 +123,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet,
     });
 
-    await user.click(screen.getByRole("button", { name: "Issues" }));
+    await user.click(screen.getByRole("button", { name: "Board" }));
 
     expect(onOpenIssueSheet).toHaveBeenCalledTimes(1);
   });
@@ -137,7 +137,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.getByRole("button", { name: "Issues" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Board" })).toBeDisabled();
   });
 
   it("disables the Issue Sheet CTA while resolving an issue", () => {
@@ -150,7 +150,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.getByRole("button", { name: "Issues" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Board" })).toBeDisabled();
   });
 
   it("posts a plain comment without issue metadata on the Comment tab", async () => {

--- a/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-panel.test.tsx
@@ -132,7 +132,7 @@ describe("ContentEditorEditorPanel UI", () => {
     const commentsSection = screen.getByText("Comments").closest("section");
     expect(commentsSection).not.toBeNull();
 
-    await user.click(within(commentsSection!).getByRole("button", { name: "Issues" }));
+    await user.click(within(commentsSection!).getByRole("button", { name: "Board" }));
 
     expect(onAddToIssueSheet).toHaveBeenCalledTimes(1);
   });

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.messages.ts
@@ -16,9 +16,9 @@ import { defineMessages } from "react-intl";
 
 export const contentEditorEditorIssuesSectionMessages = defineMessages({
   title: {
-    defaultMessage: "Issues",
+    defaultMessage: "Board",
     id: "D2Iw7bGHIc",
-    description: "Heading for the CAT segment Issues section",
+    description: "Heading for the CAT segment Board section",
   },
   createIssue: {
     defaultMessage: "New issue",
@@ -28,31 +28,31 @@ export const contentEditorEditorIssuesSectionMessages = defineMessages({
   emptyTitle: {
     defaultMessage: "No issues for this string",
     id: "Esr6tXDJJe",
-    description: "Empty-state title when the CAT segment has no linked Issues",
+    description: "Empty-state title when the CAT segment has no linked issues",
   },
   emptyDescription: {
     defaultMessage: "Create an issue to track work on this string.",
     id: "8qNqRTyyLK",
-    description: "Empty-state description when the CAT segment has no linked Issues",
+    description: "Empty-state description when the CAT segment has no linked issues",
   },
   loadError: {
     defaultMessage: "Could not load issues.",
     id: "thNgDb6rW2",
-    description: "Error message when CAT segment Issues fail to load",
+    description: "Error message when CAT segment board issues fail to load",
   },
   unavailable: {
-    defaultMessage: "Issues are unavailable for this string.",
+    defaultMessage: "Board is unavailable for this string.",
     id: "T7+otbWCxu",
-    description: "Shown when the CAT segment cannot link to Issues (missing translation key)",
+    description: "Shown when the CAT segment cannot link to the Board (missing translation key)",
   },
   requestFailed: {
     defaultMessage: "Request failed",
     id: "JprxqupePC",
-    description: "Generic fallback when a CAT Issues API request fails",
+    description: "Generic fallback when a CAT Board API request fails",
   },
   close: {
-    defaultMessage: "Close issues",
+    defaultMessage: "Close board",
     id: "sHe4qCdT7b",
-    description: "Accessible label for closing the CAT Issues panel",
+    description: "Accessible label for closing the CAT Board panel",
   },
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.messages.ts
@@ -17,7 +17,7 @@ import { defineMessages } from "react-intl";
 export const contentEditorEditorIssuesSectionMessages = defineMessages({
   title: {
     defaultMessage: "Board",
-    id: "D2Iw7bGHIc",
+    id: "igJunofoju",
     description: "Heading for the CAT segment Board section",
   },
   createIssue: {
@@ -27,32 +27,32 @@ export const contentEditorEditorIssuesSectionMessages = defineMessages({
   },
   emptyTitle: {
     defaultMessage: "No issues for this string",
-    id: "Esr6tXDJJe",
+    id: "JXB2wuhw1Z",
     description: "Empty-state title when the CAT segment has no linked issues",
   },
   emptyDescription: {
     defaultMessage: "Create an issue to track work on this string.",
-    id: "8qNqRTyyLK",
+    id: "vqmXbSZwqU",
     description: "Empty-state description when the CAT segment has no linked issues",
   },
   loadError: {
     defaultMessage: "Could not load issues.",
-    id: "thNgDb6rW2",
+    id: "h5+KJI2d7A",
     description: "Error message when CAT segment board issues fail to load",
   },
   unavailable: {
     defaultMessage: "Board is unavailable for this string.",
-    id: "T7+otbWCxu",
+    id: "6XlImduZ6L",
     description: "Shown when the CAT segment cannot link to the Board (missing translation key)",
   },
   requestFailed: {
     defaultMessage: "Request failed",
-    id: "JprxqupePC",
+    id: "Hjj+QG5LDK",
     description: "Generic fallback when a CAT Board API request fails",
   },
   close: {
     defaultMessage: "Close board",
-    id: "sHe4qCdT7b",
+    id: "E8k6bvQHrX",
     description: "Accessible label for closing the CAT Board panel",
   },
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.stories.tsx
@@ -74,7 +74,7 @@ type Story = StoryObj<typeof meta>;
 export const WithLinkedIssues: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText("Issues")).toBeInTheDocument();
+    await expect(canvas.getByText("Board")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: /New issue/i })).toBeInTheDocument();
   },
 };
@@ -102,6 +102,6 @@ export const UnavailableWithoutKey: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText("Issues are unavailable for this string.")).toBeInTheDocument();
+    await expect(canvas.getByText("Board is unavailable for this string.")).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.test.tsx
@@ -168,7 +168,7 @@ describe("ContentEditorEditorIssuesSection", () => {
     await waitFor(() =>
       expect(getCatIssueGuidanceStatus()).toEqual({ available: true, openIssueCount: 1 }),
     );
-    expect(screen.queryByRole("heading", { name: "Issues" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Board" })).toBeNull();
   });
 
   it("clears footer guidance on unmount", async () => {

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-linked-issues-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-linked-issues-dialog.messages.ts
@@ -21,7 +21,7 @@ export const contentEditorLinkedIssuesDialogMessages = defineMessages({
     description: "Dialog title for issues linked to a CAT translation string",
   },
   description: {
-    defaultMessage: "Create or link Issues for this string. Navigate to an issue to collaborate.",
+    defaultMessage: "Create or link issues for this string. Navigate to an issue to collaborate.",
     id: "qyJpxYtcpE",
     description: "Dialog description for managing issues linked to a CAT string",
   },

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-linked-issues-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-linked-issues-dialog.messages.ts
@@ -22,7 +22,7 @@ export const contentEditorLinkedIssuesDialogMessages = defineMessages({
   },
   description: {
     defaultMessage: "Create or link issues for this string. Navigate to an issue to collaborate.",
-    id: "qyJpxYtcpE",
+    id: "n/ryC/yPKS",
     description: "Dialog description for managing issues linked to a CAT string",
   },
   createIssue: {

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.messages.ts
@@ -61,12 +61,12 @@ export const projectFileCatWorkspaceMessages = defineMessages({
     description: "Link label on an issue sheet row pointing back to the Content Editor",
   },
   failedToAddToIssueSheet: {
-    defaultMessage: "Failed to add to Issue Sheet",
+    defaultMessage: "Failed to add to Board",
     id: "iwQ9dbHG3A",
     description: "Fallback error when creating an issue sheet row from CAT fails",
   },
   addedToIssueSheet: {
-    defaultMessage: "Added to Issue Sheet",
+    defaultMessage: "Added to Board",
     id: "AF35eujXwK",
     description: "Toast confirmation after adding a CAT segment to the issue sheet",
   },

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.messages.ts
@@ -62,12 +62,12 @@ export const projectFileCatWorkspaceMessages = defineMessages({
   },
   failedToAddToIssueSheet: {
     defaultMessage: "Failed to add to Board",
-    id: "iwQ9dbHG3A",
+    id: "dBZKwTIoEH",
     description: "Fallback error when creating an issue sheet row from CAT fails",
   },
   addedToIssueSheet: {
     defaultMessage: "Added to Board",
-    id: "AF35eujXwK",
+    id: "6haGvAy+HC",
     description: "Toast confirmation after adding a CAT segment to the issue sheet",
   },
   viewIssueSheetRow: {

--- a/apps/hyperlocalise-web/src/components/content-editor/shared/content-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/shared/content-editor.messages.ts
@@ -1005,9 +1005,9 @@ export const contentEditorEditorPanelMessages = defineMessages({
     description: "Button to look up repository context for the current string",
   },
   addToIssueSheet: {
-    defaultMessage: "Issues",
+    defaultMessage: "Board",
     id: "IA5Kmwt4uK",
-    description: "Button to open linked Issues for the current CAT segment",
+    description: "Button to open the Board for the current CAT segment",
   },
   refreshContextTitle: {
     defaultMessage: "Re-run repository context lookup for this string",

--- a/apps/hyperlocalise-web/src/components/content-editor/shared/content-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/shared/content-editor.messages.ts
@@ -1006,7 +1006,7 @@ export const contentEditorEditorPanelMessages = defineMessages({
   },
   addToIssueSheet: {
     defaultMessage: "Board",
-    id: "IA5Kmwt4uK",
+    id: "KCIvL0TJB4",
     description: "Button to open the Board for the current CAT segment",
   },
   refreshContextTitle: {

--- a/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side-row.test.tsx
@@ -479,7 +479,7 @@ describe("ContentEditorSideBySideRow", () => {
     renderRow({ isDirty: false, onAddToIssueSheet });
 
     expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /^Issues$/i }));
+    await user.click(screen.getByRole("button", { name: /^Board$/i }));
     expect(onAddToIssueSheet).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side.stories.tsx
@@ -149,7 +149,7 @@ export const Default: Story = {
       { timeout: 3000 },
     );
     await expect(canvas.queryByText(/Format & QA checks/i)).not.toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: /^Issues$/i })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /^Board$/i })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: /Find context/i })).toBeInTheDocument();
     await expect(canvas.queryByRole("button", { name: /^Approve/i })).not.toBeInTheDocument();
     await expect(canvas.queryByText(/ICU structure/i)).not.toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -37,7 +37,7 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Sidebar nav label in marketing app shell mock",
   },
   mockNavIssues: {
-    defaultMessage: "Issues",
+    defaultMessage: "Board",
     id: "dyxy90ZIN1",
     description: "Sidebar nav label in marketing app shell mock",
   },
@@ -67,7 +67,7 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Header breadcrumb in marketing app shell mock for inbox triage",
   },
   mockBreadcrumbIssues: {
-    defaultMessage: "Acme · Issues",
+    defaultMessage: "Acme · Board",
     id: "yqDgUgDi10",
     description: "Header breadcrumb in marketing app shell mock",
   },
@@ -164,9 +164,9 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Editor mock use case pill for TM, context, and AI suggestions",
   },
   editorIssuesPanelTitle: {
-    defaultMessage: "Issues · this string",
+    defaultMessage: "Board · this string",
     id: "ncf9XHFPKV",
-    description: "Title on the editor mock issues overlay",
+    description: "Title on the editor mock board overlay",
   },
   editorHighlightEditor: {
     defaultMessage: "File editor",
@@ -334,9 +334,9 @@ export const contentOpsMockStageMessages = defineMessages({
   },
 
   issuesTitle: {
-    defaultMessage: "Issues · acme workspace",
+    defaultMessage: "Board · acme workspace",
     id: "rugkgwDED8",
-    description: "Issues panel title in content ops mock",
+    description: "Board panel title in content ops mock",
   },
   inboxTitle: {
     defaultMessage: "Inbox",

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -38,7 +38,7 @@ export const contentOpsMockStageMessages = defineMessages({
   },
   mockNavIssues: {
     defaultMessage: "Board",
-    id: "dyxy90ZIN1",
+    id: "2Q9B8y1llx",
     description: "Sidebar nav label in marketing app shell mock",
   },
   mockNavDashboard: {
@@ -68,7 +68,7 @@ export const contentOpsMockStageMessages = defineMessages({
   },
   mockBreadcrumbIssues: {
     defaultMessage: "Acme · Board",
-    id: "yqDgUgDi10",
+    id: "08+4Nn7rgH",
     description: "Header breadcrumb in marketing app shell mock",
   },
   mockBreadcrumbCampaign: {
@@ -165,7 +165,7 @@ export const contentOpsMockStageMessages = defineMessages({
   },
   editorIssuesPanelTitle: {
     defaultMessage: "Board · this string",
-    id: "ncf9XHFPKV",
+    id: "hYi0NizHJf",
     description: "Title on the editor mock board overlay",
   },
   editorHighlightEditor: {
@@ -335,7 +335,7 @@ export const contentOpsMockStageMessages = defineMessages({
 
   issuesTitle: {
     defaultMessage: "Board · acme workspace",
-    id: "rugkgwDED8",
+    id: "tX5h+jHyR2",
     description: "Board panel title in content ops mock",
   },
   inboxTitle: {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-types.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-types.ts
@@ -389,7 +389,7 @@ export type WorkspaceAutomationConfigValidationError =
     }
   | {
       code: "scheduled_workflow_required";
-      message: "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.";
+      message: "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.";
     }
   | {
       code: "invalid_automation_timezone";

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -148,7 +148,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   github_push_branches_required: "Add at least one branch pattern for GitHub triggers.",
   github_events_required: "Choose at least one GitHub event.",
   scheduled_workflow_required:
-    "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
+    "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.",
   invalid_automation_timezone: "Choose a valid timezone for the schedule.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
   slack_channel_required: "Choose a Slack channel for notifications.",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -487,7 +487,7 @@ describe("workspace automations", () => {
     expect(notificationOnlySchedule.error).toMatchObject({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.",
     });
 
     const scheduledWebSearch = expectOk(
@@ -537,7 +537,7 @@ describe("workspace automations", () => {
     expect(scheduledUpdate.error).toMatchObject({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -157,7 +157,7 @@ function validateWorkspaceAutomationConfig(input: {
     return err({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.",
     });
   }
 

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -212,7 +212,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
 
     expect(itemLabels).not.toContain("Automations");
     expect(itemLabels).not.toContain("Guideline");
-    expect(itemLabels).toContain("Issues");
+    expect(itemLabels).toContain("Board");
     expect(itemLabels).toContain("New Request");
     expect(itemLabels).toContain("AI Engine");
     expect(itemLabels).not.toContain("Domains");
@@ -233,7 +233,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
 
     expect(itemLabels).toContain("Automations");
     expect(itemLabels).toContain("Guideline");
-    expect(itemLabels).toContain("Issues");
+    expect(itemLabels).toContain("Board");
     expect(itemLabels).toContain("Domains");
     expect(itemLabels).toContain("AI Engine");
   });

--- a/docs/platform/cat.mdx
+++ b/docs/platform/cat.mdx
@@ -56,9 +56,9 @@ Provider-specific filters such as **QA issues** and **Machine translations** app
 
 **Download** exports the filtered view. **Load more** continues the infinite-scroll list.
 
-## Issues
+## Board
 
-Open **Issues** in the project or workspace sidebar when a segment needs a tracker item instead of an in-line comment. Filter the queue with **Has issues** to find those strings.
+Open **Board** in the project or workspace sidebar when a segment needs a tracker item instead of an in-line comment. Filter the queue with **Has issues** to find those strings.
 
 ## Content Editor behavior
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Rename the Hyperlocalise **Issues** product feature to **Board** in user-facing copy.

Visible labels now say Board in:

- Workspace and project sidebar navigation
- App shell breadcrumbs, page titles, and footer CAT button
- Content Editor Board panel and toasts
- Automations tool group and validation copy
- Marketing content-ops mock
- Cloud CAT docs

Individual issue records stay **issues** (create issue, mention picker, Has issues filter). Routes (`/issues`, `/issue-sheet`), APIs, and feature-flag keys are unchanged so existing links keep working.

## How to test

- Open a workspace and confirm the sidebar item is **Board** and the workspace page heading matches.
- Open a project and confirm the sidebar item and project page heading are **Board**.
- In the Content Editor, confirm the segment action and panel heading say **Board**.
- In Automations, confirm the tool submenu is **Board**.
- Confirm GitHub Issues (docs nav) and TMS/QA “issues” copy are unchanged.

```
cd apps/hyperlocalise-web
vp test
vp check --fix
```

`vp test`: 834 files, 5761 tests passed.
`vp check --fix`: no lint or type errors.

[Workspace Board page in Storybook](https://cursor.com/agents/bc-01a05c35-d431-7a85-8e42-fe78a3241f1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkspace_board_storybook.webp)
[Workspace Board page heading](https://cursor.com/agents/bc-01a05c35-d431-7a85-8e42-fe78a3241f1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkspace_board_page.webp)
[Board load error copy](https://cursor.com/agents/bc-01a05c35-d431-7a85-8e42-fe78a3241f1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkspace_board_load_error.webp)
[board-rename-storybook-walkthrough.mp4](https://cursor.com/agents/bc-01a05c35-d431-7a85-8e42-fe78a3241f1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fboard-rename-storybook-walkthrough.mp4)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05c35-d431-7a85-8e42-fe78a3241f1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05c35-d431-7a85-8e42-fe78a3241f1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

