### PR TITLE
feat(mcp): add get_project_status tool

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-project-status.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-project-status.test.ts
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+
+import { loadMcpProjectStatus } from "@/api/routes/mcp/mcp-project-status";
+import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { db, schema } from "@/lib/database/client";
+import { ensureRepositorySourceFile } from "@/lib/file-storage/records";
+import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/test-project-identifier";
+import {
+  countProjectTranslationKeysForProject,
+  setProjectTranslationKeysHidden,
+  upsertProjectTranslationKeysFromEntries,
+} from "@/lib/projects/translations/project-translation-service";
+import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
+
+const authFixture = createAuthTestFixture();
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  await authFixture.cleanup();
+});
+
+async function seedNativeProject(input?: {
+  targetLocales?: string[];
+  source?: "native" | "external_tms";
+}) {
+  const { organization, user } = await authFixture.createLocalWorkosIdentity();
+  const team = await ensureDefaultWorkspaceTeam(organization.id);
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      id: `project_${randomUUID()}`,
+      identifier: uniqueTestProjectIdentifier(),
+      organizationId: organization.id,
+      teamId: team.id,
+      createdByUserId: user.id,
+      name: "Status",
+      description: "",
+      translationContext: "",
+      source: input?.source ?? "native",
+      sourceLocale: "en-US",
+      targetLocales: input?.targetLocales ?? ["fr-FR"],
+    })
+    .returning();
+
+  return { organization, project: project! };
+}
+
+async function seedFileKeys(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  entries: Array<{ key: string; text: string }>;
+}) {
+  const sourceFile = await ensureRepositorySourceFile({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+  });
+
+  await upsertProjectTranslationKeysFromEntries({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    repositorySourceFileId: sourceFile.id,
+    entries: input.entries,
+  });
+
+  const keys = await db
+    .select({
+      id: schema.projectTranslationKeys.id,
+      key: schema.projectTranslationKeys.key,
+    })
+    .from(schema.projectTranslationKeys)
+    .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id));
+
+  return { sourceFile, keys };
+}
+
+async function insertTranslation(input: {
+  organizationId: string;
+  projectId: string;
+  translationKeyId: string;
+  targetLocale: string;
+  text: string;
+  status: "draft" | "needs_review" | "approved" | "rejected";
+}) {
+  await db.insert(schema.projectTranslations).values(input);
+}
+
+describe("loadMcpProjectStatus", () => {
+  it("returns zero counts for an empty project", async () => {
+    const { organization, project } = await seedNativeProject({
+      targetLocales: ["fr-FR", "de-DE"],
+    });
+
+    const status = await loadMcpProjectStatus({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourceLocale: project.sourceLocale,
+      targetLocales: project.targetLocales,
+    });
+
+    expect(status).toMatchObject({
+      projectId: project.id,
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR", "de-DE"],
+      coverageSource: "native_overlay",
+    });
+    expect(status.files).toBeUndefined();
+    expect(status.locales).toEqual([
+      {
+        locale: "fr-FR",
+        total: 0,
+        translated: 0,
+        untranslated: 0,
+        needsReview: 0,
+        approved: 0,
+        hidden: 0,
+      },
+      {
+        locale: "de-DE",
+        total: 0,
+        translated: 0,
+        untranslated: 0,
+        needsReview: 0,
+        approved: 0,
+        hidden: 0,
+      },
+    ]);
+  });
+
+  it("reports one locale complete and another empty", async () => {
+    const { organization, project } = await seedNativeProject({
+      targetLocales: ["fr-FR", "de-DE"],
+    });
+    const { keys } = await seedFileKeys({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath: "locales/en-US.json",
+      entries: [
+        { key: "hello", text: "Hello" },
+        { key: "bye", text: "Goodbye" },
+      ],
+    });
+
+    for (const key of keys) {
+      await insertTranslation({
+        organizationId: organization.id,
+        projectId: project.id,
+        translationKeyId: key.id,
+        targetLocale: "fr-FR",
+        text: key.key === "hello" ? "Bonjour" : "Au revoir",
+        status: "approved",
+      });
+    }
+
+    const status = await loadMcpProjectStatus({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourceLocale: project.sourceLocale,
+      targetLocales: project.targetLocales,
+    });
+
+    expect(status.locales).toEqual([
+      {
+        locale: "fr-FR",
+        total: 2,
+        translated: 2,
+        untranslated: 0,
+        needsReview: 0,
+        approved: 2,
+        hidden: 0,
+      },
+      {
+        locale: "de-DE",
+        total: 2,
+        translated: 0,
+        untranslated: 2,
+        needsReview: 0,
+        approved: 0,
+        hidden: 0,
+      },
+    ]);
+  });
+
+  it("keeps hidden-key counts consistent with CAT queue filters", async () => {
+    const { organization, project } = await seedNativeProject();
+    const { keys } = await seedFileKeys({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath: "locales/en-US.json",
+      entries: [
+        { key: "visible.done", text: "Done" },
+        { key: "visible.todo", text: "Todo" },
+        { key: "hidden.todo", text: "Internal" },
+        { key: "visible.review", text: "Review" },
+      ],
+    });
+
+    const done = keys.find((row) => row.key === "visible.done");
+    const hidden = keys.find((row) => row.key === "hidden.todo");
+    const review = keys.find((row) => row.key === "visible.review");
+    expect(done).toBeDefined();
+    expect(hidden).toBeDefined();
+    expect(review).toBeDefined();
+
+    await insertTranslation({
+      organizationId: organization.id,
+      projectId: project.id,
+      translationKeyId: done!.id,
+      targetLocale: "fr-FR",
+      text: "Fait",
+      status: "approved",
+    });
+    await insertTranslation({
+      organizationId: organization.id,
+      projectId: project.id,
+      translationKeyId: review!.id,
+      targetLocale: "fr-FR",
+      text: "À revoir",
+      status: "needs_review",
+    });
+    await setProjectTranslationKeysHidden({
+      organizationId: organization.id,
+      projectId: project.id,
+      translationKeyIds: [hidden!.id],
+      isHidden: true,
+    });
+
+    const countInput = {
+      organizationId: organization.id,
+      projectId: project.id,
+      targetLocale: "fr-FR",
+    };
+    const [total, untranslated, needsReview, approved, hiddenCount] = await Promise.all([
+      countProjectTranslationKeysForProject(countInput),
+      countProjectTranslationKeysForProject({ ...countInput, queueFilter: "untranslated" }),
+      countProjectTranslationKeysForProject({ ...countInput, queueFilter: "needs_review" }),
+      countProjectTranslationKeysForProject({ ...countInput, queueFilter: "reviewed" }),
+      countProjectTranslationKeysForProject({ ...countInput, queueFilter: "hidden" }),
+    ]);
+
+    const status = await loadMcpProjectStatus({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourceLocale: project.sourceLocale,
+      targetLocales: project.targetLocales,
+    });
+
+    expect(status.locales).toEqual([
+      {
+        locale: "fr-FR",
+        total,
+        translated: total - untranslated,
+        untranslated,
+        needsReview,
+        approved,
+        hidden: hiddenCount,
+      },
+    ]);
+    expect(status.locales[0]).toEqual({
+      locale: "fr-FR",
+      total: 4,
+      translated: 2,
+      untranslated: 2,
+      needsReview: 1,
+      approved: 1,
+      hidden: 1,
+    });
+    expect(status.locales[0]!.translated + status.locales[0]!.untranslated).toBe(
+      status.locales[0]!.total,
+    );
+  });
+
+  it("scopes optional file rows to the requested source path", async () => {
+    const { organization, project } = await seedNativeProject();
+    const marketing = await seedFileKeys({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath: "locales/marketing.json",
+      entries: [
+        { key: "hero", text: "Hero" },
+        { key: "cta", text: "Start" },
+      ],
+    });
+    await seedFileKeys({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath: "locales/settings.json",
+      entries: [{ key: "save", text: "Save" }],
+    });
+
+    for (const key of marketing.keys) {
+      await insertTranslation({
+        organizationId: organization.id,
+        projectId: project.id,
+        translationKeyId: key.id,
+        targetLocale: "fr-FR",
+        text: "Traduit",
+        status: "approved",
+      });
+    }
+
+    const status = await loadMcpProjectStatus({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourceLocale: project.sourceLocale,
+      targetLocales: project.targetLocales,
+      sourcePath: "locales/marketing.json",
+    });
+
+    expect(status.locales).toEqual([
+      {
+        locale: "fr-FR",
+        total: 3,
+        translated: 2,
+        untranslated: 1,
+        needsReview: 0,
+        approved: 2,
+        hidden: 0,
+      },
+    ]);
+    expect(status.files).toEqual([
+      {
+        sourcePath: "locales/marketing.json",
+        locales: [
+          {
+            locale: "fr-FR",
+            total: 2,
+            translated: 2,
+            untranslated: 0,
+            needsReview: 0,
+            approved: 2,
+            hidden: 0,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("returns native overlay counts for TMS-backed projects", async () => {
+    const { organization, project } = await seedNativeProject({
+      source: "external_tms",
+      targetLocales: ["fr-FR"],
+    });
+
+    const status = await loadMcpProjectStatus({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourceLocale: project.sourceLocale,
+      targetLocales: project.targetLocales,
+    });
+
+    expect(status.coverageSource).toBe("native_overlay");
+    expect(status.locales).toEqual([
+      {
+        locale: "fr-FR",
+        total: 0,
+        translated: 0,
+        untranslated: 0,
+        needsReview: 0,
+        approved: 0,
+        hidden: 0,
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-project-status.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-project-status.test.ts
@@ -81,7 +81,7 @@ async function seedFileKeys(input: {
     organizationId: input.organizationId,
     projectId: input.projectId,
     repositorySourceFileId: sourceFile.id,
-    entries: input.entries,
+    entries: input.entries.map((entry) => ({ ...entry, context: null })),
   });
 
   const keys = await db

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-project-status.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-project-status.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ProjectFileContentEditorQueueFilter } from "@/api/routes/project/project.schema";
+import { countProjectTranslationKeysForProject } from "@/lib/projects/translations/project-translation-service";
+
+export const MCP_PROJECT_STATUS_COVERAGE_SOURCE = "native_overlay" as const;
+
+export type McpProjectLocaleStatus = {
+  locale: string;
+  total: number;
+  translated: number;
+  untranslated: number;
+  needsReview: number;
+  approved: number;
+  hidden: number;
+};
+
+export type McpProjectStatus = {
+  projectId: string;
+  sourceLocale: string | null;
+  targetLocales: string[];
+  coverageSource: typeof MCP_PROJECT_STATUS_COVERAGE_SOURCE;
+  locales: McpProjectLocaleStatus[];
+  files?: Array<{
+    sourcePath: string;
+    locales: McpProjectLocaleStatus[];
+  }>;
+};
+
+const localeQueueFilters = [
+  "untranslated",
+  "needs_review",
+  "reviewed",
+  "hidden",
+] as const satisfies readonly ProjectFileContentEditorQueueFilter[];
+
+async function countLocaleStatus(input: {
+  organizationId: string;
+  projectId: string;
+  locale: string;
+  sourcePaths?: readonly string[] | null;
+}): Promise<McpProjectLocaleStatus> {
+  const countInput = {
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    targetLocale: input.locale,
+    sourcePaths: input.sourcePaths,
+  };
+
+  const [total, untranslated, needsReview, approved, hidden] = await Promise.all([
+    countProjectTranslationKeysForProject(countInput),
+    ...localeQueueFilters.map((queueFilter) =>
+      countProjectTranslationKeysForProject({
+        ...countInput,
+        queueFilter,
+      }),
+    ),
+  ]);
+
+  return {
+    locale: input.locale,
+    total,
+    translated: total - untranslated,
+    untranslated,
+    needsReview,
+    approved,
+    hidden,
+  };
+}
+
+async function countLocales(input: {
+  organizationId: string;
+  projectId: string;
+  targetLocales: string[];
+  sourcePaths?: readonly string[] | null;
+}): Promise<McpProjectLocaleStatus[]> {
+  return Promise.all(
+    input.targetLocales.map((locale) =>
+      countLocaleStatus({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        locale,
+        sourcePaths: input.sourcePaths,
+      }),
+    ),
+  );
+}
+
+export async function loadMcpProjectStatus(input: {
+  organizationId: string;
+  projectId: string;
+  sourceLocale: string | null;
+  targetLocales: string[];
+  sourcePath?: string;
+}): Promise<McpProjectStatus> {
+  const locales = await countLocales({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    targetLocales: input.targetLocales,
+  });
+
+  const status: McpProjectStatus = {
+    projectId: input.projectId,
+    sourceLocale: input.sourceLocale,
+    targetLocales: input.targetLocales,
+    coverageSource: MCP_PROJECT_STATUS_COVERAGE_SOURCE,
+    locales,
+  };
+
+  if (!input.sourcePath) {
+    return status;
+  }
+
+  return {
+    ...status,
+    files: [
+      {
+        sourcePath: input.sourcePath,
+        locales: await countLocales({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          targetLocales: input.targetLocales,
+          sourcePaths: [input.sourcePath],
+        }),
+      },
+    ],
+  };
+}

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -384,6 +384,16 @@ describe("MCP team-scoped access", () => {
     };
     expect(getDeniedBody.project).toBeNull();
 
+    const statusDeniedResponse = await callMcpTool(accessToken, "get_project_status", {
+      projectId: betaProjectBody.project.id,
+    });
+    expect(statusDeniedResponse.status).toBe(200);
+    const statusDeniedBody = await statusDeniedResponse.json();
+    expect((statusDeniedBody as { result?: { isError?: boolean } }).result?.isError).toBe(true);
+    expect(parseToolResultText(statusDeniedBody)).toMatchObject({
+      error: "project_not_found",
+    });
+
     const createDeniedResponse = await callMcpTool(accessToken, "create_issue", {
       projectId: alphaProjectBody.project.id,
       title: "Member must not create this issue",

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -2937,4 +2937,145 @@ describe("mcpRoutes", () => {
       createSpy.mockRestore();
     }
   });
+
+  it("advertises the get_project_status tool with a bounded input schema", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "get_project_status");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("locale coverage");
+    expect(tool?.inputSchema?.required).toEqual(expect.arrayContaining(["projectId"]));
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: expect.any(Object),
+      sourcePath: {
+        type: "string",
+        minLength: 1,
+        maxLength: 2048,
+      },
+    });
+  });
+
+  it("returns locale coverage for an accessible project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "get_project_status",
+          arguments: {
+            projectId: stored.project.id,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ type: string; text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBeFalsy();
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      projectId: stored.project.id,
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      coverageSource: "native_overlay",
+      locales: [
+        {
+          locale: "fr-FR",
+          total: 0,
+          translated: 0,
+          untranslated: 0,
+          needsReview: 0,
+          approved: 0,
+          hidden: 0,
+        },
+      ],
+    });
+  });
+
+  it("returns project_not_found for an inaccessible project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const outsider = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(outsider.identity);
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "get_project_status",
+          arguments: {
+            projectId: stored.project.id,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ type: string; text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "project_not_found",
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -72,6 +72,7 @@ import {
   type IssueSheetIssue,
 } from "@/lib/projects/issue-sheet/issue-sheet-service";
 import { isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
+import { loadMcpProjectStatus } from "@/api/routes/mcp/mcp-project-status";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -633,6 +634,53 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
 
       return {
         content: [{ type: "text", text: JSON.stringify({ project: project ?? null }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "get_project_status",
+    {
+      description:
+        "Get locale coverage counts for an accessible Hyperlocalise project. Returns CAT queue totals per target locale without source or target text. Counts use the native key overlay (the same filters as the Content Editor). Live TMS provider statistics are out of scope.",
+      inputSchema: z.object({
+        projectId: projectIdSchema.describe("ID of the accessible Hyperlocalise project."),
+        sourcePath: z
+          .string()
+          .trim()
+          .min(1)
+          .max(2048)
+          .optional()
+          .describe(
+            "Optional source file path. When set, also returns counts for that file only.",
+          ),
+      }),
+    },
+    async ({ projectId, sourcePath }) => {
+      const [project] = await db
+        .select({
+          id: schema.projects.id,
+          sourceLocale: schema.projects.sourceLocale,
+          targetLocales: schema.projects.targetLocales,
+        })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      const status = await loadMcpProjectStatus({
+        organizationId: apiAuth.organization.localOrganizationId,
+        projectId: project.id,
+        sourceLocale: project.sourceLocale,
+        targetLocales: project.targetLocales,
+        sourcePath,
+      });
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(status, null, 2) }],
       };
     },
   );

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -651,9 +651,7 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
           .min(1)
           .max(2048)
           .optional()
-          .describe(
-            "Optional source file path. When set, also returns counts for that file only.",
-          ),
+          .describe("Optional source file path. When set, also returns counts for that file only."),
       }),
     },
     async ({ projectId, sourcePath }) => {

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -46,8 +46,17 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | --- | --- |
 | `list_projects` | List accessible projects (`limit`, default 20, max 50) |
 | `get_project` | Project details by `projectId` |
+| `get_project_status` | Locale coverage counts by `projectId`, with optional `sourcePath` |
 | `list_glossaries` | List glossaries linked to accessible projects |
 | `get_glossary_entries` | Concept-linked terms for a `glossaryId` (`limit`, default 50, max 100) |
+
+`get_project_status` answers “how done is French?” without paging translations. It returns `sourceLocale`, `targetLocales`, and per-locale counts: `total`, `translated`, `untranslated`, `needsReview`, `approved`, and `hidden`. Counts match Content Editor queue filters on the native key overlay. Hidden keys stay in `total` and, when they have no target text, in `untranslated`, because that is how the native CAT server filter counts them.
+
+When you pass `sourcePath`, the tool still returns project-wide locale totals and adds a `files` row for that path. The response includes counts only. It never includes source or target text.
+
+For TMS-backed projects the tool still returns native overlay counts (`coverageSource: "native_overlay"`). It does not fetch live provider statistics. Use the provider CAT or CLI for Crowdin, Phrase, Lokalise, or Smartling progress.
+
+Inaccessible projects return `project_not_found`.
 
 ### Board (issues)
 
@@ -99,6 +108,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `registration_disabled` on `/api/mcp/register` | Dynamic registration is off in production; use a client that supports metadata-based client IDs |
 | `forbidden` on issue tools | Your role is read-only for write-back operations |
 | `issue_not_found` | Wrong `projectId`, issue id, or missing project access |
+| `project_not_found` | Wrong `projectId` or missing project access on `get_project_status` |
 | Agent cannot reach local Cloud | Use `http://localhost:3000/mcp` and ensure the dev server is running |
 
 ## Next


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a hosted MCP `get_project_status` tool so coding agents can ask how complete a locale is without paging `list_translations`.

The tool returns `sourceLocale`, `targetLocales`, and per-locale CAT queue counts (`total`, `translated`, `untranslated`, `needsReview`, `approved`, `hidden`) from the native key overlay. An optional `sourcePath` adds a file-level breakdown. Inaccessible projects return `project_not_found`. TMS projects use native overlay counts only; live provider statistics stay out of scope.

Resolves HL-689.

## How to test

- `vp test` and `vp check --fix` in `apps/hyperlocalise-web` (844 files / 5820 tests passed locally)
- Call `get_project_status` with `{ "projectId": "<id>" }` on an empty native project and on a project with one complete locale
- Confirm a second organization or team receives `project_not_found`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-689](https://linear.app/hyperlocalise/issue/HL-689/add-get-project-status-tool-to-the-hosted-mcp-server)

<div><a href="https://cursor.com/agents/bc-a5f010c1-4731-4a29-abf3-2592e613ed97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f010c1-4731-4a29-abf3-2592e613ed97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

