### PR TITLE
feat(web): polish automations templates and add inline Input

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-custom-column-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-custom-column-field.tsx
@@ -156,9 +156,9 @@ export function IssueCustomColumnField({
       onBlur={onCommit}
       disabled={disabled}
       placeholder={emptyValue}
+      variant={variant === "sidebar" ? "inline" : "default"}
       className={cn(
-        variant === "sidebar" &&
-          "h-8 border-transparent bg-transparent px-1.5 text-end shadow-none hover:bg-muted/60 focus-visible:border-ring",
+        variant === "sidebar" && "text-end",
         variant === "main" ? "w-full" : "w-44 max-w-full",
       )}
     />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.stories.tsx
@@ -78,7 +78,7 @@ export const GithubTriggerHidesRun: Story = {
     await expect(canvas.queryByRole("button", { name: "Run now" })).not.toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
     await expect(canvas.getByRole("button", { name: "Delete" })).toBeEnabled();
-    await expect(canvas.getByRole("combobox", { name: "Model" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Model" })).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
@@ -104,7 +104,7 @@ export const NotifyOnPushBlockers: Story = {
   ...templateStory("notify-on-push-blockers"),
   play: async ({ canvas }) => {
     await expect(
-      canvas.getByLabelText("GitHub push → GitHub → GitHub comment"),
+      canvas.getByLabelText("GitHub pull request → GitHub → GitHub comment"),
     ).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
@@ -13,7 +13,17 @@
  * Version 2.0 or later.
  */
 
-import { Clock01Icon, Comment01Icon, Mail01Icon, Search01Icon } from "@hugeicons/core-free-icons";
+import { Fragment } from "react";
+import {
+  Clock01Icon,
+  Comment01Icon,
+  Mail01Icon,
+  Search01Icon,
+  CheckmarkCircle02Icon,
+  SparklesIcon,
+  Task01Icon,
+  Upload01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { siGithub } from "simple-icons";
 import Image from "next/image";
@@ -33,7 +43,11 @@ type IconBucket =
   | "email"
   | "contentful"
   | "web-search"
-  | "web-chat";
+  | "web-chat"
+  | "upload"
+  | "job"
+  | "translate"
+  | "validation";
 
 function iconBucketForNode(node: WorkspaceAutomationTemplateFlowNode): IconBucket {
   switch (node.id) {
@@ -43,8 +57,9 @@ function iconBucketForNode(node: WorkspaceAutomationTemplateFlowNode): IconBucke
     case "github-comment":
     case "push-source":
     case "pull-translations":
-    case "validation":
       return "github";
+    case "validation":
+      return "validation";
     case "slack":
       return "slack";
     case "email":
@@ -55,9 +70,14 @@ function iconBucketForNode(node: WorkspaceAutomationTemplateFlowNode): IconBucke
     case "web-search":
       return "web-search";
     case "web-chat":
-      return "web-chat";
     case "knowledge-files":
       return "web-chat";
+    case "source-upload":
+      return "upload";
+    case "create-job":
+      return "job";
+    case "translate-with-agent":
+      return "translate";
     case "scheduled":
     case "manual":
     default:
@@ -65,51 +85,60 @@ function iconBucketForNode(node: WorkspaceAutomationTemplateFlowNode): IconBucke
   }
 }
 
-function FlowIcon({ bucket }: { bucket: IconBucket }) {
+function FlowIcon({ bucket, className }: { bucket: IconBucket; className?: string }) {
+  const iconClassName = cn("size-3.5", className);
+
   switch (bucket) {
     case "github":
-      return <SimpleBrandIcon icon={siGithub} colored className="size-4" />;
+      return <SimpleBrandIcon icon={siGithub} colored className={iconClassName} />;
     case "slack":
       return (
-        <Image src="/images/slack-logo.svg" alt="Slack" width={16} height={16} className="size-4" />
+        <Image
+          src="/images/slack-logo.svg"
+          alt=""
+          width={16}
+          height={16}
+          className={iconClassName}
+        />
       );
     case "email":
-      return <HugeiconsIcon icon={Mail01Icon} className="size-4" />;
+      return <HugeiconsIcon icon={Mail01Icon} className={iconClassName} strokeWidth={1.8} />;
     case "contentful":
       return (
         <Image
           src="/images/contentful-logo.svg"
-          alt="Contentful"
+          alt=""
           width={16}
           height={16}
-          className="size-4"
+          className={iconClassName}
         />
       );
     case "web-search":
-      return <HugeiconsIcon icon={Search01Icon} className="size-4" strokeWidth={1.8} />;
+      return <HugeiconsIcon icon={Search01Icon} className={iconClassName} strokeWidth={1.8} />;
     case "web-chat":
-      return <HugeiconsIcon icon={Comment01Icon} className="size-4" strokeWidth={1.8} />;
+      return <HugeiconsIcon icon={Comment01Icon} className={iconClassName} strokeWidth={1.8} />;
+    case "upload":
+      return <HugeiconsIcon icon={Upload01Icon} className={iconClassName} strokeWidth={1.8} />;
+    case "job":
+      return <HugeiconsIcon icon={Task01Icon} className={iconClassName} strokeWidth={1.8} />;
+    case "translate":
+      return <HugeiconsIcon icon={SparklesIcon} className={iconClassName} strokeWidth={1.8} />;
+    case "validation":
+      return (
+        <HugeiconsIcon icon={CheckmarkCircle02Icon} className={iconClassName} strokeWidth={1.8} />
+      );
     case "schedule":
-      return <HugeiconsIcon icon={Clock01Icon} className="size-4" strokeWidth={1.8} />;
+      return <HugeiconsIcon icon={Clock01Icon} className={iconClassName} strokeWidth={1.8} />;
   }
 }
 
-function uniqueToolBuckets(
-  trigger: WorkspaceAutomationTemplateFlowNode,
-  tools: WorkspaceAutomationTemplateFlowNode[],
-) {
-  const triggerBucket = iconBucketForNode(trigger);
-  const buckets: IconBucket[] = [];
-
-  for (const tool of tools) {
-    const bucket = iconBucketForNode(tool);
-    if (bucket === triggerBucket || buckets.includes(bucket)) {
-      continue;
-    }
-    buckets.push(bucket);
-  }
-
-  return buckets;
+export function AutomationTemplateTriggerIcon({
+  template,
+}: {
+  template: WorkspaceAutomationTemplate;
+}) {
+  const flow = getWorkspaceAutomationTemplateFlow(template);
+  return <FlowIcon bucket={iconBucketForNode(flow.trigger)} className="size-4" />;
 }
 
 export function AutomationTemplateFlow({
@@ -120,25 +149,28 @@ export function AutomationTemplateFlow({
   template: WorkspaceAutomationTemplate;
 }) {
   const flow = getWorkspaceAutomationTemplateFlow(template);
-  const triggerBucket = iconBucketForNode(flow.trigger);
-  const toolBuckets = uniqueToolBuckets(flow.trigger, flow.tools);
-  const summary = [flow.trigger.label, ...flow.tools.map((tool) => tool.label)].join(" → ");
+  const steps = [flow.trigger, ...flow.tools];
+  const summary = steps.map((step) => step.label).join(" → ");
 
   return (
     <div
-      className={cn("flex items-center gap-2 text-muted-foreground", className)}
+      className={cn("flex flex-wrap items-center gap-1.5 text-muted-foreground", className)}
       title={summary}
       aria-label={summary}
     >
-      <FlowIcon bucket={triggerBucket} />
-      {toolBuckets.length > 0 ? (
-        <>
-          <span className="h-px w-3 shrink-0 bg-muted5" aria-hidden />
-          {toolBuckets.map((bucket) => (
-            <FlowIcon key={bucket} bucket={bucket} />
-          ))}
-        </>
-      ) : null}
+      {steps.map((step, index) => (
+        <Fragment key={`${step.id}-${index}`}>
+          {index > 0 ? (
+            <span aria-hidden className="text-xs">
+              →
+            </span>
+          ) : null}
+          <span className="flex items-center gap-1.5">
+            <FlowIcon bucket={iconBucketForNode(step)} />
+            <span className="text-xs whitespace-nowrap">{step.label}</span>
+          </span>
+        </Fragment>
+      ))}
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
@@ -152,14 +152,9 @@ export const automationsPageViewMessages = defineMessages({
     id: "EvF3cGlK0a",
     description: "Template category filter tab for release readiness templates",
   },
-  addTemplate: {
-    defaultMessage: "Add",
-    id: "rIuVU6iths",
-    description: "Button to create an automation from a template",
-  },
   comingSoon: {
     defaultMessage: "Coming soon",
-    id: "Oyb9LX/sl2",
-    description: "Disabled button when a template is not yet activatable",
+    id: "lHdvBQ5B1/",
+    description: "Badge when a template is not yet activatable",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -62,7 +62,7 @@ export const Default: Story = {
     await expect(canvas.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "From Hyperlocalise" })).toBeInTheDocument();
     await expect(
-      canvas.getByRole("heading", { name: "Review localisation before it merges" }),
+      canvas.getByRole("heading", { name: "Automate GTM, review, and research workflows" }),
     ).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: /Auto-review/ })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Configure" })).toBeInTheDocument();
@@ -143,14 +143,15 @@ export const MarketingTemplates: Story = {
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole("tab", { name: "Marketing" }));
     await expect(canvas.getByText("Market messaging brief")).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Coming soon" })).toBeInTheDocument();
+    await expect(canvas.getByText("Coming soon")).toBeInTheDocument();
   },
 };
 
 export const ActivatableTemplate: Story = {
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Translate Contentful article")).toBeInTheDocument();
-    await expect(canvas.getAllByRole("button", { name: "Add" })).not.toHaveLength(0);
+    await expect(
+      canvas.getByRole("link", { name: /Translate Contentful article/i }),
+    ).toHaveAttribute("href", "/org/acme/automations/new?template=translate-contentful-article");
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -25,6 +25,7 @@ import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/ca
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
 import type {
   WorkspaceAutomationTemplate,
   WorkspaceAutomationTemplateCategory,
@@ -32,7 +33,7 @@ import type {
 import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automation-types";
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
-import { AutomationTemplateFlow } from "./automation-template-flow";
+import { AutomationTemplateFlow, AutomationTemplateTriggerIcon } from "./automation-template-flow";
 import type { GithubAutoReviewSettingsDto, GithubAutoReviewSettingsWrite } from "./automations-api";
 import { automationsPageViewMessages } from "./automations-page-view.messages";
 import {
@@ -127,6 +128,54 @@ function defaultRenderActionLink({
       {children}
     </Button>
   );
+}
+
+function AutomationTemplateCard({
+  automationsBasePath,
+  renderAutomationLink,
+  template,
+}: {
+  automationsBasePath: string;
+  renderAutomationLink: AutomationsLinkRenderer;
+  template: WorkspaceAutomationTemplate;
+}) {
+  const card = (
+    <Card
+      size="sm"
+      className={cn(
+        "flex-row items-start gap-3.5 bg-muted px-5 py-5",
+        template.activatable && "transition-colors hover:bg-subtle",
+      )}
+    >
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-subtle ring-1 ring-border">
+        <AutomationTemplateTriggerIcon template={template} />
+      </div>
+      <div className="flex min-w-0 flex-col gap-2">
+        <div className="flex items-start gap-2">
+          <CardTitle className="text-sm font-semibold">{template.name}</CardTitle>
+          {template.activatable ? null : (
+            <Badge variant="outline" className="shrink-0">
+              <FormattedMessage {...automationsPageViewMessages.comingSoon} />
+            </Badge>
+          )}
+        </div>
+        <CardDescription className="line-clamp-2 text-pretty">
+          {template.description}
+        </CardDescription>
+        <AutomationTemplateFlow template={template} />
+      </div>
+    </Card>
+  );
+
+  if (!template.activatable) {
+    return card;
+  }
+
+  return renderAutomationLink({
+    href: `${automationsBasePath}/new?template=${template.id}`,
+    className: "rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-ring",
+    children: card,
+  });
 }
 
 function AutomationToolsSummary({ automation }: { automation: WorkspaceAutomationRecord }) {
@@ -356,28 +405,12 @@ export function AutomationsPageView({
           </TabsList>
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {filteredTemplates.map((template) => (
-              <Card key={template.id} size="sm" className="gap-4 px-5 py-5">
-                <AutomationTemplateFlow template={template} />
-                <div className="space-y-1.5">
-                  <h3 className="text-sm font-medium text-foreground">{template.name}</h3>
-                  <p className="text-sm text-pretty text-muted-foreground">
-                    {template.description}
-                  </p>
-                </div>
-                <div className="mt-auto flex items-center gap-2">
-                  {template.activatable ? (
-                    renderActionLink({
-                      href: `${automationsBasePath}/new?template=${template.id}`,
-                      kind: "template",
-                      children: <FormattedMessage {...automationsPageViewMessages.addTemplate} />,
-                    })
-                  ) : (
-                    <Button size="sm" variant="outline" className="rounded-full" disabled>
-                      <FormattedMessage {...automationsPageViewMessages.comingSoon} />
-                    </Button>
-                  )}
-                </div>
-              </Card>
+              <AutomationTemplateCard
+                key={template.id}
+                automationsBasePath={automationsBasePath}
+                renderAutomationLink={renderAutomationLink}
+                template={template}
+              />
             ))}
           </div>
         </Tabs>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-chrome.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-chrome.tsx
@@ -46,7 +46,8 @@ export function VisualWorkflowChrome({
           value={name}
           onChange={(event) => onNameChange(event.target.value)}
           aria-label={intl.formatMessage(messages.workflowNameLabel)}
-          className="h-8 max-w-xs border-transparent bg-transparent px-2 font-medium shadow-none focus-visible:border-ring"
+          variant="inline"
+          className="max-w-xs px-2 font-medium"
         />
         <Badge variant="outline" className="rounded-full">
           <FormattedMessage {...messages.previewBadge} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -120,8 +120,8 @@ export const CreateEmpty: Story = {
     await expect(
       canvas.getByText("Add at least one supported tool to activate this automation."),
     ).toBeInTheDocument();
-    await expect(canvas.getByRole("combobox", { name: "Model" })).toBeInTheDocument();
-    await expect(canvas.getByRole("combobox", { name: "Model" })).toHaveTextContent("GPT-5.6 Luna");
+    await expect(canvas.getByRole("button", { name: "Model" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Model" })).toHaveTextContent("GPT-5.6 Luna");
   },
 };
 
@@ -140,12 +140,12 @@ export const ProjectSelectorForScheduledTrigger: Story = {
 export const CreateModelOptions: Story = {
   play: async ({ canvas, canvasElement, userEvent }) => {
     const body = within(canvasElement.ownerDocument.body);
-    await userEvent.click(canvas.getByRole("combobox", { name: "Model" }));
-    await expect(await body.findByRole("option", { name: "GPT-5.6 Luna" })).toBeInTheDocument();
-    await expect(body.getByRole("option", { name: "GPT-5.6 Terra" })).toBeInTheDocument();
-    await expect(body.getByRole("option", { name: "GPT-5.6 Sol" })).toBeInTheDocument();
-    await expect(body.getByRole("option", { name: "Claude Sonnet 5" })).toBeInTheDocument();
-    await expect(body.getByRole("option", { name: "Claude Opus 5" })).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("button", { name: "Model" }));
+    await expect(await body.findByRole("menuitem", { name: "GPT-5.6 Luna" })).toBeInTheDocument();
+    await expect(body.getByRole("menuitem", { name: "GPT-5.6 Terra" })).toBeInTheDocument();
+    await expect(body.getByRole("menuitem", { name: "GPT-5.6 Sol" })).toBeInTheDocument();
+    await expect(body.getByRole("menuitem", { name: "Claude Sonnet 5" })).toBeInTheDocument();
+    await expect(body.getByRole("menuitem", { name: "Claude Opus 5" })).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -927,11 +927,6 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "Ej5U0a0604",
     description: "Section heading for automation agent instructions",
   },
-  modelSection: {
-    defaultMessage: "Model",
-    id: "XCYkEzJaA9",
-    description: "Section heading for the automation language model selector",
-  },
   modelLabel: {
     defaultMessage: "Model",
     id: "yKlYrz3iYw",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -102,7 +102,6 @@ import { getLocaleLabel } from "@/lib/i18n/locales";
 import {
   WORKSPACE_AUTOMATION_MODELS,
   type WorkspaceAutomationGithubTriggerEvent,
-  type WorkspaceAutomationModel,
   type WorkspaceAutomationRunRecord,
 } from "@/lib/agents/workspace-automation-types";
 import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
@@ -545,6 +544,64 @@ function GithubRepositorySelect({
       </Select>
       <FieldError message={error} />
     </div>
+  );
+}
+
+function HeaderModelSelector({
+  disabled,
+  form,
+  onChange,
+}: {
+  disabled?: boolean;
+  form: WorkspaceAutomationFormState;
+  onChange: (next: WorkspaceAutomationFormState) => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        disabled={disabled}
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            aria-label={intl.formatMessage(workspaceAutomationFormMessages.modelLabel)}
+            title={intl.formatMessage(workspaceAutomationFormMessages.modelDescription)}
+            className="h-auto gap-1 px-0 py-0 text-sm font-normal text-muted-foreground hover:bg-transparent hover:text-foreground disabled:opacity-50"
+          />
+        }
+      >
+        <HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />
+        <FormattedMessage {...AUTOMATION_MODEL_MESSAGES[form.model]} />
+        <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-56" align="start">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>
+            <FormattedMessage {...workspaceAutomationFormMessages.modelLabel} />
+          </DropdownMenuLabel>
+          {WORKSPACE_AUTOMATION_MODELS.map((model) => (
+            <DropdownMenuItem
+              key={model}
+              onClick={() =>
+                onChange({
+                  ...form,
+                  model,
+                })
+              }
+            >
+              <FormattedMessage {...AUTOMATION_MODEL_MESSAGES[model]} />
+              {form.model === model ? (
+                <DropdownMenuHint>
+                  <FormattedMessage {...workspaceAutomationFormMessages.selectedShortcut} />
+                </DropdownMenuHint>
+              ) : null}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -3213,6 +3270,8 @@ export function WorkspaceAutomationEditor({
             onChange={onChange}
             projects={projectsQuery.data ?? []}
           />
+          <span className="text-border">{METADATA_SEPARATOR}</span>
+          <HeaderModelSelector disabled={disabled} form={form} onChange={onChange} />
           {form.triggerMode !== "manual" ? (
             <>
               <span className="text-border">{METADATA_SEPARATOR}</span>
@@ -3259,46 +3318,6 @@ export function WorkspaceAutomationEditor({
             organizationSlug={organizationSlug}
             repositories={repositories}
           />
-
-          <EditorSection title={intl.formatMessage(workspaceAutomationFormMessages.modelSection)}>
-            <EditorPanel>
-              <EditorRow
-                icon={<HugeiconsIcon icon={BrainCircuitIcon} className="size-4" />}
-                title={<FormattedMessage {...workspaceAutomationFormMessages.modelLabel} />}
-                description={
-                  <FormattedMessage {...workspaceAutomationFormMessages.modelDescription} />
-                }
-              >
-                <Select
-                  value={form.model}
-                  onValueChange={(value) => {
-                    if (!value) {
-                      return;
-                    }
-                    onChange({
-                      ...form,
-                      model: value as WorkspaceAutomationModel,
-                    });
-                  }}
-                  disabled={disabled}
-                >
-                  <SelectTrigger
-                    aria-label={intl.formatMessage(workspaceAutomationFormMessages.modelLabel)}
-                    className="h-8 w-full rounded-lg md:min-w-44 md:max-w-xs"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {WORKSPACE_AUTOMATION_MODELS.map((model) => (
-                      <SelectItem key={model} value={model}>
-                        <FormattedMessage {...AUTOMATION_MODEL_MESSAGES[model]} />
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </EditorRow>
-            </EditorPanel>
-          </EditorSection>
 
           <EditorSection
             title={intl.formatMessage(workspaceAutomationFormMessages.agentInstructionsSection)}

--- a/apps/hyperlocalise-web/src/components/ui/input.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/input.stories.tsx
@@ -25,16 +25,41 @@ type Story = StoryObj<typeof meta>;
 
 export const Overview: Story = {
   render: () => (
-    <div className="flex max-w-sm flex-col gap-4 p-6">
-      <Input aria-label="Project name" placeholder="Marketing site" />
-      <Input aria-label="Repository URL" defaultValue="github.com/acme/web" />
-      <Input aria-invalid aria-label="Provider token" defaultValue="expired-token" />
-      <Input aria-label="Locked slug" disabled defaultValue="production-workspace" />
+    <div className="flex max-w-sm flex-col gap-8 p-6">
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-medium text-muted-foreground">Default</h2>
+        <div className="flex flex-col gap-4">
+          <Input aria-label="Project name" placeholder="Marketing site" />
+          <Input aria-label="Repository URL" defaultValue="github.com/acme/web" />
+          <Input aria-invalid aria-label="Provider token" defaultValue="expired-token" />
+          <Input aria-label="Locked slug" disabled defaultValue="production-workspace" />
+        </div>
+      </section>
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-medium text-muted-foreground">Inline</h2>
+        <div className="flex flex-col gap-4">
+          <Input variant="inline" aria-label="Workflow name" defaultValue="Locale QA" />
+          <Input variant="inline" aria-label="Issue field" placeholder="Add a value" />
+          <Input
+            variant="inline"
+            aria-invalid
+            aria-label="Invalid issue field"
+            defaultValue="expired-token"
+          />
+          <Input
+            variant="inline"
+            aria-label="Locked issue field"
+            disabled
+            defaultValue="production-workspace"
+          />
+        </div>
+      </section>
     </div>
   ),
   play: async ({ canvas, userEvent }) => {
     const input = canvas.getByLabelText("Project name");
     await userEvent.type(input, "Mobile app");
     await expect(input).toHaveValue("Mobile app");
+    await expect(canvas.getByLabelText("Workflow name")).toHaveAttribute("data-variant", "inline");
   },
 };

--- a/apps/hyperlocalise-web/src/components/ui/input.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/input.tsx
@@ -12,21 +12,42 @@
  */
 import * as React from "react";
 import { Input as InputPrimitive } from "@base-ui/react/input";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/primitives/cn";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+const inputVariants = cva(
+  "w-full min-w-0 rounded-lg text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+  {
+    variants: {
+      variant: {
+        default:
+          "h-9 border border-input bg-input/30 px-3 py-1 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        inline:
+          "h-8 border border-transparent bg-transparent px-1.5 shadow-none hover:bg-muted/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Input({
+  className,
+  type,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"input"> & VariantProps<typeof inputVariants>) {
   return (
     <InputPrimitive
       type={type}
       data-slot="input"
-      className={cn(
-        "h-9 w-full min-w-0 rounded-lg border border-input bg-input/30 px-3 py-1 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className,
-      )}
+      data-variant={variant}
+      className={cn(inputVariants({ variant }), className)}
       {...props}
     />
   );
 }
 
-export { Input };
+export { Input, inputVariants };


### PR DESCRIPTION
## Summary
- Make automation template cards clickable, with a trigger icon, coming-soon badge, and labeled step-by-step flow instead of an Add button.
- Move the language-model picker into the automation editor header as a compact dropdown.
- Add an `inline` Input variant and use it for issue custom-column fields and the visual workflow name.

## Test plan
- [ ] Open Automations: template cards show an icon plus labeled flow; activatable cards navigate to `/automations/new?template=…`.
- [ ] Non-activatable templates show a Coming soon badge and are not clickable.
- [ ] Open an automation editor: the model control is in the header metadata row (not a separate section) and still lists all models.
- [ ] Confirm issue-detail sidebar custom fields and the visual workflow name field use the compact inline input style.
- [ ] Storybook: Input Overview, Automations page, and workspace automation editor stories still pass.


Made with [Cursor](https://cursor.com)