### PR TITLE
Move member role changes behind a … menu dialog

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.messages.ts
@@ -136,15 +136,45 @@ export const membersPageContentMessages = defineMessages({
     id: "OUBWr2tI7F",
     description: "Badge shown next to the current user’s member row",
   },
-  revokeInvitationAria: {
-    defaultMessage: "Revoke invitation for {name}",
-    id: "+3ub8INH28",
-    description: "Accessible label for the revoke invitation button",
+  actionsForMember: {
+    defaultMessage: "Actions for {name}",
+    id: "pW1y7yrfkU",
+    description: "Accessible label for a workspace member row actions menu",
   },
-  removeMemberAria: {
-    defaultMessage: "Remove {name}",
-    id: "+91wkWHR07",
-    description: "Accessible label for the remove member button",
+  changeRole: {
+    defaultMessage: "Change role...",
+    id: "Y9Z2OL0Qj9",
+    description: "Menu item to change a workspace member’s role",
+  },
+  changeRoleTitle: {
+    defaultMessage: "Change role",
+    id: "rCXudWBslO",
+    description: "Title of the change member role dialog",
+  },
+  changeRoleDescription: {
+    defaultMessage: "Choose a new workspace role for {name}.",
+    id: "WmIEZ/nBLI",
+    description: "Description of the change member role dialog",
+  },
+  updateRole: {
+    defaultMessage: "Update role",
+    id: "5Ftr9lj7RM",
+    description: "Confirm button to update a workspace member’s role",
+  },
+  updatingRole: {
+    defaultMessage: "Updating...",
+    id: "6TDcwIX1nJ",
+    description: "Submit button label while a member role is being updated",
+  },
+  revokeInvitationMenu: {
+    defaultMessage: "Revoke invitation...",
+    id: "LeQu4ZEOkJ",
+    description: "Menu item to revoke a pending workspace invitation",
+  },
+  removeMemberMenu: {
+    defaultMessage: "Remove member...",
+    id: "acDR5UQdFA",
+    description: "Menu item to remove a workspace member",
   },
   revokeInvitation: {
     defaultMessage: "Revoke invitation",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
@@ -12,88 +12,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
 import { useState } from "react";
-import { Add01Icon, Delete01Icon, UserGroupIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Column } from "@/components/ui/layout/column";
-import { Columns } from "@/components/ui/layout/columns";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
-import { cn } from "@/lib/primitives/cn";
-
-import { WorkspacePeopleNav } from "../../_components/workspace-people-nav";
-import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 
 import { membersPageContentMessages } from "./members-page-content.messages";
+import { MembersPageView } from "./members-page-view";
 import {
-  getMembershipStatusLabel,
-  getRoleBadgeClassName,
-  getRoleBadgeVariant,
-  getRoleDescription,
-  getRoleLabel,
   resolveMembersPageState,
+  type MembersListMember,
   type MembersListResponse,
-  type MembersSettingsIntl,
 } from "./members-settings-view-model";
 
 const membersQueryKey = (organizationSlug: string) => ["workspace-members", organizationSlug];
-
-function MemberAvatar({
-  displayName,
-  avatarUrl,
-}: {
-  displayName: string;
-  avatarUrl: string | null | undefined;
-}) {
-  return (
-    <Avatar className="size-11 border border-border bg-background/60">
-      {avatarUrl ? <AvatarImage src={avatarUrl} alt={displayName} /> : null}
-      <AvatarFallback className="bg-skeleton text-xs font-medium text-subtle-foreground">
-        {memberInitials(displayName)}
-      </AvatarFallback>
-    </Avatar>
-  );
-}
-
-function memberInitials(displayName: string) {
-  const parts = displayName.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) {
-    return "?";
-  }
-
-  if (parts.length === 1) {
-    return parts[0]!.slice(0, 2).toUpperCase();
-  }
-
-  return `${parts[0]![0] ?? ""}${parts[1]![0] ?? ""}`.toUpperCase();
-}
 
 async function readMemberError(response: Response, fallback: string) {
   const body = await response.json().catch(() => null);
@@ -109,84 +44,14 @@ async function readMemberError(response: Response, fallback: string) {
   return fallback;
 }
 
-function RoleSelectItem({
-  role,
-  intl,
-}: {
-  role: OrganizationMembershipRole;
-  intl: MembersSettingsIntl;
-}) {
-  return (
-    <SelectItem
-      value={role}
-      label={getRoleLabel(role, intl)}
-      className="items-start py-2 [&>:first-child]:w-full [&>:first-child]:min-w-0 [&>:first-child]:shrink [&>:first-child]:whitespace-normal"
-    >
-      <div className="flex min-w-0 flex-col gap-0.5 text-start">
-        <span className="font-medium">{getRoleLabel(role, intl)}</span>
-        <p className="text-pretty text-xs leading-5 wrap-break-word text-muted-foreground">
-          {getRoleDescription(role, intl)}
-        </p>
-      </div>
-    </SelectItem>
-  );
-}
-
-function StatusBadge({
-  status,
-  intl,
-}: {
-  status: MembersListResponse["members"][number]["status"];
-  intl: MembersSettingsIntl;
-}) {
-  const isPending = status === "invited";
-
-  return (
-    <Badge
-      variant="outline"
-      className={cn(
-        "w-fit rounded-full border px-2.5 py-0.5 text-xs font-medium",
-        isPending
-          ? "border-bud-700/30 bg-bud-100 text-gray-900 dark:border-bud-500/25 dark:bg-bud-500/10 dark:text-bud-300"
-          : "border-grove-500/35 bg-grove-100 text-grove-900 dark:border-grove-300/20 dark:bg-grove-300/10 dark:text-grove-300",
-      )}
-    >
-      {getMembershipStatusLabel(status ?? "active", intl)}
-    </Badge>
-  );
-}
-
-function MembersTableHeader() {
-  return (
-    <div
-      role="row"
-      className="hidden grid-cols-[minmax(0,1.5fr)_9rem_minmax(12rem,1fr)_2.5rem] gap-4 border-b border-border px-1 py-2.5 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:grid"
-    >
-      <div role="columnheader">
-        <FormattedMessage {...membersPageContentMessages.columnMember} />
-      </div>
-      <div role="columnheader">
-        <FormattedMessage {...membersPageContentMessages.columnStatus} />
-      </div>
-      <div role="columnheader">
-        <FormattedMessage {...membersPageContentMessages.columnRole} />
-      </div>
-      <div role="columnheader" className="text-end">
-        <FormattedMessage {...membersPageContentMessages.columnActions} />
-      </div>
-    </div>
-  );
-}
-
 export function MembersPageContent({ organizationSlug }: { organizationSlug: string }) {
   const intl = useIntl();
   const queryClient = useQueryClient();
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<OrganizationMembershipRole>("member");
-  const [removingMember, setRemovingMember] = useState<
-    MembersListResponse["members"][number] | null
-  >(null);
+  const [removingMember, setRemovingMember] = useState<MembersListMember | null>(null);
+  const [editingMember, setEditingMember] = useState<MembersListMember | null>(null);
 
   const membersQuery = useQuery({
     queryKey: membersQueryKey(organizationSlug),
@@ -256,6 +121,7 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
       return response.json();
     },
     onSuccess: async () => {
+      setEditingMember(null);
       await queryClient.invalidateQueries({ queryKey: membersQueryKey(organizationSlug) });
       toast.success(intl.formatMessage(membersPageContentMessages.roleUpdatedToast));
     },
@@ -307,320 +173,35 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
   }
 
   return (
-    <WorkspacePageShell>
-      <WorkspacePeopleNav organizationSlug={organizationSlug} />
-
-      <PageHeader
-        icon={UserGroupIcon}
-        label={intl.formatMessage(membersPageContentMessages.pageLabel)}
-        title={intl.formatMessage(membersPageContentMessages.pageTitle)}
-        description={intl.formatMessage(membersPageContentMessages.pageDescription)}
-        actions={
-          <Columns spacing="1u" alignY="center" collapseBelow="small">
-            <Column width="containedContent">
-              <Button
-                nativeButton={false}
-                variant="ghost"
-                render={<Link href={`/org/${organizationSlug}/members/permissions`} />}
-                className="w-full sm:w-fit"
-              >
-                <FormattedMessage {...membersPageContentMessages.rolePermissions} />
-              </Button>
-            </Column>
-            {canInvite ? (
-              <Column width="containedContent">
-                <Button
-                  type="button"
-                  onClick={() => setIsInviteOpen(true)}
-                  className="w-full sm:w-fit"
-                  disabled={inviteMember.isPending}
-                >
-                  <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-                  <FormattedMessage {...membersPageContentMessages.inviteMember} />
-                </Button>
-              </Column>
-            ) : null}
-          </Columns>
-        }
-      />
-
-      <section
-        aria-label={intl.formatMessage(membersPageContentMessages.sectionAriaLabel)}
-        className="min-w-0"
-      >
-        {membersQuery.isLoading ? (
-          <TypographyP className="py-8 text-sm text-muted-foreground">
-            <FormattedMessage {...membersPageContentMessages.loading} />
-          </TypographyP>
-        ) : membersQuery.isError ? (
-          <div className="py-8">
-            <TypographyP className="text-sm font-medium text-flame-100">
-              <FormattedMessage {...membersPageContentMessages.loadErrorTitle} />
-            </TypographyP>
-            <TypographyP className="mt-1 text-xs text-muted-foreground">
-              {membersQuery.error instanceof Error
-                ? membersQuery.error.message
-                : intl.formatMessage(membersPageContentMessages.loadErrorFallback)}
-            </TypographyP>
-          </div>
-        ) : members.length === 0 ? (
-          <div className="py-10">
-            <TypographyP className="text-sm font-medium text-foreground">
-              <FormattedMessage {...membersPageContentMessages.emptyTitle} />
-            </TypographyP>
-            <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
-              <FormattedMessage {...membersPageContentMessages.emptyDescription} />
-            </TypographyP>
-          </div>
-        ) : (
-          <div role="table" className="min-w-0">
-            <MembersTableHeader />
-            {members.map((member) => {
-              const status = member.status ?? "active";
-              const isPending = status === "invited";
-              const roleDescription = getRoleDescription(member.role, intl);
-
-              return (
-                <div
-                  key={member.email}
-                  role="row"
-                  className="grid gap-4 border-t border-border px-1 py-4 md:grid-cols-[minmax(0,1.5fr)_9rem_minmax(12rem,1fr)_2.5rem] md:items-center"
-                >
-                  <div role="cell" className="flex min-w-0 items-start gap-3">
-                    <MemberAvatar displayName={member.displayName} avatarUrl={member.avatarUrl} />
-                    <div className="min-w-0">
-                      <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <TypographyP className="truncate text-sm font-medium text-foreground">
-                          {member.displayName}
-                        </TypographyP>
-                        {member.isCurrentUser ? (
-                          <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                            <FormattedMessage {...membersPageContentMessages.youBadge} />
-                          </span>
-                        ) : null}
-                      </div>
-                      <TypographyP className="mt-0.5 truncate text-sm text-muted-foreground">
-                        {member.email}
-                      </TypographyP>
-                    </div>
-                  </div>
-
-                  <div role="cell" className="min-w-0">
-                    <div className="flex items-center justify-between gap-3 md:block">
-                      <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:hidden">
-                        <FormattedMessage {...membersPageContentMessages.columnStatus} />
-                      </span>
-                      <StatusBadge status={status} intl={intl} />
-                    </div>
-                  </div>
-
-                  <div role="cell" className="min-w-0">
-                    <div className="flex items-center justify-between gap-3 md:block">
-                      <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:hidden">
-                        <FormattedMessage {...membersPageContentMessages.columnRole} />
-                      </span>
-                      {member.canUpdateRole ? (
-                        <Select
-                          value={member.role}
-                          onValueChange={(value) => {
-                            if (value === member.role) {
-                              return;
-                            }
-
-                            updateRole.mutate({
-                              workosUserId: member.workosUserId,
-                              role: value as OrganizationMembershipRole,
-                            });
-                          }}
-                          disabled={updateRole.isPending}
-                        >
-                          <SelectTrigger className="h-9 w-[12rem] max-w-full border-border bg-background/60 text-subtle-foreground hover:bg-muted">
-                            <SelectValue>{getRoleLabel(member.role, intl)}</SelectValue>
-                          </SelectTrigger>
-                          <SelectContent className="max-w-sm">
-                            {assignableRoles.map((role) => (
-                              <RoleSelectItem key={role} role={role} intl={intl} />
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      ) : (
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <Badge
-                                variant={getRoleBadgeVariant(member.role)}
-                                className={cn(
-                                  "h-auto max-w-[12rem] truncate rounded-lg px-3 py-1.5 text-sm",
-                                  getRoleBadgeClassName(member.role),
-                                )}
-                              >
-                                {getRoleLabel(member.role, intl)}
-                              </Badge>
-                            }
-                          />
-                          <TooltipContent side="bottom" align="start" className="max-w-xs">
-                            {roleDescription}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </div>
-                    {member.canUpdateRole ? (
-                      <TypographyP className="mt-1 hidden truncate text-xs text-muted-foreground lg:block">
-                        {roleDescription}
-                      </TypographyP>
-                    ) : null}
-                  </div>
-
-                  <div role="cell" className="flex items-center justify-end">
-                    {member.canRemove ? (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="icon"
-                              className="border-border bg-transparent text-muted-foreground hover:border-destructive/25 hover:bg-destructive/10 hover:text-destructive"
-                              onClick={() => setRemovingMember(member)}
-                              disabled={removeMember.isPending}
-                              aria-label={
-                                isPending
-                                  ? intl.formatMessage(
-                                      membersPageContentMessages.revokeInvitationAria,
-                                      { name: member.displayName },
-                                    )
-                                  : intl.formatMessage(
-                                      membersPageContentMessages.removeMemberAria,
-                                      {
-                                        name: member.displayName,
-                                      },
-                                    )
-                              }
-                            >
-                              <HugeiconsIcon icon={Delete01Icon} strokeWidth={1.8} />
-                            </Button>
-                          }
-                        />
-                        <TooltipContent side="bottom" align="end">
-                          {isPending ? (
-                            <FormattedMessage {...membersPageContentMessages.revokeInvitation} />
-                          ) : (
-                            <FormattedMessage {...membersPageContentMessages.removeMember} />
-                          )}
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : null}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </section>
-
-      <Dialog open={isInviteOpen} onOpenChange={setIsInviteOpen}>
-        <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>
-              <FormattedMessage {...membersPageContentMessages.inviteDialogTitle} />
-            </DialogTitle>
-            <DialogDescription>
-              <FormattedMessage {...membersPageContentMessages.inviteDialogDescription} />
-            </DialogDescription>
-          </DialogHeader>
-          <form onSubmit={handleInviteSubmit} className="grid gap-4">
-            <Field>
-              <FieldLabel>
-                <FormattedMessage {...membersPageContentMessages.emailLabel} />
-              </FieldLabel>
-              <Input
-                type="email"
-                value={inviteEmail}
-                onChange={(e) => setInviteEmail(e.target.value)}
-                placeholder={intl.formatMessage(membersPageContentMessages.emailPlaceholder)}
-                className="border-border bg-muted"
-                required
-              />
-            </Field>
-            <Field>
-              <FieldLabel>
-                <FormattedMessage {...membersPageContentMessages.roleLabel} />
-              </FieldLabel>
-              <Select
-                value={inviteRole}
-                onValueChange={(value) => setInviteRole(value as OrganizationMembershipRole)}
-              >
-                <SelectTrigger className="border-border bg-muted">
-                  <SelectValue>{getRoleLabel(inviteRole, intl)}</SelectValue>
-                </SelectTrigger>
-                <SelectContent className="max-w-sm">
-                  {assignableRoles.map((role) => (
-                    <RoleSelectItem key={role} role={role} intl={intl} />
-                  ))}
-                </SelectContent>
-              </Select>
-              <FieldDescription>{getRoleDescription(inviteRole, intl)}</FieldDescription>
-            </Field>
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setIsInviteOpen(false)}>
-                <FormattedMessage {...membersPageContentMessages.cancel} />
-              </Button>
-              <Button type="submit" disabled={inviteMember.isPending}>
-                <FormattedMessage {...membersPageContentMessages.sendInvitation} />
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={removingMember !== null}
-        onOpenChange={(open) => !open && setRemovingMember(null)}
-      >
-        <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>
-              {removingMember?.status === "invited" ? (
-                <FormattedMessage {...membersPageContentMessages.revokeInvitation} />
-              ) : (
-                <FormattedMessage {...membersPageContentMessages.removeMember} />
-              )}
-            </DialogTitle>
-            <DialogDescription>
-              {removingMember
-                ? removingMember.status === "invited"
-                  ? intl.formatMessage(membersPageContentMessages.revokeDialogDescription, {
-                      email: removingMember.email,
-                    })
-                  : intl.formatMessage(membersPageContentMessages.removeDialogDescription, {
-                      name: removingMember.displayName,
-                    })
-                : ""}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setRemovingMember(null)}>
-              <FormattedMessage {...membersPageContentMessages.cancel} />
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              disabled={!removingMember || removeMember.isPending}
-              onClick={() => {
-                if (removingMember) {
-                  removeMember.mutate(removingMember.workosUserId);
-                }
-              }}
-            >
-              {removingMember?.status === "invited" ? (
-                <FormattedMessage {...membersPageContentMessages.revokeInvitation} />
-              ) : (
-                <FormattedMessage {...membersPageContentMessages.removeMember} />
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </WorkspacePageShell>
+    <MembersPageView
+      organizationSlug={organizationSlug}
+      members={members}
+      assignableRoles={assignableRoles}
+      canInvite={canInvite}
+      isLoading={membersQuery.isLoading}
+      loadError={
+        membersQuery.isError
+          ? membersQuery.error instanceof Error
+            ? membersQuery.error.message
+            : intl.formatMessage(membersPageContentMessages.loadErrorFallback)
+          : null
+      }
+      isInviteOpen={isInviteOpen}
+      inviteEmail={inviteEmail}
+      inviteRole={inviteRole}
+      isInviting={inviteMember.isPending}
+      removingMember={removingMember}
+      isRemoving={removeMember.isPending}
+      editingMember={editingMember}
+      isUpdatingRole={updateRole.isPending}
+      onInviteOpenChange={setIsInviteOpen}
+      onInviteEmailChange={setInviteEmail}
+      onInviteRoleChange={setInviteRole}
+      onInviteSubmit={handleInviteSubmit}
+      onRemovingMemberChange={setRemovingMember}
+      onRemoveMember={(workosUserId) => removeMember.mutate(workosUserId)}
+      onEditingMemberChange={setEditingMember}
+      onUpdateRole={(input) => updateRole.mutate(input)}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.stories.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, userEvent } from "storybook/test";
+
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+
+import { MembersPageView } from "./members-page-view";
+import type { MembersListMember } from "./members-settings-view-model";
+
+function createMember(overrides: Partial<MembersListMember> = {}): MembersListMember {
+  return {
+    workosUserId: "user_001",
+    email: "mina@example.com",
+    displayName: "Mina Chen",
+    avatarUrl: null,
+    role: "reviewer",
+    isCurrentUser: false,
+    status: "active",
+    canUpdateRole: true,
+    canRemove: true,
+    ...overrides,
+  };
+}
+
+const assignableRoles: OrganizationMembershipRole[] = [
+  "admin",
+  "localization_manager",
+  "developer",
+  "reviewer",
+  "translator",
+  "member",
+];
+
+const mina = createMember();
+const otto = createMember({
+  workosUserId: "user_002",
+  email: "otto@example.com",
+  displayName: "Otto Park",
+  role: "member",
+});
+const currentUser = createMember({
+  workosUserId: "user_003",
+  email: "you@example.com",
+  displayName: "You",
+  role: "admin",
+  isCurrentUser: true,
+  canUpdateRole: false,
+  canRemove: false,
+});
+
+const meta = {
+  title: "App/Members/Page",
+  component: MembersPageView,
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/members",
+      },
+    },
+  },
+  args: {
+    organizationSlug: "acme",
+    members: [currentUser, mina, otto],
+    assignableRoles,
+    canInvite: true,
+    isLoading: false,
+    loadError: null,
+    isInviteOpen: false,
+    inviteEmail: "",
+    inviteRole: "member",
+    isInviting: false,
+    removingMember: null,
+    isRemoving: false,
+    editingMember: null,
+    isUpdatingRole: false,
+    onInviteOpenChange: fn(),
+    onInviteEmailChange: fn(),
+    onInviteRoleChange: fn(),
+    onInviteSubmit: fn(),
+    onRemovingMemberChange: fn(),
+    onRemoveMember: fn(),
+    onEditingMemberChange: fn(),
+    onUpdateRole: fn(),
+  },
+} satisfies Meta<typeof MembersPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Members" })).toBeInTheDocument();
+    await expect(canvas.getByText("Mina Chen")).toBeInTheDocument();
+    await expect(canvas.queryByRole("combobox")).not.toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Actions for Mina Chen" })).toBeInTheDocument();
+  },
+};
+
+export const ChangeRoleDialogOpen: Story = {
+  args: {
+    editingMember: mina,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Change role" })).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Choose a new workspace role for Mina Chen."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const OpensChangeRoleFromMenu: Story = {
+  play: async ({ canvas, args }) => {
+    await userEvent.click(canvas.getByRole("button", { name: "Actions for Mina Chen" }));
+    await userEvent.click(await canvas.findByText("Change role..."));
+    await expect(args.onEditingMemberChange).toHaveBeenCalledWith(mina);
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+
+import { MembersPageView } from "./members-page-view";
+import type { MembersListMember } from "./members-settings-view-model";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/org/acme/members",
+}));
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      {ui}
+    </IntlProvider>,
+  );
+}
+
+function createMember(overrides: Partial<MembersListMember> = {}): MembersListMember {
+  return {
+    workosUserId: "user_001",
+    email: "mina@example.com",
+    displayName: "Mina Chen",
+    avatarUrl: null,
+    role: "reviewer",
+    isCurrentUser: false,
+    status: "active",
+    canUpdateRole: true,
+    canRemove: true,
+    ...overrides,
+  };
+}
+
+const assignableRoles: OrganizationMembershipRole[] = [
+  "admin",
+  "localization_manager",
+  "developer",
+  "reviewer",
+  "translator",
+  "member",
+];
+
+function renderMembersPage(overrides: Partial<Parameters<typeof MembersPageView>[0]> = {}) {
+  const props = {
+    organizationSlug: "acme",
+    members: [createMember()],
+    assignableRoles,
+    canInvite: true,
+    isLoading: false,
+    loadError: null,
+    isInviteOpen: false,
+    inviteEmail: "",
+    inviteRole: "member" as const,
+    isInviting: false,
+    removingMember: null,
+    isRemoving: false,
+    editingMember: null,
+    isUpdatingRole: false,
+    onInviteOpenChange: vi.fn(),
+    onInviteEmailChange: vi.fn(),
+    onInviteRoleChange: vi.fn(),
+    onInviteSubmit: vi.fn(),
+    onRemovingMemberChange: vi.fn(),
+    onRemoveMember: vi.fn(),
+    onEditingMemberChange: vi.fn(),
+    onUpdateRole: vi.fn(),
+    ...overrides,
+  };
+
+  return { ...renderWithIntl(<MembersPageView {...props} />), props };
+}
+
+describe("MembersPageView", () => {
+  it("shows role as a badge instead of an inline select", () => {
+    renderMembersPage();
+
+    expect(screen.getByText("Reviewer")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("opens the change-role dialog from the row actions menu", async () => {
+    const user = userEvent.setup();
+    const member = createMember();
+    const { props } = renderMembersPage({ members: [member] });
+
+    await user.click(screen.getByRole("button", { name: "Actions for Mina Chen" }));
+    await user.click(await screen.findByText("Change role..."));
+
+    expect(props.onEditingMemberChange).toHaveBeenCalledWith(member);
+  });
+
+  it("updates the role only after confirming in the dialog", async () => {
+    const user = userEvent.setup();
+    const member = createMember();
+    const { props } = renderMembersPage({
+      members: [member],
+      editingMember: member,
+    });
+
+    expect(screen.getByRole("dialog", { name: "Change role" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update role" })).toBeDisabled();
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: /Admin/ }));
+    await user.click(screen.getByRole("button", { name: "Update role" }));
+
+    expect(props.onUpdateRole).toHaveBeenCalledWith({
+      workosUserId: member.workosUserId,
+      role: "admin",
+    });
+  });
+
+  it("removes a member from the row actions menu instead of a standalone icon", async () => {
+    const user = userEvent.setup();
+    const member = createMember();
+    const { props } = renderMembersPage({ members: [member] });
+
+    expect(screen.queryByRole("button", { name: "Remove Mina Chen" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Actions for Mina Chen" }));
+    await user.click(await screen.findByText("Remove member..."));
+
+    expect(props.onRemovingMemberChange).toHaveBeenCalledWith(member);
+  });
+
+  it("hides the actions menu when the member cannot be managed", () => {
+    renderMembersPage({
+      members: [
+        createMember({
+          isCurrentUser: true,
+          canUpdateRole: false,
+          canRemove: false,
+        }),
+      ],
+    });
+
+    expect(screen.queryByRole("button", { name: "Actions for Mina Chen" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
@@ -1,0 +1,666 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { type FormEvent, useEffect, useState } from "react";
+import Link from "next/link";
+import { Add01Icon, MoreHorizontalCircle01Icon, UserGroupIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+import { cn } from "@/lib/primitives/cn";
+
+import { WorkspacePeopleNav } from "../../_components/workspace-people-nav";
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+
+import { membersPageContentMessages } from "./members-page-content.messages";
+import {
+  getMembershipStatusLabel,
+  getRoleBadgeClassName,
+  getRoleBadgeVariant,
+  getRoleDescription,
+  getRoleLabel,
+  type MembersListMember,
+  type MembersSettingsIntl,
+} from "./members-settings-view-model";
+
+function MemberAvatar({
+  displayName,
+  avatarUrl,
+}: {
+  displayName: string;
+  avatarUrl: string | null | undefined;
+}) {
+  return (
+    <Avatar className="size-11 border border-border bg-background/60">
+      {avatarUrl ? <AvatarImage src={avatarUrl} alt={displayName} /> : null}
+      <AvatarFallback className="bg-skeleton text-xs font-medium text-subtle-foreground">
+        {memberInitials(displayName)}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+
+function memberInitials(displayName: string) {
+  const parts = displayName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    return "?";
+  }
+
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2).toUpperCase();
+  }
+
+  return `${parts[0]![0] ?? ""}${parts[1]![0] ?? ""}`.toUpperCase();
+}
+
+function RoleSelectItem({
+  role,
+  intl,
+}: {
+  role: OrganizationMembershipRole;
+  intl: MembersSettingsIntl;
+}) {
+  return (
+    <SelectItem
+      value={role}
+      label={getRoleLabel(role, intl)}
+      className="items-start py-2 [&>:first-child]:w-full [&>:first-child]:min-w-0 [&>:first-child]:shrink [&>:first-child]:whitespace-normal"
+    >
+      <div className="flex min-w-0 flex-col gap-0.5 text-start">
+        <span className="font-medium">{getRoleLabel(role, intl)}</span>
+        <p className="text-pretty text-xs leading-5 wrap-break-word text-muted-foreground">
+          {getRoleDescription(role, intl)}
+        </p>
+      </div>
+    </SelectItem>
+  );
+}
+
+function StatusBadge({
+  status,
+  intl,
+}: {
+  status: MembersListMember["status"];
+  intl: MembersSettingsIntl;
+}) {
+  const isPending = status === "invited";
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "w-fit rounded-full border px-2.5 py-0.5 text-xs font-medium",
+        isPending
+          ? "border-bud-700/30 bg-bud-100 text-gray-900 dark:border-bud-500/25 dark:bg-bud-500/10 dark:text-bud-300"
+          : "border-grove-500/35 bg-grove-100 text-grove-900 dark:border-grove-300/20 dark:bg-grove-300/10 dark:text-grove-300",
+      )}
+    >
+      {getMembershipStatusLabel(status ?? "active", intl)}
+    </Badge>
+  );
+}
+
+function RoleBadge({
+  role,
+  intl,
+}: {
+  role: OrganizationMembershipRole;
+  intl: MembersSettingsIntl;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Badge
+            variant={getRoleBadgeVariant(role)}
+            className={cn(
+              "h-auto max-w-[12rem] truncate rounded-lg px-3 py-1.5 text-sm",
+              getRoleBadgeClassName(role),
+            )}
+          >
+            {getRoleLabel(role, intl)}
+          </Badge>
+        }
+      />
+      <TooltipContent side="bottom" align="start" className="max-w-xs">
+        {getRoleDescription(role, intl)}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function MembersTableHeader() {
+  return (
+    <div
+      role="row"
+      className="hidden grid-cols-[minmax(0,1.5fr)_9rem_minmax(12rem,1fr)_2.5rem] gap-4 border-b border-border px-1 py-2.5 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:grid"
+    >
+      <div role="columnheader">
+        <FormattedMessage {...membersPageContentMessages.columnMember} />
+      </div>
+      <div role="columnheader">
+        <FormattedMessage {...membersPageContentMessages.columnStatus} />
+      </div>
+      <div role="columnheader">
+        <FormattedMessage {...membersPageContentMessages.columnRole} />
+      </div>
+      <div role="columnheader" className="text-end">
+        <FormattedMessage {...membersPageContentMessages.columnActions} />
+      </div>
+    </div>
+  );
+}
+
+function MemberRowActions({
+  member,
+  canUpdateRole,
+  canRemove,
+  isBusy,
+  onChangeRole,
+  onRemove,
+}: {
+  member: MembersListMember;
+  canUpdateRole: boolean;
+  canRemove: boolean;
+  isBusy: boolean;
+  onChangeRole: (member: MembersListMember) => void;
+  onRemove: (member: MembersListMember) => void;
+}) {
+  const intl = useIntl();
+  const isPending = (member.status ?? "active") === "invited";
+
+  if (!canUpdateRole && !canRemove) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className={cn(
+              "rounded-full text-muted-foreground hover:bg-accent/20 hover:text-foreground",
+              "opacity-100 transition-opacity md:opacity-0 md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100",
+              "data-popup-open:opacity-100 aria-expanded:opacity-100",
+            )}
+            aria-label={intl.formatMessage(membersPageContentMessages.actionsForMember, {
+              name: member.displayName,
+            })}
+            disabled={isBusy}
+          />
+        }
+      >
+        <HugeiconsIcon icon={MoreHorizontalCircle01Icon} strokeWidth={1.8} className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-48">
+        {canUpdateRole ? (
+          <DropdownMenuGroup>
+            <DropdownMenuItem onClick={() => onChangeRole(member)} disabled={isBusy}>
+              <FormattedMessage {...membersPageContentMessages.changeRole} />
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        ) : null}
+        {canUpdateRole && canRemove ? <DropdownMenuSeparator /> : null}
+        {canRemove ? (
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={() => onRemove(member)}
+              disabled={isBusy}
+            >
+              {isPending ? (
+                <FormattedMessage {...membersPageContentMessages.revokeInvitationMenu} />
+              ) : (
+                <FormattedMessage {...membersPageContentMessages.removeMemberMenu} />
+              )}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function ChangeMemberRoleDialog({
+  member,
+  assignableRoles,
+  isSaving,
+  onOpenChange,
+  onSubmit,
+}: {
+  member: MembersListMember | null;
+  assignableRoles: OrganizationMembershipRole[];
+  isSaving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (input: { workosUserId: string; role: OrganizationMembershipRole }) => void;
+}) {
+  const intl = useIntl();
+  const [role, setRole] = useState<OrganizationMembershipRole>(member?.role ?? "member");
+
+  useEffect(() => {
+    if (member) {
+      setRole(member.role);
+    }
+  }, [member]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!member || role === member.role) {
+      return;
+    }
+
+    onSubmit({ workosUserId: member.workosUserId, role });
+  }
+
+  return (
+    <Dialog
+      open={member !== null}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && isSaving) {
+          return;
+        }
+
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...membersPageContentMessages.changeRoleTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              {member
+                ? intl.formatMessage(membersPageContentMessages.changeRoleDescription, {
+                    name: member.displayName,
+                  })
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel>
+              <FormattedMessage {...membersPageContentMessages.roleLabel} />
+            </FieldLabel>
+            <Select
+              value={role}
+              onValueChange={(value) => setRole(value as OrganizationMembershipRole)}
+              disabled={isSaving}
+            >
+              <SelectTrigger className="border-border bg-muted">
+                <SelectValue>{getRoleLabel(role, intl)}</SelectValue>
+              </SelectTrigger>
+              <SelectContent className="max-w-sm">
+                {assignableRoles.map((assignableRole) => (
+                  <RoleSelectItem key={assignableRole} role={assignableRole} intl={intl} />
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldDescription>{getRoleDescription(role, intl)}</FieldDescription>
+          </Field>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isSaving}
+              onClick={() => onOpenChange(false)}
+            >
+              <FormattedMessage {...membersPageContentMessages.cancel} />
+            </Button>
+            <Button type="submit" disabled={isSaving || !member || role === member.role}>
+              {isSaving ? <Spinner /> : null}
+              {isSaving ? (
+                <FormattedMessage {...membersPageContentMessages.updatingRole} />
+              ) : (
+                <FormattedMessage {...membersPageContentMessages.updateRole} />
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function MembersPageView({
+  organizationSlug,
+  members,
+  assignableRoles,
+  canInvite,
+  isLoading,
+  loadError,
+  isInviteOpen,
+  inviteEmail,
+  inviteRole,
+  isInviting,
+  removingMember,
+  isRemoving,
+  editingMember,
+  isUpdatingRole,
+  onInviteOpenChange,
+  onInviteEmailChange,
+  onInviteRoleChange,
+  onInviteSubmit,
+  onRemovingMemberChange,
+  onRemoveMember,
+  onEditingMemberChange,
+  onUpdateRole,
+}: {
+  organizationSlug: string;
+  members: MembersListMember[];
+  assignableRoles: OrganizationMembershipRole[];
+  canInvite: boolean;
+  isLoading: boolean;
+  loadError: string | null;
+  isInviteOpen: boolean;
+  inviteEmail: string;
+  inviteRole: OrganizationMembershipRole;
+  isInviting: boolean;
+  removingMember: MembersListMember | null;
+  isRemoving: boolean;
+  editingMember: MembersListMember | null;
+  isUpdatingRole: boolean;
+  onInviteOpenChange: (open: boolean) => void;
+  onInviteEmailChange: (email: string) => void;
+  onInviteRoleChange: (role: OrganizationMembershipRole) => void;
+  onInviteSubmit: (event: React.SyntheticEvent) => void;
+  onRemovingMemberChange: (member: MembersListMember | null) => void;
+  onRemoveMember: (workosUserId: string) => void;
+  onEditingMemberChange: (member: MembersListMember | null) => void;
+  onUpdateRole: (input: { workosUserId: string; role: OrganizationMembershipRole }) => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <WorkspacePageShell>
+      <WorkspacePeopleNav organizationSlug={organizationSlug} />
+
+      <PageHeader
+        icon={UserGroupIcon}
+        label={intl.formatMessage(membersPageContentMessages.pageLabel)}
+        title={intl.formatMessage(membersPageContentMessages.pageTitle)}
+        description={intl.formatMessage(membersPageContentMessages.pageDescription)}
+        actions={
+          <Columns spacing="1u" alignY="center" collapseBelow="small">
+            <Column width="containedContent">
+              <Button
+                nativeButton={false}
+                variant="ghost"
+                render={<Link href={`/org/${organizationSlug}/members/permissions`} />}
+                className="w-full sm:w-fit"
+              >
+                <FormattedMessage {...membersPageContentMessages.rolePermissions} />
+              </Button>
+            </Column>
+            {canInvite ? (
+              <Column width="containedContent">
+                <Button
+                  type="button"
+                  onClick={() => onInviteOpenChange(true)}
+                  className="w-full sm:w-fit"
+                  disabled={isInviting}
+                >
+                  <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+                  <FormattedMessage {...membersPageContentMessages.inviteMember} />
+                </Button>
+              </Column>
+            ) : null}
+          </Columns>
+        }
+      />
+
+      <section
+        aria-label={intl.formatMessage(membersPageContentMessages.sectionAriaLabel)}
+        className="min-w-0"
+      >
+        {isLoading ? (
+          <TypographyP className="py-8 text-sm text-muted-foreground">
+            <FormattedMessage {...membersPageContentMessages.loading} />
+          </TypographyP>
+        ) : loadError ? (
+          <div className="py-8">
+            <TypographyP className="text-sm font-medium text-flame-100">
+              <FormattedMessage {...membersPageContentMessages.loadErrorTitle} />
+            </TypographyP>
+            <TypographyP className="mt-1 text-xs text-muted-foreground">{loadError}</TypographyP>
+          </div>
+        ) : members.length === 0 ? (
+          <div className="py-10">
+            <TypographyP className="text-sm font-medium text-foreground">
+              <FormattedMessage {...membersPageContentMessages.emptyTitle} />
+            </TypographyP>
+            <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+              <FormattedMessage {...membersPageContentMessages.emptyDescription} />
+            </TypographyP>
+          </div>
+        ) : (
+          <div role="table" className="min-w-0">
+            <MembersTableHeader />
+            {members.map((member) => {
+              const status = member.status ?? "active";
+
+              return (
+                <div
+                  key={member.email}
+                  role="row"
+                  className="group/row grid gap-4 border-t border-border px-1 py-4 transition-colors hover:bg-muted/40 md:grid-cols-[minmax(0,1.5fr)_9rem_minmax(12rem,1fr)_2.5rem] md:items-center"
+                >
+                  <div role="cell" className="flex min-w-0 items-start gap-3">
+                    <MemberAvatar displayName={member.displayName} avatarUrl={member.avatarUrl} />
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        <TypographyP className="truncate text-sm font-medium text-foreground">
+                          {member.displayName}
+                        </TypographyP>
+                        {member.isCurrentUser ? (
+                          <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                            <FormattedMessage {...membersPageContentMessages.youBadge} />
+                          </span>
+                        ) : null}
+                      </div>
+                      <TypographyP className="mt-0.5 truncate text-sm text-muted-foreground">
+                        {member.email}
+                      </TypographyP>
+                    </div>
+                  </div>
+
+                  <div role="cell" className="min-w-0">
+                    <div className="flex items-center justify-between gap-3 md:block">
+                      <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:hidden">
+                        <FormattedMessage {...membersPageContentMessages.columnStatus} />
+                      </span>
+                      <StatusBadge status={status} intl={intl} />
+                    </div>
+                  </div>
+
+                  <div role="cell" className="min-w-0">
+                    <div className="flex items-center justify-between gap-3 md:block">
+                      <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:hidden">
+                        <FormattedMessage {...membersPageContentMessages.columnRole} />
+                      </span>
+                      <RoleBadge role={member.role} intl={intl} />
+                    </div>
+                  </div>
+
+                  <div role="cell" className="flex items-center justify-end">
+                    <MemberRowActions
+                      member={member}
+                      canUpdateRole={member.canUpdateRole === true}
+                      canRemove={member.canRemove === true}
+                      isBusy={isRemoving || isUpdatingRole}
+                      onChangeRole={onEditingMemberChange}
+                      onRemove={onRemovingMemberChange}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <Dialog open={isInviteOpen} onOpenChange={onInviteOpenChange}>
+        <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...membersPageContentMessages.inviteDialogTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage {...membersPageContentMessages.inviteDialogDescription} />
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={onInviteSubmit} className="grid gap-4">
+            <Field>
+              <FieldLabel>
+                <FormattedMessage {...membersPageContentMessages.emailLabel} />
+              </FieldLabel>
+              <Input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => onInviteEmailChange(e.target.value)}
+                placeholder={intl.formatMessage(membersPageContentMessages.emailPlaceholder)}
+                className="border-border bg-muted"
+                required
+              />
+            </Field>
+            <Field>
+              <FieldLabel>
+                <FormattedMessage {...membersPageContentMessages.roleLabel} />
+              </FieldLabel>
+              <Select
+                value={inviteRole}
+                onValueChange={(value) => onInviteRoleChange(value as OrganizationMembershipRole)}
+              >
+                <SelectTrigger className="border-border bg-muted">
+                  <SelectValue>{getRoleLabel(inviteRole, intl)}</SelectValue>
+                </SelectTrigger>
+                <SelectContent className="max-w-sm">
+                  {assignableRoles.map((role) => (
+                    <RoleSelectItem key={role} role={role} intl={intl} />
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldDescription>{getRoleDescription(inviteRole, intl)}</FieldDescription>
+            </Field>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onInviteOpenChange(false)}>
+                <FormattedMessage {...membersPageContentMessages.cancel} />
+              </Button>
+              <Button type="submit" disabled={isInviting}>
+                <FormattedMessage {...membersPageContentMessages.sendInvitation} />
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ChangeMemberRoleDialog
+        member={editingMember}
+        assignableRoles={assignableRoles}
+        isSaving={isUpdatingRole}
+        onOpenChange={(open) => {
+          if (!open) {
+            onEditingMemberChange(null);
+          }
+        }}
+        onSubmit={onUpdateRole}
+      />
+
+      <Dialog
+        open={removingMember !== null}
+        onOpenChange={(open) => !open && onRemovingMemberChange(null)}
+      >
+        <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {removingMember?.status === "invited" ? (
+                <FormattedMessage {...membersPageContentMessages.revokeInvitation} />
+              ) : (
+                <FormattedMessage {...membersPageContentMessages.removeMember} />
+              )}
+            </DialogTitle>
+            <DialogDescription>
+              {removingMember
+                ? removingMember.status === "invited"
+                  ? intl.formatMessage(membersPageContentMessages.revokeDialogDescription, {
+                      email: removingMember.email,
+                    })
+                  : intl.formatMessage(membersPageContentMessages.removeDialogDescription, {
+                      name: removingMember.displayName,
+                    })
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onRemovingMemberChange(null)}>
+              <FormattedMessage {...membersPageContentMessages.cancel} />
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={!removingMember || isRemoving}
+              onClick={() => {
+                if (removingMember) {
+                  onRemoveMember(removingMember.workosUserId);
+                }
+              }}
+            >
+              {removingMember?.status === "invited" ? (
+                <FormattedMessage {...membersPageContentMessages.revokeInvitation} />
+              ) : (
+                <FormattedMessage {...membersPageContentMessages.removeMember} />
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.tsx
@@ -52,6 +52,7 @@ export function TeamDetailPageContent({
   const queryClient = useQueryClient();
   const [isAddMemberOpen, setIsAddMemberOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const [editingMember, setEditingMember] = useState<TeamMemberRow | null>(null);
   const [removingMember, setRemovingMember] = useState<TeamMemberRow | null>(null);
 
   const teamQuery = useQuery({
@@ -102,6 +103,7 @@ export function TeamDetailPageContent({
     mutationFn: (input: { workosUserId: string; role: TeamRole }) =>
       injectedTeamsApi.addTeamMember(organizationSlug, teamId, input),
     onSuccess: async () => {
+      setEditingMember(null);
       await invalidateTeam();
       toast.success(intl.formatMessage(teamDetailPageContentMessages.roleUpdated));
     },
@@ -137,15 +139,15 @@ export function TeamDetailPageContent({
       isEditOpen={isEditOpen}
       isSavingTeam={updateTeam.isPending}
       isRemovingMember={removeMember.isPending}
-      updatingMemberRoleId={
-        updateMemberRole.isPending ? (updateMemberRole.variables?.workosUserId ?? null) : null
-      }
+      isUpdatingMemberRole={updateMemberRole.isPending}
+      editingMember={editingMember}
       removingMember={removingMember}
       onAddMemberOpenChange={setIsAddMemberOpen}
       onEditOpenChange={setIsEditOpen}
       onAddMember={(input) => addMember.mutate(input)}
       onUpdateTeam={(values) => updateTeam.mutate(values)}
       onUpdateMemberRole={(input) => updateMemberRole.mutate(input)}
+      onEditingMemberChange={setEditingMember}
       onRemoveMember={(workosUserId) => removeMember.mutate(workosUserId)}
       onRemovingMemberChange={setRemovingMember}
     />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.messages.ts
@@ -40,6 +40,36 @@ export const teamDetailPageViewMessages = defineMessages({
     id: "BkNjvJSOTT",
     description: "Menu item to remove a member from the team",
   },
+  changeRole: {
+    defaultMessage: "Change role...",
+    id: "LqnXxoT6He",
+    description: "Menu item to change a team member’s role",
+  },
+  changeRoleTitle: {
+    defaultMessage: "Change role",
+    id: "smAw7U0xZ+",
+    description: "Title of the change team member role dialog",
+  },
+  changeRoleDescription: {
+    defaultMessage: "Choose a new team role for {email}.",
+    id: "xZFAbDOIux",
+    description: "Description of the change team member role dialog",
+  },
+  roleLabel: {
+    defaultMessage: "Role",
+    id: "vlvGY6fhsb",
+    description: "Label for the team role select in the change role dialog",
+  },
+  updateRole: {
+    defaultMessage: "Update role",
+    id: "8Wsdxcak0K",
+    description: "Confirm button to update a team member’s role",
+  },
+  updatingRole: {
+    defaultMessage: "Updating...",
+    id: "Gk7YcyvJlX",
+    description: "Submit button label while a team member role is being updated",
+  },
   backToTeams: {
     defaultMessage: "Back to teams",
     id: "wtUAi5KCmb",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.stories.tsx
@@ -41,13 +41,15 @@ const meta = {
     isEditOpen: false,
     isSavingTeam: false,
     isRemovingMember: false,
-    updatingMemberRoleId: null,
+    isUpdatingMemberRole: false,
+    editingMember: null,
     removingMember: null,
     onAddMemberOpenChange: fn(),
     onEditOpenChange: fn(),
     onAddMember: fn(),
     onUpdateTeam: fn(),
     onUpdateMemberRole: fn(),
+    onEditingMemberChange: fn(),
     onRemoveMember: fn(),
     onRemovingMemberChange: fn(),
   },
@@ -92,6 +94,18 @@ export const AddMemberDialogOpen: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("dialog", { name: "Add team member" })).toBeInTheDocument();
     await expect(canvas.getByText("sam@example.com")).toBeInTheDocument();
+  },
+};
+
+export const ChangeRoleDialogOpen: Story = {
+  args: {
+    editingMember: team.members[1],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Change role" })).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Choose a new team role for otto@example.com."),
+    ).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createTeamDetail, createTeamMember, memberDirectoryFixture } from "./teams.fixture";
+import { TeamDetailPageView } from "./team-detail-page-view";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/org/acme/teams/11111111-1111-4111-8111-111111111111",
+}));
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      {ui}
+    </IntlProvider>,
+  );
+}
+
+function renderTeamDetail(overrides: Partial<Parameters<typeof TeamDetailPageView>[0]> = {}) {
+  const props = {
+    organizationSlug: "acme",
+    team: createTeamDetail(),
+    canManageTeams: true,
+    currentUserWorkosId: "user_001",
+    memberDirectory: memberDirectoryFixture,
+    isLoading: false,
+    isAddMemberOpen: false,
+    isAddingMember: false,
+    isEditOpen: false,
+    isSavingTeam: false,
+    isRemovingMember: false,
+    isUpdatingMemberRole: false,
+    editingMember: null,
+    removingMember: null,
+    onAddMemberOpenChange: vi.fn(),
+    onEditOpenChange: vi.fn(),
+    onAddMember: vi.fn(),
+    onUpdateTeam: vi.fn(),
+    onUpdateMemberRole: vi.fn(),
+    onEditingMemberChange: vi.fn(),
+    onRemoveMember: vi.fn(),
+    onRemovingMemberChange: vi.fn(),
+    ...overrides,
+  };
+
+  return { ...renderWithIntl(<TeamDetailPageView {...props} />), props };
+}
+
+describe("TeamDetailPageView", () => {
+  it("shows team roles as badges instead of inline selects", () => {
+    renderTeamDetail();
+
+    expect(screen.getByText("Manager")).toBeInTheDocument();
+    expect(screen.getAllByText("Member").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("opens the change-role dialog from the row actions menu", async () => {
+    const user = userEvent.setup();
+    const member = createTeamMember({
+      workosUserId: "user_002",
+      email: "otto@example.com",
+      role: "member",
+    });
+    const { props } = renderTeamDetail();
+
+    await user.click(screen.getByRole("button", { name: "Actions for otto@example.com" }));
+    await user.click(await screen.findByText("Change role..."));
+
+    expect(props.onEditingMemberChange).toHaveBeenCalledWith(member);
+  });
+
+  it("updates the team role only after confirming in the dialog", async () => {
+    const user = userEvent.setup();
+    const member = createTeamMember({
+      workosUserId: "user_002",
+      email: "otto@example.com",
+      role: "member",
+    });
+    const { props } = renderTeamDetail({ editingMember: member });
+
+    expect(screen.getByRole("dialog", { name: "Change role" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update role" })).toBeDisabled();
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Manager" }));
+    await user.click(screen.getByRole("button", { name: "Update role" }));
+
+    expect(props.onUpdateMemberRole).toHaveBeenCalledWith({
+      workosUserId: member.workosUserId,
+      role: "manager",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
@@ -12,6 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { type FormEvent, useEffect, useState } from "react";
 import Link from "next/link";
 import {
   Add01Icon,
@@ -38,8 +39,10 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import {
   Select,
   SelectContent,
@@ -47,6 +50,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
@@ -96,20 +100,26 @@ function MembersTableHeader({ showActions }: { showActions: boolean }) {
   );
 }
 
+const teamRoles: TeamRole[] = ["manager", "member"];
+
 function MemberRowActions({
   member,
+  canUpdateRole,
   canRemove,
-  isRemovingMember,
+  isBusy,
+  onChangeRole,
   onRemoveMember,
 }: {
   member: TeamMemberRow;
+  canUpdateRole: boolean;
   canRemove: boolean;
-  isRemovingMember: boolean;
+  isBusy: boolean;
+  onChangeRole: (member: TeamMemberRow) => void;
   onRemoveMember: (member: TeamMemberRow) => void;
 }) {
   const intl = useIntl();
 
-  if (!canRemove) {
+  if (!canUpdateRole && !canRemove) {
     return null;
   }
 
@@ -129,24 +139,138 @@ function MemberRowActions({
             aria-label={intl.formatMessage(teamDetailPageViewMessages.actionsForMember, {
               email: member.email,
             })}
-            disabled={isRemovingMember}
+            disabled={isBusy}
           />
         }
       >
         <HugeiconsIcon icon={MoreHorizontalCircle01Icon} strokeWidth={1.8} className="size-4" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-48">
-        <DropdownMenuGroup>
-          <DropdownMenuItem
-            variant="destructive"
-            onClick={() => onRemoveMember(member)}
-            disabled={isRemovingMember}
-          >
-            <FormattedMessage {...teamDetailPageViewMessages.removeFromTeam} />
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
+        {canUpdateRole ? (
+          <DropdownMenuGroup>
+            <DropdownMenuItem onClick={() => onChangeRole(member)} disabled={isBusy}>
+              <FormattedMessage {...teamDetailPageViewMessages.changeRole} />
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        ) : null}
+        {canUpdateRole && canRemove ? <DropdownMenuSeparator /> : null}
+        {canRemove ? (
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={() => onRemoveMember(member)}
+              disabled={isBusy}
+            >
+              <FormattedMessage {...teamDetailPageViewMessages.removeFromTeam} />
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function ChangeTeamMemberRoleDialog({
+  member,
+  isSaving,
+  onOpenChange,
+  onSubmit,
+}: {
+  member: TeamMemberRow | null;
+  isSaving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (input: { workosUserId: string; role: TeamRole }) => void;
+}) {
+  const intl = useIntl();
+  const [role, setRole] = useState<TeamRole>(member?.role ?? "member");
+
+  useEffect(() => {
+    if (member) {
+      setRole(member.role);
+    }
+  }, [member]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!member || role === member.role) {
+      return;
+    }
+
+    onSubmit({ workosUserId: member.workosUserId, role });
+  }
+
+  return (
+    <Dialog
+      open={member !== null}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && isSaving) {
+          return;
+        }
+
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...teamDetailPageViewMessages.changeRoleTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              {member
+                ? intl.formatMessage(teamDetailPageViewMessages.changeRoleDescription, {
+                    email: member.email,
+                  })
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel>
+              <FormattedMessage {...teamDetailPageViewMessages.roleLabel} />
+            </FieldLabel>
+            <Select
+              value={role}
+              onValueChange={(value) => setRole(value as TeamRole)}
+              disabled={isSaving}
+            >
+              <SelectTrigger className="border-border bg-muted">
+                <SelectValue>{getTeamRoleLabel(role, intl)}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {teamRoles.map((teamRole) => (
+                  <SelectItem
+                    key={teamRole}
+                    value={teamRole}
+                    label={getTeamRoleLabel(teamRole, intl)}
+                  >
+                    {getTeamRoleLabel(teamRole, intl)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldDescription>{getTeamRoleDescription(role, intl)}</FieldDescription>
+          </Field>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isSaving}
+              onClick={() => onOpenChange(false)}
+            >
+              <FormattedMessage {...teamDetailPageViewMessages.cancel} />
+            </Button>
+            <Button type="submit" disabled={isSaving || !member || role === member.role}>
+              {isSaving ? <Spinner /> : null}
+              {isSaving ? (
+                <FormattedMessage {...teamDetailPageViewMessages.updatingRole} />
+              ) : (
+                <FormattedMessage {...teamDetailPageViewMessages.updateRole} />
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -163,13 +287,15 @@ export function TeamDetailPageView({
   isEditOpen,
   isSavingTeam,
   isRemovingMember,
-  updatingMemberRoleId,
+  isUpdatingMemberRole,
+  editingMember,
   removingMember,
   onAddMemberOpenChange,
   onEditOpenChange,
   onAddMember,
   onUpdateTeam,
   onUpdateMemberRole,
+  onEditingMemberChange,
   onRemoveMember,
   onRemovingMemberChange,
 }: {
@@ -185,13 +311,15 @@ export function TeamDetailPageView({
   isEditOpen: boolean;
   isSavingTeam: boolean;
   isRemovingMember: boolean;
-  updatingMemberRoleId: string | null;
+  isUpdatingMemberRole: boolean;
+  editingMember: TeamMemberRow | null;
   removingMember: TeamMemberRow | null;
   onAddMemberOpenChange: (open: boolean) => void;
   onEditOpenChange: (open: boolean) => void;
   onAddMember: (input: { workosUserId: string; role: TeamRole }) => void;
   onUpdateTeam: (values: { name: string; slug: string }) => void;
   onUpdateMemberRole: (input: { workosUserId: string; role: TeamRole }) => void;
+  onEditingMemberChange: (member: TeamMemberRow | null) => void;
   onRemoveMember: (workosUserId: string) => void;
   onRemovingMemberChange: (member: TeamMemberRow | null) => void;
 }) {
@@ -356,53 +484,24 @@ export function TeamDetailPageView({
                       <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:hidden">
                         <FormattedMessage {...teamDetailPageViewMessages.columnRole} />
                       </span>
-                      {canUpdateRole ? (
-                        <Select
-                          value={member.role}
-                          onValueChange={(value) => {
-                            if (value === member.role) {
-                              return;
-                            }
-
-                            onUpdateMemberRole({
-                              workosUserId: member.workosUserId,
-                              role: value as TeamRole,
-                            });
-                          }}
-                          disabled={updatingMemberRoleId === member.workosUserId}
-                        >
-                          <SelectTrigger className="h-9 w-[12rem] max-w-full border-border bg-background/60 text-subtle-foreground hover:bg-muted">
-                            <SelectValue>{getTeamRoleLabel(member.role, intl)}</SelectValue>
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="manager" label={getTeamRoleLabel("manager", intl)}>
-                              {getTeamRoleLabel("manager", intl)}
-                            </SelectItem>
-                            <SelectItem value="member" label={getTeamRoleLabel("member", intl)}>
-                              {getTeamRoleLabel("member", intl)}
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                      ) : (
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <Badge
-                                variant="outline"
-                                className={cn(
-                                  "h-auto max-w-[12rem] truncate rounded-lg px-3 py-1.5 text-sm",
-                                  "border-border bg-muted text-subtle-foreground",
-                                )}
-                              >
-                                {getTeamRoleLabel(member.role, intl)}
-                              </Badge>
-                            }
-                          />
-                          <TooltipContent side="bottom" align="start" className="max-w-xs">
-                            {getTeamRoleDescription(member.role, intl)}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <Badge
+                              variant="outline"
+                              className={cn(
+                                "h-auto max-w-[12rem] truncate rounded-lg px-3 py-1.5 text-sm",
+                                "border-border bg-muted text-subtle-foreground",
+                              )}
+                            >
+                              {getTeamRoleLabel(member.role, intl)}
+                            </Badge>
+                          }
+                        />
+                        <TooltipContent side="bottom" align="start" className="max-w-xs">
+                          {getTeamRoleDescription(member.role, intl)}
+                        </TooltipContent>
+                      </Tooltip>
                     </div>
                   </div>
 
@@ -410,8 +509,10 @@ export function TeamDetailPageView({
                     {pageState.canManageMembers ? (
                       <MemberRowActions
                         member={member}
+                        canUpdateRole={canUpdateRole}
                         canRemove={canRemove}
-                        isRemovingMember={isRemovingMember}
+                        isBusy={isRemovingMember || isUpdatingMemberRole}
+                        onChangeRole={onEditingMemberChange}
                         onRemoveMember={onRemovingMemberChange}
                       />
                     ) : null}
@@ -442,6 +543,17 @@ export function TeamDetailPageView({
         isSaving={isAddingMember}
         onOpenChange={onAddMemberOpenChange}
         onSubmit={onAddMember}
+      />
+
+      <ChangeTeamMemberRoleDialog
+        member={editingMember}
+        isSaving={isUpdatingMemberRole}
+        onOpenChange={(open) => {
+          if (!open) {
+            onEditingMemberChange(null);
+          }
+        }}
+        onSubmit={onUpdateMemberRole}
       />
 
       <Dialog


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Workspace and team member roles are no longer edited from an inline table select. The role column is a badge. Changing a role now takes two explicit steps:

1. Open the row **…** menu and choose **Change role...**
2. Pick the new role in a dialog and confirm with **Update role**

This keeps an accidental click from changing someone’s access. Remove / revoke stay on the same menu and still use their confirmation dialogs.

[Members table with Change role in the … menu](https://cursor.com/agents/bc-01a06613-3784-7b73-8bd9-875fd82d7aef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmembers_actions_menu.webp)
[Change workspace role dialog](https://cursor.com/agents/bc-01a06613-3784-7b73-8bd9-875fd82d7aef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmembers_change_role_dialog.webp)
[Team members table with Change role in the … menu](https://cursor.com/agents/bc-01a06613-3784-7b73-8bd9-875fd82d7aef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteams_actions_menu.webp)
[Change team role dialog](https://cursor.com/agents/bc-01a06613-3784-7b73-8bd9-875fd82d7aef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteams_change_role_dialog.webp)

[member-role-change-dialog.mp4](https://cursor.com/agents/bc-01a06613-3784-7b73-8bd9-875fd82d7aef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmember-role-change-dialog.mp4)

## How to test

- Open **Members**, confirm roles render as badges (no inline select).
- Open a manageable member’s **…** menu → **Change role...**, change the role, confirm. Cancel should leave the role unchanged.
- Repeat on a **Team** detail page for manager/member.
- Current user rows and last-manager rows should not offer a role change.
- Automated: `vp test` and `vp check --fix` in `apps/hyperlocalise-web`.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test` — 848 files / 5859 tests passed)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06613-3784-7b73-8bd9-875fd82d7aef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06613-3784-7b73-8bd9-875fd82d7aef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

