### PR TITLE
fix(web): keep Vitest compatible with happy-dom 20.12

### DIFF
--- a/apps/hyperlocalise-web/src/test/setup-dom.ts
+++ b/apps/hyperlocalise-web/src/test/setup-dom.ts
@@ -22,15 +22,10 @@ if (isDomEnvironment) {
     cleanup();
   });
 
-  if (!Element.prototype.getAnimations) {
-    Element.prototype.getAnimations = () => [];
-  }
-
-  if (!("getAnimations" in document.documentElement)) {
-    Object.defineProperty(document.documentElement, "getAnimations", {
-      value: () => [],
-    });
-  }
+  // happy-dom 20.12+ implements Web Animations. Motion then calls
+  // Animation.cancel(), which rejects `finished` as AbortError and Vitest
+  // treats that unhandled rejection as a failed run.
+  installNoopWebAnimations();
 
   if (!globalThis.ResizeObserver) {
     class ResizeObserverMock {
@@ -55,5 +50,60 @@ if (isDomEnvironment) {
 
   Element.prototype.getBoundingClientRect = function () {
     return defaultRect as DOMRect;
+  };
+}
+
+function installNoopWebAnimations() {
+  const createNoopAnimation = (): Animation => {
+    const animation = {
+      id: "",
+      currentTime: 0,
+      startTime: 0,
+      playbackRate: 1,
+      playState: "idle" as AnimationPlayState,
+      pending: false,
+      replaceState: "active" as AnimationReplaceState,
+      effect: null,
+      timeline: null,
+      onfinish: null,
+      oncancel: null,
+      onremove: null,
+      cancel() {},
+      finish() {},
+      play() {},
+      pause() {},
+      persist() {},
+      reverse() {},
+      updatePlaybackRate() {},
+      commitStyles() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return true;
+      },
+    } as Animation;
+    Object.defineProperty(animation, "finished", {
+      value: Promise.resolve(animation),
+    });
+    Object.defineProperty(animation, "ready", {
+      value: Promise.resolve(animation),
+    });
+    return animation;
+  };
+
+  Element.prototype.animate = function () {
+    return createNoopAnimation();
+  };
+  Element.prototype.getAnimations = () => [];
+  document.getAnimations = () => [];
+
+  if (typeof Animation === "undefined") {
+    return;
+  }
+
+  const originalCancel = Animation.prototype.cancel;
+  Animation.prototype.cancel = function (this: Animation) {
+    void this.finished.catch(() => undefined);
+    originalCancel.call(this);
   };
 }

--- a/apps/hyperlocalise-web/src/test/setup-dom.ts
+++ b/apps/hyperlocalise-web/src/test/setup-dom.ts
@@ -81,7 +81,7 @@ function installNoopWebAnimations() {
       dispatchEvent() {
         return true;
       },
-    } as Animation;
+    } as unknown as Animation;
     Object.defineProperty(animation, "finished", {
       value: Promise.resolve(animation),
     });
@@ -96,14 +96,4 @@ function installNoopWebAnimations() {
   };
   Element.prototype.getAnimations = () => [];
   document.getAnimations = () => [];
-
-  if (typeof Animation === "undefined") {
-    return;
-  }
-
-  const originalCancel = Animation.prototype.cancel;
-  Animation.prototype.cancel = function (this: Animation) {
-    void this.finished.catch(() => undefined);
-    originalCancel.call(this);
-  };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

PR #2179 failed `Web CI / Hyperlocalise Web Test/Build` after `happy-dom` 20.12.0.

That release implements the Web Animations API. Motion uses `Element.animate()`, and `Animation.cancel()` on unmount rejects `finished` with `AbortError`. Vitest treats that unhandled rejection as a failed run even when the test passed. CI only showed `ECONNREFUSED 127.0.0.1:3000` because happy-dom’s default origin is `http://localhost:3000`.

This stubs Web Animations in `src/test/setup-dom.ts` so DOM tests keep the previous no-op behavior.

## How to test

- `CI=true vp test src/components/marketing/hero-frame.test.tsx`
- `vp test` and `vp check --fix` in `apps/hyperlocalise-web`

Local verification after this change: `845` test files / `5837` tests passed, `vp check --fix` clean.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-896ec766-1f80-432e-a4ce-c07959bc2b45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-896ec766-1f80-432e-a4ce-c07959bc2b45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

