### PR TITLE
feat(ui): add typography token props

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.tsx
@@ -174,7 +174,7 @@ export function EmailIntegrationRow({
         <Box padding="1.5u" background="canvas" border="standard" borderRadius="standard">
           <Columns spacing="1.5u" alignY="center" collapseBelow="small">
             <Column width="fluid">
-              <TypographyP className="text-sm leading-6 text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 {intl.formatMessage(emailIntegrationRowMessages.panelInstructions)}
               </TypographyP>
             </Column>
@@ -192,7 +192,7 @@ export function EmailIntegrationRow({
         </Box>
 
         {isError ? (
-          <TypographyP className="text-sm text-destructive">
+          <TypographyP size="small" tone="critical">
             {intl.formatMessage(emailIntegrationRowMessages.loadError)}
           </TypographyP>
         ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
@@ -400,7 +400,7 @@ export function GitHubIntegrationRow({
         <Skeleton className="h-24 rounded-lg" />
       ) : isError ? (
         <Rows spacing="1.5u">
-          <TypographyP className="text-sm text-destructive">
+          <TypographyP size="small" tone="critical">
             {error instanceof Error
               ? error.message
               : intl.formatMessage(githubIntegrationRowMessages.loadError)}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.tsx
@@ -190,13 +190,13 @@ export function SlackIntegrationRow({
             <Columns spacing="1.5u" alignY="center" collapseBelow="small">
               <Column width="fluid">
                 <Rows spacing="0.5u">
-                  <TypographyP className="text-sm font-medium text-foreground">
+                  <TypographyP size="small" weight="medium" tone="content">
                     {isError
                       ? intl.formatMessage(slackIntegrationRowMessages.settingsUnavailable)
                       : viewModel.statusTitle}
                   </TypographyP>
                   {slackAgent?.teamId ? (
-                    <TypographyP className="text-xs text-muted-foreground">
+                    <TypographyP size="xsmall" tone="subtle">
                       {intl.formatMessage(slackIntegrationRowMessages.workspaceId, {
                         teamId: slackAgent.teamId,
                       })}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-section.tsx
@@ -118,7 +118,7 @@ export function NotificationPreferencesSection({ organizationSlug }: { organizat
 
   if (isLoading) {
     return (
-      <TypographyP className="text-sm text-muted-foreground">
+      <TypographyP size="small" tone="subtle">
         <FormattedMessage {...messages.saving} />
       </TypographyP>
     );
@@ -126,7 +126,7 @@ export function NotificationPreferencesSection({ organizationSlug }: { organizat
 
   if (isError) {
     return (
-      <TypographyP className="text-sm text-destructive">
+      <TypographyP size="small" tone="critical">
         <FormattedMessage {...messages.loadError} />
       </TypographyP>
     );

--- a/apps/hyperlocalise-web/src/components/ui/brand-theme.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/brand-theme.stories.tsx
@@ -43,7 +43,7 @@ function ThemeSpecimen({
       </p>
       <TypographyH1 className="text-3xl md:text-4xl">{title}</TypographyH1>
       <TypographyH2 className="mt-3 text-xl md:text-2xl">{subtitle}</TypographyH2>
-      <TypographyP className="mt-3 text-muted-foreground">
+      <TypographyP className="mt-3" tone="subtle">
         Headings use <code className="font-mono text-sm">font-heading</code>, which follows the
         brand theme.
       </TypographyP>

--- a/apps/hyperlocalise-web/src/components/ui/typography.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/typography.stories.tsx
@@ -13,7 +13,11 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
+import { Box } from "./layout/box";
+import { Rows } from "./layout/rows";
 import {
+  Text,
+  Title,
   TypographyBlockquote,
   TypographyH1,
   TypographyH2,
@@ -25,17 +29,117 @@ import {
   TypographyMuted,
   TypographyP,
   TypographySmall,
+  typographyTones,
 } from "./typography";
 
 const meta = {
   title: "UI/Typography",
-  component: TypographyP,
-} satisfies Meta<typeof TypographyP>;
+  component: Text,
+} satisfies Meta<typeof Text>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const textSizes = ["xxlarge", "xlarge", "large", "medium", "small", "xsmall"] as const;
+const titleSizes = ["xlarge", "large", "medium", "small", "xsmall", "xxsmall"] as const;
+
 export const Overview: Story = {
+  render: () => (
+    <Rows spacing="2u">
+      <Title size="xlarge">Localization dashboard</Title>
+      <Title size="large">Review queue</Title>
+      <Title size="medium">Provider sync</Title>
+      <Title size="small">Glossary updates</Title>
+      <Text size="xlarge" tone="subtle">
+        Ship consistent translations with fewer manual handoffs.
+      </Text>
+      <Text>
+        Use <TypographyInlineCode>provider.sync()</TypographyInlineCode> to refresh source strings.
+      </Text>
+      <TypographyBlockquote>Preserve product names and ICU placeholders.</TypographyBlockquote>
+      <Text size="large" weight="bold">
+        Large emphasis text
+      </Text>
+      <Text size="small" weight="medium">
+        Small supporting text
+      </Text>
+      <Text size="small" tone="subtle">
+        Muted metadata and timestamps
+      </Text>
+    </Rows>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Localization dashboard")).toBeInTheDocument();
+    await expect(canvas.getByText("Muted metadata and timestamps")).toBeInTheDocument();
+  },
+};
+
+export const TextSizes: Story = {
+  render: () => (
+    <Rows spacing="1u">
+      {textSizes.map((size) => (
+        <Text key={size} size={size}>
+          Text {size}
+        </Text>
+      ))}
+    </Rows>
+  ),
+};
+
+export const TitleSizes: Story = {
+  render: () => (
+    <Rows spacing="2u">
+      {titleSizes.map((size) => (
+        <Title key={size} size={size}>
+          Title {size}
+        </Title>
+      ))}
+    </Rows>
+  ),
+};
+
+export const Tones: Story = {
+  render: () => (
+    <Rows spacing="1u">
+      {typographyTones.map((tone) => (
+        <Text key={tone} tone={tone}>
+          Tone {tone}
+        </Text>
+      ))}
+    </Rows>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Tone critical")).toBeInTheDocument();
+    await expect(canvas.getByText("Tone subtle")).toBeInTheDocument();
+  },
+};
+
+export const AlignmentAndClamp: Story = {
+  render: () => (
+    <Rows spacing="3u">
+      <Rows spacing="1u">
+        <Text alignment="start">Aligned start</Text>
+        <Text alignment="center">Aligned center</Text>
+        <Text alignment="end">Aligned end</Text>
+      </Rows>
+      <Box width="full">
+        <Title size="small" lineClamp={1}>
+          This title truncates to a single line instead of wrapping onto the next row.
+        </Title>
+        <Text lineClamp={2}>
+          This paragraph clamps after two lines. Teams use it for filenames, activity previews, and
+          other copy that must stay compact without a one-off className.
+        </Text>
+      </Box>
+      <Text wrapStyle="balance">Balanced wrapping for headings and short marketing sentences.</Text>
+      <Text capitalization="uppercase" size="small" weight="medium">
+        Uppercase label
+      </Text>
+    </Rows>
+  ),
+};
+
+export const Wrappers: Story = {
   render: () => (
     <div className="flex max-w-3xl flex-col gap-4 p-6">
       <TypographyH1>Localization dashboard</TypographyH1>
@@ -52,7 +156,4 @@ export const Overview: Story = {
       <TypographyMuted>Muted metadata and timestamps</TypographyMuted>
     </div>
   ),
-  play: async ({ canvas }) => {
-    await expect(canvas.getByText("Localization dashboard")).toBeInTheDocument();
-  },
 };

--- a/apps/hyperlocalise-web/src/components/ui/typography.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/typography.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  Text,
+  Title,
+  TypographyH1,
+  TypographyH2,
+  TypographyInlineCode,
+  TypographyLead,
+  TypographyMuted,
+  TypographyP,
+  TypographySmall,
+} from "./typography";
+
+describe("typography components", () => {
+  it("maps Text token props onto size, tone, alignment, and weight classes", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        Text,
+        {
+          size: "small",
+          tone: "subtle",
+          alignment: "center",
+          weight: "medium",
+          wrapStyle: "pretty",
+          capitalization: "uppercase",
+        },
+        "Review queue",
+      ),
+    );
+
+    expect(markup).toContain('data-slot="text"');
+    expect(markup).toContain('data-size="small"');
+    expect(markup).toContain("text-sm");
+    expect(markup).toContain("text-muted-foreground");
+    expect(markup).toContain("text-center");
+    expect(markup).toContain("font-medium");
+    expect(markup).toContain("text-pretty");
+    expect(markup).toContain("uppercase");
+    expect(markup).toContain("Review queue");
+    expect(markup).toMatch(/^<p /);
+  });
+
+  it("renders Title with a heading tag inferred from size", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(Title, { size: "large", tone: "content" }, "Jobs"),
+    );
+
+    expect(markup).toContain('data-slot="title"');
+    expect(markup).toContain('data-size="large"');
+    expect(markup).toMatch(/^<h2 /);
+    expect(markup).toContain("font-heading");
+    expect(markup).toContain("text-2xl");
+    expect(markup).toContain("text-foreground");
+    expect(markup).toContain("Jobs");
+  });
+
+  it("keeps the existing heading defaults on Typography wrappers", () => {
+    const h1 = renderToStaticMarkup(React.createElement(TypographyH1, {}, "Ship globally"));
+    const h2 = renderToStaticMarkup(React.createElement(TypographyH2, {}, "Review queue"));
+    const lead = renderToStaticMarkup(React.createElement(TypographyLead, {}, "Lead copy"));
+    const muted = renderToStaticMarkup(React.createElement(TypographyMuted, {}, "Metadata"));
+    const small = renderToStaticMarkup(React.createElement(TypographySmall, {}, "Caption"));
+
+    expect(h1).toMatch(/^<h1 /);
+    expect(h1).toContain("font-heading");
+    expect(h1).toContain("text-3xl");
+    expect(h1).toContain("text-balance");
+    expect(h2).toMatch(/^<h2 /);
+    expect(h2).toContain("pb-2");
+    expect(lead).toContain("text-xl");
+    expect(lead).toContain("text-muted-foreground");
+    expect(muted).toMatch(/^<div /);
+    expect(muted).toContain("text-sm");
+    expect(muted).toContain("text-muted-foreground");
+    expect(small).toContain("font-medium");
+  });
+
+  it("lets wrappers override token props without className", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        TypographyP,
+        { size: "small", tone: "critical", alignment: "end", lineClamp: 2 },
+        "Provider failed",
+      ),
+    );
+
+    expect(markup).toMatch(/^<p /);
+    expect(markup).toContain("text-sm");
+    expect(markup).toContain("text-destructive");
+    expect(markup).toContain("text-end");
+    expect(markup).toContain("line-clamp-2");
+    expect(markup).not.toContain("alignment=");
+    expect(markup).not.toContain("tone=");
+    expect(markup).not.toContain("lineClamp=");
+  });
+
+  it("clamps a single line with truncate and still accepts className", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        Text,
+        { lineClamp: 1, className: "mt-2", tagName: "span" },
+        "A very long filename.json",
+      ),
+    );
+
+    expect(markup).toMatch(/^<span /);
+    expect(markup).toContain("truncate");
+    expect(markup).toContain("mt-2");
+  });
+
+  it("uses an inline clamp style when lineClamp is beyond the utility scale", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(Title, { size: "small", lineClamp: 8 }, "Overflowing title"),
+    );
+
+    expect(markup).toContain("overflow-hidden");
+    expect(markup).toContain("-webkit-line-clamp:8");
+  });
+
+  it("does not leak token props onto inline code", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        TypographyInlineCode,
+        { tone: "subtle", alignment: "start" },
+        "provider.sync()",
+      ),
+    );
+
+    expect(markup).toContain('data-slot="inline-code"');
+    expect(markup).toContain("text-muted-foreground");
+    expect(markup).not.toContain("tone=");
+    expect(markup).not.toContain("alignment=");
+  });
+
+  it("renders a floating blob on Title", () => {
+    const markup = renderToStaticMarkup(React.createElement(Title, { floatingBlob: true }, "New"));
+
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("var(--color-red-600)");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ui/typography.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/typography.tsx
@@ -84,19 +84,197 @@ export type ColorTokenCssVariable =
   | "--color-info"
   | "--color-neutral";
 
+export const typographyAlignments = ["start", "center", "end", "inherit"] as const;
+export type TypographyAlignment = (typeof typographyAlignments)[number];
+
+export const typographyTones = [
+  "content",
+  "subtle",
+  "subtlest",
+  "critical",
+  "info",
+  "positive",
+  "warn",
+  "inherit",
+] as const;
+export type TypographyTone = (typeof typographyTones)[number];
+
+export const typographyWeights = ["regular", "medium", "bold"] as const;
+export type TypographyWeight = (typeof typographyWeights)[number];
+
+export const typographyWrapStyles = ["unset", "balance", "pretty"] as const;
+export type TypographyWrapStyle = (typeof typographyWrapStyles)[number];
+
+export const typographyCapitalizations = ["default", "uppercase"] as const;
+export type TypographyCapitalization = (typeof typographyCapitalizations)[number];
+
+export const typographySizes = [
+  "xxlarge",
+  "xlarge",
+  "large",
+  "medium",
+  "small",
+  "xsmall",
+  "xxsmall",
+] as const;
+export type TypographySize = (typeof typographySizes)[number];
+export type TextTypographySize = Exclude<TypographySize, "xxsmall">;
+export type TitleTypographySize = Exclude<TypographySize, "xxlarge">;
+
+export type TextTagName = "p" | "div" | "span" | "li" | "blockquote";
+export type TitleTagName = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | TextTagName;
+
+type TypographyHtmlProps = Omit<React.HTMLAttributes<HTMLElement>, "color">;
+
+export type SharedTypographyProps = TypographyHtmlProps & {
+  alignment?: TypographyAlignment;
+  capitalization?: TypographyCapitalization;
+  lineClamp?: number;
+  tone?: TypographyTone;
+  wrapStyle?: TypographyWrapStyle;
+};
+
+export type TextProps = SharedTypographyProps & {
+  size?: TextTypographySize;
+  tagName?: TextTagName;
+  weight?: TypographyWeight;
+};
+
 interface TypographyHeadingBlobOptions {
   colorToken?: ColorTokenCssVariable;
   className?: string;
 }
 
-interface TypographyHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+export type TitleProps = SharedTypographyProps & {
   floatingBlob?: boolean | TypographyHeadingBlobOptions;
+  size?: TitleTypographySize;
+  tagName?: TitleTagName;
+  weight?: TypographyWeight;
+};
+
+const textSizeClassNames = {
+  xxlarge: "font-sans text-2xl leading-8",
+  xlarge: "font-sans text-xl",
+  large: "font-sans text-lg",
+  medium: "font-sans leading-7",
+  small: "font-sans text-sm",
+  xsmall: "font-sans text-xs",
+} as const satisfies Record<TextTypographySize, string>;
+
+const titleSizeClassNames = {
+  xlarge: "font-heading scroll-m-20 text-3xl tracking-[-0.04em] font-semibold md:text-6xl",
+  large: "font-heading scroll-m-20 text-2xl font-semibold md:text-5xl",
+  medium: "scroll-m-20 font-sans text-xl font-semibold tracking-wide md:text-3xl",
+  small: "scroll-m-20 font-sans text-lg font-semibold tracking-wide",
+  xsmall: "scroll-m-20 font-sans text-base font-semibold",
+  xxsmall: "scroll-m-20 font-sans text-sm font-semibold",
+} as const satisfies Record<TitleTypographySize, string>;
+
+const weightClassNames = {
+  regular: "font-normal",
+  medium: "font-medium",
+  bold: "font-semibold",
+} as const satisfies Record<TypographyWeight, string>;
+
+const alignmentClassNames = {
+  start: "text-start",
+  center: "text-center",
+  end: "text-end",
+  inherit: undefined,
+} as const satisfies Record<TypographyAlignment, string | undefined>;
+
+const toneClassNames = {
+  content: "text-foreground",
+  subtle: "text-muted-foreground",
+  subtlest: "text-subtle-foreground",
+  critical: "text-destructive",
+  info: "text-info",
+  positive: "text-success",
+  warn: "text-warning",
+  inherit: undefined,
+} as const satisfies Record<TypographyTone, string | undefined>;
+
+const wrapStyleClassNames = {
+  unset: undefined,
+  balance: "text-balance",
+  pretty: "text-pretty",
+} as const satisfies Record<TypographyWrapStyle, string | undefined>;
+
+const lineClampClassNames = {
+  1: "truncate",
+  2: "line-clamp-2",
+  3: "line-clamp-3",
+  4: "line-clamp-4",
+  5: "line-clamp-5",
+  6: "line-clamp-6",
+} as const;
+
+function defaultTitleTagName(size: TitleTypographySize): TitleTagName {
+  switch (size) {
+    case "xlarge":
+      return "h1";
+    case "large":
+      return "h2";
+    case "medium":
+      return "h3";
+    case "small":
+      return "h4";
+    case "xsmall":
+      return "h5";
+    case "xxsmall":
+      return "h6";
+  }
 }
 
-function HeadingContent({
-  children,
-  floatingBlob,
-}: Pick<TypographyHeadingProps, "children" | "floatingBlob">) {
+function lineClampClassName(lineClamp: number | undefined) {
+  if (lineClamp == null || lineClamp < 1) {
+    return undefined;
+  }
+
+  if (lineClamp in lineClampClassNames) {
+    return lineClampClassNames[lineClamp as keyof typeof lineClampClassNames];
+  }
+
+  return "overflow-hidden";
+}
+
+function lineClampStyle(
+  lineClamp: number | undefined,
+  style: React.CSSProperties | undefined,
+): React.CSSProperties | undefined {
+  if (lineClamp == null || lineClamp <= 6) {
+    return style;
+  }
+
+  return {
+    ...style,
+    display: "-webkit-box",
+    overflow: "hidden",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: lineClamp,
+  };
+}
+
+function typographyUtilityClassName({
+  alignment,
+  capitalization = "default",
+  lineClamp,
+  tone,
+  wrapStyle,
+}: Pick<
+  SharedTypographyProps,
+  "alignment" | "capitalization" | "lineClamp" | "tone" | "wrapStyle"
+>) {
+  return cn(
+    alignment ? alignmentClassNames[alignment] : undefined,
+    tone ? toneClassNames[tone] : undefined,
+    wrapStyle ? wrapStyleClassNames[wrapStyle] : undefined,
+    lineClampClassName(lineClamp),
+    capitalization === "uppercase" ? "uppercase" : undefined,
+  );
+}
+
+function HeadingContent({ children, floatingBlob }: Pick<TitleProps, "children" | "floatingBlob">) {
   if (!floatingBlob) {
     return <>{children}</>;
   }
@@ -118,119 +296,196 @@ function HeadingContent({
   );
 }
 
-export function TypographyH1({
+function Text({
+  alignment,
+  capitalization = "default",
   className,
-  children,
-  floatingBlob,
+  lineClamp,
+  size = "medium",
+  style,
+  tagName = "p",
+  tone,
+  weight,
+  wrapStyle,
   ...props
-}: TypographyHeadingProps) {
+}: TextProps) {
+  const Tag = tagName;
+
   return (
-    <h1
+    <Tag
+      data-slot="text"
+      data-size={size}
       className={cn(
-        "font-heading scroll-m-20 text-3xl md:text-6xl tracking-[-0.04em] text-balance font-semibold",
+        textSizeClassNames[size],
+        weight ? weightClassNames[weight] : undefined,
+        typographyUtilityClassName({
+          alignment,
+          capitalization,
+          lineClamp,
+          tone,
+          wrapStyle,
+        }),
         className,
       )}
-      {...props}
-    >
-      <HeadingContent floatingBlob={floatingBlob}>{children}</HeadingContent>
-    </h1>
-  );
-}
-
-export function TypographyH2({
-  className,
-  children,
-  floatingBlob,
-  ...props
-}: TypographyHeadingProps) {
-  return (
-    <h2
-      className={cn(
-        "font-heading scroll-m-20 pb-2 text-2xl md:text-5xl first:mt-0 font-semibold",
-        className,
-      )}
-      {...props}
-    >
-      <HeadingContent floatingBlob={floatingBlob}>{children}</HeadingContent>
-    </h2>
-  );
-}
-
-export function TypographyH3({
-  className,
-  children,
-  floatingBlob,
-  ...props
-}: TypographyHeadingProps) {
-  return (
-    <h3
-      className={cn(
-        "scroll-m-20 font-sans text-xl md:text-3xl font-semibold tracking-wide",
-        className,
-      )}
-      {...props}
-    >
-      <HeadingContent floatingBlob={floatingBlob}>{children}</HeadingContent>
-    </h3>
-  );
-}
-
-export function TypographyH4({
-  className,
-  children,
-  floatingBlob,
-  ...props
-}: TypographyHeadingProps) {
-  return (
-    <h4
-      className={cn("scroll-m-20 font-sans text-lg font-semibold tracking-wide", className)}
-      {...props}
-    >
-      <HeadingContent floatingBlob={floatingBlob}>{children}</HeadingContent>
-    </h4>
-  );
-}
-
-export function TypographyP({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn("font-sans leading-7", className)} {...props} />;
-}
-
-export function TypographyBlockquote({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLQuoteElement>) {
-  return (
-    <blockquote className={cn("mt-6 border-l-2 pl-6 font-sans italic", className)} {...props} />
-  );
-}
-
-export function TypographyInlineCode({ className, ...props }: React.HTMLAttributes<HTMLElement>) {
-  return (
-    <code
-      className={cn(
-        "bg-muted relative rounded px-[0.3rem] py-[0.2rem] font-mono text-sm font-normal",
-        className,
-      )}
+      style={lineClampStyle(lineClamp, style)}
       {...props}
     />
   );
 }
 
-export function TypographyLead({
+function Title({
+  alignment,
+  capitalization = "default",
+  children,
   className,
+  floatingBlob,
+  lineClamp,
+  size = "medium",
+  style,
+  tagName,
+  tone,
+  weight,
+  wrapStyle,
   ...props
-}: React.HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn("text-muted-foreground font-sans text-xl", className)} {...props} />;
+}: TitleProps) {
+  const Tag = tagName ?? defaultTitleTagName(size);
+  const resolvedWrapStyle = wrapStyle ?? (size === "xlarge" ? "balance" : undefined);
+
+  return (
+    <Tag
+      data-slot="title"
+      data-size={size}
+      className={cn(
+        titleSizeClassNames[size],
+        weight ? weightClassNames[weight] : undefined,
+        typographyUtilityClassName({
+          alignment,
+          capitalization,
+          lineClamp,
+          tone,
+          wrapStyle: resolvedWrapStyle,
+        }),
+        className,
+      )}
+      style={lineClampStyle(lineClamp, style)}
+      {...props}
+    >
+      <HeadingContent floatingBlob={floatingBlob}>{children}</HeadingContent>
+    </Tag>
+  );
 }
 
-export function TypographyLarge({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("font-sans text-lg font-semibold", className)} {...props} />;
+function TypographyH1({ size = "xlarge", tagName = "h1", ...props }: TitleProps) {
+  return <Title size={size} tagName={tagName} {...props} />;
 }
 
-export function TypographySmall({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("font-sans text-sm font-medium", className)} {...props} />;
+function TypographyH2({ className, size = "large", tagName = "h2", ...props }: TitleProps) {
+  return (
+    <Title size={size} tagName={tagName} className={cn("pb-2 first:mt-0", className)} {...props} />
+  );
 }
 
-export function TypographyMuted({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("text-muted-foreground font-sans text-sm", className)} {...props} />;
+function TypographyH3({ size = "medium", tagName = "h3", ...props }: TitleProps) {
+  return <Title size={size} tagName={tagName} {...props} />;
 }
+
+function TypographyH4({ size = "small", tagName = "h4", ...props }: TitleProps) {
+  return <Title size={size} tagName={tagName} {...props} />;
+}
+
+function TypographyP(props: TextProps) {
+  return <Text {...props} />;
+}
+
+function TypographyBlockquote({
+  className,
+  tagName = "blockquote",
+  wrapStyle = "unset",
+  ...props
+}: TextProps) {
+  return (
+    <Text
+      tagName={tagName}
+      wrapStyle={wrapStyle}
+      className={cn("mt-6 border-l-2 pl-6 font-sans italic", className)}
+      {...props}
+    />
+  );
+}
+
+function TypographyInlineCode({
+  alignment,
+  capitalization,
+  className,
+  lineClamp,
+  style,
+  tone,
+  wrapStyle,
+  ...props
+}: SharedTypographyProps) {
+  return (
+    <code
+      data-slot="inline-code"
+      className={cn(
+        "bg-muted relative rounded px-[0.3rem] py-[0.2rem] font-mono text-sm font-normal",
+        typographyUtilityClassName({
+          alignment,
+          capitalization,
+          lineClamp,
+          tone,
+          wrapStyle,
+        }),
+        className,
+      )}
+      style={lineClampStyle(lineClamp, style)}
+      {...props}
+    />
+  );
+}
+
+function TypographyLead({ size = "xlarge", tone = "subtle", ...props }: TextProps) {
+  return <Text size={size} tone={tone} {...props} />;
+}
+
+function TypographyLarge({
+  size = "large",
+  tagName = "div",
+  weight = "bold",
+  ...props
+}: TextProps) {
+  return <Text size={size} tagName={tagName} weight={weight} {...props} />;
+}
+
+function TypographySmall({
+  size = "small",
+  tagName = "div",
+  weight = "medium",
+  ...props
+}: TextProps) {
+  return <Text size={size} tagName={tagName} weight={weight} {...props} />;
+}
+
+function TypographyMuted({
+  size = "small",
+  tagName = "div",
+  tone = "subtle",
+  ...props
+}: TextProps) {
+  return <Text size={size} tagName={tagName} tone={tone} {...props} />;
+}
+
+export {
+  Text,
+  Title,
+  TypographyBlockquote,
+  TypographyH1,
+  TypographyH2,
+  TypographyH3,
+  TypographyH4,
+  TypographyInlineCode,
+  TypographyLarge,
+  TypographyLead,
+  TypographyMuted,
+  TypographyP,
+  TypographySmall,
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Typography components now expose token props so callers can stop using `className` for color, size, weight, alignment, wrapping, and truncation.

New `Text` and `Title` components (plus the existing `TypographyH1` / `TypographyP` wrappers) accept:

- `size` — Text: `xxlarge` … `xsmall`; Title: `xlarge` … `xxsmall` (heading tag follows size unless `tagName` is set)
- `tone` — `content`, `subtle`, `subtlest`, `critical`, `info`, `positive`, `warn`, `inherit`
- `alignment` — `start`, `center`, `end`, `inherit`
- `weight` — `regular`, `medium`, `bold`
- `lineClamp`, `wrapStyle` (`unset` | `balance` | `pretty`), `capitalization`, `tagName`

`className` still works for layout leftovers (`mt-*`, `max-w-*`) and one-off marketing sizes. Existing heading look is unchanged.

A few product call sites on the integrations and notification settings pages now use token props instead of `text-sm text-muted-foreground` / `text-destructive`.

## How to test

- `vp test src/components/ui/typography.test.tsx` (from `apps/hyperlocalise-web`)
- `vp check --fix` (from `apps/hyperlocalise-web`)
- Storybook: `UI/Typography` — Overview, TextSizes, TitleSizes, Tones, AlignmentAndClamp, Wrappers

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test` for typography)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65ad3d88-c5f1-42b2-b65c-11c8c9e16b80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65ad3d88-c5f1-42b2-b65c-11c8c9e16b80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

