### PR TITLE
feat(mcp): add update_issue tool to the hosted MCP server

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -399,6 +399,22 @@ describe("MCP team-scoped access", () => {
       error: "forbidden",
     });
 
+    const updateDeniedResponse = await callMcpTool(accessToken, "update_issue", {
+      projectId: alphaProjectBody.project.id,
+      issueId: alphaIssue.id,
+      title: "Member must not update this issue",
+    });
+
+    expect(updateDeniedResponse.status).toBe(200);
+
+    const updateDeniedBody = await updateDeniedResponse.json();
+
+    expect((updateDeniedBody as { result?: { isError?: boolean } }).result?.isError).toBe(true);
+
+    expect(parseToolResultText(updateDeniedBody)).toMatchObject({
+      error: "forbidden",
+    });
+
     const deniedIssues = await db
       .select({ id: schema.issueSheetIssues.id })
       .from(schema.issueSheetIssues)
@@ -423,6 +439,56 @@ describe("MCP team-scoped access", () => {
           eq(schema.organizationMemberships.userId, memberAuth.user.localUserId),
         ),
       );
+
+    const updateAllowedResponse = await callMcpTool(accessToken, "update_issue", {
+      projectId: alphaProjectBody.project.id,
+      issueId: alphaIssue.id,
+      title: "Updated by Team Alpha translator",
+    });
+
+    expect(updateAllowedResponse.status).toBe(200);
+
+    expect(parseToolResultText(await updateAllowedResponse.json())).toMatchObject({
+      outcome: "updated",
+      issue: {
+        id: alphaIssue.id,
+        title: "Updated by Team Alpha translator",
+      },
+    });
+
+    const inaccessibleUpdates = [
+      {
+        label: "wrong team",
+        projectId: betaProjectBody.project.id,
+        issueId: betaIssue.id,
+      },
+      {
+        label: "wrong organization",
+        projectId: externalProject.id,
+        issueId: externalIssue.id,
+      },
+    ];
+
+    for (const update of inaccessibleUpdates) {
+      const response = await callMcpTool(accessToken, "update_issue", {
+        projectId: update.projectId,
+        issueId: update.issueId,
+        title: "Must not be updated",
+      });
+
+      expect(response.status, update.label).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(
+        (responseBody as { result?: { isError?: boolean } }).result?.isError,
+        update.label,
+      ).toBe(true);
+
+      expect(parseToolResultText(responseBody), update.label).toMatchObject({
+        error: "issue_not_found",
+      });
+    }
 
     const createAllowedResponse = await callMcpTool(accessToken, "create_issue", {
       projectId: alphaProjectBody.project.id,

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -1875,6 +1875,100 @@ describe("mcpRoutes", () => {
     });
   });
 
+  it("rolls back core fields when a combined priority update fails", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const service = new IssueSheetService();
+    const created = await service.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Original atomic title",
+      },
+    });
+
+    await service.ensureStarterColumns({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+    });
+    await db
+      .update(schema.issueSheetColumns)
+      .set({
+        config: {
+          options: [{ id: "P1", label: "P1", color: "amber" }],
+        },
+      })
+      .where(
+        and(
+          eq(schema.issueSheetColumns.organizationId, auth.organization.localOrganizationId),
+          eq(schema.issueSheetColumns.projectId, stored.project.id),
+          eq(schema.issueSheetColumns.key, "priority"),
+        ),
+      );
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_issue",
+          arguments: {
+            projectId: stored.project.id,
+            issueId: created.identifier,
+            title: "Must roll back",
+            priority: "P0",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toContain("invalid_issue_update");
+
+    const [persisted] = await db
+      .select({ title: schema.issueSheetIssues.title })
+      .from(schema.issueSheetIssues)
+      .where(eq(schema.issueSheetIssues.id, created.id))
+      .limit(1);
+
+    expect(persisted?.title).toBe("Original atomic title");
+
+    const priorityActivities = await db
+      .select({ id: schema.issueSheetActivities.id })
+      .from(schema.issueSheetActivities)
+      .where(
+        and(
+          eq(schema.issueSheetActivities.issueId, created.id),
+          eq(schema.issueSheetActivities.type, "priority_changed"),
+        ),
+      );
+
+    expect(priorityActivities).toHaveLength(0);
+  });
+
   it("clears nullable update_issue fields and preserves omitted fields", async () => {
     const stored = await fixture.createStoredProjectFixture();
     const headers = await authenticatedMcpHeaders(stored.identity);

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -1000,6 +1000,52 @@ describe("mcpRoutes", () => {
         title: "Created through the MCP SDK",
       });
 
+      const updateResult = await client.callTool({
+        name: "update_issue",
+        arguments: {
+          projectId: stored.project.id,
+          issueId: createdIssue.identifier,
+          title: "Updated through the MCP SDK",
+          status: "in_progress",
+          priority: "P0",
+        },
+      });
+
+      const updateContent = (
+        updateResult as {
+          content?: Array<{
+            type?: string;
+            text?: string;
+          }>;
+        }
+      ).content?.find((item) => item.type === "text");
+
+      if (!updateContent?.text) {
+        throw new Error("expected update_issue text content");
+      }
+
+      const updatedIssue = JSON.parse(updateContent.text) as {
+        outcome: "updated" | "unchanged";
+        issue: {
+          id: string;
+          title: string;
+          status: string;
+          values: Record<string, unknown>;
+        };
+      };
+
+      expect(updatedIssue).toMatchObject({
+        outcome: "updated",
+        issue: {
+          id: createdIssue.id,
+          title: "Updated through the MCP SDK",
+          status: "in_progress",
+          values: {
+            priority: "P0",
+          },
+        },
+      });
+
       const getIssueResult = await client.callTool({
         name: "get_issue",
         arguments: {
@@ -1026,16 +1072,18 @@ describe("mcpRoutes", () => {
           id: string;
           title: string;
           description: string;
+          status: string;
           values: Record<string, unknown>;
         };
       };
 
       expect(getIssueOutput.issue).toMatchObject({
         id: createdIssue.id,
-        title: "Created through the MCP SDK",
+        title: "Updated through the MCP SDK",
         description: "SDK integration coverage",
+        status: "in_progress",
         values: {
-          priority: "P1",
+          priority: "P0",
         },
       });
 
@@ -1076,7 +1124,7 @@ describe("mcpRoutes", () => {
         total: 1,
         summary: {
           total: 1,
-          open: 1,
+          inProgress: 1,
         },
         pagination: {
           limit: 10,
@@ -1088,14 +1136,14 @@ describe("mcpRoutes", () => {
           expect.objectContaining({
             id: createdIssue.id,
             projectId: stored.project.id,
-            title: "Created through the MCP SDK",
-            priority: "P1",
+            title: "Updated through the MCP SDK",
+            priority: "P0",
           }),
         ],
       });
 
       expect(result.content).toEqual(expect.any(Array));
-      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(7);
+      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(8);
       expect(requestMethods.filter((method) => method === "GET")).toHaveLength(1);
       expect(requestMethods.every((method) => method === "POST" || method === "GET")).toBe(true);
       expect(transportErrors).toEqual([]);
@@ -1429,7 +1477,7 @@ describe("mcpRoutes", () => {
 
     expect(tool).toBeDefined();
     expect(tool?.description).toContain("issue");
-    expect(tool?.inputSchema?.required).toEqual(expect.arrayContaining(["projectId", "issueId"]));
+    expect(tool?.inputSchema?.required).toEqual(["projectId", "issueId"]);
     expect(tool?.inputSchema?.properties).toMatchObject({
       projectId: {
         type: "string",
@@ -1440,6 +1488,614 @@ describe("mcpRoutes", () => {
         type: "string",
       },
     });
+  });
+
+  it("advertises the update_issue tool with bounded mutable fields", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "update_issue");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("issue");
+    expect(tool?.inputSchema?.required).toEqual(expect.arrayContaining(["projectId", "issueId"]));
+
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      issueId: {
+        type: "string",
+      },
+      title: {
+        type: "string",
+        minLength: 1,
+        maxLength: 300,
+      },
+      description: {
+        type: "string",
+        maxLength: 20_000,
+      },
+      issueType: expect.any(Object),
+      status: expect.any(Object),
+      targetLocale: expect.any(Object),
+      sourcePath: expect.any(Object),
+      segmentId: expect.any(Object),
+      translationKeyId: expect.any(Object),
+      assigneeUserId: expect.any(Object),
+      priority: expect.any(Object),
+    });
+
+    expect(tool?.inputSchema?.properties).not.toHaveProperty("values");
+    expect(tool?.inputSchema?.properties).not.toHaveProperty("linkKind");
+    expect(tool?.inputSchema?.properties).not.toHaveProperty("linkLabel");
+    expect(tool?.inputSchema?.properties).not.toHaveProperty("linkUrl");
+  });
+
+  it("rejects an empty update_issue request", async () => {
+    const headers = await authenticatedMcpHeaders();
+    const updateSpy = vi.spyOn(IssueSheetService.prototype, "updateIssue");
+    const prioritySpy = vi.spyOn(IssueSheetService.prototype, "setPriority");
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "update_issue",
+            arguments: {
+              projectId: "project-id",
+              issueId: "HL-1",
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ text?: string }>;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+      expect(text).toContain("invalid_issue_update");
+
+      expect(updateSpy).not.toHaveBeenCalled();
+      expect(prioritySpy).not.toHaveBeenCalled();
+    } finally {
+      updateSpy.mockRestore();
+      prioritySpy.mockRestore();
+    }
+  });
+
+  it.each([
+    ["a type-invalid title", { title: 123 }],
+    ["an overlong title", { title: "x".repeat(301) }],
+    ["an invalid assignee UUID", { assigneeUserId: "not-a-uuid" }],
+    ["an invalid priority", { priority: "P3" }],
+  ])("returns invalid_issue_update for %s", async (_label, updates) => {
+    const headers = await authenticatedMcpHeaders();
+    const updateSpy = vi.spyOn(IssueSheetService.prototype, "updateIssue");
+    const prioritySpy = vi.spyOn(IssueSheetService.prototype, "setPriority");
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "update_issue",
+            arguments: {
+              projectId: "project-id",
+              issueId: "HL-1",
+              ...updates,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ text?: string }>;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+      expect(text).toContain("invalid_issue_update");
+      expect(updateSpy).not.toHaveBeenCalled();
+      expect(prioritySpy).not.toHaveBeenCalled();
+    } finally {
+      updateSpy.mockRestore();
+      prioritySpy.mockRestore();
+    }
+  });
+
+  it("updates core issue fields as the MCP-authenticated user", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const service = new IssueSheetService();
+
+    const created = await service.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Original title",
+        description: "Original description",
+        issueType: "translation_mistake",
+        status: "open",
+      },
+    });
+
+    const response = await app.request("http://localhost/mcp/sse", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_issue",
+          arguments: {
+            projectId: stored.project.id,
+            issueId: created.identifier,
+            title: "Updated through MCP",
+            description: "Updated description",
+            issueType: "qa_failure",
+            status: "in_progress",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const responseBody = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(responseBody.result?.isError).not.toBe(true);
+
+    const text = responseBody.result?.content?.[0]?.text;
+    expect(text).toBeDefined();
+
+    const output = JSON.parse(text!) as {
+      outcome: string;
+      issue: {
+        id: string;
+        title: string;
+        description: string;
+        issueType: string;
+        status: string;
+      };
+    };
+
+    expect(output).toMatchObject({
+      outcome: "updated",
+      issue: {
+        id: created.id,
+        title: "Updated through MCP",
+        description: "Updated description",
+        issueType: "qa_failure",
+        status: "in_progress",
+      },
+    });
+
+    const activities = await db
+      .select({
+        actorUserId: schema.issueSheetActivities.actorUserId,
+        type: schema.issueSheetActivities.type,
+      })
+      .from(schema.issueSheetActivities)
+      .where(
+        and(
+          eq(schema.issueSheetActivities.issueId, created.id),
+          eq(schema.issueSheetActivities.type, "status_changed"),
+        ),
+      );
+
+    expect(activities).toEqual([
+      {
+        actorUserId: auth.user.localUserId,
+        type: "status_changed",
+      },
+    ]);
+
+    const issueTypeActivities = await db
+      .select({
+        actorUserId: schema.issueSheetActivities.actorUserId,
+        type: schema.issueSheetActivities.type,
+      })
+      .from(schema.issueSheetActivities)
+      .where(
+        and(
+          eq(schema.issueSheetActivities.issueId, created.id),
+          eq(schema.issueSheetActivities.type, "issue_type_changed"),
+        ),
+      );
+
+    expect(issueTypeActivities).toEqual([
+      {
+        actorUserId: auth.user.localUserId,
+        type: "issue_type_changed",
+      },
+    ]);
+  });
+
+  it("reports title-only updates and repeated no-op updates correctly", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const service = new IssueSheetService();
+    const created = await service.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Original title",
+      },
+    });
+
+    const updateTitle = async () => {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "update_issue",
+            arguments: {
+              projectId: stored.project.id,
+              issueId: created.identifier,
+              title: "Updated title",
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ text?: string }>;
+        };
+      };
+
+      expect(body.result?.isError).not.toBe(true);
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+
+      return JSON.parse(text!) as {
+        outcome: "updated" | "unchanged";
+        issue: {
+          id: string;
+          title: string;
+        };
+      };
+    };
+
+    await expect(updateTitle()).resolves.toMatchObject({
+      outcome: "updated",
+      issue: {
+        id: created.id,
+        title: "Updated title",
+      },
+    });
+
+    await expect(updateTitle()).resolves.toMatchObject({
+      outcome: "unchanged",
+      issue: {
+        id: created.id,
+        title: "Updated title",
+      },
+    });
+  });
+
+  it("clears nullable update_issue fields and preserves omitted fields", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const service = new IssueSheetService();
+
+    const [translationKey] = await db
+      .insert(schema.projectTranslationKeys)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        projectId: stored.project.id,
+        key: "update.nullable",
+        sourceText: "Nullable source",
+        normalizedSourceText: "Nullable source",
+      })
+      .returning({
+        id: schema.projectTranslationKeys.id,
+      });
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    const created = await service.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Nullable fields issue",
+        description: "Description must remain",
+        targetLocale: "fr-FR",
+        sourcePath: "src/messages.json",
+        segmentId: "nullable-segment",
+        translationKeyId: translationKey.id,
+        assigneeUserId: auth.user.localUserId,
+      },
+    });
+
+    const clearFields = async () => {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "update_issue",
+            arguments: {
+              projectId: stored.project.id,
+              issueId: created.identifier,
+              targetLocale: null,
+              sourcePath: null,
+              segmentId: null,
+              translationKeyId: null,
+              assigneeUserId: null,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ text?: string }>;
+        };
+      };
+
+      expect(responseBody.result?.isError).not.toBe(true);
+
+      const text = responseBody.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+
+      return JSON.parse(text!) as {
+        outcome: "updated" | "unchanged";
+        issue: {
+          id: string;
+          description: string;
+          targetLocale: string | null;
+          sourcePath: string | null;
+          segmentId: string | null;
+          translationKeyId: string | null;
+          assigneeUserId: string | null;
+          linkedTranslationKey: {
+            id: string;
+            key: string;
+            sourceText: string;
+          } | null;
+        };
+      };
+    };
+
+    const first = await clearFields();
+
+    expect(first).toMatchObject({
+      outcome: "updated",
+      issue: {
+        id: created.id,
+        description: "Description must remain",
+        targetLocale: null,
+        sourcePath: null,
+        segmentId: null,
+        translationKeyId: null,
+        assigneeUserId: null,
+        linkedTranslationKey: null,
+      },
+    });
+
+    const retry = await clearFields();
+
+    expect(retry).toMatchObject({
+      outcome: "unchanged",
+      issue: {
+        id: created.id,
+        description: "Description must remain",
+        targetLocale: null,
+        sourcePath: null,
+        segmentId: null,
+        translationKeyId: null,
+        assigneeUserId: null,
+        linkedTranslationKey: null,
+      },
+    });
+
+    const activities = await db
+      .select({
+        actorUserId: schema.issueSheetActivities.actorUserId,
+        type: schema.issueSheetActivities.type,
+      })
+      .from(schema.issueSheetActivities)
+      .where(
+        and(
+          eq(schema.issueSheetActivities.issueId, created.id),
+          eq(schema.issueSheetActivities.type, "assignee_changed"),
+        ),
+      );
+
+    expect(activities).toHaveLength(2);
+    expect(activities).toEqual(
+      expect.arrayContaining([
+        {
+          actorUserId: auth.user.localUserId,
+          type: "assignee_changed",
+        },
+      ]),
+    );
+    expect(
+      activities.every(
+        (activity) =>
+          activity.actorUserId === auth.user.localUserId && activity.type === "assignee_changed",
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["assignee_not_assignable", "assignee_not_assignable"],
+    ["translation_key_not_found", "translation_key_not_found"],
+    ["invalid_issue_transition", "invalid_issue_transition"],
+    ["invalid_issue_sheet_select_value", "invalid_issue_update"],
+    ["issue_sheet_column_not_found", "invalid_issue_update"],
+  ])("maps update issue failure %s to %s", async (serviceError, expectedCode) => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const updateSpy = vi
+      .spyOn(IssueSheetService.prototype, "updateIssue")
+      .mockRejectedValueOnce(new Error(serviceError));
+
+    try {
+      const response = await app.request("http://localhost/mcp/sse", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "update_issue",
+            arguments: {
+              projectId: stored.project.id,
+              issueId: "HL-1",
+              title: "Updated title",
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ type: string; text?: string }>;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+      expect(JSON.parse(text!)).toMatchObject({
+        error: expectedCode,
+      });
+    } finally {
+      updateSpy.mockRestore();
+    }
   });
 
   it("advertises the create_issue tool with a bounded input schema", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -63,8 +63,14 @@ import { db, schema } from "@/lib/database/client";
 import { env } from "@/lib/env";
 import { resolveMcpClientMetadata } from "@/api/auth/mcp-client-metadata";
 import { isErr } from "@/lib/primitives/result/results";
-import { issueSheetCreateIssueBodySchema } from "@/api/routes/project/issue-sheet.schema";
-import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
+import {
+  issueSheetCreateIssueBodySchema,
+  issueSheetUpdateIssueBodySchema,
+} from "@/api/routes/project/issue-sheet.schema";
+import {
+  IssueSheetService,
+  type IssueSheetIssue,
+} from "@/lib/projects/issue-sheet/issue-sheet-service";
 import { isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
 
 const authorizationQuerySchema = z.object({
@@ -384,6 +390,68 @@ const mcpGetIssueInputSchema = z.object({
 
 const issueSheetService = new IssueSheetService();
 const createIssueShape = issueSheetCreateIssueBodySchema.shape;
+const updateIssueShape = issueSheetUpdateIssueBodySchema.shape;
+const invalidIssueUpdate = Symbol("invalid_issue_update");
+
+const mcpUpdateIssueInputSchema = z
+  .object({
+    projectId: z
+      .string()
+      .trim()
+      .min(1)
+      .max(128)
+      .catch(invalidIssueUpdate as never)
+      .describe("ID of the accessible Hyperlocalise project containing the issue."),
+    issueId: issueIdSchema
+      .catch(invalidIssueUpdate as never)
+      .describe("Canonical issue identifier such as HL-123, or a legacy issue UUID."),
+    title: updateIssueShape.title
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement issue title."),
+    description: updateIssueShape.description
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement issue description."),
+    issueType: updateIssueShape.issueType
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement issue classification."),
+    status: updateIssueShape.status
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement issue status."),
+    targetLocale: updateIssueShape.targetLocale
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement target locale, or null to clear it."),
+    sourcePath: updateIssueShape.sourcePath
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement source path, or null to clear it."),
+    segmentId: updateIssueShape.segmentId
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement segment identifier, or null to clear it."),
+    translationKeyId: updateIssueShape.translationKeyId
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement translation key UUID, or null to clear it."),
+    assigneeUserId: updateIssueShape.assigneeUserId
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement assignee UUID, or null to unassign."),
+    priority: createIssueShape.priority
+      .catch(invalidIssueUpdate as never)
+      .describe("Replacement priority: P0, P1, or P2."),
+  })
+  .check((context) => {
+    const { projectId: _projectId, issueId: _issueId, ...updates } = context.value;
+    const hasInvalidValue = Object.values(context.value).some(
+      (value) => (value as unknown) === invalidIssueUpdate,
+    );
+    const hasUpdate = Object.values(updates).some((value) => value !== undefined);
+
+    if (hasInvalidValue || !hasUpdate) {
+      context.issues.push({
+        code: "custom",
+        input: context.value,
+        message: "invalid_issue_update",
+        path: [],
+      });
+    }
+  });
 
 const mcpCreateIssueInputSchema = z.object({
   projectId: z
@@ -459,6 +527,21 @@ function mcpToolError(code: string, message: string) {
       },
     ],
     isError: true,
+  };
+}
+
+function detailedMcpIssue(issue: IssueSheetIssue) {
+  const { key, sourceText, ...issueDetails } = issue;
+
+  return {
+    ...issueDetails,
+    linkedTranslationKey: issue.translationKeyId
+      ? {
+          id: issue.translationKeyId,
+          key,
+          sourceText,
+        }
+      : null,
   };
 }
 
@@ -617,27 +700,144 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
         return mcpToolError("issue_not_found", "Issue not found");
       }
 
-      const { key, sourceText, ...issueDetails } = issue;
-
       return {
         content: [
           {
             type: "text",
             text: JSON.stringify({
-              issue: {
-                ...issueDetails,
-                linkedTranslationKey: issue.translationKeyId
-                  ? {
-                      id: issue.translationKeyId,
-                      key,
-                      sourceText,
-                    }
-                  : null,
-              },
+              issue: detailedMcpIssue(issue),
             }),
           },
         ],
       };
+    },
+  );
+
+  server.registerTool(
+    "update_issue",
+    {
+      description: "Update mutable fields on one accessible Hyperlocalise issue.",
+      inputSchema: mcpUpdateIssueInputSchema,
+    },
+    async ({ projectId, issueId, priority, ...updates }) => {
+      if (!isWriteBackTranslationAllowed(apiAuth.membership.role)) {
+        return mcpToolError("forbidden", "Insufficient permissions to update issues");
+      }
+
+      const [project] = await db
+        .select({ id: schema.projects.id })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("issue_not_found", "Issue not found");
+      }
+
+      const hasCoreUpdate = Object.values(updates).some((value) => value !== undefined);
+
+      let outcome: "updated" | "unchanged" = "unchanged";
+      let issue: IssueSheetIssue | null = null;
+
+      try {
+        if (hasCoreUpdate) {
+          const coreResult = await issueSheetService.updateIssue({
+            organizationId: apiAuth.organization.localOrganizationId,
+            projectId: project.id,
+            issueId,
+            actorUserId: apiAuth.user.localUserId,
+            body: updates,
+            returnOutcome: true,
+          });
+
+          if (!coreResult) {
+            return mcpToolError("issue_not_found", "Issue not found");
+          }
+
+          if (!("outcome" in coreResult)) {
+            throw new Error("expected issue update outcome");
+          }
+
+          outcome = coreResult.outcome;
+          issue = coreResult.issue;
+        }
+
+        if (priority !== undefined) {
+          const priorityResult = await issueSheetService.setPriority({
+            organizationId: apiAuth.organization.localOrganizationId,
+            projectId: project.id,
+            issueId,
+            actorUserId: apiAuth.user.localUserId,
+            priority,
+          });
+
+          if (!priorityResult) {
+            return mcpToolError("issue_not_found", "Issue not found");
+          }
+
+          if (priorityResult.outcome === "updated") {
+            outcome = "updated";
+          }
+
+          issue = await issueSheetService.getIssue({
+            organizationId: apiAuth.organization.localOrganizationId,
+            projectId: project.id,
+            issueId,
+            actorUserId: apiAuth.user.localUserId,
+          });
+        }
+
+        if (!issue) {
+          return mcpToolError(
+            "invalid_issue_update",
+            "At least one mutable issue field must be provided",
+          );
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                outcome,
+                issue: detailedMcpIssue(issue),
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof Error) {
+          if (error.message === "assignee_not_assignable") {
+            return mcpToolError(
+              "assignee_not_assignable",
+              "Assignee is not assignable to this project",
+            );
+          }
+
+          if (error.message === "translation_key_not_found") {
+            return mcpToolError(
+              "translation_key_not_found",
+              "Translation key was not found in this project",
+            );
+          }
+
+          if (error.message === "invalid_issue_transition") {
+            return mcpToolError(
+              "invalid_issue_transition",
+              "The requested issue status transition is invalid",
+            );
+          }
+
+          if (
+            error.message === "invalid_issue_sheet_select_value" ||
+            error.message === "issue_sheet_column_not_found"
+          ) {
+            return mcpToolError("invalid_issue_update", "The requested issue update is invalid");
+          }
+        }
+
+        throw error;
+      }
     },
   );
 

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -734,64 +734,23 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
         return mcpToolError("issue_not_found", "Issue not found");
       }
 
-      const hasCoreUpdate = Object.values(updates).some((value) => value !== undefined);
-
-      let outcome: "updated" | "unchanged" = "unchanged";
-      let issue: IssueSheetIssue | null = null;
-
       try {
-        if (hasCoreUpdate) {
-          const coreResult = await issueSheetService.updateIssue({
-            organizationId: apiAuth.organization.localOrganizationId,
-            projectId: project.id,
-            issueId,
-            actorUserId: apiAuth.user.localUserId,
-            body: updates,
-            returnOutcome: true,
-          });
+        const result = await issueSheetService.updateIssue({
+          organizationId: apiAuth.organization.localOrganizationId,
+          projectId: project.id,
+          issueId,
+          actorUserId: apiAuth.user.localUserId,
+          body: updates,
+          priority,
+          returnOutcome: true,
+        });
 
-          if (!coreResult) {
-            return mcpToolError("issue_not_found", "Issue not found");
-          }
-
-          if (!("outcome" in coreResult)) {
-            throw new Error("expected issue update outcome");
-          }
-
-          outcome = coreResult.outcome;
-          issue = coreResult.issue;
+        if (!result) {
+          return mcpToolError("issue_not_found", "Issue not found");
         }
 
-        if (priority !== undefined) {
-          const priorityResult = await issueSheetService.setPriority({
-            organizationId: apiAuth.organization.localOrganizationId,
-            projectId: project.id,
-            issueId,
-            actorUserId: apiAuth.user.localUserId,
-            priority,
-          });
-
-          if (!priorityResult) {
-            return mcpToolError("issue_not_found", "Issue not found");
-          }
-
-          if (priorityResult.outcome === "updated") {
-            outcome = "updated";
-          }
-
-          issue = await issueSheetService.getIssue({
-            organizationId: apiAuth.organization.localOrganizationId,
-            projectId: project.id,
-            issueId,
-            actorUserId: apiAuth.user.localUserId,
-          });
-        }
-
-        if (!issue) {
-          return mcpToolError(
-            "invalid_issue_update",
-            "At least one mutable issue field must be provided",
-          );
+        if (!("outcome" in result)) {
+          throw new Error("expected issue update outcome");
         }
 
         return {
@@ -799,8 +758,8 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
             {
               type: "text",
               text: JSON.stringify({
-                outcome,
-                issue: detailedMcpIssue(issue),
+                outcome: result.outcome,
+                issue: detailedMcpIssue(result.issue),
               }),
             },
           ],

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -1479,8 +1479,17 @@ export class IssueSheetService {
       const [current] = await tx
         .select({
           id: schema.issueSheetIssues.id,
+          title: schema.issueSheetIssues.title,
+          description: schema.issueSheetIssues.description,
           status: schema.issueSheetIssues.status,
           issueType: schema.issueSheetIssues.issueType,
+          targetLocale: schema.issueSheetIssues.targetLocale,
+          sourcePath: schema.issueSheetIssues.sourcePath,
+          segmentId: schema.issueSheetIssues.segmentId,
+          translationKeyId: schema.issueSheetIssues.translationKeyId,
+          linkKind: schema.issueSheetIssues.linkKind,
+          linkLabel: schema.issueSheetIssues.linkLabel,
+          linkUrl: schema.issueSheetIssues.linkUrl,
           assigneeUserId: schema.issueSheetIssues.assigneeUserId,
         })
         .from(schema.issueSheetIssues)
@@ -1514,32 +1523,56 @@ export class IssueSheetService {
       const assigneeActuallyChanged =
         assigneeChanging && current.assigneeUserId !== nextAssigneeUserId;
 
-      await tx
-        .update(schema.issueSheetIssues)
-        .set({
-          title: input.body.title,
-          description: input.body.description,
-          issueType: input.body.issueType,
-          status: input.body.status,
-          targetLocale: input.body.targetLocale,
-          sourcePath: input.body.sourcePath,
-          segmentId: input.body.segmentId,
-          ...(translationKeyChanging
-            ? { translationKeyId: input.body.translationKeyId ?? null }
-            : {}),
-          linkKind: input.body.linkKind,
-          linkLabel: input.body.linkLabel,
-          linkUrl: input.body.linkUrl,
-          ...(assigneeChanging ? { assigneeUserId: nextAssigneeUserId } : {}),
-          ...(resolvedAt !== undefined ? { resolvedAt } : {}),
-        })
-        .where(
-          and(
-            eq(schema.issueSheetIssues.organizationId, input.organizationId),
-            eq(schema.issueSheetIssues.projectId, input.projectId),
-            issueIdOrIdentifierMatch(input.issueId),
-          ),
-        );
+      const coreActuallyChanged =
+        (Object.hasOwn(input.body, "title") && input.body.title !== current.title) ||
+        (Object.hasOwn(input.body, "description") &&
+          input.body.description !== current.description) ||
+        statusChanging ||
+        issueTypeChanging ||
+        (Object.hasOwn(input.body, "targetLocale") &&
+          (input.body.targetLocale ?? null) !== current.targetLocale) ||
+        (Object.hasOwn(input.body, "sourcePath") &&
+          (input.body.sourcePath ?? null) !== current.sourcePath) ||
+        (Object.hasOwn(input.body, "segmentId") &&
+          (input.body.segmentId ?? null) !== current.segmentId) ||
+        (translationKeyChanging &&
+          (input.body.translationKeyId ?? null) !== current.translationKeyId) ||
+        (Object.hasOwn(input.body, "linkKind") &&
+          (input.body.linkKind ?? null) !== current.linkKind) ||
+        (Object.hasOwn(input.body, "linkLabel") &&
+          (input.body.linkLabel ?? null) !== current.linkLabel) ||
+        (Object.hasOwn(input.body, "linkUrl") &&
+          (input.body.linkUrl ?? null) !== current.linkUrl) ||
+        assigneeActuallyChanged;
+
+      if (coreActuallyChanged) {
+        await tx
+          .update(schema.issueSheetIssues)
+          .set({
+            title: input.body.title,
+            description: input.body.description,
+            issueType: input.body.issueType,
+            status: input.body.status,
+            targetLocale: input.body.targetLocale,
+            sourcePath: input.body.sourcePath,
+            segmentId: input.body.segmentId,
+            ...(translationKeyChanging
+              ? { translationKeyId: input.body.translationKeyId ?? null }
+              : {}),
+            linkKind: input.body.linkKind,
+            linkLabel: input.body.linkLabel,
+            linkUrl: input.body.linkUrl,
+            ...(assigneeChanging ? { assigneeUserId: nextAssigneeUserId } : {}),
+            ...(statusChanging && resolvedAt !== undefined ? { resolvedAt } : {}),
+          })
+          .where(
+            and(
+              eq(schema.issueSheetIssues.organizationId, input.organizationId),
+              eq(schema.issueSheetIssues.projectId, input.projectId),
+              issueIdOrIdentifierMatch(input.issueId),
+            ),
+          );
+      }
 
       if (statusChanging) {
         await this.insertStatusChangedActivity({
@@ -1579,6 +1612,7 @@ export class IssueSheetService {
 
       return {
         issueId: current.id,
+        coreActuallyChanged,
         statusChanging,
         issueTypeChanging,
         previousStatus: current.status,
@@ -1634,10 +1668,8 @@ export class IssueSheetService {
     }
 
     if (input.returnOutcome) {
-      const changed =
-        found.assigneeActuallyChanged || found.statusChanging || found.issueTypeChanging;
       return {
-        outcome: changed ? "updated" : "unchanged",
+        outcome: found.coreActuallyChanged ? "updated" : "unchanged",
         issue,
       };
     }

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -1441,6 +1441,7 @@ export class IssueSheetService {
     issueId: string;
     actorUserId: string;
     body: IssueSheetUpdateIssueBody;
+    priority?: "P0" | "P1" | "P2";
     returnOutcome?: boolean;
   }): Promise<IssueSheetIssue | IssueSheetUpdateIssueOutcome | null> {
     const nextStatus = input.body.status;
@@ -1472,6 +1473,14 @@ export class IssueSheetService {
         organizationId: input.organizationId,
         projectId: input.projectId,
         translationKeyId: input.body.translationKeyId,
+      });
+    }
+
+    if (input.priority !== undefined) {
+      await this.ensureStarterColumns({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        actorUserId: input.actorUserId,
       });
     }
 
@@ -1610,9 +1619,82 @@ export class IssueSheetService {
         });
       }
 
+      let priorityActuallyChanged = false;
+      if (input.priority !== undefined) {
+        const [column] = await tx
+          .select({
+            id: schema.issueSheetColumns.id,
+            key: schema.issueSheetColumns.key,
+            type: schema.issueSheetColumns.type,
+            config: schema.issueSheetColumns.config,
+          })
+          .from(schema.issueSheetColumns)
+          .where(
+            and(
+              eq(schema.issueSheetColumns.organizationId, input.organizationId),
+              eq(schema.issueSheetColumns.projectId, input.projectId),
+              eq(schema.issueSheetColumns.key, "priority"),
+            ),
+          )
+          .limit(1);
+
+        if (!column) {
+          throw new Error("issue_sheet_column_not_found");
+        }
+
+        const [existingValue] = await tx
+          .select({ value: schema.issueSheetRowValues.value })
+          .from(schema.issueSheetRowValues)
+          .where(
+            and(
+              eq(schema.issueSheetRowValues.issueId, current.id),
+              eq(schema.issueSheetRowValues.columnId, column.id),
+            ),
+          )
+          .limit(1);
+
+        const previousPriority =
+          existingValue?.value != null && typeof existingValue.value === "string"
+            ? existingValue.value
+            : null;
+
+        if (previousPriority !== input.priority) {
+          const value = this.normalizeValue(column, input.priority);
+          await tx
+            .insert(schema.issueSheetRowValues)
+            .values({
+              organizationId: input.organizationId,
+              projectId: input.projectId,
+              issueId: current.id,
+              columnId: column.id,
+              value,
+              computedAt: null,
+            })
+            .onConflictDoUpdate({
+              target: [schema.issueSheetRowValues.issueId, schema.issueSheetRowValues.columnId],
+              set: {
+                value,
+                updatedAt: new Date(),
+              },
+            });
+
+          await this.insertPriorityChangedActivity({
+            database: tx,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            issueId: current.id,
+            actorUserId: input.actorUserId,
+            previousPriority,
+            nextPriority: input.priority,
+          });
+          priorityActuallyChanged = true;
+        }
+      }
+
       return {
         issueId: current.id,
         coreActuallyChanged,
+        priorityActuallyChanged,
         statusChanging,
         issueTypeChanging,
         previousStatus: current.status,
@@ -1669,7 +1751,8 @@ export class IssueSheetService {
 
     if (input.returnOutcome) {
       return {
-        outcome: found.coreActuallyChanged ? "updated" : "unchanged",
+        outcome:
+          found.coreActuallyChanged || found.priorityActuallyChanged ? "updated" : "unchanged",
         issue,
       };
     }


### PR DESCRIPTION
## What changed

- Added the hosted MCP `update_issue` tool.
- Reused the existing issue-sheet validation and `IssueSheetService.updateIssue`.
- Added support for updating title, description, issue type, status, nullable linkage fields, assignee, and priority.
- Applied existing write-capability and team/project access controls.
- Added stable errors for invalid updates and expected service failures.
- Improved service-level no-op detection so unchanged updates do not perform unnecessary writes or create duplicate activity.
- Added MCP SDK coverage for creating, updating, and reading back an issue.

## How to test

```bash
vp check \
  src/api/routes/mcp/mcp.route.ts \
  src/api/routes/mcp/mcp.route.test.ts \
  src/api/routes/mcp/mcp-team-access.test.ts \
  src/lib/projects/issue-sheet/issue-sheet-service.ts

vp test \
  src/api/routes/mcp/mcp.route.test.ts \
  src/api/routes/mcp/mcp-team-access.test.ts \
  src/lib/projects/issue-sheet/issue-notification-service.test.ts \
  src/lib/projects/issue-sheet/issue-subscription-service.test.ts \
  src/lib/projects/issue-sheet/issue-sheet-feed-service.test.ts

vp run build
```

Verified:
- 66 MCP route tests passed.
- 90 related MCP and issue-service regression tests passed.
- Production build passed.

## Checklist
- I ran relevant checks locally (vp check, vp test, vp run build)
- I updated docs, comments, or examples when needed
- This PR is scoped and ready for review