### PR TITLE
feat(web): add role permission matrix to members

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/members/permissions/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/members/permissions/page.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { RolePermissionsPageView } from "../../settings/_components/role-permissions-page-view";
+
+export default async function RolePermissionsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  const { organizationSlug } = await params;
+  await requireAppAuthContext({ organizationSlug });
+
+  return <RolePermissionsPageView organizationSlug={organizationSlug} />;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.messages.ts
@@ -75,6 +75,11 @@ export const membersPageContentMessages = defineMessages({
     id: "eW2eLsJu8K",
     description: "Button to open the invite member dialog",
   },
+  rolePermissions: {
+    defaultMessage: "Role permissions",
+    id: "wmiAe9jqdo",
+    description: "Link from the members page to the role permission matrix",
+  },
   sectionAriaLabel: {
     defaultMessage: "Workspace members",
     id: "zl55Vhhf0L",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
@@ -22,6 +22,8 @@ import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
@@ -314,27 +316,31 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
         title={intl.formatMessage(membersPageContentMessages.pageTitle)}
         description={intl.formatMessage(membersPageContentMessages.pageDescription)}
         actions={
-          <div className="flex w-full flex-col gap-2 sm:w-fit sm:flex-row sm:items-center">
-            <Button
-              nativeButton={false}
-              variant="ghost"
-              render={<Link href={`/org/${organizationSlug}/members/permissions`} />}
-              className="w-full sm:w-fit"
-            >
-              <FormattedMessage {...membersPageContentMessages.rolePermissions} />
-            </Button>
-            {canInvite ? (
+          <Columns spacing="1u" alignY="center" collapseBelow="small">
+            <Column width="containedContent">
               <Button
-                type="button"
-                onClick={() => setIsInviteOpen(true)}
+                nativeButton={false}
+                variant="ghost"
+                render={<Link href={`/org/${organizationSlug}/members/permissions`} />}
                 className="w-full sm:w-fit"
-                disabled={inviteMember.isPending}
               >
-                <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-                <FormattedMessage {...membersPageContentMessages.inviteMember} />
+                <FormattedMessage {...membersPageContentMessages.rolePermissions} />
               </Button>
+            </Column>
+            {canInvite ? (
+              <Column width="containedContent">
+                <Button
+                  type="button"
+                  onClick={() => setIsInviteOpen(true)}
+                  className="w-full sm:w-fit"
+                  disabled={inviteMember.isPending}
+                >
+                  <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+                  <FormattedMessage {...membersPageContentMessages.inviteMember} />
+                </Button>
+              </Column>
             ) : null}
-          </div>
+          </Columns>
         }
       />
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
@@ -12,6 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import Link from "next/link";
 import { useState } from "react";
 import { Add01Icon, Delete01Icon, UserGroupIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -313,17 +314,27 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
         title={intl.formatMessage(membersPageContentMessages.pageTitle)}
         description={intl.formatMessage(membersPageContentMessages.pageDescription)}
         actions={
-          canInvite ? (
+          <div className="flex w-full flex-col gap-2 sm:w-fit sm:flex-row sm:items-center">
             <Button
-              type="button"
-              onClick={() => setIsInviteOpen(true)}
+              nativeButton={false}
+              variant="ghost"
+              render={<Link href={`/org/${organizationSlug}/members/permissions`} />}
               className="w-full sm:w-fit"
-              disabled={inviteMember.isPending}
             >
-              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-              <FormattedMessage {...membersPageContentMessages.inviteMember} />
+              <FormattedMessage {...membersPageContentMessages.rolePermissions} />
             </Button>
-          ) : null
+            {canInvite ? (
+              <Button
+                type="button"
+                onClick={() => setIsInviteOpen(true)}
+                className="w-full sm:w-fit"
+                disabled={inviteMember.isPending}
+              >
+                <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+                <FormattedMessage {...membersPageContentMessages.inviteMember} />
+              </Button>
+            ) : null}
+          </div>
         }
       />
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.messages.ts
@@ -1,0 +1,169 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const rolePermissionsPageViewMessages = defineMessages({
+  pageLabel: {
+    defaultMessage: "Workspace",
+    id: "qxK7wREk5o",
+    description: "Breadcrumb-style label above the role permissions page title",
+  },
+  pageTitle: {
+    defaultMessage: "Role permissions",
+    id: "0pg6zXLFtI",
+    description: "Role permissions page heading",
+  },
+  pageDescription: {
+    defaultMessage:
+      "What each workspace role can do. A mark means allowed. Empty means not allowed.",
+    id: "gy+E1G7FV0",
+    description: "Role permissions page description",
+  },
+  backToMembers: {
+    defaultMessage: "Members",
+    id: "gMK6GFoBBA",
+    description: "Back link from role permissions to the members list",
+  },
+  matrixAriaLabel: {
+    defaultMessage: "Role permission matrix",
+    id: "Fe6NxNaeWi",
+    description: "Accessible name for the role permission matrix",
+  },
+  columnPermission: {
+    defaultMessage: "Permission",
+    id: "sTY0HjJCgH",
+    description: "Column header for permission names in the role matrix",
+  },
+  groupWork: {
+    defaultMessage: "Work",
+    id: "aQCAPll/8g",
+    description: "Role permission matrix group for job and project work",
+  },
+  groupPeople: {
+    defaultMessage: "People",
+    id: "jlhNAM1L3Z",
+    description: "Role permission matrix group for inviting people and managing teams",
+  },
+  groupWorkspace: {
+    defaultMessage: "Workspace",
+    id: "XzqRCb9LWK",
+    description: "Role permission matrix group for workspace settings and billing",
+  },
+  rowViewWorkspace: {
+    defaultMessage: "View workspace",
+    id: "7qX3gQkmz8",
+    description: "Permission row for reading the workspace",
+  },
+  rowViewProjects: {
+    defaultMessage: "View projects",
+    id: "US6u2ypJBV",
+    description: "Permission row for reading projects",
+  },
+  rowViewJobs: {
+    defaultMessage: "View jobs",
+    id: "7JxV+XlcQy",
+    description: "Permission row for reading jobs",
+  },
+  rowWorkJobs: {
+    defaultMessage: "Work on jobs",
+    id: "rYa7wjb2DF",
+    description: "Permission row for writing jobs",
+  },
+  rowRunAi: {
+    defaultMessage: "Run AI",
+    id: "OYX4uMwpwD",
+    description: "Permission row for running AI actions",
+  },
+  rowPushDrafts: {
+    defaultMessage: "Push draft translations",
+    id: "oEmsIJPKd5",
+    description: "Permission row for pushing draft translations",
+  },
+  rowApproveReviews: {
+    defaultMessage: "Approve reviews",
+    id: "n7kQpjbGxA",
+    description: "Permission row for approving reviews",
+  },
+  rowApproveWriteBack: {
+    defaultMessage: "Approve write-back",
+    id: "Y/Ta4tMAG1",
+    description: "Permission row for approving write-back",
+  },
+  rowCreateProjects: {
+    defaultMessage: "Create projects",
+    id: "kQCAngZDoM",
+    description: "Permission row for creating projects",
+  },
+  rowManageProjects: {
+    defaultMessage: "Manage projects",
+    id: "rI3RUd2o85",
+    description: "Permission row for managing projects",
+  },
+  rowInvitePeople: {
+    defaultMessage: "Invite people",
+    id: "LICkSSM/jQ",
+    description: "Permission row for inviting members",
+  },
+  rowManageTeams: {
+    defaultMessage: "Manage teams",
+    id: "ALBGSq9MmL",
+    description: "Permission row for managing teams",
+  },
+  rowEditGlossaries: {
+    defaultMessage: "Edit glossaries",
+    id: "MBLJMvPrmC",
+    description: "Permission row for editing glossaries",
+  },
+  rowEditMemories: {
+    defaultMessage: "Edit memories",
+    id: "1gdAJhh6Lk",
+    description: "Permission row for editing translation memories",
+  },
+  rowViewIntegrations: {
+    defaultMessage: "View integrations",
+    id: "BCsSQdOvtG",
+    description: "Permission row for viewing integrations",
+  },
+  rowManageIntegrations: {
+    defaultMessage: "Manage integrations",
+    id: "quhhKaWY+z",
+    description: "Permission row for managing integrations",
+  },
+  rowManageCredentials: {
+    defaultMessage: "Manage credentials",
+    id: "8jOo2pj9Lk",
+    description: "Permission row for managing provider credentials",
+  },
+  rowUpdateSettings: {
+    defaultMessage: "Update workspace settings",
+    id: "G6aiREcgX6",
+    description: "Permission row for updating workspace settings",
+  },
+  rowManageBilling: {
+    defaultMessage: "Manage billing",
+    id: "2mJ+zZY2rg",
+    description: "Permission row for managing billing",
+  },
+  allowed: {
+    defaultMessage: "Allowed",
+    id: "LcATF1z/n8",
+    description: "Screen-reader label when a role has a permission",
+  },
+  notAllowed: {
+    defaultMessage: "Not allowed",
+    id: "TwAHdkAXq8",
+    description: "Screen-reader label when a role does not have a permission",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.stories.tsx
@@ -40,6 +40,7 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Role permissions" })).toBeInTheDocument();
     await expect(canvas.getByRole("link", { name: "Members" })).toBeInTheDocument();
+    await expect(canvas.getByRole("table", { name: "Role permission matrix" })).toBeInTheDocument();
     await expect(canvas.getByText("View workspace")).toBeInTheDocument();
     await expect(canvas.getByText("workspace:read")).toBeInTheDocument();
     await expect(canvas.getByText("projects:read")).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.stories.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { RolePermissionsPageView } from "./role-permissions-page-view";
+
+const meta = {
+  title: "App/Members/Role permissions",
+  component: RolePermissionsPageView,
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/org/acme/members/permissions",
+        query: {},
+      },
+    },
+  },
+  args: {
+    organizationSlug: "acme",
+  },
+} satisfies Meta<typeof RolePermissionsPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Role permissions" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Members" })).toBeInTheDocument();
+    await expect(canvas.getByText("View workspace")).toBeInTheDocument();
+    await expect(canvas.getByText("workspace:read")).toBeInTheDocument();
+    await expect(canvas.getByText("projects:read")).toBeInTheDocument();
+    await expect(canvas.getByText("provider_credentials:write")).toBeInTheDocument();
+    await expect(canvas.getByText("billing:write")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import Link from "next/link";
+import { ArrowLeft01Icon, Tick02Icon, UserGroupIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  groupRolePermissionRows,
+  ROLE_PERMISSION_MATRIX_ROLES,
+  type RolePermissionGroupId,
+  type RolePermissionRowId,
+  roleHasPermissionRow,
+} from "@/lib/members/role-permission-matrix";
+
+import { WorkspacePeopleNav } from "../../_components/workspace-people-nav";
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+
+import { getRoleLabel } from "./members-settings-view-model";
+import { rolePermissionsPageViewMessages as messages } from "./role-permissions-page-view.messages";
+
+const groupMessages = {
+  work: messages.groupWork,
+  people: messages.groupPeople,
+  workspace: messages.groupWorkspace,
+} as const satisfies Record<RolePermissionGroupId, typeof messages.groupWork>;
+
+const rowMessages = {
+  "view-workspace": messages.rowViewWorkspace,
+  "view-projects": messages.rowViewProjects,
+  "view-jobs": messages.rowViewJobs,
+  "work-jobs": messages.rowWorkJobs,
+  "run-ai": messages.rowRunAi,
+  "push-drafts": messages.rowPushDrafts,
+  "approve-reviews": messages.rowApproveReviews,
+  "approve-write-back": messages.rowApproveWriteBack,
+  "create-projects": messages.rowCreateProjects,
+  "manage-projects": messages.rowManageProjects,
+  "invite-people": messages.rowInvitePeople,
+  "manage-teams": messages.rowManageTeams,
+  "edit-glossaries": messages.rowEditGlossaries,
+  "edit-memories": messages.rowEditMemories,
+  "view-integrations": messages.rowViewIntegrations,
+  "manage-integrations": messages.rowManageIntegrations,
+  "manage-credentials": messages.rowManageCredentials,
+  "update-settings": messages.rowUpdateSettings,
+  "manage-billing": messages.rowManageBilling,
+} as const satisfies Record<RolePermissionRowId, typeof messages.rowViewWorkspace>;
+
+function PermissionMark({ allowed }: { allowed: boolean }) {
+  if (!allowed) {
+    return (
+      <span className="sr-only">
+        <FormattedMessage {...messages.notAllowed} />
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} className="size-4 text-primary" />
+      <span className="sr-only">
+        <FormattedMessage {...messages.allowed} />
+      </span>
+    </>
+  );
+}
+
+export function RolePermissionsPageView({ organizationSlug }: { organizationSlug: string }) {
+  const intl = useIntl();
+  const groups = groupRolePermissionRows();
+
+  return (
+    <WorkspacePageShell>
+      <WorkspacePeopleNav organizationSlug={organizationSlug} />
+
+      <div className="flex flex-col gap-4">
+        <Button
+          nativeButton={false}
+          render={<Link href={`/org/${organizationSlug}/members`} />}
+          variant="ghost"
+          size="sm"
+          className="w-fit px-2 text-muted-foreground hover:text-foreground"
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={1.8} />
+          <FormattedMessage {...messages.backToMembers} />
+        </Button>
+
+        <PageHeader
+          icon={UserGroupIcon}
+          label={intl.formatMessage(messages.pageLabel)}
+          title={intl.formatMessage(messages.pageTitle)}
+          description={intl.formatMessage(messages.pageDescription)}
+        />
+      </div>
+
+      <div className="min-w-0 overflow-x-auto">
+        <table className="w-full min-w-[56rem] border-collapse text-sm">
+          <caption className="sr-only">
+            <FormattedMessage {...messages.matrixAriaLabel} />
+          </caption>
+          <thead>
+            <tr className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+              <th scope="col" className="px-3 py-3 text-start font-medium">
+                <FormattedMessage {...messages.columnPermission} />
+              </th>
+              {ROLE_PERMISSION_MATRIX_ROLES.map((role) => (
+                <th
+                  key={role}
+                  scope="col"
+                  className="w-[6.75rem] px-2 py-3 text-center font-medium"
+                >
+                  {getRoleLabel(role, intl)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          {groups.map((group) => (
+            <tbody key={group.id}>
+              <tr>
+                <th
+                  scope="colgroup"
+                  colSpan={ROLE_PERMISSION_MATRIX_ROLES.length + 1}
+                  className="rounded-md bg-muted px-3 py-2 text-start text-xs font-medium text-muted-foreground"
+                >
+                  <FormattedMessage {...groupMessages[group.id]} />
+                </th>
+              </tr>
+              {group.rows.map((row) => (
+                <tr key={row.id} className="border-b border-border/60">
+                  <th scope="row" className="px-3 py-3 text-start font-normal">
+                    <div className="flex flex-col gap-0.5">
+                      <span className="font-medium text-foreground">
+                        <FormattedMessage {...rowMessages[row.id]} />
+                      </span>
+                      <span className="font-mono text-[11px] leading-4 text-muted-foreground">
+                        {row.capability}
+                      </span>
+                    </div>
+                  </th>
+                  {ROLE_PERMISSION_MATRIX_ROLES.map((role) => (
+                    <td key={role} className="px-2 py-3 text-center">
+                      <span className="inline-flex size-5 items-center justify-center">
+                        <PermissionMark allowed={roleHasPermissionRow(role, row.capability)} />
+                      </span>
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          ))}
+        </table>
+      </div>
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/role-permissions-page-view.tsx
@@ -13,15 +13,22 @@
  * Version 2.0 or later.
  */
 import Link from "next/link";
+import { Fragment } from "react";
 import { ArrowLeft01Icon, Tick02Icon, UserGroupIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
+import { Box } from "@/components/ui/layout/box";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
+import { Row } from "@/components/ui/layout/row";
+import { Rows } from "@/components/ui/layout/rows";
 import {
   groupRolePermissionRows,
   ROLE_PERMISSION_MATRIX_ROLES,
   type RolePermissionGroupId,
+  type RolePermissionRow,
   type RolePermissionRowId,
   roleHasPermissionRow,
 } from "@/lib/members/role-permission-matrix";
@@ -31,6 +38,10 @@ import { PageHeader, WorkspacePageShell } from "../../_components/workspace-reso
 
 import { getRoleLabel } from "./members-settings-view-model";
 import { rolePermissionsPageViewMessages as messages } from "./role-permissions-page-view.messages";
+
+const ROLE_COLUMN_COUNT = ROLE_PERMISSION_MATRIX_ROLES.length;
+const MATRIX_COLUMN_COUNT = ROLE_COLUMN_COUNT + 1;
+const ROLE_COLUMN_WIDTH = "1/12" as const;
 
 const groupMessages = {
   work: messages.groupWork,
@@ -70,12 +81,73 @@ function PermissionMark({ allowed }: { allowed: boolean }) {
   }
 
   return (
-    <>
+    <Box display="inline-flex" alignItems="center" justifyContent="center">
       <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} className="size-4 text-primary" />
       <span className="sr-only">
         <FormattedMessage {...messages.allowed} />
       </span>
-    </>
+    </Box>
+  );
+}
+
+function MatrixHeaderRow() {
+  const intl = useIntl();
+
+  return (
+    <Columns spacing="1u" alignY="center" role="row">
+      <Column width="fluid" role="columnheader">
+        <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+          <FormattedMessage {...messages.columnPermission} />
+        </span>
+      </Column>
+      {ROLE_PERMISSION_MATRIX_ROLES.map((role) => (
+        <Column key={role} width={ROLE_COLUMN_WIDTH} role="columnheader">
+          <Row spacing="0" align="center" alignY="center">
+            <span className="text-center text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+              {getRoleLabel(role, intl)}
+            </span>
+          </Row>
+        </Column>
+      ))}
+    </Columns>
+  );
+}
+
+function MatrixGroupHeader({ groupId }: { groupId: RolePermissionGroupId }) {
+  return (
+    <Columns spacing="0" role="row">
+      <Column width="fluid" role="columnheader" aria-colspan={MATRIX_COLUMN_COUNT}>
+        <Box background="muted" paddingX="1.5u" paddingY="1u" borderRadius="standard">
+          <span className="text-xs font-medium text-muted-foreground">
+            <FormattedMessage {...groupMessages[groupId]} />
+          </span>
+        </Box>
+      </Column>
+    </Columns>
+  );
+}
+
+function MatrixPermissionRow({ row }: { row: RolePermissionRow }) {
+  return (
+    <Columns spacing="1u" alignY="center" role="row">
+      <Column width="fluid" role="rowheader">
+        <Rows spacing="0.5u">
+          <span className="font-medium text-foreground">
+            <FormattedMessage {...rowMessages[row.id]} />
+          </span>
+          <span className="font-mono text-[11px] leading-4 text-muted-foreground">
+            {row.capability}
+          </span>
+        </Rows>
+      </Column>
+      {ROLE_PERMISSION_MATRIX_ROLES.map((role) => (
+        <Column key={role} width={ROLE_COLUMN_WIDTH} role="cell">
+          <Row spacing="0" align="center" alignY="center">
+            <PermissionMark allowed={roleHasPermissionRow(role, row.capability)} />
+          </Row>
+        </Column>
+      ))}
+    </Columns>
   );
 }
 
@@ -87,7 +159,7 @@ export function RolePermissionsPageView({ organizationSlug }: { organizationSlug
     <WorkspacePageShell>
       <WorkspacePeopleNav organizationSlug={organizationSlug} />
 
-      <div className="flex flex-col gap-4">
+      <Rows spacing="2u">
         <Button
           nativeButton={false}
           render={<Link href={`/org/${organizationSlug}/members`} />}
@@ -105,65 +177,24 @@ export function RolePermissionsPageView({ organizationSlug }: { organizationSlug
           title={intl.formatMessage(messages.pageTitle)}
           description={intl.formatMessage(messages.pageDescription)}
         />
-      </div>
+      </Rows>
 
-      <div className="min-w-0 overflow-x-auto">
-        <table className="w-full min-w-[56rem] border-collapse text-sm">
-          <caption className="sr-only">
-            <FormattedMessage {...messages.matrixAriaLabel} />
-          </caption>
-          <thead>
-            <tr className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
-              <th scope="col" className="px-3 py-3 text-start font-medium">
-                <FormattedMessage {...messages.columnPermission} />
-              </th>
-              {ROLE_PERMISSION_MATRIX_ROLES.map((role) => (
-                <th
-                  key={role}
-                  scope="col"
-                  className="w-[6.75rem] px-2 py-3 text-center font-medium"
-                >
-                  {getRoleLabel(role, intl)}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          {groups.map((group) => (
-            <tbody key={group.id}>
-              <tr>
-                <th
-                  scope="colgroup"
-                  colSpan={ROLE_PERMISSION_MATRIX_ROLES.length + 1}
-                  className="rounded-md bg-muted px-3 py-2 text-start text-xs font-medium text-muted-foreground"
-                >
-                  <FormattedMessage {...groupMessages[group.id]} />
-                </th>
-              </tr>
-              {group.rows.map((row) => (
-                <tr key={row.id} className="border-b border-border/60">
-                  <th scope="row" className="px-3 py-3 text-start font-normal">
-                    <div className="flex flex-col gap-0.5">
-                      <span className="font-medium text-foreground">
-                        <FormattedMessage {...rowMessages[row.id]} />
-                      </span>
-                      <span className="font-mono text-[11px] leading-4 text-muted-foreground">
-                        {row.capability}
-                      </span>
-                    </div>
-                  </th>
-                  {ROLE_PERMISSION_MATRIX_ROLES.map((role) => (
-                    <td key={role} className="px-2 py-3 text-center">
-                      <span className="inline-flex size-5 items-center justify-center">
-                        <PermissionMark allowed={roleHasPermissionRow(role, row.capability)} />
-                      </span>
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          ))}
-        </table>
-      </div>
+      <Rows
+        spacing="1u"
+        role="table"
+        aria-label={intl.formatMessage(messages.matrixAriaLabel)}
+        aria-colcount={MATRIX_COLUMN_COUNT}
+      >
+        <MatrixHeaderRow />
+        {groups.map((group) => (
+          <Fragment key={group.id}>
+            <MatrixGroupHeader groupId={group.id} />
+            {group.rows.map((row) => (
+              <MatrixPermissionRow key={row.id} row={row} />
+            ))}
+          </Fragment>
+        ))}
+      </Rows>
     </WorkspacePageShell>
   );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -51,6 +51,7 @@ describe("getAppShellTitle", () => {
     ["/org/acme/teams", "Teams"],
     ["/org/acme/teams/team_1", "team_1"],
     ["/org/acme/members", "Members"],
+    ["/org/acme/members/permissions", "Role permissions"],
     ["/org/acme/settings", "Settings"],
     ["/org/acme/settings/members", "Members"],
     ["/org/acme/settings/account", "Account"],
@@ -128,6 +129,10 @@ describe("getAppShellBreadcrumbs", () => {
 
   it("returns members breadcrumbs", () => {
     expect(getAppShellBreadcrumbs("/org/acme/members", intl)).toEqual([{ label: "Members" }]);
+    expect(getAppShellBreadcrumbs("/org/acme/members/permissions", intl)).toEqual([
+      { label: "Members", href: "/org/acme/members" },
+      { label: "Role permissions" },
+    ]);
   });
 
   it("returns project breadcrumbs with the project name", () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -40,6 +40,7 @@ type RouteTitleKey =
   | "members"
   | "my-jobs"
   | "my-work"
+  | "permissions"
   | "personal-access-tokens"
   | "projects"
   | "qa"
@@ -91,6 +92,7 @@ function isRouteTitleKey(value: string): value is RouteTitleKey {
     value === "members" ||
     value === "my-jobs" ||
     value === "my-work" ||
+    value === "permissions" ||
     value === "personal-access-tokens" ||
     value === "projects" ||
     value === "qa" ||
@@ -267,6 +269,12 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
         id: "YM1jd5PwaY",
         description: "App shell breadcrumb title for the my jobs page",
       });
+    case "permissions":
+      return intl.formatMessage({
+        defaultMessage: "Role permissions",
+        id: "4C48CjJZ/y",
+        description: "App shell breadcrumb title for the role permissions page",
+      });
     case "personal-access-tokens":
       return intl.formatMessage({
         defaultMessage: "Personal access tokens",
@@ -399,7 +407,17 @@ export function getAppShellBreadcrumbs(
   }
 
   if (section === "members") {
-    return [{ label: formatRouteTitle(intl, "members") }];
+    if (!subsection) {
+      return [{ label: formatRouteTitle(intl, "members") }];
+    }
+
+    return [
+      {
+        label: formatRouteTitle(intl, "members"),
+        href: buildOrgPath(organizationSlug, "members"),
+      },
+      { label: routeTitle(intl, subsection) },
+    ];
   }
 
   if (section === "projects" && subsection) {

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -130,6 +130,7 @@ describe("workspace people navigation", () => {
 
     expect(isNavigationItemActive("/org/acme/members", membersHref)).toBe(true);
     expect(isNavigationItemActive("/en/org/acme/members", membersHref)).toBe(true);
+    expect(isNavigationItemActive("/org/acme/members/permissions", membersHref)).toBe(true);
     expect(isNavigationItemActive("/org/acme/teams", membersHref)).toBe(false);
     expect(isNavigationItemActive("/org/acme/teams/team_1", membersHref)).toBe(false);
   });

--- a/apps/hyperlocalise-web/src/lib/members/role-permission-matrix.test.ts
+++ b/apps/hyperlocalise-web/src/lib/members/role-permission-matrix.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { hasCapability } from "@/api/auth/policy";
+
+import {
+  groupRolePermissionRows,
+  ROLE_PERMISSION_MATRIX_ROLES,
+  ROLE_PERMISSION_ROWS,
+  roleHasPermissionRow,
+} from "./role-permission-matrix";
+
+describe("role-permission-matrix", () => {
+  it("groups consecutive rows by section", () => {
+    const groups = groupRolePermissionRows();
+
+    expect(groups.map((group) => group.id)).toEqual(["work", "people", "workspace"]);
+    expect(groups[0]?.rows.map((row) => row.id)).toEqual([
+      "view-workspace",
+      "view-projects",
+      "view-jobs",
+      "work-jobs",
+      "run-ai",
+      "push-drafts",
+      "approve-reviews",
+      "approve-write-back",
+      "create-projects",
+      "manage-projects",
+    ]);
+    expect(groups[1]?.rows.map((row) => row.id)).toEqual(["invite-people", "manage-teams"]);
+    expect(groups[2]?.rows.map((row) => row.id)).toEqual([
+      "edit-glossaries",
+      "edit-memories",
+      "view-integrations",
+      "manage-integrations",
+      "manage-credentials",
+      "update-settings",
+      "manage-billing",
+    ]);
+  });
+
+  it("uses one capability per row", () => {
+    expect(ROLE_PERMISSION_ROWS.map((row) => row.capability)).toEqual([
+      "workspace:read",
+      "projects:read",
+      "jobs:read",
+      "jobs:write",
+      "ai_actions:run",
+      "write_back:translation",
+      "reviews:approve",
+      "write_back:approve",
+      "projects:create",
+      "projects:write",
+      "members:invite",
+      "teams:write",
+      "glossaries:write",
+      "memories:write",
+      "integrations:read",
+      "integrations:write",
+      "provider_credentials:write",
+      "workspace:update",
+      "billing:write",
+    ]);
+  });
+
+  it("marks a cell allowed only when the role has that capability", () => {
+    expect(roleHasPermissionRow("member", "workspace:read")).toBe(true);
+    expect(roleHasPermissionRow("member", "jobs:write")).toBe(false);
+    expect(roleHasPermissionRow("developer", "reviews:approve")).toBe(false);
+    expect(roleHasPermissionRow("localization_manager", "billing:write")).toBe(false);
+    expect(roleHasPermissionRow("admin", "billing:write")).toBe(true);
+  });
+
+  it("stays aligned with policy.ts for every matrix cell", () => {
+    for (const row of ROLE_PERMISSION_ROWS) {
+      for (const role of ROLE_PERMISSION_MATRIX_ROLES) {
+        expect(roleHasPermissionRow(role, row.capability), `${row.id}:${role}`).toBe(
+          hasCapability(role, row.capability),
+        );
+      }
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/members/role-permission-matrix.ts
+++ b/apps/hyperlocalise-web/src/lib/members/role-permission-matrix.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { hasCapability, type OrganizationCapability } from "@/api/auth/policy";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+
+/** Least privilege first, matching the admin-facing matrix. */
+export const ROLE_PERMISSION_MATRIX_ROLES = [
+  "member",
+  "translator",
+  "reviewer",
+  "developer",
+  "localization_manager",
+  "admin",
+] as const satisfies readonly OrganizationMembershipRole[];
+
+export type RolePermissionGroupId = "work" | "people" | "workspace";
+
+export type RolePermissionRowId =
+  | "view-workspace"
+  | "view-projects"
+  | "view-jobs"
+  | "work-jobs"
+  | "run-ai"
+  | "push-drafts"
+  | "approve-reviews"
+  | "approve-write-back"
+  | "create-projects"
+  | "manage-projects"
+  | "invite-people"
+  | "manage-teams"
+  | "edit-glossaries"
+  | "edit-memories"
+  | "view-integrations"
+  | "manage-integrations"
+  | "manage-credentials"
+  | "update-settings"
+  | "manage-billing";
+
+export type RolePermissionRow = {
+  id: RolePermissionRowId;
+  group: RolePermissionGroupId;
+  capability: OrganizationCapability;
+};
+
+export const ROLE_PERMISSION_ROWS: readonly RolePermissionRow[] = [
+  { id: "view-workspace", group: "work", capability: "workspace:read" },
+  { id: "view-projects", group: "work", capability: "projects:read" },
+  { id: "view-jobs", group: "work", capability: "jobs:read" },
+  { id: "work-jobs", group: "work", capability: "jobs:write" },
+  { id: "run-ai", group: "work", capability: "ai_actions:run" },
+  { id: "push-drafts", group: "work", capability: "write_back:translation" },
+  { id: "approve-reviews", group: "work", capability: "reviews:approve" },
+  { id: "approve-write-back", group: "work", capability: "write_back:approve" },
+  { id: "create-projects", group: "work", capability: "projects:create" },
+  { id: "manage-projects", group: "work", capability: "projects:write" },
+  { id: "invite-people", group: "people", capability: "members:invite" },
+  { id: "manage-teams", group: "people", capability: "teams:write" },
+  { id: "edit-glossaries", group: "workspace", capability: "glossaries:write" },
+  { id: "edit-memories", group: "workspace", capability: "memories:write" },
+  { id: "view-integrations", group: "workspace", capability: "integrations:read" },
+  { id: "manage-integrations", group: "workspace", capability: "integrations:write" },
+  { id: "manage-credentials", group: "workspace", capability: "provider_credentials:write" },
+  { id: "update-settings", group: "workspace", capability: "workspace:update" },
+  { id: "manage-billing", group: "workspace", capability: "billing:write" },
+];
+
+export type RolePermissionGroup = {
+  id: RolePermissionGroupId;
+  rows: readonly RolePermissionRow[];
+};
+
+export function groupRolePermissionRows(
+  rows: readonly RolePermissionRow[] = ROLE_PERMISSION_ROWS,
+): RolePermissionGroup[] {
+  const groups: RolePermissionGroup[] = [];
+
+  for (const row of rows) {
+    const last = groups.at(-1);
+    if (last && last.id === row.group) {
+      groups[groups.length - 1] = { id: last.id, rows: [...last.rows, row] };
+      continue;
+    }
+
+    groups.push({ id: row.group, rows: [row] });
+  }
+
+  return groups;
+}
+
+export function roleHasPermissionRow(
+  role: OrganizationMembershipRole,
+  capability: OrganizationCapability,
+): boolean {
+  return hasCapability(role, capability);
+}


### PR DESCRIPTION
## What changed

Adds a Role permissions page under Members so workspace operators can see what each role can do, one capability per row, derived from `policy.ts`. Members now links to `/org/[slug]/members/permissions`.

## How to test

- Open Members and click **Role permissions**.
- Confirm Teams | Members stays on Members, and the back link returns to the member list.
- Check that each capability is its own row (for example `workspace:read` and `projects:read` are not combined).
- Confirm Admin has billing write, Localization manager does not, and Developer cannot approve reviews.
- `cd apps/hyperlocalise-web && vp test src/lib/members/role-permission-matrix.test.ts src/components/app-shell/app-shell-title.test.ts src/components/app-shell/navigation-config.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)