### PR TITLE
feat(mcp): add list_files tool for project source discovery

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-files.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-files.test.ts
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { generateMcpToken, hashMcpToken } from "@/api/auth/mcp";
+import { createApp } from "@/api/app";
+import { createMcpTestApp } from "@/api/routes/mcp/mcp.fixture";
+import { insertStoredSourceFile } from "@/api/routes/public-jobs/public-jobs.fixture";
+import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
+import type { AppType } from "@/api/typed-app";
+import { db, schema } from "@/lib/database/client";
+import { ensureRepositorySourceFileVersionForStoredFile } from "@/lib/file-storage/records";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const mcpApp = createMcpTestApp();
+const apiApp = createApp();
+const apiClient = testClient<AppType>(apiApp);
+const fixture = createProjectTestFixture();
+
+type McpFileRow = {
+  id: string;
+  sourcePath: string;
+  filename: string;
+  contentType: string | null;
+  byteSize: number | null;
+  updatedAt: string;
+  sourceLocale: string | null;
+};
+
+type McpListFilesOutput = {
+  error?: string;
+  total?: number;
+  pagination?: {
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+    nextOffset: number | null;
+  };
+  files?: McpFileRow[];
+};
+
+async function authenticatedMcpHeaders(identity = fixture.createWorkosIdentity()) {
+  const headers = await fixture.authHeadersFor(identity);
+
+  const accessToken = generateMcpToken();
+  const refreshToken = generateMcpToken();
+
+  const auth = globalThis.__testApiAuthContext;
+  if (!auth) {
+    throw new Error("expected test auth context");
+  }
+
+  await db.insert(schema.mcpSessions).values({
+    userId: auth.user.localUserId,
+    organizationId: auth.organization.localOrganizationId,
+    scope: "mcp",
+    accessTokenHash: hashMcpToken(accessToken),
+    refreshTokenHash: hashMcpToken(refreshToken),
+    expiresAt: new Date(Date.now() + 60_000),
+    refreshExpiresAt: new Date(Date.now() + 120_000),
+  });
+
+  return {
+    ...headers,
+    authorization: `Bearer ${accessToken}`,
+  };
+}
+
+async function callMcpTool(headers: Record<string, string>, args: Record<string, unknown>) {
+  return mcpApp.request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      ...headers,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "list_files",
+        arguments: args,
+      },
+    }),
+  });
+}
+
+async function readToolResult(response: Response) {
+  expect(response.status).toBe(200);
+
+  const body = (await response.json()) as {
+    result?: {
+      isError?: boolean;
+      content?: Array<{ type: string; text?: string }>;
+    };
+  };
+
+  const text = body.result?.content?.[0]?.text;
+  expect(text).toBeDefined();
+
+  return {
+    isError: body.result?.isError === true,
+    output: JSON.parse(text!) as McpListFilesOutput,
+  };
+}
+
+async function seedNativeSourceFile(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  contentType?: string;
+}) {
+  const filename = input.sourcePath.split("/").at(-1) ?? input.sourcePath;
+  const storedFile = await insertStoredSourceFile({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    filename,
+    contentType: input.contentType ?? "application/json",
+    sourceKind: "repository_file",
+    metadata: { sourcePath: input.sourcePath, sourceHash: `hash-${input.sourcePath}` },
+  });
+  const version = await ensureRepositorySourceFileVersionForStoredFile({
+    db,
+    fileId: storedFile.id,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+
+  if (!version) {
+    throw new Error(`expected repository source file version for ${input.sourcePath}`);
+  }
+
+  return storedFile;
+}
+
+describe("MCP list_files", () => {
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  it("advertises list_files with bounded pagination and search", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpApp.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "list_files");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("source files");
+    expect(tool?.inputSchema?.required).toEqual(["projectId"]);
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+        default: 20,
+      },
+      offset: {
+        type: "integer",
+        minimum: 0,
+        default: 0,
+      },
+      search: {
+        type: "string",
+        maxLength: 256,
+      },
+    });
+  });
+
+  it("lists native project files that match the Files UI and paginates stably", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const sourcePaths = ["locales/aaa.json", "locales/bbb.json", "locales/zzz-late.json"];
+
+    const seeded = [];
+    for (const sourcePath of sourcePaths) {
+      seeded.push(
+        await seedNativeSourceFile({
+          organizationId: stored.organization.id,
+          projectId: stored.project.id,
+          sourcePath,
+        }),
+      );
+    }
+
+    const filesUiResponse = await apiClient.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.$get(
+      {
+        param: {
+          organizationSlug: stored.identity.organization.slug ?? "missing-slug",
+          projectId: stored.project.id,
+        },
+        query: {
+          origin: "repository",
+        },
+      },
+      { headers: await fixture.authHeadersFor(stored.identity) },
+    );
+
+    expect(filesUiResponse.status).toBe(200);
+    const filesUiBody = (await filesUiResponse.json()) as {
+      files: Array<{ sourcePath: string; filename: string; storedFileId: string | null }>;
+    };
+
+    const firstPage = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        limit: 2,
+        offset: 0,
+      }),
+    );
+    const secondPage = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        limit: 2,
+        offset: 2,
+      }),
+    );
+
+    expect(firstPage.isError).toBe(false);
+    expect(secondPage.isError).toBe(false);
+
+    expect(firstPage.output).toMatchObject({
+      total: 3,
+      pagination: {
+        limit: 2,
+        offset: 0,
+        hasMore: true,
+        nextOffset: 2,
+      },
+    });
+    expect(secondPage.output).toMatchObject({
+      total: 3,
+      pagination: {
+        limit: 2,
+        offset: 2,
+        hasMore: false,
+        nextOffset: null,
+      },
+    });
+
+    const mcpFiles = [...(firstPage.output.files ?? []), ...(secondPage.output.files ?? [])];
+    expect(mcpFiles.map((file) => file.sourcePath)).toEqual(
+      filesUiBody.files.map((file) => file.sourcePath),
+    );
+    expect(mcpFiles.map((file) => file.sourcePath)).toEqual(sourcePaths);
+    expect(mcpFiles.map((file) => file.id)).toEqual(seeded.map((file) => file.id));
+    expect(mcpFiles[0]).toMatchObject({
+      filename: "aaa.json",
+      contentType: "application/json",
+      byteSize: 2,
+      sourceLocale: "en-US",
+    });
+    expect(mcpFiles[0]?.updatedAt).toEqual(expect.any(String));
+  });
+
+  it("filters files by path or filename search", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await seedNativeSourceFile({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/home.json",
+    });
+    await seedNativeSourceFile({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/checkout.json",
+    });
+
+    const byPath = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        search: "locales/home",
+      }),
+    );
+    const byFilename = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        search: "checkout.json",
+      }),
+    );
+
+    expect(byPath.output.files?.map((file) => file.sourcePath)).toEqual(["locales/home.json"]);
+    expect(byFilename.output.files?.map((file) => file.sourcePath)).toEqual([
+      "locales/checkout.json",
+    ]);
+  });
+
+  it("returns project_not_found for inaccessible projects", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const external = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await seedNativeSourceFile({
+      organizationId: external.organization.id,
+      projectId: external.project.id,
+      sourcePath: "locales/secret.json",
+    });
+
+    const missing = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: "project_does_not_exist",
+      }),
+    );
+    const otherOrg = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: external.project.id,
+      }),
+    );
+
+    expect(missing.isError).toBe(true);
+    expect(missing.output).toMatchObject({
+      error: "project_not_found",
+    });
+    expect(otherOrg.isError).toBe(true);
+    expect(otherOrg.output).toMatchObject({
+      error: "project_not_found",
+    });
+  });
+
+  it.each([
+    ["an over-limit page size", { limit: 51 }],
+    ["a zero page size", { limit: 0 }],
+    ["a negative offset", { offset: -1 }],
+    ["an overlong search", { search: "x".repeat(257) }],
+  ])("rejects %s", async (_label, args) => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        ...args,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-files.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-files.test.ts
@@ -259,6 +259,7 @@ describe("MCP list_files", () => {
           projectId: stored.project.id,
         },
         query: {
+          limit: "500",
           origin: "repository",
         },
       },
@@ -397,13 +398,21 @@ describe("MCP list_files", () => {
     const stored = await fixture.createStoredProjectFixture();
     const headers = await authenticatedMcpHeaders(stored.identity);
 
-    const result = await readToolResult(
-      await callMcpTool(headers, {
-        projectId: stored.project.id,
-        ...args,
-      }),
-    );
+    const response = await callMcpTool(headers, {
+      projectId: stored.project.id,
+      ...args,
+    });
 
-    expect(result.isError).toBe(true);
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ type: string; text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toBeDefined();
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -21,8 +21,10 @@ import { createAuthorizationCode } from "@/api/auth/mcp";
 import { createApp } from "@/api/app";
 import type { AppType } from "@/api/typed-app";
 import { db, schema } from "@/lib/database/client";
+import { ensureRepositorySourceFileVersionForStoredFile } from "@/lib/file-storage/records";
 import { testClient } from "hono/testing";
 
+import { insertStoredSourceFile } from "../public-jobs/public-jobs.fixture";
 import { createProjectTestFixture } from "../project/project.fixture";
 import type { ProjectResponse } from "../project/project.schema";
 import { createTeamTestFixture } from "../team/team.fixture";
@@ -255,6 +257,47 @@ describe("MCP team-scoped access", () => {
       throw new Error("expected external issue fixture");
     }
 
+    const seedProjectFile = async (input: {
+      organizationId: string;
+      projectId: string;
+      sourcePath: string;
+    }) => {
+      const storedFile = await insertStoredSourceFile({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        filename: input.sourcePath.split("/").at(-1),
+        contentType: "application/json",
+        sourceKind: "repository_file",
+        metadata: { sourcePath: input.sourcePath, sourceHash: `hash-${input.sourcePath}` },
+      });
+      const version = await ensureRepositorySourceFileVersionForStoredFile({
+        db,
+        fileId: storedFile.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+      if (!version) {
+        throw new Error(`expected repository source file version for ${input.sourcePath}`);
+      }
+      return storedFile;
+    };
+
+    const alphaFile = await seedProjectFile({
+      organizationId: memberAuth.organization.localOrganizationId,
+      projectId: alphaProjectBody.project.id,
+      sourcePath: "locales/alpha.json",
+    });
+    await seedProjectFile({
+      organizationId: memberAuth.organization.localOrganizationId,
+      projectId: betaProjectBody.project.id,
+      sourcePath: "locales/beta.json",
+    });
+    await seedProjectFile({
+      organizationId: externalOrganization.id,
+      projectId: externalProject.id,
+      sourcePath: "locales/external.json",
+    });
+
     const accessToken = await mcpAccessTokenForAuth(memberAuth);
 
     const adminAccessToken = await mcpAccessTokenForAuth(adminAuth);
@@ -383,6 +426,51 @@ describe("MCP team-scoped access", () => {
       project: { id: string } | null;
     };
     expect(getDeniedBody.project).toBeNull();
+
+    const accessibleFilesResponse = await callMcpTool(accessToken, "list_files", {
+      projectId: alphaProjectBody.project.id,
+    });
+    expect(accessibleFilesResponse.status).toBe(200);
+    expect(parseToolResultText(await accessibleFilesResponse.json())).toMatchObject({
+      total: 1,
+      files: [
+        expect.objectContaining({
+          id: alphaFile.id,
+          sourcePath: "locales/alpha.json",
+          filename: "alpha.json",
+        }),
+      ],
+    });
+
+    const inaccessibleFileLookups = [
+      {
+        label: "wrong team",
+        projectId: betaProjectBody.project.id,
+      },
+      {
+        label: "wrong organization",
+        projectId: externalProject.id,
+      },
+    ];
+
+    for (const lookup of inaccessibleFileLookups) {
+      const response = await callMcpTool(accessToken, "list_files", {
+        projectId: lookup.projectId,
+      });
+
+      expect(response.status, lookup.label).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(
+        (responseBody as { result?: { isError?: boolean } }).result?.isError,
+        lookup.label,
+      ).toBe(true);
+
+      expect(parseToolResultText(responseBody), lookup.label).toMatchObject({
+        error: "project_not_found",
+      });
+    }
 
     const createDeniedResponse = await callMcpTool(accessToken, "create_issue", {
       projectId: alphaProjectBody.project.id,

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -12,7 +12,7 @@
  */
 import { createHash, randomUUID } from "node:crypto";
 
-import { and, desc, eq, gt, isNotNull, isNull } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, isNotNull, isNull } from "drizzle-orm";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { createMiddleware } from "hono/factory";
@@ -72,6 +72,11 @@ import {
   type IssueSheetIssue,
 } from "@/lib/projects/issue-sheet/issue-sheet-service";
 import { isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import {
+  filterProjectFiles,
+  listProjectFilesForProject,
+} from "@/lib/projects/files/project-file-service";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -376,6 +381,31 @@ const mcpListIssuesInputSchema = z
     }
   });
 
+const mcpListFilesInputSchema = z.object({
+  projectId: projectIdSchema.describe(
+    "ID of the accessible Hyperlocalise project whose source files to list.",
+  ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe("Maximum number of files to return."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe("Number of files to skip before returning results."),
+  search: z
+    .string()
+    .trim()
+    .max(256)
+    .optional()
+    .describe("Optional case-insensitive filter on source path or filename."),
+});
+
 const mcpGetIssueInputSchema = z.object({
   projectId: z
     .string()
@@ -545,6 +575,22 @@ function detailedMcpIssue(issue: IssueSheetIssue) {
   };
 }
 
+function compactMcpFile(input: {
+  file: ProjectFileRecord;
+  stored: { contentType: string; updatedAt: Date } | undefined;
+  sourceLocale: string | null;
+}) {
+  return {
+    id: input.file.storedFileId ?? input.file.provider?.externalResourceId ?? input.file.sourcePath,
+    sourcePath: input.file.sourcePath,
+    filename: input.file.filename,
+    contentType: input.stored?.contentType ?? null,
+    byteSize: input.file.byteSize,
+    updatedAt: input.stored?.updatedAt.toISOString() ?? input.file.uploadedAt,
+    sourceLocale: input.file.provider?.sourceLocale ?? input.sourceLocale,
+  };
+}
+
 function compactMcpIssue(issue: OrganizationIssueListItem) {
   return {
     id: issue.id,
@@ -633,6 +679,82 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
 
       return {
         content: [{ type: "text", text: JSON.stringify({ project: project ?? null }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "list_files",
+    {
+      description:
+        "List source files in an accessible Hyperlocalise project. Returns metadata only — use sourcePath values for upload, download, or run_workflow.",
+      inputSchema: mcpListFilesInputSchema,
+    },
+    async ({ projectId, limit, offset, search }) => {
+      const [project] = await db
+        .select({
+          id: schema.projects.id,
+          sourceLocale: schema.projects.sourceLocale,
+        })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      const listed = await listProjectFilesForProject({
+        organizationId: apiAuth.organization.localOrganizationId,
+        projectId: project.id,
+        providerFilters: search ? { search } : undefined,
+      });
+      const filtered = filterProjectFiles(listed, { search });
+      const page = filtered.slice(offset, offset + limit);
+      const nextOffset = offset + page.length;
+      const hasMore = nextOffset < filtered.length;
+
+      const storedFileIds = page.flatMap((file) => (file.storedFileId ? [file.storedFileId] : []));
+      const storedRows =
+        storedFileIds.length > 0
+          ? await db
+              .select({
+                id: schema.storedFiles.id,
+                contentType: schema.storedFiles.contentType,
+                updatedAt: schema.storedFiles.updatedAt,
+              })
+              .from(schema.storedFiles)
+              .where(
+                and(
+                  eq(schema.storedFiles.organizationId, apiAuth.organization.localOrganizationId),
+                  inArray(schema.storedFiles.id, storedFileIds),
+                ),
+              )
+          : [];
+      const storedById = new Map(storedRows.map((row) => [row.id, row]));
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              total: filtered.length,
+              pagination: {
+                limit,
+                offset,
+                hasMore,
+                nextOffset: hasMore ? nextOffset : null,
+              },
+              files: page.map((file) =>
+                compactMcpFile({
+                  file,
+                  stored: file.storedFileId ? storedById.get(file.storedFileId) : undefined,
+                  sourceLocale: project.sourceLocale,
+                }),
+              ),
+            }),
+          },
+        ],
       };
     },
   );

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -385,13 +385,7 @@ const mcpListFilesInputSchema = z.object({
   projectId: projectIdSchema.describe(
     "ID of the accessible Hyperlocalise project whose source files to list.",
   ),
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(50)
-    .default(20)
-    .describe("Maximum number of files to return."),
+  limit: z.number().int().min(1).max(50).default(20).describe("Maximum number of files to return."),
   offset: z
     .number()
     .int()

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -3,7 +3,7 @@ title: "MCP server"
 description: "Connect coding agents to Hyperlocalise Cloud over the Model Context Protocol."
 ---
 
-Hyperlocalise hosts an MCP (Model Context Protocol) server so agents such as Claude Code, Codex, and Cursor can read projects, glossaries, and Board items from your workspace.
+Hyperlocalise hosts an MCP (Model Context Protocol) server so agents such as Claude Code, Codex, and Cursor can read projects, source files, glossaries, and Board items from your workspace.
 
 The server uses OAuth with PKCE. After you approve access, the agent receives a bearer token scoped to one organization and your current membership role.
 
@@ -46,8 +46,11 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | --- | --- |
 | `list_projects` | List accessible projects (`limit`, default 20, max 50) |
 | `get_project` | Project details by `projectId` |
+| `list_files` | List source files in a project (`projectId`, `limit` default 20 max 50, `offset`, optional `search`) |
 | `list_glossaries` | List glossaries linked to accessible projects |
 | `get_glossary_entries` | Concept-linked terms for a `glossaryId` (`limit`, default 50, max 100) |
+
+`list_files` returns metadata only: `id` (stored file or source-file id), `sourcePath`, `filename`, `contentType`, `byteSize`, `updatedAt`, and `sourceLocale` when known. Pagination includes `total`, `limit`, `offset`, `hasMore`, and `nextOffset`. The tool does not return file contents. Inaccessible projects return `project_not_found`. Use the listed `sourcePath` values for later upload, download, or `run_workflow` calls.
 
 ### Board (issues)
 
@@ -85,7 +88,7 @@ See [Integrations](/platform/integrations#mcp-server-connections).
 
 An MCP session inherits your live organization membership:
 
-- Project and glossary reads respect team and project access.
+- Project, file, and glossary reads respect team and project access.
 - Issue writes follow the same rules as the Board UI.
 - Revoking your membership or disabling MCP auth ends the session on the next refresh.
 
@@ -99,6 +102,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `registration_disabled` on `/api/mcp/register` | Dynamic registration is off in production; use a client that supports metadata-based client IDs |
 | `forbidden` on issue tools | Your role is read-only for write-back operations |
 | `issue_not_found` | Wrong `projectId`, issue id, or missing project access |
+| `project_not_found` | Wrong `projectId` or missing project access on `list_files` |
 | Agent cannot reach local Cloud | Use `http://localhost:3000/mcp` and ensure the dev server is running |
 
 ## Next


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a hosted MCP `list_files` tool so agents can discover `sourcePath` values before upload, download, or `run_workflow`.

`get_project` still returns name and description only. `list_files` lists the same native source files as the Files UI, with metadata only (no file contents):

- Input: `projectId`, `limit` (1–50, default 20), `offset`, optional `search` on path/filename
- Output: `id`, `sourcePath`, `filename`, `contentType`, `byteSize`, `updatedAt`, `sourceLocale` when known, plus pagination
- Inaccessible projects return `project_not_found`
- Team-scoped members only see files on accessible projects

The tool reuses `listProjectFilesForProject` and `filterProjectFiles` from the project file service.

## How to test

- `vp test src/api/routes/mcp/mcp-list-files.test.ts src/api/routes/mcp/mcp-team-access.test.ts`
- `vp check --fix` in `apps/hyperlocalise-web`
- Full `vp test` in `apps/hyperlocalise-web`: 844 files, 5820 tests passed

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-683](https://linear.app/hyperlocalise/issue/HL-683/add-list-files-tool-to-the-hosted-mcp-server)

<div><a href="https://cursor.com/agents/bc-d3534daa-cc43-45e9-a1f6-5419026b2261?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3534daa-cc43-45e9-a1f6-5419026b2261&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

