### PR TITLE
feat(seo): add DataForSEO and GSC Go API clients

### DIFF
--- a/apps/go-svc/README.md
+++ b/apps/go-svc/README.md
@@ -1,0 +1,114 @@
+# go-svc
+
+Go container service for CPU-heavy work that runs beside the Next.js app on Vercel. Today it powers CAT segment validation (format, length, and Hunspell spelling checks). Future Domains SEO features will call DataForSEO through `internal/dataforseo` and Google Search Console through `internal/gsc`.
+
+Public routes are served at `/api/go-svc/...` in production (Vercel rewrite) and at `/v1/...` when called directly via the `GO_SVC_URL` binding.
+
+## Environment variables
+
+### Required
+
+| Variable | Description |
+|----------|-------------|
+| `WORKOS_COOKIE_PASSWORD` | Secret used to seal and verify WorkOS session cookies. Must match the web app value. At least 32 characters. |
+
+### Required for session refresh
+
+These must match the web app's WorkOS configuration. Without them, valid sessions that need a token refresh will be rejected.
+
+| Variable | Description |
+|----------|-------------|
+| `WORKOS_API_KEY` | WorkOS API key (`sk_test_...` or `sk_live_...`). |
+| `WORKOS_CLIENT_ID` | WorkOS client ID (`client_...`). |
+
+### Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8080` | HTTP listen port. |
+| `HUNSPELL_DICT_DIR` | `/usr/share/hunspell` | Directory containing Hunspell `.aff` / `.dic` files. The container image bundles dictionaries at the default path. |
+| `WORKOS_COOKIE_DOMAIN` | _(unset)_ | Cookie `Domain` attribute when setting a refreshed session cookie. Leave unset for host-only cookies. |
+
+### DataForSEO (upcoming SEO features)
+
+Used by `internal/dataforseo` for keyword research, domain overview, rank tracking, and AI visibility. Not required for the current segment-validation API.
+
+| Variable | Description |
+|----------|-------------|
+| `DATAFORSEO_API_KEY` | Base64-encoded `email:api_password` from [DataForSEO API Access](https://app.dataforseo.com/api-access). This is **not** the short dashboard API key — use the **Base64** credentials DataForSEO emails you, or generate one with:<br><br>`echo -n 'your@email.com:your_api_password' \| base64` |
+
+Example Go usage:
+
+```go
+client, err := dataforseo.NewClient(dataforseo.Config{
+    APIKey: os.Getenv("DATAFORSEO_API_KEY"),
+})
+```
+
+Do **not** set separate `DATAFORSEO_LOGIN` / `DATAFORSEO_PASSWORD` env vars. Pass the single base64 API key.
+
+### Google Search Console (upcoming SEO features)
+
+Used by `internal/gsc` for search performance and URL inspection. GSC is OAuth-based — there is no API key env var for go-svc. Users connect Search Console in the web app; go-svc receives a minted access token (or `oauth2.TokenSource`) per request.
+
+The web app needs these OAuth variables to enable the connection flow:
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID for the Search Console connection. |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret. |
+
+Example Go usage once a token is available:
+
+```go
+client, err := gsc.NewClient(gsc.Config{
+    TokenSource: oauth2.StaticTokenSource(&oauth2.Token{
+        AccessToken: accessToken,
+    }),
+})
+```
+
+GSC API calls are free and do not consume DataForSEO credits.
+
+## Local development
+
+From the repository root:
+
+```bash
+# Build check (requires libhunspell-dev for spelling support)
+make check-build-go-svc-cgo
+
+# Run locally
+export WORKOS_COOKIE_PASSWORD='this-is-a-test-cookie-password-at-least-32-characters'
+export WORKOS_API_KEY='sk_test_...'
+export WORKOS_CLIENT_ID='client_...'
+go run ./apps/go-svc
+```
+
+Health check:
+
+```bash
+curl http://localhost:8080/health
+# {"status":"ok"}
+```
+
+The web app reaches go-svc through `GO_SVC_URL` (set automatically on Vercel via the service binding) or through the `/api/go-svc` rewrite when running the full stack locally.
+
+## Docker / Vercel
+
+Production builds use `Dockerfile.vercel` at the repository root. The image:
+
+- Compiles with `cgo_hunspell` for spelling checks
+- Bundles Hunspell dictionaries under `/usr/share/hunspell`
+- Listens on `PORT` (default `8080`)
+
+Set the required WorkOS variables in the Vercel `go_svc` service environment. Use the same `WORKOS_COOKIE_PASSWORD` as `hyperlocalise-web`.
+
+## API
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/health` | No | Liveness probe |
+| `POST` | `/v1/validate/segment` | WorkOS session cookie | Validate a CAT segment (format, length, spelling) |
+
+Authenticated requests must include the `wos-session` cookie from a signed-in Hyperlocalise user.

--- a/internal/dataforseo/BUILD.bazel
+++ b/internal/dataforseo/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "dataforseo",
+    srcs = [
+        "ai.go",
+        "client.go",
+        "config.go",
+        "doc.go",
+        "envelope.go",
+        "errors.go",
+        "labs.go",
+        "serp.go",
+        "types.go",
+    ],
+    importpath = "github.com/hyperlocalise/hyperlocalise/internal/dataforseo",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "dataforseo_test",
+    srcs = ["client_test.go"],
+    embed = [":dataforseo"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/internal/dataforseo/ai.go
+++ b/internal/dataforseo/ai.go
@@ -6,7 +6,7 @@ const (
 	pathLlmMentionsSearch                 = "/v3/ai_optimization/llm_mentions/search/live"
 	pathLlmMentionsAggregatedMetrics      = "/v3/ai_optimization/llm_mentions/aggregated_metrics/live"
 	pathLlmMentionsTopPages               = "/v3/ai_optimization/llm_mentions/top_pages/live"
-	pathLlmMentionsCrossAggregatedMetrics   = "/v3/ai_optimization/llm_mentions/cross_aggregated_metrics/live"
+	pathLlmMentionsCrossAggregatedMetrics = "/v3/ai_optimization/llm_mentions/cross_aggregated_metrics/live"
 	pathChatGPTLlmResponsesLive           = "/v3/ai_optimization/chat_gpt/llm_responses/live"
 	pathClaudeLlmResponsesLive            = "/v3/ai_optimization/claude/llm_responses/live"
 	pathGeminiLlmResponsesLive            = "/v3/ai_optimization/gemini/llm_responses/live"
@@ -53,12 +53,12 @@ type LlmCrossAggregatedMetricsInput struct {
 
 // LlmResponseInput runs one prompt through one LLM provider.
 type LlmResponseInput struct {
-	UserPrompt            string
-	Model                 LlmResponseModel
-	ModelName             string
-	WebSearch             bool
-	MaxOutputTokens       int
-	WebSearchCountryCode  string
+	UserPrompt           string
+	Model                LlmResponseModel
+	ModelName            string
+	WebSearch            bool
+	MaxOutputTokens      int
+	WebSearchCountryCode string
 }
 
 func (a *AI) MentionsSearch(
@@ -70,11 +70,11 @@ func (a *AI) MentionsSearch(
 	}
 
 	task, err := a.client.client.post(ctx, pathLlmMentionsSearch, []map[string]any{{
-		"target":          []LlmTarget{input.Target},
-		"platform":        input.Platform,
-		"location_code":   input.Market.LocationCode,
-		"language_code":   input.Market.LanguageCode,
-		"limit":           clampLimit(input.Limit, 1, 1000),
+		"target":        []LlmTarget{input.Target},
+		"platform":      input.Platform,
+		"location_code": input.Market.LocationCode,
+		"language_code": input.Market.LanguageCode,
+		"limit":         clampLimit(input.Limit, 1, 1000),
 	}}, postOptions{})
 	if err != nil {
 		return TaskResponse[[]LlmMentionItem]{}, err

--- a/internal/dataforseo/ai.go
+++ b/internal/dataforseo/ai.go
@@ -1,0 +1,219 @@
+package dataforseo
+
+import "context"
+
+const (
+	pathLlmMentionsSearch                 = "/v3/ai_optimization/llm_mentions/search/live"
+	pathLlmMentionsAggregatedMetrics      = "/v3/ai_optimization/llm_mentions/aggregated_metrics/live"
+	pathLlmMentionsTopPages               = "/v3/ai_optimization/llm_mentions/top_pages/live"
+	pathLlmMentionsCrossAggregatedMetrics   = "/v3/ai_optimization/llm_mentions/cross_aggregated_metrics/live"
+	pathChatGPTLlmResponsesLive           = "/v3/ai_optimization/chat_gpt/llm_responses/live"
+	pathClaudeLlmResponsesLive            = "/v3/ai_optimization/claude/llm_responses/live"
+	pathGeminiLlmResponsesLive            = "/v3/ai_optimization/gemini/llm_responses/live"
+	pathPerplexityLlmResponsesLive        = "/v3/ai_optimization/perplexity/llm_responses/live"
+)
+
+// LlmMentionsSearchInput searches LLM mention rows for a brand lookup.
+type LlmMentionsSearchInput struct {
+	Target   LlmTarget
+	Platform LlmPlatform
+	Market   MarketScope
+	Limit    int
+}
+
+// LlmAggregatedMetricsInput fetches total mention metrics for brand lookup.
+type LlmAggregatedMetricsInput struct {
+	Target            LlmTarget
+	Platform          LlmPlatform
+	Market            MarketScope
+	InternalListLimit int
+}
+
+// LlmTopPagesInput fetches cited pages for brand lookup.
+type LlmTopPagesInput struct {
+	Target         LlmTarget
+	Platform       LlmPlatform
+	Market         MarketScope
+	ItemsListLimit int
+}
+
+// LlmCrossAggregatedMetricsGroup is one competitor group in share-of-voice.
+type LlmCrossAggregatedMetricsGroup struct {
+	Key    string
+	Target LlmTarget
+}
+
+// LlmCrossAggregatedMetricsInput compares mention share across groups.
+type LlmCrossAggregatedMetricsInput struct {
+	Groups            []LlmCrossAggregatedMetricsGroup
+	Platform          LlmPlatform
+	Market            MarketScope
+	InternalListLimit int
+}
+
+// LlmResponseInput runs one prompt through one LLM provider.
+type LlmResponseInput struct {
+	UserPrompt            string
+	Model                 LlmResponseModel
+	ModelName             string
+	WebSearch             bool
+	MaxOutputTokens       int
+	WebSearchCountryCode  string
+}
+
+func (a *AI) MentionsSearch(
+	ctx context.Context,
+	input LlmMentionsSearchInput,
+) (TaskResponse[[]LlmMentionItem], error) {
+	if err := validateLlmTarget(input.Target); err != nil {
+		return TaskResponse[[]LlmMentionItem]{}, err
+	}
+
+	task, err := a.client.client.post(ctx, pathLlmMentionsSearch, []map[string]any{{
+		"target":          []LlmTarget{input.Target},
+		"platform":        input.Platform,
+		"location_code":   input.Market.LocationCode,
+		"language_code":   input.Market.LanguageCode,
+		"limit":           clampLimit(input.Limit, 1, 1000),
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]LlmMentionItem]{}, err
+	}
+	return taskResponseFromItems[[]LlmMentionItem](task)
+}
+
+func (a *AI) AggregatedMetrics(
+	ctx context.Context,
+	input LlmAggregatedMetricsInput,
+) (TaskResponse[LlmAggregatedTotal], error) {
+	if err := validateLlmTarget(input.Target); err != nil {
+		return TaskResponse[LlmAggregatedTotal]{}, err
+	}
+
+	task, err := a.client.client.post(ctx, pathLlmMentionsAggregatedMetrics, []map[string]any{{
+		"target":              []LlmTarget{input.Target},
+		"platform":            input.Platform,
+		"location_code":       input.Market.LocationCode,
+		"language_code":       input.Market.LanguageCode,
+		"internal_list_limit": clampLimit(input.InternalListLimit, 1, 20),
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[LlmAggregatedTotal]{}, err
+	}
+	return taskResponseFromTotal[LlmAggregatedTotal](task)
+}
+
+func (a *AI) TopPages(
+	ctx context.Context,
+	input LlmTopPagesInput,
+) (TaskResponse[[]LlmTopPagesItem], error) {
+	if err := validateLlmTarget(input.Target); err != nil {
+		return TaskResponse[[]LlmTopPagesItem]{}, err
+	}
+
+	task, err := a.client.client.post(ctx, pathLlmMentionsTopPages, []map[string]any{{
+		"target":              []LlmTarget{input.Target},
+		"platform":            input.Platform,
+		"location_code":       input.Market.LocationCode,
+		"language_code":       input.Market.LanguageCode,
+		"links_scope":         "sources",
+		"items_list_limit":    clampLimit(input.ItemsListLimit, 1, 10),
+		"internal_list_limit": 5,
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]LlmTopPagesItem]{}, err
+	}
+	return taskResponseFromItems[[]LlmTopPagesItem](task)
+}
+
+func (a *AI) CrossAggregatedMetrics(
+	ctx context.Context,
+	input LlmCrossAggregatedMetricsInput,
+) (TaskResponse[[]LlmCrossAggregatedItem], error) {
+	if len(input.Groups) < 2 || len(input.Groups) > 10 {
+		return TaskResponse[[]LlmCrossAggregatedItem]{}, newError(
+			ErrorCodeValidation,
+			"cross aggregated metrics requires 2 to 10 target groups",
+			pathLlmMentionsCrossAggregatedMetrics,
+			0,
+		)
+	}
+
+	targets := make([]map[string]any, 0, len(input.Groups))
+	for _, group := range input.Groups {
+		if err := validateLlmTarget(group.Target); err != nil {
+			return TaskResponse[[]LlmCrossAggregatedItem]{}, err
+		}
+		targets = append(targets, map[string]any{
+			"aggregation_key": group.Key,
+			"target":          []LlmTarget{group.Target},
+		})
+	}
+
+	task, err := a.client.client.post(ctx, pathLlmMentionsCrossAggregatedMetrics, []map[string]any{{
+		"targets":             targets,
+		"platform":            input.Platform,
+		"location_code":       input.Market.LocationCode,
+		"language_code":       input.Market.LanguageCode,
+		"internal_list_limit": clampLimit(input.InternalListLimit, 1, 10),
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]LlmCrossAggregatedItem]{}, err
+	}
+	return taskResponseFromItems[[]LlmCrossAggregatedItem](task)
+}
+
+func (a *AI) LlmResponse(
+	ctx context.Context,
+	input LlmResponseInput,
+) (TaskResponse[LlmResponseResult], error) {
+	if err := validateLLMModelName(input.Model, input.ModelName); err != nil {
+		return TaskResponse[LlmResponseResult]{}, err
+	}
+	if normalizeKeyword(input.UserPrompt) == "" {
+		return TaskResponse[LlmResponseResult]{}, newError(
+			ErrorCodeValidation,
+			"userPrompt is required",
+			llmResponsePath(input.Model),
+			0,
+		)
+	}
+
+	payload := map[string]any{
+		"user_prompt":       input.UserPrompt,
+		"model_name":        input.ModelName,
+		"web_search":        input.WebSearch,
+		"max_output_tokens": clampLimit(input.MaxOutputTokens, 256, 4096),
+	}
+	if input.Model != LlmResponseModelGemini && input.WebSearch && input.WebSearchCountryCode != "" {
+		payload["web_search_country_iso_code"] = input.WebSearchCountryCode
+	}
+
+	task, err := a.client.client.post(ctx, llmResponsePath(input.Model), []map[string]any{payload}, postOptions{})
+	if err != nil {
+		return TaskResponse[LlmResponseResult]{}, err
+	}
+	return taskResponseFromFirstResult[LlmResponseResult](task)
+}
+
+func llmResponsePath(model LlmResponseModel) string {
+	switch model {
+	case LlmResponseModelChatGPT:
+		return pathChatGPTLlmResponsesLive
+	case LlmResponseModelClaude:
+		return pathClaudeLlmResponsesLive
+	case LlmResponseModelGemini:
+		return pathGeminiLlmResponsesLive
+	case LlmResponseModelPerplexity:
+		return pathPerplexityLlmResponsesLive
+	default:
+		return string(model)
+	}
+}
+
+func validateLlmTarget(target LlmTarget) error {
+	if normalizeKeyword(target.Domain) == "" && normalizeKeyword(target.Keyword) == "" {
+		return newError(ErrorCodeValidation, "LLM target domain or keyword is required", "", 0)
+	}
+	return nil
+}

--- a/internal/dataforseo/client.go
+++ b/internal/dataforseo/client.go
@@ -93,10 +93,7 @@ func (c *Client) post(ctx context.Context, path string, payload any, opts postOp
 	if err != nil {
 		return nil, err
 	}
-	return assertResponse(response, path, assertTaskOptions{
-		okTaskStatusCode:      opts.okTaskStatusCode,
-		treatNoResultsAsEmpty: opts.treatNoResultsAsEmpty,
-	})
+	return assertResponse(response, path, assertTaskOptions(opts))
 }
 
 func (c *Client) postResponse(ctx context.Context, path string, payload any, opts postOptions) (*APIResponse, error) {

--- a/internal/dataforseo/client.go
+++ b/internal/dataforseo/client.go
@@ -183,7 +183,7 @@ func (c *Client) getResponse(ctx context.Context, path string) (*APIResponse, er
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/dataforseo/client.go
+++ b/internal/dataforseo/client.go
@@ -1,0 +1,224 @@
+package dataforseo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client is a low-level DataForSEO HTTP client. Higher-level feature methods are
+// grouped on Labs, SERP, and AI sub-clients.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	authHeader string
+	maxRetries int
+}
+
+// Labs exposes keyword research and domain overview endpoints.
+type Labs struct {
+	client *Client
+}
+
+// SERP exposes live and queued organic SERP endpoints.
+type SERP struct {
+	client *Client
+}
+
+// AI exposes LLM mentions (brand lookup) and LLM response (prompt explorer) endpoints.
+type AI struct {
+	client *httpClientBundle
+}
+
+type httpClientBundle struct {
+	client *Client
+}
+
+// NewClient constructs a DataForSEO API client.
+func NewClient(cfg Config) (*Client, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	timeout := cfg.timeout()
+	httpClient := &http.Client{Timeout: timeout}
+	if httpClient.Transport == nil {
+		httpClient.Transport = http.DefaultTransport
+	}
+
+	return &Client{
+		baseURL:    cfg.baseURL(),
+		httpClient: httpClient,
+		authHeader: "Basic " + cfg.authorizationValue(),
+		maxRetries: cfg.maxRetries(),
+	}, nil
+}
+
+// NewClientWithHTTPClient is primarily for tests and custom transport wiring.
+func NewClientWithHTTPClient(cfg Config, httpClient *http.Client) (*Client, error) {
+	if httpClient == nil {
+		return nil, fmt.Errorf("dataforseo: http client must not be nil")
+	}
+	client, err := NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	client.httpClient = httpClient
+	return client, nil
+}
+
+func (c *Client) Labs() *Labs {
+	return &Labs{client: c}
+}
+
+func (c *Client) SERP() *SERP {
+	return &SERP{client: c}
+}
+
+func (c *Client) AI() *AI {
+	return &AI{client: &httpClientBundle{client: c}}
+}
+
+type postOptions struct {
+	okTaskStatusCode      int
+	treatNoResultsAsEmpty bool
+	allowNonRetryablePost bool
+}
+
+func (c *Client) post(ctx context.Context, path string, payload any, opts postOptions) (*Task, error) {
+	response, err := c.postResponse(ctx, path, payload, opts)
+	if err != nil {
+		return nil, err
+	}
+	return assertResponse(response, path, assertTaskOptions{
+		okTaskStatusCode:      opts.okTaskStatusCode,
+		treatNoResultsAsEmpty: opts.treatNoResultsAsEmpty,
+	})
+}
+
+func (c *Client) postResponse(ctx context.Context, path string, payload any, opts postOptions) (*APIResponse, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("dataforseo: marshal request: %w", err)
+	}
+
+	url := c.baseURL + path
+	maxAttempts := c.maxRetries + 1
+	if opts.allowNonRetryablePost {
+		maxAttempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * 250 * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("dataforseo: build request: %w", err)
+		}
+		req.Header.Set("Authorization", c.authHeader)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		responseBody, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			lastErr = readErr
+			continue
+		}
+
+		if resp.StatusCode >= 500 && attempt < maxAttempts-1 {
+			lastErr = httpError(resp.StatusCode, path, string(responseBody))
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, httpError(resp.StatusCode, path, string(responseBody))
+		}
+
+		var parsed APIResponse
+		if err := json.Unmarshal(responseBody, &parsed); err != nil {
+			return nil, newError(
+				ErrorCodeInvalidResponse,
+				"DataForSEO returned invalid JSON",
+				path,
+				resp.StatusCode,
+			)
+		}
+		return &parsed, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("dataforseo: request failed")
+	}
+	return nil, lastErr
+}
+
+func (c *Client) getResponse(ctx context.Context, path string) (*APIResponse, error) {
+	url := c.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dataforseo: build request: %w", err)
+	}
+	req.Header.Set("Authorization", c.authHeader)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, httpError(resp.StatusCode, path, string(responseBody))
+	}
+
+	var parsed APIResponse
+	if err := json.Unmarshal(responseBody, &parsed); err != nil {
+		return nil, newError(
+			ErrorCodeInvalidResponse,
+			"DataForSEO returned invalid JSON",
+			path,
+			resp.StatusCode,
+		)
+	}
+	return &parsed, nil
+}
+
+func clampLimit(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func clampSerpDepth(depth int) int {
+	return clampLimit(depth, 10, 100)
+}
+
+func normalizeKeyword(keyword string) string {
+	return strings.TrimSpace(keyword)
+}

--- a/internal/dataforseo/client.go
+++ b/internal/dataforseo/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // Client is a low-level DataForSEO HTTP client. Higher-level feature methods are
@@ -87,7 +86,6 @@ func (c *Client) AI() *AI {
 type postOptions struct {
 	okTaskStatusCode      int
 	treatNoResultsAsEmpty bool
-	allowNonRetryablePost bool
 }
 
 func (c *Client) post(ctx context.Context, path string, payload any, opts postOptions) (*Task, error) {
@@ -108,66 +106,38 @@ func (c *Client) postResponse(ctx context.Context, path string, payload any, opt
 	}
 
 	url := c.baseURL + path
-	maxAttempts := c.maxRetries + 1
-	if opts.allowNonRetryablePost {
-		maxAttempts = 1
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("dataforseo: build request: %w", err)
+	}
+	req.Header.Set("Authorization", c.authHeader)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
 	}
 
-	var lastErr error
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		if attempt > 0 {
-			backoff := time.Duration(attempt) * 250 * time.Millisecond
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(backoff):
-			}
-		}
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-		if err != nil {
-			return nil, fmt.Errorf("dataforseo: build request: %w", err)
-		}
-		req.Header.Set("Authorization", c.authHeader)
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-
-		responseBody, readErr := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		if readErr != nil {
-			lastErr = readErr
-			continue
-		}
-
-		if resp.StatusCode >= 500 && attempt < maxAttempts-1 {
-			lastErr = httpError(resp.StatusCode, path, string(responseBody))
-			continue
-		}
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return nil, httpError(resp.StatusCode, path, string(responseBody))
-		}
-
-		var parsed APIResponse
-		if err := json.Unmarshal(responseBody, &parsed); err != nil {
-			return nil, newError(
-				ErrorCodeInvalidResponse,
-				"DataForSEO returned invalid JSON",
-				path,
-				resp.StatusCode,
-			)
-		}
-		return &parsed, nil
+	responseBody, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, httpError(resp.StatusCode, path, string(responseBody))
 	}
 
-	if lastErr == nil {
-		lastErr = fmt.Errorf("dataforseo: request failed")
+	var parsed APIResponse
+	if err := json.Unmarshal(responseBody, &parsed); err != nil {
+		return nil, newError(
+			ErrorCodeInvalidResponse,
+			"DataForSEO returned invalid JSON",
+			path,
+			resp.StatusCode,
+		)
 	}
-	return nil, lastErr
+	return &parsed, nil
 }
 
 func (c *Client) getResponse(ctx context.Context, path string) (*APIResponse, error) {

--- a/internal/dataforseo/client_test.go
+++ b/internal/dataforseo/client_test.go
@@ -1,0 +1,194 @@
+package dataforseo
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientRequiresCredentials(t *testing.T) {
+	_, err := NewClient(Config{})
+	require.Error(t, err)
+}
+
+func TestLabsRelatedKeywords(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v3/dataforseo_labs/google/related_keywords/live", r.URL.Path)
+		require.Equal(t, "Basic dGVzdA==", r.Header.Get("Authorization"))
+
+		_, _ = w.Write([]byte(`{
+			"status_code": 20000,
+			"status_message": "Ok.",
+			"tasks": [{
+				"status_code": 20000,
+				"status_message": "Ok.",
+				"path": ["v3","dataforseo_labs","google","related_keywords","live"],
+				"cost": 0.12,
+				"result": [{
+					"items": [{"keyword":"seo tools","search_volume":1200}]
+				}]
+			}]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClientWithHTTPClient(Config{APIKey: "dGVzdA=="}, server.Client())
+	require.NoError(t, err)
+	client.baseURL = server.URL
+
+	response, err := client.Labs().RelatedKeywords(t.Context(), RelatedKeywordsInput{
+		Keyword: "seo",
+		Market:  MarketScope{LocationCode: 2840, LanguageCode: "en"},
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0.12, response.Billing.CostUSD)
+	require.Len(t, response.Data, 1)
+	require.Equal(t, "seo tools", response.Data[0]["keyword"])
+}
+
+func TestLabsDomainRankOverview(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"status_code": 20000,
+			"tasks": [{
+				"status_code": 20000,
+				"path": ["v3","dataforseo_labs","google","domain_rank_overview","live"],
+				"cost": 0.05,
+				"result": [{
+					"items": [{"metrics": {"organic": {"etv": 1500}}}]
+				}]
+			}]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClientWithHTTPClient(Config{APIKey: "dGVzdA=="}, server.Client())
+	require.NoError(t, err)
+	client.baseURL = server.URL
+
+	response, err := client.Labs().DomainRankOverview(t.Context(), DomainRankOverviewInput{
+		Target: "example.com",
+		Market: MarketScope{LocationCode: 2840, LanguageCode: "en"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0.05, response.Billing.CostUSD)
+	require.Len(t, response.Data, 1)
+}
+
+func TestSERPRankCheck(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v3/serp/google/organic/live/advanced", r.URL.Path)
+
+		var payload []map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		require.Equal(t, "example pricing", payload[0]["keyword"])
+
+		_, _ = w.Write([]byte(`{
+			"status_code": 20000,
+			"tasks": [{
+				"status_code": 20000,
+				"path": ["v3","serp","google","organic","live","advanced"],
+				"cost": 0.002,
+				"result": [{
+					"items": [{
+						"type": "organic",
+						"domain": "www.example.com",
+						"rank_group": 3,
+						"url": "https://www.example.com/pricing"
+					}]
+				}]
+			}]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClientWithHTTPClient(Config{APIKey: "dGVzdA=="}, server.Client())
+	require.NoError(t, err)
+	client.baseURL = server.URL
+
+	response, err := client.SERP().RankCheck(t.Context(), RankCheckSerpInput{
+		KeywordID:    "kw_1",
+		Keyword:      "example pricing",
+		TargetDomain: "example.com",
+		Market:       MarketScope{LocationCode: 2840, LanguageCode: "en"},
+		Device:       "desktop",
+		Depth:        20,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, response.Data.Position)
+	require.Equal(t, 3, *response.Data.Position)
+	require.Equal(t, "https://www.example.com/pricing", response.Data.URL)
+}
+
+func TestAIMentionsSearch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v3/ai_optimization/llm_mentions/search/live", r.URL.Path)
+		_, _ = w.Write([]byte(`{
+			"status_code": 20000,
+			"tasks": [{
+				"status_code": 20000,
+				"path": ["v3","ai_optimization","llm_mentions","search","live"],
+				"cost": 0.2,
+				"result": [{
+					"items": [{"question":"what is example.com"}]
+				}]
+			}]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClientWithHTTPClient(Config{APIKey: "dGVzdA=="}, server.Client())
+	require.NoError(t, err)
+	client.baseURL = server.URL
+
+	response, err := client.AI().MentionsSearch(t.Context(), LlmMentionsSearchInput{
+		Target:   BuildLlmDomainTarget("example.com", true),
+		Platform: LlmPlatformChatGPT,
+		Market:   MarketScope{LocationCode: ChatGPTLocationCode, LanguageCode: ChatGPTLanguageCode},
+		Limit:    10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0.2, response.Billing.CostUSD)
+	require.Len(t, response.Data, 1)
+}
+
+func TestAILlmResponseRejectsUnknownModel(t *testing.T) {
+	client, err := NewClient(Config{Login: "login", Password: "password"})
+	require.NoError(t, err)
+
+	_, err = client.AI().LlmResponse(t.Context(), LlmResponseInput{
+		UserPrompt: "best crm software",
+		Model:      LlmResponseModelChatGPT,
+		ModelName:  "gpt-4",
+	})
+	require.Error(t, err)
+
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestAssertTaskTreatsNoResultsAsEmpty(t *testing.T) {
+	task := &Task{
+		StatusCode:    40501,
+		StatusMessage: "No Search Results.",
+		Path:          []string{"v3", "serp", "google", "organic", "live", "advanced"},
+		Cost:          0.001,
+	}
+
+	parsed, err := assertTask(task, "/v3/serp/google/organic/live/advanced", assertTaskOptions{
+		treatNoResultsAsEmpty: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, task, parsed)
+}
+
+func TestConfigAuthorizationFromLoginPassword(t *testing.T) {
+	cfg := Config{Login: "user", Password: "secret"}
+	require.Equal(t, "dXNlcjpzZWNyZXQ=", cfg.authorizationValue())
+}

--- a/internal/dataforseo/config.go
+++ b/internal/dataforseo/config.go
@@ -1,0 +1,72 @@
+package dataforseo
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL        = "https://api.dataforseo.com"
+	defaultRequestTimeout = 60 * time.Second
+	defaultMaxRetries     = 2
+)
+
+// Config holds DataForSEO API credentials and transport settings.
+//
+// Prefer APIKey: a base64-encoded "login:password" string from the DataForSEO
+// dashboard (the value emailed as API credentials, exposed as DATAFORSEO_API_KEY
+// in go-svc). Login and Password are an alternative for programmatic setup
+// only — do not use separate env vars in deployment.
+type Config struct {
+	APIKey     string
+	Login      string
+	Password   string
+	BaseURL    string
+	Timeout    time.Duration
+	MaxRetries int
+}
+
+func (c Config) validate() error {
+	if strings.TrimSpace(c.authorizationValue()) == "" {
+		return fmt.Errorf("dataforseo: API key or login and password are required")
+	}
+	return nil
+}
+
+func (c Config) baseURL() string {
+	if strings.TrimSpace(c.BaseURL) == "" {
+		return defaultBaseURL
+	}
+	return strings.TrimRight(strings.TrimSpace(c.BaseURL), "/")
+}
+
+func (c Config) timeout() time.Duration {
+	if c.Timeout <= 0 {
+		return defaultRequestTimeout
+	}
+	return c.Timeout
+}
+
+func (c Config) maxRetries() int {
+	if c.MaxRetries < 0 {
+		return 0
+	}
+	if c.MaxRetries == 0 {
+		return defaultMaxRetries
+	}
+	return c.MaxRetries
+}
+
+func (c Config) authorizationValue() string {
+	if trimmed := strings.TrimSpace(c.APIKey); trimmed != "" {
+		return trimmed
+	}
+	login := strings.TrimSpace(c.Login)
+	password := strings.TrimSpace(c.Password)
+	if login == "" || password == "" {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString([]byte(login + ":" + password))
+}

--- a/internal/dataforseo/doc.go
+++ b/internal/dataforseo/doc.go
@@ -1,0 +1,13 @@
+// Package dataforseo provides a typed HTTP client for the DataForSEO API.
+//
+// The client is organized into feature groups that mirror the Domains SEO
+// roadmap:
+//   - Labs: keyword research and domain overview
+//   - SERP: live SERP inspection and rank tracking
+//   - AI: brand lookup (LLM mentions) and prompt explorer (LLM responses)
+//
+// Authentication uses a base64-encoded API key (DATAFORSEO_API_KEY). Login and
+// password fields exist for programmatic config only. Every successful call
+// returns provider billing metadata alongside the parsed payload so upstream
+// services can meter usage later.
+package dataforseo

--- a/internal/dataforseo/envelope.go
+++ b/internal/dataforseo/envelope.go
@@ -1,0 +1,221 @@
+package dataforseo
+
+import (
+	"encoding/json"
+)
+
+// APICallCost captures provider billing metadata for a single DataForSEO task.
+type APICallCost struct {
+	Path    []string `json:"path"`
+	CostUSD float64  `json:"costUsd"`
+}
+
+// APIResponse is the top-level DataForSEO response envelope.
+type APIResponse struct {
+	StatusCode    int     `json:"status_code"`
+	StatusMessage string  `json:"status_message"`
+	Tasks         []*Task `json:"tasks"`
+}
+
+// TaskResult is the first-level result object inside a task.
+type TaskResult map[string]json.RawMessage
+
+// Task is a single DataForSEO task result.
+type Task struct {
+	ID            string          `json:"id"`
+	StatusCode    int             `json:"status_code"`
+	StatusMessage string          `json:"status_message"`
+	Path          []string        `json:"path"`
+	Cost          float64         `json:"cost"`
+	ResultCount   *int            `json:"result_count"`
+	Data          json.RawMessage `json:"data"`
+	Result        []TaskResult    `json:"result"`
+}
+
+// TaskResponse pairs parsed task data with billing metadata.
+type TaskResponse[T any] struct {
+	Data    T
+	Billing APICallCost
+}
+
+type assertTaskOptions struct {
+	okTaskStatusCode     int
+	treatNoResultsAsEmpty bool
+}
+
+func buildTaskBilling(task *Task) (APICallCost, error) {
+	if task == nil || len(task.Path) == 0 {
+		return APICallCost{}, newError(
+			ErrorCodeInvalidResponse,
+			"DataForSEO task is missing billing metadata (path/cost)",
+			"",
+			0,
+		)
+	}
+	return APICallCost{
+		Path:    append([]string(nil), task.Path...),
+		CostUSD: task.Cost,
+	}, nil
+}
+
+func assertTask(task *Task, path string, opts assertTaskOptions) (*Task, error) {
+	if task == nil {
+		return nil, newError(ErrorCodeInvalidResponse, "DataForSEO response missing task", path, 0)
+	}
+
+	okStatus := opts.okTaskStatusCode
+	if okStatus == 0 {
+		okStatus = 20000
+	}
+
+	if task.StatusCode != okStatus {
+		if opts.treatNoResultsAsEmpty && IsNoResultsTask(task) {
+			return task, nil
+		}
+
+		message := task.StatusMessage
+		if message == "" {
+			message = "DataForSEO task failed"
+		}
+
+		billing, billingErr := buildTaskBilling(task)
+		if billingErr == nil && task.Cost > 0 {
+			return nil, &Error{
+				Code:       ErrorCodeTaskFailed,
+				Message:    message,
+				StatusCode: task.StatusCode,
+				Path:       path,
+				Billing:    &billing,
+			}
+		}
+
+		return nil, newError(ErrorCodeTaskFailed, message, path, task.StatusCode)
+	}
+
+	return task, nil
+}
+
+func assertResponse(response *APIResponse, path string, opts assertTaskOptions) (*Task, error) {
+	if response == nil {
+		return nil, newError(ErrorCodeInvalidResponse, "DataForSEO returned an empty response", path, 0)
+	}
+	if response.StatusCode != 20000 {
+		message := response.StatusMessage
+		if message == "" {
+			message = "DataForSEO request failed"
+		}
+		return nil, newError(ErrorCodeTaskFailed, message, path, response.StatusCode)
+	}
+	if len(response.Tasks) == 0 {
+		return nil, newError(ErrorCodeInvalidResponse, "DataForSEO response missing task", path, 0)
+	}
+	return assertTask(response.Tasks[0], path, opts)
+}
+
+func firstResultItems(task *Task) json.RawMessage {
+	if task == nil || len(task.Result) == 0 {
+		return nil
+	}
+	return task.Result[0]["items"]
+}
+
+func firstResultTotalCount(task *Task) *int {
+	if task == nil || len(task.Result) == 0 {
+		return nil
+	}
+	raw := task.Result[0]["total_count"]
+	if len(raw) == 0 {
+		return nil
+	}
+	var totalCount int
+	if err := json.Unmarshal(raw, &totalCount); err != nil {
+		return nil
+	}
+	return &totalCount
+}
+
+func firstResultTotal(task *Task) json.RawMessage {
+	if task == nil || len(task.Result) == 0 {
+		return nil
+	}
+	return task.Result[0]["total"]
+}
+
+func firstResultObject(task *Task) json.RawMessage {
+	if task == nil || len(task.Result) == 0 {
+		return nil
+	}
+	raw, err := json.Marshal(task.Result[0])
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+func decodeItems[T any](items json.RawMessage) (T, error) {
+	var out T
+	if len(items) == 0 {
+		return out, nil
+	}
+	if err := json.Unmarshal(items, &out); err != nil {
+		return out, newError(
+			ErrorCodeInvalidResponse,
+			"DataForSEO returned an invalid items payload",
+			"",
+			0,
+		)
+	}
+	return out, nil
+}
+
+func decodeTotal[T any](total json.RawMessage) (T, error) {
+	var out T
+	if len(total) == 0 {
+		return out, nil
+	}
+	if err := json.Unmarshal(total, &out); err != nil {
+		return out, newError(
+			ErrorCodeInvalidResponse,
+			"DataForSEO returned an invalid total payload",
+			"",
+			0,
+		)
+	}
+	return out, nil
+}
+
+func taskResponseFromItems[T any](task *Task) (TaskResponse[T], error) {
+	billing, err := buildTaskBilling(task)
+	if err != nil {
+		return TaskResponse[T]{}, err
+	}
+	data, err := decodeItems[T](firstResultItems(task))
+	if err != nil {
+		return TaskResponse[T]{}, err
+	}
+	return TaskResponse[T]{Data: data, Billing: billing}, nil
+}
+
+func taskResponseFromTotal[T any](task *Task) (TaskResponse[T], error) {
+	billing, err := buildTaskBilling(task)
+	if err != nil {
+		return TaskResponse[T]{}, err
+	}
+	data, err := decodeTotal[T](firstResultTotal(task))
+	if err != nil {
+		return TaskResponse[T]{}, err
+	}
+	return TaskResponse[T]{Data: data, Billing: billing}, nil
+}
+
+func taskResponseFromFirstResult[T any](task *Task) (TaskResponse[T], error) {
+	billing, err := buildTaskBilling(task)
+	if err != nil {
+		return TaskResponse[T]{}, err
+	}
+	data, err := decodeItems[T](firstResultObject(task))
+	if err != nil {
+		return TaskResponse[T]{}, err
+	}
+	return TaskResponse[T]{Data: data, Billing: billing}, nil
+}

--- a/internal/dataforseo/envelope.go
+++ b/internal/dataforseo/envelope.go
@@ -39,7 +39,7 @@ type TaskResponse[T any] struct {
 }
 
 type assertTaskOptions struct {
-	okTaskStatusCode     int
+	okTaskStatusCode      int
 	treatNoResultsAsEmpty bool
 }
 

--- a/internal/dataforseo/errors.go
+++ b/internal/dataforseo/errors.go
@@ -1,0 +1,103 @@
+package dataforseo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrorCode classifies DataForSEO client failures for callers.
+type ErrorCode string
+
+const (
+	ErrorCodeAuthFailed          ErrorCode = "dataforseo_auth_failed"
+	ErrorCodeRateLimited         ErrorCode = "dataforseo_rate_limited"
+	ErrorCodeUpstreamUnavailable ErrorCode = "dataforseo_upstream_unavailable"
+	ErrorCodeValidation          ErrorCode = "dataforseo_validation_error"
+	ErrorCodeTaskFailed          ErrorCode = "dataforseo_task_failed"
+	ErrorCodeInvalidResponse     ErrorCode = "dataforseo_invalid_response"
+)
+
+// Error is a typed DataForSEO client error.
+type Error struct {
+	Code       ErrorCode
+	Message    string
+	StatusCode int
+	Path       string
+	Billing    *APICallCost
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Path != "" {
+		return fmt.Sprintf("%s: %s (%s)", e.Code, e.Message, e.Path)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func newError(code ErrorCode, message, path string, statusCode int) *Error {
+	return &Error{
+		Code:       code,
+		Message:    message,
+		StatusCode: statusCode,
+		Path:       path,
+	}
+}
+
+func httpError(statusCode int, path, body string) *Error {
+	message := fmt.Sprintf("DataForSEO HTTP %d", statusCode)
+	if trimmed := truncate(body, 300); trimmed != "" {
+		message = fmt.Sprintf("%s: %s", message, trimmed)
+	}
+
+	switch {
+	case statusCode == 401:
+		return newError(ErrorCodeAuthFailed, message, path, statusCode)
+	case statusCode == 429:
+		return newError(ErrorCodeRateLimited, message, path, statusCode)
+	case statusCode >= 500:
+		return newError(ErrorCodeUpstreamUnavailable, message, path, statusCode)
+	default:
+		return newError(ErrorCodeTaskFailed, message, path, statusCode)
+	}
+}
+
+func truncate(value string, max int) string {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) <= max {
+		return trimmed
+	}
+	return trimmed[:max] + "..."
+}
+
+// IsNoResultsTask reports whether DataForSEO returned a billed empty result set.
+func IsNoResultsTask(task *Task) bool {
+	if task == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(task.StatusMessage), "no search results")
+}
+
+// IsTaskInProgress reports whether a queued task is still pending collection.
+func IsTaskInProgress(task *Task) bool {
+	if task == nil || task.StatusCode == 0 {
+		return false
+	}
+	switch task.StatusCode {
+	case 20100, 40601, 40602:
+		return true
+	default:
+		return false
+	}
+}
+
+// AsError unwraps a *Error from err.
+func AsError(err error) (*Error, bool) {
+	var typed *Error
+	if errors.As(err, &typed) {
+		return typed, true
+	}
+	return nil, false
+}

--- a/internal/dataforseo/labs.go
+++ b/internal/dataforseo/labs.go
@@ -3,22 +3,22 @@ package dataforseo
 import "context"
 
 const (
-	pathRelatedKeywords   = "/v3/dataforseo_labs/google/related_keywords/live"
+	pathRelatedKeywords    = "/v3/dataforseo_labs/google/related_keywords/live"
 	pathKeywordSuggestions = "/v3/dataforseo_labs/google/keyword_suggestions/live"
-	pathKeywordIdeas      = "/v3/dataforseo_labs/google/keyword_ideas/live"
+	pathKeywordIdeas       = "/v3/dataforseo_labs/google/keyword_ideas/live"
 	pathDomainRankOverview = "/v3/dataforseo_labs/google/domain_rank_overview/live"
-	pathRankedKeywords    = "/v3/dataforseo_labs/google/ranked_keywords/live"
-	pathRelevantPages     = "/v3/dataforseo_labs/google/relevant_pages/live"
-	pathKeywordOverview   = "/v3/dataforseo_labs/google/keyword_overview/live"
+	pathRankedKeywords     = "/v3/dataforseo_labs/google/ranked_keywords/live"
+	pathRelevantPages      = "/v3/dataforseo_labs/google/relevant_pages/live"
+	pathKeywordOverview    = "/v3/dataforseo_labs/google/keyword_overview/live"
 )
 
 // RelatedKeywordsInput expands a seed keyword into related terms.
 type RelatedKeywordsInput struct {
-	Keyword                 string
-	Market                  MarketScope
-	Limit                   int
-	Depth                   int
-	IncludeClickstreamData  bool
+	Keyword                string
+	Market                 MarketScope
+	Limit                  int
+	Depth                  int
+	IncludeClickstreamData bool
 }
 
 // KeywordSuggestionsInput expands a seed keyword into suggestions.
@@ -176,10 +176,10 @@ func (l *Labs) DomainRankOverview(
 	}
 
 	task, err := l.client.post(ctx, pathDomainRankOverview, []map[string]any{{
-		"target":         target,
-		"location_code":  input.Market.LocationCode,
-		"language_code":  input.Market.LanguageCode,
-		"limit":          1,
+		"target":        target,
+		"location_code": input.Market.LocationCode,
+		"language_code": input.Market.LanguageCode,
+		"limit":         1,
 	}}, postOptions{})
 	if err != nil {
 		return TaskResponse[[]DomainRankOverviewItem]{}, err

--- a/internal/dataforseo/labs.go
+++ b/internal/dataforseo/labs.go
@@ -1,0 +1,309 @@
+package dataforseo
+
+import "context"
+
+const (
+	pathRelatedKeywords   = "/v3/dataforseo_labs/google/related_keywords/live"
+	pathKeywordSuggestions = "/v3/dataforseo_labs/google/keyword_suggestions/live"
+	pathKeywordIdeas      = "/v3/dataforseo_labs/google/keyword_ideas/live"
+	pathDomainRankOverview = "/v3/dataforseo_labs/google/domain_rank_overview/live"
+	pathRankedKeywords    = "/v3/dataforseo_labs/google/ranked_keywords/live"
+	pathRelevantPages     = "/v3/dataforseo_labs/google/relevant_pages/live"
+	pathKeywordOverview   = "/v3/dataforseo_labs/google/keyword_overview/live"
+)
+
+// RelatedKeywordsInput expands a seed keyword into related terms.
+type RelatedKeywordsInput struct {
+	Keyword                 string
+	Market                  MarketScope
+	Limit                   int
+	Depth                   int
+	IncludeClickstreamData  bool
+}
+
+// KeywordSuggestionsInput expands a seed keyword into suggestions.
+type KeywordSuggestionsInput struct {
+	Keyword                string
+	Market                 MarketScope
+	Limit                  int
+	IncludeClickstreamData bool
+}
+
+// KeywordIdeasInput expands a seed keyword into ideas.
+type KeywordIdeasInput struct {
+	Keyword                string
+	Market                 MarketScope
+	Limit                  int
+	IncludeClickstreamData bool
+}
+
+// DomainRankOverviewInput fetches organic footprint metrics for a domain.
+type DomainRankOverviewInput struct {
+	Target string
+	Market MarketScope
+}
+
+// RankedKeywordsInput lists keywords a domain ranks for.
+type RankedKeywordsInput struct {
+	Target    string
+	Market    MarketScope
+	Limit     int
+	Offset    int
+	OrderBy   []string
+	Filters   []any
+	ItemTypes []string
+}
+
+// RelevantPagesInput lists top organic pages for a domain.
+type RelevantPagesInput struct {
+	Target  string
+	Market  MarketScope
+	Limit   int
+	Offset  int
+	OrderBy []string
+	Filters []any
+}
+
+// KeywordOverviewInput hydrates metrics for known keywords.
+type KeywordOverviewInput struct {
+	Keywords               []string
+	Market                 MarketScope
+	IncludeClickstreamData bool
+}
+
+func (l *Labs) RelatedKeywords(
+	ctx context.Context,
+	input RelatedKeywordsInput,
+) (TaskResponse[[]KeywordDataItem], error) {
+	keyword := normalizeKeyword(input.Keyword)
+	if keyword == "" {
+		return TaskResponse[[]KeywordDataItem]{}, newError(
+			ErrorCodeValidation,
+			"keyword is required",
+			pathRelatedKeywords,
+			0,
+		)
+	}
+
+	task, err := l.client.post(ctx, pathRelatedKeywords, []map[string]any{{
+		"keyword":                  keyword,
+		"location_code":            input.Market.LocationCode,
+		"language_code":            input.Market.LanguageCode,
+		"limit":                    input.Limit,
+		"depth":                    defaultDepth(input.Depth),
+		"include_clickstream_data": input.IncludeClickstreamData,
+		"include_serp_info":        false,
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]KeywordDataItem]{}, err
+	}
+	return taskResponseFromItems[[]KeywordDataItem](task)
+}
+
+func (l *Labs) KeywordSuggestions(
+	ctx context.Context,
+	input KeywordSuggestionsInput,
+) (TaskResponse[[]KeywordDataItem], error) {
+	keyword := normalizeKeyword(input.Keyword)
+	if keyword == "" {
+		return TaskResponse[[]KeywordDataItem]{}, newError(
+			ErrorCodeValidation,
+			"keyword is required",
+			pathKeywordSuggestions,
+			0,
+		)
+	}
+
+	task, err := l.client.post(ctx, pathKeywordSuggestions, []map[string]any{{
+		"keyword":                  keyword,
+		"location_code":            input.Market.LocationCode,
+		"language_code":            input.Market.LanguageCode,
+		"limit":                    input.Limit,
+		"include_clickstream_data": input.IncludeClickstreamData,
+		"include_serp_info":        false,
+		"include_seed_keyword":     true,
+		"ignore_synonyms":          false,
+		"exact_match":              false,
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]KeywordDataItem]{}, err
+	}
+	return taskResponseFromItems[[]KeywordDataItem](task)
+}
+
+func (l *Labs) KeywordIdeas(
+	ctx context.Context,
+	input KeywordIdeasInput,
+) (TaskResponse[[]KeywordDataItem], error) {
+	keyword := normalizeKeyword(input.Keyword)
+	if keyword == "" {
+		return TaskResponse[[]KeywordDataItem]{}, newError(
+			ErrorCodeValidation,
+			"keyword is required",
+			pathKeywordIdeas,
+			0,
+		)
+	}
+
+	task, err := l.client.post(ctx, pathKeywordIdeas, []map[string]any{{
+		"keywords":                 []string{keyword},
+		"location_code":            input.Market.LocationCode,
+		"language_code":            input.Market.LanguageCode,
+		"limit":                    input.Limit,
+		"include_clickstream_data": input.IncludeClickstreamData,
+		"include_serp_info":        false,
+		"ignore_synonyms":          false,
+		"closely_variants":         false,
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]KeywordDataItem]{}, err
+	}
+	return taskResponseFromItems[[]KeywordDataItem](task)
+}
+
+func (l *Labs) DomainRankOverview(
+	ctx context.Context,
+	input DomainRankOverviewInput,
+) (TaskResponse[[]DomainRankOverviewItem], error) {
+	target := normalizeKeyword(input.Target)
+	if target == "" {
+		return TaskResponse[[]DomainRankOverviewItem]{}, newError(
+			ErrorCodeValidation,
+			"target is required",
+			pathDomainRankOverview,
+			0,
+		)
+	}
+
+	task, err := l.client.post(ctx, pathDomainRankOverview, []map[string]any{{
+		"target":         target,
+		"location_code":  input.Market.LocationCode,
+		"language_code":  input.Market.LanguageCode,
+		"limit":          1,
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]DomainRankOverviewItem]{}, err
+	}
+	return taskResponseFromItems[[]DomainRankOverviewItem](task)
+}
+
+func (l *Labs) RankedKeywords(
+	ctx context.Context,
+	input RankedKeywordsInput,
+) (TaskResponse[RankedKeywordsPage], error) {
+	target := normalizeKeyword(input.Target)
+	if target == "" {
+		return TaskResponse[RankedKeywordsPage]{}, newError(
+			ErrorCodeValidation,
+			"target is required",
+			pathRankedKeywords,
+			0,
+		)
+	}
+
+	task, err := l.client.post(ctx, pathRankedKeywords, []map[string]any{{
+		"target":        target,
+		"location_code": input.Market.LocationCode,
+		"language_code": input.Market.LanguageCode,
+		"limit":         input.Limit,
+		"offset":        input.Offset,
+		"order_by":      input.OrderBy,
+		"filters":       input.Filters,
+		"item_types":    input.ItemTypes,
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[RankedKeywordsPage]{}, err
+	}
+
+	billing, err := buildTaskBilling(task)
+	if err != nil {
+		return TaskResponse[RankedKeywordsPage]{}, err
+	}
+	items, err := decodeItems[[]DomainRankedKeywordItem](firstResultItems(task))
+	if err != nil {
+		return TaskResponse[RankedKeywordsPage]{}, err
+	}
+	return TaskResponse[RankedKeywordsPage]{
+		Data: RankedKeywordsPage{
+			Items:      items,
+			TotalCount: firstResultTotalCount(task),
+		},
+		Billing: billing,
+	}, nil
+}
+
+func (l *Labs) RelevantPages(
+	ctx context.Context,
+	input RelevantPagesInput,
+) (TaskResponse[RelevantPagesPage], error) {
+	target := normalizeKeyword(input.Target)
+	if target == "" {
+		return TaskResponse[RelevantPagesPage]{}, newError(
+			ErrorCodeValidation,
+			"target is required",
+			pathRelevantPages,
+			0,
+		)
+	}
+
+	task, err := l.client.post(ctx, pathRelevantPages, []map[string]any{{
+		"target":        target,
+		"location_code": input.Market.LocationCode,
+		"language_code": input.Market.LanguageCode,
+		"limit":         input.Limit,
+		"offset":        input.Offset,
+		"order_by":      input.OrderBy,
+		"filters":       input.Filters,
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[RelevantPagesPage]{}, err
+	}
+
+	billing, err := buildTaskBilling(task)
+	if err != nil {
+		return TaskResponse[RelevantPagesPage]{}, err
+	}
+	items, err := decodeItems[[]RelevantPageItem](firstResultItems(task))
+	if err != nil {
+		return TaskResponse[RelevantPagesPage]{}, err
+	}
+	return TaskResponse[RelevantPagesPage]{
+		Data: RelevantPagesPage{
+			Items:      items,
+			TotalCount: firstResultTotalCount(task),
+		},
+		Billing: billing,
+	}, nil
+}
+
+func (l *Labs) KeywordOverview(
+	ctx context.Context,
+	input KeywordOverviewInput,
+) (TaskResponse[[]KeywordOverviewItem], error) {
+	if len(input.Keywords) == 0 {
+		return TaskResponse[[]KeywordOverviewItem]{}, newError(
+			ErrorCodeValidation,
+			"at least one keyword is required",
+			pathKeywordOverview,
+			0,
+		)
+	}
+
+	task, err := l.client.post(ctx, pathKeywordOverview, []map[string]any{{
+		"keywords":                 input.Keywords,
+		"location_code":            input.Market.LocationCode,
+		"language_code":            input.Market.LanguageCode,
+		"include_clickstream_data": input.IncludeClickstreamData,
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]KeywordOverviewItem]{}, err
+	}
+	return taskResponseFromItems[[]KeywordOverviewItem](task)
+}
+
+func defaultDepth(depth int) int {
+	if depth <= 0 {
+		return 3
+	}
+	return depth
+}

--- a/internal/dataforseo/serp.go
+++ b/internal/dataforseo/serp.go
@@ -16,10 +16,10 @@ const (
 
 // LiveSerpInput fetches a live organic SERP snapshot.
 type LiveSerpInput struct {
-	Keyword  string
-	Market   MarketScope
-	Device   string
-	Depth    int
+	Keyword string
+	Market  MarketScope
+	Device  string
+	Depth   int
 }
 
 // RankCheckSerpInput performs a live rank check for one keyword.
@@ -66,12 +66,12 @@ func (s *SERP) LiveAdvanced(
 
 	device := defaultDevice(input.Device)
 	task, err := s.client.post(ctx, pathOrganicLiveAdvanced, []map[string]any{{
-		"keyword":        keyword,
-		"location_code":  input.Market.LocationCode,
-		"language_code":  input.Market.LanguageCode,
-		"device":         device,
-		"os":             serpOS(device),
-		"depth":          clampSerpDepth(input.Depth),
+		"keyword":       keyword,
+		"location_code": input.Market.LocationCode,
+		"language_code": input.Market.LanguageCode,
+		"device":        device,
+		"os":            serpOS(device),
+		"depth":         clampSerpDepth(input.Depth),
 	}}, postOptions{})
 	if err != nil {
 		return TaskResponse[[]SerpItem]{}, err

--- a/internal/dataforseo/serp.go
+++ b/internal/dataforseo/serp.go
@@ -182,8 +182,7 @@ func (s *SERP) PostRankCheckTasks(
 	}
 
 	response, err := s.client.postResponse(ctx, pathOrganicTaskPost, payload, postOptions{
-		okTaskStatusCode:      20000,
-		allowNonRetryablePost: true,
+		okTaskStatusCode: 20000,
 	})
 	if err != nil {
 		return TaskResponse[[]PostedRankCheckTask]{}, err

--- a/internal/dataforseo/serp.go
+++ b/internal/dataforseo/serp.go
@@ -1,0 +1,400 @@
+package dataforseo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	pathOrganicLiveAdvanced = "/v3/serp/google/organic/live/advanced"
+	pathOrganicTaskPost     = "/v3/serp/google/organic/task_post"
+	pathOrganicTaskGetFmt   = "/v3/serp/google/organic/task_get/advanced/%s"
+	maxTasksPerPost         = 100
+)
+
+// LiveSerpInput fetches a live organic SERP snapshot.
+type LiveSerpInput struct {
+	Keyword  string
+	Market   MarketScope
+	Device   string
+	Depth    int
+}
+
+// RankCheckSerpInput performs a live rank check for one keyword.
+type RankCheckSerpInput struct {
+	KeywordID    string
+	Keyword      string
+	TargetDomain string
+	Market       MarketScope
+	LocationName string
+	Device       string
+	Depth        int
+}
+
+// PostRankCheckTasksInput queues rank-check tasks for later collection.
+type PostRankCheckTasksInput struct {
+	Tasks        []RankCheckTaskInput
+	TargetDomain string
+	Market       MarketScope
+	LocationName string
+	Depth        int
+}
+
+// RankCheckTaskResultInput collects one queued rank-check task.
+type RankCheckTaskResultInput struct {
+	TaskID       string
+	KeywordID    string
+	Keyword      string
+	TargetDomain string
+}
+
+func (s *SERP) LiveAdvanced(
+	ctx context.Context,
+	input LiveSerpInput,
+) (TaskResponse[[]SerpItem], error) {
+	keyword := normalizeKeyword(input.Keyword)
+	if keyword == "" {
+		return TaskResponse[[]SerpItem]{}, newError(
+			ErrorCodeValidation,
+			"keyword is required",
+			pathOrganicLiveAdvanced,
+			0,
+		)
+	}
+
+	device := defaultDevice(input.Device)
+	task, err := s.client.post(ctx, pathOrganicLiveAdvanced, []map[string]any{{
+		"keyword":        keyword,
+		"location_code":  input.Market.LocationCode,
+		"language_code":  input.Market.LanguageCode,
+		"device":         device,
+		"os":             serpOS(device),
+		"depth":          clampSerpDepth(input.Depth),
+	}}, postOptions{})
+	if err != nil {
+		return TaskResponse[[]SerpItem]{}, err
+	}
+	return taskResponseFromItems[[]SerpItem](task)
+}
+
+func (s *SERP) RankCheck(
+	ctx context.Context,
+	input RankCheckSerpInput,
+) (TaskResponse[RankCheckResult], error) {
+	keyword := normalizeKeyword(input.Keyword)
+	targetDomain := normalizeKeyword(input.TargetDomain)
+	if keyword == "" || targetDomain == "" {
+		return TaskResponse[RankCheckResult]{}, newError(
+			ErrorCodeValidation,
+			"keyword and targetDomain are required",
+			pathOrganicLiveAdvanced,
+			0,
+		)
+	}
+
+	device := defaultDevice(input.Device)
+	payload := map[string]any{
+		"keyword":       keyword,
+		"language_code": input.Market.LanguageCode,
+		"device":        device,
+		"os":            serpOS(device),
+		"depth":         clampSerpDepth(input.Depth),
+	}
+	if strings.TrimSpace(input.LocationName) != "" {
+		payload["location_name"] = strings.TrimSpace(input.LocationName)
+	} else {
+		payload["location_code"] = input.Market.LocationCode
+	}
+	for key, value := range stopCrawlOnTarget(targetDomain) {
+		payload[key] = value
+	}
+
+	task, err := s.client.post(ctx, pathOrganicLiveAdvanced, []map[string]any{payload}, postOptions{
+		treatNoResultsAsEmpty: true,
+	})
+	if err != nil {
+		return TaskResponse[RankCheckResult]{}, err
+	}
+
+	items, err := decodeItems[[]SerpItem](firstResultItems(task))
+	if err != nil {
+		return TaskResponse[RankCheckResult]{}, err
+	}
+	billing, err := buildTaskBilling(task)
+	if err != nil {
+		return TaskResponse[RankCheckResult]{}, err
+	}
+	return TaskResponse[RankCheckResult]{
+		Data: buildRankCheckResult(RankCheckSerpInput{
+			KeywordID:    input.KeywordID,
+			Keyword:      keyword,
+			TargetDomain: targetDomain,
+		}, items),
+		Billing: billing,
+	}, nil
+}
+
+func (s *SERP) PostRankCheckTasks(
+	ctx context.Context,
+	input PostRankCheckTasksInput,
+) (TaskResponse[[]PostedRankCheckTask], error) {
+	if len(input.Tasks) == 0 || len(input.Tasks) > maxTasksPerPost {
+		return TaskResponse[[]PostedRankCheckTask]{}, newError(
+			ErrorCodeValidation,
+			fmt.Sprintf("task_post accepts 1-%d tasks", maxTasksPerPost),
+			pathOrganicTaskPost,
+			0,
+		)
+	}
+
+	targetDomain := normalizeKeyword(input.TargetDomain)
+	if targetDomain == "" {
+		return TaskResponse[[]PostedRankCheckTask]{}, newError(
+			ErrorCodeValidation,
+			"targetDomain is required",
+			pathOrganicTaskPost,
+			0,
+		)
+	}
+
+	payload := make([]map[string]any, 0, len(input.Tasks))
+	for _, taskInput := range input.Tasks {
+		device := defaultDevice(taskInput.Device)
+		row := map[string]any{
+			"keyword":       normalizeKeyword(taskInput.Keyword),
+			"language_code": input.Market.LanguageCode,
+			"device":        device,
+			"os":            serpOS(device),
+			"depth":         clampSerpDepth(input.Depth),
+			"tag":           fmt.Sprintf("%s:%s", taskInput.KeywordID, device),
+		}
+		if strings.TrimSpace(input.LocationName) != "" {
+			row["location_name"] = strings.TrimSpace(input.LocationName)
+		} else {
+			row["location_code"] = input.Market.LocationCode
+		}
+		for key, value := range stopCrawlOnTarget(targetDomain) {
+			row[key] = value
+		}
+		payload = append(payload, row)
+	}
+
+	response, err := s.client.postResponse(ctx, pathOrganicTaskPost, payload, postOptions{
+		okTaskStatusCode:      20000,
+		allowNonRetryablePost: true,
+	})
+	if err != nil {
+		return TaskResponse[[]PostedRankCheckTask]{}, err
+	}
+	if response.StatusCode != 20000 {
+		message := response.StatusMessage
+		if message == "" {
+			message = "DataForSEO task_post failed"
+		}
+		return TaskResponse[[]PostedRankCheckTask]{}, newError(
+			ErrorCodeTaskFailed,
+			message,
+			pathOrganicTaskPost,
+			response.StatusCode,
+		)
+	}
+
+	byTag := make(map[string]RankCheckTaskInput, len(input.Tasks))
+	for _, taskInput := range input.Tasks {
+		device := defaultDevice(taskInput.Device)
+		byTag[fmt.Sprintf("%s:%s", taskInput.KeywordID, device)] = taskInput
+	}
+
+	posted := make([]PostedRankCheckTask, 0, len(response.Tasks))
+	var costUSD float64
+	for _, entry := range response.Tasks {
+		if entry == nil {
+			continue
+		}
+		costUSD += entry.Cost
+		if entry.StatusCode != 20100 || entry.ID == "" {
+			continue
+		}
+		tag := parseTaskTag(entry.Data)
+		taskInput, ok := byTag[tag]
+		if !ok {
+			continue
+		}
+		posted = append(posted, PostedRankCheckTask{
+			RankCheckTaskInput: taskInput,
+			TaskID:             entry.ID,
+		})
+	}
+
+	return TaskResponse[[]PostedRankCheckTask]{
+		Data: posted,
+		Billing: APICallCost{
+			Path:    []string{"v3", "serp", "google", "organic", "task_post"},
+			CostUSD: costUSD,
+		},
+	}, nil
+}
+
+func (s *SERP) RankCheckTaskResult(
+	ctx context.Context,
+	input RankCheckTaskResultInput,
+) (RankCheckTaskOutcome, error) {
+	if strings.TrimSpace(input.TaskID) == "" {
+		return RankCheckTaskOutcome{}, newError(
+			ErrorCodeValidation,
+			"taskId is required",
+			pathOrganicTaskGetFmt,
+			0,
+		)
+	}
+
+	path := fmt.Sprintf(pathOrganicTaskGetFmt, input.TaskID)
+	response, err := s.client.getResponse(ctx, path)
+	if err != nil {
+		return RankCheckTaskOutcome{}, err
+	}
+	if response.StatusCode != 20000 || len(response.Tasks) == 0 {
+		message := response.StatusMessage
+		if message == "" {
+			message = "DataForSEO task_get failed"
+		}
+		return RankCheckTaskOutcome{}, newError(ErrorCodeTaskFailed, message, path, response.StatusCode)
+	}
+
+	task := response.Tasks[0]
+	if IsTaskInProgress(task) {
+		return RankCheckTaskOutcome{Status: "pending"}, nil
+	}
+	if task.StatusCode != 20000 {
+		if !IsNoResultsTask(task) {
+			message := task.StatusMessage
+			if message == "" {
+				message = fmt.Sprintf("DataForSEO task failed (%d)", task.StatusCode)
+			}
+			return RankCheckTaskOutcome{Status: "failed", Message: message}, nil
+		}
+		result := buildRankCheckResult(RankCheckSerpInput{
+			KeywordID:    input.KeywordID,
+			Keyword:      input.Keyword,
+			TargetDomain: input.TargetDomain,
+		}, nil)
+		return RankCheckTaskOutcome{Status: "completed", Result: &result}, nil
+	}
+
+	items, err := decodeItems[[]SerpItem](firstResultItems(task))
+	if err != nil {
+		return RankCheckTaskOutcome{}, err
+	}
+	result := buildRankCheckResult(RankCheckSerpInput{
+		KeywordID:    input.KeywordID,
+		Keyword:      input.Keyword,
+		TargetDomain: input.TargetDomain,
+	}, items)
+	return RankCheckTaskOutcome{Status: "completed", Result: &result}, nil
+}
+
+func buildRankCheckResult(input RankCheckSerpInput, items []SerpItem) RankCheckResult {
+	target := strings.ToLower(strings.TrimSpace(input.TargetDomain))
+	var match SerpItem
+	for _, item := range items {
+		itemType, _ := item["type"].(string)
+		domainValue, _ := item["domain"].(string)
+		domain := strings.ToLower(strings.TrimSpace(domainValue))
+		if itemType != "organic" || domain == "" {
+			continue
+		}
+		if domain == target || strings.HasSuffix(domain, "."+target) {
+			match = item
+			break
+		}
+	}
+
+	features := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		itemType, _ := item["type"].(string)
+		if itemType == "" {
+			continue
+		}
+		if _, ok := seen[itemType]; ok {
+			continue
+		}
+		seen[itemType] = struct{}{}
+		features = append(features, itemType)
+	}
+
+	result := RankCheckResult{
+		KeywordID:    input.KeywordID,
+		Keyword:      input.Keyword,
+		SerpFeatures: features,
+	}
+	if match == nil {
+		return result
+	}
+
+	if position := intFromAny(match["rank_group"]); position != nil {
+		result.Position = position
+	} else if position := intFromAny(match["rank_absolute"]); position != nil {
+		result.Position = position
+	}
+	if urlValue, ok := match["url"].(string); ok {
+		result.URL = urlValue
+	}
+	return result
+}
+
+func stopCrawlOnTarget(targetDomain string) map[string]any {
+	return map[string]any{
+		"stop_crawl_on_match": []map[string]any{{
+			"match_value": targetDomain,
+			"match_type":  "with_subdomains",
+		}},
+		"find_targets_in": []string{"organic"},
+	}
+}
+
+func defaultDevice(device string) string {
+	if strings.TrimSpace(device) == "" {
+		return "desktop"
+	}
+	return strings.TrimSpace(device)
+}
+
+func serpOS(device string) string {
+	if device == "mobile" {
+		return "android"
+	}
+	return "windows"
+}
+
+func intFromAny(value any) *int {
+	switch typed := value.(type) {
+	case int:
+		return &typed
+	case int32:
+		converted := int(typed)
+		return &converted
+	case int64:
+		converted := int(typed)
+		return &converted
+	case float64:
+		converted := int(typed)
+		return &converted
+	default:
+		return nil
+	}
+}
+
+func parseTaskTag(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return ""
+	}
+	tag, _ := payload["tag"].(string)
+	return tag
+}

--- a/internal/dataforseo/types.go
+++ b/internal/dataforseo/types.go
@@ -1,0 +1,198 @@
+package dataforseo
+
+import "fmt"
+
+// MarketScope identifies keyword and domain research targets.
+type MarketScope struct {
+	LocationCode int
+	LanguageCode string
+}
+
+// LlmPlatform is a supported LLM mentions platform.
+type LlmPlatform string
+
+const (
+	LlmPlatformChatGPT LlmPlatform = "chat_gpt"
+	LlmPlatformGoogle  LlmPlatform = "google"
+)
+
+// LlmResponseModel identifies a DataForSEO LLM response provider.
+type LlmResponseModel string
+
+const (
+	LlmResponseModelChatGPT    LlmResponseModel = "chat_gpt"
+	LlmResponseModelClaude     LlmResponseModel = "claude"
+	LlmResponseModelGemini     LlmResponseModel = "gemini"
+	LlmResponseModelPerplexity LlmResponseModel = "perplexity"
+)
+
+// ChatGPTLocationCode and ChatGPTLanguageCode are required for ChatGPT mentions.
+const (
+	ChatGPTLocationCode = 2840
+	ChatGPTLanguageCode = "en"
+)
+
+// LlmDomainTarget scopes LLM mentions to a domain.
+type LlmDomainTarget struct {
+	Domain             string `json:"domain"`
+	IncludeSubdomains  *bool  `json:"include_subdomains,omitempty"`
+	SearchFilter       string `json:"search_filter,omitempty"`
+	SearchScope        []string `json:"search_scope,omitempty"`
+}
+
+// LlmKeywordTarget scopes LLM mentions to a keyword.
+type LlmKeywordTarget struct {
+	Keyword      string   `json:"keyword"`
+	SearchFilter string   `json:"search_filter,omitempty"`
+	SearchScope  []string `json:"search_scope,omitempty"`
+	MatchType    string   `json:"match_type,omitempty"`
+}
+
+// LlmTarget is the union accepted by DataForSEO LLM mentions endpoints.
+type LlmTarget struct {
+	Domain            string   `json:"domain,omitempty"`
+	Keyword           string   `json:"keyword,omitempty"`
+	IncludeSubdomains *bool    `json:"include_subdomains,omitempty"`
+	SearchFilter      string   `json:"search_filter,omitempty"`
+	SearchScope       []string `json:"search_scope,omitempty"`
+	MatchType         string   `json:"match_type,omitempty"`
+}
+
+// BuildLlmDomainTarget returns a domain target for LLM mentions calls.
+func BuildLlmDomainTarget(domain string, includeSubdomains bool) LlmTarget {
+	return LlmTarget{
+		Domain:            domain,
+		IncludeSubdomains: boolPtr(includeSubdomains),
+		SearchFilter:      "include",
+		SearchScope:       []string{"any"},
+	}
+}
+
+// BuildLlmKeywordTarget returns a keyword target for LLM mentions calls.
+func BuildLlmKeywordTarget(keyword string) LlmTarget {
+	return LlmTarget{
+		Keyword:      keyword,
+		SearchFilter: "include",
+		SearchScope:  []string{"any", "brand_entities"},
+		MatchType:    "word_match",
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+// KeywordDataItem is a keyword metric row from Labs endpoints.
+type KeywordDataItem map[string]any
+
+// RelatedKeywordPage is a Labs related-keywords response page.
+type RelatedKeywordPage struct {
+	Items []KeywordDataItem `json:"items"`
+}
+
+// DomainRankOverviewItem is a domain overview metrics row.
+type DomainRankOverviewItem map[string]any
+
+// DomainRankedKeywordItem is a ranked keyword row for a domain.
+type DomainRankedKeywordItem map[string]any
+
+// RankedKeywordsPage is a paginated ranked-keywords response.
+type RankedKeywordsPage struct {
+	Items      []DomainRankedKeywordItem
+	TotalCount *int
+}
+
+// RelevantPageItem is a top organic page row for a domain.
+type RelevantPageItem map[string]any
+
+// RelevantPagesPage is a paginated relevant-pages response.
+type RelevantPagesPage struct {
+	Items      []RelevantPageItem
+	TotalCount *int
+}
+
+// KeywordOverviewItem is a keyword metrics row from keyword overview.
+type KeywordOverviewItem map[string]any
+
+// SerpItem is a live organic SERP row.
+type SerpItem map[string]any
+
+// RankCheckResult is the normalized output of a rank check.
+type RankCheckResult struct {
+	KeywordID    string   `json:"keywordId"`
+	Keyword      string   `json:"keyword"`
+	Position     *int     `json:"position"`
+	URL          string   `json:"url,omitempty"`
+	SerpFeatures []string `json:"serpFeatures"`
+}
+
+// RankCheckTaskInput identifies one queued rank-check task.
+type RankCheckTaskInput struct {
+	Keyword   string `json:"keyword"`
+	KeywordID string `json:"keywordId"`
+	Device    string `json:"device"`
+}
+
+// PostedRankCheckTask is a queued rank-check task accepted by DataForSEO.
+type PostedRankCheckTask struct {
+	RankCheckTaskInput
+	TaskID string `json:"taskId"`
+}
+
+// RankCheckTaskOutcome is the collection result for a queued task.
+type RankCheckTaskOutcome struct {
+	Status  string           `json:"status"`
+	Message string           `json:"message,omitempty"`
+	Result  *RankCheckResult `json:"result,omitempty"`
+}
+
+// LlmMentionItem is a brand lookup mention row.
+type LlmMentionItem map[string]any
+
+// LlmAggregatedTotal is the total block from aggregated metrics.
+type LlmAggregatedTotal map[string]any
+
+// LlmTopPagesItem is a cited page row from brand lookup.
+type LlmTopPagesItem map[string]any
+
+// LlmCrossAggregatedItem is one competitor group in share-of-voice analysis.
+type LlmCrossAggregatedItem map[string]any
+
+// LlmResponseResult is one model response from prompt explorer.
+type LlmResponseResult map[string]any
+
+// Accepted model names per provider slug. DataForSEO bills failed model_name
+// validation tasks, so the client rejects unknown names before dispatch.
+var acceptedLLMModelNames = map[LlmResponseModel]map[string]struct{}{
+	LlmResponseModelChatGPT: {
+		"gpt-5": {},
+	},
+	LlmResponseModelClaude: {
+		"claude-sonnet-4-5": {},
+		"claude-sonnet-4-6": {},
+	},
+	LlmResponseModelGemini: {
+		"gemini-2.5-pro": {},
+	},
+	LlmResponseModelPerplexity: {
+		"sonar-reasoning-pro": {},
+		"sonar-pro":           {},
+		"sonar":               {},
+	},
+}
+
+func validateLLMModelName(model LlmResponseModel, modelName string) error {
+	allowed, ok := acceptedLLMModelNames[model]
+	if !ok {
+		return newError(ErrorCodeValidation, "unsupported LLM response model slug", string(model), 0)
+	}
+	if _, ok := allowed[modelName]; !ok {
+		return newError(
+			ErrorCodeValidation,
+			fmt.Sprintf("unsupported DataForSEO model_name %q for %s", modelName, model),
+			string(model),
+			0,
+		)
+	}
+	return nil
+}

--- a/internal/dataforseo/types.go
+++ b/internal/dataforseo/types.go
@@ -34,10 +34,10 @@ const (
 
 // LlmDomainTarget scopes LLM mentions to a domain.
 type LlmDomainTarget struct {
-	Domain             string `json:"domain"`
-	IncludeSubdomains  *bool  `json:"include_subdomains,omitempty"`
-	SearchFilter       string `json:"search_filter,omitempty"`
-	SearchScope        []string `json:"search_scope,omitempty"`
+	Domain            string   `json:"domain"`
+	IncludeSubdomains *bool    `json:"include_subdomains,omitempty"`
+	SearchFilter      string   `json:"search_filter,omitempty"`
+	SearchScope       []string `json:"search_scope,omitempty"`
 }
 
 // LlmKeywordTarget scopes LLM mentions to a keyword.

--- a/internal/gsc/BUILD.bazel
+++ b/internal/gsc/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "gsc",
+    srcs = [
+        "client.go",
+        "config.go",
+        "daterange.go",
+        "doc.go",
+        "errors.go",
+        "scopes.go",
+        "searchanalytics.go",
+        "sites.go",
+        "types.go",
+        "urlinspection.go",
+        "userinfo.go",
+    ],
+    importpath = "github.com/hyperlocalise/hyperlocalise/internal/gsc",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_oauth2//:oauth2"],
+)
+
+go_test(
+    name = "gsc_test",
+    srcs = ["client_test.go"],
+    embed = [":gsc"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_oauth2//:oauth2",
+    ],
+)

--- a/internal/gsc/client.go
+++ b/internal/gsc/client.go
@@ -1,0 +1,122 @@
+package gsc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// Client is a low-level Google Search Console HTTP client.
+type Client struct {
+	tokenSource          oauth2.TokenSource
+	httpClient           *http.Client
+	webmastersBaseURL    string
+	urlInspectionBaseURL string
+	userInfoURL          string
+}
+
+// NewClient constructs a Search Console API client.
+func NewClient(cfg Config) (*Client, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return &Client{
+		tokenSource:          cfg.TokenSource,
+		httpClient:           cfg.httpClient(),
+		webmastersBaseURL:    cfg.webmastersBaseURL(),
+		urlInspectionBaseURL: cfg.urlInspectionBaseURL(),
+		userInfoURL:          cfg.userInfoURL(),
+	}, nil
+}
+
+// NewClientWithHTTPClient is primarily for tests and custom transport wiring.
+func NewClientWithHTTPClient(cfg Config, httpClient *http.Client) (*Client, error) {
+	if httpClient == nil {
+		return nil, fmt.Errorf("gsc: http client must not be nil")
+	}
+	client, err := NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	client.httpClient = httpClient
+	return client, nil
+}
+
+func (c *Client) request(ctx context.Context, method, url string, body any, out any) error {
+	var payload io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("gsc: marshal request: %w", err)
+		}
+		payload = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, payload)
+	if err != nil {
+		return fmt.Errorf("gsc: build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	token, err := c.tokenSource.Token()
+	if err != nil {
+		return newError(
+			ErrorCodeAuthFailed,
+			"Could not mint a Search Console access token (grant revoked or expired).",
+			req.URL.Path,
+			0,
+			err.Error(),
+		)
+	}
+	if strings.TrimSpace(token.AccessToken) == "" {
+		return newError(
+			ErrorCodeAuthFailed,
+			"Search Console returned no access token (grant revoked or expired).",
+			req.URL.Path,
+			0,
+			"",
+		)
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return httpError(resp.StatusCode, req.URL.Path, string(responseBody))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(responseBody, out); err != nil {
+		return newError(
+			ErrorCodeAPI,
+			"Search Console returned invalid JSON",
+			req.URL.Path,
+			resp.StatusCode,
+			string(responseBody),
+		)
+	}
+	return nil
+}
+
+func encodeSiteURL(siteURL string) string {
+	// Match encodeURIComponent so both sc-domain: and URL-prefix properties work.
+	return strings.ReplaceAll(url.QueryEscape(siteURL), "+", "%20")
+}

--- a/internal/gsc/client.go
+++ b/internal/gsc/client.go
@@ -92,7 +92,7 @@ func (c *Client) request(ctx context.Context, method, url string, body any, out 
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/gsc/client_test.go
+++ b/internal/gsc/client_test.go
@@ -155,6 +155,35 @@ func TestHTTPErrorMapping(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, typed.StatusCode)
 }
 
+func TestHTTPQuotaErrorMapping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{
+			"error": {
+				"code": 403,
+				"message": "Quota exceeded for quota metric 'Queries' and limit 'Queries per day' of service 'searchconsole.googleapis.com'",
+				"status": "RESOURCE_EXHAUSTED",
+				"errors": [{"reason": "rateLimitExceeded"}]
+			}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gsc.NewClientWithHTTPClient(gsc.Config{
+		TokenSource:       oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok_123"}),
+		WebmastersBaseURL: server.URL,
+	}, server.Client())
+	require.NoError(t, err)
+
+	_, err = client.ListSites(t.Context())
+	require.Error(t, err)
+
+	typed, ok := gsc.AsError(err)
+	require.True(t, ok)
+	require.Equal(t, gsc.ErrorCodeRateLimited, typed.Code)
+	require.Equal(t, http.StatusForbidden, typed.StatusCode)
+}
+
 func TestBuildSearchAnalyticsRequestWrapsFilters(t *testing.T) {
 	today := time.Date(2026, 1, 31, 12, 0, 0, 0, time.UTC)
 	request := gsc.BuildSearchAnalyticsRequest(gsc.PerformanceInput{
@@ -167,7 +196,7 @@ func TestBuildSearchAnalyticsRequestWrapsFilters(t *testing.T) {
 	}, today)
 
 	require.Equal(t, "2026-01-28", request.EndDate)
-	require.Equal(t, "2025-12-31", request.StartDate)
+	require.Equal(t, "2026-01-01", request.StartDate)
 	require.Len(t, request.DimensionFilterGroups, 1)
 	require.Equal(t, "and", request.DimensionFilterGroups[0].GroupType)
 	require.Equal(t, "pricing", request.DimensionFilterGroups[0].Filters[0].Expression)

--- a/internal/gsc/client_test.go
+++ b/internal/gsc/client_test.go
@@ -12,16 +12,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func testClient(t *testing.T, server *httptest.Server) *gsc.Client {
-	t.Helper()
-
-	client, err := gsc.NewClientWithHTTPClient(gsc.Config{
-		TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok_123"}),
-	}, server.Client())
-	require.NoError(t, err)
-	return client
-}
-
 func TestNewClientRequiresTokenSource(t *testing.T) {
 	_, err := gsc.NewClient(gsc.Config{})
 	require.Error(t, err)

--- a/internal/gsc/client_test.go
+++ b/internal/gsc/client_test.go
@@ -1,0 +1,195 @@
+package gsc_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/gsc"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func testClient(t *testing.T, server *httptest.Server) *gsc.Client {
+	t.Helper()
+
+	client, err := gsc.NewClientWithHTTPClient(gsc.Config{
+		TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok_123"}),
+	}, server.Client())
+	require.NoError(t, err)
+	return client
+}
+
+func TestNewClientRequiresTokenSource(t *testing.T) {
+	_, err := gsc.NewClient(gsc.Config{})
+	require.Error(t, err)
+}
+
+func TestListSites(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/sites", r.URL.Path)
+		require.Equal(t, "Bearer tok_123", r.Header.Get("Authorization"))
+
+		_, _ = w.Write([]byte(`{
+			"siteEntry": [{"siteUrl":"https://x/","permissionLevel":"siteOwner"}]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gsc.NewClientWithHTTPClient(gsc.Config{
+		TokenSource:       oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok_123"}),
+		WebmastersBaseURL: server.URL,
+	}, server.Client())
+	require.NoError(t, err)
+
+	sites, err := client.ListSites(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sites, 1)
+	require.Equal(t, "https://x/", sites[0].SiteURL)
+	require.Equal(t, "siteOwner", sites[0].PermissionLevel)
+}
+
+func TestUserInfoEmail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/userinfo", r.URL.Path)
+		_, _ = w.Write([]byte(`{"email":"client@example.com"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gsc.NewClientWithHTTPClient(gsc.Config{
+		TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok_123"}),
+		UserInfoURL: server.URL + "/v1/userinfo",
+	}, server.Client())
+	require.NoError(t, err)
+
+	email, err := client.UserInfoEmail(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "client@example.com", email)
+}
+
+func TestQuerySearchAnalyticsEncodesSiteURL(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.String())
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var body gsc.SearchAnalyticsRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "2026-01-01", body.StartDate)
+		require.Equal(t, "2026-01-28", body.EndDate)
+
+		_, _ = w.Write([]byte(`{"rows":[{"keys":["seo"],"clicks":1,"impressions":10,"ctr":0.1,"position":3.2}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gsc.NewClientWithHTTPClient(gsc.Config{
+		TokenSource:       oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok_123"}),
+		WebmastersBaseURL: server.URL,
+	}, server.Client())
+	require.NoError(t, err)
+
+	_, err = client.QuerySearchAnalytics(t.Context(), "sc-domain:example.com", gsc.SearchAnalyticsRequest{
+		StartDate: "2026-01-01",
+		EndDate:   "2026-01-28",
+	})
+	require.NoError(t, err)
+
+	_, err = client.QuerySearchAnalytics(t.Context(), "https://example.com/", gsc.SearchAnalyticsRequest{
+		StartDate: "2026-01-01",
+		EndDate:   "2026-01-28",
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, paths[0], "/sites/sc-domain%3Aexample.com/searchAnalytics/query")
+	require.Contains(t, paths[1], "/sites/https%3A%2F%2Fexample.com%2F/searchAnalytics/query")
+}
+
+func TestInspectURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/urlInspection/index:inspect", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var body gsc.InspectURLRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "sc-domain:example.com", body.SiteURL)
+		require.Equal(t, "https://example.com/post", body.InspectionURL)
+		require.Equal(t, "en-US", body.LanguageCode)
+
+		_, _ = w.Write([]byte(`{
+			"inspectionResult": {
+				"indexStatusResult": {"verdict":"PASS","coverageState":"Indexed"}
+			}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gsc.NewClientWithHTTPClient(gsc.Config{
+		TokenSource:          oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok_123"}),
+		URLInspectionBaseURL: server.URL + "/v1",
+	}, server.Client())
+	require.NoError(t, err)
+
+	result, err := client.InspectURL(
+		t.Context(),
+		"sc-domain:example.com",
+		"https://example.com/post",
+		"en-US",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "PASS", result.IndexStatusResult.Verdict)
+}
+
+func TestHTTPErrorMapping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gsc.NewClientWithHTTPClient(gsc.Config{
+		TokenSource:       oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok_123"}),
+		WebmastersBaseURL: server.URL,
+	}, server.Client())
+	require.NoError(t, err)
+
+	_, err = client.ListSites(t.Context())
+	require.Error(t, err)
+
+	typed, ok := gsc.AsError(err)
+	require.True(t, ok)
+	require.Equal(t, gsc.ErrorCodeAuthFailed, typed.Code)
+	require.Equal(t, http.StatusForbidden, typed.StatusCode)
+}
+
+func TestBuildSearchAnalyticsRequestWrapsFilters(t *testing.T) {
+	today := time.Date(2026, 1, 31, 12, 0, 0, 0, time.UTC)
+	request := gsc.BuildSearchAnalyticsRequest(gsc.PerformanceInput{
+		Filters: []gsc.DimensionFilter{{
+			Dimension:  gsc.DimensionQuery,
+			Operator:   gsc.FilterOperatorContains,
+			Expression: "pricing",
+		}},
+		DateRange: gsc.DateRangeLast28Days,
+	}, today)
+
+	require.Equal(t, "2026-01-28", request.EndDate)
+	require.Equal(t, "2025-12-31", request.StartDate)
+	require.Len(t, request.DimensionFilterGroups, 1)
+	require.Equal(t, "and", request.DimensionFilterGroups[0].GroupType)
+	require.Equal(t, "pricing", request.DimensionFilterGroups[0].Filters[0].Expression)
+}
+
+func TestResolveDateRangeClampsToSixteenMonths(t *testing.T) {
+	today := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+	start, end := gsc.ResolveDateRange(gsc.PerformanceInput{
+		StartDate: "2020-01-01",
+		EndDate:   "2026-01-28",
+	}, today)
+
+	require.Equal(t, "2024-09-30", start)
+	require.Equal(t, "2026-01-28", end)
+}

--- a/internal/gsc/config.go
+++ b/internal/gsc/config.go
@@ -1,0 +1,74 @@
+package gsc
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+const (
+	defaultWebmastersBaseURL    = "https://www.googleapis.com/webmasters/v3"
+	defaultURLInspectionBaseURL = "https://searchconsole.googleapis.com/v1"
+	defaultUserInfoURL          = "https://openidconnect.googleapis.com/v1/userinfo"
+	defaultRequestTimeout       = 30 * time.Second
+)
+
+// Config holds transport settings and OAuth credentials for the GSC client.
+type Config struct {
+	TokenSource oauth2.TokenSource
+
+	HTTPClient *http.Client
+
+	WebmastersBaseURL    string
+	URLInspectionBaseURL string
+	UserInfoURL          string
+	Timeout              time.Duration
+}
+
+func (c Config) validate() error {
+	if c.TokenSource == nil {
+		return fmt.Errorf("gsc: token source is required")
+	}
+	return nil
+}
+
+func (c Config) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	timeout := c.Timeout
+	if timeout <= 0 {
+		timeout = defaultRequestTimeout
+	}
+	return &http.Client{Timeout: timeout}
+}
+
+func (c Config) webmastersBaseURL() string {
+	if trimmed := trimRightSlash(c.WebmastersBaseURL); trimmed != "" {
+		return trimmed
+	}
+	return defaultWebmastersBaseURL
+}
+
+func (c Config) urlInspectionBaseURL() string {
+	if trimmed := trimRightSlash(c.URLInspectionBaseURL); trimmed != "" {
+		return trimmed
+	}
+	return defaultURLInspectionBaseURL
+}
+
+func (c Config) userInfoURL() string {
+	if trimmed := trimRightSlash(c.UserInfoURL); trimmed != "" {
+		return trimmed
+	}
+	return defaultUserInfoURL
+}
+
+func trimRightSlash(value string) string {
+	for len(value) > 0 && value[len(value)-1] == '/' {
+		value = value[:len(value)-1]
+	}
+	return value
+}

--- a/internal/gsc/daterange.go
+++ b/internal/gsc/daterange.go
@@ -1,0 +1,173 @@
+package gsc
+
+import "time"
+
+// Search Analytics option sets shared with API callers.
+const (
+	DimensionQuery            = "query"
+	DimensionPage             = "page"
+	DimensionCountry          = "country"
+	DimensionDevice           = "device"
+	DimensionDate             = "date"
+	DimensionSearchAppearance = "searchAppearance"
+
+	FilterOperatorEquals      = "equals"
+	FilterOperatorNotEquals   = "notEquals"
+	FilterOperatorContains    = "contains"
+	FilterOperatorNotContains = "notContains"
+
+	SearchTypeWeb        = "web"
+	SearchTypeImage      = "image"
+	SearchTypeVideo      = "video"
+	SearchTypeNews       = "news"
+	SearchTypeGoogleNews = "googleNews"
+	SearchTypeDiscover   = "discover"
+
+	DataStateAll   = "all"
+	DataStateFinal = "final"
+
+	DefaultRowLimit = 1000
+	MaxRowLimit     = 1000
+	DataLagDays     = 3
+)
+
+// DateRange is a convenience preset for Search Analytics queries.
+type DateRange string
+
+const (
+	DateRangeLast7Days    DateRange = "last_7_days"
+	DateRangeLast28Days   DateRange = "last_28_days"
+	DateRangeLast3Months  DateRange = "last_3_months"
+	DateRangeLast6Months  DateRange = "last_6_months"
+	DateRangeLast12Months DateRange = "last_12_months"
+	DateRangeLast16Months DateRange = "last_16_months"
+)
+
+// PerformanceInput is a higher-level request shape for Search Analytics.
+type PerformanceInput struct {
+	Dimensions []string
+	DateRange  DateRange
+	StartDate  string
+	EndDate    string
+	Filters    []DimensionFilter
+	RowLimit   int
+	StartRow   int
+	Type       string
+	DataState  string
+}
+
+// BuildSearchAnalyticsRequest converts validated input into a GSC API request.
+// Flat filters are wrapped into dimensionFilterGroups because GSC silently
+// ignores a top-level filters field.
+func BuildSearchAnalyticsRequest(input PerformanceInput, today time.Time) SearchAnalyticsRequest {
+	if today.IsZero() {
+		today = time.Now().UTC()
+	}
+
+	startDate, endDate := ResolveDateRange(input, today)
+	dimensions := input.Dimensions
+	if len(dimensions) == 0 {
+		dimensions = []string{DimensionQuery}
+	}
+
+	request := SearchAnalyticsRequest{
+		StartDate:  startDate,
+		EndDate:    endDate,
+		Dimensions: dimensions,
+		RowLimit:   clampLimit(input.RowLimit, 1, MaxRowLimit, DefaultRowLimit),
+		Type:       defaultString(input.Type, SearchTypeWeb),
+		DataState:  defaultString(input.DataState, DataStateAll),
+	}
+	if input.StartRow > 0 {
+		request.StartRow = input.StartRow
+	}
+	if len(input.Filters) > 0 {
+		request.DimensionFilterGroups = []DimensionFilterGroup{{
+			GroupType: "and",
+			Filters:   input.Filters,
+		}}
+	}
+	return request
+}
+
+// ResolveDateRange resolves a convenience date range or explicit start/end into
+// GSC dates. today is injectable for deterministic tests.
+func ResolveDateRange(input PerformanceInput, today time.Time) (startDate, endDate string) {
+	floor := formatDate(subtractUTCMonths(today, 16))
+
+	if input.StartDate != "" && input.EndDate != "" {
+		start := input.StartDate
+		if start < floor {
+			start = floor
+		}
+		return start, input.EndDate
+	}
+
+	end := today.UTC()
+	end = end.AddDate(0, 0, -DataLagDays)
+	start := subtractRange(end, input.DateRange)
+	startStr := formatDate(start)
+	if startStr < floor {
+		startStr = floor
+	}
+	return startStr, formatDate(end)
+}
+
+func subtractRange(end time.Time, dateRange DateRange) time.Time {
+	switch dateRange {
+	case DateRangeLast7Days:
+		return end.AddDate(0, 0, -7)
+	case DateRangeLast28Days:
+		return end.AddDate(0, 0, -28)
+	case DateRangeLast3Months:
+		return subtractUTCMonths(end, 3)
+	case DateRangeLast6Months:
+		return subtractUTCMonths(end, 6)
+	case DateRangeLast12Months:
+		return subtractUTCMonths(end, 12)
+	case DateRangeLast16Months:
+		return subtractUTCMonths(end, 16)
+	default:
+		return end.AddDate(0, 0, -28)
+	}
+}
+
+func subtractUTCMonths(date time.Time, months int) time.Time {
+	year, month, day := date.Date()
+	target := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC).AddDate(0, -months, 0)
+	daysInTargetMonth := time.Date(
+		target.Year(),
+		target.Month()+1,
+		0,
+		0, 0, 0, 0,
+		time.UTC,
+	).Day()
+	if day > daysInTargetMonth {
+		day = daysInTargetMonth
+	}
+	return time.Date(target.Year(), target.Month(), day, 0, 0, 0, 0, time.UTC)
+}
+
+func formatDate(date time.Time) string {
+	return date.UTC().Format("2006-01-02")
+}
+
+func clampLimit(value, min, max, fallback int) int {
+	if value <= 0 {
+		value = fallback
+	}
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func defaultString(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/gsc/daterange.go
+++ b/internal/gsc/daterange.go
@@ -116,9 +116,9 @@ func ResolveDateRange(input PerformanceInput, today time.Time) (startDate, endDa
 func subtractRange(end time.Time, dateRange DateRange) time.Time {
 	switch dateRange {
 	case DateRangeLast7Days:
-		return end.AddDate(0, 0, -7)
+		return end.AddDate(0, 0, -6)
 	case DateRangeLast28Days:
-		return end.AddDate(0, 0, -28)
+		return end.AddDate(0, 0, -27)
 	case DateRangeLast3Months:
 		return subtractUTCMonths(end, 3)
 	case DateRangeLast6Months:
@@ -128,7 +128,7 @@ func subtractRange(end time.Time, dateRange DateRange) time.Time {
 	case DateRangeLast16Months:
 		return subtractUTCMonths(end, 16)
 	default:
-		return end.AddDate(0, 0, -28)
+		return end.AddDate(0, 0, -27)
 	}
 }
 

--- a/internal/gsc/doc.go
+++ b/internal/gsc/doc.go
@@ -1,0 +1,12 @@
+// Package gsc provides a typed HTTP client for the Google Search Console API.
+//
+// The client covers the endpoints needed for Domains SEO features:
+//   - listing verified properties
+//   - Search Analytics performance queries
+//   - URL Inspection
+//
+// Authentication is OAuth 2.0. Pass an oauth2.TokenSource minted by the web
+// app's Google Search Console connection; this package does not store or refresh
+// tokens itself. Unlike DataForSEO, GSC calls are free and carry no billing
+// metadata.
+package gsc

--- a/internal/gsc/errors.go
+++ b/internal/gsc/errors.go
@@ -1,6 +1,7 @@
 package gsc
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -51,7 +52,12 @@ func httpError(statusCode int, path, body string) *Error {
 	message := messageForStatus(statusCode, body)
 
 	switch {
-	case statusCode == 401 || statusCode == 403:
+	case statusCode == 401:
+		return newError(ErrorCodeAuthFailed, message, path, statusCode, body)
+	case statusCode == 403:
+		if isQuotaRelatedError(body) {
+			return newError(ErrorCodeRateLimited, message, path, statusCode, body)
+		}
 		return newError(ErrorCodeAuthFailed, message, path, statusCode, body)
 	case statusCode == 404:
 		return newError(ErrorCodeNotFound, message, path, statusCode, body)
@@ -64,9 +70,60 @@ func httpError(statusCode int, path, body string) *Error {
 	}
 }
 
+func isQuotaRelatedError(body string) bool {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return false
+	}
+
+	var payload struct {
+		Error struct {
+			Errors []struct {
+				Reason string `json:"reason"`
+			} `json:"errors"`
+			Status string `json:"status"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+		return containsQuotaSignal(trimmed)
+	}
+
+	if payload.Error.Status == "RESOURCE_EXHAUSTED" {
+		return true
+	}
+	for _, item := range payload.Error.Errors {
+		if containsQuotaSignal(item.Reason) {
+			return true
+		}
+	}
+	return containsQuotaSignal(trimmed)
+}
+
+func containsQuotaSignal(value string) bool {
+	lower := strings.ToLower(value)
+	quotaSignals := []string{
+		"ratelimitexceeded",
+		"userratelimitexceeded",
+		"quotaexceeded",
+		"dailylimitexceeded",
+		"resource_exhausted",
+		"quota metric",
+		"rate limit",
+	}
+	for _, signal := range quotaSignals {
+		if strings.Contains(lower, signal) {
+			return true
+		}
+	}
+	return false
+}
+
 func messageForStatus(status int, body string) string {
 	switch status {
 	case 401, 403:
+		if status == 403 && isQuotaRelatedError(body) {
+			return "Search Console rate limit reached. Retry shortly."
+		}
 		return "Search Console denied access to this property (no verified permission, or the connection was revoked)."
 	case 429:
 		return "Search Console rate limit reached. Retry shortly."

--- a/internal/gsc/errors.go
+++ b/internal/gsc/errors.go
@@ -1,0 +1,99 @@
+package gsc
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrorCode classifies Search Console client failures for callers.
+type ErrorCode string
+
+const (
+	ErrorCodeAuthFailed          ErrorCode = "gsc_auth_failed"
+	ErrorCodeRateLimited         ErrorCode = "gsc_rate_limited"
+	ErrorCodeNotFound            ErrorCode = "gsc_not_found"
+	ErrorCodeUpstreamUnavailable ErrorCode = "gsc_upstream_unavailable"
+	ErrorCodeValidation          ErrorCode = "gsc_validation_error"
+	ErrorCodeAPI                 ErrorCode = "gsc_api_error"
+)
+
+// Error is a typed Search Console client error.
+type Error struct {
+	Code       ErrorCode
+	Message    string
+	StatusCode int
+	Path       string
+	Body       string
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Path != "" {
+		return fmt.Sprintf("%s: %s (%s)", e.Code, e.Message, e.Path)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func newError(code ErrorCode, message, path string, statusCode int, body string) *Error {
+	return &Error{
+		Code:       code,
+		Message:    message,
+		StatusCode: statusCode,
+		Path:       path,
+		Body:       body,
+	}
+}
+
+func httpError(statusCode int, path, body string) *Error {
+	message := messageForStatus(statusCode, body)
+
+	switch {
+	case statusCode == 401 || statusCode == 403:
+		return newError(ErrorCodeAuthFailed, message, path, statusCode, body)
+	case statusCode == 404:
+		return newError(ErrorCodeNotFound, message, path, statusCode, body)
+	case statusCode == 429:
+		return newError(ErrorCodeRateLimited, message, path, statusCode, body)
+	case statusCode >= 500:
+		return newError(ErrorCodeUpstreamUnavailable, message, path, statusCode, body)
+	default:
+		return newError(ErrorCodeAPI, message, path, statusCode, body)
+	}
+}
+
+func messageForStatus(status int, body string) string {
+	switch status {
+	case 401, 403:
+		return "Search Console denied access to this property (no verified permission, or the connection was revoked)."
+	case 429:
+		return "Search Console rate limit reached. Retry shortly."
+	case 404:
+		return "Search Console property not found. It may have been removed in Search Console."
+	default:
+		snippet := truncate(body, 300)
+		if snippet == "" {
+			return fmt.Sprintf("Search Console API error (%d)", status)
+		}
+		return fmt.Sprintf("Search Console API error (%d): %s", status, snippet)
+	}
+}
+
+func truncate(value string, max int) string {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) <= max {
+		return trimmed
+	}
+	return trimmed[:max] + "..."
+}
+
+// AsError unwraps a *Error from err.
+func AsError(err error) (*Error, bool) {
+	var typed *Error
+	if errors.As(err, &typed) {
+		return typed, true
+	}
+	return nil, false
+}

--- a/internal/gsc/scopes.go
+++ b/internal/gsc/scopes.go
@@ -6,10 +6,10 @@ const OAuthProviderID = "google-search-console"
 
 // OAuth scopes requested when connecting Search Console.
 const (
-	ScopeOpenID              = "openid"
-	ScopeEmail               = "email"
-	ScopeProfile             = "profile"
-	ScopeWebmastersReadonly  = "https://www.googleapis.com/auth/webmasters.readonly"
+	ScopeOpenID             = "openid"
+	ScopeEmail              = "email"
+	ScopeProfile            = "profile"
+	ScopeWebmastersReadonly = "https://www.googleapis.com/auth/webmasters.readonly"
 )
 
 // OAuthScopes is the full scope set for a Search Console connection.

--- a/internal/gsc/scopes.go
+++ b/internal/gsc/scopes.go
@@ -1,0 +1,21 @@
+package gsc
+
+// OAuthProviderID is the Better Auth / provider identifier for incremental
+// Google Search Console connections in Hyperlocalise.
+const OAuthProviderID = "google-search-console"
+
+// OAuth scopes requested when connecting Search Console.
+const (
+	ScopeOpenID              = "openid"
+	ScopeEmail               = "email"
+	ScopeProfile             = "profile"
+	ScopeWebmastersReadonly  = "https://www.googleapis.com/auth/webmasters.readonly"
+)
+
+// OAuthScopes is the full scope set for a Search Console connection.
+var OAuthScopes = []string{
+	ScopeOpenID,
+	ScopeEmail,
+	ScopeProfile,
+	ScopeWebmastersReadonly,
+}

--- a/internal/gsc/searchanalytics.go
+++ b/internal/gsc/searchanalytics.go
@@ -1,0 +1,47 @@
+package gsc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// QuerySearchAnalytics runs searchAnalytics.query for a property. siteURL is
+// passed verbatim (for example sc-domain:example.com or https://example.com/).
+func (c *Client) QuerySearchAnalytics(
+	ctx context.Context,
+	siteURL string,
+	request SearchAnalyticsRequest,
+) ([]SearchAnalyticsRow, error) {
+	if err := validateSearchAnalyticsRequest(request); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf(
+		"%s/sites/%s/searchAnalytics/query",
+		c.webmastersBaseURL,
+		encodeSiteURL(siteURL),
+	)
+
+	var response SearchAnalyticsResponse
+	if err := c.request(ctx, http.MethodPost, path, request, &response); err != nil {
+		return nil, err
+	}
+	if response.Rows == nil {
+		return []SearchAnalyticsRow{}, nil
+	}
+	return response.Rows, nil
+}
+
+func validateSearchAnalyticsRequest(request SearchAnalyticsRequest) error {
+	if request.StartDate == "" || request.EndDate == "" {
+		return newError(
+			ErrorCodeValidation,
+			"startDate and endDate are required",
+			"/searchAnalytics/query",
+			0,
+			"",
+		)
+	}
+	return nil
+}

--- a/internal/gsc/sites.go
+++ b/internal/gsc/sites.go
@@ -1,0 +1,22 @@
+package gsc
+
+import (
+	"context"
+	"net/http"
+)
+
+type listSitesResponse struct {
+	SiteEntry []Site `json:"siteEntry"`
+}
+
+// ListSites returns verified properties on the connected grant.
+func (c *Client) ListSites(ctx context.Context) ([]Site, error) {
+	var response listSitesResponse
+	if err := c.request(ctx, http.MethodGet, c.webmastersBaseURL+"/sites", nil, &response); err != nil {
+		return nil, err
+	}
+	if response.SiteEntry == nil {
+		return []Site{}, nil
+	}
+	return response.SiteEntry, nil
+}

--- a/internal/gsc/types.go
+++ b/internal/gsc/types.go
@@ -2,8 +2,8 @@ package gsc
 
 // Site is a verified Search Console property on the connected grant.
 type Site struct {
-	SiteURL          string `json:"siteUrl"`
-	PermissionLevel  string `json:"permissionLevel"`
+	SiteURL         string `json:"siteUrl"`
+	PermissionLevel string `json:"permissionLevel"`
 }
 
 // PermissionSiteUnverifiedUser is returned for properties the grant can see but
@@ -52,17 +52,17 @@ type SearchAnalyticsResponse struct {
 
 // InspectURLRequest is the body for urlInspection.index.inspect.
 type InspectURLRequest struct {
-	SiteURL        string `json:"siteUrl"`
-	InspectionURL  string `json:"inspectionUrl"`
-	LanguageCode   string `json:"languageCode,omitempty"`
+	SiteURL       string `json:"siteUrl"`
+	InspectionURL string `json:"inspectionUrl"`
+	LanguageCode  string `json:"languageCode,omitempty"`
 }
 
 // URLInspectionResult is the subset of the inspection API result we surface.
 type URLInspectionResult struct {
-	IndexStatusResult      *IndexStatusResult      `json:"indexStatusResult,omitempty"`
-	MobileUsabilityResult  *VerdictResult          `json:"mobileUsabilityResult,omitempty"`
-	RichResultsResult      *VerdictResult          `json:"richResultsResult,omitempty"`
-	InspectionResultLink   string                  `json:"inspectionResultLink,omitempty"`
+	IndexStatusResult     *IndexStatusResult `json:"indexStatusResult,omitempty"`
+	MobileUsabilityResult *VerdictResult     `json:"mobileUsabilityResult,omitempty"`
+	RichResultsResult     *VerdictResult     `json:"richResultsResult,omitempty"`
+	InspectionResultLink  string             `json:"inspectionResultLink,omitempty"`
 }
 
 // IndexStatusResult captures index coverage details for an inspected URL.

--- a/internal/gsc/types.go
+++ b/internal/gsc/types.go
@@ -1,0 +1,91 @@
+package gsc
+
+// Site is a verified Search Console property on the connected grant.
+type Site struct {
+	SiteURL          string `json:"siteUrl"`
+	PermissionLevel  string `json:"permissionLevel"`
+}
+
+// PermissionSiteUnverifiedUser is returned for properties the grant can see but
+// cannot query.
+const PermissionSiteUnverifiedUser = "siteUnverifiedUser"
+
+// SearchAnalyticsRow is one row from searchAnalytics.query.
+type SearchAnalyticsRow struct {
+	Keys        []string `json:"keys,omitempty"`
+	Clicks      float64  `json:"clicks"`
+	Impressions float64  `json:"impressions"`
+	CTR         float64  `json:"ctr"`
+	Position    float64  `json:"position"`
+}
+
+// DimensionFilter filters rows in a Search Analytics query.
+type DimensionFilter struct {
+	Dimension  string `json:"dimension"`
+	Operator   string `json:"operator"`
+	Expression string `json:"expression"`
+}
+
+// DimensionFilterGroup combines filters with AND/OR logic.
+type DimensionFilterGroup struct {
+	GroupType string            `json:"groupType"`
+	Filters   []DimensionFilter `json:"filters"`
+}
+
+// SearchAnalyticsRequest is the body for searchAnalytics.query.
+type SearchAnalyticsRequest struct {
+	StartDate             string                 `json:"startDate"`
+	EndDate               string                 `json:"endDate"`
+	Dimensions            []string               `json:"dimensions,omitempty"`
+	DimensionFilterGroups []DimensionFilterGroup `json:"dimensionFilterGroups,omitempty"`
+	RowLimit              int                    `json:"rowLimit,omitempty"`
+	StartRow              int                    `json:"startRow,omitempty"`
+	Type                  string                 `json:"type,omitempty"`
+	DataState             string                 `json:"dataState,omitempty"`
+	AggregationType       string                 `json:"aggregationType,omitempty"`
+}
+
+// SearchAnalyticsResponse is the searchAnalytics.query response envelope.
+type SearchAnalyticsResponse struct {
+	Rows []SearchAnalyticsRow `json:"rows,omitempty"`
+}
+
+// InspectURLRequest is the body for urlInspection.index.inspect.
+type InspectURLRequest struct {
+	SiteURL        string `json:"siteUrl"`
+	InspectionURL  string `json:"inspectionUrl"`
+	LanguageCode   string `json:"languageCode,omitempty"`
+}
+
+// URLInspectionResult is the subset of the inspection API result we surface.
+type URLInspectionResult struct {
+	IndexStatusResult      *IndexStatusResult      `json:"indexStatusResult,omitempty"`
+	MobileUsabilityResult  *VerdictResult          `json:"mobileUsabilityResult,omitempty"`
+	RichResultsResult      *VerdictResult          `json:"richResultsResult,omitempty"`
+	InspectionResultLink   string                  `json:"inspectionResultLink,omitempty"`
+}
+
+// IndexStatusResult captures index coverage details for an inspected URL.
+type IndexStatusResult struct {
+	Verdict         string   `json:"verdict,omitempty"`
+	CoverageState   string   `json:"coverageState,omitempty"`
+	RobotsTxtState  string   `json:"robotsTxtState,omitempty"`
+	IndexingState   string   `json:"indexingState,omitempty"`
+	LastCrawlTime   string   `json:"lastCrawlTime,omitempty"`
+	PageFetchState  string   `json:"pageFetchState,omitempty"`
+	GoogleCanonical string   `json:"googleCanonical,omitempty"`
+	UserCanonical   string   `json:"userCanonical,omitempty"`
+	CrawledAs       string   `json:"crawledAs,omitempty"`
+	Sitemap         []string `json:"sitemap,omitempty"`
+	ReferringURLs   []string `json:"referringUrls,omitempty"`
+}
+
+// VerdictResult is a simple pass/fail verdict block.
+type VerdictResult struct {
+	Verdict string `json:"verdict,omitempty"`
+}
+
+// UserInfo holds the OpenID Connect userinfo fields we read.
+type UserInfo struct {
+	Email string `json:"email"`
+}

--- a/internal/gsc/urlinspection.go
+++ b/internal/gsc/urlinspection.go
@@ -1,0 +1,100 @@
+package gsc
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+type inspectURLResponse struct {
+	InspectionResult *URLInspectionResult `json:"inspectionResult"`
+}
+
+// InspectURL runs urlInspection.index.inspect for a single URL.
+func (c *Client) InspectURL(
+	ctx context.Context,
+	siteURL string,
+	inspectionURL string,
+	languageCode string,
+) (*URLInspectionResult, error) {
+	siteURL = strings.TrimSpace(siteURL)
+	inspectionURL = strings.TrimSpace(inspectionURL)
+	if siteURL == "" || inspectionURL == "" {
+		return nil, newError(
+			ErrorCodeValidation,
+			"siteUrl and inspectionUrl are required",
+			"/urlInspection/index:inspect",
+			0,
+			"",
+		)
+	}
+
+	body := InspectURLRequest{
+		SiteURL:       siteURL,
+		InspectionURL: inspectionURL,
+	}
+	if trimmed := strings.TrimSpace(languageCode); trimmed != "" {
+		body.LanguageCode = trimmed
+	}
+
+	path := c.urlInspectionBaseURL + "/urlInspection/index:inspect"
+	var response inspectURLResponse
+	if err := c.request(ctx, http.MethodPost, path, body, &response); err != nil {
+		return nil, err
+	}
+	if response.InspectionResult == nil {
+		return nil, nil
+	}
+	return response.InspectionResult, nil
+}
+
+// InspectURLs inspects up to maxURLs URLs, returning per-URL results. Errors for
+// individual URLs are returned in the result slice; a connection-level failure
+// aborts the whole call.
+func (c *Client) InspectURLs(
+	ctx context.Context,
+	siteURL string,
+	inspectionURLs []string,
+	languageCode string,
+) ([]URLInspectionOutcome, error) {
+	if len(inspectionURLs) == 0 {
+		return nil, newError(
+			ErrorCodeValidation,
+			"at least one inspection URL is required",
+			"/urlInspection/index:inspect",
+			0,
+			"",
+		)
+	}
+
+	outcomes := make([]URLInspectionOutcome, 0, len(inspectionURLs))
+	for _, inspectionURL := range inspectionURLs {
+		result, err := c.InspectURL(ctx, siteURL, inspectionURL, languageCode)
+		outcomes = append(outcomes, URLInspectionOutcome{
+			InspectionURL: inspectionURL,
+			Result:        result,
+			Error:         err,
+		})
+		if err != nil {
+			if typed, ok := AsError(err); ok && (typed.Code == ErrorCodeAuthFailed || typed.StatusCode == 401 || typed.StatusCode == 403) {
+				return outcomes, err
+			}
+		}
+	}
+	return outcomes, nil
+}
+
+// URLInspectionOutcome is one URL in a batch inspection call.
+type URLInspectionOutcome struct {
+	InspectionURL string
+	Result        *URLInspectionResult
+	Error         error
+}
+
+// ErrorString returns a human-readable error for the outcome, if any.
+func (o URLInspectionOutcome) ErrorString() string {
+	if o.Error == nil {
+		return ""
+	}
+	return o.Error.Error()
+}

--- a/internal/gsc/userinfo.go
+++ b/internal/gsc/userinfo.go
@@ -1,0 +1,20 @@
+package gsc
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+// UserInfoEmail returns the Google account email for the connected grant.
+func (c *Client) UserInfoEmail(ctx context.Context) (string, error) {
+	var response UserInfo
+	if err := c.request(ctx, http.MethodGet, c.userInfoURL, nil, &response); err != nil {
+		return "", err
+	}
+	email := strings.TrimSpace(response.Email)
+	if email == "" {
+		return "", nil
+	}
+	return email, nil
+}


### PR DESCRIPTION
## Summary
- Add `internal/dataforseo`, a typed Go client for keyword research, domain overview, SERP rank checks, and AI visibility endpoints.
- Add `internal/gsc`, a typed Go client for Search Console sites, search analytics, and URL inspection, using OAuth token sources.
- Document go-svc environment variables in `apps/go-svc/README.md`, including `DATAFORSEO_API_KEY` and Google OAuth setup for upcoming Search Console features.

## Test plan
- [x] `go test ./internal/dataforseo/...`
- [x] `go test ./internal/gsc/...`
- [x] `make fmt`


Made with [Cursor](https://cursor.com)