### PR TITLE
feat(web): improve CAT file view generate flow and layout

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -116,6 +116,7 @@ import {
   listFilteredProjectFiles,
 } from "@/lib/projects/files/project-file-service";
 import { enqueueSourceFileIngestAfterUpload } from "@/lib/projects/files/source-file-ingest";
+import { localizeAndStoreDocumentVariant } from "@/lib/projects/files/document-variant-service";
 import {
   localizeAndStoreImageVariant,
   projectImageAssetPath,
@@ -252,6 +253,7 @@ import {
   loadContentEditorSegmentVisualContext,
 } from "@/lib/translation/content-editor-core";
 import {
+  inferSupportedDocumentTranslationFileFormat,
   inferSupportedFileTranslationFileFormat,
   inferSupportedImageTranslationFileFormat,
   inferSupportedSourceUploadFormat,
@@ -2174,6 +2176,68 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
 
           const targetAssetUrl = result.value.storedFileId
             ? projectVideoAssetPath({
+                organizationSlug,
+                projectId: params.projectId,
+                fileId: result.value.storedFileId,
+              })
+            : null;
+
+          return c.json(
+            {
+              imageVariant: {
+                id: result.value.id,
+                status: result.value.status,
+                targetAssetUrl,
+                storedFileId: result.value.storedFileId,
+              },
+            },
+            200,
+          );
+        }
+
+        if (inferSupportedDocumentTranslationFileFormat(body.sourcePath)) {
+          const sourceFile = fileBackedSourceFile;
+          if (!sourceFile) {
+            return badRequestResponse(
+              c,
+              "source_file_not_found",
+              "Source file not found for the given path",
+            );
+          }
+
+          const latestVersion = await getLatestRepositorySourceFileVersion({
+            organizationId,
+            projectId: params.projectId,
+            sourcePath: body.sourcePath,
+          });
+          if (!latestVersion?.storedFileId) {
+            return badRequestResponse(
+              c,
+              "source_bytes_missing",
+              "Source document bytes are missing",
+            );
+          }
+
+          const result = await localizeAndStoreDocumentVariant({
+            organizationId,
+            projectId: params.projectId,
+            sourcePath: body.sourcePath,
+            targetLocale: body.targetLocale,
+            sourceLocale: project.sourceLocale,
+            sourceStoredFileId: latestVersion.storedFileId,
+            repositorySourceFileId: sourceFile.id,
+            instructions: body.instructions,
+            provenance: "agent",
+            createdByUserId: c.var.auth.user.localUserId,
+            force: body.force,
+          });
+
+          if (!result.ok) {
+            return badRequestResponse(c, result.error.code, "Document regeneration failed");
+          }
+
+          const targetAssetUrl = result.value.storedFileId
+            ? projectImageAssetPath({
                 organizationSlug,
                 projectId: params.projectId,
                 fileId: result.value.storedFileId,

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-file-viewer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-file-viewer.test.tsx
@@ -58,7 +58,9 @@ describe("ContentEditorDocumentFileViewerPane", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Translated document")).toHaveValue("# Hello from source\n");
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Hello from source" }),
+      ).toBeInTheDocument();
     });
 
     rerender(
@@ -102,9 +104,56 @@ describe("ContentEditorDocumentFileViewerPane", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Translated document")).toHaveValue("");
+      expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
     });
-    expect(screen.queryByDisplayValue("# Source body")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { level: 1, name: "Source body" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("saves markdown document edits on save", async () => {
+    const user = userEvent.setup();
+    const markdownBody = `---
+title: Guide
+---
+
+# Guide
+
+Translate this paragraph.
+`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(markdownBody, { status: 200 })),
+    );
+    const onSave = vi.fn<(file: File) => Promise<void>>(async () => undefined);
+
+    render(
+      <ContentEditorTestProviders>
+        <ContentEditorDocumentFileViewerPane
+          role="target"
+          src="https://example.com/guide.md"
+          filename="guide.md"
+          onSave={onSave}
+        />
+      </ContentEditorTestProviders>,
+    );
+
+    const titleField = await screen.findByLabelText("title");
+    expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
+    await screen.findByRole("heading", { level: 1, name: "Guide" });
+    await user.clear(titleField);
+    await user.type(titleField, "Updated Guide");
+    await user.click(screen.getByRole("button", { name: /save edits/i }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    const savedFile = onSave.mock.calls[0]?.[0];
+    expect(savedFile).toBeInstanceOf(File);
+    const savedText = await savedFile!.text();
+    expect(savedText).toContain("title: Updated Guide");
+    expect(savedText).toContain("# Guide");
+    expect(savedText).toContain("Translate this paragraph.");
   });
 
   it("preserves MDX JSX and raw HTML when saving after an edit", async () => {

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-file-viewer.tsx
@@ -23,13 +23,17 @@ import {
   type ContentEditorDocumentFrontmatterField,
 } from "@/components/content-editor/file-view/content-editor-document-frontmatter";
 import { contentEditorFileViewMessages } from "@/components/content-editor/file-view/content-editor-file-view.messages";
-import { MarkdownPreview } from "@/components/markdown-editor/markdown-editor";
+import { MarkdownEditor, MarkdownPreview } from "@/components/markdown-editor/markdown-editor";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
 export const CONTENT_EDITOR_DOCUMENT_FILE_UPLOAD_ACCEPT = ".md,.markdown,.mdx";
+
+function isMdxDocumentFilename(filename: string) {
+  return filename.toLowerCase().endsWith(".mdx");
+}
 
 type LoadedDocument = { status: "missing" } | { status: "ok"; text: string } | { status: "error" };
 
@@ -212,17 +216,25 @@ export function ContentEditorDocumentFileViewerPane({
             ) : null}
             {readOnly ? (
               <MarkdownPreview value={body} className="min-h-[16rem]" emptyMessage={emptyLabel} />
-            ) : (
+            ) : isMdxDocumentFilename(filename) ? (
               /*
-                Author edits in a raw textarea — not TipTap MarkdownEditor. TipTap's
-                getMarkdown() HTML-escapes angle brackets, which permanently corrupts
-                MDX/JSX and raw HTML on Save (e.g. <Callout> → &lt;Callout&gt;).
+                MDX keeps a raw textarea: TipTap getMarkdown() HTML-escapes angle brackets,
+                which corrupts JSX and raw HTML on save (e.g. <Callout> → &lt;Callout&gt;).
               */
               <Textarea
                 value={body}
                 onChange={(event) => setBody(event.currentTarget.value)}
                 aria-label={intl.formatMessage(contentEditorFileViewMessages.documentEditorAria)}
                 className="min-h-[16rem] resize-y font-mono text-sm leading-relaxed"
+              />
+            ) : (
+              <MarkdownEditor
+                key={`${role}-${src ?? seedSrc ?? "missing"}-${filename}`}
+                value={body}
+                onChange={setBody}
+                disabled={isBusy || isSaving}
+                ariaLabel={intl.formatMessage(contentEditorFileViewMessages.documentEditorAria)}
+                className="min-h-[16rem]"
               />
             )}
           </div>

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-msw-handlers.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { http, HttpResponse } from "msw";
+
+export const CAT_STORY_DOCUMENT_SOURCE_URL = "/storybook/cat/content/intro.source.md";
+export const CAT_STORY_DOCUMENT_TARGET_URL = "/storybook/cat/content/intro.target.md";
+export const CAT_STORY_DOCUMENT_MDX_SOURCE_URL = "/storybook/cat/content/guide.source.mdx";
+export const CAT_STORY_DOCUMENT_MDX_TARGET_URL = "/storybook/cat/content/guide.target.mdx";
+export const CAT_STORY_DOCUMENT_ERROR_TARGET_URL = "/storybook/cat/content/missing.target.md";
+
+export const catStoryDocumentSourceMarkdown = `---
+title: Getting started
+description: Intro to the product
+---
+
+# Getting started
+
+Welcome to the product guide.
+
+Use the dashboard to review translations.
+`;
+
+export const catStoryDocumentTargetMarkdown = `---
+title: Bắt đầu
+description: Giới thiệu sản phẩm
+---
+
+# Bắt đầu
+
+Chào mừng bạn đến với hướng dẫn sản phẩm.
+
+Sử dụng bảng điều khiển để xem xét bản dịch.
+`;
+
+export const catStoryDocumentMdxSourceMarkdown = `---
+title: Component guide
+---
+
+# Component guide
+
+<Callout type="info">Keep JSX intact when translating.</Callout>
+
+Press <kbd>Esc</kbd> to cancel.
+`;
+
+export const catStoryDocumentMdxTargetMarkdown = `---
+title: Hướng dẫn thành phần
+---
+
+# Hướng dẫn thành phần
+
+<Callout type="info">Giữ nguyên JSX khi dịch.</Callout>
+
+Nhấn <kbd>Esc</kbd> để hủy.
+`;
+
+function markdownResponse(text: string) {
+  return new HttpResponse(text, {
+    status: 200,
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}
+
+export const contentEditorDocumentMswHandlers = [
+  http.get(CAT_STORY_DOCUMENT_SOURCE_URL, () => markdownResponse(catStoryDocumentSourceMarkdown)),
+  http.get(CAT_STORY_DOCUMENT_TARGET_URL, () => markdownResponse(catStoryDocumentTargetMarkdown)),
+  http.get(CAT_STORY_DOCUMENT_MDX_SOURCE_URL, () =>
+    markdownResponse(catStoryDocumentMdxSourceMarkdown),
+  ),
+  http.get(CAT_STORY_DOCUMENT_MDX_TARGET_URL, () =>
+    markdownResponse(catStoryDocumentMdxTargetMarkdown),
+  ),
+  http.get(
+    CAT_STORY_DOCUMENT_ERROR_TARGET_URL,
+    () => new HttpResponse("not found", { status: 404 }),
+  ),
+];

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-generate-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-generate-dialog.test.tsx
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
 // @vitest-environment happy-dom
 
 import { render, screen } from "@testing-library/react";

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-generate-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-generate-dialog.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { ContentEditorTestProviders } from "@/components/content-editor/shared/content-editor-test-utils";
+
+import { ContentEditorFileGenerateDialog } from "./content-editor-file-generate-dialog";
+
+describe("ContentEditorFileGenerateDialog", () => {
+  it.each([
+    ["image", "translate on-screen text"],
+    ["video", "match the original pacing"],
+    ["markdown", "preserve MDX components"],
+    ["docx", "heading styles"],
+    ["xlsx", "formula cells"],
+    ["pptx", "slide layout"],
+  ] as const)("shows a file-type-specific placeholder for %s", (viewerId, snippet) => {
+    render(
+      <ContentEditorTestProviders>
+        <ContentEditorFileGenerateDialog
+          open
+          onOpenChange={vi.fn()}
+          mode="generate"
+          viewerId={viewerId}
+          onSubmit={vi.fn()}
+        />
+      </ContentEditorTestProviders>,
+    );
+
+    expect(screen.getByLabelText(/Instructions for the model/i)).toHaveAttribute(
+      "placeholder",
+      expect.stringContaining(snippet),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-generate-dialog.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-generate-dialog.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { ContentEditorFileViewerId } from "@/components/content-editor/workspace/content-editor-file-view-capabilities";
+
+import {
+  contentEditorFileGeneratePromptPlaceholderMessage,
+  contentEditorFileViewMessages,
+} from "./content-editor-file-view.messages";
+
+export function ContentEditorFileGenerateDialog({
+  open,
+  onOpenChange,
+  mode,
+  viewerId,
+  isSubmitting = false,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "generate" | "regenerate";
+  viewerId: ContentEditorFileViewerId | null;
+  isSubmitting?: boolean;
+  onSubmit: (instructions: string) => void | Promise<void>;
+}) {
+  const intl = useIntl();
+  const [instructions, setInstructions] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      setInstructions("");
+    }
+  }, [open]);
+
+  const titleMessage =
+    mode === "generate"
+      ? contentEditorFileViewMessages.generateDialogTitle
+      : contentEditorFileViewMessages.regenerateDialogTitle;
+  const submitMessage =
+    mode === "generate"
+      ? contentEditorFileViewMessages.generate
+      : contentEditorFileViewMessages.regenerate;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            <FormattedMessage {...titleMessage} />
+          </DialogTitle>
+          <DialogDescription>
+            <FormattedMessage {...contentEditorFileViewMessages.generateDialogDescription} />
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <label
+            htmlFor="content-editor-file-generate-instructions"
+            className="text-sm font-medium text-foreground"
+          >
+            <FormattedMessage {...contentEditorFileViewMessages.generatePromptLabel} />
+          </label>
+          <Textarea
+            id="content-editor-file-generate-instructions"
+            value={instructions}
+            onChange={(event) => setInstructions(event.currentTarget.value)}
+            placeholder={intl.formatMessage(
+              contentEditorFileGeneratePromptPlaceholderMessage(viewerId),
+            )}
+            rows={5}
+            disabled={isSubmitting}
+            className="resize-y"
+          />
+        </div>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isSubmitting}
+            onClick={() => onOpenChange(false)}
+          >
+            <FormattedMessage {...contentEditorFileViewMessages.generateDialogCancel} />
+          </Button>
+          <Button
+            type="button"
+            disabled={isSubmitting}
+            onClick={() => void onSubmit(instructions.trim())}
+          >
+            {isSubmitting ? <Spinner className="size-4" /> : null}
+            <FormattedMessage {...submitMessage} />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.test.tsx
@@ -40,7 +40,7 @@ function imageSegment(overrides: Partial<ContentEditorSegment> = {}): ContentEdi
 }
 
 describe("ContentEditorFileViewPanel", () => {
-  it("renders translated pane before source pane", () => {
+  it("renders source pane before translated pane", () => {
     render(
       <ContentEditorTestProviders>
         <ContentEditorFileViewPanel segment={imageSegment()} viewerId="image" filename="hero.png" />
@@ -58,10 +58,10 @@ describe("ContentEditorFileViewPanel", () => {
       "https://example.com/source.png",
     );
 
-    const translatedHeading = screen.getByRole("heading", { name: /Translated \(de\)/i });
     const sourceHeading = screen.getByRole("heading", { name: /Source \(en\)/i });
+    const translatedHeading = screen.getByRole("heading", { name: /Translated \(de\)/i });
     expect(
-      translatedHeading.compareDocumentPosition(sourceHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+      sourceHeading.compareDocumentPosition(translatedHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.tsx
@@ -12,13 +12,14 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { useState } from "react";
 import type { ReactNode } from "react";
 import dynamic from "next/dynamic";
 import {
   ArrowLeft01Icon,
   ArrowRight01Icon,
   Loading03Icon,
-  RefreshIcon,
+  SparklesIcon,
   Upload01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -38,6 +39,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/primitives/cn";
 
 import { contentEditorFileViewMessages } from "./content-editor-file-view.messages";
+import { ContentEditorFileGenerateDialog } from "./content-editor-file-generate-dialog";
 import {
   CAT_IMAGE_FILE_UPLOAD_ACCEPT,
   ContentEditorImageFileViewerPane,
@@ -108,10 +110,11 @@ export function ContentEditorFileViewPanel({
   onNext?: () => void;
   onApprove?: () => void;
   onUpload?: (file: File) => void;
-  onRegenerate?: () => void;
+  onRegenerate?: (input: { instructions?: string }) => void | Promise<void>;
   className?: string;
 }) {
   const intl = useIntl();
+  const [generateDialogOpen, setGenerateDialogOpen] = useState(false);
   const resolvedPrimaryActionLabel =
     primaryActionLabel ?? intl.formatMessage(contentEditorFileViewMessages.approve);
   const hasTarget = Boolean(segment.targetAssetUrl || segment.targetText.trim());
@@ -136,6 +139,15 @@ export function ContentEditorFileViewPanel({
       ? (segment.targetAssetUrl ??
         (/^https?:\/\//i.test(segment.targetText) ? segment.targetText : null))
       : null;
+  const generateMode = hasTarget ? "regenerate" : "generate";
+
+  async function handleGenerateSubmit(instructions: string) {
+    if (!onRegenerate) {
+      return;
+    }
+    await onRegenerate({ instructions: instructions || undefined });
+    setGenerateDialogOpen(false);
+  }
 
   return (
     <div className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
@@ -191,6 +203,38 @@ export function ContentEditorFileViewPanel({
           <FileViewPane
             title={
               <FormattedMessage
+                {...contentEditorFileViewMessages.sourceHeading}
+                values={{ locale: segment.sourceLocale }}
+              />
+            }
+          >
+            {viewerId === "image" ? (
+              <ContentEditorImageFileViewerPane role="source" src={sourceSrc} />
+            ) : viewerId === "video" ? (
+              <ContentEditorVideoFileViewerPane role="source" src={sourceSrc} />
+            ) : officeKind ? (
+              <ContentEditorOfficeFileViewerPane
+                kind={officeKind}
+                role="source"
+                src={sourceSrc}
+                filename={displayName}
+                canEdit={false}
+              />
+            ) : isDocumentViewer ? (
+              <ContentEditorDocumentFileViewerPane
+                role="source"
+                src={sourceSrc}
+                filename={displayName}
+                canEdit={false}
+              />
+            ) : (
+              <UnsupportedPreview />
+            )}
+          </FileViewPane>
+
+          <FileViewPane
+            title={
+              <FormattedMessage
                 {...contentEditorFileViewMessages.targetHeading}
                 values={{ locale: segment.targetLocale }}
               />
@@ -203,7 +247,7 @@ export function ContentEditorFileViewPanel({
                     variant="outline"
                     size="xs"
                     disabled={!canEdit || isImageBusy}
-                    onClick={onRegenerate}
+                    onClick={() => setGenerateDialogOpen(true)}
                   >
                     {isImageBusy ? (
                       <HugeiconsIcon
@@ -212,9 +256,13 @@ export function ContentEditorFileViewPanel({
                         aria-hidden
                       />
                     ) : (
-                      <HugeiconsIcon icon={RefreshIcon} className="size-3" aria-hidden />
+                      <HugeiconsIcon icon={SparklesIcon} className="size-3" aria-hidden />
                     )}
-                    <FormattedMessage {...contentEditorFileViewMessages.regenerate} />
+                    <FormattedMessage
+                      {...(hasTarget
+                        ? contentEditorFileViewMessages.regenerate
+                        : contentEditorFileViewMessages.generate)}
+                    />
                   </Button>
                 ) : null}
                 {onUpload && uploadAccept ? (
@@ -282,40 +330,18 @@ export function ContentEditorFileViewPanel({
               <UnsupportedPreview />
             )}
           </FileViewPane>
-
-          <FileViewPane
-            title={
-              <FormattedMessage
-                {...contentEditorFileViewMessages.sourceHeading}
-                values={{ locale: segment.sourceLocale }}
-              />
-            }
-          >
-            {viewerId === "image" ? (
-              <ContentEditorImageFileViewerPane role="source" src={sourceSrc} />
-            ) : viewerId === "video" ? (
-              <ContentEditorVideoFileViewerPane role="source" src={sourceSrc} />
-            ) : officeKind ? (
-              <ContentEditorOfficeFileViewerPane
-                kind={officeKind}
-                role="source"
-                src={sourceSrc}
-                filename={displayName}
-                canEdit={false}
-              />
-            ) : isDocumentViewer ? (
-              <ContentEditorDocumentFileViewerPane
-                role="source"
-                src={sourceSrc}
-                filename={displayName}
-                canEdit={false}
-              />
-            ) : (
-              <UnsupportedPreview />
-            )}
-          </FileViewPane>
         </div>
       </div>
+      {onRegenerate ? (
+        <ContentEditorFileGenerateDialog
+          open={generateDialogOpen}
+          onOpenChange={setGenerateDialogOpen}
+          mode={generateMode}
+          viewerId={viewerId}
+          isSubmitting={isImageBusy}
+          onSubmit={handleGenerateSubmit}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.tsx
@@ -145,8 +145,13 @@ export function ContentEditorFileViewPanel({
     if (!onRegenerate) {
       return;
     }
-    await onRegenerate({ instructions: instructions || undefined });
-    setGenerateDialogOpen(false);
+
+    try {
+      await onRegenerate({ instructions: instructions || undefined });
+      setGenerateDialogOpen(false);
+    } catch {
+      // Keep the dialog open so the user can retry after a failed generation.
+    }
   }
 
   return (

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.fixture.ts
@@ -34,6 +34,13 @@ export const CAT_STORY_VIDEO_SOURCE_URL =
 export const CAT_STORY_VIDEO_TARGET_URL =
   "https://www.w3.org/WAI/content-images/wai-videos/perspective-video-form-controls.mp4";
 
+import {
+  CAT_STORY_DOCUMENT_MDX_SOURCE_URL,
+  CAT_STORY_DOCUMENT_MDX_TARGET_URL,
+  CAT_STORY_DOCUMENT_SOURCE_URL,
+  CAT_STORY_DOCUMENT_TARGET_URL,
+} from "./content-editor-document-msw-handlers";
+
 export const contentEditorImageFileIntelligenceFixture: ContentEditorSegmentIntelligence = {
   ...contentEditorIntelligenceFixture,
   reviewReason:
@@ -46,6 +53,22 @@ export const contentEditorImageFileIntelligenceFixture: ContentEditorSegmentInte
   productMeaning: "Hero image that introduces pending review work on the dashboard.",
   segmentType: "Image file",
   constraints: "Keep the product UI readable. Do not crop the CTA.",
+  aiSuggestion: undefined,
+  aiReasoning: undefined,
+};
+
+export const contentEditorDocumentFileIntelligenceFixture: ContentEditorSegmentIntelligence = {
+  ...contentEditorIntelligenceFixture,
+  reviewReason:
+    "The intro guide still uses English section headings. Localize the Markdown body and frontmatter fields.",
+  reviewRisk: "medium",
+  intent: "Onboarding guide for new reviewers.",
+  locationBreadcrumb: "Docs > Getting started",
+  filePath: "content/intro.md",
+  componentName: "IntroGuide",
+  productMeaning: "Markdown guide that explains how to review translations in the dashboard.",
+  segmentType: "Document file",
+  constraints: "Preserve MDX components and keyboard markup.",
   aiSuggestion: undefined,
   aiReasoning: undefined,
 };
@@ -86,6 +109,44 @@ export function createCatImageFileSegment(
     targetAssetUrl: CAT_STORY_IMAGE_TARGET_URL,
     ...overrides,
   };
+}
+
+export function createCatDocumentFileSegment(
+  overrides: Partial<ContentEditorSegment> = {},
+): ContentEditorSegment {
+  return {
+    id: "seg-document-file",
+    index: 1,
+    key: "content/intro.md",
+    sourceText: "content/intro.md",
+    targetText: "",
+    sourcePath: "content/intro.md",
+    sourceLocale: SOURCE_LOCALE,
+    targetLocale: TARGET_LOCALE,
+    status: "needs_review",
+    contextLabel: "Intro guide",
+    tags: ["document", "docs"],
+    contentKind: "document",
+    sourceAssetUrl: CAT_STORY_DOCUMENT_SOURCE_URL,
+    targetAssetUrl: CAT_STORY_DOCUMENT_TARGET_URL,
+    ...overrides,
+  };
+}
+
+export function createCatDocumentMdxFileSegment(
+  overrides: Partial<ContentEditorSegment> = {},
+): ContentEditorSegment {
+  return createCatDocumentFileSegment({
+    id: "seg-document-mdx-file",
+    key: "content/guide.mdx",
+    sourceText: "content/guide.mdx",
+    sourcePath: "content/guide.mdx",
+    contextLabel: "Component guide",
+    tags: ["document", "mdx"],
+    sourceAssetUrl: CAT_STORY_DOCUMENT_MDX_SOURCE_URL,
+    targetAssetUrl: CAT_STORY_DOCUMENT_MDX_TARGET_URL,
+    ...overrides,
+  });
 }
 
 export function createCatVideoFileSegment(
@@ -165,6 +226,51 @@ export function createCatVideoFileWorkspaceState(
     contentEditorVideoFileIntelligenceFixture,
     createMediaFileContext(segment.sourcePath ?? "onboarding/walkthrough.mp4", "walkthrough.mp4"),
   );
+}
+
+export function createCatDocumentFileWorkspaceState(
+  overrides: Partial<ContentEditorSegment> = {},
+): ContentEditorWorkspaceState {
+  const segment = createCatDocumentFileSegment(overrides);
+  return createMediaWorkspaceState(
+    [segment],
+    segment.id,
+    contentEditorDocumentFileIntelligenceFixture,
+    createMediaFileContext(segment.sourcePath ?? "content/intro.md", "intro.md"),
+  );
+}
+
+export function createCatDocumentMdxFileWorkspaceState(
+  overrides: Partial<ContentEditorSegment> = {},
+): ContentEditorWorkspaceState {
+  const segment = createCatDocumentMdxFileSegment(overrides);
+  return createMediaWorkspaceState(
+    [segment],
+    segment.id,
+    contentEditorDocumentFileIntelligenceFixture,
+    createMediaFileContext(segment.sourcePath ?? "content/guide.mdx", "guide.mdx"),
+  );
+}
+
+export function createCatDocumentAndImageWorkspaceState(): ContentEditorWorkspaceState {
+  const documentSegment = createCatDocumentFileSegment({ index: 1 });
+  const imageSegment = createCatImageFileSegment({ index: 2 });
+  const segments = [documentSegment, imageSegment];
+
+  return createContentEditorWorkspaceState({
+    segments,
+    queueSegments: segments.map(toQueueSegment),
+    selectedSegmentId: documentSegment.id,
+    formatChecks: [],
+    segmentFormatChecks: {},
+    intelligence: contentEditorDocumentFileIntelligenceFixture,
+    segmentIntelligence: {
+      [documentSegment.id]: contentEditorDocumentFileIntelligenceFixture,
+      [imageSegment.id]: contentEditorImageFileIntelligenceFixture,
+    },
+    fileContext: createMediaFileContext("All Files", "All Files"),
+    breadcrumbs: ["Project", "HL-Test", "Files", "All Files"],
+  });
 }
 
 export function createCatImageAndVideoWorkspaceState(): ContentEditorWorkspaceState {

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.messages.ts
@@ -14,6 +14,8 @@
  */
 import { defineMessages } from "react-intl";
 
+import type { ContentEditorFileViewerId } from "@/components/content-editor/workspace/content-editor-file-view-capabilities";
+
 export const contentEditorFileViewMessages = defineMessages({
   sourceHeading: {
     defaultMessage: "Source ({locale})",
@@ -34,6 +36,76 @@ export const contentEditorFileViewMessages = defineMessages({
     defaultMessage: "Regenerate",
     id: "xVvlWpH5FH",
     description: "Button to regenerate the translated file with the agent in CAT File view",
+  },
+  generate: {
+    defaultMessage: "Generate",
+    id: "QhDAk8yitQ",
+    description: "Button to generate the first translated file with AI in CAT File view",
+  },
+  generateDialogTitle: {
+    defaultMessage: "Generate translation",
+    id: "BydbarlJgJ",
+    description: "Title for the CAT file view AI generate dialog when no target exists",
+  },
+  regenerateDialogTitle: {
+    defaultMessage: "Regenerate translation",
+    id: "yXsvLbPLZX",
+    description: "Title for the CAT file view AI regenerate dialog when a target exists",
+  },
+  generateDialogDescription: {
+    defaultMessage:
+      "Add optional instructions for the AI model, then generate the translated file.",
+    id: "1j5qZoDR84",
+    description: "Description for the CAT file view AI generate/regenerate dialog",
+  },
+  generatePromptLabel: {
+    defaultMessage: "Instructions for the model",
+    id: "iK15Pu+eHU",
+    description: "Label for the optional AI prompt textarea in CAT file view generate dialog",
+  },
+  generatePromptPlaceholderImage: {
+    defaultMessage: "e.g. Keep the logo unchanged and translate on-screen text only.",
+    id: "wGWzsLB7PP",
+    description: "Placeholder for AI prompt when generating a translated image in CAT file view",
+  },
+  generatePromptPlaceholderVideo: {
+    defaultMessage: "e.g. Keep the logo visible and match the original pacing and tone.",
+    id: "nHm2321vb2",
+    description: "Placeholder for AI prompt when generating a translated video in CAT file view",
+  },
+  generatePromptPlaceholderDocument: {
+    defaultMessage: "e.g. Keep product names in English and preserve MDX components.",
+    id: "XeXZ1sE3tK",
+    description:
+      "Placeholder for AI prompt when generating a translated Markdown/MDX document in CAT file view",
+  },
+  generatePromptPlaceholderDocx: {
+    defaultMessage: "e.g. Preserve heading styles and leave company names untranslated.",
+    id: "IbH+KBJEVh",
+    description:
+      "Placeholder for AI prompt when generating a translated Word file in CAT file view",
+  },
+  generatePromptPlaceholderXlsx: {
+    defaultMessage: "e.g. Keep column headers formal and do not translate formula cells.",
+    id: "Sgqu6sf3FE",
+    description:
+      "Placeholder for AI prompt when generating a translated spreadsheet in CAT file view",
+  },
+  generatePromptPlaceholderPptx: {
+    defaultMessage: "e.g. Keep speaker notes concise and preserve slide layout.",
+    id: "7F+nlF4WOX",
+    description:
+      "Placeholder for AI prompt when generating a translated presentation in CAT file view",
+  },
+  generatePromptPlaceholderDefault: {
+    defaultMessage: "e.g. Add tone, terminology, or layout preferences for the model.",
+    id: "VFu590psFB",
+    description: "Fallback placeholder for AI prompt in CAT file view generate dialog",
+  },
+  generateDialogCancel: {
+    defaultMessage: "Cancel",
+    id: "06WDA4hoab",
+    description: "Cancel button in the CAT file view AI generate dialog",
   },
   saveEdits: {
     defaultMessage: "Save edits",
@@ -66,9 +138,10 @@ export const contentEditorFileViewMessages = defineMessages({
     description: "Error when CAT document viewer fails to fetch an existing target file",
   },
   documentFrontmatter: {
-    defaultMessage: "Frontmatter",
-    id: "8Y86+IM3Ps",
-    description: "Heading for YAML frontmatter fields in the CAT document editor",
+    defaultMessage: "Document properties",
+    id: "IBYpVWNrJA",
+    description:
+      "Heading for YAML metadata fields at the top of a Markdown/MDX document in CAT file view",
   },
   documentBody: {
     defaultMessage: "Body",
@@ -102,3 +175,24 @@ export const contentEditorFileViewMessages = defineMessages({
     description: "Accessible label for next-file navigation in CAT File view",
   },
 });
+
+export function contentEditorFileGeneratePromptPlaceholderMessage(
+  viewerId: ContentEditorFileViewerId | null,
+) {
+  switch (viewerId) {
+    case "image":
+      return contentEditorFileViewMessages.generatePromptPlaceholderImage;
+    case "video":
+      return contentEditorFileViewMessages.generatePromptPlaceholderVideo;
+    case "markdown":
+      return contentEditorFileViewMessages.generatePromptPlaceholderDocument;
+    case "docx":
+      return contentEditorFileViewMessages.generatePromptPlaceholderDocx;
+    case "xlsx":
+      return contentEditorFileViewMessages.generatePromptPlaceholderXlsx;
+    case "pptx":
+      return contentEditorFileViewMessages.generatePromptPlaceholderPptx;
+    default:
+      return contentEditorFileViewMessages.generatePromptPlaceholderDefault;
+  }
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.stories.tsx
@@ -25,10 +25,17 @@ import {
   CAT_STORY_IMAGE_TARGET_URL,
   CAT_STORY_VIDEO_SOURCE_URL,
   CAT_STORY_VIDEO_TARGET_URL,
+  createCatDocumentAndImageWorkspaceState,
+  createCatDocumentFileWorkspaceState,
+  createCatDocumentMdxFileWorkspaceState,
   createCatImageAndVideoWorkspaceState,
   createCatImageFileWorkspaceState,
   createCatVideoFileWorkspaceState,
 } from "./content-editor-file-view.fixture";
+import {
+  CAT_STORY_DOCUMENT_ERROR_TARGET_URL,
+  contentEditorDocumentMswHandlers,
+} from "./content-editor-document-msw-handlers";
 
 const meta = {
   title: "CAT/File view",
@@ -70,6 +77,12 @@ const mediaReview = {
   onAskQuestion: fn(),
 };
 
+const documentMswParameters = {
+  msw: {
+    handlers: contentEditorDocumentMswHandlers,
+  },
+} as const;
+
 function fileViewArgs(initialState: ContentEditorWorkspaceState): Story["args"] {
   return {
     initialState,
@@ -84,12 +97,21 @@ function viewModeButtons(canvas: ReturnType<typeof within>) {
   return canvas.getAllByRole("button", { name: "Content Editor view mode" });
 }
 
+async function expectDocumentFileViewChrome(canvas: ReturnType<typeof within>, filename: string) {
+  await expect(viewModeButtons(canvas).length).toBeGreaterThan(0);
+  await expect(canvas.getByText(filename)).toBeInTheDocument();
+  await expect(canvas.getByRole("heading", { name: /Translated \(vi\)/i })).toBeInTheDocument();
+  await expect(canvas.getByRole("heading", { name: /Source \(en-US\)/i })).toBeInTheDocument();
+  await expect(canvas.getByRole("button", { name: /Generate|Regenerate/i })).toBeInTheDocument();
+  await expect(canvas.getByText("Upload translated file")).toBeInTheDocument();
+}
+
 async function expectFileViewChrome(canvas: ReturnType<typeof within>, filename: string) {
   await expect(viewModeButtons(canvas).length).toBeGreaterThan(0);
   await expect(canvas.getByText(filename)).toBeInTheDocument();
   await expect(canvas.getByRole("heading", { name: /Translated \(vi\)/i })).toBeInTheDocument();
   await expect(canvas.getByRole("heading", { name: /Source \(en-US\)/i })).toBeInTheDocument();
-  await expect(canvas.getByRole("button", { name: /Regenerate/i })).toBeInTheDocument();
+  await expect(canvas.getByRole("button", { name: /Generate|Regenerate/i })).toBeInTheDocument();
   await expect(canvas.getByText("Upload translated file")).toBeInTheDocument();
 }
 
@@ -163,8 +185,8 @@ export const VideoFile: Story = {
     await expectFileViewChrome(canvas, "onboarding/walkthrough.mp4");
     const videos = canvasElement.querySelectorAll("video");
     await expect(videos).toHaveLength(2);
-    await expect(videos[0]).toHaveAttribute("src", CAT_STORY_VIDEO_TARGET_URL);
-    await expect(videos[1]).toHaveAttribute("src", CAT_STORY_VIDEO_SOURCE_URL);
+    await expect(videos[0]).toHaveAttribute("src", CAT_STORY_VIDEO_SOURCE_URL);
+    await expect(videos[1]).toHaveAttribute("src", CAT_STORY_VIDEO_TARGET_URL);
     await expect(canvas.getByRole("button", { name: /^Approve$/i })).toBeEnabled();
   },
 };
@@ -217,5 +239,95 @@ export const ImageAndVideoQueue: Story = {
     await expect(canvas.queryByAltText("Source image")).not.toBeInTheDocument();
 
     await expect(window.localStorage.getItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY)).toBe("file");
+  },
+};
+
+export const DocumentFile: Story = {
+  parameters: documentMswParameters,
+  args: fileViewArgs(createCatDocumentFileWorkspaceState()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectDocumentFileViewChrome(canvas, "content/intro.md");
+    await waitFor(() =>
+      expect(
+        canvas.getByRole("heading", { level: 1, name: "Getting started" }),
+      ).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(canvas.getByRole("heading", { level: 1, name: "Bắt đầu" })).toBeInTheDocument(),
+    );
+    await expect(canvas.getByText("Document properties")).toBeInTheDocument();
+    const titleField = canvasElement.querySelector<HTMLInputElement>(
+      "#content-editor-document-field-target-title",
+    );
+    await expect(titleField).toHaveValue("Bắt đầu");
+    await expect(canvas.getByRole("button", { name: /^Approve$/i })).toBeEnabled();
+  },
+};
+
+export const DocumentFileEmptyTarget: Story = {
+  parameters: documentMswParameters,
+  args: fileViewArgs(createCatDocumentFileWorkspaceState({ targetAssetUrl: null })),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectDocumentFileViewChrome(canvas, "content/intro.md");
+    await expect(canvas.getByRole("button", { name: /^Generate$/i })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        canvas.getByRole("heading", { level: 1, name: "Getting started" }),
+      ).toBeInTheDocument(),
+    );
+    await expect(canvas.getByRole("button", { name: /^Approve$/i })).toBeDisabled();
+  },
+};
+
+export const DocumentFileWithMdx: Story = {
+  parameters: documentMswParameters,
+  args: fileViewArgs(createCatDocumentMdxFileWorkspaceState()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectDocumentFileViewChrome(canvas, "content/guide.mdx");
+    const editor = await canvas.findByLabelText("Translated document");
+    await expect(editor).toHaveValue(expect.stringContaining('<Callout type="info">'));
+    await expect(editor).toHaveValue(expect.stringContaining("<kbd>Esc</kbd>"));
+    await expect(canvas.getByRole("button", { name: /Save edits/i })).toBeInTheDocument();
+  },
+};
+
+export const DocumentFileLoadError: Story = {
+  parameters: documentMswParameters,
+  args: fileViewArgs(
+    createCatDocumentFileWorkspaceState({ targetAssetUrl: CAT_STORY_DOCUMENT_ERROR_TARGET_URL }),
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectDocumentFileViewChrome(canvas, "content/intro.md");
+    await waitFor(() =>
+      expect(canvas.getByText("Could not load the translated file")).toBeInTheDocument(),
+    );
+    await expect(canvas.queryByLabelText("Translated document")).not.toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /^Approve$/i })).toBeDisabled();
+  },
+};
+
+export const DocumentAndImageQueue: Story = {
+  parameters: documentMswParameters,
+  args: fileViewArgs(createCatDocumentAndImageWorkspaceState()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expectDocumentFileViewChrome(canvas, "content/intro.md");
+    await waitFor(() =>
+      expect(canvas.getByRole("heading", { level: 1, name: "Bắt đầu" })).toBeInTheDocument(),
+    );
+
+    await userEvent.click(canvas.getByRole("button", { name: /Next file/i }));
+    await waitFor(() => expect(canvas.getByText("marketing/hero.png")).toBeInTheDocument());
+    await expect(canvas.getByAltText("Source image")).toBeInTheDocument();
+    await expect(canvas.queryByLabelText("Translated document")).not.toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.tsx
@@ -874,8 +874,12 @@ export function ProjectFileContentEditorWorkspace({
                   },
                   ...(aiFeaturesAllowed
                     ? {
-                        onRegenerateImage: async (segmentId: string) => {
-                          await regenerateImage({ externalStringId: segmentId });
+                        onRegenerateImage: async (segmentId, options) => {
+                          await regenerateImage({
+                            externalStringId: segmentId,
+                            instructions: options?.instructions,
+                            force: options?.force,
+                          });
                         },
                       }
                     : {}),

--- a/apps/hyperlocalise-web/src/components/content-editor/queue/content-editor-queue-toolbar-connected.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/queue/content-editor-queue-toolbar-connected.tsx
@@ -72,6 +72,20 @@ export const ContentEditorQueueToolbarConnected = observer(
       setHost(document.getElementById(CAT_QUEUE_TOOLBAR_HOST_ID));
     }, []);
 
+    useEffect(() => {
+      if (!store.ui.isFileView) {
+        return;
+      }
+
+      if (store.selectionMode) {
+        store.setSelectionMode(false);
+      }
+    }, [store, store.ui.isFileView, store.selectionMode]);
+
+    if (store.ui.isFileView) {
+      return null;
+    }
+
     const handleSearchChange = useCallback(
       (value: string) => {
         store.setQueueSearch(value);

--- a/apps/hyperlocalise-web/src/components/content-editor/queue/content-editor-queue-toolbar-connected.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/queue/content-editor-queue-toolbar-connected.tsx
@@ -82,10 +82,6 @@ export const ContentEditorQueueToolbarConnected = observer(
       }
     }, [store, store.ui.isFileView, store.selectionMode]);
 
-    if (store.ui.isFileView) {
-      return null;
-    }
-
     const handleSearchChange = useCallback(
       (value: string) => {
         store.setQueueSearch(value);
@@ -114,6 +110,10 @@ export const ContentEditorQueueToolbarConnected = observer(
       },
       [onQueueSortChange, store],
     );
+
+    if (store.ui.isFileView) {
+      return null;
+    }
 
     const toolbar = (
       <ContentEditorQueueToolbar

--- a/apps/hyperlocalise-web/src/components/content-editor/shared/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/shared/dependencies.ts
@@ -52,7 +52,10 @@ export interface ContentEditorWorkspaceEditing {
   onTreatAsImage?: (segmentId: string, treatAsImage: boolean) => void | Promise<void>;
   onTreatAsVideo?: (segmentId: string, treatAsVideo: boolean) => void | Promise<void>;
   onSetMaxLength?: (segmentId: string, maxLength: number | null) => void | Promise<void>;
-  onRegenerateImage?: (segmentId: string) => void | Promise<void>;
+  onRegenerateImage?: (
+    segmentId: string,
+    options?: { instructions?: string; force?: boolean },
+  ) => void | Promise<void>;
   onUploadImage?: (segmentId: string, file: File) => void | Promise<void>;
 }
 

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-file-view-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-file-view-capabilities.test.ts
@@ -26,7 +26,7 @@ describe("cat-file-view-capabilities", () => {
 
     expect(capabilities).toEqual({
       family: "image",
-      availableViews: ["file", "comfortable", "side-by-side"],
+      availableViews: ["file"],
       defaultView: "file",
       viewerId: "image",
     });
@@ -51,7 +51,7 @@ describe("cat-file-view-capabilities", () => {
 
     expect(capabilities).toEqual({
       family: "video",
-      availableViews: ["file", "comfortable", "side-by-side"],
+      availableViews: ["file"],
       defaultView: "file",
       viewerId: "video",
     });
@@ -127,7 +127,7 @@ describe("cat-file-view-capabilities", () => {
     expect(clampCatWorkspaceViewMode("file", text)).toBe("comfortable");
 
     const image = resolveCatFileViewCapabilities({ sourcePath: "a.webp" });
-    expect(clampCatWorkspaceViewMode("comfortable", image)).toBe("comfortable");
+    expect(clampCatWorkspaceViewMode("comfortable", image)).toBe("file");
     expect(clampCatWorkspaceViewMode("file", image)).toBe("file");
   });
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-file-view-capabilities.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-file-view-capabilities.ts
@@ -35,14 +35,7 @@ const SEGMENT_VIEWS = [
   "comfortable",
   "side-by-side",
 ] as const satisfies readonly ContentEditorWorkspaceViewMode[];
-const IMAGE_VIEWS = [
-  "file",
-  "comfortable",
-  "side-by-side",
-] as const satisfies readonly ContentEditorWorkspaceViewMode[];
-const VIDEO_VIEWS = IMAGE_VIEWS;
-const OFFICE_VIEWS = ["file"] as const satisfies readonly ContentEditorWorkspaceViewMode[];
-const DOCUMENT_VIEWS = ["file"] as const satisfies readonly ContentEditorWorkspaceViewMode[];
+const FILE_ONLY_VIEWS = ["file"] as const satisfies readonly ContentEditorWorkspaceViewMode[];
 
 function extensionOf(sourcePath: string): string | null {
   const basename = sourcePath.split(/[\\/]/).pop() ?? sourcePath;
@@ -77,7 +70,7 @@ export function resolveCatFileViewCapabilities(input: {
   if (contentKind === "image_file" || inferSupportedImageTranslationFileFormat(sourcePath)) {
     return {
       family: "image",
-      availableViews: IMAGE_VIEWS,
+      availableViews: FILE_ONLY_VIEWS,
       defaultView: "file",
       viewerId: "image",
     };
@@ -86,7 +79,7 @@ export function resolveCatFileViewCapabilities(input: {
   if (contentKind === "video_file" || inferSupportedVideoTranslationFileFormat(sourcePath)) {
     return {
       family: "video",
-      availableViews: VIDEO_VIEWS,
+      availableViews: FILE_ONLY_VIEWS,
       defaultView: "file",
       viewerId: "video",
     };
@@ -98,7 +91,7 @@ export function resolveCatFileViewCapabilities(input: {
   if (officeFormat) {
     return {
       family: "office",
-      availableViews: OFFICE_VIEWS,
+      availableViews: FILE_ONLY_VIEWS,
       defaultView: "file",
       viewerId: officeViewerIdForExtension(extension) ?? "docx",
     };
@@ -107,7 +100,7 @@ export function resolveCatFileViewCapabilities(input: {
   if (contentKind === "document" || inferSupportedDocumentTranslationFileFormat(sourcePath)) {
     return {
       family: "document",
-      availableViews: DOCUMENT_VIEWS,
+      availableViews: FILE_ONLY_VIEWS,
       defaultView: "file",
       viewerId: "markdown",
     };

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.test.tsx
@@ -21,6 +21,7 @@ import {
   createCatImageFileWorkspaceState,
   createCatVideoFileWorkspaceState,
 } from "@/components/content-editor/file-view/content-editor-file-view.fixture";
+import { ContentEditorQueueToolbarHost } from "@/components/content-editor/queue/content-editor-queue-toolbar-host";
 import {
   contentEditorSegmentsFixture,
   createContentEditorWorkspaceState,
@@ -254,5 +255,31 @@ describe("ContentEditorWorkspaceContainer UI", () => {
     expect(document.querySelectorAll("video")).toHaveLength(2);
     expect(screen.getByText("Upload translated file")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Approve$/i })).toBeEnabled();
+  });
+
+  it("hides queue toolbar controls in file view", async () => {
+    renderCatWorkspace(
+      <>
+        <ContentEditorQueueToolbarHost />
+        <ContentEditorWorkspaceContainer
+          initialState={createCatImageFileWorkspaceState()}
+          initialViewMode="file"
+          editing={{
+            onRegenerateImage: vi.fn(),
+            onUploadImage: vi.fn(),
+          }}
+        />
+      </>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Translated \(vi\)/i })).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByRole("button", { name: "Filter queue" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Show multi-select")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Content Editor view mode" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-view-mode-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-view-mode-sync.tsx
@@ -19,7 +19,6 @@ import { useEffect } from "react";
 import {
   clampCatWorkspaceViewMode,
   resolveCatFileViewCapabilities,
-  type ContentEditorFileViewFamily,
 } from "./content-editor-file-view-capabilities";
 import { useContentEditorWorkspace } from "./content-editor-workspace-context";
 
@@ -42,8 +41,6 @@ export const ContentEditorWorkspaceViewModeSync = observer(
     }, [onPageLimitChange, store]);
 
     useEffect(() => {
-      let previousFamily: ContentEditorFileViewFamily | null = null;
-
       return reaction(
         () => {
           const selected = store.selectedSegmentView;
@@ -55,20 +52,7 @@ export const ContentEditorWorkspaceViewModeSync = observer(
         },
         ({ viewMode, sourcePath, contentKind }) => {
           const capabilities = resolveCatFileViewCapabilities({ sourcePath, contentKind });
-          let nextMode = clampCatWorkspaceViewMode(viewMode, capabilities);
-
-          // Entering a binary-first family selects File view by default.
-          // Staying in the same family keeps an explicit Comfortable / Side by side choice.
-          if (
-            (capabilities.family === "image" ||
-              capabilities.family === "video" ||
-              capabilities.family === "office") &&
-            previousFamily !== capabilities.family
-          ) {
-            nextMode = capabilities.defaultView;
-          }
-
-          previousFamily = capabilities.family;
+          const nextMode = clampCatWorkspaceViewMode(viewMode, capabilities);
 
           if (nextMode !== viewMode) {
             store.ui.setViewMode(nextMode);

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-view-switcher-connected.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-view-switcher-connected.tsx
@@ -43,7 +43,7 @@ export const ContentEditorWorkspaceViewSwitcherConnected = observer(
       ? (mode: ContentEditorWorkspaceViewMode) => store.ui.setViewMode(mode)
       : onChange;
 
-    if (!resolvedOnChange) {
+    if (!resolvedOnChange || resolvedAvailableViews.length <= 1) {
       return null;
     }
 

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
@@ -465,7 +465,7 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
               capabilities.viewerId === "video" ||
               capabilities.viewerId === "markdown") &&
             editing.onRegenerateImage
-              ? (input) => void editing.onRegenerateImage?.(editorSegment.id, input)
+              ? (input) => editing.onRegenerateImage?.(editorSegment.id, input)
               : undefined
           }
         />

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
@@ -461,9 +461,11 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
               : undefined
           }
           onRegenerate={
-            (capabilities.viewerId === "image" || capabilities.viewerId === "video") &&
+            (capabilities.viewerId === "image" ||
+              capabilities.viewerId === "video" ||
+              capabilities.viewerId === "markdown") &&
             editing.onRegenerateImage
-              ? () => void editing.onRegenerateImage?.(editorSegment.id)
+              ? (input) => void editing.onRegenerateImage?.(editorSegment.id, input)
               : undefined
           }
         />

--- a/apps/hyperlocalise-web/src/lib/projects/files/document-variant-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/document-variant-service.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { generateText } from "ai";
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database/client";
+import { getStoredFileContent } from "@/lib/file-storage/records";
+import { getManagedLanguageModel } from "@/lib/providers/language-model";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+import {
+  getImageVariant,
+  replaceImageVariantBytes,
+  type ImageVariantError,
+  type ProjectImageVariantProvenance,
+} from "./image-variant-service";
+
+async function loadSourceDocumentBytes(input: {
+  organizationId: string;
+  storedFileId: string;
+}): Promise<Result<{ content: Buffer; contentType: string; filename: string }, ImageVariantError>> {
+  const [file] = await db
+    .select({
+      id: schema.storedFiles.id,
+      contentType: schema.storedFiles.contentType,
+      filename: schema.storedFiles.filename,
+    })
+    .from(schema.storedFiles)
+    .where(
+      and(
+        eq(schema.storedFiles.id, input.storedFileId),
+        eq(schema.storedFiles.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1);
+
+  if (!file) {
+    return err({ code: "source_file_not_found" });
+  }
+
+  try {
+    const stored = await getStoredFileContent({
+      organizationId: input.organizationId,
+      fileId: file.id,
+    });
+    return ok({
+      content: stored.content,
+      contentType: file.contentType || "text/markdown",
+      filename: file.filename,
+    });
+  } catch (error) {
+    return err({
+      code: "localization_failed",
+      message: error instanceof Error ? error.message : "Failed to load source document",
+    });
+  }
+}
+
+function buildDocumentLocalizationPrompt(input: {
+  sourceLocale?: string | null;
+  targetLocale: string;
+  instructions?: string | null;
+  sourceText: string;
+}) {
+  const lines = [
+    "You are an expert software localization assistant.",
+    `Translate the following document from ${input.sourceLocale ?? "the source locale"} to ${input.targetLocale}.`,
+    "Preserve YAML frontmatter field keys, markdown structure, MDX/JSX tags, HTML tags, code spans, and placeholders.",
+    "Only translate human-readable text.",
+    "Return only the translated document with no explanations or code fences.",
+  ];
+
+  const trimmedInstructions = input.instructions?.trim();
+  if (trimmedInstructions) {
+    lines.push(`Additional instructions: ${trimmedInstructions}`);
+  }
+
+  lines.push("", input.sourceText);
+  return lines.join("\n");
+}
+
+export async function localizeAndStoreDocumentVariant(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  sourceLocale?: string | null;
+  sourceStoredFileId: string;
+  repositorySourceFileId: string;
+  instructions?: string | null;
+  provenance: ProjectImageVariantProvenance;
+  createdByUserId?: string | null;
+  force?: boolean;
+}): Promise<Result<typeof schema.projectImageVariants.$inferSelect, ImageVariantError>> {
+  const existing = await getImageVariant({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+    targetLocale: input.targetLocale,
+  });
+
+  if (existing?.status === "approved" && !input.force) {
+    return err({ code: "approved_locked" });
+  }
+
+  const sourceBytes = await loadSourceDocumentBytes({
+    organizationId: input.organizationId,
+    storedFileId: input.sourceStoredFileId,
+  });
+  if (!sourceBytes.ok) {
+    return sourceBytes;
+  }
+
+  const sourceText = sourceBytes.value.content.toString("utf8");
+  if (!sourceText.trim()) {
+    return err({ code: "source_bytes_missing" });
+  }
+
+  const model = getManagedLanguageModel();
+
+  let translatedText: string;
+  try {
+    const result = await generateText({
+      model,
+      prompt: buildDocumentLocalizationPrompt({
+        sourceLocale: input.sourceLocale,
+        targetLocale: input.targetLocale,
+        instructions: input.instructions,
+        sourceText,
+      }),
+    });
+    translatedText = result.text.trim();
+  } catch (error) {
+    return err({
+      code: "localization_failed",
+      message: error instanceof Error ? error.message : "Document translation failed",
+    });
+  }
+
+  if (!translatedText) {
+    return err({ code: "localization_failed", message: "Document translation was empty" });
+  }
+
+  return replaceImageVariantBytes({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+    targetLocale: input.targetLocale,
+    content: Buffer.from(translatedText, "utf8"),
+    contentType: sourceBytes.value.contentType,
+    filename: sourceBytes.value.filename,
+    repositorySourceFileId: input.repositorySourceFileId,
+    createdByUserId: input.createdByUserId,
+    force: input.force,
+    provenance: input.provenance,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/projects/files/document-variant-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/document-variant-service.ts
@@ -139,6 +139,17 @@ export async function localizeAndStoreDocumentVariant(input: {
         sourceText,
       }),
     });
+
+    if (result.finishReason !== "stop") {
+      return err({
+        code: "localization_failed",
+        message:
+          result.finishReason === "length"
+            ? "Document translation was truncated because the output exceeded the model limit"
+            : "Document translation did not complete successfully",
+      });
+    }
+
     translatedText = result.text.trim();
   } catch (error) {
     return err({


### PR DESCRIPTION
## What changed

Improves CAT **File view** for whole-file assets (images, videos, Markdown/MDX):

- **Generate / Regenerate** with sparkles button and a modal for optional AI instructions (placeholders vary by file type)
- **Document translation** via new `document-variant-service` and API branch on regenerate
- **TipTap** for `.md` body editing; raw textarea for `.mdx` to preserve JSX
- **Source left, translated right** layout in file view panel
- **File-only views** for image/video/document/office (no Comfortable / Side by side)
- **Hide queue toolbar** (filters, multi-select, view switcher) while in file view
- **Storybook** document stories fixed with same-origin MSW handlers
- Rename **Frontmatter** label to **Document properties** in message source (no lang JSON changes)

## How to test

- `cd apps/hyperlocalise-web && vp test src/components/content-editor/file-view/`
- `cd apps/hyperlocalise-web && vp test src/components/content-editor/workspace/content-editor-workspace-container.test.ts`
- `cd apps/hyperlocalise-web && vp check`
- Storybook: `DocumentFile`, `DocumentFileEmptyTarget` under CAT / File view
- Manually: open an image or `.md` file in CAT → File view → Generate/Regenerate modal, confirm queue filters/multi-select are hidden

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check` on touched areas)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review