### PR TITLE
feat(cli): add version pin to i18n.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: Optional working directory for the check.
     default: .
   hyperlocalise-version:
-    description: Hyperlocalise release version to install.
+    description: Hyperlocalise release version to install. Use `config` to read `version` from the i18n config file (for example hyperlocalise@1.2.3). Defaults to `latest`.
     default: latest
   fail-on-drift:
     description: Fail the action when drift is detected.
@@ -137,12 +137,14 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.hyperlocalise-version }}
+        CONFIG_PATH: ${{ inputs.config-path }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         install_dir="${RUNNER_TEMP}/hyperlocalise-bin"
         mkdir -p "${install_dir}"
-        bash "${GITHUB_ACTION_PATH}/tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${VERSION}" "${install_dir}"
+        resolved_version="$(bash "${GITHUB_ACTION_PATH}/tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh" "${VERSION}" "${CONFIG_PATH}")"
+        bash "${GITHUB_ACTION_PATH}/tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${resolved_version}" "${install_dir}"
         echo "${install_dir}" >>"${GITHUB_PATH}"
 
     - name: Fetch GitHub pull request diff

--- a/action.yml
+++ b/action.yml
@@ -133,17 +133,25 @@ runs:
         echo "summary-path=${artifact_dir}/${CHECK}-summary.txt" >>"${GITHUB_OUTPUT}"
         echo "github-diff-path=${artifact_dir}/github-pr.diff" >>"${GITHUB_OUTPUT}"
 
+    - name: Setup Go for config version resolution
+      if: ${{ inputs.hyperlocalise-version == 'config' }}
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      with:
+        go-version-file: ${{ github.action_path }}/go.mod
+        cache: true
+
     - name: Install Hyperlocalise
       shell: bash
       env:
         VERSION: ${{ inputs.hyperlocalise-version }}
         CONFIG_PATH: ${{ inputs.config-path }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         install_dir="${RUNNER_TEMP}/hyperlocalise-bin"
         mkdir -p "${install_dir}"
-        resolved_version="$(bash "${GITHUB_ACTION_PATH}/tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh" "${VERSION}" "${CONFIG_PATH}")"
+        resolved_version="$(bash "${GITHUB_ACTION_PATH}/tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh" "${VERSION}" "${CONFIG_PATH}" "${WORKING_DIRECTORY}")"
         bash "${GITHUB_ACTION_PATH}/tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${resolved_version}" "${install_dir}"
         echo "${install_dir}" >>"${GITHUB_PATH}"
 

--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -357,7 +357,7 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	}
 
 	_, resolveSpan := tr.Start(ctx, "check.resolve")
-	cfg, err := config.Load(o.configPath)
+	cfg, err := config.LoadForCLI(o.configPath)
 	if err != nil {
 		resolveSpan.SetStatus(codes.Error, "load_config")
 		resolveSpan.End()

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -567,7 +567,7 @@ func resolveLokaliseDownloadSourcesConfig(cmd *cobra.Command, o lokaliseDownload
 }
 
 func loadLokaliseDownloadSourcesStorageConfig(configPath string) (lokalise.Config, error) {
-	cfg, err := i18nconfig.Load(configPath)
+	cfg, err := i18nconfig.LoadForCLI(configPath)
 	if err != nil {
 		return lokalise.Config{}, fmt.Errorf("lokalise download sources: load config: %w", err)
 	}
@@ -757,7 +757,7 @@ func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOpt
 func resolveLokaliseUploadSourcesConfig(cmd *cobra.Command, o lokaliseUploadSourcesOptions, requireAuth bool) (lokalise.Config, string, error) {
 	cfg := lokalise.Config{}
 	if strings.TrimSpace(o.configPath) != "" {
-		loaded, err := i18nconfig.Load(o.configPath)
+		loaded, err := i18nconfig.LoadForCLI(o.configPath)
 		if err != nil {
 			return lokalise.Config{}, "", err
 		}
@@ -910,7 +910,7 @@ func loadLokaliseStorageConfig(configPath string) (lokalise.Config, error) {
 }
 
 func loadLokaliseStorageConfigForAction(configPath string, action string) (lokalise.Config, error) {
-	cfg, err := i18nconfig.Load(configPath)
+	cfg, err := i18nconfig.LoadForCLI(configPath)
 	if err != nil {
 		return lokalise.Config{}, fmt.Errorf("%s: load config: %w", action, err)
 	}

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -112,7 +112,7 @@ func validatePackOptions(args []string, options packOptions) error {
 }
 
 func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
-	cfg, err := config.Load(options.configPath)
+	cfg, err := config.LoadForCLI(options.configPath)
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
 	}

--- a/apps/cli/cmd/root.go
+++ b/apps/cli/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/hyperlocalise/hyperlocalise/apps/cli/internal/envloader"
+	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,8 @@ func newRootCmd(version string) *cobra.Command {
 
 // Execute invokes the command.
 func Execute(version string) error {
+	config.SetCLIVersion(version)
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	if err := newRootCmd(version).ExecuteContext(ctx); err != nil {

--- a/apps/cli/cmd/status.go
+++ b/apps/cli/cmd/status.go
@@ -51,7 +51,7 @@ Status values:
   - untranslated: empty translation value`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cfg, err := config.Load(o.configPath)
+			cfg, err := config.LoadForCLI(o.configPath)
 			if err != nil {
 				return fmt.Errorf("load config: %w", err)
 			}

--- a/apps/cli/cmd/sync_hyperlocalise.go
+++ b/apps/cli/cmd/sync_hyperlocalise.go
@@ -97,7 +97,7 @@ type hyperlocaliseUploadFileResponse struct {
 }
 
 func newHyperlocaliseSyncRuntime(configPath string) (*hyperlocaliseSyncRuntime, error) {
-	cfg, err := config.Load(configPath)
+	cfg, err := config.LoadForCLI(configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/cli/cmd/templates/i18n.yml
+++ b/apps/cli/cmd/templates/i18n.yml
@@ -2,6 +2,8 @@
 # Read this file top-to-bottom: locales -> buckets -> llm.
 # This starter intentionally skips advanced sections like groups, rules, and remote cache config.
 # When groups are omitted, Hyperlocalise runs all buckets for all target locales.
+# Pin the Hyperlocalise CLI version (like packageManager in package.json).
+# version: hyperlocalise@1.10.0
 locales:
   # Source locale: the language your original content is written in.
   source: en-US

--- a/apps/cli/cmd/version_pin_test.go
+++ b/apps/cli/cmd/version_pin_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
+)
+
+func TestStatusCommandRejectsPinnedVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.yml")
+	content := `
+version: hyperlocalise@1.2.3
+locales:
+  source: en
+  targets:
+    - fr
+buckets:
+  ui:
+    files:
+      - from: ui.json
+        to: lang/[locale].json
+groups:
+  default:
+    targets:
+      - fr
+    buckets:
+      - ui
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: gpt-4.1-mini
+      prompt: Translate
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	config.SetCLIVersion("v1.2.4")
+	t.Cleanup(func() {
+		config.SetCLIVersion("")
+	})
+
+	cmd := newRootCmd("v1.2.4")
+	cmd.SetArgs([]string{"status", "--config", configPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected pinned version mismatch")
+	}
+	if !strings.Contains(err.Error(), "does not match pinned") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -323,7 +323,7 @@ type Service struct {
 
 func New() *Service {
 	return &Service{
-		loadConfig: config.Load,
+		loadConfig: config.LoadForCLI,
 		loadLock:   lockfile.Load,
 		saveLock:   lockfile.Save,
 		readFile:   os.ReadFile,

--- a/apps/cli/internal/i18n/runsvc/version_pin_test.go
+++ b/apps/cli/internal/i18n/runsvc/version_pin_test.go
@@ -1,0 +1,67 @@
+package runsvc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
+)
+
+func TestRunRejectsPinnedCLIVersionMismatch(t *testing.T) {
+	projectDir := t.TempDir()
+	sourcePath := filepath.Join(projectDir, "en", "messages.json")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	configPath := filepath.Join(projectDir, "i18n.yml")
+	content := `
+version: hyperlocalise@1.2.3
+locales:
+  source: en
+  targets:
+    - fr
+buckets:
+  ui:
+    files:
+      - from: "{{source}}/messages.json"
+        to: "{{target}}/messages.json"
+groups:
+  default:
+    targets:
+      - fr
+    buckets:
+      - ui
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: gpt-4.1-mini
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	config.SetCLIVersion("v1.2.4")
+	t.Cleanup(func() {
+		config.SetCLIVersion("")
+	})
+
+	svc := newTestService()
+	svc.loadConfig = config.LoadForCLI
+	svc.readFile = os.ReadFile
+
+	_, err := svc.Run(context.Background(), Input{ConfigPath: configPath, DryRun: true})
+	if err == nil {
+		t.Fatal("expected pinned version mismatch")
+	}
+	if !strings.Contains(err.Error(), "does not match pinned") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/cli/configuration/i18n-config.mdx
+++ b/docs/cli/configuration/i18n-config.mdx
@@ -7,6 +7,18 @@ description: "Field-by-field guide for the i18n config file used by run, status,
 
 `i18n.yml` controls locales, file mapping, model profiles, and optional advanced routing. `i18n.jsonc` is still supported for compatibility.
 
+## CLI version pin
+
+Pin the Hyperlocalise CLI version at the top of `i18n.yml`, similar to `packageManager` in `package.json`:
+
+```yaml
+version: hyperlocalise@1.10.0
+```
+
+When set, commands that load the config (`run`, `check`, `status`, `pack`, `sync`, and others) fail if the running CLI version does not match the pinned value. The `hl` alias is also accepted (`hl@1.10.0`).
+
+In GitHub Actions, set `hyperlocalise-version: config` to install the version declared in your i18n config file.
+
 ## Starter config
 
 ```yaml

--- a/install/action.yml
+++ b/install/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   version:
-    description: Hyperlocalise release version to install (for example latest, v1.2.3, or 1.2.3).
+    description: Hyperlocalise release version to install (for example latest, v1.2.3, 1.2.3, or config to read version from i18n.yml).
     default: latest
   install-dir:
     description: Directory to install the hyperlocalise binary into. Defaults to a runner temp directory.
@@ -32,6 +32,7 @@ runs:
         set -euo pipefail
         install_dir="${INSTALL_DIR_INPUT:-${RUNNER_TEMP}/hyperlocalise-bin}"
         mkdir -p "${install_dir}"
-        bash "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${VERSION}" "${install_dir}"
+        resolved_version="$(bash "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh" "${VERSION}")"
+        bash "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${resolved_version}" "${install_dir}"
         echo "${install_dir}" >>"${GITHUB_PATH}"
         echo "install-dir=${install_dir}" >>"${GITHUB_OUTPUT}"

--- a/install/action.yml
+++ b/install/action.yml
@@ -9,6 +9,12 @@ inputs:
   version:
     description: Hyperlocalise release version to install (for example latest, v1.2.3, 1.2.3, or config to read version from i18n.yml).
     default: latest
+  config-path:
+    description: Path to the i18n config file used when version is config.
+    default: i18n.yml
+  working-directory:
+    description: Working directory used to resolve a relative config-path when version is config.
+    default: .
   install-dir:
     description: Directory to install the hyperlocalise binary into. Defaults to a runner temp directory.
     default: ""
@@ -21,18 +27,27 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Setup Go for config version resolution
+      if: ${{ inputs.version == 'config' }}
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      with:
+        go-version-file: ${{ github.action_path }}/../go.mod
+        cache: true
+
     - name: Install Hyperlocalise
       id: install
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
+        CONFIG_PATH: ${{ inputs.config-path }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
         INSTALL_DIR_INPUT: ${{ inputs.install-dir }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         install_dir="${INSTALL_DIR_INPUT:-${RUNNER_TEMP}/hyperlocalise-bin}"
         mkdir -p "${install_dir}"
-        resolved_version="$(bash "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh" "${VERSION}")"
+        resolved_version="$(bash "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh" "${VERSION}" "${CONFIG_PATH}" "${WORKING_DIRECTORY}")"
         bash "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${resolved_version}" "${install_dir}"
         echo "${install_dir}" >>"${GITHUB_PATH}"
         echo "install-dir=${install_dir}" >>"${GITHUB_OUTPUT}"

--- a/pkg/i18nconfig/BUILD.bazel
+++ b/pkg/i18nconfig/BUILD.bazel
@@ -5,12 +5,14 @@ go_library(
     srcs = [
         "i18n.go",
         "schema.go",
+        "version.go",
     ],
     importpath = "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/hyperlocaliseapi",
         "@com_github_invopop_jsonschema//:jsonschema",
+        "@com_github_masterminds_semver_v3//:semver",
         "@com_github_tidwall_jsonc//:jsonc",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],

--- a/pkg/i18nconfig/i18n.go
+++ b/pkg/i18nconfig/i18n.go
@@ -39,6 +39,8 @@ var safeLocalePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]*$`)
 
 // I18NConfig defines the i18n configuration file structure.
 type I18NConfig struct {
+	// Version pins the Hyperlocalise CLI version, for example hyperlocalise@1.2.3.
+	Version       string                  `json:"version,omitempty"`
 	Locales       LocaleConfig            `json:"locales" jsonschema:"required"`
 	Buckets       map[string]BucketConfig `json:"buckets" jsonschema:"required"`
 	Groups        map[string]GroupConfig  `json:"groups,omitempty"`
@@ -249,6 +251,10 @@ func normalizeYAMLValue(value any) (any, error) {
 
 // Validate validates all cross-field i18n configuration semantics.
 func (c I18NConfig) Validate() error {
+	if err := c.validateVersion(); err != nil {
+		return err
+	}
+
 	targetSet, err := c.validateLocales()
 	if err != nil {
 		return err

--- a/pkg/i18nconfig/i18n_test.go
+++ b/pkg/i18nconfig/i18n_test.go
@@ -525,6 +525,16 @@ func TestLoad(t *testing.T) {
 			}`,
 			errContains: "must be >= 0",
 		},
+		{
+			name: "invalid pinned cli version",
+			content: `{
+			  "version": "1.2.3",
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}}
+			}`,
+			errContains: "version:",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/i18nconfig/version.go
+++ b/pkg/i18nconfig/version.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+const (
+	pinnedCLIToolHyperlocalise = "hyperlocalise"
+	pinnedCLIToolHL            = "hl"
+)
+
+var currentCLIVersion string
+
+// SetCLIVersion records the running Hyperlocalise CLI version for pinned-version checks.
+func SetCLIVersion(version string) {
+	currentCLIVersion = strings.TrimSpace(version)
+}
+
+// CurrentCLIVersion returns the running Hyperlocalise CLI version set by SetCLIVersion.
+func CurrentCLIVersion() string {
+	return currentCLIVersion
+}
+
+// ParsePinnedCLIVersion parses a pinned CLI version string such as hyperlocalise@1.2.3.
+func ParsePinnedCLIVersion(value string) (*semver.Version, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, fmt.Errorf("version: must not be empty")
+	}
+
+	tool, versionPart, ok := strings.Cut(trimmed, "@")
+	if !ok {
+		return nil, fmt.Errorf("version: expected %q or %q, got %q", pinnedCLIToolHyperlocalise+"@<version>", pinnedCLIToolHL+"@<version>", trimmed)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(tool)) {
+	case pinnedCLIToolHyperlocalise, pinnedCLIToolHL:
+	default:
+		return nil, fmt.Errorf("version: unsupported tool %q (expected %q or %q)", tool, pinnedCLIToolHyperlocalise, pinnedCLIToolHL)
+	}
+
+	versionPart = strings.TrimSpace(versionPart)
+	if versionPart == "" {
+		return nil, fmt.Errorf("version: missing semver after @")
+	}
+
+	versionPart = strings.TrimPrefix(versionPart, "v")
+	parsed, err := semver.NewVersion(versionPart)
+	if err != nil {
+		return nil, fmt.Errorf("version: invalid semver %q: %w", versionPart, err)
+	}
+
+	return parsed, nil
+}
+
+// CheckPinnedCLIVersion verifies the running CLI matches the pinned version in the config.
+// When version is omitted or the running CLI version is unavailable, the check is skipped.
+func (c I18NConfig) CheckPinnedCLIVersion(cliVersion string) error {
+	if strings.TrimSpace(c.Version) == "" {
+		return nil
+	}
+
+	pinned, err := ParsePinnedCLIVersion(c.Version)
+	if err != nil {
+		return err
+	}
+
+	current, ok := normalizeCLIVersion(cliVersion)
+	if !ok {
+		return nil
+	}
+
+	if !current.Equal(pinned) {
+		return fmt.Errorf(
+			"version: running %s %s does not match pinned %s (upgrade or update i18n.yml)",
+			pinnedCLIToolHyperlocalise,
+			current.Original(),
+			c.Version,
+		)
+	}
+
+	return nil
+}
+
+// LoadForCLI loads and validates i18n config, then checks the pinned CLI version when set.
+func LoadForCLI(path string) (*I18NConfig, error) {
+	cfg, err := Load(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cfg.CheckPinnedCLIVersion(CurrentCLIVersion()); err != nil {
+		return nil, fmt.Errorf("validate i18n config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func (c I18NConfig) validateVersion() error {
+	if strings.TrimSpace(c.Version) == "" {
+		return nil
+	}
+
+	_, err := ParsePinnedCLIVersion(c.Version)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func normalizeCLIVersion(version string) (*semver.Version, bool) {
+	trimmed := strings.TrimSpace(version)
+	if trimmed == "" {
+		return nil, false
+	}
+
+	trimmed = strings.TrimPrefix(trimmed, "v")
+	parsed, err := semver.NewVersion(trimmed)
+	if err != nil {
+		return nil, false
+	}
+
+	return parsed, true
+}

--- a/pkg/i18nconfig/version.go
+++ b/pkg/i18nconfig/version.go
@@ -56,6 +56,25 @@ func ParsePinnedCLIVersion(value string) (*semver.Version, error) {
 	return parsed, nil
 }
 
+// InstallerVersionFromConfigFile reads the pinned CLI installer version from an i18n config file.
+func InstallerVersionFromConfigFile(path string) (string, error) {
+	cfg, err := Load(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve version from config: %w", err)
+	}
+
+	if strings.TrimSpace(cfg.Version) == "" {
+		return "", fmt.Errorf("version is not set in %s", path)
+	}
+
+	pinned, err := ParsePinnedCLIVersion(cfg.Version)
+	if err != nil {
+		return "", err
+	}
+
+	return pinned.Original(), nil
+}
+
 // CheckPinnedCLIVersion verifies the running CLI matches the pinned version in the config.
 // When version is omitted or the running CLI version is unavailable, the check is skipped.
 func (c I18NConfig) CheckPinnedCLIVersion(cliVersion string) error {

--- a/pkg/i18nconfig/version_test.go
+++ b/pkg/i18nconfig/version_test.go
@@ -91,6 +91,50 @@ func TestCheckPinnedCLIVersion(t *testing.T) {
 	}
 }
 
+func TestInstallerVersionFromConfigFile(t *testing.T) {
+	yamlPath := writeConfigFileNamed(t, "i18n.yml", `
+version: hyperlocalise@1.2.3 # pinned
+locales:
+  source: en-US
+  targets:
+    - es-ES
+buckets:
+  ui:
+    files:
+      - from: a
+        to: b
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: x
+`)
+
+	got, err := InstallerVersionFromConfigFile(yamlPath)
+	if err != nil {
+		t.Fatalf("installer version from yaml config: %v", err)
+	}
+	if got != "1.2.3" {
+		t.Fatalf("installer version = %q, want 1.2.3", got)
+	}
+
+	jsoncPath := writeConfigFileNamed(t, "i18n.jsonc", `{
+  // pinned cli
+  "version": "hyperlocalise@2.0.0",
+  "locales": {"source": "en-US", "targets": ["es-ES"]},
+  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}}
+}`)
+
+	got, err = InstallerVersionFromConfigFile(jsoncPath)
+	if err != nil {
+		t.Fatalf("installer version from jsonc config: %v", err)
+	}
+	if got != "2.0.0" {
+		t.Fatalf("installer version = %q, want 2.0.0", got)
+	}
+}
+
 func TestLoadForCLIEnforcesPinnedVersion(t *testing.T) {
 	path := writeConfigFile(t, `{
 	  "version": "hyperlocalise@1.2.3",

--- a/pkg/i18nconfig/version_test.go
+++ b/pkg/i18nconfig/version_test.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePinnedCLIVersion(t *testing.T) {
+	testCases := []struct {
+		name        string
+		value       string
+		want        string
+		errContains string
+	}{
+		{
+			name:  "hyperlocalise with v prefix",
+			value: "hyperlocalise@v1.2.3",
+			want:  "1.2.3",
+		},
+		{
+			name:  "hyperlocalise without v prefix",
+			value: "hyperlocalise@1.2.3",
+			want:  "1.2.3",
+		},
+		{
+			name:  "hl alias",
+			value: "hl@2.0.0",
+			want:  "2.0.0",
+		},
+		{
+			name:        "missing tool name",
+			value:       "1.2.3",
+			errContains: "expected",
+		},
+		{
+			name:        "unsupported tool",
+			value:       "pnpm@1.2.3",
+			errContains: "unsupported tool",
+		},
+		{
+			name:        "invalid semver",
+			value:       "hyperlocalise@latest",
+			errContains: "invalid semver",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParsePinnedCLIVersion(tc.value)
+			if tc.errContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tc.errContains)
+				}
+				if !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("unexpected error: got %q want substring %q", err.Error(), tc.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parse pinned version: %v", err)
+			}
+			if got.String() != tc.want {
+				t.Fatalf("parsed version = %q, want %q", got.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckPinnedCLIVersion(t *testing.T) {
+	cfg := I18NConfig{Version: "hyperlocalise@1.2.3"}
+
+	if err := cfg.CheckPinnedCLIVersion("v1.2.3"); err != nil {
+		t.Fatalf("expected matching version to pass: %v", err)
+	}
+
+	if err := cfg.CheckPinnedCLIVersion("v1.2.4"); err == nil {
+		t.Fatal("expected version mismatch error")
+	} else if !strings.Contains(err.Error(), "does not match pinned") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	empty := I18NConfig{}
+	if err := empty.CheckPinnedCLIVersion("v9.9.9"); err != nil {
+		t.Fatalf("expected omitted version to skip check: %v", err)
+	}
+
+	if err := cfg.CheckPinnedCLIVersion(""); err != nil {
+		t.Fatalf("expected unavailable CLI version to skip check: %v", err)
+	}
+}
+
+func TestLoadForCLIEnforcesPinnedVersion(t *testing.T) {
+	path := writeConfigFile(t, `{
+	  "version": "hyperlocalise@1.2.3",
+	  "locales": {"source": "en-US", "targets": ["es-ES"]},
+	  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+	  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}}
+	}`)
+
+	SetCLIVersion("v1.2.3")
+	t.Cleanup(func() {
+		SetCLIVersion("")
+	})
+
+	if _, err := LoadForCLI(path); err != nil {
+		t.Fatalf("load for cli with matching version: %v", err)
+	}
+
+	SetCLIVersion("v1.2.4")
+	if _, err := LoadForCLI(path); err == nil {
+		t.Fatal("expected pinned version mismatch")
+	} else if !strings.Contains(err.Error(), "does not match pinned") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadYAMLVersionField(t *testing.T) {
+	path := writeConfigFileNamed(t, "i18n.yml", `
+version: hyperlocalise@1.2.3
+locales:
+  source: en-US
+  targets:
+    - es-ES
+buckets:
+  ui:
+    files:
+      - from: lang/{{source}}.json
+        to: lang/{{target}}.json
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: gpt-4.1-mini
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load yaml config with version: %v", err)
+	}
+	if cfg.Version != "hyperlocalise@1.2.3" {
+		t.Fatalf("version = %q, want hyperlocalise@1.2.3", cfg.Version)
+	}
+
+	SetCLIVersion("v1.2.3")
+	t.Cleanup(func() {
+		SetCLIVersion("")
+	})
+
+	if _, err := LoadForCLI(path); err != nil {
+		t.Fatalf("load yaml config for cli with matching version: %v", err)
+	}
+
+	SetCLIVersion("v1.2.4")
+	if _, err := LoadForCLI(path); err == nil {
+		t.Fatal("expected pinned yaml version mismatch")
+	} else if !strings.Contains(err.Error(), "does not match pinned") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/tools/github-action/hyperlocalise-ci/cmd/resolve-config-version/main.go
+++ b/tools/github-action/hyperlocalise-ci/cmd/resolve-config-version/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: resolve-config-version <latest|config|version> [config-path] [working-directory]")
+		os.Exit(2)
+	}
+
+	requested := os.Args[1]
+	if requested != "config" {
+		fmt.Println(requested)
+		return
+	}
+
+	configPath := "i18n.yml"
+	if len(os.Args) >= 3 && strings.TrimSpace(os.Args[2]) != "" {
+		configPath = os.Args[2]
+	}
+
+	workingDirectory := "."
+	if len(os.Args) >= 4 && strings.TrimSpace(os.Args[3]) != "" {
+		workingDirectory = os.Args[3]
+	}
+
+	resolvedPath, err := resolveConfigPath(workingDirectory, configPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	version, err := config.InstallerVersionFromConfigFile(resolvedPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Println(version)
+}
+
+func resolveConfigPath(workingDirectory, configPath string) (string, error) {
+	if filepath.IsAbs(configPath) {
+		return configPath, nil
+	}
+
+	workingDirectory = filepath.Clean(workingDirectory)
+	if workingDirectory == "" {
+		workingDirectory = "."
+	}
+
+	return filepath.Join(workingDirectory, configPath), nil
+}

--- a/tools/github-action/hyperlocalise-ci/cmd/resolve-config-version/main_test.go
+++ b/tools/github-action/hyperlocalise-ci/cmd/resolve-config-version/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestResolveConfigPath(t *testing.T) {
+	got, err := resolveConfigPath("apps/web", "i18n.yml")
+	if err != nil {
+		t.Fatalf("resolve config path: %v", err)
+	}
+	if got != "apps/web/i18n.yml" {
+		t.Fatalf("resolveConfigPath() = %q, want apps/web/i18n.yml", got)
+	}
+
+	got, err = resolveConfigPath(".", "/tmp/i18n.yml")
+	if err != nil {
+		t.Fatalf("resolve absolute config path: %v", err)
+	}
+	if got != "/tmp/i18n.yml" {
+		t.Fatalf("resolveConfigPath() = %q, want /tmp/i18n.yml", got)
+	}
+}

--- a/tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh
+++ b/tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh
@@ -3,40 +3,20 @@ set -euo pipefail
 
 requested="${1:-latest}"
 config_path="${2:-i18n.yml}"
+working_directory="${3:-.}"
+repo_root="${GITHUB_ACTION_PATH:-${GITHUB_WORKSPACE:-.}}"
 
 if [[ "${requested}" != "config" ]]; then
   printf '%s\n' "${requested}"
   exit 0
 fi
 
-if [[ ! -f "${config_path}" ]]; then
-  echo "Failed to resolve Hyperlocalise version from config: ${config_path} does not exist." >&2
+if ! command -v go >/dev/null 2>&1; then
+  echo "Failed to resolve Hyperlocalise version from config: Go is required when hyperlocalise-version is set to config." >&2
   exit 1
 fi
 
-pinned="$(
-  awk -F: '
-    /^[[:space:]]*version:[[:space:]]*/ {
-      value = substr($0, index($0, ":") + 1)
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
-      gsub(/^["'\'']|["'\'']$/, "", value)
-      print value
-      exit
-    }
-  ' "${config_path}"
-)"
-
-if [[ -z "${pinned}" ]]; then
-  echo "Failed to resolve Hyperlocalise version from config: version is not set in ${config_path}." >&2
-  exit 1
-fi
-
-case "${pinned}" in
-  hyperlocalise@*|hl@*)
-    printf '%s\n' "${pinned#*@}"
-    ;;
-  *)
-    echo "Failed to resolve Hyperlocalise version from config: expected hyperlocalise@<version> or hl@<version>, got ${pinned}." >&2
-    exit 1
-    ;;
-esac
+(
+  cd "${repo_root}"
+  go run ./tools/github-action/hyperlocalise-ci/cmd/resolve-config-version "${requested}" "${config_path}" "${working_directory}"
+)

--- a/tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh
+++ b/tools/github-action/hyperlocalise-ci/scripts/resolve-hyperlocalise-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+requested="${1:-latest}"
+config_path="${2:-i18n.yml}"
+
+if [[ "${requested}" != "config" ]]; then
+  printf '%s\n' "${requested}"
+  exit 0
+fi
+
+if [[ ! -f "${config_path}" ]]; then
+  echo "Failed to resolve Hyperlocalise version from config: ${config_path} does not exist." >&2
+  exit 1
+fi
+
+pinned="$(
+  awk -F: '
+    /^[[:space:]]*version:[[:space:]]*/ {
+      value = substr($0, index($0, ":") + 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^["'\'']|["'\'']$/, "", value)
+      print value
+      exit
+    }
+  ' "${config_path}"
+)"
+
+if [[ -z "${pinned}" ]]; then
+  echo "Failed to resolve Hyperlocalise version from config: version is not set in ${config_path}." >&2
+  exit 1
+fi
+
+case "${pinned}" in
+  hyperlocalise@*|hl@*)
+    printf '%s\n' "${pinned#*@}"
+    ;;
+  *)
+    echo "Failed to resolve Hyperlocalise version from config: expected hyperlocalise@<version> or hl@<version>, got ${pinned}." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## What changed

Adds an optional `version` field to `i18n.yml` so projects can pin the Hyperlocalise CLI version (for example `hyperlocalise@1.10.0`), similar to `packageManager` in `package.json`.

- Parse and validate the pin in `pkg/i18nconfig`
- Enforce the pin via `LoadForCLI` across CLI commands and `runsvc`
- Document the field in the i18n config guide and init template
- Support `hyperlocalise-version: config` in GitHub Actions to install the pinned version from the config file
- Add tests for YAML loading, CLI command wiring, and runsvc integration

## How to test

Run:

    make fmt
    make lint
    make test
    go test ./pkg/i18nconfig/... ./apps/cli/cmd/... ./apps/cli/internal/i18n/runsvc/... -run 'Version|Pinned' -count=1

Manual check:

1. Add `version: hyperlocalise@<your-version>` to `i18n.yml`
2. Run `hyperlocalise status` with a mismatched CLI build and confirm it fails with a clear version error
3. Run with a matching version and confirm commands still work

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review