### PR TITLE
feat(mcp): add list_issue_comments tool to the hosted MCP server

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -326,6 +326,28 @@ describe("MCP team-scoped access", () => {
 
     expect(accessibleIssueResponse.status).toBe(200);
 
+    const accessibleCommentsResponse = await callMcpTool(accessToken, "list_issue_comments", {
+      projectId: alphaProjectBody.project.id,
+      issueId: alphaIssue.id,
+    });
+
+    expect(accessibleCommentsResponse.status).toBe(200);
+
+    const accessibleCommentsResponseBody = await accessibleCommentsResponse.json();
+
+    expect(
+      (
+        accessibleCommentsResponseBody as {
+          result?: { isError?: boolean };
+        }
+      ).result?.isError,
+    ).not.toBe(true);
+
+    expect(parseToolResultText(accessibleCommentsResponseBody)).toEqual({
+      comments: [],
+      nextCursor: null,
+    });
+
     const accessibleIssueResponseBody = await accessibleIssueResponse.json();
 
     expect(parseToolResultText(accessibleIssueResponseBody)).toMatchObject({
@@ -374,6 +396,28 @@ describe("MCP team-scoped access", () => {
       ).toBe(true);
 
       expect(parseToolResultText(responseBody), lookup.label).toMatchObject({
+        error: "issue_not_found",
+      });
+
+      const commentsResponse = await callMcpTool(accessToken, "list_issue_comments", {
+        projectId: lookup.projectId,
+        issueId: lookup.issueId,
+      });
+
+      expect(commentsResponse.status, lookup.label).toBe(200);
+
+      const commentsResponseBody = await commentsResponse.json();
+
+      expect(
+        (
+          commentsResponseBody as {
+            result?: { isError?: boolean };
+          }
+        ).result?.isError,
+        lookup.label,
+      ).toBe(true);
+
+      expect(parseToolResultText(commentsResponseBody), lookup.label).toMatchObject({
         error: "issue_not_found",
       });
     }

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -23,6 +23,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
+import { IssueSheetCommentService } from "@/lib/projects/issue-sheet/issue-sheet-comment-service";
 
 import {
   createAuthorizationCode,
@@ -1146,8 +1147,75 @@ describe("mcpRoutes", () => {
         ],
       });
 
+      const auth = globalThis.__testApiAuthContext;
+
+      if (!auth) {
+        throw new Error("expected test auth context");
+      }
+
+      const commentService = new IssueSheetCommentService();
+
+      const sdkComment = await commentService.create({
+        organizationId: auth.organization.localOrganizationId,
+        projectId: stored.project.id,
+        issueId: createdIssue.id,
+        actorUserId: auth.user.localUserId,
+        role: auth.membership.role,
+        auth,
+        body: {
+          body: "Comment created for MCP SDK coverage",
+        },
+      });
+
+      expect(sdkComment.ok).toBe(true);
+
+      if (!sdkComment.ok) {
+        throw new Error("expected SDK comment fixture creation to succeed");
+      }
+
+      const commentsResult = await client.callTool({
+        name: "list_issue_comments",
+        arguments: {
+          projectId: stored.project.id,
+          issueId: createdIssue.identifier,
+        },
+      });
+
+      const commentsContent = (
+        commentsResult as {
+          content?: Array<{
+            type?: string;
+            text?: string;
+          }>;
+        }
+      ).content?.find((item) => item.type === "text");
+
+      if (!commentsContent?.text) {
+        throw new Error("expected list_issue_comments text content");
+      }
+
+      const commentsOutput = JSON.parse(commentsContent.text) as {
+        comments: Array<{
+          id: string;
+          body: string;
+          parentId: string | null;
+        }>;
+        nextCursor: string | null;
+      };
+
+      expect(commentsOutput).toEqual({
+        comments: [
+          expect.objectContaining({
+            id: sdkComment.value.id,
+            body: "Comment created for MCP SDK coverage",
+            parentId: null,
+          }),
+        ],
+        nextCursor: null,
+      });
+
       expect(result.content).toEqual(expect.any(Array));
-      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(8);
+      expect(requestMethods.filter((method) => method === "POST")).toHaveLength(9);
       expect(requestMethods.filter((method) => method === "GET")).toHaveLength(1);
       expect(requestMethods.every((method) => method === "POST" || method === "GET")).toBe(true);
       expect(transportErrors).toEqual([]);
@@ -2313,6 +2381,792 @@ describe("mcpRoutes", () => {
         description: expect.stringContaining("retry key"),
       },
     });
+  });
+
+  it("advertises the list_issue_comments tool with bounded pagination input", async () => {
+    const headers = await authenticatedMcpHeaders();
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "list_issue_comments");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("comment");
+    expect(tool?.inputSchema?.required).toEqual(expect.arrayContaining(["projectId", "issueId"]));
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+      },
+      issueId: {
+        type: "string",
+      },
+      limit: {
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "string",
+        minLength: 1,
+        maxLength: 512,
+      },
+    });
+  });
+
+  it("returns an empty comment page for an accessible issue without comments", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const issue = await new IssueSheetService().createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Issue without comments",
+        issueType: "general_question",
+      },
+    });
+
+    const listFeedSpy = vi.spyOn(IssueSheetService.prototype, "listFeed");
+
+    try {
+      const response = await app.request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "list_issue_comments",
+            arguments: {
+              projectId: stored.project.id,
+              issueId: issue.identifier,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{
+            type: string;
+            text?: string;
+          }>;
+        };
+      };
+
+      expect(body.result?.isError).not.toBe(true);
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+
+      const output = JSON.parse(text!) as {
+        comments: unknown[];
+        nextCursor: string | null;
+      };
+
+      expect(output).toEqual({
+        comments: [],
+        nextCursor: null,
+      });
+
+      expect(listFeedSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: auth.organization.localOrganizationId,
+          projectId: stored.project.id,
+          issueId: issue.identifier,
+          actorUserId: auth.user.localUserId,
+        }),
+      );
+    } finally {
+      listFeedSpy.mockRestore();
+    }
+  });
+
+  it("returns root comments and replies without feed activities", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const issueService = new IssueSheetService();
+    const commentService = new IssueSheetCommentService();
+
+    const issue = await issueService.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Issue with discussion",
+        issueType: "general_question",
+      },
+    });
+
+    const root = await commentService.create({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      issueId: issue.id,
+      actorUserId: auth.user.localUserId,
+      role: auth.membership.role,
+      auth,
+      body: {
+        body: "Root comment",
+        mentionedUserIds: [auth.user.localUserId],
+        mentionedIssueIds: [issue.id],
+      },
+    });
+
+    expect(root.ok).toBe(true);
+
+    if (!root.ok) {
+      throw new Error("expected root comment creation to succeed");
+    }
+
+    const reply = await commentService.create({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      issueId: issue.id,
+      actorUserId: auth.user.localUserId,
+      role: auth.membership.role,
+      auth,
+      body: {
+        body: "Reply comment",
+        parentId: root.value.id,
+      },
+    });
+
+    expect(reply.ok).toBe(true);
+
+    if (!reply.ok) {
+      throw new Error("expected reply creation to succeed");
+    }
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "list_issue_comments",
+          arguments: {
+            projectId: stored.project.id,
+            issueId: issue.identifier,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{
+          type: string;
+          text?: string;
+        }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+
+    const text = body.result?.content?.[0]?.text;
+    expect(text).toBeDefined();
+
+    const output = JSON.parse(text!) as {
+      comments: Array<{
+        id: string;
+        body: string;
+        parentId: string | null;
+        author: {
+          userId: string;
+          displayName: string;
+          email: string | null;
+          avatarUrl: string | null;
+        } | null;
+        mentionedUserIds: string[];
+        mentionedIssueIds: string[];
+        createdAt: string;
+        updatedAt: string;
+      }>;
+      nextCursor: string | null;
+    };
+
+    expect(output.comments).toHaveLength(2);
+    expect(output.comments[0]).toMatchObject({
+      id: root.value.id,
+      body: "Root comment",
+      parentId: null,
+      author: {
+        userId: auth.user.localUserId,
+        displayName: expect.any(String),
+      },
+      mentionedUserIds: [auth.user.localUserId],
+      mentionedIssueIds: [issue.id],
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+    });
+
+    expect(output.comments[1]).toMatchObject({
+      body: "Reply comment",
+      parentId: root.value.id,
+    });
+
+    expect(output.comments.map((comment) => comment.id)).toEqual([root.value.id, reply.value.id]);
+    expect(output.nextCursor).toBeNull();
+
+    expect(output.comments[0]).not.toHaveProperty("organizationId");
+    expect(output.comments[0]).not.toHaveProperty("projectId");
+    expect(output.comments[0]).not.toHaveProperty("issueId");
+    expect(output.comments[0]).not.toHaveProperty("path");
+    expect(output.comments[0]).not.toHaveProperty("depth");
+    expect(output.comments[0]).not.toHaveProperty("canEdit");
+    expect(output.comments[0]).not.toHaveProperty("canDelete");
+  });
+
+  it("does not return deleted comments", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const issueService = new IssueSheetService();
+    const commentService = new IssueSheetCommentService();
+
+    const issue = await issueService.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Issue with deleted comment",
+        issueType: "general_question",
+      },
+    });
+
+    const comment = await commentService.create({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      issueId: issue.id,
+      actorUserId: auth.user.localUserId,
+      role: auth.membership.role,
+      auth,
+      body: {
+        body: "Comment to delete",
+      },
+    });
+
+    expect(comment.ok).toBe(true);
+
+    if (!comment.ok) {
+      throw new Error("expected comment creation to succeed");
+    }
+
+    const deleted = await commentService.delete({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      issueId: issue.id,
+      commentId: comment.value.id,
+      actorUserId: auth.user.localUserId,
+      role: auth.membership.role,
+    });
+
+    expect(deleted).toEqual({ ok: true });
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "list_issue_comments",
+          arguments: {
+            projectId: stored.project.id,
+            issueId: issue.identifier,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{
+          type: string;
+          text?: string;
+        }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+
+    const text = body.result?.content?.[0]?.text;
+    expect(text).toBeDefined();
+
+    const output = JSON.parse(text!) as {
+      comments: Array<{
+        id: string;
+        body: string;
+      }>;
+      nextCursor: string | null;
+    };
+
+    expect(output).toEqual({
+      comments: [],
+      nextCursor: null,
+    });
+
+    expect(output.comments.some((item) => item.id === comment.value.id)).toBe(false);
+  });
+
+  it("paginates comments without activity-only pages", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const issueService = new IssueSheetService();
+    const commentService = new IssueSheetCommentService();
+
+    const issue = await issueService.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Issue with paginated comments",
+        issueType: "general_question",
+      },
+    });
+
+    const firstComment = await commentService.create({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      issueId: issue.id,
+      actorUserId: auth.user.localUserId,
+      role: auth.membership.role,
+      auth,
+      body: {
+        body: "First comment",
+      },
+    });
+
+    expect(firstComment.ok).toBe(true);
+
+    if (!firstComment.ok) {
+      throw new Error("expected first comment creation to succeed");
+    }
+
+    const secondComment = await commentService.create({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      issueId: issue.id,
+      actorUserId: auth.user.localUserId,
+      role: auth.membership.role,
+      auth,
+      body: {
+        body: "Second comment",
+      },
+    });
+
+    expect(secondComment.ok).toBe(true);
+
+    if (!secondComment.ok) {
+      throw new Error("expected second comment creation to succeed");
+    }
+
+    // Give the comments deterministic ordering even if PostgreSQL assigned
+    // equal timestamps during this fast test.
+    const sharedCreatedAt = new Date(Date.now() + 60_000);
+
+    await db
+      .update(schema.issueSheetComments)
+      .set({
+        createdAt: sharedCreatedAt,
+        updatedAt: sharedCreatedAt,
+      })
+      .where(eq(schema.issueSheetComments.id, firstComment.value.id));
+
+    await db
+      .update(schema.issueSheetComments)
+      .set({
+        createdAt: sharedCreatedAt,
+        updatedAt: sharedCreatedAt,
+      })
+      .where(eq(schema.issueSheetComments.id, secondComment.value.id));
+
+    const expectedComments = [
+      {
+        id: firstComment.value.id,
+        body: "First comment",
+      },
+      {
+        id: secondComment.value.id,
+        body: "Second comment",
+      },
+    ].sort((left, right) => left.id.localeCompare(right.id));
+
+    const callListIssueComments = async (cursor?: string) => {
+      const response = await app.request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "list_issue_comments",
+            arguments: {
+              projectId: stored.project.id,
+              issueId: issue.identifier,
+              limit: 1,
+              ...(cursor ? { cursor } : {}),
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{
+            type: string;
+            text?: string;
+          }>;
+        };
+      };
+
+      expect(body.result?.isError).not.toBe(true);
+
+      const text = body.result?.content?.[0]?.text;
+      expect(text).toBeDefined();
+
+      return JSON.parse(text!) as {
+        comments: Array<{
+          id: string;
+          body: string;
+        }>;
+        nextCursor: string | null;
+      };
+    };
+
+    const firstPage = await callListIssueComments();
+
+    expect(firstPage.comments).toEqual([expect.objectContaining(expectedComments[0])]);
+
+    expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const secondPage = await callListIssueComments(firstPage.nextCursor!);
+
+    expect(secondPage.comments).toEqual([expect.objectContaining(expectedComments[1])]);
+
+    expect(secondPage.nextCursor).toBeNull();
+
+    expect([firstPage.comments[0]?.id, secondPage.comments[0]?.id]).toEqual(
+      expectedComments.map((comment) => comment.id),
+    );
+  });
+
+  it("rejects a comment cursor belonging to another issue", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const issueService = new IssueSheetService();
+    const commentService = new IssueSheetCommentService();
+
+    const issueA = await issueService.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Issue A",
+        issueType: "general_question",
+      },
+    });
+
+    const issueB = await issueService.createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Issue B",
+        issueType: "general_question",
+      },
+    });
+
+    for (const body of ["First issue A comment", "Second issue A comment"]) {
+      const comment = await commentService.create({
+        organizationId: auth.organization.localOrganizationId,
+        projectId: stored.project.id,
+        issueId: issueA.id,
+        actorUserId: auth.user.localUserId,
+        role: auth.membership.role,
+        auth,
+        body: { body },
+      });
+
+      expect(comment.ok).toBe(true);
+
+      if (!comment.ok) {
+        throw new Error("expected comment creation to succeed");
+      }
+    }
+
+    const callListIssueComments = async (input: {
+      issueId: string;
+      cursor?: string;
+      limit?: number;
+    }) => {
+      const response = await app.request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "list_issue_comments",
+            arguments: {
+              projectId: stored.project.id,
+              issueId: input.issueId,
+              limit: input.limit ?? 1,
+              ...(input.cursor ? { cursor: input.cursor } : {}),
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      return (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{
+            type: string;
+            text?: string;
+          }>;
+        };
+      };
+    };
+
+    const issueAResponse = await callListIssueComments({
+      issueId: issueA.identifier,
+      limit: 1,
+    });
+
+    expect(issueAResponse.result?.isError).not.toBe(true);
+
+    const firstPageText = issueAResponse.result?.content?.[0]?.text;
+
+    expect(firstPageText).toBeDefined();
+
+    const firstPage = JSON.parse(firstPageText!) as {
+      comments: Array<{ id: string }>;
+      nextCursor: string | null;
+    };
+
+    expect(firstPage.comments).toHaveLength(1);
+    expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const issueBResponse = await callListIssueComments({
+      issueId: issueB.identifier,
+      cursor: firstPage.nextCursor!,
+    });
+
+    expect(issueBResponse.result?.isError).toBe(true);
+
+    const errorText = issueBResponse.result?.content?.[0]?.text;
+
+    expect(errorText).toBeDefined();
+    expect(errorText).toContain("invalid_comment_cursor");
+  });
+
+  it("returns invalid_comment_cursor for a malformed cursor", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const issue = await new IssueSheetService().createIssue({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      actorUserId: auth.user.localUserId,
+      body: {
+        title: "Issue with invalid cursor",
+        issueType: "general_question",
+      },
+    });
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "list_issue_comments",
+          arguments: {
+            projectId: stored.project.id,
+            issueId: issue.identifier,
+            cursor: "not-a-valid-cursor",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{
+          type: string;
+          text?: string;
+        }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toContain("invalid_comment_cursor");
+  });
+
+  it.each([
+    {
+      label: "wrong JSON type",
+      cursor: 123,
+    },
+    {
+      label: "overlong value",
+      cursor: "x".repeat(513),
+    },
+  ])("returns invalid_comment_cursor for a $label cursor", async ({ cursor }) => {
+    const headers = await authenticatedMcpHeaders();
+    const listFeedSpy = vi.spyOn(IssueSheetService.prototype, "listFeed");
+
+    try {
+      const response = await app.request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "list_issue_comments",
+            arguments: {
+              projectId: "project-id",
+              issueId: "HL-1",
+              cursor,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{
+            type: string;
+            text?: string;
+          }>;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toContain("invalid_comment_cursor");
+      expect(listFeedSpy).not.toHaveBeenCalled();
+    } finally {
+      listFeedSpy.mockRestore();
+    }
   });
 
   it("rejects get_issue calls with a non-UUID issue ID", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -2777,7 +2777,7 @@ describe("mcpRoutes", () => {
     expect(output.comments.some((item) => item.id === comment.value.id)).toBe(false);
   });
 
-  it("paginates comments without activity-only pages", async () => {
+  it("paginates comments after the cursor comment is deleted", async () => {
     const stored = await fixture.createStoredProjectFixture();
     const headers = await authenticatedMcpHeaders(stored.identity);
     const auth = globalThis.__testApiAuthContext;
@@ -2921,6 +2921,17 @@ describe("mcpRoutes", () => {
     expect(firstPage.comments).toEqual([expect.objectContaining(expectedComments[0])]);
 
     expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const deleted = await commentService.delete({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      issueId: issue.id,
+      commentId: firstPage.comments[0]!.id,
+      actorUserId: auth.user.localUserId,
+      role: auth.membership.role,
+    });
+
+    expect(deleted).toEqual({ ok: true });
 
     const secondPage = await callListIssueComments(firstPage.nextCursor!);
 

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -65,12 +65,14 @@ import { resolveMcpClientMetadata } from "@/api/auth/mcp-client-metadata";
 import { isErr } from "@/lib/primitives/result/results";
 import {
   issueSheetCreateIssueBodySchema,
+  issueSheetFeedQuerySchema,
   issueSheetUpdateIssueBodySchema,
 } from "@/api/routes/project/issue-sheet.schema";
 import {
   IssueSheetService,
   type IssueSheetIssue,
 } from "@/lib/projects/issue-sheet/issue-sheet-service";
+import type { IssueSheetComment } from "@/lib/projects/issue-sheet/issue-sheet-comment-service";
 import { isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
 
 const authorizationQuerySchema = z.object({
@@ -388,6 +390,29 @@ const mcpGetIssueInputSchema = z.object({
   ),
 });
 
+const issueSheetFeedQueryShape = issueSheetFeedQuerySchema.shape;
+
+const invalidCommentCursor = Symbol("invalid_comment_cursor");
+
+const mcpListIssueCommentsInputSchema = z.object({
+  projectId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(128)
+    .describe("ID of the accessible project containing the issue."),
+  issueId: issueIdSchema.describe(
+    "Canonical issue identifier such as HL-123, or a legacy issue UUID.",
+  ),
+  limit: issueSheetFeedQueryShape.limit.describe(
+    "Maximum number of comment threads to return, from 1 to 100.",
+  ),
+  cursor: issueSheetFeedQueryShape.cursor
+    .catch(invalidCommentCursor as never)
+    .meta({ default: undefined })
+    .describe("Opaque cursor returned by a previous list_issue_comments call."),
+});
+
 const issueSheetService = new IssueSheetService();
 const createIssueShape = issueSheetCreateIssueBodySchema.shape;
 const updateIssueShape = issueSheetUpdateIssueBodySchema.shape;
@@ -573,6 +598,19 @@ function compactMcpIssue(issue: OrganizationIssueListItem) {
   };
 }
 
+function mcpIssueComment(comment: IssueSheetComment) {
+  return {
+    id: comment.id,
+    body: comment.body,
+    author: comment.author,
+    parentId: comment.parentId,
+    mentionedUserIds: comment.mentionedUserIds,
+    mentionedIssueIds: comment.mentionedIssueIds,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  };
+}
+
 async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
   const apiAuth = apiAuthContextFromMcpAuth(auth);
   const server = new McpServer({
@@ -669,6 +707,73 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
           },
         ],
       };
+    },
+  );
+
+  server.registerTool(
+    "list_issue_comments",
+    {
+      description:
+        "List comment threads for one accessible Hyperlocalise issue with cursor pagination. Root comments are ordered chronologically, with each root followed by its replies in chronological order.",
+      inputSchema: mcpListIssueCommentsInputSchema,
+    },
+    async ({ projectId, issueId, limit, cursor }) => {
+      if ((cursor as unknown) === invalidCommentCursor) {
+        return mcpToolError("invalid_comment_cursor", "Invalid comment cursor");
+      }
+
+      const [project] = await db
+        .select({ id: schema.projects.id })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("issue_not_found", "Issue not found");
+      }
+
+      try {
+        const feed = await issueSheetService.listFeed({
+          organizationId: apiAuth.organization.localOrganizationId,
+          projectId: project.id,
+          issueId,
+          actorUserId: apiAuth.user.localUserId,
+          role: apiAuth.membership.role,
+          limit,
+          cursor,
+          mode: "comments",
+        });
+
+        const comments = feed.items.flatMap((item) => {
+          if (item.kind !== "comment_thread") {
+            return [];
+          }
+
+          return [mcpIssueComment(item.root), ...item.replies.map(mcpIssueComment)];
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                comments,
+                nextCursor: feed.nextCursor,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof Error && error.message === "issue_sheet_issue_not_found") {
+          return mcpToolError("issue_not_found", "Issue not found");
+        }
+
+        if (error instanceof Error && error.message === "invalid_issue_sheet_feed_cursor") {
+          return mcpToolError("invalid_comment_cursor", "Invalid comment cursor");
+        }
+
+        throw error;
+      }
     },
   );
 

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -825,6 +825,7 @@ export class IssueSheetService {
     role: OrganizationMembershipRole;
     limit?: number;
     cursor?: string;
+    mode?: "all" | "comments";
   }): Promise<IssueSheetFeedResult> {
     const [issue] = await this.database
       .select({ id: schema.issueSheetIssues.id })
@@ -848,66 +849,106 @@ export class IssueSheetService {
       throw new Error("invalid_issue_sheet_feed_cursor");
     }
 
+    const commentsOnly = input.mode === "comments";
+
+    if (parsedCursor && commentsOnly) {
+      if (parsedCursor.sortRank !== 1) {
+        throw new Error("invalid_issue_sheet_feed_cursor");
+      }
+
+      const [cursorComment] = await this.database
+        .select({ id: schema.issueSheetComments.id })
+        .from(schema.issueSheetComments)
+        .where(
+          and(
+            eq(schema.issueSheetComments.organizationId, input.organizationId),
+            eq(schema.issueSheetComments.projectId, input.projectId),
+            eq(schema.issueSheetComments.issueId, issue.id),
+            eq(schema.issueSheetComments.id, parsedCursor.id),
+            eq(schema.issueSheetComments.depth, 0),
+            sql`${schema.issueSheetComments.createdAt} = ${parsedCursor.createdAt}::timestamptz`,
+          ),
+        )
+        .limit(1);
+
+      if (!cursorComment) {
+        throw new Error("invalid_issue_sheet_feed_cursor");
+      }
+    }
+
+    const kindFilter = commentsOnly ? sql`and feed.kind = 'comment_thread'` : sql``;
+
     const cursorFilter = parsedCursor
       ? sql`and (feed.created_at, feed.sort_rank, feed.id) > (${parsedCursor.createdAt}::timestamptz, ${parsedCursor.sortRank}, ${parsedCursor.id}::uuid)`
       : sql``;
 
+    const activityCount = commentsOnly
+      ? sql`0`
+      : sql`
+      (
+        select count(*)::int
+        from ${schema.issueSheetActivities}
+        where ${schema.issueSheetActivities.organizationId} = ${input.organizationId}
+          and ${schema.issueSheetActivities.projectId} = ${input.projectId}
+          and ${schema.issueSheetActivities.issueId} = ${issue.id}
+      )
+    `;
+
+    const totalQuery = sql`
+  select (
+    ${activityCount}
+    +
+    (
+      select count(*)::int
+      from ${schema.issueSheetComments}
+      where ${schema.issueSheetComments.organizationId} = ${input.organizationId}
+        and ${schema.issueSheetComments.projectId} = ${input.projectId}
+        and ${schema.issueSheetComments.issueId} = ${issue.id}
+        and ${schema.issueSheetComments.depth} = 0
+    )
+  ) as total
+`;
+
     const [totalRow, feedResult] = await Promise.all([
+      this.database.execute(totalQuery),
       this.database.execute(sql`
-        select (
-          (
-            select count(*)::int
-            from ${schema.issueSheetActivities}
-            where ${schema.issueSheetActivities.organizationId} = ${input.organizationId}
-              and ${schema.issueSheetActivities.projectId} = ${input.projectId}
-              and ${schema.issueSheetActivities.issueId} = ${issue.id}
-          )
-          +
-          (
-            select count(*)::int
-            from ${schema.issueSheetComments}
-            where ${schema.issueSheetComments.organizationId} = ${input.organizationId}
-              and ${schema.issueSheetComments.projectId} = ${input.projectId}
-              and ${schema.issueSheetComments.issueId} = ${issue.id}
-              and ${schema.issueSheetComments.depth} = 0
-          )
-        ) as total
-      `),
-      this.database.execute(sql`
-        select feed.id, feed.kind, feed.created_at, feed.created_at_cursor, feed.sort_rank
-        from (
-          select
-            ${schema.issueSheetActivities.id} as id,
-            'activity'::text as kind,
-            ${schema.issueSheetActivities.createdAt} as created_at,
-            ${schema.issueSheetActivities.createdAt}::text as created_at_cursor,
-            case
-              when ${schema.issueSheetActivities.type} = ${ISSUE_SHEET_ACTIVITY_ISSUE_CREATED}
-              then 0
-              else 1
-            end as sort_rank
-          from ${schema.issueSheetActivities}
-          where ${schema.issueSheetActivities.organizationId} = ${input.organizationId}
-            and ${schema.issueSheetActivities.projectId} = ${input.projectId}
-            and ${schema.issueSheetActivities.issueId} = ${issue.id}
-          union all
-          select
-            ${schema.issueSheetComments.id} as id,
-            'comment_thread'::text as kind,
-            ${schema.issueSheetComments.createdAt} as created_at,
-            ${schema.issueSheetComments.createdAt}::text as created_at_cursor,
-            1 as sort_rank
-          from ${schema.issueSheetComments}
-          where ${schema.issueSheetComments.organizationId} = ${input.organizationId}
-            and ${schema.issueSheetComments.projectId} = ${input.projectId}
-            and ${schema.issueSheetComments.issueId} = ${issue.id}
-            and ${schema.issueSheetComments.depth} = 0
-        ) as feed
-        where true
-        ${cursorFilter}
-        order by feed.created_at asc, feed.sort_rank asc, feed.id asc
-        limit ${limit + 1}
-      `),
+    select feed.id, feed.kind, feed.created_at, feed.created_at_cursor, feed.sort_rank
+    from (
+      select
+        ${schema.issueSheetActivities.id} as id,
+        'activity'::text as kind,
+        ${schema.issueSheetActivities.createdAt} as created_at,
+        ${schema.issueSheetActivities.createdAt}::text as created_at_cursor,
+        case
+          when ${schema.issueSheetActivities.type} = ${ISSUE_SHEET_ACTIVITY_ISSUE_CREATED}
+          then 0
+          else 1
+        end as sort_rank
+      from ${schema.issueSheetActivities}
+      where ${schema.issueSheetActivities.organizationId} = ${input.organizationId}
+        and ${schema.issueSheetActivities.projectId} = ${input.projectId}
+        and ${schema.issueSheetActivities.issueId} = ${issue.id}
+
+      union all
+
+      select
+        ${schema.issueSheetComments.id} as id,
+        'comment_thread'::text as kind,
+        ${schema.issueSheetComments.createdAt} as created_at,
+        ${schema.issueSheetComments.createdAt}::text as created_at_cursor,
+        1 as sort_rank
+      from ${schema.issueSheetComments}
+      where ${schema.issueSheetComments.organizationId} = ${input.organizationId}
+        and ${schema.issueSheetComments.projectId} = ${input.projectId}
+        and ${schema.issueSheetComments.issueId} = ${issue.id}
+        and ${schema.issueSheetComments.depth} = 0
+    ) as feed
+    where true
+    ${kindFilter}
+    ${cursorFilter}
+    order by feed.created_at asc, feed.sort_rank asc, feed.id asc
+    limit ${limit + 1}
+  `),
     ]);
 
     const total = Number(rowsFromExecute<{ total?: number }>(totalRow)[0]?.total ?? 0);

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -163,12 +163,12 @@ const FEED_CURSOR_UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 
 function parseFeedCursor(
   cursor: string,
-): { createdAt: string; sortRank: number; id: string } | null {
+): { createdAt: string; sortRank: number; id: string; issueId?: string } | null {
   const parts = cursor.split("|");
-  if (parts.length !== 3) {
+  if (parts.length !== 3 && parts.length !== 4) {
     return null;
   }
-  const [createdAt, sortRankRaw, id] = parts;
+  const [createdAt, sortRankRaw, id, issueId] = parts;
   if (!createdAt || Number.isNaN(Date.parse(createdAt))) {
     return null;
   }
@@ -178,11 +178,20 @@ function parseFeedCursor(
   if (!id || !FEED_CURSOR_UUID_PATTERN.test(id)) {
     return null;
   }
-  return { createdAt, sortRank: Number(sortRankRaw), id };
+  if (issueId !== undefined && !FEED_CURSOR_UUID_PATTERN.test(issueId)) {
+    return null;
+  }
+  return { createdAt, sortRank: Number(sortRankRaw), id, issueId };
 }
 
-function encodeFeedCursor(input: { createdAt: string; sortRank: number; id: string }) {
-  return `${input.createdAt}|${input.sortRank}|${input.id}`;
+function encodeFeedCursor(input: {
+  createdAt: string;
+  sortRank: number;
+  id: string;
+  issueId?: string;
+}) {
+  const cursor = `${input.createdAt}|${input.sortRank}|${input.id}`;
+  return input.issueId ? `${cursor}|${input.issueId}` : cursor;
 }
 
 type ActivityRow = {
@@ -851,29 +860,16 @@ export class IssueSheetService {
 
     const commentsOnly = input.mode === "comments";
 
-    if (parsedCursor && commentsOnly) {
-      if (parsedCursor.sortRank !== 1) {
-        throw new Error("invalid_issue_sheet_feed_cursor");
-      }
+    if (parsedCursor?.issueId && parsedCursor.issueId !== issue.id) {
+      throw new Error("invalid_issue_sheet_feed_cursor");
+    }
 
-      const [cursorComment] = await this.database
-        .select({ id: schema.issueSheetComments.id })
-        .from(schema.issueSheetComments)
-        .where(
-          and(
-            eq(schema.issueSheetComments.organizationId, input.organizationId),
-            eq(schema.issueSheetComments.projectId, input.projectId),
-            eq(schema.issueSheetComments.issueId, issue.id),
-            eq(schema.issueSheetComments.id, parsedCursor.id),
-            eq(schema.issueSheetComments.depth, 0),
-            sql`${schema.issueSheetComments.createdAt} = ${parsedCursor.createdAt}::timestamptz`,
-          ),
-        )
-        .limit(1);
-
-      if (!cursorComment) {
-        throw new Error("invalid_issue_sheet_feed_cursor");
-      }
+    if (
+      parsedCursor &&
+      commentsOnly &&
+      (parsedCursor.sortRank !== 1 || parsedCursor.issueId === undefined)
+    ) {
+      throw new Error("invalid_issue_sheet_feed_cursor");
     }
 
     const kindFilter = commentsOnly ? sql`and feed.kind = 'comment_thread'` : sql``;
@@ -1058,6 +1054,7 @@ export class IssueSheetService {
         createdAt: String(last.created_at_cursor),
         sortRank: Number(last.sort_rank),
         id: String(last.id),
+        ...(commentsOnly ? { issueId: issue.id } : {}),
       });
     }
 


### PR DESCRIPTION
## What changed

- Added the `list_issue_comments` tool to the hosted MCP server.
- Reused the Issue Sheet feed service instead of introducing a parallel comments query.
- Added a comments-only feed mode that excludes activity entries while preserving the existing web feed behavior.
- Returned root comments followed by their replies in stable chronological order.
- Added opaque cursor pagination with deterministic ordering across equal timestamps.
- Validated cursors against the requested issue and mapped malformed, invalid, and foreign cursors to `invalid_comment_cursor`.
- Preserved project, team, and organization isolation with indistinguishable `issue_not_found` errors.
- Shaped comment output to expose author, mentions, thread relationships, and timestamps without leaking internal fields.
- Added route, access-control, pagination, validation, deleted-comment, and MCP SDK integration coverage.

## How to test

- Run the MCP route tests:

  ```bash
  vp test src/api/routes/mcp/mcp.route.test.ts

- Run the full test suite:
   ```bash
   vp test

- Run the production build:
   ```bash
   vp run build

## Checklist
-  I ran relevant checks locally (make fmt, make lint, make test)
-  I updated docs, comments, or examples when needed
-  This PR is scoped and ready for review