### PR TITLE
feat(integrations): add coming-soon Google Drive, SharePoint, and Notion

### DIFF
--- a/apps/hyperlocalise-web/public/images/sharepoint-logo.svg
+++ b/apps/hyperlocalise-web/public/images/sharepoint-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="3" y="8" width="10" height="10" rx="1.5" fill="#038387" />
+  <circle cx="16.5" cy="9.5" r="4.5" fill="#1A9BA1" />
+  <circle cx="18.5" cy="15.5" r="3.5" fill="#37C6D0" />
+</svg>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.messages.ts
@@ -154,37 +154,37 @@ export const agentIntegrationsSectionMessages = defineMessages({
   },
   guidelinesCategory: {
     defaultMessage: "Guidelines",
-    id: "kG7nQw2pLm",
+    id: "kg1/W3O+Sr",
     description: "Integrations page section heading for guideline source connectors",
   },
   googleDriveName: {
     defaultMessage: "Google Drive",
-    id: "rT4vBn8xCq",
+    id: "EQ48eGG7/X",
     description: "Google Drive integration name on the integrations page",
   },
   googleDriveDescription: {
     defaultMessage: "Import brand guidelines and style docs from Google Drive.",
-    id: "wP9sHj3kLm",
+    id: "EgJBlBjf3r",
     description: "Google Drive integration description on the integrations page",
   },
   sharepointName: {
     defaultMessage: "SharePoint",
-    id: "nF2cYd7uVa",
+    id: "LxzxKCrG8Q",
     description: "SharePoint integration name on the integrations page",
   },
   sharepointDescription: {
     defaultMessage: "Import localization guidance from SharePoint.",
-    id: "qL6mXt1zRe",
+    id: "YgXBEI+WDA",
     description: "SharePoint integration description on the integrations page",
   },
   notionName: {
     defaultMessage: "Notion",
-    id: "bH8pKw5sNd",
+    id: "geRgaRor6g",
     description: "Notion integration name on the integrations page",
   },
   notionDescription: {
     defaultMessage: "Import style guides and market notes from Notion.",
-    id: "cV3jRa0yTf",
+    id: "m9ESiA+Ppw",
     description: "Notion integration description on the integrations page",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.messages.ts
@@ -152,4 +152,39 @@ export const agentIntegrationsSectionMessages = defineMessages({
     id: "HYHV9OorEn",
     description: "Resend integration description on the integrations page",
   },
+  guidelinesCategory: {
+    defaultMessage: "Guidelines",
+    id: "kG7nQw2pLm",
+    description: "Integrations page section heading for guideline source connectors",
+  },
+  googleDriveName: {
+    defaultMessage: "Google Drive",
+    id: "rT4vBn8xCq",
+    description: "Google Drive integration name on the integrations page",
+  },
+  googleDriveDescription: {
+    defaultMessage: "Import brand guidelines and style docs from Google Drive.",
+    id: "wP9sHj3kLm",
+    description: "Google Drive integration description on the integrations page",
+  },
+  sharepointName: {
+    defaultMessage: "SharePoint",
+    id: "nF2cYd7uVa",
+    description: "SharePoint integration name on the integrations page",
+  },
+  sharepointDescription: {
+    defaultMessage: "Import localization guidance from SharePoint.",
+    id: "qL6mXt1zRe",
+    description: "SharePoint integration description on the integrations page",
+  },
+  notionName: {
+    defaultMessage: "Notion",
+    id: "bH8pKw5sNd",
+    description: "Notion integration name on the integrations page",
+  },
+  notionDescription: {
+    defaultMessage: "Import style guides and market notes from Notion.",
+    id: "cV3jRa0yTf",
+    description: "Notion integration description on the integrations page",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.tsx
@@ -15,11 +15,13 @@
 import type { SimpleIcon } from "simple-icons";
 import {
   siGitlab,
+  siGoogledrive,
   siHubspot,
   siJira,
   siLinear,
   siLoops,
   siMailchimp,
+  siNotion,
   siResend,
 } from "simple-icons";
 import { useIntl, type MessageDescriptor } from "react-intl";
@@ -60,6 +62,24 @@ const comingSoonCollaborationAgents: readonly ComingSoonAgent[] = [
     nameMessage: agentIntegrationsSectionMessages.linearName,
     descriptionMessage: agentIntegrationsSectionMessages.linearDescription,
     icon: siLinear,
+  },
+] as const;
+
+const comingSoonGuidelineSources: readonly ComingSoonAgent[] = [
+  {
+    nameMessage: agentIntegrationsSectionMessages.googleDriveName,
+    descriptionMessage: agentIntegrationsSectionMessages.googleDriveDescription,
+    icon: siGoogledrive,
+  },
+  {
+    nameMessage: agentIntegrationsSectionMessages.sharepointName,
+    descriptionMessage: agentIntegrationsSectionMessages.sharepointDescription,
+    logoSrc: "/images/sharepoint-logo.svg",
+  },
+  {
+    nameMessage: agentIntegrationsSectionMessages.notionName,
+    descriptionMessage: agentIntegrationsSectionMessages.notionDescription,
+    icon: siNotion,
   },
 ] as const;
 
@@ -171,6 +191,23 @@ export function CollaborationIntegrationsSection({
           icon={agent.icon}
           logoSrc={agent.logoSrc}
           isLast={index === comingSoonCollaborationAgents.length - 1}
+        />
+      ))}
+    </>
+  );
+}
+
+export function GuidelineIntegrationsSection() {
+  return (
+    <>
+      {comingSoonGuidelineSources.map((source, index) => (
+        <ComingSoonIntegrationRow
+          key={source.nameMessage.id}
+          nameMessage={source.nameMessage}
+          descriptionMessage={source.descriptionMessage}
+          icon={source.icon}
+          logoSrc={source.logoSrc}
+          isLast={index === comingSoonGuidelineSources.length - 1}
         />
       ))}
     </>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.stories.tsx
@@ -57,6 +57,10 @@ export const Default: Story = {
     await expect(canvas.getByRole("heading", { name: "Source control" })).toBeInTheDocument();
     await expect(canvas.getByText("Translation Management System")).toBeInTheDocument();
     await expect(canvas.getByText("Content & publishing")).toBeInTheDocument();
+    await expect(canvas.getByText("Guidelines")).toBeInTheDocument();
+    await expect(canvas.getByText("Google Drive")).toBeInTheDocument();
+    await expect(canvas.getByText("SharePoint")).toBeInTheDocument();
+    await expect(canvas.getByText("Notion")).toBeInTheDocument();
     await expect(canvas.getByText("Experimentation")).toBeInTheDocument();
     await expect(canvas.getByText("Projects & files")).toBeInTheDocument();
     await expect(canvas.getByText("Pages")).toBeInTheDocument();
@@ -98,6 +102,24 @@ export const FilteredCategory: Story = {
     await expect(canvas.getByRole("heading", { name: "MCP servers" })).toBeInTheDocument();
     await expect(canvas.getByText("MCP Server")).toBeInTheDocument();
     await expect(canvas.queryByRole("heading", { name: "Source control" })).not.toBeInTheDocument();
+  },
+};
+
+export const GuidelinesComingSoon: Story = {
+  parameters: {
+    msw: {
+      handlers: integrationsConnectedMswHandlers,
+    },
+  },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Guidelines" }));
+    await expect(canvas.getByRole("heading", { name: "Guidelines" })).toBeInTheDocument();
+    await expect(canvas.getByText("Google Drive")).toBeInTheDocument();
+    await expect(canvas.getByText("SharePoint")).toBeInTheDocument();
+    await expect(canvas.getByText("Notion")).toBeInTheDocument();
+    await expect(canvas.getAllByRole("button", { name: "Coming soon" })).toHaveLength(3);
+    await expect(canvas.queryByRole("heading", { name: "Source control" })).not.toBeInTheDocument();
+    await expect(canvas.queryByText("Contentful")).not.toBeInTheDocument();
   },
 };
 
@@ -165,6 +187,7 @@ export const WithoutProviderIntegrations: Story = {
     await expect(canvas.getByRole("heading", { name: "Integrations" })).toBeInTheDocument();
     await expect(canvas.getByText("Source control")).toBeInTheDocument();
     await expect(canvas.getByText("Collaboration")).toBeInTheDocument();
+    await expect(canvas.getByText("Guidelines")).toBeInTheDocument();
     await expect(canvas.getByText("Customer engagement")).toBeInTheDocument();
     await expect(canvas.queryByText("Translation Management System")).not.toBeInTheDocument();
     await expect(canvas.queryByText("Model provider")).not.toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -58,6 +58,7 @@ import { agentIntegrationsSectionMessages } from "./agent-integrations-section.m
 import {
   CollaborationIntegrationsSection,
   CustomerEngagementIntegrationsSection,
+  GuidelineIntegrationsSection,
   SourceControlIntegrationsSection,
 } from "./agent-integrations-section";
 import { CanvaConnectionPanel } from "./canva-connection-panel";
@@ -93,6 +94,7 @@ const INTEGRATION_CATEGORY_IDS = [
   "collaboration",
   "tms",
   "cms",
+  "guidelines",
   "customer-engagement",
   "experimentation",
   "seo-tools",
@@ -115,6 +117,7 @@ const INTEGRATION_CATEGORY_MESSAGES = {
   "source-control": agentIntegrationsSectionMessages.sourceControlCategory,
   tms: integrationsPageContentMessages.tmsCategory,
   cms: integrationsPageContentMessages.cmsCategory,
+  guidelines: agentIntegrationsSectionMessages.guidelinesCategory,
   experimentation: integrationsPageContentMessages.experimentationCategory,
   "seo-tools": integrationsPageContentMessages.seoToolsCategory,
   "mcp-servers": integrationsPageContentMessages.mcpServersCategory,
@@ -1185,6 +1188,11 @@ export function IntegrationsPageContent({
                   disabled={!userIsAdmin}
                   isLast
                 />
+              </IntegrationCategorySection>
+            ) : null}
+            {showCategory("guidelines") ? (
+              <IntegrationCategorySection categoryId="guidelines">
+                <GuidelineIntegrationsSection />
               </IntegrationCategorySection>
             ) : null}
             {showCategory("customer-engagement") ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Guideline upload already teases Google Drive, SharePoint, and Notion as coming-soon sources. The integrations page did not list them.

This adds a **Guidelines** category with those three connectors as disabled Coming soon rows, using the same row pattern as GitLab, Teams, and Jira.

[Guidelines section on the integrations page](https://cursor.com/agents/bc-01a05c71-d5f9-7a66-b13f-e1bad8563040/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegrations_guidelines_section.webp)

[integrations_guidelines_coming_soon.mp4](https://cursor.com/agents/bc-01a05c71-d5f9-7a66-b13f-e1bad8563040/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegrations_guidelines_coming_soon.mp4)

## How to test

- Open Integrations and confirm a **Guidelines** section with Google Drive, SharePoint, and Notion, each showing **Coming soon**.
- Filter by the **Guidelines** tab and confirm only those three rows remain.
- Confirm the section still appears when provider integrations are hidden (developer role).

```
cd apps/hyperlocalise-web
vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations
vp check --fix
```

Storybook: `App/Integrations/Page` → Default and GuidelinesComingSoon.

## Checklist

- [x] I ran relevant checks locally (`vp test` on integrations, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05c71-d5f9-7a66-b13f-e1bad8563040?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05c71-d5f9-7a66-b13f-e1bad8563040&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

