### PR TITLE
feat(mt): add machine translation client contract

### DIFF
--- a/apps/go-svc/README.md
+++ b/apps/go-svc/README.md
@@ -70,6 +70,13 @@ client, err := gsc.NewClient(gsc.Config{
 
 GSC API calls are free and do not consume DataForSEO credits.
 
+### Machine translation client
+
+`internal/mt` defines the shared machine-translation client contract for
+go-svc, including the `Engine` interface, request and response types,
+configuration, and typed errors. Vendor MT integrations use this package as
+library clients; it does not expose an HTTP route.
+
 ## Local development
 
 From the repository root:

--- a/internal/mt/BUILD.bazel
+++ b/internal/mt/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "mt",
+    srcs = [
+        "config.go",
+        "doc.go",
+        "engine.go",
+        "errors.go",
+        "types.go",
+        "validate.go",
+    ],
+    importpath = "github.com/hyperlocalise/hyperlocalise/internal/mt",
+    visibility = ["//:__subpackages__"],
+    deps = ["@org_golang_x_text//language"],
+)
+
+go_test(
+    name = "mt_test",
+    srcs = [
+        "config_test.go",
+        "errors_test.go",
+        "testhelpers_test.go",
+        "validate_test.go",
+    ],
+    embed = [":mt"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/internal/mt/config.go
+++ b/internal/mt/config.go
@@ -1,0 +1,37 @@
+package mt
+
+import (
+	"net/http"
+	"time"
+)
+
+const defaultHTTPTimeout = 30 * time.Second
+
+type Config struct {
+	// APIKey authenticates Google and DeepL.
+	APIKey string
+
+	// SubscriptionKey authenticates Microsoft.
+	SubscriptionKey string
+
+	// AccessKeyID and SecretAccessKey authenticate Amazon.
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+
+	// Region is required by Microsoft and Amazon.
+	Region string
+
+	// CustomModel is an optional Microsoft custom model ID.
+	CustomModel string
+
+	BaseURL string
+	HTTPClient *http.Client
+}
+
+func (c Config) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{Timeout: defaultHTTPTimeout}
+}

--- a/internal/mt/config.go
+++ b/internal/mt/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	// CustomModel is an optional Microsoft custom model ID.
 	CustomModel string
 
-	BaseURL string
+	BaseURL    string
 	HTTPClient *http.Client
 }
 

--- a/internal/mt/config_test.go
+++ b/internal/mt/config_test.go
@@ -1,0 +1,27 @@
+package mt
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigHTTPClientDefaultsWhenUnset(t *testing.T) {
+	cfg := Config{}
+
+	client := cfg.httpClient()
+
+	require.NotNil(t, client)
+	require.Equal(t, defaultHTTPTimeout, client.Timeout)
+}
+
+func TestConfigHTTPClientReturnsConfiguredClient(t *testing.T) {
+	custom := &http.Client{Timeout: 5 * time.Second}
+	cfg := Config{HTTPClient: custom}
+
+	client := cfg.httpClient()
+
+	require.Same(t, custom, client)
+}

--- a/internal/mt/doc.go
+++ b/internal/mt/doc.go
@@ -1,0 +1,2 @@
+// Package mt defines shared types and interfaces for machine-translation clients.
+package mt

--- a/internal/mt/engine.go
+++ b/internal/mt/engine.go
@@ -1,0 +1,10 @@
+package mt
+
+import "context"
+
+// Engine translates batches of text between locales.
+type Engine interface {
+    // Translate returns translations in the same order as req.Sources.
+	// Context cancellation and deadline errors remain detectable with errors.Is.
+	Translate(ctx context.Context, req Request) (Response, error)
+}

--- a/internal/mt/engine.go
+++ b/internal/mt/engine.go
@@ -4,7 +4,7 @@ import "context"
 
 // Engine translates batches of text between locales.
 type Engine interface {
-    // Translate returns translations in the same order as req.Sources.
+	// Translate returns translations in the same order as req.Sources.
 	// Context cancellation and deadline errors remain detectable with errors.Is.
 	Translate(ctx context.Context, req Request) (Response, error)
 }

--- a/internal/mt/errors.go
+++ b/internal/mt/errors.go
@@ -1,0 +1,42 @@
+package mt
+
+import (
+	"errors"
+	"fmt"
+)
+
+type ErrorCode string
+
+const (
+	ErrorCodeAuthFailed              ErrorCode = "mt_auth_failed"
+	ErrorCodeRateLimited             ErrorCode = "mt_rate_limited"
+	ErrorCodeUnsupportedLanguagePair ErrorCode = "mt_unsupported_language_pair"
+	ErrorCodeValidation              ErrorCode = "mt_validation_error"
+	ErrorCodeUpstreamUnavailable     ErrorCode = "mt_upstream_unavailable"
+	ErrorCodeUpstream ErrorCode = "mt_upstream_error"
+)
+
+type Error struct {
+	Code       ErrorCode
+	Message    string
+	StatusCode int
+	Path       string
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Path != "" {
+		return fmt.Sprintf("%s: %s (%s)", e.Code, e.Message, e.Path)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func AsError(err error) (*Error, bool) {
+	var typed *Error
+	if errors.As(err, &typed) {
+		return typed, true
+	}
+	return nil, false
+}

--- a/internal/mt/errors.go
+++ b/internal/mt/errors.go
@@ -13,7 +13,7 @@ const (
 	ErrorCodeUnsupportedLanguagePair ErrorCode = "mt_unsupported_language_pair"
 	ErrorCodeValidation              ErrorCode = "mt_validation_error"
 	ErrorCodeUpstreamUnavailable     ErrorCode = "mt_upstream_unavailable"
-	ErrorCodeUpstream ErrorCode = "mt_upstream_error"
+	ErrorCodeUpstream                ErrorCode = "mt_upstream_error"
 )
 
 type Error struct {

--- a/internal/mt/errors_test.go
+++ b/internal/mt/errors_test.go
@@ -1,0 +1,48 @@
+package mt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorErrorNilReceiver(t *testing.T) {
+	var err *Error
+
+	require.Equal(t, "<nil>", err.Error())
+}
+
+func TestErrorErrorFormatting(t *testing.T) {
+	withPath := &Error{Code: ErrorCodeAuthFailed, Message: "invalid credentials", Path: "/translate"}
+	require.Equal(t, "mt_auth_failed: invalid credentials (/translate)", withPath.Error())
+
+	withoutPath := &Error{Code: ErrorCodeRateLimited, Message: "too many requests"}
+	require.Equal(t, "mt_rate_limited: too many requests", withoutPath.Error())
+}
+
+func TestAsErrorDirectMatch(t *testing.T) {
+	original := &Error{Code: ErrorCodeValidation, Message: "bad request"}
+
+	typed, ok := AsError(original)
+
+	require.True(t, ok)
+	require.Same(t, original, typed)
+}
+
+func TestAsErrorThroughWrap(t *testing.T) {
+	original := &Error{Code: ErrorCodeUpstreamUnavailable, Message: "service down"}
+	wrapped := fmt.Errorf("vendor request failed: %w", original)
+
+	typed, ok := AsError(wrapped)
+
+	require.True(t, ok)
+	require.Same(t, original, typed)
+}
+
+func TestAsErrorNoMatch(t *testing.T) {
+	typed, ok := AsError(fmt.Errorf("plain error"))
+
+	require.False(t, ok)
+	require.Nil(t, typed)
+}

--- a/internal/mt/testhelpers_test.go
+++ b/internal/mt/testhelpers_test.go
@@ -1,0 +1,34 @@
+package mt
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestServer(t *testing.T, handler http.HandlerFunc) Config {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return Config{
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+	}
+}
+
+func TestNewTestServerServesHandler(t *testing.T) {
+	var gotPath string
+	cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+
+	resp, err := cfg.HTTPClient.Get(cfg.BaseURL + "/ping")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, "/ping", gotPath)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/internal/mt/testhelpers_test.go
+++ b/internal/mt/testhelpers_test.go
@@ -27,7 +27,10 @@ func TestNewTestServerServesHandler(t *testing.T) {
 
 	resp, err := cfg.HTTPClient.Get(cfg.BaseURL + "/ping")
 	require.NoError(t, err)
-	defer resp.Body.Close()
+
+	defer func() {
+		require.NoError(t, resp.Body.Close())
+	}()
 
 	require.Equal(t, "/ping", gotPath)
 	require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/internal/mt/types.go
+++ b/internal/mt/types.go
@@ -1,0 +1,13 @@
+package mt
+
+// Request is a batch machine-translation request using BCP 47 locales.
+type Request struct {
+	SourceLocale string
+	TargetLocale string
+	Sources      []string
+}
+
+// Response contains translations in the same order as Request.Sources.
+type Response struct {
+	Translations []string
+}

--- a/internal/mt/validate.go
+++ b/internal/mt/validate.go
@@ -8,11 +8,16 @@ import (
 )
 
 func validateBCP47(locale string) error {
-	trimmed := strings.TrimSpace(locale)
-	if trimmed == "" {
+	if locale == "" {
 		return &Error{Code: ErrorCodeValidation, Message: "locale is required"}
 	}
-	if _, err := language.Parse(trimmed); err != nil {
+	if strings.TrimSpace(locale) != locale {
+		return &Error{
+			Code:    ErrorCodeValidation,
+			Message: fmt.Sprintf("locale %q must not contain leading or trailing whitespace", locale),
+		}
+	}
+	if _, err := language.Parse(locale); err != nil {
 		return &Error{
 			Code:    ErrorCodeValidation,
 			Message: fmt.Sprintf("locale %q must be a valid BCP 47 language tag", locale),

--- a/internal/mt/validate.go
+++ b/internal/mt/validate.go
@@ -1,0 +1,35 @@
+package mt
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/text/language"
+)
+
+func validateBCP47(locale string) error {
+	trimmed := strings.TrimSpace(locale)
+	if trimmed == "" {
+		return &Error{Code: ErrorCodeValidation, Message: "locale is required"}
+	}
+	if _, err := language.Parse(trimmed); err != nil {
+		return &Error{
+			Code:    ErrorCodeValidation,
+			Message: fmt.Sprintf("locale %q must be a valid BCP 47 language tag", locale),
+		}
+	}
+	return nil
+}
+
+func validateRequest(req Request) error {
+	if err := validateBCP47(req.SourceLocale); err != nil {
+		return err
+	}
+	if err := validateBCP47(req.TargetLocale); err != nil {
+		return err
+	}
+	if len(req.Sources) == 0 {
+		return &Error{Code: ErrorCodeValidation, Message: "sources must not be empty"}
+	}
+	return nil
+}

--- a/internal/mt/validate_test.go
+++ b/internal/mt/validate_test.go
@@ -18,6 +18,9 @@ func TestValidateBCP47(t *testing.T) {
 		{name: "empty", locale: "", wantErr: true},
 		{name: "whitespace only", locale: "   ", wantErr: true},
 		{name: "not a locale", locale: "not a locale", wantErr: true},
+		{name: "leading and trailing whitespace", locale: " en ", wantErr: true},
+		{name: "trailing whitespace", locale: "en ", wantErr: true},
+		{name: "leading whitespace", locale: " en", wantErr: true},
 	}
 
 	for _, tc := range cases {

--- a/internal/mt/validate_test.go
+++ b/internal/mt/validate_test.go
@@ -1,0 +1,124 @@
+package mt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateBCP47(t *testing.T) {
+	cases := []struct {
+		name    string
+		locale  string
+		wantErr bool
+	}{
+		{name: "simple language", locale: "en", wantErr: false},
+		{name: "language and region", locale: "en-US", wantErr: false},
+		{name: "language and script", locale: "zh-Hans", wantErr: false},
+		{name: "empty", locale: "", wantErr: true},
+		{name: "whitespace only", locale: "   ", wantErr: true},
+		{name: "not a locale", locale: "not a locale", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBCP47(tc.locale)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeValidation, typed.Code)
+		})
+	}
+}
+
+func TestValidateRequest(t *testing.T) {
+	valid := Request{
+		SourceLocale: "en",
+		TargetLocale: "fr",
+		Sources:      []string{"hello"},
+	}
+
+	cases := []struct {
+		name    string
+		req     Request
+		wantErr bool
+	}{
+		{
+			name:    "valid request",
+			req:     valid,
+			wantErr: false,
+		},
+		{
+			name: "same source and target locale is allowed",
+			req: Request{
+				SourceLocale: "en",
+				TargetLocale: "en",
+				Sources:      []string{"hello"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing source locale",
+			req: Request{
+				SourceLocale: "",
+				TargetLocale: "fr",
+				Sources:      []string{"hello"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid source locale",
+			req: Request{
+				SourceLocale: "not a locale",
+				TargetLocale: "fr",
+				Sources:      []string{"hello"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing target locale",
+			req: Request{
+				SourceLocale: "en",
+				TargetLocale: "",
+				Sources:      []string{"hello"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid target locale",
+			req: Request{
+				SourceLocale: "en",
+				TargetLocale: "not a locale",
+				Sources:      []string{"hello"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty sources",
+			req: Request{
+				SourceLocale: "en",
+				TargetLocale: "fr",
+				Sources:      []string{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRequest(tc.req)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeValidation, typed.Code)
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Added the shared `internal/mt` machine-translation client contract, including batch request/response types, configuration, typed errors, and validation.
- Added shared `httptest` scaffolding for vendor client tests.
- Documented the MT client in the go-svc README.

## How to test

- `go test ./internal/mt`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
