### PR TITLE
feat(mcp): add get_job tool for translation job status

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -25,6 +25,7 @@ import { testClient } from "hono/testing";
 
 import { createProjectTestFixture } from "../project/project.fixture";
 import type { ProjectResponse } from "../project/project.schema";
+import { insertPublicTranslationJob } from "../public-jobs/public-jobs.fixture";
 import { createTeamTestFixture } from "../team/team.fixture";
 import type { TeamResponse } from "../team/team.schema";
 
@@ -555,5 +556,128 @@ describe("MCP team-scoped access", () => {
         externalRef: "mcp:translator-alpha",
       },
     ]);
+  });
+
+  it("scopes get_job to accessible projects and hides other organizations", async () => {
+    const admin = projectFixture.createWorkosIdentityWithRole("admin");
+    const member = projectFixture.createWorkosIdentityForOrganization(admin.organization, "member");
+
+    await projectFixture.authHeadersFor(admin);
+    const adminAuth = globalThis.__testApiAuthContext;
+    if (!adminAuth) {
+      throw new Error("expected admin auth context");
+    }
+
+    await projectFixture.authHeadersFor(member);
+    const memberAuth = globalThis.__testApiAuthContext;
+    if (!memberAuth) {
+      throw new Error("expected member auth context");
+    }
+
+    const teamAlphaResponse = await teamFixture.createTeamViaApi(admin, { name: "MCP Job Alpha" });
+    const teamAlphaBody = (await teamAlphaResponse.json()) as TeamResponse;
+    const teamBetaResponse = await teamFixture.createTeamViaApi(admin, { name: "MCP Job Beta" });
+    const teamBetaBody = (await teamBetaResponse.json()) as TeamResponse;
+
+    trackedMemberLocalUserId = await projectFixture.getLocalUserId(member.user.workosUserId);
+    await db.insert(schema.teamMemberships).values({
+      teamId: teamAlphaBody.team.id,
+      userId: trackedMemberLocalUserId,
+      role: "member",
+    });
+
+    const alphaProjectResponse = await client.api.orgs[":organizationSlug"].projects.$post(
+      {
+        param: { organizationSlug: admin.organization.slug ?? "missing-slug" },
+        json: {
+          name: "MCP Job Alpha Project",
+          teamId: teamAlphaBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(admin) },
+    );
+    expect(alphaProjectResponse.status).toBe(201);
+    const alphaProjectBody = (await alphaProjectResponse.json()) as ProjectResponse;
+
+    const betaProjectResponse = await client.api.orgs[":organizationSlug"].projects.$post(
+      {
+        param: { organizationSlug: admin.organization.slug ?? "missing-slug" },
+        json: {
+          name: "MCP Job Beta Project",
+          teamId: teamBetaBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["de-DE"],
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(admin) },
+    );
+    expect(betaProjectResponse.status).toBe(201);
+    const betaProjectBody = (await betaProjectResponse.json()) as ProjectResponse;
+
+    const { organization: externalOrganization, project: externalProject } =
+      await projectFixture.createStoredProjectFixture();
+
+    const [alphaJob, betaJob, externalJob] = await Promise.all([
+      insertPublicTranslationJob({
+        organizationId: memberAuth.organization.localOrganizationId,
+        projectId: alphaProjectBody.project.id,
+        status: "queued",
+      }),
+      insertPublicTranslationJob({
+        organizationId: memberAuth.organization.localOrganizationId,
+        projectId: betaProjectBody.project.id,
+        status: "running",
+      }),
+      insertPublicTranslationJob({
+        organizationId: externalOrganization.id,
+        projectId: externalProject.id,
+        status: "succeeded",
+      }),
+    ]);
+
+    const accessToken = await mcpAccessTokenForAuth(memberAuth);
+    const adminAccessToken = await mcpAccessTokenForAuth(adminAuth);
+
+    const accessibleJobResponse = await callMcpTool(accessToken, "get_job", {
+      jobId: alphaJob.id,
+    });
+    expect(accessibleJobResponse.status).toBe(200);
+    expect(parseToolResultText(await accessibleJobResponse.json())).toMatchObject({
+      job: {
+        id: alphaJob.id,
+        projectId: alphaProjectBody.project.id,
+        status: "queued",
+      },
+    });
+
+    const adminBetaJobResponse = await callMcpTool(adminAccessToken, "get_job", {
+      jobId: betaJob.id,
+    });
+    expect(adminBetaJobResponse.status).toBe(200);
+    expect(parseToolResultText(await adminBetaJobResponse.json())).toMatchObject({
+      job: {
+        id: betaJob.id,
+        projectId: betaProjectBody.project.id,
+        status: "running",
+      },
+    });
+
+    for (const [label, jobId] of [
+      ["inaccessible team job", betaJob.id],
+      ["cross-organization job", externalJob.id],
+      ["missing job", "job_does_not_exist"],
+    ] as const) {
+      const response = await callMcpTool(accessToken, "get_job", { jobId });
+      expect(response.status, label).toBe(200);
+      const responseBody = await response.json();
+      expect((responseBody as { result?: { isError?: boolean } }).result?.isError, label).toBe(
+        true,
+      );
+      expect(parseToolResultText(responseBody), label).toMatchObject({
+        error: "job_not_found",
+      });
+    }
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -40,6 +40,10 @@ import { db, schema } from "@/lib/database/client";
 import { env } from "@/lib/env";
 
 import { createProjectTestFixture } from "../project/project.fixture";
+import {
+  insertCompletedPublicFileJob,
+  insertPublicTranslationJob,
+} from "../public-jobs/public-jobs.fixture";
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
@@ -2937,4 +2941,241 @@ describe("mcpRoutes", () => {
       createSpy.mockRestore();
     }
   });
+
+  it("advertises the get_job tool with jobId validation", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "get_job");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("job");
+    expect(tool?.inputSchema?.required).toEqual(["jobId"]);
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      jobId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+    });
+  });
+
+  it.each([
+    ["queued", { status: "queued" as const, lastError: null, completedAt: null }],
+    ["running", { status: "running" as const, lastError: null, completedAt: null }],
+    [
+      "succeeded",
+      {
+        status: "succeeded" as const,
+        lastError: null,
+        completedAt: new Date("2026-03-01T12:00:00.000Z"),
+      },
+    ],
+    [
+      "failed",
+      {
+        status: "failed" as const,
+        lastError: "Provider timed out",
+        completedAt: new Date("2026-03-01T12:00:00.000Z"),
+      },
+    ],
+  ])("returns a distinguishable %s job envelope", async (_label, jobState) => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const job = await insertPublicTranslationJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      ...jobState,
+    });
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "get_job",
+          arguments: {
+            jobId: job.id,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+
+    const output = JSON.parse(body.result?.content?.[0]?.text ?? "") as {
+      job: Record<string, unknown>;
+    };
+
+    expect(output.job).toEqual({
+      id: job.id,
+      projectId: stored.project.id,
+      type: "string",
+      kind: "translation",
+      status: jobState.status,
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+      completedAt: jobState.completedAt ? expect.any(String) : null,
+      lastError: jobState.lastError,
+      outputFiles: null,
+    });
+    expect(output.job).not.toHaveProperty("inputPayload");
+    expect(output.job).not.toHaveProperty("outcomePayload");
+    expect(output.job).not.toHaveProperty("workflowRunId");
+    expect(output.job).not.toHaveProperty("organizationId");
+  });
+
+  it("includes output file ids for a completed file job", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const job = await insertCompletedPublicFileJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      outputFiles: [
+        {
+          fileId: "file_output_fr",
+          locale: "fr-FR",
+          filename: "source.fr-FR.xliff",
+        },
+      ],
+    });
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "get_job",
+          arguments: {
+            jobId: job.id,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+
+    const output = JSON.parse(body.result?.content?.[0]?.text ?? "") as {
+      job: { status: string; outputFiles: unknown };
+    };
+
+    expect(output.job.status).toBe("succeeded");
+    expect(output.job.outputFiles).toEqual([
+      {
+        fileId: "file_output_fr",
+        locale: "fr-FR",
+        filename: "source.fr-FR.xliff",
+      },
+    ]);
+  });
+
+  it.each(["missing", "cross-organization"])(
+    "returns job_not_found for a %s job id",
+    async (scenario) => {
+      const stored = await fixture.createStoredProjectFixture();
+      const headers = await authenticatedMcpHeaders(stored.identity);
+      const other = await fixture.createStoredProjectFixture();
+      const otherJob = await insertPublicTranslationJob({
+        organizationId: other.organization.id,
+        projectId: other.project.id,
+        status: "queued",
+      });
+
+      const response = await app.request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "get_job",
+            arguments: {
+              jobId: scenario === "missing" ? "job_does_not_exist" : otherJob.id,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ text?: string }>;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+      expect(JSON.parse(body.result?.content?.[0]?.text ?? "")).toEqual({
+        error: "job_not_found",
+        message: "Job not found",
+      });
+    },
+  );
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -39,6 +39,11 @@ import {
   canAccessGlossary,
   ownedProjectWhere,
 } from "@/api/auth/team-access";
+import { jobIdParamsSchema } from "@/api/routes/public-jobs/public-jobs.schema";
+import {
+  findAccessiblePublicJob,
+  toMcpJobEnvelope,
+} from "@/api/routes/public-jobs/public-jobs.read";
 import {
   createAuthorizationCode,
   createMcpAuthorizationRequest,
@@ -493,6 +498,12 @@ const mcpCreateIssueInputSchema = z.object({
     .describe(
       "Caller-generated retry key. Reusing it with an equivalent payload returns the existing issue.",
     ),
+});
+
+const mcpGetJobInputSchema = z.object({
+  jobId: jobIdParamsSchema.shape.jobId.describe(
+    "ID of the translation or workflow job to inspect, typically returned by run_workflow.",
+  ),
 });
 
 type McpCreateIssueInput = z.infer<typeof mcpCreateIssueInputSchema>;
@@ -975,6 +986,33 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
 
       return {
         content: [{ type: "text", text: JSON.stringify({ glossaries }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "get_job",
+    {
+      description:
+        "Get status and results for one accessible Hyperlocalise job. Poll after run_workflow until the job reaches a terminal status.",
+      inputSchema: mcpGetJobInputSchema,
+    },
+    async ({ jobId }) => {
+      const job = await findAccessiblePublicJob(apiAuth, jobId);
+
+      if (!job) {
+        return mcpToolError("job_not_found", "Job not found");
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              job: toMcpJobEnvelope(job),
+            }),
+          },
+        ],
       };
     },
   );

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.fixture.ts
@@ -129,14 +129,20 @@ export async function insertStoredSourceFile(params: {
   return file;
 }
 
-export async function insertCompletedPublicFileJob(params: {
+export async function insertPublicTranslationJob(params: {
   projectId: string;
   organizationId: string;
   apiKeyId?: string;
-  outputFiles: Array<{ fileId: string; locale: string; filename: string }>;
+  status: (typeof schema.jobStatusEnum.enumValues)[number];
+  type?: "string" | "file";
+  lastError?: string | null;
+  completedAt?: Date | null;
+  outputFiles?: Array<{ fileId: string; locale: string; filename: string }>;
 }) {
   return db.transaction(async (tx) => {
     const id = `job_${randomUUID()}`;
+    const type = params.type ?? (params.outputFiles ? "file" : "string");
+    const outputFiles = params.outputFiles ?? [];
     const [job] = await tx
       .insert(schema.jobs)
       .values({
@@ -144,18 +150,24 @@ export async function insertCompletedPublicFileJob(params: {
         organizationId: params.organizationId,
         projectId: params.projectId,
         kind: "translation",
-        status: "succeeded",
-        inputPayload: {
-          sourceFileId: "file_source",
-          fileFormat: "xliff",
-          sourceLocale: "en-US",
-          targetLocales: params.outputFiles.map((file) => file.locale),
-        },
-        outcomePayload: {
-          outputFiles: params.outputFiles,
-        },
+        status: params.status,
+        inputPayload:
+          type === "file"
+            ? {
+                sourceFileId: "file_source",
+                fileFormat: "xliff",
+                sourceLocale: "en-US",
+                targetLocales: outputFiles.map((file) => file.locale),
+              }
+            : {
+                sourceText: "Hello world",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+              },
+        outcomePayload: outputFiles.length > 0 ? { outputFiles } : null,
+        lastError: params.lastError ?? null,
         apiKeyId: params.apiKeyId ?? null,
-        completedAt: new Date(),
+        completedAt: params.completedAt ?? (params.status === "succeeded" ? new Date() : null),
       })
       .returning();
 
@@ -165,11 +177,25 @@ export async function insertCompletedPublicFileJob(params: {
 
     await tx.insert(schema.translationJobDetails).values({
       jobId: id,
-      type: "file",
-      outcomeKind: "file_result",
+      type,
+      outcomeKind: outputFiles.length > 0 ? "file_result" : null,
     });
 
     return job;
+  });
+}
+
+export async function insertCompletedPublicFileJob(params: {
+  projectId: string;
+  organizationId: string;
+  apiKeyId?: string;
+  outputFiles: Array<{ fileId: string; locale: string; filename: string }>;
+}) {
+  return insertPublicTranslationJob({
+    ...params,
+    status: "succeeded",
+    type: "file",
+    outputFiles: params.outputFiles,
   });
 }
 

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.read.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.read.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq } from "drizzle-orm";
+
+import type { ApiAuthContext } from "@/api/auth/workos";
+import { buildAccessibleJobsWhere } from "@/api/auth/team-access";
+import { db, schema } from "@/lib/database/client";
+
+export type PublicJobOutputFile = {
+  fileId: string;
+  locale: string;
+  filename: string;
+};
+
+export type AccessiblePublicJob = {
+  id: string;
+  projectId: string | null;
+  kind: (typeof schema.jobs.$inferSelect)["kind"];
+  type: (typeof schema.translationJobDetails.$inferSelect)["type"] | null;
+  status: (typeof schema.jobs.$inferSelect)["status"];
+  outcomeKind: (typeof schema.translationJobDetails.$inferSelect)["outcomeKind"] | null;
+  outcomePayload: unknown;
+  lastError: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  completedAt: Date | null;
+};
+
+function hasValue(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function isPublicJobOutputFile(value: unknown): value is PublicJobOutputFile {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return hasValue(candidate.fileId) && hasValue(candidate.locale) && hasValue(candidate.filename);
+}
+
+export function publicJobOutputFiles(input: {
+  type: string | null;
+  outcomeKind: string | null;
+  outcomePayload: unknown;
+}): PublicJobOutputFile[] | null {
+  if (input.type !== "file" || input.outcomeKind !== "file_result") {
+    return null;
+  }
+
+  if (!input.outcomePayload || typeof input.outcomePayload !== "object") {
+    return null;
+  }
+
+  const outputFiles = (input.outcomePayload as Record<string, unknown>).outputFiles;
+  if (!Array.isArray(outputFiles) || !outputFiles.every(isPublicJobOutputFile)) {
+    return null;
+  }
+
+  return outputFiles.map((outputFile) => ({
+    fileId: outputFile.fileId,
+    locale: outputFile.locale,
+    filename: outputFile.filename,
+  }));
+}
+
+export function toPublicJobEnvelope(job: AccessiblePublicJob) {
+  return {
+    id: job.id,
+    projectId: job.projectId,
+    type: job.type,
+    status: job.status,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    completedAt: job.completedAt,
+    lastError: job.lastError,
+    outputFiles: publicJobOutputFiles(job),
+  };
+}
+
+export function toMcpJobEnvelope(job: AccessiblePublicJob) {
+  return {
+    ...toPublicJobEnvelope(job),
+    kind: job.kind,
+  };
+}
+
+export async function findAccessiblePublicJob(
+  auth: ApiAuthContext,
+  jobId: string,
+): Promise<AccessiblePublicJob | null> {
+  const accessibleJobsWhere = await buildAccessibleJobsWhere(auth);
+
+  const [job] = await db
+    .select({
+      id: schema.jobs.id,
+      projectId: schema.jobs.projectId,
+      kind: schema.jobs.kind,
+      type: schema.translationJobDetails.type,
+      status: schema.jobs.status,
+      outcomeKind: schema.translationJobDetails.outcomeKind,
+      outcomePayload: schema.jobs.outcomePayload,
+      lastError: schema.jobs.lastError,
+      createdAt: schema.jobs.createdAt,
+      updatedAt: schema.jobs.updatedAt,
+      completedAt: schema.jobs.completedAt,
+    })
+    .from(schema.jobs)
+    .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+    .where(and(eq(schema.jobs.id, jobId), accessibleJobsWhere))
+    .limit(1);
+
+  return job ?? null;
+}

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -23,11 +23,7 @@ import {
   type ApiKeyAuthVariables,
 } from "@/api/auth/api-key";
 import type { ApiAuthContext } from "@/api/auth/workos";
-import {
-  buildAccessibleJobsWhere,
-  getAccessibleProjectIds,
-  hasOrganizationWideProjectAccess,
-} from "@/api/auth/team-access";
+import { getAccessibleProjectIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
 import { badRequestResponse } from "@/api/response.schema";
 import { rejectIfAiFeaturesUnavailable } from "@/api/billing/ai-features-response";
 import { db, schema } from "@/lib/database/client";
@@ -55,6 +51,11 @@ import {
   jobIdParamsSchema,
   latestPublicJobQuerySchema,
 } from "./public-jobs.schema";
+import {
+  findAccessiblePublicJob,
+  publicJobOutputFiles,
+  toPublicJobEnvelope,
+} from "./public-jobs.read";
 import {
   invalidJobPayloadResponse,
   jobNotFoundResponse,
@@ -91,12 +92,6 @@ const validateLatestPublicJobQuery = validator("query", (value, c) => {
 
 type CreatePublicJobRoutesOptions = {
   jobQueue?: JobQueue<TranslationJobEventData>;
-};
-
-type PublicJobOutputFile = {
-  fileId: string;
-  locale: string;
-  filename: string;
 };
 
 type ApiKeyProjectAccessScope = {
@@ -178,44 +173,6 @@ function buildAccessibleJobsWhereFromProjectScope(scope: ApiKeyProjectAccessScop
   }
 
   return and(organizationScope, inArray(schema.jobs.projectId, scope.accessibleProjectIds))!;
-}
-
-function hasValue(value: unknown): value is string {
-  return typeof value === "string" && value.trim() !== "";
-}
-
-function isPublicJobOutputFile(value: unknown): value is PublicJobOutputFile {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const candidate = value as Record<string, unknown>;
-  return hasValue(candidate.fileId) && hasValue(candidate.locale) && hasValue(candidate.filename);
-}
-
-function publicJobOutputFiles(input: {
-  type: string | null;
-  outcomeKind: string | null;
-  outcomePayload: unknown;
-}) {
-  if (input.type !== "file" || input.outcomeKind !== "file_result") {
-    return null;
-  }
-
-  if (!input.outcomePayload || typeof input.outcomePayload !== "object") {
-    return null;
-  }
-
-  const outputFiles = (input.outcomePayload as Record<string, unknown>).outputFiles;
-  if (!Array.isArray(outputFiles) || !outputFiles.every(isPublicJobOutputFile)) {
-    return null;
-  }
-
-  return outputFiles.map((outputFile) => ({
-    fileId: outputFile.fileId,
-    locale: outputFile.locale,
-    filename: outputFile.filename,
-  }));
 }
 
 export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}) {
@@ -455,32 +412,17 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
     )
     .get("/:jobId", requireApiKeyPermission("jobs:read"), validateJobIdParams, async (c) => {
       const params = c.req.valid("param");
-      const accessibleJobsWhere = await buildAccessibleJobsWhere(c.var.auth.teamAccess);
+      const job = await findAccessiblePublicJob(c.var.auth.teamAccess, params.jobId);
 
-      const [job] = await db
-        .select({
-          id: schema.jobs.id,
-          organizationId: schema.jobs.organizationId,
-          projectId: schema.jobs.projectId,
-          kind: schema.jobs.kind,
-          status: schema.jobs.status,
-          type: schema.translationJobDetails.type,
-          inputPayload: schema.jobs.inputPayload,
-          outcomeKind: schema.translationJobDetails.outcomeKind,
-          outcomePayload: schema.jobs.outcomePayload,
-          lastError: schema.jobs.lastError,
-          workflowRunId: schema.jobs.workflowRunId,
-          createdAt: schema.jobs.createdAt,
-          updatedAt: schema.jobs.updatedAt,
-          completedAt: schema.jobs.completedAt,
-        })
-        .from(schema.jobs)
-        .leftJoin(
-          schema.translationJobDetails,
-          eq(schema.translationJobDetails.jobId, schema.jobs.id),
-        )
-        .where(and(eq(schema.jobs.id, params.jobId), accessibleJobsWhere))
-        .limit(1);
+      if (!job) {
+        return jobNotFoundResponse(c);
+      }
+
+      return c.json({ job: toPublicJobEnvelope(job) }, 200);
+    })
+    .get("/:jobId/status", requireApiKeyPermission("jobs:read"), validateJobIdParams, async (c) => {
+      const params = c.req.valid("param");
+      const job = await findAccessiblePublicJob(c.var.auth.teamAccess, params.jobId);
 
       if (!job) {
         return jobNotFoundResponse(c);
@@ -491,46 +433,16 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
           job: {
             id: job.id,
             projectId: job.projectId,
+            kind: job.kind,
             type: job.type,
             status: job.status,
             createdAt: job.createdAt,
             updatedAt: job.updatedAt,
             completedAt: job.completedAt,
             lastError: job.lastError,
-            outputFiles: publicJobOutputFiles(job),
           },
         },
         200,
       );
-    })
-    .get("/:jobId/status", requireApiKeyPermission("jobs:read"), validateJobIdParams, async (c) => {
-      const params = c.req.valid("param");
-      const accessibleJobsWhere = await buildAccessibleJobsWhere(c.var.auth.teamAccess);
-
-      const [job] = await db
-        .select({
-          id: schema.jobs.id,
-          projectId: schema.jobs.projectId,
-          kind: schema.jobs.kind,
-          type: schema.translationJobDetails.type,
-          status: schema.jobs.status,
-          createdAt: schema.jobs.createdAt,
-          updatedAt: schema.jobs.updatedAt,
-          completedAt: schema.jobs.completedAt,
-          lastError: schema.jobs.lastError,
-        })
-        .from(schema.jobs)
-        .leftJoin(
-          schema.translationJobDetails,
-          eq(schema.translationJobDetails.jobId, schema.jobs.id),
-        )
-        .where(and(eq(schema.jobs.id, params.jobId), accessibleJobsWhere))
-        .limit(1);
-
-      if (!job) {
-        return jobNotFoundResponse(c);
-      }
-
-      return c.json({ job }, 200);
     });
 }

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -64,6 +64,16 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 
 `list_issues` supports the same filters as the workspace Board API, including `view`, `status`, `issueType`, `priority`, `locale`, `assignee`, `projectId`, `search`, `sort`, `sortDir`, `limit` (max 50), and `offset`.
 
+### Jobs
+
+| Tool | Description |
+| --- | --- |
+| `get_job` | Job status by `jobId`. Poll after `run_workflow` until the job is terminal. |
+
+`get_job` returns the public job envelope: `id`, `projectId`, `type`, `kind`, `status`, timestamps, and `lastError`. Status values include `queued`, `running`, `succeeded`, and `failed`. Completed file jobs also include `outputFiles` with `{ fileId, locale, filename }` so you can pass those ids to `download_translations` or file reads.
+
+Missing or inaccessible jobs, including jobs from another organization, return `job_not_found`.
+
 ### Reserved (not implemented)
 
 These tools are advertised but return `not_implemented` today:
@@ -99,6 +109,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `registration_disabled` on `/api/mcp/register` | Dynamic registration is off in production; use a client that supports metadata-based client IDs |
 | `forbidden` on issue tools | Your role is read-only for write-back operations |
 | `issue_not_found` | Wrong `projectId`, issue id, or missing project access |
+| `job_not_found` | Wrong `jobId`, missing project access, or a job from another organization |
 | Agent cannot reach local Cloud | Use `http://localhost:3000/mcp` and ensure the dev server is running |
 
 ## Next


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a hosted MCP `get_job` tool so agents can poll translation job status after `run_workflow`, matching `GET /v1/jobs/{jobId}` and `GET /v1/jobs/{jobId}/status`.

- New `get_job` tool on the MCP server. Input is `jobId`. The payload is the public job envelope plus `kind`: `id`, `projectId`, `type`, `kind`, `status`, timestamps, `lastError`, and `outputFiles` when a file job has completed.
- Shared `findAccessiblePublicJob` / envelope helpers in `public-jobs.read.ts`. Public job GET routes and MCP both use this path, including `buildAccessibleJobsWhere` so team-scoped members only see jobs on accessible projects.
- Missing or inaccessible jobs, including cross-organization ids, return `job_not_found`. The tool does not expose `inputPayload`, `outcomePayload`, or other internal job fields.
- Tests cover queued, running, succeeded, and failed statuses, completed file output ids, and team/org isolation.
- Docs in `docs/platform/mcp.mdx`.

Merged with `main` after `get_project_status` landed. Conflicts were additive: both tool test suites and both troubleshooting rows are kept.

Fixes HL-681.

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/api/routes/mcp/mcp.route.test.ts src/api/routes/mcp/mcp-team-access.test.ts src/api/routes/mcp/mcp-project-status.test.ts src/api/routes/public-jobs/public-jobs.route.test.ts
vp check --fix
```

Post-merge targeted tests: 98 passed.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-681](https://linear.app/hyperlocalise/issue/HL-681/add-get-job-tool-to-the-hosted-mcp-server)

<div><a href="https://cursor.com/agents/bc-99dc05db-bab4-44d4-9275-cd2b569aa8ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99dc05db-bab4-44d4-9275-cd2b569aa8ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

