### PR TITLE
perf(cli): speed up React-Intl extract with SIMD string scans

### DIFF
--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -627,37 +627,42 @@ func extractMessageDescriptor(src, file string, objectStart, objectEnd int) (ext
 		return extractMessage{}, false, err
 	}
 
-	values := make(map[string]string)
+	var id, defaultMessage, description string
+	var hasID, hasDefaultMessage bool
 	for _, property := range properties {
 		if !property.stringValueSet {
 			continue
 		}
 		switch property.key {
-		case "description", "defaultMessage", "id":
-			values[property.key] = property.stringValue
+		case "id":
+			id = property.stringValue
+			hasID = true
+		case "defaultMessage":
+			defaultMessage = property.stringValue
+			hasDefaultMessage = true
+		case "description":
+			description = property.stringValue
 		}
 	}
 
-	id, ok := values["id"]
-	if !ok || strings.TrimSpace(id) == "" {
-		defaultMessage, ok := values["defaultMessage"]
-		if !ok {
+	if !hasID || strings.TrimSpace(id) == "" {
+		if !hasDefaultMessage {
 			return extractMessage{}, false, nil
 		}
-		id = generatedFormatJSMessageID(defaultMessage, values["description"])
+		id = generatedFormatJSMessageID(defaultMessage, description)
 	}
 
 	return extractMessage{
 		ID:             id,
-		DefaultMessage: values["defaultMessage"],
-		Description:    values["description"],
+		DefaultMessage: defaultMessage,
+		Description:    description,
 		sourcePath:     file,
 		sourcePos:      objectStart,
 	}, true, nil
 }
 
 func parseObjectProperties(src string, objectStart, objectEnd int) ([]extractObjectProperty, error) {
-	properties := make([]extractObjectProperty, 0)
+	properties := make([]extractObjectProperty, 0, 4)
 	for i := objectStart + 1; i < objectEnd; {
 		i = skipWhitespaceAndComments(src, i)
 		if i >= objectEnd {
@@ -964,7 +969,11 @@ func parseJSXAttributeValue(src string, index, tagEnd int) (string, int, bool, e
 		if end > tagEnd {
 			return "", index, false, fmt.Errorf("unterminated JSX attribute at line %d", sourceLine(src, index))
 		}
-		return html.UnescapeString(src[index+1 : end-1]), end, true, nil
+		raw := src[index+1 : end-1]
+		if strings.IndexByte(raw, '&') >= 0 {
+			return html.UnescapeString(raw), end, true, nil
+		}
+		return strings.Clone(raw), end, true, nil
 	case '{':
 		end, ok := findMatchingDelimiter(src, index, '{', '}')
 		if !ok || end > tagEnd {
@@ -1002,12 +1011,8 @@ func parseStaticJSXExpression(expr string) (string, bool) {
 
 func skipQuotedJSXAttribute(src string, index int) int {
 	quote := src[index]
-	i := index + 1
-	for i < len(src) {
-		if src[i] == quote {
-			return i + 1
-		}
-		i++
+	if i := strings.IndexByte(src[index+1:], quote); i >= 0 {
+		return index + 1 + i + 1
 	}
 
 	return len(src) + 1
@@ -1055,28 +1060,44 @@ func parseStaticStringLiteral(src string, index int) (string, int, bool) {
 
 func readStringLiteralContent(src string, index int) (string, int, bool) {
 	quote := src[index]
-	var b strings.Builder
-	for i := index + 1; i < len(src); i++ {
-		if src[i] == '\\' {
-			if i+1 >= len(src) {
-				return b.String(), len(src), false
-			}
-			b.WriteByte(src[i])
-			i++
-			b.WriteByte(src[i])
-			continue
-		}
-		if src[i] == quote {
-			return b.String(), i + 1, true
-		}
-		b.WriteByte(src[i])
+	var target string
+	switch quote {
+	case '\'':
+		target = "'\\"
+	case '"':
+		target = "\"\\"
+	case '`':
+		target = "`\\"
+	default:
+		target = string(quote) + "\\"
 	}
 
-	return b.String(), len(src), false
+	i := index + 1
+	for i < len(src) {
+		pos := strings.IndexAny(src[i:], target)
+		if pos < 0 {
+			return "", len(src), false
+		}
+		i += pos
+		if src[i] == quote {
+			return src[index+1 : i], i + 1, true
+		}
+		if i+1 >= len(src) {
+			return "", len(src), false
+		}
+		i += 2
+	}
+
+	return "", len(src), false
 }
 
 func unescapeJavaScriptString(raw string) string {
+	if strings.IndexByte(raw, '\\') < 0 {
+		return strings.Clone(raw)
+	}
+
 	var b strings.Builder
+	b.Grow(len(raw))
 	for i := 0; i < len(raw); i++ {
 		if raw[i] != '\\' || i+1 >= len(raw) {
 			b.WriteByte(raw[i])
@@ -1407,9 +1428,13 @@ func skipComment(src string, index int) (int, bool) {
 	}
 }
 
+func isWhitespaceByte(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' || ch == '\v'
+}
+
 func skipWhitespaceAndComments(src string, index int) int {
 	for i := index; i < len(src); {
-		for i < len(src) && unicode.IsSpace(rune(src[i])) {
+		for i < len(src) && isWhitespaceByte(src[i]) {
 			i++
 		}
 

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unsafe"
 )
 
 func TestExtractCommandExtractsReactIntlMessages(t *testing.T) {
@@ -823,6 +824,359 @@ func TestUnescapeJavaScriptStringSupportsHighByteHexEscapes(t *testing.T) {
 	if !bytes.Equal(got, want) {
 		t.Fatalf("unescaped bytes = %v, want %v", got, want)
 	}
+}
+
+func TestParseStaticStringLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		index    int
+		want     string
+		wantNext int
+		wantOK   bool
+	}{
+		{name: "double quoted", src: `"hello"`, want: "hello", wantNext: 7, wantOK: true},
+		{name: "single quoted", src: `'hello'`, want: "hello", wantNext: 7, wantOK: true},
+		{name: "template literal", src: "`hello`", want: "hello", wantNext: 7, wantOK: true},
+		{name: "empty double quoted", src: `""`, want: "", wantNext: 2, wantOK: true},
+		{name: "escaped double quote", src: `"say \"hi\""`, want: `say "hi"`, wantNext: 12, wantOK: true},
+		{name: "escaped single quote", src: `'it\'s fine'`, want: "it's fine", wantNext: 12, wantOK: true},
+		{name: "escaped backtick", src: "`say \\`hi\\``", want: "say `hi`", wantNext: 12, wantOK: true},
+		{name: "escaped backslash before close", src: `"foo\\"`, want: `foo\`, wantNext: 7, wantOK: true},
+		{name: "double escaped backslash", src: `"\\\\"`, want: `\\`, wantNext: 6, wantOK: true},
+		{name: "newline escape", src: `"one\ntwo"`, want: "one\ntwo", wantNext: 10, wantOK: true},
+		{name: "tab return escapes", src: `"a\tb\rc"`, want: "a\tb\rc", wantNext: 9, wantOK: true},
+		{name: "unicode escape", src: `"em\u2014dash"`, want: "em\u2014dash", wantNext: 14, wantOK: true},
+		{name: "braced unicode escape", src: `"hi\u{1F600}"`, want: "hi\U0001F600", wantNext: 13, wantOK: true},
+		{name: "hex escape", src: `"\x41BC"`, want: "ABC", wantNext: 8, wantOK: true},
+		{name: "line continuation lf", src: "\"foo\\\nbar\"", want: "foobar", wantNext: 10, wantOK: true},
+		{name: "prefix then literal", src: `xx"hello"yy`, index: 2, want: "hello", wantNext: 9, wantOK: true},
+		{name: "unterminated", src: `"hello`, wantOK: false, wantNext: 6},
+		{name: "trailing backslash", src: `"hello\`, wantOK: false, wantNext: 7},
+		{name: "not a quote", src: `hello`, wantOK: false, wantNext: 0},
+		{name: "template interpolation rejected", src: "`hello ${name}`", wantOK: false, wantNext: 15},
+		{name: "escaped interpolation still rejected", src: "`hello \\${name}`", wantOK: false, wantNext: 16},
+		{name: "quoted key then more", src: `"id": "value"`, want: "id", wantNext: 4, wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, next, ok := parseStaticStringLiteral(tt.src, tt.index)
+			if ok != tt.wantOK || got != tt.want || next != tt.wantNext {
+				t.Fatalf("parseStaticStringLiteral(%q, %d) = (%q, %d, %t), want (%q, %d, %t)",
+					tt.src, tt.index, got, next, ok, tt.want, tt.wantNext, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestReadStringLiteralContentSkipsEscapedQuotes(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		want     string
+		wantNext int
+		wantOK   bool
+	}{
+		{name: "plain", src: `"abc"`, want: "abc", wantNext: 5, wantOK: true},
+		{name: "escaped quote mid literal", src: `"ab\"cd"`, want: `ab\"cd`, wantNext: 8, wantOK: true},
+		{name: "escaped quote then more text", src: `"ab\"cd\"ef"`, want: `ab\"cd\"ef`, wantNext: 12, wantOK: true},
+		{name: "escaped backslash then closer", src: `"ab\\"`, want: `ab\\`, wantNext: 6, wantOK: true},
+		{name: "unterminated after escape", src: `"ab\"`, wantOK: false, wantNext: 5},
+		{name: "lone backslash at eof", src: `"ab\`, wantOK: false, wantNext: 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, next, ok := readStringLiteralContent(tt.src, 0)
+			if ok != tt.wantOK || got != tt.want || next != tt.wantNext {
+				t.Fatalf("readStringLiteralContent(%q) = (%q, %d, %t), want (%q, %d, %t)",
+					tt.src, got, next, ok, tt.want, tt.wantNext, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestReadStringLiteralContentDoesNotAllocateRemainingSource(t *testing.T) {
+	prefix := strings.Repeat("x", 1<<20)
+	src := prefix + `"hello\"world"`
+	index := len(prefix)
+
+	allocs := testing.AllocsPerRun(50, func() {
+		got, next, ok := readStringLiteralContent(src, index)
+		if !ok || got != `hello\"world` || next != len(src) {
+			t.Fatalf("readStringLiteralContent = (%q, %d, %t)", got, next, ok)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("allocs = %v, want 0 for escaped literal scan", allocs)
+	}
+}
+
+func TestUnescapeJavaScriptString(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "plain", raw: "hello", want: "hello"},
+		{name: "empty", raw: "", want: ""},
+		{name: "quotes", raw: `say \"hi\"`, want: `say "hi"`},
+		{name: "backslash", raw: `a\\b`, want: `a\b`},
+		{name: "common escapes", raw: `\b\f\n\r\t\v`, want: "\b\f\n\r\t\v"},
+		{name: "literal quote chars", raw: "\\'\\\"\\`", want: "'\"`"},
+		{name: "unknown escape", raw: `\q`, want: "q"},
+		{name: "trailing backslash", raw: `abc\`, want: `abc\`},
+		{name: "hex", raw: `\x41`, want: "A"},
+		{name: "invalid hex", raw: `\xZZ`, want: "xZZ"},
+		{name: "unicode", raw: `\u0041`, want: "A"},
+		{name: "invalid unicode", raw: `\uZZZZ`, want: "uZZZZ"},
+		{name: "braced unicode", raw: `\u{2E}`, want: "."},
+		{name: "line continuation lf", raw: "foo\\\nbar", want: "foobar"},
+		{name: "line continuation cr", raw: "foo\\\rbar", want: "foobar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unescapeJavaScriptString(tt.raw); got != tt.want {
+				t.Fatalf("unescapeJavaScriptString(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnescapeJavaScriptStringClonesPlainLiterals(t *testing.T) {
+	src := `prefix-PLAIN-suffix`
+	raw := src[7:12]
+	got := unescapeJavaScriptString(raw)
+	if got != "PLAIN" {
+		t.Fatalf("unescaped = %q, want PLAIN", got)
+	}
+	if stringSharesBacking(got, src) {
+		t.Fatalf("plain unescape still shares backing with source")
+	}
+}
+
+func TestParseJSXAttributeValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		want    string
+		wantOK  bool
+		wantErr bool
+	}{
+		{name: "double quoted", src: `"hello"`, want: "hello", wantOK: true},
+		{name: "single quoted", src: `'hello'`, want: "hello", wantOK: true},
+		{name: "html entity", src: `"Tom &amp; Jerry"`, want: "Tom & Jerry", wantOK: true},
+		{name: "numeric entity", src: `"&#39;quoted&#39;"`, want: "'quoted'", wantOK: true},
+		{name: "ampersand without entity", src: `"A & B"`, want: "A & B", wantOK: true},
+		{name: "expression string", src: `{"hello"}`, want: "hello", wantOK: true},
+		{name: "expression escaped", src: `{"say \"hi\""}`, want: `say "hi"`, wantOK: true},
+		{name: "non-static expression", src: `{name}`, wantOK: false},
+		{name: "unterminated quote", src: `"hello`, wantErr: true},
+		{name: "unterminated expression", src: `{"hello"`, wantErr: true},
+		{name: "empty quoted", src: `""`, want: "", wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, ok, err := parseJSXAttributeValue(tt.src, 0, len(tt.src))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got (%q, %t)", got, ok)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseJSXAttributeValue: %v", err)
+			}
+			if ok != tt.wantOK || got != tt.want {
+				t.Fatalf("parseJSXAttributeValue(%q) = (%q, %t), want (%q, %t)",
+					tt.src, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseJSXAttributeValueClonesPlainQuotedText(t *testing.T) {
+	src := `xx"plain"yy`
+	got, end, ok, err := parseJSXAttributeValue(src, 2, len(src))
+	if err != nil {
+		t.Fatalf("parseJSXAttributeValue: %v", err)
+	}
+	if !ok || got != "plain" || end != 9 {
+		t.Fatalf("parseJSXAttributeValue = (%q, %d, %t)", got, end, ok)
+	}
+	if stringSharesBacking(got, src) {
+		t.Fatalf("plain JSX attribute still shares backing with source")
+	}
+}
+
+func TestExtractedMessagesDoNotRetainSourceBacking(t *testing.T) {
+	src := `
+formatMessage({
+  id: "plain.id",
+  defaultMessage: "Plain text",
+  description: "Plain description",
+});
+
+formatMessage({
+  id: "escaped.id",
+  defaultMessage: "Say \"hello\"",
+  description: "Line one\nand two",
+});
+`
+	src += strings.Repeat("// padding keeps the source buffer large\n", 256)
+	src += `
+<FormattedMessage
+  id="jsx.plain"
+  defaultMessage="JSX plain"
+  description="JSX description"
+/>
+<FormattedMessage
+  id="jsx.entity"
+  defaultMessage="Tom &amp; Jerry"
+  description="Names"
+/>
+`
+
+	messages, err := extractMessagesFromReactIntlSource(src, "retain.tsx")
+	if err != nil {
+		t.Fatalf("extractMessagesFromReactIntlSource: %v", err)
+	}
+	if got, want := len(messages), 4; got != want {
+		t.Fatalf("message count = %d, want %d", got, want)
+	}
+
+	for _, message := range messages {
+		for _, field := range []struct {
+			name  string
+			value string
+		}{
+			{"id", message.ID},
+			{"defaultMessage", message.DefaultMessage},
+			{"description", message.Description},
+		} {
+			if stringSharesBacking(field.value, src) {
+				t.Fatalf("message %q field %s %q still shares backing with source",
+					message.ID, field.name, field.value)
+			}
+		}
+	}
+}
+
+func TestExtractMessagesFromEscapedStringLiterals(t *testing.T) {
+	src := `
+formatMessage({
+  id: "escaped.quotes",
+  defaultMessage: "Say \"hello\" and 'bye'",
+  description: "Quoted copy",
+});
+
+formatMessage({
+  id: "escaped.unicode",
+  defaultMessage: "Range\u2014end",
+  description: "Dash copy",
+});
+
+formatMessage({
+  id: 'escaped.newline',
+  defaultMessage: 'Line one\nLine two',
+});
+
+formatMessage({
+  id: "escaped.backslash",
+  defaultMessage: "C:\\Users\\name",
+});
+`
+	messages, err := extractMessagesFromReactIntlSource(src, "escaped.ts")
+	if err != nil {
+		t.Fatalf("extractMessagesFromReactIntlSource: %v", err)
+	}
+
+	got := map[string]extractMessage{}
+	for _, message := range messages {
+		got[message.ID] = message
+	}
+
+	want := map[string]extractCatalogMessage{
+		"escaped.quotes": {
+			DefaultMessage: `Say "hello" and 'bye'`,
+			Description:    "Quoted copy",
+		},
+		"escaped.unicode": {
+			DefaultMessage: "Range\u2014end",
+			Description:    "Dash copy",
+		},
+		"escaped.newline": {
+			DefaultMessage: "Line one\nLine two",
+		},
+		"escaped.backslash": {
+			DefaultMessage: `C:\Users\name`,
+		},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("message count = %d, want %d; ids=%v", len(got), len(want), got)
+	}
+	for id, wantMessage := range want {
+		gotMessage, ok := got[id]
+		if !ok {
+			t.Fatalf("missing message %q", id)
+		}
+		if gotMessage.DefaultMessage != wantMessage.DefaultMessage ||
+			gotMessage.Description != wantMessage.Description {
+			t.Fatalf("message %q = {%q, %q}, want {%q, %q}",
+				id, gotMessage.DefaultMessage, gotMessage.Description,
+				wantMessage.DefaultMessage, wantMessage.Description)
+		}
+	}
+}
+
+func TestExtractMessagesFromJSXAttributeEntities(t *testing.T) {
+	src := `
+<FormattedMessage
+  id="jsx.entities"
+  defaultMessage="Tom &amp; Jerry"
+  description="Cartoon names"
+/>
+<FormattedMessage
+  id={"jsx.expression"}
+  defaultMessage={"Say \"hello\""}
+  description={'Single quoted'}
+/>
+`
+	messages, err := extractMessagesFromReactIntlSource(src, "jsx-attrs.tsx")
+	if err != nil {
+		t.Fatalf("extractMessagesFromReactIntlSource: %v", err)
+	}
+
+	got := map[string]extractMessage{}
+	for _, message := range messages {
+		got[message.ID] = message
+	}
+
+	if got, want := len(got), 2; got != want {
+		t.Fatalf("message count = %d, want %d", got, want)
+	}
+	if message := got["jsx.entities"]; message.DefaultMessage != "Tom & Jerry" || message.Description != "Cartoon names" {
+		t.Fatalf("jsx.entities = {%q, %q}", message.DefaultMessage, message.Description)
+	}
+	if message := got["jsx.expression"]; message.DefaultMessage != `Say "hello"` || message.Description != "Single quoted" {
+		t.Fatalf("jsx.expression = {%q, %q}", message.DefaultMessage, message.Description)
+	}
+}
+
+func stringSharesBacking(value, src string) bool {
+	if len(value) == 0 || len(src) == 0 {
+		return false
+	}
+
+	valueStart := uintptr(unsafe.Pointer(unsafe.StringData(value)))
+	srcStart := uintptr(unsafe.Pointer(unsafe.StringData(src)))
+	srcEnd := srcStart + uintptr(len(src))
+	valueEnd := valueStart + uintptr(len(value))
+
+	return valueStart < srcEnd && srcStart < valueEnd
 }
 
 func TestExtractCommandSkipsFilesWithExtractionErrors(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Clean re-cut of the React-Intl extract hot-path work from #2174, based on current `main`. This PR touches only `apps/cli/cmd/extract.go` and its tests.

- Scan string literals with `strings.IndexAny` and JSX quotes with `strings.IndexByte`.
- Skip `html.UnescapeString` and JS unescape work when the text has no entities or backslashes.
- Replace the descriptor `map[string]string` with local fields, and use an ASCII whitespace fast path.
- Clone extracted IDs, default messages, and descriptions so catalogs do not pin whole TS/TSX buffers (Codex).
- Bound escaped-literal scans to the closing quote instead of growing a builder to the rest of the file (Codex).

#2174 picked up unrelated `main` commits (version pin, translations, GitHub Action, GSC/DataForSEO tests). Those are not in this PR.

## How to test

- `go test ./apps/cli/cmd/ -count=1 -run 'Extract|Unescape|ParseStatic|ReadString|ParseJSX'`
- `go test -race -count=1 ./apps/cli/cmd/`
- `go test ./apps/cli/cmd/ -run '^$' -bench BenchmarkExtractMessagesFromReactIntlSource -benchmem`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab29ab2a-30aa-4ee2-8cca-b9a279f11e20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab29ab2a-30aa-4ee2-8cca-b9a279f11e20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

