### PR TITLE
feat(web): add marketing vs product brand theme provider

### DIFF
--- a/apps/hyperlocalise-web/.storybook/preview.tsx
+++ b/apps/hyperlocalise-web/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import "@pierre/trees/web-components";
 import "../src/app/globals.css";
 import { QueryProvider } from "../src/components/query-provider";
 import { ThemeProvider } from "../src/components/theme-provider";
+import { BrandThemeProvider } from "../src/components/ui/brand-theme";
 import { Toaster } from "../src/components/ui/sonner";
 import { TooltipProvider } from "../src/components/ui/tooltip";
 import { SUPPORTED_APP_LOCALES } from "../src/lib/app-i18n/locales";
@@ -22,19 +23,19 @@ const inter = Inter({
 
 const domine = Domine({
   subsets: ["latin", "latin-ext"],
-  variable: "--font-heading",
+  variable: "--font-heading-marketing",
 });
 
 const notoSerif = Noto_Serif({
   subsets: ["latin", "latin-ext", "vietnamese"],
-  variable: "--font-heading",
+  variable: "--font-heading-marketing",
 });
 
 const notoSerifSc = Noto_Serif_SC({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
   preload: false,
-  variable: "--font-heading",
+  variable: "--font-heading-marketing",
 });
 
 const geistMono = Geist_Mono({
@@ -79,10 +80,23 @@ const preview: Preview = {
         dynamicTitle: true,
       },
     },
+    brandTheme: {
+      description: "Heading typography for marketing vs product",
+      toolbar: {
+        title: "Brand",
+        icon: "paragraph",
+        items: [
+          { value: "marketing", title: "Marketing" },
+          { value: "product", title: "Product" },
+        ],
+        dynamicTitle: true,
+      },
+    },
   },
   initialGlobals: {
     locale: "en",
     theme: "dark",
+    brandTheme: "product",
   },
   decorators: [
     (Story, { globals }) => (
@@ -101,7 +115,11 @@ const preview: Preview = {
                   headingFontVariable(globals.locale),
                 )}
               >
-                <Story />
+                <BrandThemeProvider
+                  theme={globals.brandTheme === "marketing" ? "marketing" : "product"}
+                >
+                  <Story />
+                </BrandThemeProvider>
               </div>
               <Toaster richColors closeButton />
             </TooltipProvider>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/layout.tsx
@@ -12,6 +12,8 @@
  */
 import type { ReactNode } from "react";
 
+import { BrandThemeProvider } from "@/components/ui/brand-theme";
+
 export default async function AuthenticatedLayout({ children }: { children: ReactNode }) {
-  return children;
+  return <BrandThemeProvider theme="product">{children}</BrandThemeProvider>;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/layout.tsx
@@ -14,6 +14,7 @@ import type { Metadata } from "next";
 
 import { JsonLd } from "@/components/seo/json-ld";
 import { organizationJsonLd } from "@/components/seo/organization-json-ld";
+import { BrandThemeProvider } from "@/components/ui/brand-theme";
 import { INDEXABLE_ROBOTS } from "@/lib/seo/robots-metadata";
 
 import Navbar from "./_components/navbar";
@@ -24,10 +25,10 @@ export const metadata: Metadata = {
 
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <>
+    <BrandThemeProvider theme="marketing">
       <JsonLd data={organizationJsonLd} />
       <Navbar />
       <main>{children}</main>
-    </>
+    </BrandThemeProvider>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(public-chat)/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(public-chat)/layout.tsx
@@ -12,6 +12,12 @@
  */
 import type { ReactNode } from "react";
 
+import { BrandThemeProvider } from "@/components/ui/brand-theme";
+
 export default function PublicChatLayout({ children }: { children: ReactNode }) {
-  return <main className="min-h-svh bg-background">{children}</main>;
+  return (
+    <BrandThemeProvider theme="product">
+      <main className="min-h-svh bg-background">{children}</main>
+    </BrandThemeProvider>
+  );
 }

--- a/apps/hyperlocalise-web/src/app/auth/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/layout.tsx
@@ -14,22 +14,6 @@ import type { ReactNode } from "react";
 
 import { BrandThemeProvider } from "@/components/ui/brand-theme";
 
-import "./crowdin-app.css";
-
-export const metadata = {
-  title: "Hyperlocalise",
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
-
-export default function CrowdinAppLayout({ children }: { children: ReactNode }) {
-  return (
-    <BrandThemeProvider theme="product">
-      <div data-crowdin-app className="crowdin-app-root min-h-svh bg-background text-foreground">
-        {children}
-      </div>
-    </BrandThemeProvider>
-  );
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return <BrandThemeProvider theme="product">{children}</BrandThemeProvider>;
 }

--- a/apps/hyperlocalise-web/src/app/globals.css
+++ b/apps/hyperlocalise-web/src/app/globals.css
@@ -185,6 +185,8 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-geist-mono);
+  --font-heading-marketing: var(--font-heading-marketing);
+  --font-heading-product: var(--font-sans);
   --font-heading: var(--font-heading);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -228,6 +230,23 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+/*
+ * Heading face follows BrandThemeProvider (`data-brand-theme`).
+ * `font-heading` reads --font-heading so the subtree can swap faces.
+ * Without a provider, headings keep the marketing serif.
+ */
+html {
+  --font-heading: var(--font-heading-marketing);
+}
+
+[data-brand-theme="marketing"] {
+  --font-heading: var(--font-heading-marketing);
+}
+
+[data-brand-theme="product"] {
+  --font-heading: var(--font-sans);
 }
 
 :root {

--- a/apps/hyperlocalise-web/src/app/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/layout.tsx
@@ -37,13 +37,13 @@ const inter = Inter({
 /** Domine only ships latin + latin-ext (covers en / de-DE / fr-FR). */
 const domine = Domine({
   subsets: ["latin", "latin-ext"],
-  variable: "--font-heading",
+  variable: "--font-heading-marketing",
 });
 
 /** Fallback heading face when Domine lacks Vietnamese glyphs. */
 const notoSerif = Noto_Serif({
   subsets: ["latin", "latin-ext", "vietnamese"],
-  variable: "--font-heading",
+  variable: "--font-heading-marketing",
 });
 
 /** Fallback heading face when Domine lacks CJK glyphs. */
@@ -51,7 +51,7 @@ const notoSerifSc = Noto_Serif_SC({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
   preload: false,
-  variable: "--font-heading",
+  variable: "--font-heading-marketing",
 });
 
 const geistMono = Geist_Mono({

--- a/apps/hyperlocalise-web/src/components/ui/brand-theme.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/brand-theme.stories.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { BrandThemeProvider } from "./brand-theme";
+import { TypographyH1, TypographyH2, TypographyP } from "./typography";
+
+const meta = {
+  title: "UI/Brand Theme",
+  component: BrandThemeProvider,
+  args: {
+    theme: "marketing",
+  },
+} satisfies Meta<typeof BrandThemeProvider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ThemeSpecimen({
+  theme,
+  title,
+  subtitle,
+}: {
+  theme: "marketing" | "product";
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <BrandThemeProvider theme={theme} className="rounded-lg border border-border p-6">
+      <p className="mb-3 font-sans text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        {theme}
+      </p>
+      <TypographyH1 className="text-3xl md:text-4xl">{title}</TypographyH1>
+      <TypographyH2 className="mt-3 text-xl md:text-2xl">{subtitle}</TypographyH2>
+      <TypographyP className="mt-3 text-muted-foreground">
+        Headings use <code className="font-mono text-sm">font-heading</code>, which follows the
+        brand theme.
+      </TypographyP>
+    </BrandThemeProvider>
+  );
+}
+
+export const Overview: Story = {
+  render: () => (
+    <div className="grid max-w-5xl gap-4 p-6 md:grid-cols-2">
+      <ThemeSpecimen
+        theme="marketing"
+        title="Launch in every market"
+        subtitle="Serif display headings"
+      />
+      <ThemeSpecimen theme="product" title="Review queue" subtitle="Sans product headings" />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("marketing")).toBeInTheDocument();
+    const marketing = canvas.getByText("Launch in every market").closest("[data-brand-theme]");
+    const product = canvas.getByText("Review queue").closest("[data-brand-theme]");
+    await expect(marketing).toHaveAttribute("data-brand-theme", "marketing");
+    await expect(product).toHaveAttribute("data-brand-theme", "product");
+  },
+};

--- a/apps/hyperlocalise-web/src/components/ui/brand-theme.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/brand-theme.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { BrandThemeProvider, useBrandTheme } from "./brand-theme";
+import { TypographyH1 } from "./typography";
+
+function ThemeProbe() {
+  const theme = useBrandTheme();
+  return React.createElement("span", { "data-theme": theme }, theme);
+}
+
+describe("BrandThemeProvider", () => {
+  it("marks the subtree as the marketing theme", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        BrandThemeProvider,
+        { theme: "marketing" },
+        React.createElement(TypographyH1, {}, "Ship globally"),
+      ),
+    );
+
+    expect(markup).toContain('data-slot="brand-theme"');
+    expect(markup).toContain('data-brand-theme="marketing"');
+    expect(markup).toContain("font-heading");
+    expect(markup).toContain("Ship globally");
+  });
+
+  it("marks the subtree as the product theme", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        BrandThemeProvider,
+        { theme: "product" },
+        React.createElement(ThemeProbe),
+      ),
+    );
+
+    expect(markup).toContain('data-brand-theme="product"');
+    expect(markup).toContain('data-theme="product"');
+    expect(markup).toContain("product</span>");
+  });
+
+  it("throws when useBrandTheme is used outside a provider", () => {
+    expect(() => renderToStaticMarkup(React.createElement(ThemeProbe))).toThrow(
+      "useBrandTheme must be used within a BrandThemeProvider.",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ui/brand-theme.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/brand-theme.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import * as React from "react";
+
+import { cn } from "@/lib/primitives/cn";
+
+export const BRAND_THEMES = ["marketing", "product"] as const;
+
+export type BrandTheme = (typeof BRAND_THEMES)[number];
+
+const BrandThemeContext = React.createContext<BrandTheme | null>(null);
+
+function BrandThemeProvider({
+  theme,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & { theme: BrandTheme }) {
+  return (
+    <BrandThemeContext.Provider value={theme}>
+      <div data-slot="brand-theme" data-brand-theme={theme} className={cn(className)} {...props} />
+    </BrandThemeContext.Provider>
+  );
+}
+
+function useBrandTheme() {
+  const theme = React.useContext(BrandThemeContext);
+
+  if (theme == null) {
+    throw new Error("useBrandTheme must be used within a BrandThemeProvider.");
+  }
+
+  return theme;
+}
+
+export { BrandThemeProvider, useBrandTheme };


### PR DESCRIPTION
## What changed

Adds a `BrandThemeProvider` so marketing and product surfaces can use different heading type. Marketing keeps Domine; product switches `font-heading` to Inter. Layouts for marketing, authenticated app, public chat, auth, and Crowdin wrap the matching theme. Storybook gets a Brand toolbar and a side-by-side specimen.

## How to test

- [ ] Open Storybook **UI/Brand Theme** and confirm marketing headings are Domine and product headings are Inter
- [ ] Toggle the Storybook **Brand** toolbar on **UI/Typography** and confirm `font-heading` follows marketing vs product
- [ ] Open a marketing page (homepage) and confirm display headings still use Domine
- [ ] Open an authenticated app page with `font-heading` and confirm headings use Inter
- [ ] In `apps/hyperlocalise-web`, run `vp test src/components/ui/brand-theme.test.tsx` and `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; brand-theme unit tests passed)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)