### PR TITLE
refactor(web): use shared UI layout on integrations page

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.tsx
@@ -29,6 +29,10 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/input-group";
+import { Box } from "@/components/ui/layout/box";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
+import { Rows } from "@/components/ui/layout/rows";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -166,18 +170,26 @@ export function EmailIntegrationRow({
       isLoading={isLoading}
       isLast={isLast}
     >
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-3 rounded-lg border border-border bg-background/70 p-3 sm:flex-row sm:items-center sm:justify-between">
-          <TypographyP className="text-sm leading-6 text-muted-foreground">
-            {intl.formatMessage(emailIntegrationRowMessages.panelInstructions)}
-          </TypographyP>
-          <Switch
-            checked={emailAgent?.enabled ?? false}
-            onCheckedChange={toggleEnabled}
-            aria-label={intl.formatMessage(emailIntegrationRowMessages.enableEmailAgentAriaLabel)}
-            disabled={isLoading || isError || updateEmailAgentState.isPending || !userCanManage}
-          />
-        </div>
+      <Rows spacing="2u">
+        <Box padding="1.5u" background="canvas" border="standard" borderRadius="standard">
+          <Columns spacing="1.5u" alignY="center" collapseBelow="small">
+            <Column width="fluid">
+              <TypographyP className="text-sm leading-6 text-muted-foreground">
+                {intl.formatMessage(emailIntegrationRowMessages.panelInstructions)}
+              </TypographyP>
+            </Column>
+            <Column width="content">
+              <Switch
+                checked={emailAgent?.enabled ?? false}
+                onCheckedChange={toggleEnabled}
+                aria-label={intl.formatMessage(
+                  emailIntegrationRowMessages.enableEmailAgentAriaLabel,
+                )}
+                disabled={isLoading || isError || updateEmailAgentState.isPending || !userCanManage}
+              />
+            </Column>
+          </Columns>
+        </Box>
 
         {isError ? (
           <TypographyP className="text-sm text-destructive">
@@ -233,7 +245,7 @@ export function EmailIntegrationRow({
             </Tooltip>
           </InputGroupAddon>
         </InputGroup>
-      </div>
+      </Rows>
     </IntegrationRow>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
@@ -30,6 +30,8 @@ import { RepositoryAutomationSettingsAction } from "./repository-automation-sett
 import { SimpleBrandIcon } from "./simple-brand-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Box } from "@/components/ui/layout/box";
+import { Rows } from "@/components/ui/layout/rows";
 import { Skeleton } from "@/components/ui/skeleton";
 import { createApiClient } from "@/lib/api-client";
 import { cn } from "@/lib/primitives/cn";
@@ -397,7 +399,7 @@ export function GitHubIntegrationRow({
       {isLoading ? (
         <Skeleton className="h-24 rounded-lg" />
       ) : isError ? (
-        <div className="flex flex-col gap-3">
+        <Rows spacing="1.5u">
           <TypographyP className="text-sm text-destructive">
             {error instanceof Error
               ? error.message
@@ -406,10 +408,10 @@ export function GitHubIntegrationRow({
           <Button variant="outline" size="sm" onClick={() => void refetchInstallation()}>
             <FormattedMessage {...githubIntegrationRowMessages.retry} />
           </Button>
-        </div>
+        </Rows>
       ) : connected ? (
-        <div className="flex flex-col gap-5">
-          <div className="flex flex-wrap gap-2">
+        <Rows spacing="2u">
+          <Box display="flex" flexWrap="wrap" gap="1u">
             {installationSettingsUrl ? (
               <Button
                 variant="outline"
@@ -451,9 +453,9 @@ export function GitHubIntegrationRow({
                 <FormattedMessage {...githubIntegrationRowMessages.disconnect} />
               )}
             </Button>
-          </div>
+          </Box>
 
-          <div className="flex flex-col gap-3">
+          <Rows spacing="1.5u">
             <div className="flex flex-col gap-2 md:flex-row">
               <div className="relative min-w-0 flex-1">
                 <HugeiconsIcon
@@ -605,8 +607,8 @@ export function GitHubIntegrationRow({
                 </div>
               )}
             </div>
-          </div>
-        </div>
+          </Rows>
+        </Rows>
       ) : null}
     </IntegrationRow>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
@@ -14,19 +14,25 @@
  */
 import { ArrowDown01Icon, ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type { ReactNode, Ref } from "react";
+import type { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { integrationRowMessages } from "./integration-row.messages";
 
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
 import { Box } from "@/components/ui/layout/box";
-import { Column } from "@/components/ui/layout/column";
-import { Columns } from "@/components/ui/layout/columns";
 import { Rows } from "@/components/ui/layout/rows";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TypographyH3 } from "@/components/ui/typography";
+import { TypographyH4, TypographyMuted } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
 export type IntegrationRowAction = "connect" | "manage" | "coming-soon" | "view-only";
@@ -46,109 +52,65 @@ type IntegrationRowProps = {
   children?: ReactNode;
 };
 
-const actionStyles: Record<
-  IntegrationRowAction,
-  {
-    icon: string;
-    row: string;
-    panel: string;
-    button?: string;
-  }
-> = {
-  "coming-soon": {
-    icon: "border-border bg-muted text-muted-foreground",
-    row: "hover:bg-muted/20",
-    panel: "border-border bg-muted/20",
-  },
-  "view-only": {
-    icon: "border-border bg-muted text-muted-foreground",
-    row: "hover:bg-muted/20",
-    panel: "border-border bg-muted/20",
-  },
-  connect: {
-    icon: "border-border bg-muted/50 text-muted-foreground",
-    row: "hover:bg-muted/20",
-    panel: "border-border bg-muted/20",
-    button: "border-primary/30 bg-primary/10 text-primary hover:bg-primary/15",
-  },
-  manage: {
-    icon: "border-border bg-muted text-foreground",
-    row: "hover:bg-muted/20",
-    panel: "border-border bg-muted/20",
-  },
-};
-
 export function IntegrationRowFrame({
   open,
   onOpenChange,
-  isLast = false,
   highlighted,
-  hoverClassName,
-  highlightClassName,
   icon,
-  iconClassName,
+  iconMuted = false,
   name,
   description,
   nameExtra,
   action,
   showPanel,
-  panelClassName,
   children,
 }: {
   open: boolean;
   onOpenChange?: (open: boolean) => void;
-  isLast?: boolean;
   highlighted: boolean;
-  hoverClassName: string;
-  highlightClassName: string;
   icon?: ReactNode;
-  iconClassName: string;
+  iconMuted?: boolean;
   name: string;
   description: string;
   nameExtra?: ReactNode;
   action: ReactNode;
   showPanel: boolean;
-  panelClassName: string;
   children?: ReactNode;
 }) {
   return (
-    <Collapsible
-      open={open}
-      onOpenChange={onOpenChange}
-      className={cn(!isLast && "border-b border-border")}
-    >
-      <div className={cn("transition-colors", hoverClassName, highlighted && highlightClassName)}>
-        <Box paddingX="2u" paddingY="2u">
-          <Columns spacing="2u" alignY="center">
-            <Column width="content">
-              <div
-                className={cn(
-                  "flex size-10 items-center justify-center rounded-lg border p-2 transition-colors",
-                  iconClassName,
-                )}
-              >
-                {icon}
-              </div>
-            </Column>
-            <Column width="fluid">
-              <Rows spacing="0.5u">
-                <Box display="flex" flexWrap="wrap" alignItems="center" gap="1u">
-                  <p className="text-base font-medium text-foreground">{name}</p>
-                  {nameExtra}
-                </Box>
-                <p className="text-sm leading-6 text-muted-foreground">{description}</p>
-              </Rows>
-            </Column>
-            <Column width="content">{action}</Column>
-          </Columns>
-        </Box>
-      </div>
+    <Collapsible open={open} onOpenChange={onOpenChange}>
+      <Rows spacing="1u">
+        <Item variant={highlighted ? "muted" : "outline"}>
+          <ItemMedia variant="image">
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              width="full"
+              height="full"
+              background={iconMuted ? "muted" : "canvas"}
+            >
+              {icon}
+            </Box>
+          </ItemMedia>
+          <ItemContent>
+            <ItemTitle>
+              {name}
+              {nameExtra}
+            </ItemTitle>
+            <ItemDescription>{description}</ItemDescription>
+          </ItemContent>
+          <ItemActions>{action}</ItemActions>
+        </Item>
 
-      {showPanel ? (
-        <CollapsibleContent className={cn("border-t", panelClassName)}>
-          <Box padding="2u">{children}</Box>
-        </CollapsibleContent>
-      ) : null}
+        {showPanel ? (
+          <CollapsibleContent>
+            <Box background="muted" border="standard" borderRadius="large" padding="2u">
+              {children}
+            </Box>
+          </CollapsibleContent>
+        ) : null}
+      </Rows>
     </Collapsible>
   );
 }
@@ -164,48 +126,38 @@ export function IntegrationRow({
   onConnect,
   isConnecting = false,
   isLoading = false,
-  isLast = false,
   children,
 }: IntegrationRowProps) {
   const showPanel = Boolean(action === "manage" && children);
-  const activeStyle = actionStyles[action];
-  const iconContainerClass = iconMuted
-    ? "border-border bg-background text-foreground"
-    : activeStyle.icon;
 
   return (
     <IntegrationRowFrame
       open={expanded}
       onOpenChange={onExpandedChange}
-      isLast={isLast}
       highlighted={expanded}
-      hoverClassName={activeStyle.row}
-      highlightClassName={activeStyle.panel}
       icon={icon}
-      iconClassName={iconContainerClass}
+      iconMuted={iconMuted || action !== "manage"}
       name={name}
       description={description}
       showPanel={showPanel}
-      panelClassName={activeStyle.panel}
       action={
         isLoading && (action === "connect" || action === "manage") ? (
-          <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
+          <Skeleton className="h-8 w-[5.75rem]" aria-hidden />
         ) : action === "coming-soon" ? (
           <Button type="button" variant="outline" size="sm" disabled>
             <FormattedMessage {...integrationRowMessages.comingSoon} />
           </Button>
         ) : action === "view-only" ? (
-          <span className="text-sm text-muted-foreground">
+          <TypographyMuted>
             <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
-          </span>
+          </TypographyMuted>
         ) : action === "connect" ? (
           <Button
             type="button"
-            variant="outline"
+            variant="default"
             size="sm"
             onClick={onConnect}
             disabled={isConnecting}
-            className={activeStyle.button}
           >
             {isConnecting ? (
               <FormattedMessage {...integrationRowMessages.connecting} />
@@ -235,8 +187,6 @@ export function IntegrationRow({
   );
 }
 
-export const integrationConnectButtonClassName = actionStyles.connect.button!;
-
 type CollapsibleIntegrationRowProps = {
   name: string;
   description: string;
@@ -259,7 +209,6 @@ export function CollapsibleIntegrationRow({
   expanded,
   onExpandedChange,
   isLoading = false,
-  isLast = false,
   children,
 }: CollapsibleIntegrationRowProps) {
   const showPanel = userIsAdmin || isConnected;
@@ -268,33 +217,22 @@ export function CollapsibleIntegrationRow({
     <IntegrationRowFrame
       open={showPanel && expanded}
       onOpenChange={onExpandedChange}
-      isLast={isLast}
       highlighted={expanded}
-      hoverClassName="hover:bg-muted/20"
-      highlightClassName="bg-muted/20"
       icon={icon}
-      iconClassName={
-        isConnected
-          ? "border-border bg-muted text-foreground"
-          : "border-border bg-muted/50 text-muted-foreground"
-      }
+      iconMuted={!isConnected}
       name={name}
       description={description}
       showPanel={showPanel}
-      panelClassName="border-border bg-muted/20"
       action={
         isLoading && showPanel ? (
-          <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
+          <Skeleton className="h-8 w-[5.75rem]" aria-hidden />
         ) : showPanel ? (
           <CollapsibleTrigger
             render={
               <Button
                 type="button"
-                variant="outline"
+                variant={userIsAdmin && !isConnected ? "default" : "outline"}
                 size="sm"
-                className={
-                  userIsAdmin && !isConnected ? integrationConnectButtonClassName : undefined
-                }
               >
                 {userIsAdmin ? (
                   isConnected ? (
@@ -314,9 +252,9 @@ export function CollapsibleIntegrationRow({
             }
           />
         ) : (
-          <span className="text-sm text-muted-foreground">
+          <TypographyMuted>
             <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
-          </span>
+          </TypographyMuted>
         )
       }
     >
@@ -325,40 +263,14 @@ export function CollapsibleIntegrationRow({
   );
 }
 
-export function IntegrationCategoryLabel({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <TypographyH3
-      className={cn("pb-0 font-sans text-lg font-medium tracking-normal md:text-lg", className)}
-    >
-      {children}
-    </TypographyH3>
-  );
+export function IntegrationCategoryLabel({ children }: { children: ReactNode }) {
+  return <TypographyH4>{children}</TypographyH4>;
 }
 
-export function IntegrationCategoryCard({
-  children,
-  className,
-  ref,
-}: {
-  children: ReactNode;
-  className?: string;
-  ref?: Ref<HTMLDivElement>;
-}) {
+export function IntegrationCategoryCard({ children }: { children: ReactNode }) {
   return (
-    <div
-      ref={ref}
-      className={cn(
-        "overflow-hidden rounded-lg border border-border bg-card text-card-foreground",
-        className,
-      )}
-    >
+    <Box border="standard" borderRadius="standard" background="surface">
       {children}
-    </div>
+    </Box>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
@@ -21,6 +21,10 @@ import { integrationRowMessages } from "./integration-row.messages";
 
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Box } from "@/components/ui/layout/box";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
+import { Rows } from "@/components/ui/layout/rows";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH3 } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
@@ -74,6 +78,81 @@ const actionStyles: Record<
   },
 };
 
+export function IntegrationRowFrame({
+  open,
+  onOpenChange,
+  isLast = false,
+  highlighted,
+  hoverClassName,
+  highlightClassName,
+  icon,
+  iconClassName,
+  name,
+  description,
+  nameExtra,
+  action,
+  showPanel,
+  panelClassName,
+  children,
+}: {
+  open: boolean;
+  onOpenChange?: (open: boolean) => void;
+  isLast?: boolean;
+  highlighted: boolean;
+  hoverClassName: string;
+  highlightClassName: string;
+  icon?: ReactNode;
+  iconClassName: string;
+  name: string;
+  description: string;
+  nameExtra?: ReactNode;
+  action: ReactNode;
+  showPanel: boolean;
+  panelClassName: string;
+  children?: ReactNode;
+}) {
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={onOpenChange}
+      className={cn(!isLast && "border-b border-border")}
+    >
+      <div className={cn("transition-colors", hoverClassName, highlighted && highlightClassName)}>
+        <Box paddingX="2u" paddingY="2u">
+          <Columns spacing="2u" alignY="center">
+            <Column width="content">
+              <div
+                className={cn(
+                  "flex size-10 items-center justify-center rounded-lg border p-2 transition-colors",
+                  iconClassName,
+                )}
+              >
+                {icon}
+              </div>
+            </Column>
+            <Column width="fluid">
+              <Rows spacing="0.5u">
+                <Box display="flex" flexWrap="wrap" alignItems="center" gap="1u">
+                  <p className="text-base font-medium text-foreground">{name}</p>
+                  {nameExtra}
+                </Box>
+                <p className="text-sm leading-6 text-muted-foreground">{description}</p>
+              </Rows>
+            </Column>
+            <Column width="content">{action}</Column>
+          </Columns>
+        </Box>
+      </div>
+
+      {showPanel ? (
+        <CollapsibleContent className={cn("border-t", panelClassName)}>
+          <Box padding="2u">{children}</Box>
+        </CollapsibleContent>
+      ) : null}
+    </Collapsible>
+  );
+}
+
 export function IntegrationRow({
   name,
   description,
@@ -88,89 +167,71 @@ export function IntegrationRow({
   isLast = false,
   children,
 }: IntegrationRowProps) {
-  const showPanel = action === "manage" && children;
+  const showPanel = Boolean(action === "manage" && children);
   const activeStyle = actionStyles[action];
   const iconContainerClass = iconMuted
     ? "border-border bg-background text-foreground"
     : activeStyle.icon;
 
   return (
-    <Collapsible
+    <IntegrationRowFrame
       open={expanded}
       onOpenChange={onExpandedChange}
-      className={cn(!isLast && "border-b border-border")}
+      isLast={isLast}
+      highlighted={expanded}
+      hoverClassName={activeStyle.row}
+      highlightClassName={activeStyle.panel}
+      icon={icon}
+      iconClassName={iconContainerClass}
+      name={name}
+      description={description}
+      showPanel={showPanel}
+      panelClassName={activeStyle.panel}
+      action={
+        isLoading && (action === "connect" || action === "manage") ? (
+          <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
+        ) : action === "coming-soon" ? (
+          <Button type="button" variant="outline" size="sm" disabled>
+            <FormattedMessage {...integrationRowMessages.comingSoon} />
+          </Button>
+        ) : action === "view-only" ? (
+          <span className="text-sm text-muted-foreground">
+            <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
+          </span>
+        ) : action === "connect" ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onConnect}
+            disabled={isConnecting}
+            className={activeStyle.button}
+          >
+            {isConnecting ? (
+              <FormattedMessage {...integrationRowMessages.connecting} />
+            ) : (
+              <FormattedMessage {...integrationRowMessages.connect} />
+            )}
+            <HugeiconsIcon icon={ArrowUpRight01Icon} className="size-3.5" strokeWidth={2} />
+          </Button>
+        ) : showPanel ? (
+          <CollapsibleTrigger
+            render={
+              <Button type="button" variant="outline" size="sm">
+                <FormattedMessage {...integrationRowMessages.manage} />
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
+                  className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
+                  strokeWidth={2}
+                />
+              </Button>
+            }
+          />
+        ) : null
+      }
     >
-      <div
-        className={cn(
-          "flex items-center gap-4 px-5 py-4 transition-colors",
-          activeStyle.row,
-          expanded && activeStyle.panel,
-        )}
-      >
-        <div
-          className={cn(
-            "flex size-10 shrink-0 items-center justify-center rounded-lg border p-2 transition-colors",
-            iconContainerClass,
-          )}
-        >
-          {icon}
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <p className="text-base font-medium text-foreground">{name}</p>
-          <p className="mt-0.5 text-sm leading-6 text-muted-foreground">{description}</p>
-        </div>
-
-        <div className="shrink-0">
-          {isLoading && (action === "connect" || action === "manage") ? (
-            <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
-          ) : action === "coming-soon" ? (
-            <Button type="button" variant="outline" size="sm" disabled>
-              <FormattedMessage {...integrationRowMessages.comingSoon} />
-            </Button>
-          ) : action === "view-only" ? (
-            <span className="text-sm text-muted-foreground">
-              <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
-            </span>
-          ) : action === "connect" ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={onConnect}
-              disabled={isConnecting}
-              className={activeStyle.button}
-            >
-              {isConnecting ? (
-                <FormattedMessage {...integrationRowMessages.connecting} />
-              ) : (
-                <FormattedMessage {...integrationRowMessages.connect} />
-              )}
-              <HugeiconsIcon icon={ArrowUpRight01Icon} className="size-3.5" strokeWidth={2} />
-            </Button>
-          ) : showPanel ? (
-            <CollapsibleTrigger
-              render={
-                <Button type="button" variant="outline" size="sm">
-                  <FormattedMessage {...integrationRowMessages.manage} />
-                  <HugeiconsIcon
-                    icon={ArrowDown01Icon}
-                    className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
-                    strokeWidth={2}
-                  />
-                </Button>
-              }
-            />
-          ) : null}
-        </div>
-      </div>
-
-      {showPanel ? (
-        <CollapsibleContent className={cn("border-t px-5 py-5", activeStyle.panel)}>
-          {children}
-        </CollapsibleContent>
-      ) : null}
-    </Collapsible>
+      {children}
+    </IntegrationRowFrame>
   );
 }
 
@@ -204,79 +265,63 @@ export function CollapsibleIntegrationRow({
   const showPanel = userIsAdmin || isConnected;
 
   return (
-    <Collapsible
+    <IntegrationRowFrame
       open={showPanel && expanded}
       onOpenChange={onExpandedChange}
-      className={cn(!isLast && "border-b border-border")}
-    >
-      <div
-        className={cn(
-          "flex items-center gap-4 px-5 py-4 transition-colors",
-          "hover:bg-muted/20",
-          expanded && "bg-muted/20",
-        )}
-      >
-        <div
-          className={cn(
-            "flex size-10 shrink-0 items-center justify-center rounded-lg border border-border p-2",
-            isConnected
-              ? "border-border bg-muted text-foreground"
-              : "border-border bg-muted/50 text-muted-foreground",
-          )}
-        >
-          {icon}
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <p className="text-base font-medium text-foreground">{name}</p>
-          <p className="mt-0.5 text-sm leading-6 text-muted-foreground">{description}</p>
-        </div>
-
-        <div className="shrink-0">
-          {isLoading && showPanel ? (
-            <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
-          ) : showPanel ? (
-            <CollapsibleTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className={
-                    userIsAdmin && !isConnected ? integrationConnectButtonClassName : undefined
-                  }
-                >
-                  {userIsAdmin ? (
-                    isConnected ? (
-                      <FormattedMessage {...integrationRowMessages.manage} />
-                    ) : (
-                      <FormattedMessage {...integrationRowMessages.connect} />
-                    )
+      isLast={isLast}
+      highlighted={expanded}
+      hoverClassName="hover:bg-muted/20"
+      highlightClassName="bg-muted/20"
+      icon={icon}
+      iconClassName={
+        isConnected
+          ? "border-border bg-muted text-foreground"
+          : "border-border bg-muted/50 text-muted-foreground"
+      }
+      name={name}
+      description={description}
+      showPanel={showPanel}
+      panelClassName="border-border bg-muted/20"
+      action={
+        isLoading && showPanel ? (
+          <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
+        ) : showPanel ? (
+          <CollapsibleTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className={
+                  userIsAdmin && !isConnected ? integrationConnectButtonClassName : undefined
+                }
+              >
+                {userIsAdmin ? (
+                  isConnected ? (
+                    <FormattedMessage {...integrationRowMessages.manage} />
                   ) : (
-                    <FormattedMessage {...integrationRowMessages.viewOnly} />
-                  )}
-                  <HugeiconsIcon
-                    icon={ArrowDown01Icon}
-                    className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
-                    strokeWidth={2}
-                  />
-                </Button>
-              }
-            />
-          ) : (
-            <span className="text-sm text-muted-foreground">
-              <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
-            </span>
-          )}
-        </div>
-      </div>
-
-      {showPanel ? (
-        <CollapsibleContent className={cn("border-t px-5 py-5", "border-border bg-muted/20")}>
-          {children}
-        </CollapsibleContent>
-      ) : null}
-    </Collapsible>
+                    <FormattedMessage {...integrationRowMessages.connect} />
+                  )
+                ) : (
+                  <FormattedMessage {...integrationRowMessages.viewOnly} />
+                )}
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
+                  className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
+                  strokeWidth={2}
+                />
+              </Button>
+            }
+          />
+        ) : (
+          <span className="text-sm text-muted-foreground">
+            <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
+          </span>
+        )
+      }
+    >
+      {children}
+    </IntegrationRowFrame>
   );
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.messages.ts
@@ -15,10 +15,21 @@
 import { defineMessages } from "react-intl";
 
 export const integrationsPageContentMessages = defineMessages({
+  pageLabel: {
+    defaultMessage: "Workspace",
+    id: "MlPI89XpLh",
+    description: "Integrations page header eyebrow label",
+  },
   pageTitle: {
     defaultMessage: "Integrations",
     id: "9glYgHRgqB",
     description: "Integrations page heading",
+  },
+  pageDescription: {
+    defaultMessage:
+      "Connect the systems this workspace uses for source content, collaboration, and translation.",
+    id: "c4Om5rZTyf",
+    description: "Integrations page description under the heading",
   },
   categoryFilterAll: {
     defaultMessage: "All",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -37,6 +37,7 @@ import {
   OAUTH_AUTH_MODE,
   PAT_AUTH_MODE,
 } from "@/lib/providers/contracts/external-tms-provider-credential";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -49,12 +50,12 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Box } from "@/components/ui/layout/box";
-import { Row } from "@/components/ui/layout/row";
+import { ItemGroup } from "@/components/ui/item";
 import { Rows } from "@/components/ui/layout/rows";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TypographyMuted } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 import { agentIntegrationsSectionMessages } from "./agent-integrations-section.messages";
@@ -80,11 +81,9 @@ import { integrationsPageContentMessages } from "./integrations-page-content.mes
 import { IntegrationLogo } from "./integration-logo";
 import {
   CollapsibleIntegrationRow,
-  IntegrationCategoryCard,
   IntegrationCategoryLabel,
   IntegrationRow,
   IntegrationRowFrame,
-  integrationConnectButtonClassName,
 } from "./integration-row";
 import { SimpleBrandIcon } from "./simple-brand-icon";
 import { TmsProviderCredentialPanel } from "./tms-provider-credential-panel";
@@ -141,7 +140,7 @@ function IntegrationCategorySection({
       <IntegrationCategoryLabel>
         <FormattedMessage {...INTEGRATION_CATEGORY_MESSAGES[categoryId]} />
       </IntegrationCategoryLabel>
-      <IntegrationCategoryCard>{children}</IntegrationCategoryCard>
+      <ItemGroup>{children}</ItemGroup>
     </Rows>
   );
 }
@@ -564,7 +563,6 @@ function TmsIntegrationRow({
   expanded,
   onExpandedChange,
   isLoading = false,
-  isLast,
   children,
 }: {
   integration: TmsIntegrationConfig;
@@ -575,7 +573,7 @@ function TmsIntegrationRow({
   expanded: boolean;
   onExpandedChange: (expanded: boolean) => void;
   isLoading?: boolean;
-  isLast: boolean;
+  isLast?: boolean;
   children?: ReactNode;
 }) {
   const intl = useIntl();
@@ -597,31 +595,15 @@ function TmsIntegrationRow({
     <IntegrationRowFrame
       open={showPanel && expanded}
       onOpenChange={onExpandedChange}
-      isLast={isLast}
       highlighted={expanded}
-      hoverClassName="hover:bg-muted/20"
-      highlightClassName="bg-muted/20"
       icon={
         "icon" in integration && integration.icon ? (
           <SimpleBrandIcon icon={integration.icon} colored={isConnected && !isComingSoon} />
         ) : (
-          <Image
-            src={integration.logo}
-            alt=""
-            width={30}
-            height={30}
-            className={cn(
-              "max-h-7 w-auto object-contain",
-              (!isConnected || isComingSoon) && "opacity-75",
-            )}
-          />
+          <Image src={integration.logo} alt="" width={30} height={30} />
         )
       }
-      iconClassName={
-        isConnected && !isComingSoon
-          ? "border-border bg-muted text-foreground"
-          : "border-border bg-muted/50 text-muted-foreground"
-      }
+      iconMuted={!isConnected || isComingSoon}
       name={integration.name}
       description={integration.detail}
       nameExtra={
@@ -632,10 +614,9 @@ function TmsIntegrationRow({
         ) : null
       }
       showPanel={showPanel}
-      panelClassName="border-border bg-muted/20"
       action={
         isLoading && !isIncluded && userIsAdmin ? (
-          <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
+          <Skeleton className="h-8 w-[5.75rem]" aria-hidden />
         ) : isIncluded ? (
           <Button
             type="button"
@@ -666,12 +647,7 @@ function TmsIntegrationRow({
         ) : userIsAdmin && showPanel ? (
           <CollapsibleTrigger
             render={
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className={isConnected ? undefined : integrationConnectButtonClassName}
-              >
+              <Button type="button" variant={isConnected ? "outline" : "default"} size="sm">
                 {isConnected ? (
                   <FormattedMessage {...integrationRowMessages.manage} />
                 ) : (
@@ -690,9 +666,9 @@ function TmsIntegrationRow({
             <FormattedMessage {...integrationRowMessages.viewOnly} />
           </Badge>
         ) : (
-          <span className="text-sm text-muted-foreground">
+          <TypographyMuted>
             <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
-          </span>
+          </TypographyMuted>
         )
       }
     >
@@ -925,30 +901,16 @@ export function IntegrationsPageContent({
       />
 
       {integrationError ? (
-        <div
-          role="alert"
-          className="rounded-lg border border-destructive/30 bg-destructive/10 text-sm text-destructive"
-        >
-          <Box padding="2u">
-            <Row spacing="1.5u" alignY="start">
-              <HugeiconsIcon
-                icon={Alert02Icon}
-                strokeWidth={1.8}
-                className="mt-0.5 size-4 shrink-0"
-              />
-              <Rows spacing="0.5u">
-                <p className="font-medium">{integrationError.title}</p>
-                <p className="leading-6 text-destructive/80">{integrationError.description}</p>
-              </Rows>
-            </Row>
-          </Box>
-        </div>
+        <Alert variant="destructive">
+          <HugeiconsIcon icon={Alert02Icon} strokeWidth={1.8} />
+          <AlertTitle>{integrationError.title}</AlertTitle>
+          <AlertDescription>{integrationError.description}</AlertDescription>
+        </Alert>
       ) : null}
 
       <Tabs
         value={categoryFilter}
         onValueChange={(value) => setCategoryFilter(value as IntegrationCategoryFilter)}
-        className="gap-5"
       >
         <TabsList>
           <TabsTrigger value="all">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -16,7 +16,7 @@ import { useId, useMemo, useState, type ReactNode } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
-import { Alert02Icon, ArrowDown01Icon, Delete02Icon } from "@hugeicons/core-free-icons";
+import { Alert02Icon, ArrowDown01Icon, Delete02Icon, PuzzleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SimpleIcon } from "simple-icons";
 import { siCrowdin } from "simple-icons";
@@ -48,12 +48,15 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Box } from "@/components/ui/layout/box";
+import { Row } from "@/components/ui/layout/row";
+import { Rows } from "@/components/ui/layout/rows";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { TypographyH1 } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 import { agentIntegrationsSectionMessages } from "./agent-integrations-section.messages";
 import {
   CollaborationIntegrationsSection,
@@ -80,6 +83,7 @@ import {
   IntegrationCategoryCard,
   IntegrationCategoryLabel,
   IntegrationRow,
+  IntegrationRowFrame,
   integrationConnectButtonClassName,
 } from "./integration-row";
 import { SimpleBrandIcon } from "./simple-brand-icon";
@@ -133,12 +137,12 @@ function IntegrationCategorySection({
   children: ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-3">
+    <Rows spacing="1.5u">
       <IntegrationCategoryLabel>
         <FormattedMessage {...INTEGRATION_CATEGORY_MESSAGES[categoryId]} />
       </IntegrationCategoryLabel>
       <IntegrationCategoryCard>{children}</IntegrationCategoryCard>
-    </section>
+    </Rows>
   );
 }
 
@@ -590,124 +594,110 @@ function TmsIntegrationRow({
   const showPanel = userIsAdmin && !isComingSoon && !isBlockedByActiveProvider;
 
   return (
-    <Collapsible
+    <IntegrationRowFrame
       open={showPanel && expanded}
       onOpenChange={onExpandedChange}
-      className={cn(!isLast && "border-b border-border")}
-    >
-      <div
-        className={cn(
-          "flex items-center gap-4 px-5 py-4 transition-colors",
-          "hover:bg-muted/20",
-          expanded && "bg-muted/20",
-        )}
-      >
-        <div
-          className={cn(
-            "flex size-10 shrink-0 items-center justify-center rounded-lg border border-border p-2",
-            isConnected && !isComingSoon
-              ? "border-border bg-muted text-foreground"
-              : "border-border bg-muted/50 text-muted-foreground",
-          )}
-        >
-          {"icon" in integration && integration.icon ? (
-            <SimpleBrandIcon icon={integration.icon} colored={isConnected && !isComingSoon} />
-          ) : (
-            <Image
-              src={integration.logo}
-              alt=""
-              width={30}
-              height={30}
-              className={cn(
-                "max-h-7 w-auto object-contain",
-                (!isConnected || isComingSoon) && "opacity-75",
-              )}
-            />
-          )}
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <p className="text-base font-medium text-foreground">{integration.name}</p>
-            {isIncluded ? (
-              <Badge variant="outline">
-                <FormattedMessage {...integrationRowMessages.included} />
-              </Badge>
-            ) : null}
-          </div>
-          <p className="mt-0.5 text-sm leading-6 text-muted-foreground">{integration.detail}</p>
-        </div>
-
-        <div className="shrink-0">
-          {isLoading && !isIncluded && userIsAdmin ? (
-            <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
-          ) : isIncluded ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              nativeButton={false}
-              render={<Link href={`/org/${organizationSlug}/projects`} />}
-            >
-              {intl.formatMessage(integrationsPageContentMessages.viewProjects)}
-            </Button>
-          ) : isComingSoon ? (
-            <Button type="button" variant="outline" size="sm" disabled>
-              <FormattedMessage {...integrationRowMessages.comingSoon} />
-            </Button>
-          ) : isBlockedByActiveProvider ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button type="button" variant="outline" size="sm" disabled>
-                    <FormattedMessage {...integrationRowMessages.connect} />
-                  </Button>
-                }
-              />
-              <TooltipContent>
-                {intl.formatMessage(integrationsPageContentMessages.disconnectTmsTooltip)}
-              </TooltipContent>
-            </Tooltip>
-          ) : userIsAdmin && showPanel ? (
-            <CollapsibleTrigger
+      isLast={isLast}
+      highlighted={expanded}
+      hoverClassName="hover:bg-muted/20"
+      highlightClassName="bg-muted/20"
+      icon={
+        "icon" in integration && integration.icon ? (
+          <SimpleBrandIcon icon={integration.icon} colored={isConnected && !isComingSoon} />
+        ) : (
+          <Image
+            src={integration.logo}
+            alt=""
+            width={30}
+            height={30}
+            className={cn(
+              "max-h-7 w-auto object-contain",
+              (!isConnected || isComingSoon) && "opacity-75",
+            )}
+          />
+        )
+      }
+      iconClassName={
+        isConnected && !isComingSoon
+          ? "border-border bg-muted text-foreground"
+          : "border-border bg-muted/50 text-muted-foreground"
+      }
+      name={integration.name}
+      description={integration.detail}
+      nameExtra={
+        isIncluded ? (
+          <Badge variant="outline">
+            <FormattedMessage {...integrationRowMessages.included} />
+          </Badge>
+        ) : null
+      }
+      showPanel={showPanel}
+      panelClassName="border-border bg-muted/20"
+      action={
+        isLoading && !isIncluded && userIsAdmin ? (
+          <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
+        ) : isIncluded ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            nativeButton={false}
+            render={<Link href={`/org/${organizationSlug}/projects`} />}
+          >
+            {intl.formatMessage(integrationsPageContentMessages.viewProjects)}
+          </Button>
+        ) : isComingSoon ? (
+          <Button type="button" variant="outline" size="sm" disabled>
+            <FormattedMessage {...integrationRowMessages.comingSoon} />
+          </Button>
+        ) : isBlockedByActiveProvider ? (
+          <Tooltip>
+            <TooltipTrigger
               render={
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className={isConnected ? undefined : integrationConnectButtonClassName}
-                >
-                  {isConnected ? (
-                    <FormattedMessage {...integrationRowMessages.manage} />
-                  ) : (
-                    <FormattedMessage {...integrationRowMessages.connect} />
-                  )}
-                  <HugeiconsIcon
-                    icon={ArrowDown01Icon}
-                    className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
-                    strokeWidth={2}
-                  />
+                <Button type="button" variant="outline" size="sm" disabled>
+                  <FormattedMessage {...integrationRowMessages.connect} />
                 </Button>
               }
             />
-          ) : isConnected ? (
-            <Badge variant="outline">
-              <FormattedMessage {...integrationRowMessages.viewOnly} />
-            </Badge>
-          ) : (
-            <span className="text-sm text-muted-foreground">
-              <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
-            </span>
-          )}
-        </div>
-      </div>
-
-      {showPanel ? (
-        <CollapsibleContent className={cn("border-t px-5 py-5", "border-border bg-muted/20")}>
-          {children}
-        </CollapsibleContent>
-      ) : null}
-    </Collapsible>
+            <TooltipContent>
+              {intl.formatMessage(integrationsPageContentMessages.disconnectTmsTooltip)}
+            </TooltipContent>
+          </Tooltip>
+        ) : userIsAdmin && showPanel ? (
+          <CollapsibleTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className={isConnected ? undefined : integrationConnectButtonClassName}
+              >
+                {isConnected ? (
+                  <FormattedMessage {...integrationRowMessages.manage} />
+                ) : (
+                  <FormattedMessage {...integrationRowMessages.connect} />
+                )}
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
+                  className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
+                  strokeWidth={2}
+                />
+              </Button>
+            }
+          />
+        ) : isConnected ? (
+          <Badge variant="outline">
+            <FormattedMessage {...integrationRowMessages.viewOnly} />
+          </Badge>
+        ) : (
+          <span className="text-sm text-muted-foreground">
+            <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
+          </span>
+        )
+      }
+    >
+      {children}
+    </IntegrationRowFrame>
   );
 }
 
@@ -926,328 +916,334 @@ export function IntegrationsPageContent({
   }
 
   return (
-    <main className="space-y-5">
-      <TypographyH1 className="font-heading text-2xl font-medium text-foreground md:text-2xl">
-        <FormattedMessage {...integrationsPageContentMessages.pageTitle} />
-      </TypographyH1>
+    <WorkspacePageShell>
+      <PageHeader
+        icon={PuzzleIcon}
+        label={intl.formatMessage(integrationsPageContentMessages.pageLabel)}
+        title={intl.formatMessage(integrationsPageContentMessages.pageTitle)}
+        description={intl.formatMessage(integrationsPageContentMessages.pageDescription)}
+      />
 
       {integrationError ? (
         <div
           role="alert"
-          className="flex gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
+          className="rounded-lg border border-destructive/30 bg-destructive/10 text-sm text-destructive"
         >
-          <HugeiconsIcon icon={Alert02Icon} strokeWidth={1.8} className="mt-0.5 size-4 shrink-0" />
-          <div className="space-y-1">
-            <p className="font-medium">{integrationError.title}</p>
-            <p className="leading-6 text-destructive/80">{integrationError.description}</p>
-          </div>
+          <Box padding="2u">
+            <Row spacing="1.5u" alignY="start">
+              <HugeiconsIcon
+                icon={Alert02Icon}
+                strokeWidth={1.8}
+                className="mt-0.5 size-4 shrink-0"
+              />
+              <Rows spacing="0.5u">
+                <p className="font-medium">{integrationError.title}</p>
+                <p className="leading-6 text-destructive/80">{integrationError.description}</p>
+              </Rows>
+            </Row>
+          </Box>
         </div>
       ) : null}
 
-      <section className="flex flex-col gap-4">
-        <Tabs
-          value={categoryFilter}
-          onValueChange={(value) => setCategoryFilter(value as IntegrationCategoryFilter)}
-          className="gap-5"
-        >
-          <TabsList>
-            <TabsTrigger value="all">
-              <FormattedMessage {...integrationsPageContentMessages.categoryFilterAll} />
+      <Tabs
+        value={categoryFilter}
+        onValueChange={(value) => setCategoryFilter(value as IntegrationCategoryFilter)}
+        className="gap-5"
+      >
+        <TabsList>
+          <TabsTrigger value="all">
+            <FormattedMessage {...integrationsPageContentMessages.categoryFilterAll} />
+          </TabsTrigger>
+          {visibleCategoryIds.map((categoryId) => (
+            <TabsTrigger key={categoryId} value={categoryId}>
+              <FormattedMessage {...INTEGRATION_CATEGORY_MESSAGES[categoryId]} />
             </TabsTrigger>
-            {visibleCategoryIds.map((categoryId) => (
-              <TabsTrigger key={categoryId} value={categoryId}>
-                <FormattedMessage {...INTEGRATION_CATEGORY_MESSAGES[categoryId]} />
-              </TabsTrigger>
-            ))}
-          </TabsList>
-          <div ref={categoryListRef} className="flex flex-col gap-6">
-            {showCategory("source-control") ? (
-              <IntegrationCategorySection categoryId="source-control">
-                <SourceControlIntegrationsSection
-                  organizationSlug={organizationSlug}
-                  userCanManage={userCanManageAgents}
-                />
-              </IntegrationCategorySection>
-            ) : null}
-            {showCategory("collaboration") ? (
-              <IntegrationCategorySection categoryId="collaboration">
-                <CollaborationIntegrationsSection
-                  organizationSlug={organizationSlug}
-                  userCanManage={userCanManageAgents}
-                />
-              </IntegrationCategorySection>
-            ) : null}
-            {showCategory("tms") && canManageProviderIntegrations ? (
-              <IntegrationCategorySection categoryId="tms">
-                {tmsIntegrations.map((integration, index) => {
-                  const tmsCredential =
-                    integration.providerKind === "native"
-                      ? undefined
-                      : externalTmsCredentials?.find(
-                          (item) => item.providerKind === integration.providerKind,
-                        );
-
-                  return (
-                    <TmsIntegrationRow
-                      key={integration.name}
-                      integration={integration}
-                      credential={tmsCredential}
-                      activeExternalProviderKind={activeExternalTmsProviderCredential?.providerKind}
-                      organizationSlug={organizationSlug}
-                      userIsAdmin={userIsAdmin}
-                      isLoading={isLoadingExternalTms}
-                      isLast={index === tmsIntegrations.length - 1}
-                      expanded={
-                        integration.providerKind !== "native" &&
-                        expandedTmsProvider === integration.providerKind
-                      }
-                      onExpandedChange={(expanded) => {
-                        if (integration.providerKind === "native") {
-                          return;
-                        }
-                        handleTmsExpandedChange(integration.providerKind, tmsCredential, expanded);
-                      }}
-                    >
-                      {userIsAdmin &&
-                      integration.providerKind !== "native" &&
-                      expandedTmsProvider === integration.providerKind ? (
-                        <TmsProviderCredentialPanel
-                          providerKind={integration.providerKind}
-                          providerName={integration.name}
-                          credential={tmsCredential}
-                          organizationSlug={organizationSlug}
-                          userIsAdmin={userIsAdmin}
-                          displayName={tmsDisplayName}
-                          onDisplayNameChange={setTmsDisplayName}
-                          secret={tmsSecret}
-                          onSecretChange={setTmsSecret}
-                          crowdinAuthMode={tmsCrowdinAuthMode}
-                          onCrowdinAuthModeChange={setTmsCrowdinAuthMode}
-                          oauthClientId={tmsOauthClientId}
-                          onOauthClientIdChange={setTmsOauthClientId}
-                          oauthClientSecret={tmsOauthClientSecret}
-                          onOauthClientSecretChange={setTmsOauthClientSecret}
-                          baseUrl={tmsBaseUrl}
-                          onBaseUrlChange={setTmsBaseUrl}
-                          showSecret={showTmsSecret}
-                          onToggleShowSecret={() => setShowTmsSecret((current) => !current)}
-                          onDisconnect={() => setDisconnectingTmsProvider(integration.providerKind)}
-                          onSave={() => {
-                            const oauthPayload = buildTmsOAuthAppPayload({
-                              displayName: tmsDisplayName,
-                              oauthClientId: tmsOauthClientId,
-                              oauthClientSecret: tmsOauthClientSecret,
-                              baseUrl: tmsBaseUrl,
-                            });
-
-                            if (integration.providerKind === "crowdin") {
-                              if (tmsCrowdinAuthMode === PAT_AUTH_MODE) {
-                                saveCrowdinPatSetup.mutate(
-                                  {
-                                    displayName: tmsDisplayName.trim(),
-                                    ...(tmsBaseUrl.trim() ? { baseUrl: tmsBaseUrl.trim() } : {}),
-                                  },
-                                  {
-                                    onSuccess: () => {
-                                      setShowTmsSecret(false);
-                                    },
-                                  },
-                                );
-                                return;
-                              }
-
-                              saveCrowdinOAuthApp.mutate(oauthPayload, {
-                                onSuccess: () => {
-                                  setTmsOauthClientId("");
-                                  setTmsOauthClientSecret("");
-                                  setShowTmsSecret(false);
-                                },
-                              });
-                              return;
-                            }
-                            if (integration.providerKind === "phrase") {
-                              savePhraseOAuthApp.mutate(oauthPayload, {
-                                onSuccess: () => {
-                                  setTmsOauthClientId("");
-                                  setTmsOauthClientSecret("");
-                                  setShowTmsSecret(false);
-                                },
-                              });
-                              return;
-                            }
-                            if (integration.providerKind === "lokalise") {
-                              saveLokaliseOAuthApp.mutate(oauthPayload, {
-                                onSuccess: () => {
-                                  setTmsOauthClientId("");
-                                  setTmsOauthClientSecret("");
-                                  setShowTmsSecret(false);
-                                },
-                              });
-                              return;
-                            }
-                            saveExternalTms.mutate(
-                              {
-                                providerKind: integration.providerKind,
-                                displayName: tmsDisplayName.trim(),
-                                secretMaterial: tmsSecret.trim(),
-                                ...(tmsCredential?.region ? { region: tmsCredential.region } : {}),
-                                ...(tmsBaseUrl.trim() ? { baseUrl: tmsBaseUrl.trim() } : {}),
-                              },
-                              {
-                                onSuccess: () => {
-                                  setTmsSecret("");
-                                  setShowTmsSecret(false);
-                                },
-                              },
-                            );
-                          }}
-                          isSaving={
-                            saveExternalTms.isPending ||
-                            saveCrowdinOAuthApp.isPending ||
-                            saveCrowdinPatSetup.isPending ||
-                            savePhraseOAuthApp.isPending ||
-                            saveLokaliseOAuthApp.isPending
-                          }
-                          isDisconnecting={deleteExternalTms.isPending}
-                          displayNameFieldId={tmsDisplayNameFieldId}
-                          secretFieldId={tmsSecretFieldId}
-                          oauthClientIdFieldId={tmsOauthClientIdFieldId}
-                          oauthClientSecretFieldId={tmsOauthClientSecretFieldId}
-                          redirectUriFieldId={tmsOauthRedirectUriFieldId}
-                          baseUrlFieldId={tmsBaseUrlFieldId}
-                          crowdinAuthModeFieldId={tmsCrowdinAuthModeFieldId}
-                        />
-                      ) : null}
-                    </TmsIntegrationRow>
-                  );
-                })}
-              </IntegrationCategorySection>
-            ) : null}
-            {showCategory("cms") && canManageProviderIntegrations ? (
-              <IntegrationCategorySection categoryId="cms">
-                <IntegrationRow
-                  name={intl.formatMessage(
-                    integrationsPageContentMessages.contentPublishingFilesName,
-                  )}
-                  description={intl.formatMessage(
-                    integrationsPageContentMessages.contentPublishingFilesDetail,
-                  )}
-                  icon={<IntegrationLogo src="/images/logo.png" />}
-                  iconMuted
-                  action="coming-soon"
-                />
-                <CollapsibleIntegrationRow
-                  name={contentfulIntegration.name}
-                  description={contentfulIntegration.detail}
-                  icon={<IntegrationLogo src={contentfulIntegration.logo} />}
-                  isConnected={Boolean(contentfulConnections?.[0])}
-                  userIsAdmin={userIsAdmin}
-                  expanded={expandedContentful}
-                  onExpandedChange={handleContentfulExpandedChange}
-                  isLoading={isLoadingContentful}
-                >
-                  <ContentfulConnectionPanel
-                    connection={contentfulConnections?.[0]}
-                    disabled={!userIsAdmin}
-                    form={contentfulForm}
-                    onFormChange={setContentfulForm}
-                    lastWebhookSecret={lastContentfulWebhookSecret}
-                    isSaving={saveContentfulConnection.isPending}
-                    organizationSlug={organizationSlug}
-                    onSave={() => {
-                      const accessToken = contentfulForm.accessToken.trim();
-                      const existingConnection = contentfulConnections?.[0];
-
-                      const payload = {
-                        displayName: contentfulForm.displayName.trim(),
-                        spaceId: contentfulForm.spaceId.trim(),
-                        environmentId: contentfulForm.environmentId.trim() || "master",
-                        contentTypeIds: contentfulForm.contentTypeIds,
-                      };
-
-                      saveContentfulConnection.mutate(
-                        existingConnection
-                          ? {
-                              ...payload,
-                              connectionId: existingConnection.id,
-                              ...(accessToken ? { accessToken } : {}),
-                            }
-                          : { ...payload, accessToken },
-                        {
-                          onSuccess: (result) => {
-                            setContentfulForm((current) => ({ ...current, accessToken: "" }));
-                            setLastContentfulWebhookSecret(result.webhookSecret ?? "");
-                          },
-                        },
+          ))}
+        </TabsList>
+        <Rows ref={categoryListRef} spacing="3u">
+          {showCategory("source-control") ? (
+            <IntegrationCategorySection categoryId="source-control">
+              <SourceControlIntegrationsSection
+                organizationSlug={organizationSlug}
+                userCanManage={userCanManageAgents}
+              />
+            </IntegrationCategorySection>
+          ) : null}
+          {showCategory("collaboration") ? (
+            <IntegrationCategorySection categoryId="collaboration">
+              <CollaborationIntegrationsSection
+                organizationSlug={organizationSlug}
+                userCanManage={userCanManageAgents}
+              />
+            </IntegrationCategorySection>
+          ) : null}
+          {showCategory("tms") && canManageProviderIntegrations ? (
+            <IntegrationCategorySection categoryId="tms">
+              {tmsIntegrations.map((integration, index) => {
+                const tmsCredential =
+                  integration.providerKind === "native"
+                    ? undefined
+                    : externalTmsCredentials?.find(
+                        (item) => item.providerKind === integration.providerKind,
                       );
+
+                return (
+                  <TmsIntegrationRow
+                    key={integration.name}
+                    integration={integration}
+                    credential={tmsCredential}
+                    activeExternalProviderKind={activeExternalTmsProviderCredential?.providerKind}
+                    organizationSlug={organizationSlug}
+                    userIsAdmin={userIsAdmin}
+                    isLoading={isLoadingExternalTms}
+                    isLast={index === tmsIntegrations.length - 1}
+                    expanded={
+                      integration.providerKind !== "native" &&
+                      expandedTmsProvider === integration.providerKind
+                    }
+                    onExpandedChange={(expanded) => {
+                      if (integration.providerKind === "native") {
+                        return;
+                      }
+                      handleTmsExpandedChange(integration.providerKind, tmsCredential, expanded);
                     }}
-                  />
-                </CollapsibleIntegrationRow>
-                <CanvaConnectionPanel
-                  organizationSlug={organizationSlug}
+                  >
+                    {userIsAdmin &&
+                    integration.providerKind !== "native" &&
+                    expandedTmsProvider === integration.providerKind ? (
+                      <TmsProviderCredentialPanel
+                        providerKind={integration.providerKind}
+                        providerName={integration.name}
+                        credential={tmsCredential}
+                        organizationSlug={organizationSlug}
+                        userIsAdmin={userIsAdmin}
+                        displayName={tmsDisplayName}
+                        onDisplayNameChange={setTmsDisplayName}
+                        secret={tmsSecret}
+                        onSecretChange={setTmsSecret}
+                        crowdinAuthMode={tmsCrowdinAuthMode}
+                        onCrowdinAuthModeChange={setTmsCrowdinAuthMode}
+                        oauthClientId={tmsOauthClientId}
+                        onOauthClientIdChange={setTmsOauthClientId}
+                        oauthClientSecret={tmsOauthClientSecret}
+                        onOauthClientSecretChange={setTmsOauthClientSecret}
+                        baseUrl={tmsBaseUrl}
+                        onBaseUrlChange={setTmsBaseUrl}
+                        showSecret={showTmsSecret}
+                        onToggleShowSecret={() => setShowTmsSecret((current) => !current)}
+                        onDisconnect={() => setDisconnectingTmsProvider(integration.providerKind)}
+                        onSave={() => {
+                          const oauthPayload = buildTmsOAuthAppPayload({
+                            displayName: tmsDisplayName,
+                            oauthClientId: tmsOauthClientId,
+                            oauthClientSecret: tmsOauthClientSecret,
+                            baseUrl: tmsBaseUrl,
+                          });
+
+                          if (integration.providerKind === "crowdin") {
+                            if (tmsCrowdinAuthMode === PAT_AUTH_MODE) {
+                              saveCrowdinPatSetup.mutate(
+                                {
+                                  displayName: tmsDisplayName.trim(),
+                                  ...(tmsBaseUrl.trim() ? { baseUrl: tmsBaseUrl.trim() } : {}),
+                                },
+                                {
+                                  onSuccess: () => {
+                                    setShowTmsSecret(false);
+                                  },
+                                },
+                              );
+                              return;
+                            }
+
+                            saveCrowdinOAuthApp.mutate(oauthPayload, {
+                              onSuccess: () => {
+                                setTmsOauthClientId("");
+                                setTmsOauthClientSecret("");
+                                setShowTmsSecret(false);
+                              },
+                            });
+                            return;
+                          }
+                          if (integration.providerKind === "phrase") {
+                            savePhraseOAuthApp.mutate(oauthPayload, {
+                              onSuccess: () => {
+                                setTmsOauthClientId("");
+                                setTmsOauthClientSecret("");
+                                setShowTmsSecret(false);
+                              },
+                            });
+                            return;
+                          }
+                          if (integration.providerKind === "lokalise") {
+                            saveLokaliseOAuthApp.mutate(oauthPayload, {
+                              onSuccess: () => {
+                                setTmsOauthClientId("");
+                                setTmsOauthClientSecret("");
+                                setShowTmsSecret(false);
+                              },
+                            });
+                            return;
+                          }
+                          saveExternalTms.mutate(
+                            {
+                              providerKind: integration.providerKind,
+                              displayName: tmsDisplayName.trim(),
+                              secretMaterial: tmsSecret.trim(),
+                              ...(tmsCredential?.region ? { region: tmsCredential.region } : {}),
+                              ...(tmsBaseUrl.trim() ? { baseUrl: tmsBaseUrl.trim() } : {}),
+                            },
+                            {
+                              onSuccess: () => {
+                                setTmsSecret("");
+                                setShowTmsSecret(false);
+                              },
+                            },
+                          );
+                        }}
+                        isSaving={
+                          saveExternalTms.isPending ||
+                          saveCrowdinOAuthApp.isPending ||
+                          saveCrowdinPatSetup.isPending ||
+                          savePhraseOAuthApp.isPending ||
+                          saveLokaliseOAuthApp.isPending
+                        }
+                        isDisconnecting={deleteExternalTms.isPending}
+                        displayNameFieldId={tmsDisplayNameFieldId}
+                        secretFieldId={tmsSecretFieldId}
+                        oauthClientIdFieldId={tmsOauthClientIdFieldId}
+                        oauthClientSecretFieldId={tmsOauthClientSecretFieldId}
+                        redirectUriFieldId={tmsOauthRedirectUriFieldId}
+                        baseUrlFieldId={tmsBaseUrlFieldId}
+                        crowdinAuthModeFieldId={tmsCrowdinAuthModeFieldId}
+                      />
+                    ) : null}
+                  </TmsIntegrationRow>
+                );
+              })}
+            </IntegrationCategorySection>
+          ) : null}
+          {showCategory("cms") && canManageProviderIntegrations ? (
+            <IntegrationCategorySection categoryId="cms">
+              <IntegrationRow
+                name={intl.formatMessage(
+                  integrationsPageContentMessages.contentPublishingFilesName,
+                )}
+                description={intl.formatMessage(
+                  integrationsPageContentMessages.contentPublishingFilesDetail,
+                )}
+                icon={<IntegrationLogo src="/images/logo.png" />}
+                iconMuted
+                action="coming-soon"
+              />
+              <CollapsibleIntegrationRow
+                name={contentfulIntegration.name}
+                description={contentfulIntegration.detail}
+                icon={<IntegrationLogo src={contentfulIntegration.logo} />}
+                isConnected={Boolean(contentfulConnections?.[0])}
+                userIsAdmin={userIsAdmin}
+                expanded={expandedContentful}
+                onExpandedChange={handleContentfulExpandedChange}
+                isLoading={isLoadingContentful}
+              >
+                <ContentfulConnectionPanel
+                  connection={contentfulConnections?.[0]}
                   disabled={!userIsAdmin}
-                  isLast
-                />
-              </IntegrationCategorySection>
-            ) : null}
-            {showCategory("guidelines") ? (
-              <IntegrationCategorySection categoryId="guidelines">
-                <GuidelineIntegrationsSection />
-              </IntegrationCategorySection>
-            ) : null}
-            {showCategory("customer-engagement") ? (
-              <IntegrationCategorySection categoryId="customer-engagement">
-                <CustomerEngagementIntegrationsSection
+                  form={contentfulForm}
+                  onFormChange={setContentfulForm}
+                  lastWebhookSecret={lastContentfulWebhookSecret}
+                  isSaving={saveContentfulConnection.isPending}
                   organizationSlug={organizationSlug}
-                  userIsAdmin={userIsAdmin}
-                  showIntercom={canManageProviderIntegrations}
+                  onSave={() => {
+                    const accessToken = contentfulForm.accessToken.trim();
+                    const existingConnection = contentfulConnections?.[0];
+
+                    const payload = {
+                      displayName: contentfulForm.displayName.trim(),
+                      spaceId: contentfulForm.spaceId.trim(),
+                      environmentId: contentfulForm.environmentId.trim() || "master",
+                      contentTypeIds: contentfulForm.contentTypeIds,
+                    };
+
+                    saveContentfulConnection.mutate(
+                      existingConnection
+                        ? {
+                            ...payload,
+                            connectionId: existingConnection.id,
+                            ...(accessToken ? { accessToken } : {}),
+                          }
+                        : { ...payload, accessToken },
+                      {
+                        onSuccess: (result) => {
+                          setContentfulForm((current) => ({ ...current, accessToken: "" }));
+                          setLastContentfulWebhookSecret(result.webhookSecret ?? "");
+                        },
+                      },
+                    );
+                  }}
                 />
-              </IntegrationCategorySection>
-            ) : null}
-            {showCategory("experimentation") && canManageProviderIntegrations ? (
-              <IntegrationCategorySection categoryId="experimentation">
-                <IntegrationRow
-                  name={intl.formatMessage(integrationsPageContentMessages.hyperlabName)}
-                  description={intl.formatMessage(integrationsPageContentMessages.hyperlabDetail)}
-                  icon={<IntegrationLogo src="/images/logo.png" />}
-                  iconMuted
-                  action="coming-soon"
-                  isLast
-                />
-              </IntegrationCategorySection>
-            ) : null}
-            {showCategory("seo-tools") && canManageProviderIntegrations ? (
-              <IntegrationCategorySection categoryId="seo-tools">
-                <IntegrationRow
-                  name={intl.formatMessage(integrationsPageContentMessages.hyperSeoName)}
-                  description={intl.formatMessage(integrationsPageContentMessages.hyperSeoDetail)}
-                  icon={<IntegrationLogo src="/images/logo.png" />}
-                  iconMuted
-                  action="coming-soon"
-                />
-                <SemrushConnectionPanel
-                  organizationSlug={organizationSlug}
-                  disabled={!userIsAdmin}
-                />
-                <AhrefsConnectionPanel
-                  organizationSlug={organizationSlug}
-                  disabled={!userIsAdmin}
-                  isLast
-                />
-              </IntegrationCategorySection>
-            ) : null}
-            {showCategory("mcp-servers") && canManageProviderIntegrations ? (
-              <IntegrationCategorySection categoryId="mcp-servers">
-                <McpServerConnectionPanel
-                  organizationSlug={organizationSlug}
-                  disabled={!userIsAdmin}
-                  isLast
-                />
-              </IntegrationCategorySection>
-            ) : null}
-          </div>
-        </Tabs>
-      </section>
+              </CollapsibleIntegrationRow>
+              <CanvaConnectionPanel
+                organizationSlug={organizationSlug}
+                disabled={!userIsAdmin}
+                isLast
+              />
+            </IntegrationCategorySection>
+          ) : null}
+          {showCategory("guidelines") ? (
+            <IntegrationCategorySection categoryId="guidelines">
+              <GuidelineIntegrationsSection />
+            </IntegrationCategorySection>
+          ) : null}
+          {showCategory("customer-engagement") ? (
+            <IntegrationCategorySection categoryId="customer-engagement">
+              <CustomerEngagementIntegrationsSection
+                organizationSlug={organizationSlug}
+                userIsAdmin={userIsAdmin}
+                showIntercom={canManageProviderIntegrations}
+              />
+            </IntegrationCategorySection>
+          ) : null}
+          {showCategory("experimentation") && canManageProviderIntegrations ? (
+            <IntegrationCategorySection categoryId="experimentation">
+              <IntegrationRow
+                name={intl.formatMessage(integrationsPageContentMessages.hyperlabName)}
+                description={intl.formatMessage(integrationsPageContentMessages.hyperlabDetail)}
+                icon={<IntegrationLogo src="/images/logo.png" />}
+                iconMuted
+                action="coming-soon"
+                isLast
+              />
+            </IntegrationCategorySection>
+          ) : null}
+          {showCategory("seo-tools") && canManageProviderIntegrations ? (
+            <IntegrationCategorySection categoryId="seo-tools">
+              <IntegrationRow
+                name={intl.formatMessage(integrationsPageContentMessages.hyperSeoName)}
+                description={intl.formatMessage(integrationsPageContentMessages.hyperSeoDetail)}
+                icon={<IntegrationLogo src="/images/logo.png" />}
+                iconMuted
+                action="coming-soon"
+              />
+              <SemrushConnectionPanel organizationSlug={organizationSlug} disabled={!userIsAdmin} />
+              <AhrefsConnectionPanel
+                organizationSlug={organizationSlug}
+                disabled={!userIsAdmin}
+                isLast
+              />
+            </IntegrationCategorySection>
+          ) : null}
+          {showCategory("mcp-servers") && canManageProviderIntegrations ? (
+            <IntegrationCategorySection categoryId="mcp-servers">
+              <McpServerConnectionPanel
+                organizationSlug={organizationSlug}
+                disabled={!userIsAdmin}
+                isLast
+              />
+            </IntegrationCategorySection>
+          ) : null}
+        </Rows>
+      </Tabs>
 
       {canManageProviderIntegrations ? (
         <AlertDialog
@@ -1308,6 +1304,6 @@ export function IntegrationsPageContent({
           </AlertDialogContent>
         </AlertDialog>
       ) : null}
-    </main>
+    </WorkspacePageShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.tsx
@@ -23,6 +23,10 @@ import { slackIntegrationRowMessages } from "./slack-integration-row.messages";
 import { IntegrationLogo } from "./integration-logo";
 import { IntegrationRow } from "./integration-row";
 import { Button } from "@/components/ui/button";
+import { Box } from "@/components/ui/layout/box";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
+import { Rows } from "@/components/ui/layout/rows";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { createApiClient } from "@/lib/api-client";
@@ -181,36 +185,44 @@ export function SlackIntegrationRow({
       {isLoading ? (
         <Skeleton className="h-16 rounded-lg" />
       ) : (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-3 rounded-lg border border-border bg-background/70 p-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <TypographyP className="text-sm font-medium text-foreground">
-                {isError
-                  ? intl.formatMessage(slackIntegrationRowMessages.settingsUnavailable)
-                  : viewModel.statusTitle}
-              </TypographyP>
-              {slackAgent?.teamId ? (
-                <TypographyP className="mt-1 text-xs text-muted-foreground">
-                  {intl.formatMessage(slackIntegrationRowMessages.workspaceId, {
-                    teamId: slackAgent.teamId,
-                  })}
-                </TypographyP>
-              ) : null}
-            </div>
-            <Switch
-              checked={viewModel.enabled}
-              onCheckedChange={(enabled) => updateSlackAgentState.mutate(enabled)}
-              aria-label={intl.formatMessage(slackIntegrationRowMessages.enableSlackAgentAriaLabel)}
-              disabled={
-                viewModel.toggleDisabled ||
-                isError ||
-                updateSlackAgentState.isPending ||
-                isCreatingInstallUrl ||
-                !userCanManage
-              }
-            />
-          </div>
-          <div className="flex flex-wrap gap-2">
+        <Rows spacing="2u">
+          <Box padding="1.5u" background="canvas" border="standard" borderRadius="standard">
+            <Columns spacing="1.5u" alignY="center" collapseBelow="small">
+              <Column width="fluid">
+                <Rows spacing="0.5u">
+                  <TypographyP className="text-sm font-medium text-foreground">
+                    {isError
+                      ? intl.formatMessage(slackIntegrationRowMessages.settingsUnavailable)
+                      : viewModel.statusTitle}
+                  </TypographyP>
+                  {slackAgent?.teamId ? (
+                    <TypographyP className="text-xs text-muted-foreground">
+                      {intl.formatMessage(slackIntegrationRowMessages.workspaceId, {
+                        teamId: slackAgent.teamId,
+                      })}
+                    </TypographyP>
+                  ) : null}
+                </Rows>
+              </Column>
+              <Column width="content">
+                <Switch
+                  checked={viewModel.enabled}
+                  onCheckedChange={(enabled) => updateSlackAgentState.mutate(enabled)}
+                  aria-label={intl.formatMessage(
+                    slackIntegrationRowMessages.enableSlackAgentAriaLabel,
+                  )}
+                  disabled={
+                    viewModel.toggleDisabled ||
+                    isError ||
+                    updateSlackAgentState.isPending ||
+                    isCreatingInstallUrl ||
+                    !userCanManage
+                  }
+                />
+              </Column>
+            </Columns>
+          </Box>
+          <Box display="flex" flexWrap="wrap" gap="1u">
             <Button size="sm" onClick={() => void handleConnect()} disabled={isCreatingInstallUrl}>
               {isCreatingInstallUrl
                 ? intl.formatMessage(slackIntegrationRowMessages.openingSlack)
@@ -228,8 +240,8 @@ export function SlackIntegrationRow({
                   : intl.formatMessage(slackIntegrationRowMessages.disable)}
               </Button>
             ) : null}
-          </div>
-        </div>
+          </Box>
+        </Rows>
       )}
     </IntegrationRow>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Integrations drops the row-level Tailwind className overrides and uses design-system primitives instead.

- Each integration is an `Item` (`outline`, or `muted` when expanded) with `ItemMedia`, `ItemTitle`, `ItemDescription`, and `ItemActions`.
- Category lists use `ItemGroup`. Category headings use `TypographyH4`.
- OAuth errors use `Alert variant="destructive"`.
- Connect uses the default button; Manage stays outline.
- `IntegrationCategoryCard` is a `Box` with surface/border tokens so AI Engine keeps a card without custom classes.

[Default integrations rows as Item cards, Slack panel expanded](https://cursor.com/agents/bc-01a065d2-3897-7b20-8106-9540d98dd091/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegrations_item_slack_expanded.webp)
[OAuth error using Alert destructive](https://cursor.com/agents/bc-01a065d2-3897-7b20-8106-9540d98dd091/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegrations_alert_oauth_error.webp)
[Read-only Intercom View only panel](https://cursor.com/agents/bc-01a065d2-3897-7b20-8106-9540d98dd091/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegrations_item_readonly_intercom.webp)
[Disconnected Connect buttons using default variant](https://cursor.com/agents/bc-01a065d2-3897-7b20-8106-9540d98dd091/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegrations_item_disconnected_connect.webp)

[integrations-item-alert-stories.mp4](https://cursor.com/agents/bc-01a065d2-3897-7b20-8106-9540d98dd091/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintegrations-item-alert-stories.mp4)

## How to test

- [x] `vp check --fix` (pass)
- [x] `vp test` on `integration-row.test.tsx` (3 passed)
- [x] Storybook `App/Integrations/Page`: Default (Slack/Crowdin Manage), OAuth Error, Read Only (Intercom View only), Disconnected (Connect)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a065d2-3897-7b20-8106-9540d98dd091?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a065d2-3897-7b20-8106-9540d98dd091&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

