### PR TITLE
fix(members): keep row action menu visible

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
@@ -97,6 +97,14 @@ describe("MembersPageView", () => {
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
   });
 
+  it("keeps the row actions trigger visible without requiring hover", () => {
+    renderMembersPage();
+
+    const trigger = screen.getByRole("button", { name: "Actions for Mina Chen" });
+    expect(trigger).toBeVisible();
+    expect(trigger.className).not.toMatch(/opacity-0/);
+  });
+
   it("opens the change-role dialog from the row actions menu", async () => {
     const user = userEvent.setup();
     const member = createMember();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
@@ -178,7 +178,7 @@ function MembersTableHeader() {
   return (
     <div
       role="row"
-      className="hidden grid-cols-[minmax(0,1.5fr)_9rem_minmax(12rem,1fr)_2.5rem] gap-4 border-b border-border px-1 py-2.5 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:grid"
+      className="hidden grid-cols-[minmax(0,1.5fr)_9rem_minmax(12rem,1fr)_3rem] gap-4 border-b border-border px-1 py-2.5 text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:grid"
     >
       <div role="columnheader">
         <FormattedMessage {...membersPageContentMessages.columnMember} />
@@ -226,11 +226,7 @@ function MemberRowActions({
             type="button"
             variant="ghost"
             size="icon-sm"
-            className={cn(
-              "rounded-full text-muted-foreground hover:bg-accent/20 hover:text-foreground",
-              "opacity-100 transition-opacity md:opacity-0 md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100",
-              "data-popup-open:opacity-100 aria-expanded:opacity-100",
-            )}
+            className="rounded-full text-muted-foreground hover:bg-accent/20 hover:text-foreground"
             aria-label={intl.formatMessage(membersPageContentMessages.actionsForMember, {
               name: member.displayName,
             })}
@@ -490,7 +486,7 @@ export function MembersPageView({
                 <div
                   key={member.email}
                   role="row"
-                  className="group/row grid gap-4 border-t border-border px-1 py-4 transition-colors hover:bg-muted/40 md:grid-cols-[minmax(0,1.5fr)_9rem_minmax(12rem,1fr)_2.5rem] md:items-center"
+                  className="group/row grid gap-4 border-t border-border px-1 py-4 transition-colors hover:bg-muted/40 md:grid-cols-[minmax(0,1.5fr)_9rem_minmax(12rem,1fr)_3rem] md:items-center"
                 >
                   <div role="cell" className="flex min-w-0 items-start gap-3">
                     <MemberAvatar displayName={member.displayName} avatarUrl={member.avatarUrl} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The Members table hid the `...` row-actions trigger until desktop hover (`md:opacity-0`), so the Actions column looked empty even for admins who can change roles or remove members.

The menu button is now always visible on manageable rows, matching other workspace tables. The signed-in user's own row still has no menu.

## How to test

- Open `/org/<slug>/members` as an admin.
- Confirm every member except the signed-in user shows a `...` button in the Actions column without hovering.
- Click `...` and confirm Change role / Remove member still work.
- Confirm the signed-in user's row still has no actions menu.

Automated:

```
cd apps/hyperlocalise-web
vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
vp check --fix
```

[Members table with always-visible row action buttons](https://cursor.com/agents/bc-e80bf622-5779-4110-a82a-2a9adc336db3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmembers-actions-visible-without-hover.webp)
[members-row-actions-visible.mp4](https://cursor.com/agents/bc-e80bf622-5779-4110-a82a-2a9adc336db3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmembers-row-actions-visible.mp4)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e80bf622-5779-4110-a82a-2a9adc336db3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e80bf622-5779-4110-a82a-2a9adc336db3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

