### PR TITLE
fix(cli): resolve i18n paths relative to config directory

### DIFF
--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -408,12 +408,12 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 		prefixIndex = collectPackPrefixIndex()
 	}
 
-	selection, err := buildCheckSelection(index, o.file, o.key, o.prefixID, prefixIndex)
+	selection, err := buildCheckSelection(index, o.file, o.key, o.prefixID, prefixIndex, configRoot)
 	if err != nil {
 		return checkReport{}, err
 	}
 	if o.diffStdin {
-		selection, err = buildCheckSelectionFromDiff(index, o.diffContent, o.key, o.prefixID, o.ignoreDuplicateID, prefixIndex)
+		selection, err = buildCheckSelectionFromDiff(index, o.diffContent, o.key, o.prefixID, o.ignoreDuplicateID, prefixIndex, configRoot)
 		if err != nil {
 			return checkReport{}, err
 		}
@@ -453,7 +453,7 @@ func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string, co
 				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
 			}
 			for _, sourcePath := range sourcePaths {
-				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
+				if shouldIgnoreSourcePathForStatus(sourcePath, configRoot, cfg.Locales.Targets) {
 					continue
 				}
 
@@ -486,7 +486,7 @@ func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string, co
 	return index, nil
 }
 
-func buildCheckSelection(index *checkConfigIndex, sourceFileFilter, keyFilter string, prefixID bool, prefixIndex packPrefixIndex) (checkSelection, error) {
+func buildCheckSelection(index *checkConfigIndex, sourceFileFilter, keyFilter string, prefixID bool, prefixIndex packPrefixIndex, configRoot string) (checkSelection, error) {
 	selection := checkSelection{}
 
 	trimmedKey := strings.TrimSpace(keyFilter)
@@ -501,22 +501,18 @@ func buildCheckSelection(index *checkConfigIndex, sourceFileFilter, keyFilter st
 	if trimmedFile == "" {
 		return selection, nil
 	}
-	fileFilter, err := filepath.Abs(trimmedFile)
-	if err != nil {
-		return checkSelection{}, fmt.Errorf("resolve --file path %q: %w", trimmedFile, err)
-	}
-	fileFilter = filepath.Clean(fileFilter)
-	if _, ok := index.sourceByPath[fileFilter]; !ok {
+	desc, ok := lookupCheckSourceDescriptor(index, configRoot, trimmedFile)
+	if !ok {
 		selection.bySource = map[string]checkSourceScope{}
 		return selection, nil
 	}
 	selection.bySource = map[string]checkSourceScope{
-		fileFilter: {},
+		filepath.Clean(desc.sourcePath): {},
 	}
 	return selection, nil
 }
 
-func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, keyFilter string, prefixID, ignoreDuplicateID bool, prefixIndex packPrefixIndex) (checkSelection, error) {
+func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, keyFilter string, prefixID, ignoreDuplicateID bool, prefixIndex packPrefixIndex, configRoot string) (checkSelection, error) {
 	changedFiles, err := parseUnifiedDiffChangedFiles(diffContent)
 	if err != nil {
 		return checkSelection{}, err
@@ -535,7 +531,7 @@ func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, ke
 		changedPath := filepath.Clean(changed.path)
 		changedKeys := changed.keys
 		if prefixID {
-			if _, isSource := index.sourceByPath[changedPath]; isSource {
+			if _, isSource := lookupCheckSourceDescriptor(index, configRoot, changedPath); isSource {
 				var err error
 				changedKeys, err = normalizeCheckChangedKeys(changed.keys, prefixIndex, ignoreDuplicateID)
 				if err != nil {
@@ -543,7 +539,7 @@ func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, ke
 				}
 			}
 		}
-		if sourceDesc, ok := index.sourceByPath[changedPath]; ok {
+		if sourceDesc, ok := lookupCheckSourceDescriptor(index, configRoot, changedPath); ok {
 			scope := selection.bySource[filepath.Clean(sourceDesc.sourcePath)]
 			scope.keys = intersectChangedKeys(scope.keys, changedKeys, filterKey)
 			scope.sourceInDiff = true
@@ -551,7 +547,7 @@ func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, ke
 			selection.bySource[filepath.Clean(sourceDesc.sourcePath)] = scope
 			continue
 		}
-		targetLookup, ok := index.targetToSource[changedPath]
+		targetLookup, ok := lookupCheckTargetLookup(index, configRoot, changedPath)
 		if !ok {
 			continue
 		}

--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -393,7 +393,12 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	)
 	resolveSpan.End()
 
-	index, err := buildCheckConfigIndex(cfg, buckets, locales)
+	configRoot, err := config.ConfigDirectory(o.configPath)
+	if err != nil {
+		return checkReport{}, fmt.Errorf("resolve config directory: %w", err)
+	}
+
+	index, err := buildCheckConfigIndex(cfg, buckets, locales, configRoot)
 	if err != nil {
 		return checkReport{}, err
 	}
@@ -433,7 +438,7 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	}, nil
 }
 
-func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string) (*checkConfigIndex, error) {
+func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string, configRoot string) (*checkConfigIndex, error) {
 	index := &checkConfigIndex{
 		sourceByPath:   make(map[string]checkSourceDescriptor),
 		targetToSource: make(map[string]checkTargetLookup),
@@ -443,7 +448,7 @@ func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string) (*
 		bucket := cfg.Buckets[bucketName]
 		for _, file := range bucket.Files {
 			sourcePattern := pathresolver.ResolveSourcePath(file.From, cfg.Locales.Source)
-			sourcePaths, err := resolveSourcePathsForStatus(sourcePattern)
+			sourcePaths, err := resolveSourcePathsForStatus(configRoot, sourcePattern)
 			if err != nil {
 				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
 			}
@@ -459,7 +464,7 @@ func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string) (*
 				}
 				for _, locale := range locales {
 					targetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, locale)
-					targetPath, err := resolveTargetPathForStatus(sourcePattern, targetPattern, sourcePath)
+					targetPath, err := resolveTargetPathForStatus(configRoot, sourcePattern, targetPattern, sourcePath)
 					if err != nil {
 						return nil, fmt.Errorf("resolve target path for source %q: %w", sourcePath, err)
 					}

--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -60,6 +60,46 @@ func TestCheckCommandPrefixIDAlignsSourceAndTargetKeys(t *testing.T) {
 	}
 }
 
+func TestCheckCommandResolvesPathsRelativeToConfigDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	projectDir := filepath.Join(repoRoot, "nested-app")
+	configPath := filepath.Join(projectDir, "i18n.jsonc")
+	sourcePath := filepath.Join(projectDir, "src", "locales", "en", "common.json")
+	targetPath := filepath.Join(projectDir, "src", "locales", "fr", "common.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"hello":"Bonjour"}`), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfigWithMappings(t, configPath, []checkConfigMapping{
+		{source: "src/locales/en/common.json", target: "src/locales/fr/common.json"},
+	}, []string{"fr"})
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check command from repo root with nested config: %v", err)
+	}
+	if !strings.Contains(out.String(), "No problems.") {
+		t.Fatalf("expected no-findings stylish output, got %q", out.String())
+	}
+}
+
 func TestCheckCommandWithoutPrefixIDReportsPrefixedSourceMismatch(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -100,6 +100,27 @@ func TestCheckCommandResolvesPathsRelativeToConfigDirectory(t *testing.T) {
 	}
 }
 
+func TestCheckDiffStdinMatchesConfigRelativeSourcePaths(t *testing.T) {
+	configPath, _, targetPath := setupNestedConfigLocaleProject(t)
+	if err := os.WriteFile(targetPath, []byte("{\n  \"hello\": \"\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	report := executeCheckJSON(t, configPath, unifiedDiffForPath("src/locales/fr/common.json", `@@ -1,3 +1,3 @@
+ {
+-  "hello": "Bonjour"
++  "hello": ""
+ }
+`), "--diff-stdin", "--no-fail", "--check", checkNotLocalized)
+
+	if len(report.Findings) != 1 || report.Findings[0].Key != "hello" {
+		t.Fatalf("expected diff-stdin to match config-relative target path, got %+v", report.Findings)
+	}
+}
+
 func TestCheckCommandWithoutPrefixIDReportsPrefixedSourceMismatch(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -145,7 +145,7 @@ func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
 				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
 			}
 			for _, sourcePath := range sourcePaths {
-				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
+				if shouldIgnoreSourcePathForStatus(sourcePath, configRoot, cfg.Locales.Targets) {
 					continue
 				}
 				for _, locale := range locales {

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -116,6 +116,10 @@ func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
+	configRoot, err := config.ConfigDirectory(options.configPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config directory: %w", err)
+	}
 
 	locales, err := resolveStatusLocales(cfg, nil, options.group)
 	if err != nil {
@@ -136,7 +140,7 @@ func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
 		bucket := cfg.Buckets[bucketName]
 		for _, file := range bucket.Files {
 			sourcePattern := pathresolver.ResolveSourcePath(file.From, cfg.Locales.Source)
-			sourcePaths, err := resolveSourcePathsForStatus(sourcePattern)
+			sourcePaths, err := resolveSourcePathsForStatus(configRoot, sourcePattern)
 			if err != nil {
 				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
 			}
@@ -146,7 +150,7 @@ func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
 				}
 				for _, locale := range locales {
 					targetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, locale)
-					targetPath, err := resolveTargetPathForStatus(sourcePattern, targetPattern, sourcePath)
+					targetPath, err := resolveTargetPathForStatus(configRoot, sourcePattern, targetPattern, sourcePath)
 					if err != nil {
 						return nil, fmt.Errorf("resolve target path for source %q: %w", sourcePath, err)
 					}

--- a/apps/cli/cmd/pack_test.go
+++ b/apps/cli/cmd/pack_test.go
@@ -963,3 +963,54 @@ func assertPackPrefixIDCollisionError(t *testing.T, err error, idA, idB, packedI
 		t.Fatalf("error %q must mention packed id %q", msg, packedID)
 	}
 }
+
+func TestPackCommandResolvesPathsRelativeToConfigDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	projectDir := filepath.Join(repoRoot, "nested-app")
+	configPath := filepath.Join(projectDir, "i18n.jsonc")
+	langDir := filepath.Join(projectDir, "lang")
+	distDir := filepath.Join(projectDir, "dist")
+
+	writePackTestFile(t, filepath.Join(langDir, "en-US.json"), `{
+  "home.title": {
+    "defaultMessage": "Dashboard",
+    "description": "Home heading"
+  }
+}`)
+	writePackTestFile(t, filepath.Join(distDir, "es-ES.json"), `{
+  "home.title": {
+    "defaultMessage": "Panel",
+    "description": "Home heading"
+  }
+}`)
+	writePackConfigWithFiles(t, configPath, []packConfigFileMapping{
+		{from: "lang/{{source}}.json", to: "dist/{{target}}.json"},
+	})
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	errOut := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.SetArgs([]string{"--config", configPath, "--out-suffix", ".packed"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("pack command from foreign cwd with nested config: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "dist/es-ES.packed.json") {
+		t.Fatalf("expected status output for packed file, got %q", errOut.String())
+	}
+
+	content, err := os.ReadFile(filepath.Join(distDir, "es-ES.packed.json"))
+	if err != nil {
+		t.Fatalf("read packed output file: %v", err)
+	}
+	got := decodePackCatalogOutput(t, content)
+	want := map[string]extractCatalogMessage{
+		"home.title": {DefaultMessage: "Panel"},
+	}
+	assertPackCatalogOutput(t, got, want)
+}

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -2047,3 +2047,29 @@ func TestLoadPrefilledEntriesFlatAndLocaleKeyed(t *testing.T) {
 		t.Fatalf("expected mixed shape error, got %v", err)
 	}
 }
+
+func TestRunDryRunResolvesPathsRelativeToConfigDirectory(t *testing.T) {
+	configPath, _, targetPath := setupNestedConfigLocaleProject(t)
+	if err := os.Remove(targetPath); err != nil {
+		t.Fatalf("remove target before dry-run: %v", err)
+	}
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run command dry-run from foreign cwd with nested config: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry_run=true") {
+		t.Fatalf("expected dry-run output, got %q", out.String())
+	}
+	if _, statErr := os.Stat(targetPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no target file written in dry-run, stat err=%v", statErr)
+	}
+}

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -2073,3 +2073,26 @@ func TestRunDryRunResolvesPathsRelativeToConfigDirectory(t *testing.T) {
 		t.Fatalf("expected no target file written in dry-run, stat err=%v", statErr)
 	}
 }
+
+func TestRunDryRunFileFilterResolvesRelativeToConfigDirectory(t *testing.T) {
+	configPath, _, targetPath := setupNestedConfigLocaleProject(t)
+	if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove target before dry-run: %v", err)
+	}
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run", "--file", "src/locales/en/common.json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run command dry-run with relative --file from foreign cwd: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry_run=true") {
+		t.Fatalf("expected dry-run output, got %q", out.String())
+	}
+}

--- a/apps/cli/cmd/status.go
+++ b/apps/cli/cmd/status.go
@@ -386,11 +386,13 @@ func filterByLocaleAndBucket(entries []storage.Entry, locales []string, bucket s
 
 func shouldIgnoreSourcePathForStatus(sourcePath, configRoot string, targetLocales []string) bool {
 	pathForScan := sourcePath
+	configRelative := false
 	if root := strings.TrimSpace(configRoot); root != "" {
 		if rel, err := filepath.Rel(root, sourcePath); err == nil {
 			rel = filepath.ToSlash(rel)
 			if rel != ".." && !strings.HasPrefix(rel, "../") {
 				pathForScan = rel
+				configRelative = true
 			}
 		}
 	}
@@ -406,7 +408,11 @@ func shouldIgnoreSourcePathForStatus(sourcePath, configRoot string, targetLocale
 		targets[locale] = struct{}{}
 	}
 
-	for i := 1; i < len(segments)-1; i++ {
+	start := 1
+	if configRelative {
+		start = 0
+	}
+	for i := start; i < len(segments)-1; i++ {
 		if _, ok := targets[segments[i]]; ok {
 			return true
 		}

--- a/apps/cli/cmd/status.go
+++ b/apps/cli/cmd/status.go
@@ -69,9 +69,14 @@ Status values:
 				return err
 			}
 
+			configRoot, err := config.ConfigDirectory(o.configPath)
+			if err != nil {
+				return fmt.Errorf("resolve config directory: %w", err)
+			}
+
 			entries, err := collectStatusEntries(context.Background(), cfg, syncsvc.LocalReadRequest{
 				Locales: locales,
-			}, buckets)
+			}, buckets, configRoot)
 			if err != nil {
 				return fmt.Errorf("read local translations: %w", err)
 			}
@@ -198,7 +203,7 @@ func statusBucketFiles(cfg *config.I18NConfig, bucket string) (map[string]struct
 	return files, nil
 }
 
-func collectStatusEntries(_ context.Context, cfg *config.I18NConfig, req syncsvc.LocalReadRequest, buckets []string) ([]storage.Entry, error) {
+func collectStatusEntries(_ context.Context, cfg *config.I18NConfig, req syncsvc.LocalReadRequest, buckets []string, configRoot string) ([]storage.Entry, error) {
 	parser := translationfileparser.NewDefaultStrategy()
 	locales := req.Locales
 	if len(locales) == 0 {
@@ -210,7 +215,7 @@ func collectStatusEntries(_ context.Context, cfg *config.I18NConfig, req syncsvc
 		bucket := cfg.Buckets[bucketName]
 		for _, file := range bucket.Files {
 			sourcePattern := pathresolver.ResolveSourcePath(file.From, cfg.Locales.Source)
-			sourcePaths, err := resolveSourcePathsForStatus(sourcePattern)
+			sourcePaths, err := resolveSourcePathsForStatus(configRoot, sourcePattern)
 			if err != nil {
 				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
 			}
@@ -245,7 +250,7 @@ func collectStatusEntries(_ context.Context, cfg *config.I18NConfig, req syncsvc
 
 				for _, locale := range locales {
 					targetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, locale)
-					targetPath, err := resolveTargetPathForStatus(sourcePattern, targetPattern, sourcePath)
+					targetPath, err := resolveTargetPathForStatus(configRoot, sourcePattern, targetPattern, sourcePath)
 					if err != nil {
 						return nil, fmt.Errorf("resolve target path for source %q: %w", sourcePath, err)
 					}
@@ -399,12 +404,55 @@ func shouldIgnoreSourcePathForStatus(sourcePath string, targetLocales []string) 
 	return false
 }
 
-func resolveSourcePathsForStatus(sourcePattern string) ([]string, error) {
-	if !strings.ContainsAny(sourcePattern, "*?[") {
-		return []string{sourcePattern}, nil
+func resolveConfigRelativePath(configRoot, path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("path is empty")
 	}
-	if !strings.Contains(sourcePattern, "**") {
-		matches, err := filepath.Glob(sourcePattern)
+	if filepath.IsAbs(trimmed) {
+		return filepath.Clean(trimmed), nil
+	}
+	root := strings.TrimSpace(configRoot)
+	if root == "" {
+		return filepath.Clean(trimmed), nil
+	}
+	return filepath.Join(root, trimmed), nil
+}
+
+func relativizeConfigPath(configRoot, path string) (string, error) {
+	root := strings.TrimSpace(configRoot)
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	if root == "" {
+		return filepath.Clean(trimmed), nil
+	}
+	abs, err := resolveConfigRelativePath(root, trimmed)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
+		return "", fmt.Errorf("relativize path %q against config root: %w", trimmed, err)
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", fmt.Errorf("path %q escapes config root %q", trimmed, root)
+	}
+	return rel, nil
+}
+
+func resolveSourcePathsForStatus(configRoot, sourcePattern string) ([]string, error) {
+	resolvedPattern, err := resolveConfigRelativePath(configRoot, sourcePattern)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.ContainsAny(resolvedPattern, "*?[") {
+		return []string{resolvedPattern}, nil
+	}
+	if !strings.Contains(resolvedPattern, "**") {
+		matches, err := filepath.Glob(resolvedPattern)
 		if err != nil {
 			return nil, err
 		}
@@ -412,13 +460,13 @@ func resolveSourcePathsForStatus(sourcePattern string) ([]string, error) {
 		return matches, nil
 	}
 
-	normalizedPattern := filepath.ToSlash(sourcePattern)
+	normalizedPattern := filepath.ToSlash(resolvedPattern)
 	re, err := globToRegexForStatus(normalizedPattern)
 	if err != nil {
 		return nil, err
 	}
 
-	baseDir := baseDirForDoublestarForStatus(sourcePattern)
+	baseDir := baseDirForDoublestarForStatus(resolvedPattern)
 	matches := make([]string, 0)
 	err = filepath.WalkDir(baseDir, func(candidate string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -440,16 +488,28 @@ func resolveSourcePathsForStatus(sourcePattern string) ([]string, error) {
 	return matches, nil
 }
 
-func resolveTargetPathForStatus(sourcePattern, targetPattern, sourcePath string) (string, error) {
-	if !strings.ContainsAny(sourcePattern, "*?[") {
-		return targetPattern, nil
+func resolveTargetPathForStatus(configRoot, sourcePattern, targetPattern, sourcePath string) (string, error) {
+	resolvedSourcePattern, err := resolveConfigRelativePath(configRoot, sourcePattern)
+	if err != nil {
+		return "", err
 	}
-	if !strings.ContainsAny(targetPattern, "*?[") {
-		return "", fmt.Errorf("target pattern %q must include glob tokens when source pattern %q includes globs", targetPattern, sourcePattern)
+	resolvedTargetPattern, err := resolveConfigRelativePath(configRoot, targetPattern)
+	if err != nil {
+		return "", err
 	}
-	sourceBase := globBaseDirForStatus(sourcePattern)
-	targetBase := globBaseDirForStatus(targetPattern)
-	relative, err := filepath.Rel(sourceBase, sourcePath)
+	resolvedSourcePath, err := resolveConfigRelativePath(configRoot, sourcePath)
+	if err != nil {
+		return "", err
+	}
+	if !strings.ContainsAny(resolvedSourcePattern, "*?[") {
+		return resolvedTargetPattern, nil
+	}
+	if !strings.ContainsAny(resolvedTargetPattern, "*?[") {
+		return "", fmt.Errorf("target pattern %q must include glob tokens when source pattern %q includes globs", resolvedTargetPattern, resolvedSourcePattern)
+	}
+	sourceBase := globBaseDirForStatus(resolvedSourcePattern)
+	targetBase := globBaseDirForStatus(resolvedTargetPattern)
+	relative, err := filepath.Rel(sourceBase, resolvedSourcePath)
 	if err != nil {
 		return "", err
 	}

--- a/apps/cli/cmd/status.go
+++ b/apps/cli/cmd/status.go
@@ -220,7 +220,7 @@ func collectStatusEntries(_ context.Context, cfg *config.I18NConfig, req syncsvc
 				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
 			}
 			for _, sourcePath := range sourcePaths {
-				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
+				if shouldIgnoreSourcePathForStatus(sourcePath, configRoot, cfg.Locales.Targets) {
 					continue
 				}
 
@@ -384,8 +384,18 @@ func filterByLocaleAndBucket(entries []storage.Entry, locales []string, bucket s
 	return withBucket
 }
 
-func shouldIgnoreSourcePathForStatus(sourcePath string, targetLocales []string) bool {
-	normalized := filepath.ToSlash(sourcePath)
+func shouldIgnoreSourcePathForStatus(sourcePath, configRoot string, targetLocales []string) bool {
+	pathForScan := sourcePath
+	if root := strings.TrimSpace(configRoot); root != "" {
+		if rel, err := filepath.Rel(root, sourcePath); err == nil {
+			rel = filepath.ToSlash(rel)
+			if rel != ".." && !strings.HasPrefix(rel, "../") {
+				pathForScan = rel
+			}
+		}
+	}
+
+	normalized := filepath.ToSlash(pathForScan)
 	segments := strings.Split(normalized, "/")
 	if len(segments) < 2 {
 		return false
@@ -441,6 +451,63 @@ func relativizeConfigPath(configRoot, path string) (string, error) {
 		return "", fmt.Errorf("path %q escapes config root %q", trimmed, root)
 	}
 	return rel, nil
+}
+
+func checkPathLookupCandidates(configRoot, path string) []string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	add := func(candidate string) {
+		candidate = filepath.Clean(candidate)
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+	}
+
+	add(trimmed)
+	if abs, err := filepath.Abs(trimmed); err == nil {
+		add(abs)
+	}
+	if root := strings.TrimSpace(configRoot); root != "" {
+		if resolved, err := resolveConfigRelativePath(root, trimmed); err == nil {
+			add(resolved)
+		}
+		if rel, err := relativizeConfigPath(root, trimmed); err == nil {
+			add(rel)
+		}
+	}
+
+	candidates := make([]string, 0, len(seen))
+	for candidate := range seen {
+		candidates = append(candidates, candidate)
+	}
+	slices.Sort(candidates)
+	return candidates
+}
+
+func lookupCheckSourceDescriptor(index *checkConfigIndex, configRoot, path string) (checkSourceDescriptor, bool) {
+	for _, candidate := range checkPathLookupCandidates(configRoot, path) {
+		if desc, ok := index.sourceByPath[candidate]; ok {
+			return desc, true
+		}
+	}
+	return checkSourceDescriptor{}, false
+}
+
+func lookupCheckTargetLookup(index *checkConfigIndex, configRoot, path string) (checkTargetLookup, bool) {
+	for _, candidate := range checkPathLookupCandidates(configRoot, path) {
+		if lookup, ok := index.targetToSource[candidate]; ok {
+			return lookup, true
+		}
+	}
+	return checkTargetLookup{}, false
 }
 
 func resolveSourcePathsForStatus(configRoot, sourcePattern string) ([]string, error) {

--- a/apps/cli/cmd/status_paths_test.go
+++ b/apps/cli/cmd/status_paths_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
 )
 
 func TestResolveConfigRelativePath(t *testing.T) {
@@ -222,4 +224,37 @@ func setupNestedConfigLocaleProject(t *testing.T) (configPath, sourcePath, targe
 	}, []string{"fr"})
 
 	return configPath, sourcePath, targetPath
+}
+
+func TestShouldIgnoreSourcePathForStatusIgnoresLocaleOutsideConfigRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	projectDir := filepath.Join(repoRoot, "fr", "nested-app")
+	sourcePath := filepath.Join(projectDir, "src", "locales", "en", "common.json")
+	if shouldIgnoreSourcePathForStatus(sourcePath, projectDir, []string{"fr"}) {
+		t.Fatalf("expected ancestor locale directory outside config-relative path to be ignored for filtering")
+	}
+}
+
+func TestLookupCheckSourceDescriptorMatchesConfigRelativeDiffPath(t *testing.T) {
+	configPath, sourcePath, _ := setupNestedConfigLocaleProject(t)
+	index, err := buildCheckConfigIndex(mustLoadCheckConfig(t, configPath), []string{"ui"}, []string{"fr"}, filepath.Dir(configPath))
+	if err != nil {
+		t.Fatalf("buildCheckConfigIndex: %v", err)
+	}
+
+	if _, ok := lookupCheckSourceDescriptor(index, filepath.Dir(configPath), "src/locales/en/common.json"); !ok {
+		t.Fatalf("expected config-relative diff path to match indexed source")
+	}
+	if _, ok := lookupCheckSourceDescriptor(index, filepath.Dir(configPath), sourcePath); !ok {
+		t.Fatalf("expected absolute source path to match indexed source")
+	}
+}
+
+func mustLoadCheckConfig(t *testing.T, configPath string) *config.I18NConfig {
+	t.Helper()
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	return cfg
 }

--- a/apps/cli/cmd/status_paths_test.go
+++ b/apps/cli/cmd/status_paths_test.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveConfigRelativePath(t *testing.T) {
+	root := t.TempDir()
+	absInside := filepath.Join(root, "src", "en.json")
+
+	tests := []struct {
+		name       string
+		configRoot string
+		path       string
+		want       string
+		wantErr    string
+	}{
+		{
+			name:       "joins relative path to config root",
+			configRoot: root,
+			path:       "src/en.json",
+			want:       filepath.Join(root, "src", "en.json"),
+		},
+		{
+			name:       "keeps absolute path",
+			configRoot: root,
+			path:       absInside,
+			want:       absInside,
+		},
+		{
+			name:       "returns cleaned relative path without config root",
+			configRoot: "",
+			path:       "src/en.json",
+			want:       "src/en.json",
+		},
+		{
+			name:    "rejects empty path",
+			path:    "  ",
+			wantErr: "path is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveConfigRelativePath(tt.configRoot, tt.path)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveConfigRelativePath() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveConfigRelativePath() error = %v", err)
+			}
+			if filepath.Clean(got) != filepath.Clean(tt.want) {
+				t.Fatalf("resolveConfigRelativePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelativizeConfigPath(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	inside := filepath.Join(root, "src", "en.json")
+	if err := os.MkdirAll(filepath.Dir(inside), 0o755); err != nil {
+		t.Fatalf("mkdir inside: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		configRoot string
+		path       string
+		want       string
+		wantErr    string
+	}{
+		{
+			name:       "relativizes absolute path under config root",
+			configRoot: root,
+			path:       inside,
+			want:       "src/en.json",
+		},
+		{
+			name:       "relativizes config-relative path",
+			configRoot: root,
+			path:       "src/en.json",
+			want:       "src/en.json",
+		},
+		{
+			name:       "returns cleaned path without config root",
+			configRoot: "",
+			path:       "src/en.json",
+			want:       "src/en.json",
+		},
+		{
+			name:       "rejects path outside config root",
+			configRoot: root,
+			path:       filepath.Join(outside, "en.json"),
+			wantErr:    "escapes config root",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := relativizeConfigPath(tt.configRoot, tt.path)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("relativizeConfigPath() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("relativizeConfigPath() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("relativizeConfigPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveSourcePathsForStatusUsesConfigRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	projectDir := filepath.Join(repoRoot, "nested-app")
+	sourcePath := filepath.Join(projectDir, "src", "locales", "en", "common.json")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	got, err := resolveSourcePathsForStatus(projectDir, "src/locales/en/common.json")
+	if err != nil {
+		t.Fatalf("resolveSourcePathsForStatus() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("resolveSourcePathsForStatus() = %v, want one path", got)
+	}
+	if filepath.Clean(got[0]) != filepath.Clean(sourcePath) {
+		t.Fatalf("resolveSourcePathsForStatus() = %q, want %q", got[0], sourcePath)
+	}
+}
+
+func TestResolveSourcePathsForStatusExpandsDoublestarGlobFromConfigRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	projectDir := filepath.Join(repoRoot, "nested-app")
+	first := filepath.Join(projectDir, "_posts", "en", "alpha.md")
+	second := filepath.Join(projectDir, "_posts", "en", "nested", "beta.md")
+	for _, path := range []string{first, second} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %q: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte("# post"), 0o600); err != nil {
+			t.Fatalf("write %q: %v", path, err)
+		}
+	}
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	got, err := resolveSourcePathsForStatus(projectDir, "_posts/en/**/*.md")
+	if err != nil {
+		t.Fatalf("resolveSourcePathsForStatus() error = %v", err)
+	}
+	want := []string{first, second}
+	if len(got) != len(want) {
+		t.Fatalf("resolveSourcePathsForStatus() = %v, want %v", got, want)
+	}
+	for i, path := range want {
+		if filepath.Clean(got[i]) != filepath.Clean(path) {
+			t.Fatalf("resolveSourcePathsForStatus()[%d] = %q, want %q", i, got[i], path)
+		}
+	}
+}
+
+func TestResolveTargetPathForStatusMapsGlobFromConfigRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	projectDir := filepath.Join(repoRoot, "nested-app")
+	sourcePattern := "_posts/en/**/*.md"
+	sourcePath := filepath.Join(projectDir, "_posts", "en", "guides", "intro.md")
+
+	got, err := resolveTargetPathForStatus(projectDir, sourcePattern, "_posts/fr/**/*.md", sourcePath)
+	if err != nil {
+		t.Fatalf("resolveTargetPathForStatus() error = %v", err)
+	}
+	want := filepath.Join(projectDir, "_posts", "fr", "guides", "intro.md")
+	if filepath.Clean(got) != filepath.Clean(want) {
+		t.Fatalf("resolveTargetPathForStatus() = %q, want %q", got, want)
+	}
+}
+
+func setupNestedConfigLocaleProject(t *testing.T) (configPath, sourcePath, targetPath string) {
+	t.Helper()
+
+	repoRoot := t.TempDir()
+	projectDir := filepath.Join(repoRoot, "nested-app")
+	configPath = filepath.Join(projectDir, "i18n.jsonc")
+	sourcePath = filepath.Join(projectDir, "src", "locales", "en", "common.json")
+	targetPath = filepath.Join(projectDir, "src", "locales", "fr", "common.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"hello":"Bonjour"}`), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfigWithMappings(t, configPath, []checkConfigMapping{
+		{source: "src/locales/en/common.json", target: "src/locales/fr/common.json"},
+	}, []string{"fr"})
+
+	return configPath, sourcePath, targetPath
+}

--- a/apps/cli/cmd/status_test.go
+++ b/apps/cli/cmd/status_test.go
@@ -920,3 +920,31 @@ func testStatusConfig() *config.I18NConfig {
 		},
 	}
 }
+
+func TestStatusCommandResolvesPathsRelativeToConfigDirectory(t *testing.T) {
+	configPath, _, _ := setupNestedConfigLocaleProject(t)
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"status", "--config", configPath, "--output", "csv"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status command from foreign cwd with nested config: %v", err)
+	}
+
+	rows, err := csv.NewReader(bytes.NewReader(out.Bytes())).ReadAll()
+	if err != nil {
+		t.Fatalf("parse csv: %v\n%s", err, out.String())
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected header plus one row, got %d: %v", len(rows), rows)
+	}
+	if rows[1][0] != "hello" || rows[1][2] != "fr" || rows[1][3] != "translated" {
+		t.Fatalf("expected translated hello row for fr, got %v", rows[1])
+	}
+}

--- a/apps/cli/cmd/sync_hyperlocalise.go
+++ b/apps/cli/cmd/sync_hyperlocalise.go
@@ -357,7 +357,7 @@ func planHyperlocaliseFilesWithOptions(cfg *config.I18NConfig, localeFilter []st
 				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
 			}
 			for _, resolvedSourcePath := range sourcePaths {
-				if shouldIgnoreSourcePathForStatus(resolvedSourcePath, cfg.Locales.Targets) {
+				if shouldIgnoreSourcePathForStatus(resolvedSourcePath, configRoot, cfg.Locales.Targets) {
 					continue
 				}
 				fileFormat := inferHyperlocaliseFileFormat(resolvedSourcePath)

--- a/apps/cli/cmd/sync_hyperlocalise.go
+++ b/apps/cli/cmd/sync_hyperlocalise.go
@@ -148,7 +148,7 @@ func newHyperlocaliseSyncRuntime(configPath string) (*hyperlocaliseSyncRuntime, 
 }
 
 func runHyperlocalisePush(ctx context.Context, rt *hyperlocaliseSyncRuntime, o syncCommonOptions) (hyperlocalisePushReport, error) {
-	plans, err := planHyperlocaliseFiles(rt.cfg, o.locales)
+	plans, err := planHyperlocaliseFiles(rt.cfg, o.locales, rt.configRoot)
 	if err != nil {
 		return hyperlocalisePushReport{}, err
 	}
@@ -166,7 +166,7 @@ func runHyperlocalisePush(ctx context.Context, rt *hyperlocaliseSyncRuntime, o s
 
 	var failedItems []string
 	for _, plan := range plans {
-		if _, uploadErr := rt.client.uploadFile(ctx, rt.projectID, plan); uploadErr != nil {
+		if _, uploadErr := rt.client.uploadFile(ctx, rt.projectID, rt.configRoot, plan); uploadErr != nil {
 			failedItems = append(failedItems, fmt.Sprintf("%s: %v", plan.SourcePath, uploadErr))
 			continue
 		}
@@ -183,7 +183,7 @@ func runHyperlocalisePush(ctx context.Context, rt *hyperlocaliseSyncRuntime, o s
 }
 
 func runHyperlocalisePull(ctx context.Context, rt *hyperlocaliseSyncRuntime, o syncCommonOptions) (hyperlocalisePullReport, error) {
-	plans, err := planHyperlocaliseFilesWithOptions(rt.cfg, o.locales, false)
+	plans, err := planHyperlocaliseFilesWithOptions(rt.cfg, o.locales, false, rt.configRoot)
 	if err != nil {
 		return hyperlocalisePullReport{}, err
 	}
@@ -331,11 +331,11 @@ func (rt *hyperlocaliseSyncRuntime) reconstructPullFile(plan hyperlocaliseFilePl
 	})
 }
 
-func planHyperlocaliseFiles(cfg *config.I18NConfig, localeFilter []string) ([]hyperlocaliseFilePlan, error) {
-	return planHyperlocaliseFilesWithOptions(cfg, localeFilter, true)
+func planHyperlocaliseFiles(cfg *config.I18NConfig, localeFilter []string, configRoot string) ([]hyperlocaliseFilePlan, error) {
+	return planHyperlocaliseFilesWithOptions(cfg, localeFilter, true, configRoot)
 }
 
-func planHyperlocaliseFilesWithOptions(cfg *config.I18NConfig, localeFilter []string, hashSources bool) ([]hyperlocaliseFilePlan, error) {
+func planHyperlocaliseFilesWithOptions(cfg *config.I18NConfig, localeFilter []string, hashSources bool, configRoot string) ([]hyperlocaliseFilePlan, error) {
 	targetLocales, err := resolveHyperlocaliseTargetLocales(cfg.Locales.Targets, localeFilter)
 	if err != nil {
 		return nil, err
@@ -352,31 +352,39 @@ func planHyperlocaliseFilesWithOptions(cfg *config.I18NConfig, localeFilter []st
 		bucket := cfg.Buckets[bucketName]
 		for _, mapping := range bucket.Files {
 			sourcePattern := pathresolver.ResolveSourcePath(mapping.From, cfg.Locales.Source)
-			sourcePaths, err := resolveSourcePathsForStatus(sourcePattern)
+			sourcePaths, err := resolveSourcePathsForStatus(configRoot, sourcePattern)
 			if err != nil {
 				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
 			}
-			for _, sourcePath := range sourcePaths {
-				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
+			for _, resolvedSourcePath := range sourcePaths {
+				if shouldIgnoreSourcePathForStatus(resolvedSourcePath, cfg.Locales.Targets) {
 					continue
 				}
-				fileFormat := inferHyperlocaliseFileFormat(sourcePath)
+				fileFormat := inferHyperlocaliseFileFormat(resolvedSourcePath)
 				if fileFormat == "" {
-					return nil, fmt.Errorf("unsupported source file format for %q", sourcePath)
+					return nil, fmt.Errorf("unsupported source file format for %q", resolvedSourcePath)
+				}
+				sourcePath, err := relativizeConfigPath(configRoot, resolvedSourcePath)
+				if err != nil {
+					return nil, fmt.Errorf("relativize source path %q: %w", resolvedSourcePath, err)
 				}
 				sourceHash := ""
 				if hashSources {
-					sourceHash, err = sha256File(sourcePath)
+					sourceHash, err = sha256File(resolvedSourcePath)
 					if err != nil {
-						return nil, fmt.Errorf("hash source file %q: %w", sourcePath, err)
+						return nil, fmt.Errorf("hash source file %q: %w", resolvedSourcePath, err)
 					}
 				}
 				targetPaths := make(map[string]string, len(targetLocales))
 				for _, locale := range targetLocales {
 					targetPattern := pathresolver.ResolveTargetPath(mapping.To, cfg.Locales.Source, locale)
-					targetPath, err := resolveTargetPathForStatus(sourcePattern, targetPattern, sourcePath)
+					resolvedTargetPath, err := resolveTargetPathForStatus(configRoot, sourcePattern, targetPattern, resolvedSourcePath)
 					if err != nil {
-						return nil, fmt.Errorf("resolve target path for source %q: %w", sourcePath, err)
+						return nil, fmt.Errorf("resolve target path for source %q: %w", resolvedSourcePath, err)
+					}
+					targetPath, err := relativizeConfigPath(configRoot, resolvedTargetPath)
+					if err != nil {
+						return nil, fmt.Errorf("relativize target path %q: %w", resolvedTargetPath, err)
 					}
 					targetPaths[locale] = targetPath
 				}
@@ -532,8 +540,12 @@ func sha256File(path string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func (c *hyperlocaliseAPIClient) uploadFile(ctx context.Context, projectID string, plan hyperlocaliseFilePlan) (string, error) {
-	content, err := os.ReadFile(plan.SourcePath)
+func (c *hyperlocaliseAPIClient) uploadFile(ctx context.Context, projectID, configRoot string, plan hyperlocaliseFilePlan) (string, error) {
+	resolvedSourcePath, err := runsvc.ResolveExportPath(configRoot, plan.SourcePath)
+	if err != nil {
+		return "", fmt.Errorf("resolve source path %q: %w", plan.SourcePath, err)
+	}
+	content, err := os.ReadFile(resolvedSourcePath)
 	if err != nil {
 		return "", err
 	}

--- a/apps/cli/cmd/sync_hyperlocalise_test.go
+++ b/apps/cli/cmd/sync_hyperlocalise_test.go
@@ -555,7 +555,7 @@ func TestPlanHyperlocaliseFilesExpandsBlogMarkdownGlob(t *testing.T) {
 		},
 	}
 
-	plans, err := planHyperlocaliseFiles(cfg, nil)
+	plans, err := planHyperlocaliseFiles(cfg, nil, dir)
 	if err != nil {
 		t.Fatalf("planHyperlocaliseFiles: %v", err)
 	}
@@ -1092,6 +1092,11 @@ func newHyperlocalisePushTestRuntime(server *httptest.Server, extraFiles []confi
 	}}
 	files = append(files, extraFiles...)
 
+	configRoot, err := os.Getwd()
+	if err != nil {
+		configRoot = ""
+	}
+
 	return &hyperlocaliseSyncRuntime{
 		cfg: &config.I18NConfig{
 			Locales: config.LocaleConfig{
@@ -1104,7 +1109,8 @@ func newHyperlocalisePushTestRuntime(server *httptest.Server, extraFiles []confi
 				},
 			},
 		},
-		projectID: "project-1",
+		configRoot: configRoot,
+		projectID:  "project-1",
 		client: &hyperlocaliseAPIClient{
 			baseURL:    server.URL,
 			apiKey:     "test-key",

--- a/apps/cli/internal/i18n/runsvc/executor.go
+++ b/apps/cli/internal/i18n/runsvc/executor.go
@@ -79,7 +79,7 @@ type contextMemorySlot struct {
 	memory string
 }
 
-func newExecutorState(tasks []Task, initialStaged map[string]stagedOutput, pruneTargets map[string]map[string]struct{}, contextPlan contextMemoryPlan, omitPerEntryBatches bool) (*executorState, error) {
+func newExecutorState(tasks []Task, projectRoot string, initialStaged map[string]stagedOutput, pruneTargets map[string]map[string]struct{}, contextPlan contextMemoryPlan, omitPerEntryBatches bool) (*executorState, error) {
 	staged := map[string]stagedOutput{}
 	for targetPath, output := range initialStaged {
 		entries := map[string]string{}
@@ -106,7 +106,7 @@ func newExecutorState(tasks []Task, initialStaged map[string]stagedOutput, prune
 	}
 	for _, task := range tasks {
 		state.pendingByTarget[task.TargetPath]++
-		state.idsByTarget[task.TargetPath] = append(state.idsByTarget[task.TargetPath], taskIdentity(task.TargetPath, task.EntryKey))
+		state.idsByTarget[task.TargetPath] = append(state.idsByTarget[task.TargetPath], preferredTaskIdentity(projectRoot, task.TargetPath, task.EntryKey))
 		existing := state.sourceByTarget[task.TargetPath]
 		if existing != "" && existing != task.SourcePath {
 			return nil, fmt.Errorf("output staging conflict: %s has conflicting source paths", task.TargetPath)
@@ -132,7 +132,7 @@ func (s *Service) executePool(ctx context.Context, tasks []Task, initialStaged m
 		scheduledTasks = interleaveTasksByContextKey(tasks)
 	}
 
-	state, err := newExecutorState(scheduledTasks, initialStaged, pruneTargets, contextPlan, omitPerEntryBatches)
+	state, err := newExecutorState(scheduledTasks, s.projectRoot, initialStaged, pruneTargets, contextPlan, omitPerEntryBatches)
 	if err != nil {
 		return nil, nil, executionReport{}, err
 	}

--- a/apps/cli/internal/i18n/runsvc/executor.go
+++ b/apps/cli/internal/i18n/runsvc/executor.go
@@ -544,7 +544,7 @@ func (s *Service) processTask(ctx context.Context, task Task, completions chan<-
 	}
 
 	select {
-	case completions <- taskCompletion{identity: taskIdentity(task.TargetPath, task.EntryKey), entryKey: task.EntryKey, value: outputValue, sourceHash: sourceHash, taskHash: taskHash, targetPath: task.TargetPath, sourcePath: task.SourcePath, targetLocale: task.TargetLocale}:
+	case completions <- taskCompletion{identity: preferredTaskIdentity(s.projectRoot, task.TargetPath, task.EntryKey), entryKey: task.EntryKey, value: outputValue, sourceHash: sourceHash, taskHash: taskHash, targetPath: task.TargetPath, sourcePath: task.SourcePath, targetLocale: task.TargetLocale}:
 		state.reportMu.Lock()
 		state.report.Succeeded++
 		state.report.TokenUsage = addTokenUsage(state.report.TokenUsage, toRunTokenUsage(usage))

--- a/apps/cli/internal/i18n/runsvc/lock_prune.go
+++ b/apps/cli/internal/i18n/runsvc/lock_prune.go
@@ -6,13 +6,14 @@ import (
 	"github.com/hyperlocalise/hyperlocalise/apps/cli/internal/i18n/lockfile"
 )
 
-func buildPlannedLockKeySet(planned []Task) map[string]map[string]struct{} {
+func buildPlannedLockKeySet(planned []Task, projectRoot string) map[string]map[string]struct{} {
 	keep := map[string]map[string]struct{}{}
 	for _, task := range planned {
-		bucket := keep[task.TargetPath]
+		targetPath := plannedLockTargetPath(projectRoot, task.TargetPath)
+		bucket := keep[targetPath]
 		if bucket == nil {
 			bucket = map[string]struct{}{}
-			keep[task.TargetPath] = bucket
+			keep[targetPath] = bucket
 		}
 		bucket[task.EntryKey] = struct{}{}
 	}
@@ -77,5 +78,5 @@ func (s *Service) reconcileLockEntries(in Input, planned []Task, state *lockfile
 	if !shouldPruneLock(in) {
 		return 0
 	}
-	return pruneLockEntries(state, buildPlannedLockKeySet(planned))
+	return pruneLockEntries(state, buildPlannedLockKeySet(planned, s.projectRoot))
 }

--- a/apps/cli/internal/i18n/runsvc/lock_prune_test.go
+++ b/apps/cli/internal/i18n/runsvc/lock_prune_test.go
@@ -1,6 +1,7 @@
 package runsvc
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/hyperlocalise/hyperlocalise/apps/cli/internal/i18n/lockfile"
@@ -52,5 +53,43 @@ func TestShouldPruneLock(t *testing.T) {
 	}
 	if shouldPruneLock(Input{Bucket: "docs"}) {
 		t.Fatal("expected scoped run without prune to skip lock pruning")
+	}
+}
+
+func TestRollbackLockForTargetUsesPreferredIdentity(t *testing.T) {
+	projectDir := t.TempDir()
+	targetAbs := filepath.Join(projectDir, "dist", "fr", "strings.json")
+	task := Task{TargetPath: targetAbs, EntryKey: "hello"}
+
+	state, err := newExecutorState([]Task{task}, projectDir, nil, nil, contextMemoryPlan{}, false)
+	if err != nil {
+		t.Fatalf("newExecutorState: %v", err)
+	}
+
+	identity := preferredTaskIdentity(projectDir, targetAbs, "hello")
+	lockState := &lockfile.File{
+		RunCompleted: map[string]lockfile.RunCompletion{
+			identity: {SourceHash: "abc"},
+		},
+	}
+
+	removed, changed := (&Service{}).rollbackLockForTarget(lockState, targetAbs, map[string]struct{}{}, state)
+	if !changed || removed != 1 {
+		t.Fatalf("rollbackLockForTarget() = (%d, %v), want (1, true)", removed, changed)
+	}
+	if _, ok := lockState.RunCompleted[identity]; ok {
+		t.Fatalf("expected completion %q to be rolled back", identity)
+	}
+}
+
+func TestBuildPlannedLockKeySetUsesRelativeTargetPath(t *testing.T) {
+	projectDir := t.TempDir()
+	targetAbs := filepath.Join(projectDir, "dist", "fr", "strings.json")
+	keep := buildPlannedLockKeySet([]Task{{TargetPath: targetAbs, EntryKey: "hello"}}, projectDir)
+	if _, ok := keep["dist/fr/strings.json"]; !ok {
+		t.Fatalf("expected relative target path key, got %+v", keep)
+	}
+	if _, ok := keep[targetAbs]; ok {
+		t.Fatalf("did not expect absolute target path key, got %+v", keep)
 	}
 }

--- a/apps/cli/internal/i18n/runsvc/path_glob.go
+++ b/apps/cli/internal/i18n/runsvc/path_glob.go
@@ -11,15 +11,21 @@ import (
 
 func shouldIgnoreSourcePath(sourcePath, projectRoot string, targetLocales []string) bool {
 	pathForScan := sourcePath
+	configRelative := false
 	if root := strings.TrimSpace(projectRoot); root != "" {
 		if rel, err := filepath.Rel(root, sourcePath); err == nil {
 			rel = filepath.ToSlash(rel)
 			if rel != ".." && !strings.HasPrefix(rel, "../") {
 				pathForScan = rel
+				configRelative = true
 			}
 		}
 	}
 
+	return shouldIgnoreLocalePathSegments(pathForScan, configRelative, targetLocales)
+}
+
+func shouldIgnoreLocalePathSegments(pathForScan string, configRelative bool, targetLocales []string) bool {
 	normalized := filepath.ToSlash(pathForScan)
 	segments := strings.Split(normalized, "/")
 	if len(segments) < 2 {
@@ -31,7 +37,11 @@ func shouldIgnoreSourcePath(sourcePath, projectRoot string, targetLocales []stri
 		targets[locale] = struct{}{}
 	}
 
-	for i := 1; i < len(segments)-1; i++ {
+	start := 1
+	if configRelative {
+		start = 0
+	}
+	for i := start; i < len(segments)-1; i++ {
 		if _, ok := targets[segments[i]]; ok {
 			return true
 		}

--- a/apps/cli/internal/i18n/runsvc/path_glob.go
+++ b/apps/cli/internal/i18n/runsvc/path_glob.go
@@ -9,8 +9,18 @@ import (
 	"strings"
 )
 
-func shouldIgnoreSourcePath(sourcePath string, targetLocales []string) bool {
-	normalized := filepath.ToSlash(sourcePath)
+func shouldIgnoreSourcePath(sourcePath, projectRoot string, targetLocales []string) bool {
+	pathForScan := sourcePath
+	if root := strings.TrimSpace(projectRoot); root != "" {
+		if rel, err := filepath.Rel(root, sourcePath); err == nil {
+			rel = filepath.ToSlash(rel)
+			if rel != ".." && !strings.HasPrefix(rel, "../") {
+				pathForScan = rel
+			}
+		}
+	}
+
+	normalized := filepath.ToSlash(pathForScan)
 	segments := strings.Split(normalized, "/")
 	if len(segments) < 2 {
 		return false

--- a/apps/cli/internal/i18n/runsvc/path_glob_test.go
+++ b/apps/cli/internal/i18n/runsvc/path_glob_test.go
@@ -45,6 +45,11 @@ func TestShouldIgnoreSourcePathIgnoresLocaleOutsideProjectRoot(t *testing.T) {
 	if !shouldIgnoreSourcePath(localeInsideProject, projectDir, []string{"fr"}) {
 		t.Fatalf("expected locale segment in project-relative path to be ignored")
 	}
+
+	topLevelLocaleFile := filepath.Join(projectDir, "fr", "messages.json")
+	if !shouldIgnoreSourcePath(topLevelLocaleFile, projectDir, []string{"fr"}) {
+		t.Fatalf("expected top-level locale directory under project root to be ignored")
+	}
 }
 
 func TestResolveSourcePathsNoGlobReturnsInput(t *testing.T) {

--- a/apps/cli/internal/i18n/runsvc/path_glob_test.go
+++ b/apps/cli/internal/i18n/runsvc/path_glob_test.go
@@ -26,11 +26,24 @@ func TestShouldIgnoreSourcePathScenarios(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldIgnoreSourcePath(tt.path, tt.target)
+			got := shouldIgnoreSourcePath(tt.path, "", tt.target)
 			if got != tt.want {
 				t.Fatalf("shouldIgnoreSourcePath(%q, %v) = %t, want %t", tt.path, tt.target, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestShouldIgnoreSourcePathIgnoresLocaleOutsideProjectRoot(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "fr", "nested-app")
+	sourcePath := filepath.Join(projectDir, "src", "locales", "en", "common.json")
+	if shouldIgnoreSourcePath(sourcePath, projectDir, []string{"fr"}) {
+		t.Fatalf("expected ancestor locale directory outside project-relative path to be ignored for filtering")
+	}
+
+	localeInsideProject := filepath.Join(projectDir, "docs", "fr", "index.mdx")
+	if !shouldIgnoreSourcePath(localeInsideProject, projectDir, []string{"fr"}) {
+		t.Fatalf("expected locale segment in project-relative path to be ignored")
 	}
 }
 

--- a/apps/cli/internal/i18n/runsvc/path_security.go
+++ b/apps/cli/internal/i18n/runsvc/path_security.go
@@ -105,6 +105,13 @@ func preferredTaskIdentity(projectRoot, targetPath, entryKey string) string {
 	return taskIdentity(targetPath, entryKey)
 }
 
+func plannedLockTargetPath(projectRoot, targetPath string) string {
+	if rel, ok := relativizeProjectPath(projectRoot, targetPath); ok {
+		return rel
+	}
+	return targetPath
+}
+
 func sourcePathMatchesFilter(projectRoot, filter, sourcePath string) bool {
 	for _, candidate := range sourcePathFilterCandidates(projectRoot, filter) {
 		if filepath.Clean(candidate) == filepath.Clean(sourcePath) {

--- a/apps/cli/internal/i18n/runsvc/path_security.go
+++ b/apps/cli/internal/i18n/runsvc/path_security.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/pathguard"
@@ -78,6 +79,96 @@ func (s *Service) resolveProjectTargetPath(sourcePattern, targetPattern, sourceP
 		s.resolveProjectPattern(targetPattern),
 		s.resolveProjectPattern(sourcePath),
 	)
+}
+
+func relativizeProjectPath(projectRoot, path string) (string, bool) {
+	root := strings.TrimSpace(projectRoot)
+	trimmed := strings.TrimSpace(path)
+	if root == "" || trimmed == "" {
+		return "", false
+	}
+	rel, err := filepath.Rel(root, trimmed)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", false
+	}
+	return rel, true
+}
+
+func preferredTaskIdentity(projectRoot, targetPath, entryKey string) string {
+	if rel, ok := relativizeProjectPath(projectRoot, targetPath); ok {
+		return taskIdentity(rel, entryKey)
+	}
+	return taskIdentity(targetPath, entryKey)
+}
+
+func sourcePathMatchesFilter(projectRoot, filter, sourcePath string) bool {
+	for _, candidate := range sourcePathFilterCandidates(projectRoot, filter) {
+		if filepath.Clean(candidate) == filepath.Clean(sourcePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func sourcePathMatchesAnyFilter(projectRoot string, filters []string, sourcePath string) bool {
+	for _, filter := range filters {
+		if sourcePathMatchesFilter(projectRoot, filter, sourcePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func sourcePathFilterCandidates(projectRoot, filter string) []string {
+	trimmed := strings.TrimSpace(filter)
+	if trimmed == "" {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	add := func(candidate string) {
+		candidate = filepath.Clean(candidate)
+		if candidate == "" {
+			return
+		}
+		seen[candidate] = struct{}{}
+	}
+	add(trimmed)
+	if abs, err := filepath.Abs(trimmed); err == nil {
+		add(abs)
+	}
+	if root := strings.TrimSpace(projectRoot); root != "" && !filepath.IsAbs(trimmed) {
+		add(filepath.Join(root, trimmed))
+	}
+	candidates := make([]string, 0, len(seen))
+	for candidate := range seen {
+		candidates = append(candidates, candidate)
+	}
+	slices.Sort(candidates)
+	return candidates
+}
+
+func (s *Service) expandSourcePathFilters(paths []string) (map[string]struct{}, []string, error) {
+	if len(paths) == 0 {
+		return nil, nil, nil
+	}
+
+	originals := make([]string, 0, len(paths))
+	matchSet := make(map[string]struct{})
+	for _, path := range paths {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" {
+			return nil, nil, fmt.Errorf("invalid source file value: must not be empty")
+		}
+		originals = append(originals, trimmed)
+		for _, candidate := range sourcePathFilterCandidates(s.projectRoot, trimmed) {
+			matchSet[candidate] = struct{}{}
+		}
+	}
+	return matchSet, originals, nil
 }
 
 func (s *Service) readProjectFile(path string) ([]byte, error) {

--- a/apps/cli/internal/i18n/runsvc/path_security.go
+++ b/apps/cli/internal/i18n/runsvc/path_security.go
@@ -60,6 +60,26 @@ func (s *Service) validateProjectPath(path string) error {
 	return pathguard.EnsureUnderRoot(s.projectRoot, path)
 }
 
+func (s *Service) resolveProjectPattern(pattern string) string {
+	trimmed := strings.TrimSpace(pattern)
+	if trimmed == "" || filepath.IsAbs(trimmed) || !s.enforceProjectPaths || strings.TrimSpace(s.projectRoot) == "" {
+		return trimmed
+	}
+	return filepath.Join(s.projectRoot, trimmed)
+}
+
+func (s *Service) resolveProjectSourcePaths(sourcePattern string) ([]string, error) {
+	return resolveSourcePaths(s.resolveProjectPattern(sourcePattern))
+}
+
+func (s *Service) resolveProjectTargetPath(sourcePattern, targetPattern, sourcePath string) (string, error) {
+	return resolveTargetPath(
+		s.resolveProjectPattern(sourcePattern),
+		s.resolveProjectPattern(targetPattern),
+		s.resolveProjectPattern(sourcePath),
+	)
+}
+
 func (s *Service) readProjectFile(path string) ([]byte, error) {
 	if err := s.validateProjectPath(path); err != nil {
 		return nil, err

--- a/apps/cli/internal/i18n/runsvc/path_security_test.go
+++ b/apps/cli/internal/i18n/runsvc/path_security_test.go
@@ -138,3 +138,34 @@ func TestResolveProjectSourcePathsUsesConfigRoot(t *testing.T) {
 		t.Fatalf("resolveProjectSourcePaths() = %q, want %q", got[0], want)
 	}
 }
+
+func TestRelativizeProjectPath(t *testing.T) {
+	projectDir := t.TempDir()
+	sourceAbs := filepath.Join(projectDir, "locales", "en", "messages.json")
+	if got, ok := relativizeProjectPath(projectDir, sourceAbs); !ok || got != "locales/en/messages.json" {
+		t.Fatalf("relativizeProjectPath() = (%q, %v), want (locales/en/messages.json, true)", got, ok)
+	}
+}
+
+func TestSourcePathMatchesFilterResolvesRelativeFlagAgainstProjectRoot(t *testing.T) {
+	projectDir := t.TempDir()
+	sourceAbs := filepath.Join(projectDir, "docs", "en", "messages.json")
+	if !sourcePathMatchesFilter(projectDir, "docs/en/messages.json", sourceAbs) {
+		t.Fatalf("expected relative --file filter to match absolute source path")
+	}
+}
+
+func TestTaskIdentityCandidatesIncludeRelativeTargetPath(t *testing.T) {
+	projectDir := t.TempDir()
+	targetAbs := filepath.Join(projectDir, "dist", "fr", "strings.json")
+	task := Task{TargetPath: targetAbs, EntryKey: "hello"}
+
+	identities := taskIdentityCandidates(task, projectDir)
+	want := taskIdentity("dist/fr/strings.json", "hello")
+	for _, identity := range identities {
+		if identity == want {
+			return
+		}
+	}
+	t.Fatalf("taskIdentityCandidates() = %v, want to include %q", identities, want)
+}

--- a/apps/cli/internal/i18n/runsvc/path_security_test.go
+++ b/apps/cli/internal/i18n/runsvc/path_security_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hyperlocalise/hyperlocalise/internal/pathguard"
 	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
 )
 
@@ -98,4 +99,42 @@ llm:
 		t.Fatalf("write config: %v", err)
 	}
 	return configPath
+}
+
+func TestResolveProjectSourcePathsUsesConfigRoot(t *testing.T) {
+	projectDir := t.TempDir()
+	sourceRel := filepath.Join("locales", "en", "messages.json")
+	sourceAbs := filepath.Join(projectDir, sourceRel)
+	if err := os.MkdirAll(filepath.Dir(sourceAbs), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(sourceAbs, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	otherCWD := t.TempDir()
+	t.Chdir(otherCWD)
+
+	svc := newTestService()
+	svc.enforceProjectPaths = true
+	root, err := pathguard.CanonicalForContainment(projectDir)
+	if err != nil {
+		t.Fatalf("canonical project dir: %v", err)
+	}
+	svc.projectRoot = root
+
+	got, err := svc.resolveProjectSourcePaths(filepath.ToSlash("locales/en/messages.json"))
+	if err != nil {
+		t.Fatalf("resolveProjectSourcePaths() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("resolveProjectSourcePaths() = %v, want one path", got)
+	}
+	want, err := pathguard.CanonicalForContainment(sourceAbs)
+	if err != nil {
+		t.Fatalf("canonical source path: %v", err)
+	}
+	if filepath.Clean(got[0]) != filepath.Clean(want) {
+		t.Fatalf("resolveProjectSourcePaths() = %q, want %q", got[0], want)
+	}
 }

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -78,7 +78,7 @@ func (s *Service) run(ctx context.Context, in Input) (report Report, err error) 
 	initializeLockState(state)
 
 	activeRunID := ensureActiveRunID(state)
-	report, executable, checkpointStaged, lockMigrated, err := applyLockFilterWithReader(planned, state.RunCompleted, state.RunCheckpoint, activeRunID, in.Force, s.readProjectFile)
+	report, executable, checkpointStaged, lockMigrated, err := applyLockFilterWithReader(planned, state.RunCompleted, state.RunCheckpoint, activeRunID, in.Force, s.readProjectFile, s.projectRoot)
 	if err != nil {
 		endRunSpan(lockSpan, err, "lock_filter")
 		return Report{}, err
@@ -353,10 +353,10 @@ func initializeLockState(state *lockfile.File) {
 }
 
 func applyLockFilter(planned []Task, completed map[string]lockfile.RunCompletion, checkpoints map[string]lockfile.RunCheckpoint, activeRunID string, force bool) (Report, []Task, map[string]stagedOutput, bool, error) {
-	return applyLockFilterWithReader(planned, completed, checkpoints, activeRunID, force, nil)
+	return applyLockFilterWithReader(planned, completed, checkpoints, activeRunID, force, nil, "")
 }
 
-func applyLockFilterWithReader(planned []Task, completed map[string]lockfile.RunCompletion, checkpoints map[string]lockfile.RunCheckpoint, activeRunID string, force bool, readFile func(string) ([]byte, error)) (Report, []Task, map[string]stagedOutput, bool, error) {
+func applyLockFilterWithReader(planned []Task, completed map[string]lockfile.RunCompletion, checkpoints map[string]lockfile.RunCheckpoint, activeRunID string, force bool, readFile func(string) ([]byte, error), projectRoot string) (Report, []Task, map[string]stagedOutput, bool, error) {
 	report := Report{PlannedTotal: len(planned)}
 	executable := make([]Task, 0, len(planned))
 	checkpointStaged := map[string]stagedOutput{}
@@ -368,11 +368,11 @@ func applyLockFilterWithReader(planned []Task, completed map[string]lockfile.Run
 	}
 
 	for _, task := range planned {
-		identity := taskIdentity(task.TargetPath, task.EntryKey)
+		identity := preferredTaskIdentity(projectRoot, task.TargetPath, task.EntryKey)
 		sourceHash := taskLockSourceHash(task)
 		taskHashes := lockTaskHashCandidates(task)
 		taskHash := taskHashes[0]
-		if cp, matchedIdentity, ok := findCheckpointForTask(checkpoints, task, activeRunID, sourceHash, taskHashes); ok {
+		if cp, matchedIdentity, ok := findCheckpointForTask(checkpoints, task, projectRoot, activeRunID, sourceHash, taskHashes); ok {
 			if !lockFingerprintEqual(cp.TaskHash, taskHash) {
 				cp.TaskHash = taskHash
 				lockMigrated = true
@@ -401,7 +401,7 @@ func applyLockFilterWithReader(planned []Task, completed map[string]lockfile.Run
 				return Report{}, nil, nil, false, fmt.Errorf("stage checkpoint output for %s: %w", identity, stageErr)
 			}
 		}
-		if completion, matchedIdentity, ok := findCompletionForTask(completed, task, sourceHash, taskHashes); ok {
+		if completion, matchedIdentity, ok := findCompletionForTask(completed, task, projectRoot, sourceHash, taskHashes); ok {
 			if !lockFingerprintEqual(completion.TaskHash, taskHash) {
 				completion.TaskHash = taskHash
 				lockMigrated = true
@@ -432,10 +432,11 @@ func taskLockSourceHash(task Task) string {
 func findCompletionForTask(
 	completed map[string]lockfile.RunCompletion,
 	task Task,
+	projectRoot string,
 	sourceHash string,
 	taskHashes []string,
 ) (lockfile.RunCompletion, string, bool) {
-	for _, identity := range taskIdentityCandidates(task) {
+	for _, identity := range taskIdentityCandidates(task, projectRoot) {
 		if completion, ok := completed[identity]; ok && completionMatchesTask(completion, sourceHash, taskHashes) {
 			return completion, identity, true
 		}
@@ -446,11 +447,12 @@ func findCompletionForTask(
 func findCheckpointForTask(
 	checkpoints map[string]lockfile.RunCheckpoint,
 	task Task,
+	projectRoot string,
 	activeRunID string,
 	sourceHash string,
 	taskHashes []string,
 ) (lockfile.RunCheckpoint, string, bool) {
-	for _, identity := range taskIdentityCandidates(task) {
+	for _, identity := range taskIdentityCandidates(task, projectRoot) {
 		if checkpoint, ok := checkpoints[identity]; ok &&
 			checkpointMatchesActiveRun(checkpoint, activeRunID) &&
 			checkpointMatchesTask(checkpoint, sourceHash, taskHashes) {

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -357,11 +357,11 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 	if err != nil {
 		return nil, nil, fmt.Errorf("planning tasks: %w", err)
 	}
-	filteredSourcePaths, err := normalizeSourcePaths(onlySourcePaths)
+	_, filteredSourceOriginals, err := s.expandSourcePathFilters(onlySourcePaths)
 	if err != nil {
 		return nil, nil, fmt.Errorf("planning tasks: %w", err)
 	}
-	matchedSourcePaths := make(map[string]struct{}, len(filteredSourcePaths))
+	matchedSourceOriginals := make(map[string]struct{}, len(filteredSourceOriginals))
 	if filteredBucket != "" {
 		if _, ok := cfg.Buckets[filteredBucket]; !ok {
 			return nil, nil, fmt.Errorf("planning tasks: unknown bucket %q", filteredBucket)
@@ -461,19 +461,21 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 				}
 
 				for _, sourcePath := range sources {
-					if len(filteredSourcePaths) > 0 {
-						if _, ok := filteredSourcePaths[sourcePath]; !ok {
-							continue
-						}
-					}
-					if shouldIgnoreSourcePath(sourcePath, cfg.Locales.Targets) {
+					if len(filteredSourceOriginals) > 0 && !sourcePathMatchesAnyFilter(s.projectRoot, filteredSourceOriginals, sourcePath) {
 						continue
+					}
+					if shouldIgnoreSourcePath(sourcePath, s.projectRoot, cfg.Locales.Targets) {
+						continue
+					}
+					if len(filteredSourceOriginals) > 0 {
+						for _, original := range filteredSourceOriginals {
+							if sourcePathMatchesFilter(s.projectRoot, original, sourcePath) {
+								matchedSourceOriginals[original] = struct{}{}
+							}
+						}
 					}
 					if err := s.validateProjectPath(sourcePath); err != nil {
 						return nil, nil, fmt.Errorf("planning tasks: source path %q: %w", sourcePath, err)
-					}
-					if len(filteredSourcePaths) > 0 {
-						matchedSourcePaths[sourcePath] = struct{}{}
 					}
 					if isSupportedImagePath(sourcePath) {
 						sourceContent, err := s.readProjectFile(sourcePath)
@@ -625,11 +627,11 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 		}
 	}
 
-	if len(filteredSourcePaths) > 0 {
+	if len(filteredSourceOriginals) > 0 {
 		unmatched := make([]string, 0)
-		for sourcePath := range filteredSourcePaths {
-			if _, ok := matchedSourcePaths[sourcePath]; !ok {
-				unmatched = append(unmatched, sourcePath)
+		for _, original := range filteredSourceOriginals {
+			if _, ok := matchedSourceOriginals[original]; !ok {
+				unmatched = append(unmatched, original)
 			}
 		}
 		slices.Sort(unmatched)
@@ -708,22 +710,6 @@ func normalizeTargetLocales(locales []string) ([]string, error) {
 		normalized = append(normalized, trimmed)
 	}
 
-	return normalized, nil
-}
-
-func normalizeSourcePaths(paths []string) (map[string]struct{}, error) {
-	if len(paths) == 0 {
-		return nil, nil
-	}
-
-	normalized := make(map[string]struct{}, len(paths))
-	for _, path := range paths {
-		trimmed := strings.TrimSpace(path)
-		if trimmed == "" {
-			return nil, fmt.Errorf("invalid source file value: must not be empty")
-		}
-		normalized[filepath.Clean(trimmed)] = struct{}{}
-	}
 	return normalized, nil
 }
 
@@ -1002,11 +988,21 @@ func taskIdentity(targetPath, entryKey string) string {
 	return targetPath + "::" + entryKey
 }
 
-func taskIdentityCandidates(task Task) []string {
-	identities := []string{taskIdentity(task.TargetPath, task.EntryKey)}
+func taskIdentityCandidates(task Task, projectRoot string) []string {
+	identities := []string{
+		preferredTaskIdentity(projectRoot, task.TargetPath, task.EntryKey),
+		taskIdentity(task.TargetPath, task.EntryKey),
+	}
+	if rel, ok := relativizeProjectPath(projectRoot, task.TargetPath); ok {
+		identities = append(identities, taskIdentity(rel, task.EntryKey))
+	}
 	if isMarkdownEntryKey(task.EntryKey) {
 		for _, entryKey := range legacyMarkdownEntryKeyCandidates(task.EntryKey) {
+			identities = append(identities, preferredTaskIdentity(projectRoot, task.TargetPath, entryKey))
 			identities = append(identities, taskIdentity(task.TargetPath, entryKey))
+			if rel, ok := relativizeProjectPath(projectRoot, task.TargetPath); ok {
+				identities = append(identities, taskIdentity(rel, entryKey))
+			}
 		}
 	}
 	return dedupeStrings(identities)

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -450,7 +450,7 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 				sourcePattern := pathresolver.ResolveSourcePath(file.From, cfg.Locales.Source)
 				sources, ok := resolvedSourcesCache[sourcePattern]
 				if !ok {
-					sources, err = resolveSourcePaths(sourcePattern)
+					sources, err = s.resolveProjectSourcePaths(sourcePattern)
 					if err != nil {
 						return nil, nil, fmt.Errorf("planning tasks: resolve source paths for %q: %w", sourcePattern, err)
 					}
@@ -492,7 +492,7 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 						}
 						for _, target := range targets {
 							resolvedTargetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, target)
-							targetPath, err := resolveTargetPath(sourcePattern, resolvedTargetPattern, sourcePath)
+							targetPath, err := s.resolveProjectTargetPath(sourcePattern, resolvedTargetPattern, sourcePath)
 							if err != nil {
 								return nil, nil, fmt.Errorf("planning tasks: resolve target path for source %q: %w", sourcePath, err)
 							}
@@ -560,7 +560,7 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 
 					for _, target := range targets {
 						resolvedTargetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, target)
-						targetPath, err := resolveTargetPath(sourcePattern, resolvedTargetPattern, sourcePath)
+						targetPath, err := s.resolveProjectTargetPath(sourcePattern, resolvedTargetPattern, sourcePath)
 						if err != nil {
 							return nil, nil, fmt.Errorf("planning tasks: resolve target path for source %q: %w", sourcePath, err)
 						}

--- a/apps/cli/internal/i18n/runsvc/service_test.go
+++ b/apps/cli/internal/i18n/runsvc/service_test.go
@@ -4290,13 +4290,13 @@ llm:
 
 func TestShouldIgnoreSourcePath(t *testing.T) {
 	targets := []string{"fr", "es", "zh"}
-	if !shouldIgnoreSourcePath("docs/fr/index.mdx", targets) {
+	if !shouldIgnoreSourcePath("docs/fr/index.mdx", "", targets) {
 		t.Fatalf("expected docs/fr/index.mdx to be ignored")
 	}
-	if !shouldIgnoreSourcePath("docs/es/guides/quickstart.mdx", targets) {
+	if !shouldIgnoreSourcePath("docs/es/guides/quickstart.mdx", "", targets) {
 		t.Fatalf("expected nested locale path to be ignored")
 	}
-	if shouldIgnoreSourcePath("docs/index.mdx", targets) {
+	if shouldIgnoreSourcePath("docs/index.mdx", "", targets) {
 		t.Fatalf("expected root docs source path not to be ignored")
 	}
 }


### PR DESCRIPTION
## What changed

CLI commands (check, status, pack, sync, run) now resolve bucket file paths relative to the i18n config file's directory instead of the process working directory. This fixes failures when running from a monorepo root against a nested project config (for example nested-app/i18n.jsonc with src/locales/en/common.json).

Added unit tests for path helpers and integration tests for check, status, pack, and run --dry-run from a foreign CWD.

## How to test

make fmt
make lint
make test
go test ./apps/cli/cmd/... ./apps/cli/internal/i18n/runsvc/...

Manual check from a monorepo root:

go run ./apps/cli check --config nested-app/i18n.jsonc
go run ./apps/cli status --config nested-app/i18n.jsonc

## Checklist

- [x] I ran relevant checks locally (make fmt, make lint, make test)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review