### PR TITLE
refactor(ui): migrate Typography className usage to token props

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-thread.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-thread.tsx
@@ -669,7 +669,7 @@ export function IssueCommentThread({
 
   return (
     <section className="mt-2 grid gap-3 border-t border-border pt-4">
-      <TypographyP className="text-sm font-medium text-foreground">
+      <TypographyP size="small" weight="medium" tone="content">
         <FormattedMessage {...messages.sectionTitle} />
       </TypographyP>
 
@@ -681,13 +681,13 @@ export function IssueCommentThread({
       ) : null}
 
       {isError ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.loadError} />
         </TypographyP>
       ) : null}
 
       {isEmpty ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.empty} />
         </TypographyP>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -167,7 +167,7 @@ function ReadOnlyValue({
   className?: string;
 }) {
   return (
-    <TypographyP className={cn("text-sm leading-5 text-foreground", className)}>
+    <TypographyP className="leading-5" size="small" tone="content">
       {value?.trim() ? value : empty}
     </TypographyP>
   );
@@ -568,7 +568,7 @@ export const IssueDetailPanel = forwardRef<
   if (issueQuery.isError) {
     return (
       <div className="px-6 py-5">
-        <TypographyP className="text-sm text-destructive">
+        <TypographyP size="small" tone="critical">
           <FormattedMessage {...messages.loadError} />
         </TypographyP>
       </div>
@@ -578,7 +578,7 @@ export const IssueDetailPanel = forwardRef<
   if (!issue) {
     return (
       <div className="px-6 py-5">
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.notFound} />
         </TypographyP>
       </div>
@@ -678,7 +678,7 @@ export const IssueDetailPanel = forwardRef<
 
         {showOwnerNoteField ? (
           <section className="mt-2 grid gap-2 border-t border-border pt-4">
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...messages.fieldOwnerNote} />
             </TypographyP>
             <IssueMarkdownField
@@ -698,7 +698,12 @@ export const IssueDetailPanel = forwardRef<
         {showCustomColumns
           ? mainCustomColumns.map((column) => (
               <section key={column.id} className="mt-2 grid gap-2 border-t border-border pt-4">
-                <TypographyP className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+                <TypographyP
+                  className="inline-flex items-center gap-1.5"
+                  size="small"
+                  weight="medium"
+                  tone="content"
+                >
                   <IssueColumnIcon iconId={column.icon} className="text-muted-foreground" />
                   {column.label}
                 </TypographyP>
@@ -723,7 +728,12 @@ export const IssueDetailPanel = forwardRef<
         {hasLinkedContext ? (
           <section className="mt-2 grid gap-3 border-t border-border pt-4">
             <div className="flex items-center justify-between gap-2">
-              <TypographyP className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+              <TypographyP
+                className="inline-flex items-center gap-1.5"
+                size="small"
+                weight="medium"
+                tone="content"
+              >
                 <HugeiconsIcon
                   icon={LinkSquare02Icon}
                   strokeWidth={1.8}
@@ -834,7 +844,7 @@ export const IssueDetailPanel = forwardRef<
                   </Button>
                 ) : (
                   <div className="flex min-w-0 flex-1 items-center rounded-lg border border-dashed border-border px-3 py-2">
-                    <TypographyP className="text-xs text-muted-foreground">
+                    <TypographyP size="xsmall" tone="subtle">
                       <FormattedMessage {...messages.openInContentEditorUnavailable} />
                     </TypographyP>
                   </div>
@@ -886,7 +896,7 @@ export const IssueDetailPanel = forwardRef<
           <div className={cn("flex flex-col gap-1", !sidebarOpen && "lg:hidden")}>
             {columnsQuery.isError ? (
               <div className="mb-3 space-y-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
-                <TypographyP className="text-xs text-destructive">
+                <TypographyP size="xsmall" tone="critical">
                   <FormattedMessage {...messages.loadColumnsError} />
                 </TypographyP>
                 <Button

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-relationship-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-relationship-section.tsx
@@ -130,7 +130,12 @@ export function IssueRelationshipSection({
   return (
     <section className="mt-2 grid gap-3 border-t border-border pt-4">
       <div className="flex items-center justify-between gap-2">
-        <TypographyP className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+        <TypographyP
+          className="inline-flex items-center gap-1.5"
+          size="small"
+          weight="medium"
+          tone="content"
+        >
           <HugeiconsIcon
             icon={LinkSquare02Icon}
             strokeWidth={1.8}
@@ -156,11 +161,11 @@ export function IssueRelationshipSection({
       {isLoading ? (
         <RelationshipSkeleton />
       ) : isError ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.loadError} />
         </TypographyP>
       ) : relationships.length === 0 ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.empty} />
         </TypographyP>
       ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-action-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-action-card.tsx
@@ -54,7 +54,7 @@ export function OverviewActionCard({
           >
             {category}
           </Badge>
-          <TypographyP className="line-clamp-2 text-sm font-medium text-foreground">
+          <TypographyP lineClamp={2} size="small" weight="medium" tone="content">
             {title}
           </TypographyP>
           <Badge

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.tsx
@@ -168,7 +168,7 @@ export function OverviewConnectAgentCard({
         </Tabs>
 
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.description} />
           </TypographyP>
           <a
@@ -206,7 +206,7 @@ export function OverviewConnectAgentCard({
           </SnippetAddon>
         </Snippet>
 
-        <TypographyP className="text-pretty text-sm text-muted-foreground">
+        <TypographyP wrapStyle="pretty" size="small" tone="subtle">
           <ClientNextStep client={client} />
         </TypographyP>
       </CardContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-hero-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-hero-card.tsx
@@ -55,7 +55,7 @@ export function OverviewHeroCard({
     >
       <CardContent className="flex h-full flex-col justify-between gap-6 px-6 py-6">
         <div>
-          <TypographyP className="text-sm font-medium text-subtle-foreground">
+          <TypographyP size="small" weight="medium" tone="subtlest">
             {isCaughtUp ? (
               <FormattedMessage {...overviewHeroCardMessages.allCaughtUp} />
             ) : (
@@ -65,10 +65,10 @@ export function OverviewHeroCard({
               />
             )}
           </TypographyP>
-          <TypographyP className="mt-2 font-heading text-2xl font-medium text-foreground">
+          <TypographyP className="mt-2 font-heading" size="xxlarge" weight="medium" tone="content">
             {title}
           </TypographyP>
-          <TypographyP className="mt-2 max-w-lg text-sm leading-6 text-muted-foreground">
+          <TypographyP className="mt-2 max-w-lg leading-6" size="small" tone="subtle">
             {description}
           </TypographyP>
         </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-section-header.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-section-header.tsx
@@ -31,7 +31,9 @@ export function OverviewSectionHeader({
 }) {
   return (
     <div className={cn("flex items-center gap-2.5", className)}>
-      <TypographyP className="text-base font-medium text-foreground">{title}</TypographyP>
+      <TypographyP weight="medium" tone="content">
+        {title}
+      </TypographyP>
       {count !== undefined && count > 0 ? (
         <Badge
           variant="outline"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-snapshot-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-snapshot-card.tsx
@@ -52,8 +52,12 @@ export function OverviewSnapshotCard({
         <dl className="grid gap-3">
           {rows.map((row) => (
             <div key={row.label} className="grid gap-0.5">
-              <TypographyP className="text-xs text-muted-foreground">{row.label}</TypographyP>
-              <TypographyP className="text-sm font-medium text-foreground">{row.value}</TypographyP>
+              <TypographyP size="xsmall" tone="subtle">
+                {row.label}
+              </TypographyP>
+              <TypographyP size="small" weight="medium" tone="content">
+                {row.value}
+              </TypographyP>
             </div>
           ))}
         </dl>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-resource-shared.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-resource-shared.tsx
@@ -97,10 +97,9 @@ export function PageHeader({
           </div>
         ) : null}
         <TypographyH1
-          className={cn(
-            "font-sans text-2xl font-medium text-foreground md:text-2xl",
-            label ? "mt-2" : "flex items-center gap-2",
-          )}
+          className={cn("text-2xl md:text-2xl", label ? "mt-2" : "flex items-center gap-2")}
+          weight="medium"
+          tone="content"
         >
           {label ? (
             title
@@ -111,11 +110,11 @@ export function PageHeader({
             </>
           )}
         </TypographyH1>
-        <TypographyP className="mt-2 text-pretty text-sm leading-6 text-muted-foreground">
+        <TypographyP className="mt-2 leading-6" wrapStyle="pretty" size="small" tone="subtle">
           {description}
         </TypographyP>
         {descriptionDetail ? (
-          <TypographyP className="mt-1.5 text-pretty text-sm leading-6 text-muted-foreground">
+          <TypographyP className="mt-1.5 leading-6" wrapStyle="pretty" size="small" tone="subtle">
             {descriptionDetail}
           </TypographyP>
         ) : null}
@@ -150,9 +149,11 @@ export function MetricsGrid({
           className="rounded-lg border border-border bg-muted py-0 text-foreground ring-0"
         >
           <CardContent className="px-4 py-4">
-            <TypographyP className="text-sm text-muted-foreground">{metric.label}</TypographyP>
+            <TypographyP size="small" tone="subtle">
+              {metric.label}
+            </TypographyP>
             <div className="mt-3 flex items-end justify-between gap-4">
-              <TypographyP className="font-heading text-3xl font-medium text-foreground">
+              <TypographyP className="font-heading text-3xl" weight="medium" tone="content">
                 {metric.value}
               </TypographyP>
               <Badge variant="outline" className={cn("rounded-full", toneClass(metric.tone))}>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-page-content.tsx
@@ -345,10 +345,10 @@ export function AiEnginePageContent({
   return (
     <main className="space-y-8">
       <div className="flex flex-col gap-1.5">
-        <TypographyH1 className="font-heading text-2xl font-medium text-foreground md:text-2xl">
+        <TypographyH1 className="font-heading text-2xl md:text-2xl" weight="medium" tone="content">
           <FormattedMessage {...aiEnginePageContentMessages.pageTitle} />
         </TypographyH1>
-        <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
+        <TypographyP className="max-w-2xl leading-6" size="small" tone="subtle">
           <FormattedMessage {...aiEnginePageContentMessages.pageDescription} />
         </TypographyP>
       </div>
@@ -426,7 +426,7 @@ export function AiEnginePageContent({
             <IntegrationCategoryLabel>
               <FormattedMessage {...aiEnginePageContentMessages.agentSectionTitle} />
             </IntegrationCategoryLabel>
-            <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            <TypographyP className="max-w-2xl leading-6" size="small" tone="subtle">
               <FormattedMessage {...aiEnginePageContentMessages.agentSectionDescription} />
             </TypographyP>
 
@@ -446,7 +446,7 @@ export function AiEnginePageContent({
               </IntegrationCategoryCard>
             )}
 
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               <FormattedMessage {...aiEnginePageContentMessages.agentAutomationsNote} />
             </TypographyP>
           </section>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -349,10 +349,10 @@ export function AutomationsPageView({
             <AutomationListSkeleton />
           ) : error ? (
             <div className="px-4 py-10">
-              <TypographyP className="text-sm font-medium text-flame-100">
+              <TypographyP className="text-flame-100" size="small" weight="medium">
                 <FormattedMessage {...automationsPageViewMessages.loadError} />
               </TypographyP>
-              <TypographyP className="mt-1 text-xs text-muted-foreground">
+              <TypographyP className="mt-1" size="xsmall" tone="subtle">
                 {error instanceof Error
                   ? error.message
                   : intl.formatMessage(automationsPageViewMessages.loadErrorFallback)}
@@ -404,7 +404,7 @@ export function AutomationsPageView({
           <h2 className="font-sans text-base font-medium text-balance text-foreground">
             <FormattedMessage {...automationsPageViewMessages.templatesTitle} />
           </h2>
-          <TypographyP className="text-muted-foreground">
+          <TypographyP tone="subtle">
             <FormattedMessage {...automationsPageViewMessages.templatesDescription} />
           </TypographyP>
         </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/github-auto-review-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/github-auto-review-card.tsx
@@ -113,7 +113,7 @@ function GithubAutoReviewSettingsForm({
 
   if (error) {
     return (
-      <TypographyP className="text-sm font-medium text-flame-100">
+      <TypographyP className="text-flame-100" size="small" weight="medium">
         <FormattedMessage {...messages.loadError} />
       </TypographyP>
     );
@@ -134,7 +134,7 @@ function GithubAutoReviewSettingsForm({
         />
       </div>
 
-      <TypographyP className="text-sm text-muted-foreground">
+      <TypographyP size="small" tone="subtle">
         <FormattedMessage {...messages.mentionNote} />
       </TypographyP>
 
@@ -143,7 +143,7 @@ function GithubAutoReviewSettingsForm({
           <FormattedMessage {...messages.repositoriesLabel} />
         </Label>
         {!hasAnyRepositories ? (
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...messages.noGithub} />{" "}
             <Link
               href={`/org/${organizationSlug}/integrations`}
@@ -153,7 +153,7 @@ function GithubAutoReviewSettingsForm({
             </Link>
           </TypographyP>
         ) : selectableRepositories.length === 0 ? (
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...messages.noEnabledRepos} />{" "}
             <Link
               href={`/org/${organizationSlug}/integrations`}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.tsx
@@ -280,7 +280,7 @@ export function VisualWorkflowConfigPanel({
         config.kind === "trigger.github" ||
         config.kind === "trigger.source_upload" ? (
           config.kind === "trigger.manual" ? (
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               <FormattedMessage {...messages.noConfig} />
             </TypographyP>
           ) : null

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.tsx
@@ -107,7 +107,7 @@ export function VisualWorkflowsPageContent({
           </ul>
         ) : (
           <div className="p-8 text-center">
-            <TypographyP className="text-muted-foreground">
+            <TypographyP tone="subtle">
               <FormattedMessage {...visualWorkflowsPageMessages.emptyState} />
             </TypographyP>
           </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -188,7 +188,7 @@ function DashboardPanel({
                 strokeWidth={1.8}
                 className="mt-0.5 size-5 text-flame-100"
               />
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 {errorMessage ??
                   intl.formatMessage(dashboardPageViewMessages.panelLoadError, { title })}
               </TypographyP>
@@ -197,7 +197,7 @@ function DashboardPanel({
         ) : (
           <>
             {isEmpty && emptyMessage ? (
-              <TypographyP className="px-5 py-4 text-sm text-muted-foreground">
+              <TypographyP className="px-5 py-4" size="small" tone="subtle">
                 {emptyMessage}
               </TypographyP>
             ) : (
@@ -211,7 +211,7 @@ function DashboardPanel({
                     strokeWidth={1.8}
                     className="mt-0.5 size-4 text-warning"
                   />
-                  <TypographyP className="text-sm text-warning-foreground">
+                  <TypographyP className="text-warning-foreground" size="small">
                     {warningMessage}
                   </TypographyP>
                 </div>
@@ -252,7 +252,7 @@ function DashboardSetupHero({
       <CardContent className="flex h-full flex-col justify-between gap-6 px-6 py-6">
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,14rem)] lg:items-end">
           <div>
-            <TypographyP className="text-sm font-medium text-subtle-foreground">
+            <TypographyP size="small" weight="medium" tone="subtlest">
               <FormattedMessage
                 {...dashboardPageViewMessages.setupProgressLabel}
                 values={{
@@ -261,10 +261,15 @@ function DashboardSetupHero({
                 }}
               />
             </TypographyP>
-            <TypographyP className="mt-2 font-heading text-2xl font-medium text-foreground">
+            <TypographyP
+              className="mt-2 font-heading"
+              size="xxlarge"
+              weight="medium"
+              tone="content"
+            >
               {hero.title}
             </TypographyP>
-            <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+            <TypographyP className="mt-2 max-w-xl leading-6" size="small" tone="subtle">
               {hero.description}
             </TypographyP>
             <div className="mt-5 flex flex-wrap gap-2">
@@ -431,10 +436,10 @@ function DashboardIntegrationsSection({
                           <DashboardIntegrationMark item={item} />
                         </div>
                         <div className="min-w-0">
-                          <TypographyP className="text-sm font-medium text-foreground">
+                          <TypographyP size="small" weight="medium" tone="content">
                             {item.label}
                           </TypographyP>
-                          <TypographyP className="mt-1 text-sm text-subtle-foreground">
+                          <TypographyP className="mt-1" size="small" tone="subtlest">
                             {item.description}
                           </TypographyP>
                         </div>
@@ -537,14 +542,14 @@ function DashboardAutomationsSection({
                   strokeWidth={1.8}
                   className="mt-0.5 size-5 text-flame-100"
                 />
-                <TypographyP className="text-sm text-muted-foreground">
+                <TypographyP size="small" tone="subtle">
                   <FormattedMessage {...dashboardPageViewMessages.automationRunsLoadError} />
                 </TypographyP>
               </div>
             </div>
           ) : (
             <div className="flex flex-col divide-y divide-border">
-              <TypographyP className="px-5 py-4 text-sm text-muted-foreground">
+              <TypographyP className="px-5 py-4" size="small" tone="subtle">
                 <FormattedMessage
                   {...dashboardPageViewMessages.automationStats}
                   values={{
@@ -555,7 +560,7 @@ function DashboardAutomationsSection({
                 />
               </TypographyP>
               {runs.length === 0 ? (
-                <TypographyP className="px-5 py-4 text-sm text-muted-foreground">
+                <TypographyP className="px-5 py-4" size="small" tone="subtle">
                   <FormattedMessage {...dashboardPageViewMessages.noAutomationRuns} />
                 </TypographyP>
               ) : (
@@ -571,7 +576,13 @@ function DashboardAutomationsSection({
                         children: (
                           <>
                             <div className="flex flex-wrap items-center gap-2">
-                              <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
+                              <TypographyP
+                                className="min-w-0"
+                                lineClamp={1}
+                                size="small"
+                                weight="medium"
+                                tone="content"
+                              >
                                 {run.automationName}
                               </TypographyP>
                               <Badge
@@ -581,7 +592,7 @@ function DashboardAutomationsSection({
                                 {formatAutomationRunStatus(run.status, intl)}
                               </Badge>
                             </div>
-                            <TypographyP className="mt-1 text-xs text-muted-foreground">
+                            <TypographyP className="mt-1" size="xsmall" tone="subtle">
                               {run.completedAt
                                 ? intl.formatMessage(dashboardPageViewMessages.runCompleted, {
                                     triggerSource: triggerSourceLabel,
@@ -649,7 +660,13 @@ function DashboardJobsPanel({
         const content = (
           <>
             <div className="flex flex-wrap items-center gap-2">
-              <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
+              <TypographyP
+                className="min-w-0"
+                lineClamp={1}
+                size="small"
+                weight="medium"
+                tone="content"
+              >
                 {job.name}
               </TypographyP>
               <Badge
@@ -659,7 +676,7 @@ function DashboardJobsPanel({
                 {formatJobStatusLabel(job.status)}
               </Badge>
             </div>
-            <TypographyP className="mt-1 text-xs text-muted-foreground">
+            <TypographyP className="mt-1" size="xsmall" tone="subtle">
               {intl.formatMessage(dashboardPageViewMessages.jobMeta, {
                 projectName,
                 kindLabel: job.kindLabel,
@@ -740,7 +757,13 @@ function DashboardProjectsPanel({
             children: (
               <>
                 <div className="flex flex-wrap items-center gap-2">
-                  <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
+                  <TypographyP
+                    className="min-w-0"
+                    lineClamp={1}
+                    size="small"
+                    weight="medium"
+                    tone="content"
+                  >
                     {project.name}
                   </TypographyP>
                   {project.pendingActionCount > 0 ? (
@@ -763,7 +786,7 @@ function DashboardProjectsPanel({
                     </Badge>
                   )}
                 </div>
-                <TypographyP className="mt-1 text-xs text-muted-foreground">
+                <TypographyP className="mt-1" size="xsmall" tone="subtle">
                   {project.updatedAt
                     ? intl.formatMessage(dashboardPageViewMessages.projectMetaWithUpdate, {
                         sourceLabel: project.sourceLabel,
@@ -893,13 +916,18 @@ export function DashboardPageView({
             <Card className="rounded-2xl border border-border bg-muted py-0 ring-0">
               <CardContent className="flex h-full flex-col justify-between gap-4 px-6 py-6">
                 <div>
-                  <TypographyP className="text-sm font-medium text-subtle-foreground">
+                  <TypographyP size="small" weight="medium" tone="subtlest">
                     <FormattedMessage {...dashboardPageViewMessages.quickStartLabel} />
                   </TypographyP>
-                  <TypographyP className="mt-2 font-heading text-xl font-medium text-foreground">
+                  <TypographyP
+                    className="mt-2 font-heading"
+                    size="xlarge"
+                    weight="medium"
+                    tone="content"
+                  >
                     <FormattedMessage {...dashboardPageViewMessages.quickStartTitle} />
                   </TypographyP>
-                  <TypographyP className="mt-2 text-sm leading-6 text-muted-foreground">
+                  <TypographyP className="mt-2 leading-6" size="small" tone="subtle">
                     <FormattedMessage {...dashboardPageViewMessages.quickStartDescription} />
                   </TypographyP>
                 </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/slack-connect-invite-banner.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/slack-connect-invite-banner.tsx
@@ -74,14 +74,14 @@ export function SlackConnectInviteBannerView({
           <IntegrationLogo src="/images/slack-logo.svg" className="size-5" />
         </div>
         <div className="min-w-0">
-          <TypographyP className="text-sm font-medium text-foreground">
+          <TypographyP size="small" weight="medium" tone="content">
             {invited ? (
               <FormattedMessage {...slackConnectInviteBannerMessages.invitedTitle} />
             ) : (
               <FormattedMessage {...slackConnectInviteBannerMessages.createTitle} />
             )}
           </TypographyP>
-          <TypographyP className="mt-1 text-sm text-muted-foreground">
+          <TypographyP className="mt-1" size="small" tone="subtle">
             {invited ? (
               <FormattedMessage {...slackConnectInviteBannerMessages.invitedDescription} />
             ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/_components/domain-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/_components/domain-detail-page-content.tsx
@@ -103,13 +103,13 @@ export function DomainDetailPageContent({
       </div>
 
       {domainQuery.isLoading ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.loading} />
         </TypographyP>
       ) : null}
 
       {domainQuery.isError ? (
-        <TypographyP className="text-sm text-destructive">
+        <TypographyP size="small" tone="critical">
           {domainQuery.error instanceof Error
             ? domainQuery.error.message
             : intl.formatMessage(messages.loadError)}
@@ -165,30 +165,30 @@ export function DomainDetailPageContent({
           </div>
 
           <section className="space-y-4">
-            <TypographyH2 className="pb-0 text-xl">
+            <TypographyH2 className="pb-0" size="xlarge">
               <FormattedMessage {...messages.reportHeading} />
             </TypographyH2>
 
             {!linkedDomain.localisationAuditId ? (
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage {...messages.noAudit} />
               </TypographyP>
             ) : null}
 
             {linkedDomain.localisationAuditId && linkedDomain.status !== "verified" ? (
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage {...messages.verifyPending} />
               </TypographyP>
             ) : null}
 
             {auditQuery.isLoading ? (
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage {...messages.loading} />
               </TypographyP>
             ) : null}
 
             {auditQuery.isError ? (
-              <TypographyP className="text-sm text-destructive">
+              <TypographyP size="small" tone="critical">
                 {auditQuery.error instanceof Error
                   ? auditQuery.error.message
                   : intl.formatMessage(messages.auditLoadError)}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
@@ -76,7 +76,7 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
       />
 
       {domainsQuery.isError ? (
-        <TypographyP className="text-sm text-destructive">
+        <TypographyP size="small" tone="critical">
           {domainsQuery.error instanceof Error
             ? domainsQuery.error.message
             : intl.formatMessage(messages.loadError)}
@@ -84,13 +84,13 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
       ) : null}
 
       {domainsQuery.isLoading ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.loading} />
         </TypographyP>
       ) : null}
 
       {!domainsQuery.isLoading && !domainsQuery.isError && linkedDomains.length === 0 ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.empty} />
         </TypographyP>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -920,7 +920,7 @@ export function GlossaryDetailPageContent({
     return conceptPageMode ? <ConceptDetailSkeleton /> : <ConceptListSkeleton />;
   if (!glossary)
     return (
-      <TypographyP className="py-8 text-sm text-muted-foreground">
+      <TypographyP className="py-8" size="small" tone="subtle">
         <FormattedMessage {...messages.notFound} />
       </TypographyP>
     );
@@ -1012,7 +1012,7 @@ export function GlossaryDetailPageContent({
     conceptIsDirty || termsAreDirty || newTermIsDirty || creatingTermDrafts.length > 0;
   if (conceptPageMode && !isCreatingConcept && conceptsQuery.isSuccess && !selected) {
     return (
-      <TypographyP className="py-8 text-sm text-muted-foreground">
+      <TypographyP className="py-8" size="small" tone="subtle">
         <FormattedMessage {...messages.notFound} />
       </TypographyP>
     );
@@ -1113,11 +1113,15 @@ export function GlossaryDetailPageContent({
                 />
               </>
             ) : (
-              <TypographyH1 className="font-sans text-3xl font-semibold text-balance md:text-5xl lg:text-6xl">
+              <TypographyH1
+                className="text-3xl md:text-5xl lg:text-6xl"
+                weight="bold"
+                wrapStyle="balance"
+              >
                 {glossary.name}
               </TypographyH1>
             )}
-            <TypographyP className="max-w-3xl text-sm leading-6 text-muted-foreground">
+            <TypographyP className="max-w-3xl leading-6" size="small" tone="subtle">
               {glossary.description || intl.formatMessage(messages.descriptionFallback)}
             </TypographyP>
             {canManage && isNative ? (
@@ -1139,10 +1143,10 @@ export function GlossaryDetailPageContent({
             <section className="grid gap-4 rounded-lg border border-border p-4">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div>
-                  <TypographyP className="text-sm font-medium text-foreground">
+                  <TypographyP size="small" weight="medium" tone="content">
                     <FormattedMessage {...messages.conceptsTitle} />
                   </TypographyP>
-                  <TypographyP className="text-xs text-muted-foreground">
+                  <TypographyP size="xsmall" tone="subtle">
                     <FormattedMessage {...messages.conceptsDescription} />
                   </TypographyP>
                 </div>
@@ -1276,7 +1280,7 @@ export function GlossaryDetailPageContent({
                 ) : null}
               </div>
               {conceptsQuery.isError ? (
-                <TypographyP className="text-sm text-destructive">
+                <TypographyP size="small" tone="critical">
                   {conceptsQuery.error.message}
                 </TypographyP>
               ) : null}
@@ -1391,7 +1395,7 @@ export function GlossaryDetailPageContent({
                 </table>
                 {conceptsQuery.isSuccess && filteredConcepts.length === 0 ? (
                   <div className="flex flex-col items-center gap-4 px-4 py-10 text-center">
-                    <TypographyP className="text-sm text-muted-foreground">
+                    <TypographyP size="small" tone="subtle">
                       <FormattedMessage {...messages.noConcepts} />
                     </TypographyP>
                     {canContribute || canManage ? (
@@ -1431,7 +1435,7 @@ export function GlossaryDetailPageContent({
             </section>
           ) : (
             <section className="rounded-lg border border-border p-4">
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage {...messages.providerReadOnly} />
               </TypographyP>
             </section>
@@ -1444,14 +1448,14 @@ export function GlossaryDetailPageContent({
             <>
               {conceptPageMode ? (
                 <div className="grid gap-1">
-                  <TypographyH1 className="font-sans text-2xl font-medium">
+                  <TypographyH1 className="text-2xl" weight="medium">
                     {isCreatingConcept ? (
                       <FormattedMessage {...messages.addConcept} />
                     ) : (
                       sourceTermText || selectedConceptId
                     )}
                   </TypographyH1>
-                  <TypographyP className="text-sm text-muted-foreground">
+                  <TypographyP size="small" tone="subtle">
                     {sourceLanguage.name} · {sourceLanguage.locale}
                   </TypographyP>
                 </div>
@@ -2268,7 +2272,11 @@ export function GlossaryDetailPageContent({
                                                   />
                                                 </Field>
                                                 <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-3">
-                                                  <TypographyP className="text-xs text-muted-foreground tabular-nums">
+                                                  <TypographyP
+                                                    className="tabular-nums"
+                                                    size="xsmall"
+                                                    tone="subtle"
+                                                  >
                                                     ID {term.id} · {formatDate(term.createdAt)} ·{" "}
                                                     {formatDate(term.updatedAt)}
                                                   </TypographyP>
@@ -2539,12 +2547,12 @@ export function GlossaryDetailPageContent({
       {!conceptPageMode && (isNative || isLiveCrowdin) ? (
         <section className="grid gap-4 rounded-lg border border-border p-4">
           <div>
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage
                 {...(isLiveCrowdin ? messages.linkedProjectTitle : messages.assignedProjectsTitle)}
               />
             </TypographyP>
-            <TypographyP className="text-xs text-muted-foreground">
+            <TypographyP size="xsmall" tone="subtle">
               <FormattedMessage
                 {...(isLiveCrowdin
                   ? messages.linkedProjectDescription
@@ -2621,7 +2629,7 @@ export function GlossaryDetailPageContent({
               </div>
             ))}
             {attachedProjectsQuery.isSuccess && (attachedProjectsQuery.data ?? []).length === 0 ? (
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage {...messages.noProjectsAssigned} />
               </TypographyP>
             ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
@@ -409,10 +409,10 @@ export function GlossariesPageView({
                 <div className="w-full">{liveProviderControls}</div>
               </div>
               <div className="space-y-3 rounded-lg border border-border px-5 py-8">
-                <TypographyP className="text-sm font-medium text-foreground">
+                <TypographyP size="small" weight="medium" tone="content">
                   <FormattedMessage {...glossariesPageViewMessages.chooseTmsProjectTitle} />
                 </TypographyP>
-                <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
+                <TypographyP className="max-w-xl leading-6" size="small" tone="subtle">
                   <FormattedMessage {...glossariesPageViewMessages.chooseTmsProjectDescription} />
                 </TypographyP>
               </div>
@@ -658,7 +658,7 @@ export function GlossariesPageView({
                   createErrors.projectIds ? [{ message: createErrors.projectIds }] : undefined
                 }
               />
-              <TypographyP className="text-xs text-muted-foreground">
+              <TypographyP size="xsmall" tone="subtle">
                 <FormattedMessage {...glossariesPageViewMessages.projectOptional} />
               </TypographyP>
             </Field>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -309,7 +309,9 @@ function GlossaryRow({
           <SourceLabel glossary={glossary} />
           <ResourceTypeBadge glossary={glossary} />
         </div>
-        <TypographyP className="mt-1 text-xs text-muted-foreground">{sourceDetail}</TypographyP>
+        <TypographyP className="mt-1" size="xsmall" tone="subtle">
+          {sourceDetail}
+        </TypographyP>
         <div className="mt-4 max-w-full">
           <GlossaryInfoCell label={intl.formatMessage(glossariesTableMessages.languagesLabel)}>
             <div
@@ -444,7 +446,7 @@ export function GlossariesTable({
           aria-busy="true"
           aria-label={intl.formatMessage(glossariesTableMessages.loading)}
         >
-          <TypographyP className="border-b border-border px-5 py-3 text-sm text-muted-foreground">
+          <TypographyP className="border-b border-border px-5 py-3" size="small" tone="subtle">
             <FormattedMessage {...glossariesTableMessages.loading} />
           </TypographyP>
           {Array.from({ length: 3 }).map((_, index) => (
@@ -458,10 +460,10 @@ export function GlossariesTable({
 
       {glossariesQuery.isError ? (
         <div className="py-8">
-          <TypographyP className="text-sm font-medium text-flame-100">
+          <TypographyP className="text-flame-100" size="small" weight="medium">
             <FormattedMessage {...glossariesTableMessages.loadFailed} />
           </TypographyP>
-          <TypographyP className="mt-1 text-xs text-muted-foreground">
+          <TypographyP className="mt-1" size="xsmall" tone="subtle">
             {glossariesQuery.error instanceof Error
               ? glossariesQuery.error.message
               : intl.formatMessage(glossariesTableMessages.loadFailedFallback)}
@@ -482,8 +484,10 @@ export function GlossariesTable({
 
       {glossariesQuery.isSuccess && glossaries.length === 0 ? (
         <div className="space-y-3 py-10">
-          <TypographyP className="text-sm font-medium text-foreground">{emptyTitle}</TypographyP>
-          <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
+          <TypographyP size="small" weight="medium" tone="content">
+            {emptyTitle}
+          </TypographyP>
+          <TypographyP className="max-w-xl leading-6" size="small" tone="subtle">
             {emptyDescription}
           </TypographyP>
           {emptyAction}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audience-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audience-detail.tsx
@@ -103,14 +103,14 @@ export function HyperlabAudienceDetail({
     >
       <Rows spacing="2u">
         {detailQuery.isError ? (
-          <TypographyP className="text-pretty text-sm text-destructive">
+          <TypographyP wrapStyle="pretty" size="small" tone="critical">
             {detailQuery.error instanceof Error
               ? detailQuery.error.message
               : intl.formatMessage(messages.loadError)}
           </TypographyP>
         ) : null}
         {detailQuery.isLoading ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.loading} />
           </TypographyP>
         ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audiences-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audiences-page.tsx
@@ -109,19 +109,19 @@ export function HyperlabAudiencesPage({
         ) : null}
 
         {audiencesQuery.isError ? (
-          <TypographyP className="text-pretty text-sm text-destructive">
+          <TypographyP wrapStyle="pretty" size="small" tone="critical">
             {audiencesQuery.error instanceof Error
               ? audiencesQuery.error.message
               : intl.formatMessage(messages.loadError)}
           </TypographyP>
         ) : null}
         {audiencesQuery.isLoading ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.loading} />
           </TypographyP>
         ) : null}
         {!audiencesQuery.isLoading && audiences.length === 0 ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.audiencesEmpty} />
           </TypographyP>
         ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiment-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiment-detail.tsx
@@ -183,14 +183,14 @@ export function HyperlabExperimentDetail({
     >
       <Rows spacing="2u">
         {detailQuery.isError ? (
-          <TypographyP className="text-pretty text-sm text-destructive">
+          <TypographyP wrapStyle="pretty" size="small" tone="critical">
             {detailQuery.error instanceof Error
               ? detailQuery.error.message
               : intl.formatMessage(messages.loadError)}
           </TypographyP>
         ) : null}
         {detailQuery.isLoading ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.loading} />
           </TypographyP>
         ) : null}
@@ -198,7 +198,9 @@ export function HyperlabExperimentDetail({
           <Rows spacing="2u">
             <Row spacing="1u" alignY="center">
               <Badge variant="outline">{experiment.status}</Badge>
-              <TypographyP className="text-sm text-muted-foreground">{experiment.kind}</TypographyP>
+              <TypographyP size="small" tone="subtle">
+                {experiment.kind}
+              </TypographyP>
             </Row>
             <Field>
               <FieldLabel htmlFor="hyperlab-experiment-name">
@@ -306,7 +308,7 @@ export function HyperlabExperimentDetail({
                         </Button>
                       </Column>
                     </Columns>
-                    <TypographyP className="text-pretty text-xs text-muted-foreground">
+                    <TypographyP wrapStyle="pretty" size="xsmall" tone="subtle">
                       <FormattedMessage {...messages.variantRolloutHint} />
                     </TypographyP>
                   </Rows>
@@ -362,8 +364,10 @@ function HyperlabVariantRow({
     <Box paddingX="2u" paddingY="1.5u">
       <Row spacing="1.5u" align="spaceBetween" alignY="center">
         <Rows spacing="0.5u">
-          <TypographyP className="font-medium">{variant.key}</TypographyP>
-          <TypographyP className="text-xs text-muted-foreground">{variant.id}</TypographyP>
+          <TypographyP weight="medium">{variant.key}</TypographyP>
+          <TypographyP size="xsmall" tone="subtle">
+            {variant.id}
+          </TypographyP>
         </Rows>
         <Row spacing="1u" alignY="center">
           {variant.isControl ? (
@@ -386,12 +390,12 @@ function HyperlabVariantRow({
               />
             </Field>
           ) : (
-            <TypographyP className="text-sm tabular-nums text-muted-foreground">
+            <TypographyP className="tabular-nums" size="small" tone="subtle">
               {variant.rolloutPercentage}
             </TypographyP>
           )}
           {allocation ? (
-            <TypographyP className="text-sm tabular-nums text-muted-foreground">
+            <TypographyP className="tabular-nums" size="small" tone="subtle">
               <FormattedMessage
                 {...messages.allocation}
                 values={{ start: allocation.start, end: allocation.end }}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiments-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiments-page.tsx
@@ -130,19 +130,19 @@ export function HyperlabExperimentsPage({
         ) : null}
 
         {experimentsQuery.isError ? (
-          <TypographyP className="text-pretty text-sm text-destructive">
+          <TypographyP wrapStyle="pretty" size="small" tone="critical">
             {experimentsQuery.error instanceof Error
               ? experimentsQuery.error.message
               : intl.formatMessage(messages.loadError)}
           </TypographyP>
         ) : null}
         {experimentsQuery.isLoading ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.loading} />
           </TypographyP>
         ) : null}
         {!experimentsQuery.isLoading && experiments.length === 0 ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.experimentsEmpty} />
           </TypographyP>
         ) : null}
@@ -160,7 +160,7 @@ export function HyperlabExperimentsPage({
                     </Link>
                     <Row spacing="1u" alignY="center">
                       <Badge variant="outline">{experiment.status}</Badge>
-                      <TypographyP className="text-sm text-muted-foreground">
+                      <TypographyP size="small" tone="subtle">
                         {experiment.kind}
                       </TypographyP>
                     </Row>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flag-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flag-detail.tsx
@@ -162,14 +162,14 @@ export function HyperlabFlagDetail({
     >
       <Rows spacing="2u">
         {detailQuery.isError ? (
-          <TypographyP className="text-pretty text-sm text-destructive">
+          <TypographyP wrapStyle="pretty" size="small" tone="critical">
             {detailQuery.error instanceof Error
               ? detailQuery.error.message
               : intl.formatMessage(messages.loadError)}
           </TypographyP>
         ) : null}
         {detailQuery.isLoading ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.loading} />
           </TypographyP>
         ) : null}
@@ -247,7 +247,7 @@ export function HyperlabFlagDetail({
                 <Rows spacing="0">
                   {(assignmentsQuery.data ?? []).map((assignment) => (
                     <Box key={assignment.id} paddingX="2u" paddingY="1.5u">
-                      <TypographyP className="text-sm">
+                      <TypographyP size="small">
                         {assignment.variantId} · {assignment.enabled ? "on" : "off"}
                       </TypographyP>
                     </Box>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flags-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flags-page.tsx
@@ -129,19 +129,19 @@ export function HyperlabFlagsPage({
         ) : null}
 
         {flagsQuery.isError ? (
-          <TypographyP className="text-pretty text-sm text-destructive">
+          <TypographyP wrapStyle="pretty" size="small" tone="critical">
             {flagsQuery.error instanceof Error
               ? flagsQuery.error.message
               : intl.formatMessage(messages.loadError)}
           </TypographyP>
         ) : null}
         {flagsQuery.isLoading ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.loading} />
           </TypographyP>
         ) : null}
         {!flagsQuery.isLoading && flags.length === 0 ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.flagsEmpty} />
           </TypographyP>
         ) : null}
@@ -157,7 +157,9 @@ export function HyperlabFlagsPage({
                     >
                       {flag.key}
                     </Link>
-                    <TypographyP className="text-sm text-muted-foreground">{flag.kind}</TypographyP>
+                    <TypographyP size="small" tone="subtle">
+                      {flag.kind}
+                    </TypographyP>
                   </Rows>
                 </Box>
               ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-keys-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-keys-page.tsx
@@ -129,7 +129,7 @@ export function HyperlabKeysPage({
         {createdSecret ? (
           <Box border="standard" borderRadius="standard" background="muted" padding="2u">
             <Rows spacing="1u">
-              <TypographyP className="text-pretty text-sm font-medium">
+              <TypographyP wrapStyle="pretty" size="small" weight="medium">
                 <FormattedMessage {...messages.copySecret} />
               </TypographyP>
               <code className="overflow-x-auto text-sm">{createdSecret}</code>
@@ -138,19 +138,19 @@ export function HyperlabKeysPage({
         ) : null}
 
         {keysQuery.isError ? (
-          <TypographyP className="text-pretty text-sm text-destructive">
+          <TypographyP wrapStyle="pretty" size="small" tone="critical">
             {keysQuery.error instanceof Error
               ? keysQuery.error.message
               : intl.formatMessage(messages.loadError)}
           </TypographyP>
         ) : null}
         {keysQuery.isLoading ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.loading} />
           </TypographyP>
         ) : null}
         {!keysQuery.isLoading && keys.length === 0 ? (
-          <TypographyP className="text-pretty text-sm text-muted-foreground">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage {...messages.keysEmpty} />
           </TypographyP>
         ) : null}
@@ -161,8 +161,8 @@ export function HyperlabKeysPage({
                 <Box key={key.id} paddingX="2u" paddingY="1.5u">
                   <Row spacing="1.5u" align="spaceBetween" alignY="center">
                     <Rows spacing="0.5u">
-                      <TypographyP className="font-medium">{key.name}</TypographyP>
-                      <TypographyP className="text-sm text-muted-foreground">
+                      <TypographyP weight="medium">{key.name}</TypographyP>
+                      <TypographyP size="small" tone="subtle">
                         {key.keyPrefix}…
                       </TypographyP>
                     </Rows>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-overview.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-overview.tsx
@@ -55,7 +55,7 @@ OpenFeature.setProvider(
             </CardHeader>
             <CardContent>
               <Rows spacing="1.5u">
-                <TypographyP className="text-pretty text-sm text-muted-foreground">
+                <TypographyP wrapStyle="pretty" size="small" tone="subtle">
                   <FormattedMessage {...messages.ofrepHint} />
                 </TypographyP>
                 <Box

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -330,7 +330,7 @@ function MessageFrame({
         <MessageContent className="w-full max-w-full leading-6">
           {children}
           <MessageFooter className="px-0">
-            <TypographyMuted className="text-xs">{timestamp}</TypographyMuted>
+            <TypographyMuted size="xsmall">{timestamp}</TypographyMuted>
           </MessageFooter>
         </MessageContent>
       </Message>
@@ -354,7 +354,7 @@ function MessageFrame({
           {children}
         </div>
         <MessageFooter className="px-0">
-          <TypographyMuted className="text-xs">{timestamp}</TypographyMuted>
+          <TypographyMuted size="xsmall">{timestamp}</TypographyMuted>
         </MessageFooter>
       </MessageContent>
     </Message>
@@ -580,7 +580,7 @@ function AssistantSources({ parts }: { parts: SourcePart[] }) {
               key={part.sourceId}
               className="flex items-center gap-2 rounded-md bg-muted px-2 py-1.5 text-xs"
             >
-              <TypographySmall className="text-xs">
+              <TypographySmall size="xsmall">
                 {part.title || part.filename || documentFallback}
               </TypographySmall>
               <span className="text-muted-foreground">{part.mediaType}</span>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -118,10 +118,10 @@ export function ConversationPanel({
               className="mt-0.5 size-5 shrink-0 text-muted-foreground"
             />
             <div className="min-w-0">
-              <TypographyH4 className="truncate text-base">
+              <TypographyH4 lineClamp={1} size="medium">
                 <FormattedMessage {...conversationPanelMessages.newRequestTitle} />
               </TypographyH4>
-              <TypographyMuted className="mt-1.5 text-xs">
+              <TypographyMuted className="mt-1.5" size="xsmall">
                 <FormattedMessage {...conversationPanelMessages.newRequestSubtitle} />
               </TypographyMuted>
             </div>
@@ -237,7 +237,9 @@ function ConversationHeader({
           className="mt-0.5 size-5 shrink-0 text-muted-foreground"
         />
         <div className="min-w-0">
-          <TypographyH4 className="truncate text-base">{conversation.title}</TypographyH4>
+          <TypographyH4 lineClamp={1} size="medium">
+            {conversation.title}
+          </TypographyH4>
           <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <Badge variant="outline" className="border-border bg-muted text-foreground">
               {getSourceLabel(conversation.source, intl)}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-issue-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-issue-panel.tsx
@@ -44,7 +44,7 @@ export function InboxIssuePanel({
   if (issueQuery.isError || (!issueQuery.isLoading && !issueQuery.data)) {
     return (
       <section className="flex min-h-0 flex-1 items-center justify-center p-6">
-        <TypographyP className="text-center text-muted-foreground">
+        <TypographyP className="text-center" tone="subtle">
           <FormattedMessage {...messages.issuePanelNotFound} />
         </TypographyP>
       </section>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -240,10 +240,10 @@ const NewRequestListItem = memo(function NewRequestListItem() {
         <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} className="size-4" />
       </div>
       <div className="min-w-0">
-        <TypographySmall className="truncate">
+        <TypographySmall lineClamp={1}>
           <FormattedMessage {...inboxListMessages.newRequestTitle} />
         </TypographySmall>
-        <TypographyMuted className="mt-1 truncate">
+        <TypographyMuted className="mt-1" lineClamp={1}>
           <FormattedMessage {...inboxListMessages.newRequestPreview} />
         </TypographyMuted>
       </div>
@@ -305,9 +305,11 @@ const ConversationListItem = memo(function ConversationListItem({
       </Avatar>
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
-          <TypographySmall className="truncate">{conversation.title}</TypographySmall>
+          <TypographySmall lineClamp={1}>{conversation.title}</TypographySmall>
         </div>
-        <TypographyMuted className="mt-1 truncate">{preview}</TypographyMuted>
+        <TypographyMuted className="mt-1" lineClamp={1}>
+          {preview}
+        </TypographyMuted>
         <div className="mt-2 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
           <span className="truncate">{getSourceLabel(conversation.source, intl)}</span>
           <span className="size-1 rounded-full bg-muted" />
@@ -362,12 +364,14 @@ const NotificationListItem = memo(function NotificationListItem({
       </Avatar>
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
-          <TypographySmall className={cn("truncate", isUnread && "font-semibold")}>
+          <TypographySmall lineClamp={1} weight="bold">
             {notification.payload.issueTitle}
           </TypographySmall>
           {isUnread ? <span className="size-1.5 shrink-0 rounded-full bg-primary" /> : null}
         </div>
-        <TypographyMuted className="mt-1 truncate">{secondary}</TypographyMuted>
+        <TypographyMuted className="mt-1" lineClamp={1}>
+          {secondary}
+        </TypographyMuted>
         <div className="mt-2 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
           <span className="truncate">
             <FormattedMessage {...inboxNotificationsMessages.issueNotification} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/github/repositories/[githubRepositoryId]/automation/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/github/repositories/[githubRepositoryId]/automation/page.tsx
@@ -83,7 +83,7 @@ export default async function GithubRepositoryAutomationPage({
             description: "Page heading for GitHub repository automation settings",
           })}
         </TypographyH1>
-        <TypographyP className="text-muted-foreground">
+        <TypographyP tone="subtle">
           {intl.formatMessage(
             {
               defaultMessage:

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
@@ -33,7 +33,7 @@ export default async function IssuesPage({
   return (
     <Suspense
       fallback={
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           {intl.formatMessage({
             defaultMessage: "Loading board...",
             id: "wZsNKEWooe",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
@@ -132,10 +132,10 @@ function JobKanbanCard({
         })
       ) : (
         <div className="min-w-0">
-          <TypographyP className="truncate text-sm font-medium text-foreground">
+          <TypographyP lineClamp={1} size="small" weight="medium" tone="content">
             {getJobName(job, intl)}
           </TypographyP>
-          <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
+          <TypographyP className="mt-1" lineClamp={1} size="xsmall" tone="subtle">
             <FormattedMessage
               {...jobsKanbanBoardMessages.kindWithTaskId}
               values={{
@@ -158,10 +158,10 @@ function JobKanbanCard({
         ) : null}
       </div>
 
-      <TypographyP className="mt-3 line-clamp-2 text-xs text-subtle-foreground">
+      <TypographyP className="mt-3" lineClamp={2} size="xsmall" tone="subtlest">
         {taskDetailSummary(job, intl)}
       </TypographyP>
-      <TypographyP className="mt-1 text-[11px] text-muted-foreground">
+      <TypographyP className="mt-1 text-[11px]" tone="subtle">
         <FormattedMessage
           {...jobsKanbanBoardMessages.dueMeta}
           values={{
@@ -196,14 +196,16 @@ function KanbanColumn({
   return (
     <section className="flex min-w-[17rem] flex-1 flex-col rounded-xl border border-border bg-muted">
       <header className="flex items-center justify-between gap-2 border-b border-border px-3 py-3">
-        <TypographyP className="text-sm font-medium text-foreground">{label}</TypographyP>
+        <TypographyP size="small" weight="medium" tone="content">
+          {label}
+        </TypographyP>
         <Badge variant="outline" className={cn("rounded-full", toneClass(statusTone))}>
           {jobs.length}
         </Badge>
       </header>
       <div className="flex flex-1 flex-col gap-3 p-3">
         {jobs.length === 0 ? (
-          <TypographyP className="px-1 py-6 text-center text-xs text-muted-foreground">
+          <TypographyP className="px-1 py-6 text-center" size="xsmall" tone="subtle">
             <FormattedMessage {...jobsKanbanBoardMessages.noJobs} />
           </TypographyP>
         ) : (
@@ -218,7 +220,9 @@ function KanbanColumnSkeleton({ label }: { label: string }) {
   return (
     <section className="flex min-w-[17rem] flex-1 flex-col rounded-xl border border-border bg-muted">
       <header className="flex items-center justify-between gap-2 border-b border-border px-3 py-3">
-        <TypographyP className="text-sm font-medium text-foreground">{label}</TypographyP>
+        <TypographyP size="small" weight="medium" tone="content">
+          {label}
+        </TypographyP>
         <Skeleton className="h-5 w-8 rounded-full" />
       </header>
       <div className="flex flex-1 flex-col gap-3 p-3">
@@ -293,7 +297,9 @@ export function JobsKanbanBoard({
 
   if (jobs.length === 0) {
     return (
-      <TypographyP className="px-3 py-8 text-sm text-muted-foreground">{emptyLabel}</TypographyP>
+      <TypographyP className="px-3 py-8" size="small" tone="subtle">
+        {emptyLabel}
+      </TypographyP>
     );
   }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -413,10 +413,10 @@ export function JobsPageErrorMessage({ error }: { error: unknown }) {
 
   return (
     <>
-      <TypographyP className="text-sm font-medium text-flame-100">
+      <TypographyP className="text-flame-100" size="small" weight="medium">
         <FormattedMessage {...jobsPageViewMessages.loadErrorTitle} />
       </TypographyP>
-      <TypographyP className="mt-1 text-sm text-muted-foreground">
+      <TypographyP className="mt-1" size="small" tone="subtle">
         {error instanceof Error
           ? error.message
           : intl.formatMessage(jobsPageViewMessages.loadErrorFallback)}
@@ -448,13 +448,15 @@ function JobsList({
 
   if (isLoading)
     return (
-      <TypographyP className="px-3 py-8 text-sm text-muted-foreground">
+      <TypographyP className="px-3 py-8" size="small" tone="subtle">
         <FormattedMessage {...jobsPageViewMessages.loadingJobs} />
       </TypographyP>
     );
   if (jobs.length === 0) {
     return (
-      <TypographyP className="px-3 py-8 text-sm text-muted-foreground">{emptyLabel}</TypographyP>
+      <TypographyP className="px-3 py-8" size="small" tone="subtle">
+        {emptyLabel}
+      </TypographyP>
     );
   }
 
@@ -504,7 +506,7 @@ function JobsList({
                   </div>
                 )}
                 <JobSourceLabel job={job} />
-                <TypographyP className="truncate text-sm text-muted-foreground">
+                <TypographyP lineClamp={1} size="small" tone="subtle">
                   {job.projectName ??
                     job.projectId ??
                     intl.formatMessage(jobsPageViewMessages.workspaceFallback)}
@@ -516,10 +518,10 @@ function JobsList({
                   {intl.formatMessage(getJobStatusMessage(job.status))}
                 </Badge>
                 <div className="min-w-0">
-                  <TypographyP className="truncate text-sm text-subtle-foreground">
+                  <TypographyP lineClamp={1} size="small" tone="subtlest">
                     {taskDetailSummary(job, intl)}
                   </TypographyP>
-                  <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
+                  <TypographyP className="mt-1" lineClamp={1} size="xsmall" tone="subtle">
                     <FormattedMessage
                       {...jobsPageViewMessages.dueMeta}
                       values={{
@@ -654,9 +656,13 @@ function JobsCollection({
 function JobsSectionHeader({ title, description }: { title: string; description?: string }) {
   return (
     <div className="space-y-1">
-      <TypographyP className="text-sm font-medium text-foreground">{title}</TypographyP>
+      <TypographyP size="small" weight="medium" tone="content">
+        {title}
+      </TypographyP>
       {description ? (
-        <TypographyP className="text-sm leading-6 text-muted-foreground">{description}</TypographyP>
+        <TypographyP className="leading-6" size="small" tone="subtle">
+          {description}
+        </TypographyP>
       ) : null}
     </div>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-page-view.tsx
@@ -67,7 +67,7 @@ export function KnowledgePageHeader({
           <TypographyH1 className="text-2xl tracking-[-0.02em] md:text-2xl">
             <FormattedMessage {...knowledgePageViewMessages.title} />
           </TypographyH1>
-          <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          <TypographyP className="max-w-2xl leading-6" size="small" tone="subtle">
             <FormattedMessage
               {...(scope === "project"
                 ? knowledgePageViewMessages.projectDescription

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/link-domain/[domainSlug]/_components/link-domain-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/link-domain/[domainSlug]/_components/link-domain-page-content.tsx
@@ -155,7 +155,7 @@ export function LinkDomainPageContent({
     return (
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-10">
         <TypographyH1>Domain linked</TypographyH1>
-        <TypographyP className="text-muted-foreground">
+        <TypographyP tone="subtle">
           {linkedDomain.domainKey} is verified for this workspace.
         </TypographyP>
         <div className="flex flex-wrap gap-3">
@@ -192,7 +192,7 @@ export function LinkDomainPageContent({
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-10">
       <div>
         <TypographyH1>Link domain</TypographyH1>
-        <TypographyP className="mt-3 text-muted-foreground">
+        <TypographyP className="mt-3" tone="subtle">
           Prove you control this domain to attach the localisation audit to your workspace, then
           link it to a project for deeper work.
         </TypographyP>
@@ -207,14 +207,14 @@ export function LinkDomainPageContent({
       ) : (
         <>
           <section className="space-y-2">
-            <TypographyH2 className="pb-0 text-lg">{linkedDomain.domainKey}</TypographyH2>
+            <TypographyH2 className="pb-0">{linkedDomain.domainKey}</TypographyH2>
             <p className="text-sm text-muted-foreground">
               Status: {linkedDomain.status.replaceAll("_", " ")}
             </p>
           </section>
 
           <section className="space-y-4">
-            <TypographyH2 className="pb-0 text-lg">Project</TypographyH2>
+            <TypographyH2 className="pb-0">Project</TypographyH2>
             <div className="flex flex-wrap gap-2">
               <Button
                 type="button"
@@ -262,7 +262,7 @@ export function LinkDomainPageContent({
           </section>
 
           <section className="space-y-4">
-            <TypographyH2 className="pb-0 text-lg">Choose a verification method</TypographyH2>
+            <TypographyH2 className="pb-0">Choose a verification method</TypographyH2>
             <div className="flex flex-wrap gap-2">
               {(
                 [

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -124,10 +124,14 @@ function TriageRow({
       className="group flex items-center justify-between gap-4 rounded-xl border border-border/70 bg-background/70 px-4 py-3 transition-colors hover:border-border hover:bg-background/90"
     >
       <div className="min-w-0">
-        <TypographyP className="truncate text-sm font-medium text-foreground">{title}</TypographyP>
-        <TypographyP className="mt-0.5 text-xs text-muted-foreground">{description}</TypographyP>
+        <TypographyP lineClamp={1} size="small" weight="medium" tone="content">
+          {title}
+        </TypographyP>
+        <TypographyP className="mt-0.5" size="xsmall" tone="subtle">
+          {description}
+        </TypographyP>
         {meta ? (
-          <TypographyP className="mt-0.5 truncate text-xs text-muted-foreground">
+          <TypographyP className="mt-0.5" lineClamp={1} size="xsmall" tone="subtle">
             {meta}
           </TypographyP>
         ) : null}
@@ -205,19 +209,19 @@ export function ProjectOverviewPageContentView({
             </>
           ) : isProjectError ? (
             <>
-              <TypographyH1 className="font-sans text-2xl font-medium text-foreground">
+              <TypographyH1 className="text-2xl" weight="medium" tone="content">
                 <FormattedMessage {...messages.projectOverviewFallbackTitle} />
               </TypographyH1>
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage {...messages.loadProjectError} />
               </TypographyP>
             </>
           ) : (
             <>
-              <TypographyH1 className="font-sans text-2xl font-medium text-foreground">
+              <TypographyH1 className="text-2xl" weight="medium" tone="content">
                 {project?.name ?? intl.formatMessage(messages.projectFallbackName)}
               </TypographyH1>
-              <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              <TypographyP className="max-w-2xl leading-6" size="small" tone="subtle">
                 {projectDescription}
               </TypographyP>
             </>
@@ -259,11 +263,11 @@ export function ProjectOverviewPageContentView({
         <ProjectOverviewMeshStage tone={meshTone}>
           <div className="flex flex-col gap-4">
             <div className="flex flex-wrap items-baseline justify-between gap-2">
-              <TypographyP className="font-heading text-xl font-medium text-foreground">
+              <TypographyP className="font-heading" size="xlarge" weight="medium" tone="content">
                 <FormattedMessage {...messages.needsYouNowTitle} />
               </TypographyP>
               {triageItems.length > 0 ? (
-                <TypographyP className="text-sm text-muted-foreground">
+                <TypographyP size="small" tone="subtle">
                   <FormattedMessage
                     {...messages.needsYouNowCount}
                     values={{ count: triageItems.length }}
@@ -309,10 +313,10 @@ export function ProjectOverviewPageContentView({
               </div>
             ) : isJobsError ? (
               <div className="rounded-xl border border-dashed border-border bg-background/60 px-4 py-4">
-                <TypographyP className="text-sm font-medium text-foreground">
+                <TypographyP size="small" weight="medium" tone="content">
                   <FormattedMessage {...messages.jobsUnavailable} />
                 </TypographyP>
-                <TypographyP className="mt-1 text-sm text-muted-foreground">
+                <TypographyP className="mt-1" size="small" tone="subtle">
                   <FormattedMessage {...messages.jobsUnavailableDescription} />
                 </TypographyP>
                 <Button
@@ -327,10 +331,10 @@ export function ProjectOverviewPageContentView({
               </div>
             ) : (
               <div className="space-y-2">
-                <TypographyP className="text-sm font-medium text-foreground">
+                <TypographyP size="small" weight="medium" tone="content">
                   <FormattedMessage {...messages.triageEmptyTitle} />
                 </TypographyP>
-                <TypographyP className="text-sm text-muted-foreground">
+                <TypographyP size="small" tone="subtle">
                   <FormattedMessage {...messages.triageEmptyDescription} />
                 </TypographyP>
               </div>
@@ -344,10 +348,10 @@ export function ProjectOverviewPageContentView({
           <OverviewSectionHeader title={intl.formatMessage(messages.signalsTitle)} />
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="rounded-2xl border border-border px-5 py-4">
-              <TypographyP className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              <TypographyP size="xsmall" weight="medium" tone="subtle" capitalization="uppercase">
                 <FormattedMessage {...messages.signalsLocales} />
               </TypographyP>
-              <TypographyP className="mt-2 font-mono text-sm text-foreground">
+              <TypographyP className="mt-2 font-mono" size="small" tone="content">
                 {project.targetLocales.length > 0 ? (
                   localeRoute
                 ) : (
@@ -369,10 +373,10 @@ export function ProjectOverviewPageContentView({
 
             {isNative ? (
               <div className="rounded-2xl border border-border px-5 py-4">
-                <TypographyP className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                <TypographyP size="xsmall" weight="medium" tone="subtle" capitalization="uppercase">
                   <FormattedMessage {...messages.shipTitle} />
                 </TypographyP>
-                <TypographyP className="mt-2 text-sm text-foreground">
+                <TypographyP className="mt-2" size="small" tone="content">
                   {project.lastSyncedAt ? (
                     <FormattedMessage
                       {...messages.shipLastSynced}
@@ -382,7 +386,7 @@ export function ProjectOverviewPageContentView({
                     <FormattedMessage {...messages.shipNeverSynced} />
                   )}
                 </TypographyP>
-                <TypographyP className="mt-1 text-sm text-muted-foreground">
+                <TypographyP className="mt-1" size="small" tone="subtle">
                   <FormattedMessage
                     {...messages.shipCliHint}
                     values={{
@@ -410,7 +414,7 @@ export function ProjectOverviewPageContentView({
       {isNative && hasTranslationGuidance ? (
         <section className="space-y-3 rounded-2xl border border-border bg-muted/30 px-5 py-5">
           <div className="flex items-center justify-between gap-3">
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...messages.guidanceTitle} />
             </TypographyP>
             <Button
@@ -423,7 +427,12 @@ export function ProjectOverviewPageContentView({
               <FormattedMessage {...messages.guidanceEdit} />
             </Button>
           </div>
-          <TypographyP className="line-clamp-3 whitespace-pre-wrap text-sm leading-6 text-muted-foreground">
+          <TypographyP
+            className="whitespace-pre-wrap leading-6"
+            lineClamp={3}
+            size="small"
+            tone="subtle"
+          >
             {project?.translationContextValue}
           </TypographyP>
         </section>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-content-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-content-editor-page-content.tsx
@@ -296,7 +296,7 @@ export function ProjectFileContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...messages.chooseSourceFile} />
           </TypographyP>
           <Button className="mt-4" variant="outline" size="sm" render={<Link href={filesHref} />}>
@@ -313,7 +313,7 @@ export function ProjectFileContentEditorPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...messages.loadingFile} />
           </TypographyP>
         </div>
@@ -325,7 +325,7 @@ export function ProjectFileContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-flame-100">
+          <TypographyP className="text-flame-100" size="small">
             {projectQuery.error instanceof Error
               ? projectQuery.error.message
               : filesQuery.error instanceof Error
@@ -357,8 +357,10 @@ export function ProjectFileContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="font-mono text-sm text-foreground">{sourcePath}</TypographyP>
-          <TypographyP className="mt-2 text-sm text-muted-foreground">
+          <TypographyP className="font-mono" size="small" tone="content">
+            {sourcePath}
+          </TypographyP>
+          <TypographyP className="mt-2" size="small" tone="subtle">
             <FormattedMessage {...messages.sourceFileMissing} />
           </TypographyP>
           <Button className="mt-4" variant="outline" size="sm" render={<Link href={filesHref} />}>
@@ -374,7 +376,7 @@ export function ProjectFileContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...messages.providerTypeUnsupported} />
           </TypographyP>
           <Button className="mt-4" variant="outline" size="sm" render={<Link href={filesHref} />}>
@@ -433,7 +435,7 @@ export function ProjectFileContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...messages.chooseTargetLocale} />
           </TypographyP>
           <Button className="mt-4" variant="outline" size="sm" render={<Link href={filesHref} />}>
@@ -450,7 +452,7 @@ export function ProjectFileContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-flame-100">
+          <TypographyP className="text-flame-100" size="small">
             <FormattedMessage {...messages.missingSourceLocale} />
           </TypographyP>
         </div>
@@ -463,7 +465,7 @@ export function ProjectFileContentEditorPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...messages.loadingFile} />
           </TypographyP>
         </div>
@@ -597,7 +599,7 @@ export function ProjectFileContentEditorPageContent({
               onRepositoryChange={handleRepositoryChange}
             />
           ) : (
-            <TypographyP className="max-w-44 truncate font-mono text-xs text-muted-foreground">
+            <TypographyP className="max-w-44 font-mono" lineClamp={1} size="xsmall" tone="subtle">
               {sourcePath}
             </TypographyP>
           )}
@@ -618,11 +620,11 @@ export function ProjectFileContentEditorPageContent({
         (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName)) && (
         <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
           {repositoriesQuery.isError ? (
-            <TypographyP className="text-xs text-muted-foreground">
+            <TypographyP size="xsmall" tone="subtle">
               <FormattedMessage {...messages.repositoriesLoadFailed} />
             </TypographyP>
           ) : (
-            <TypographyP className="text-xs text-muted-foreground">
+            <TypographyP size="xsmall" tone="subtle">
               <FormattedMessage {...messages.selectRepositoryForContext} />
             </TypographyP>
           )}
@@ -631,7 +633,7 @@ export function ProjectFileContentEditorPageContent({
 
       {localeFallbackMessage ? (
         <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
-          <TypographyP className="text-xs text-muted-foreground">
+          <TypographyP size="xsmall" tone="subtle">
             {localeFallbackMessage}
           </TypographyP>
         </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -224,13 +224,13 @@ export function ProjectFileDetailPanelView({
     if (requestedSourcePath) {
       return (
         <div className="flex h-full min-h-48 flex-col items-center justify-center gap-2 px-6 py-10 text-center">
-          <TypographyP className="text-sm font-medium text-foreground">
+          <TypographyP size="small" weight="medium" tone="content">
             <FormattedMessage {...messages.fileNotFound} />
           </TypographyP>
-          <TypographyP className="max-w-sm font-mono text-sm text-muted-foreground">
+          <TypographyP className="max-w-sm font-mono" size="small" tone="subtle">
             {requestedSourcePath}
           </TypographyP>
-          <TypographyP className="max-w-sm text-sm text-muted-foreground">
+          <TypographyP className="max-w-sm" size="small" tone="subtle">
             <FormattedMessage {...messages.fileNotFoundDescription} />
           </TypographyP>
         </div>
@@ -239,10 +239,10 @@ export function ProjectFileDetailPanelView({
 
     return (
       <div className="flex h-full min-h-48 flex-col items-center justify-center gap-2 px-6 py-10 text-center">
-        <TypographyP className="text-sm font-medium text-foreground">
+        <TypographyP size="small" weight="medium" tone="content">
           <FormattedMessage {...messages.selectFile} />
         </TypographyP>
-        <TypographyP className="max-w-sm text-sm text-muted-foreground">
+        <TypographyP className="max-w-sm" size="small" tone="subtle">
           <FormattedMessage {...messages.selectFileDescription} />
         </TypographyP>
       </div>
@@ -253,7 +253,7 @@ export function ProjectFileDetailPanelView({
     return (
       <div className="flex h-full min-h-48 items-center justify-center gap-2 px-6 py-10">
         <Spinner />
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.loadingFile} />
         </TypographyP>
       </div>
@@ -263,7 +263,7 @@ export function ProjectFileDetailPanelView({
   if (error) {
     return (
       <div className="flex h-full min-h-48 flex-col justify-center gap-2 px-6 py-10">
-        <TypographyP className="text-sm text-flame-100">
+        <TypographyP className="text-flame-100" size="small">
           {error instanceof Error ? error.message : intl.formatMessage(messages.loadDetailsFailed)}
         </TypographyP>
       </div>
@@ -314,7 +314,7 @@ export function ProjectFileDetailPanelView({
         />
       ) : null}
       <header className="space-y-2 border-b border-border pb-4">
-        <TypographyP className="font-mono text-sm font-medium text-foreground">
+        <TypographyP className="font-mono" size="small" weight="medium" tone="content">
           {sourcePath}
         </TypographyP>
         <div className="flex flex-wrap items-center gap-2">
@@ -334,24 +334,24 @@ export function ProjectFileDetailPanelView({
               <FormattedMessage {...messages.uploaded} />
             </Badge>
           )}
-          <TypographyP className="text-xs text-muted-foreground">
+          <TypographyP size="xsmall" tone="subtle">
             {fileMetadataLine(displayByteSize, latestVersion?.revision, file.uploadedAt, intl)}
           </TypographyP>
         </div>
         {latestVersion?.sourceHash ? (
-          <TypographyP className="font-mono text-xs text-muted-foreground">
+          <TypographyP className="font-mono" size="xsmall" tone="subtle">
             <FormattedMessage {...messages.hash} values={{ hash: latestVersion.sourceHash }} />
           </TypographyP>
         ) : null}
         {provider ? (
           <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
             {provider.format ? (
-              <TypographyP className="text-xs text-muted-foreground">
+              <TypographyP size="xsmall" tone="subtle">
                 <FormattedMessage {...messages.format} values={{ format: provider.format }} />
               </TypographyP>
             ) : null}
             {provider.sourceLocale ? (
-              <TypographyP className="text-xs text-muted-foreground">
+              <TypographyP size="xsmall" tone="subtle">
                 <FormattedMessage
                   {...messages.sourceLocale}
                   values={{ locale: provider.sourceLocale }}
@@ -359,7 +359,7 @@ export function ProjectFileDetailPanelView({
               </TypographyP>
             ) : null}
             {provider.targetLocales.length > 0 ? (
-              <TypographyP className="text-xs text-muted-foreground">
+              <TypographyP size="xsmall" tone="subtle">
                 <FormattedMessage
                   {...messages.targets}
                   values={{ locales: provider.targetLocales.join(", ") }}
@@ -369,7 +369,9 @@ export function ProjectFileDetailPanelView({
           </div>
         ) : null}
         {!provider && readinessSummary ? (
-          <TypographyP className="text-xs text-muted-foreground">{readinessSummary}</TypographyP>
+          <TypographyP size="xsmall" tone="subtle">
+            {readinessSummary}
+          </TypographyP>
         ) : null}
         {!provider ? (
           <div className="flex flex-wrap gap-2 pt-1">
@@ -408,7 +410,7 @@ export function ProjectFileDetailPanelView({
 
       {orderedJobsByLocale.length > 0 ? (
         <section className="space-y-3">
-          <TypographyP className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          <TypographyP size="xsmall" weight="medium" tone="subtle" capitalization="uppercase">
             <FormattedMessage {...messages.jobsByLocale} />
           </TypographyP>
           <div className="flex flex-col gap-3">
@@ -420,7 +422,7 @@ export function ProjectFileDetailPanelView({
                   highlightLocale === group.locale && "border-primary bg-muted",
                 )}
               >
-                <TypographyP className="mb-2 text-sm font-medium text-foreground">
+                <TypographyP className="mb-2" size="small" weight="medium" tone="content">
                   {group.locale}
                 </TypographyP>
                 <ul className="flex flex-col gap-1.5">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -162,10 +162,10 @@ export const ProjectFileSelectionActions = forwardRef<
       <ProjectFileActionDialogs file={file} actions={actions} />
       <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0">
-          <TypographyP className="truncate font-mono text-sm text-foreground">
+          <TypographyP className="font-mono" lineClamp={1} size="small" tone="content">
             {file.sourcePath}
           </TypographyP>
-          <TypographyP className="text-xs text-muted-foreground">
+          <TypographyP size="xsmall" tone="subtle">
             {actions.canOpenCat ? (
               <FormattedMessage {...messages.contentEditorAvailableHint} />
             ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-source-strings-preview.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-source-strings-preview.tsx
@@ -37,7 +37,7 @@ function SourceStringsTable({ preview }: { preview: ProjectSourceStringsPreview 
 
   return (
     <div className="space-y-3">
-      <TypographyP className="text-xs text-muted-foreground">
+      <TypographyP size="xsmall" tone="subtle">
         <FormattedMessage
           {...(preview.truncated ? messages.stringCountTruncated : messages.stringCount)}
           values={{ count: preview.entries.length }}
@@ -45,7 +45,9 @@ function SourceStringsTable({ preview }: { preview: ProjectSourceStringsPreview 
       </TypographyP>
 
       {preview.note ? (
-        <TypographyP className="text-xs text-muted-foreground">{preview.note}</TypographyP>
+        <TypographyP size="xsmall" tone="subtle">
+          {preview.note}
+        </TypographyP>
       ) : null}
 
       <div className="overflow-hidden rounded-md border border-border bg-background">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-branch-filter-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-branch-filter-view.tsx
@@ -45,7 +45,7 @@ export function ProjectFilesBranchFilterView({
 
   if (isLoading) {
     return (
-      <TypographyP className="text-xs text-muted-foreground">
+      <TypographyP size="xsmall" tone="subtle">
         <FormattedMessage {...messages.loadingBranches} />
       </TypographyP>
     );
@@ -57,7 +57,7 @@ export function ProjectFilesBranchFilterView({
 
   return (
     <div className="flex items-center gap-2">
-      <TypographyP className="shrink-0 text-xs text-muted-foreground">
+      <TypographyP className="shrink-0" size="xsmall" tone="subtle">
         <FormattedMessage {...messages.branchLabel} />
       </TypographyP>
       <Select

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-error-boundary.tsx
@@ -72,14 +72,16 @@ function ProjectFilesPanelFallback({
           aria-hidden
         />
         <div className="space-y-1">
-          <TypographyP className="text-sm font-medium text-flame-100">
+          <TypographyP className="text-flame-100" size="small" weight="medium">
             {scope === "tree" ? (
               <FormattedMessage {...messages.treeFailed} />
             ) : (
               <FormattedMessage {...messages.detailFailed} />
             )}
           </TypographyP>
-          <TypographyP className="text-sm text-muted-foreground">{errorMessage}</TypographyP>
+          <TypographyP size="small" tone="subtle">
+            {errorMessage}
+          </TypographyP>
         </div>
       </div>
       <Button

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
@@ -59,7 +59,7 @@ function storyFilesTree({
       <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-2.5">
         <div className="min-w-0">
           <ProjectSectionTitle>Project files</ProjectSectionTitle>
-          <TypographyP className="mt-0.5 text-sm text-muted-foreground">
+          <TypographyP className="mt-0.5" size="small" tone="subtle">
             {files.length} file{files.length === 1 ? "" : "s"}
           </TypographyP>
         </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -185,10 +185,10 @@ function DefaultRenderFilesError({
 
   return (
     <>
-      <TypographyP className="text-sm font-medium text-flame-100">
+      <TypographyP className="text-flame-100" size="small" weight="medium">
         <FormattedMessage {...messages.filesFailedToLoad} />
       </TypographyP>
-      <TypographyP className="mt-1 text-sm text-muted-foreground">
+      <TypographyP className="mt-1" size="small" tone="subtle">
         {error instanceof Error ? error.message : intl.formatMessage(messages.loadFailedFallback)}
       </TypographyP>
     </>
@@ -612,7 +612,7 @@ export function ProjectFilesPageContentView({
               <ProjectSectionTitle>
                 <FormattedMessage {...messages.readyToUpload} />
               </ProjectSectionTitle>
-              <TypographyP className="mt-1 text-sm text-muted-foreground">
+              <TypographyP className="mt-1" size="small" tone="subtle">
                 <FormattedMessage
                   {...messages.filesSelected}
                   values={{ count: selectedFiles.length, max: MAX_UPLOAD_FILES }}
@@ -637,10 +637,10 @@ export function ProjectFilesPageContentView({
             {selectedFiles.map((file) => (
               <li key={fileKey(file)} className="flex items-center justify-between gap-3 px-3 py-2">
                 <div className="min-w-0">
-                  <TypographyP className="truncate font-mono text-sm text-foreground">
+                  <TypographyP className="font-mono" lineClamp={1} size="small" tone="content">
                     {sourcePathForFile(file)}
                   </TypographyP>
-                  <TypographyP className="text-xs text-muted-foreground">
+                  <TypographyP size="xsmall" tone="subtle">
                     {formatBytes(file.size, intl)}
                   </TypographyP>
                 </div>
@@ -669,7 +669,7 @@ export function ProjectFilesPageContentView({
                 <ProjectSectionTitle>
                   <FormattedMessage {...messages.projectFilesTitle} />
                 </ProjectSectionTitle>
-                <TypographyP className="mt-0.5 text-sm text-muted-foreground">
+                <TypographyP className="mt-0.5" size="small" tone="subtle">
                   {isFilesLoading ? (
                     <FormattedMessage {...messages.loading} />
                   ) : filesError ? (
@@ -684,17 +684,17 @@ export function ProjectFilesPageContentView({
 
             <div className="flex min-h-0 flex-1 flex-col">
               {isFilesLoading ? (
-                <TypographyP className="p-4 text-sm text-muted-foreground">
+                <TypographyP className="p-4" size="small" tone="subtle">
                   <FormattedMessage {...messages.loadingFiles} />
                 </TypographyP>
               ) : filesError ? (
                 <div className="p-4">{renderError({ organizationSlug, error: filesError })}</div>
               ) : files.length === 0 ? (
                 <div className="flex flex-col gap-2 p-4">
-                  <TypographyP className="text-sm font-medium text-foreground">
+                  <TypographyP size="small" weight="medium" tone="content">
                     <FormattedMessage {...messages.noFilesYet} />
                   </TypographyP>
-                  <TypographyP className="text-sm text-muted-foreground">
+                  <TypographyP size="small" tone="subtle">
                     {isProviderProject ? (
                       <FormattedMessage {...messages.noProviderFiles} />
                     ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -145,10 +145,10 @@ function ProjectFilesTreeBody({
   if (files.length === 0) {
     return (
       <div className="flex flex-col gap-2 p-4">
-        <TypographyP className="text-sm font-medium text-foreground">
+        <TypographyP size="small" weight="medium" tone="content">
           <FormattedMessage {...messages.noFilesYet} />
         </TypographyP>
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           {isProviderProject ? (
             <FormattedMessage {...messages.noProviderFiles} />
           ) : (
@@ -163,10 +163,10 @@ function ProjectFilesTreeBody({
     <div className="flex min-h-0 flex-1 flex-col gap-2 p-2">
       {onActivateFile && selectedSourcePath && contentEditorOpenHint ? (
         <div className="rounded-lg border border-border bg-background px-4 py-3">
-          <TypographyP className="truncate font-mono text-xs text-foreground">
+          <TypographyP className="font-mono" lineClamp={1} size="xsmall" tone="content">
             {selectedSourcePath}
           </TypographyP>
-          <TypographyP className="text-xs text-muted-foreground">
+          <TypographyP size="xsmall" tone="subtle">
             {contentEditorOpenHint}
           </TypographyP>
         </div>
@@ -319,7 +319,7 @@ export function ProjectFilesTreePanel({
           <ProjectSectionTitle>
             <FormattedMessage {...messages.projectFilesTitle} />
           </ProjectSectionTitle>
-          <TypographyP className="mt-0.5 text-sm text-muted-foreground">
+          <TypographyP className="mt-0.5" size="small" tone="subtle">
             {filesQuery.isLoading ? (
               <FormattedMessage {...messages.loading} />
             ) : filesQuery.isError ? (
@@ -341,7 +341,7 @@ export function ProjectFilesTreePanel({
       </header>
 
       {filesQuery.isLoading ? (
-        <TypographyP className="p-4 text-sm text-muted-foreground">
+        <TypographyP className="p-4" size="small" tone="subtle">
           <FormattedMessage {...messages.loadingFiles} />
         </TypographyP>
       ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/page.tsx
@@ -31,7 +31,7 @@ export default async function ProjectFilesPage({
   return (
     <Suspense
       fallback={
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           {intl.formatMessage({
             defaultMessage: "Loading files...",
             id: "KWzlpvb4xC",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/[issueId]/_components/issue-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/[issueId]/_components/issue-detail-page-content.tsx
@@ -57,7 +57,7 @@ export function IssueDetailPageContent({
   if (issueQuery.isError || (!issueQuery.isLoading && !issueQuery.data)) {
     return (
       <main className="mx-auto flex w-full max-w-3xl flex-col gap-3 py-16">
-        <TypographyP className="text-center text-muted-foreground">
+        <TypographyP className="text-center" tone="subtle">
           <FormattedMessage {...messages.notFound} />
         </TypographyP>
       </main>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/[issueId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/[issueId]/page.tsx
@@ -33,7 +33,7 @@ export default async function IssueDetailPage({
   return (
     <Suspense
       fallback={
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           {intl.formatMessage({
             defaultMessage: "Loading issue...",
             id: "JxSxJmFns3",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.tsx
@@ -337,10 +337,10 @@ export function IssueSheetImportDialog({
             >
               <HugeiconsIcon icon={Upload01Icon} className="size-8 text-muted-foreground" />
               <div>
-                <TypographyP className="font-medium">
+                <TypographyP weight="medium">
                   <FormattedMessage {...messages.chooseCsvFile} />
                 </TypographyP>
-                <TypographyP className="text-sm text-muted-foreground">
+                <TypographyP size="small" tone="subtle">
                   <FormattedMessage {...messages.csvLimits} />
                 </TypographyP>
               </div>
@@ -508,7 +508,7 @@ export function IssueSheetImportDialog({
               </Badge>
             </div>
             {previewResult.columnsCreated.length > 0 ? (
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage
                   {...messages.newColumns}
                   values={{
@@ -558,7 +558,7 @@ export function IssueSheetImportDialog({
 
         {step === "done" && previewResult ? (
           <div className="space-y-3">
-            <TypographyP className="text-sm">
+            <TypographyP size="small">
               {[
                 intl.formatMessage(messages.importSummaryCreated, {
                   count: previewResult.created,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -254,10 +254,10 @@ export function IssueSheetPageContent({
           }}
           empty={
             <div>
-              <TypographyP className="text-sm font-medium">
+              <TypographyP size="small" weight="medium">
                 <FormattedMessage {...messages.emptyTitle} />
               </TypographyP>
-              <TypographyP className="mt-1 text-sm text-muted-foreground">
+              <TypographyP className="mt-1" size="small" tone="subtle">
                 <FormattedMessage {...messages.emptyDescription} />
               </TypographyP>
             </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
@@ -33,7 +33,7 @@ export default async function IssueSheetPage({
   return (
     <Suspense
       fallback={
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           {intl.formatMessage({
             defaultMessage: "Loading board...",
             id: "LGF0oZcJpk",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-agent-run-diff-review-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-agent-run-diff-review-section.tsx
@@ -377,7 +377,7 @@ export function JobAgentRunDiffReviewSection({
   return (
     <section className="rounded-lg border border-border bg-muted p-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+        <TypographyH2 className="font-heading md:text-lg" weight="medium" tone="content">
           <FormattedMessage {...messages.agentProposalReviewHeading} />
         </TypographyH2>
         <div className="flex flex-wrap gap-2">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
@@ -168,7 +168,7 @@ export function JobProviderDetailSectionView({
       {showProviderMetadata ? (
         <section className="rounded-lg border border-border bg-muted p-5">
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+            <TypographyH2 className="font-heading md:text-lg" weight="medium" tone="content">
               <FormattedMessage {...messages.providerDetailsHeading} />
             </TypographyH2>
             <Badge variant="outline" className="rounded-full capitalize">
@@ -261,7 +261,7 @@ export function JobProviderDetailSectionView({
       {projectId && renderSourceFiles ? (
         <section className="rounded-lg border border-border bg-muted p-5">
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+            <TypographyH2 className="font-heading md:text-lg" weight="medium" tone="content">
               <FormattedMessage {...messages.sourceFilesHeading} />
             </TypographyH2>
             {!sourceFilesExpanded ? (
@@ -282,7 +282,7 @@ export function JobProviderDetailSectionView({
 
       {showAgentActions && visibleActions.length > 0 ? (
         <section className="rounded-lg border border-border bg-muted p-5">
-          <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+          <TypographyH2 className="font-heading md:text-lg" weight="medium" tone="content">
             <FormattedMessage {...messages.agentActionsHeading} />
           </TypographyH2>
           <div className="mt-4 flex flex-wrap gap-2">
@@ -317,7 +317,7 @@ export function JobProviderDetailSectionView({
         : null}
 
       <section className="rounded-lg border border-border bg-muted p-5">
-        <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+        <TypographyH2 className="font-heading md:text-lg" weight="medium" tone="content">
           <FormattedMessage {...messages.agentActivityHeading} />
         </TypographyH2>
         {agentRunsLoading ? <Skeleton className="mt-4 h-20 w-full bg-skeleton" /> : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -232,10 +232,10 @@ export function JobSourceFilesPanel({
           {encodedJobId ? (
             <div className="flex flex-col gap-2 rounded-lg border border-border bg-background px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="min-w-0">
-                <TypographyP className="truncate font-mono text-xs text-foreground">
+                <TypographyP className="font-mono" lineClamp={1} size="xsmall" tone="content">
                   {selectedFile?.sourcePath}
                 </TypographyP>
-                <TypographyP className="text-xs text-muted-foreground">
+                <TypographyP size="xsmall" tone="subtle">
                   {selectedTargetLocale ? (
                     <FormattedMessage
                       {...messages.contentEditorWorkspaceHintWithLocale}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-content-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-content-editor-page-content.tsx
@@ -371,11 +371,11 @@ export function JobContentEditorPageContent({
     (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName) ? (
       <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
         {repositoriesQuery.isError ? (
-          <TypographyP className="text-xs text-muted-foreground">
+          <TypographyP size="xsmall" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.repositoriesLoadFailed} />
           </TypographyP>
         ) : (
-          <TypographyP className="text-xs text-muted-foreground">
+          <TypographyP size="xsmall" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.selectRepositoryForContext} />
           </TypographyP>
         )}
@@ -470,7 +470,7 @@ export function JobContentEditorPageContent({
         <ProjectPageShell>
           <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
             <Spinner />
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
             </TypographyP>
           </div>
@@ -482,7 +482,7 @@ export function JobContentEditorPageContent({
       return (
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
-            <TypographyP className="text-sm text-flame-100">
+            <TypographyP className="text-flame-100" size="small">
               {defaultFileQuery.error instanceof Error
                 ? defaultFileQuery.error.message
                 : intl.formatMessage(jobCatPageContentMessages.unableToLoadTaskFiles)}
@@ -502,7 +502,9 @@ export function JobContentEditorPageContent({
       return (
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
-            <TypographyP className="text-sm text-muted-foreground">{emptyStateMessage}</TypographyP>
+            <TypographyP size="small" tone="subtle">
+              {emptyStateMessage}
+            </TypographyP>
           </div>
         </ProjectPageShell>
       );
@@ -512,7 +514,7 @@ export function JobContentEditorPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.openingWorkspace} />
           </TypographyP>
         </div>
@@ -546,7 +548,7 @@ export function JobContentEditorPageContent({
         <ProjectPageShell>
           <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
             <Spinner />
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
             </TypographyP>
           </div>
@@ -559,7 +561,7 @@ export function JobContentEditorPageContent({
       return (
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
-            <TypographyP className="text-sm text-flame-100">
+            <TypographyP className="text-flame-100" size="small">
               <FormattedMessage {...jobCatPageContentMessages.projectMissingSourceLocale} />
             </TypographyP>
           </div>
@@ -571,7 +573,7 @@ export function JobContentEditorPageContent({
       return (
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               {!sourceLocale ? (
                 <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
               ) : (
@@ -700,7 +702,7 @@ export function JobContentEditorPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
           </TypographyP>
         </div>
@@ -712,7 +714,7 @@ export function JobContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-flame-100">
+          <TypographyP className="text-flame-100" size="small">
             {projectQuery.error instanceof Error
               ? projectQuery.error.message
               : targetFileQuery.error instanceof Error
@@ -728,10 +730,10 @@ export function JobContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="font-mono text-sm text-foreground">
+          <TypographyP className="font-mono" size="small" tone="content">
             {targetFileQuery.data.reference}
           </TypographyP>
-          <TypographyP className="mt-2 text-sm text-muted-foreground">
+          <TypographyP className="mt-2" size="small" tone="subtle">
             <FormattedMessage
               {...jobCatPageContentMessages.listTruncated}
               values={{ fetchedCount: targetFileQuery.data.fetchedCount }}
@@ -746,10 +748,10 @@ export function JobContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="font-mono text-sm text-foreground">
+          <TypographyP className="font-mono" size="small" tone="content">
             {sourcePath ?? storedFileId}
           </TypographyP>
-          <TypographyP className="mt-2 text-sm text-muted-foreground">
+          <TypographyP className="mt-2" size="small" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.sourceFileNoLongerLinked} />
           </TypographyP>
         </div>
@@ -762,7 +764,7 @@ export function JobContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-flame-100">
+          <TypographyP className="text-flame-100" size="small">
             <FormattedMessage {...jobCatPageContentMessages.projectMissingSourceLocale} />
           </TypographyP>
         </div>
@@ -775,7 +777,7 @@ export function JobContentEditorPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
           </TypographyP>
         </div>
@@ -788,7 +790,7 @@ export function JobContentEditorPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
           </TypographyP>
         </div>
@@ -801,7 +803,7 @@ export function JobContentEditorPageContent({
       return (
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               <FormattedMessage {...jobCatPageContentMessages.noTargetLocaleForTaskFile} />
             </TypographyP>
           </div>
@@ -876,7 +878,7 @@ export function JobContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.stringEditingUnsupported} />
           </TypographyP>
         </div>
@@ -890,7 +892,7 @@ export function JobContentEditorPageContent({
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             <FormattedMessage {...jobCatPageContentMessages.noTargetLocaleForProviderFile} />
           </TypographyP>
         </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/page.tsx
@@ -28,7 +28,7 @@ export default async function ProjectOverviewPage({
   return (
     <Suspense
       fallback={
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           {intl.formatMessage({
             defaultMessage: "Loading project…",
             id: "PtTtkKUG7c",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-content-editor-behavior-settings.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-content-editor-behavior-settings.tsx
@@ -125,7 +125,7 @@ export function ProjectContentEditorBehaviorSettings({
         <ProjectSectionTitle>
           <FormattedMessage {...projectContentEditorBehaviorMessages.title} />
         </ProjectSectionTitle>
-        <TypographyP className="mt-1 text-sm text-muted-foreground">
+        <TypographyP className="mt-1" size="small" tone="subtle">
           <FormattedMessage {...projectContentEditorBehaviorMessages.description} />
         </TypographyP>
       </div>
@@ -134,11 +134,11 @@ export function ProjectContentEditorBehaviorSettings({
           <label htmlFor="automatic-identical-string-grouping" className="text-sm font-medium">
             <FormattedMessage {...projectContentEditorBehaviorMessages.settingLabel} />
           </label>
-          <TypographyP className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          <TypographyP className="mt-1 max-w-2xl" size="small" tone="subtle">
             <FormattedMessage {...projectContentEditorBehaviorMessages.settingDescription} />
           </TypographyP>
           {!canManage ? (
-            <TypographyP className="mt-2 text-xs text-muted-foreground">
+            <TypographyP className="mt-2" size="xsmall" tone="subtle">
               <FormattedMessage {...projectContentEditorBehaviorMessages.managerOnly} />
             </TypographyP>
           ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-columns-settings.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-columns-settings.tsx
@@ -313,7 +313,7 @@ export function ProjectIssueColumnsSettings({
             ) : (
               <IssueColumnIcon iconId={column.icon} className="text-muted-foreground" />
             )}
-            <TypographyP className="truncate text-sm font-medium text-foreground">
+            <TypographyP lineClamp={1} size="small" weight="medium" tone="content">
               {column.label}
             </TypographyP>
             <Badge variant="outline">
@@ -330,7 +330,7 @@ export function ProjectIssueColumnsSettings({
               </Badge>
             ) : null}
           </div>
-          <TypographyP className="mt-0.5 truncate text-xs text-muted-foreground">
+          <TypographyP className="mt-0.5" lineClamp={1} size="xsmall" tone="subtle">
             {column.key}
           </TypographyP>
         </div>
@@ -414,7 +414,7 @@ export function ProjectIssueColumnsSettings({
           <ProjectSectionTitle>
             <FormattedMessage {...messages.title} />
           </ProjectSectionTitle>
-          <TypographyP className="mt-1 text-sm text-muted-foreground">
+          <TypographyP className="mt-1" size="small" tone="subtle">
             <FormattedMessage {...messages.description} />
           </TypographyP>
         </div>
@@ -424,13 +424,13 @@ export function ProjectIssueColumnsSettings({
       </div>
 
       {columnsQuery.isLoading ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.loading} />
         </TypographyP>
       ) : null}
 
       {columnsQuery.isError ? (
-        <TypographyP className="text-sm text-flame-100">
+        <TypographyP className="text-flame-100" size="small">
           <FormattedMessage {...messages.loadError} />
         </TypographyP>
       ) : null}
@@ -438,10 +438,10 @@ export function ProjectIssueColumnsSettings({
       {columnsQuery.isSuccess ? (
         <div className="grid gap-5">
           <div>
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...messages.systemTitle} />
             </TypographyP>
-            <TypographyP className="mt-1 text-xs text-muted-foreground">
+            <TypographyP className="mt-1" size="xsmall" tone="subtle">
               <FormattedMessage {...messages.systemDescription} />
             </TypographyP>
             <div className="mt-2 grid gap-2">
@@ -450,7 +450,9 @@ export function ProjectIssueColumnsSettings({
                   key={field.key}
                   className="flex items-center justify-between gap-2 border-b border-border py-2 last:border-b-0"
                 >
-                  <TypographyP className="text-sm text-foreground">{field.label}</TypographyP>
+                  <TypographyP size="small" tone="content">
+                    {field.label}
+                  </TypographyP>
                   <Badge variant="outline">
                     <FormattedMessage {...messages.builtInBadge} />
                   </Badge>
@@ -460,7 +462,7 @@ export function ProjectIssueColumnsSettings({
           </div>
 
           <div>
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...messages.builtInTitle} />
             </TypographyP>
             <div className="mt-1">
@@ -469,11 +471,11 @@ export function ProjectIssueColumnsSettings({
           </div>
 
           <div>
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...messages.customTitle} />
             </TypographyP>
             {customColumns.length === 0 ? (
-              <TypographyP className="mt-2 text-sm text-muted-foreground">
+              <TypographyP className="mt-2" size="small" tone="subtle">
                 <FormattedMessage {...messages.emptyCustom} />
               </TypographyP>
             ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-templates-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-templates-panel.tsx
@@ -140,7 +140,7 @@ export function ProjectIssueTemplatesPanel({
         <ProjectSectionTitle>
           <FormattedMessage {...messages.title} />
         </ProjectSectionTitle>
-        <TypographyP className="mt-1 text-sm text-muted-foreground">
+        <TypographyP className="mt-1" size="small" tone="subtle">
           <FormattedMessage {...messages.description} />
         </TypographyP>
       </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-native-connect-cli-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-native-connect-cli-panel.tsx
@@ -56,16 +56,22 @@ export function ProjectNativeConnectCliPanel({
   return (
     <section className="grid gap-4 rounded-lg border border-border bg-muted p-4">
       <div>
-        <TypographyP className="text-sm font-medium text-foreground">
+        <TypographyP size="small" weight="medium" tone="content">
           <FormattedMessage {...projectNativeConnectCliPanelMessages.title} />
         </TypographyP>
-        <TypographyP className="mt-1 text-sm text-muted-foreground">
+        <TypographyP className="mt-1" size="small" tone="subtle">
           <FormattedMessage {...projectNativeConnectCliPanelMessages.description} />
         </TypographyP>
       </div>
 
       <div className="space-y-2">
-        <TypographyP className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+        <TypographyP
+          className="tracking-[0.08em]"
+          size="xsmall"
+          weight="medium"
+          tone="subtle"
+          capitalization="uppercase"
+        >
           <FormattedMessage {...projectNativeConnectCliPanelMessages.projectIdLabel} />
         </TypographyP>
         <div className="flex flex-wrap items-center gap-2">
@@ -90,7 +96,13 @@ export function ProjectNativeConnectCliPanel({
 
       <div className="space-y-2">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <TypographyP className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+          <TypographyP
+            className="tracking-[0.08em]"
+            size="xsmall"
+            weight="medium"
+            tone="subtle"
+            capitalization="uppercase"
+          >
             <FormattedMessage {...projectNativeConnectCliPanelMessages.sampleConfigLabel} />
           </TypographyP>
           <Button

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -154,10 +154,16 @@ function DetailRow({ label, value }: { label: string; value: string | null }) {
 
   return (
     <div className="min-w-0">
-      <TypographyP className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+      <TypographyP
+        className="tracking-[0.08em]"
+        size="xsmall"
+        weight="medium"
+        tone="subtle"
+        capitalization="uppercase"
+      >
         {label}
       </TypographyP>
-      <TypographyP className="mt-1 truncate text-sm text-subtle-foreground">
+      <TypographyP className="mt-1" lineClamp={1} size="small" tone="subtlest">
         {value ?? intl.formatMessage(projectSettingsPageContentMessages.emptyValue)}
       </TypographyP>
     </div>
@@ -178,7 +184,7 @@ function ProjectSourceDetails({ project }: { project: ProjectListRow }) {
           <ProjectSectionTitle>
             <FormattedMessage {...projectSettingsPageContentMessages.sourceConnectionTitle} />
           </ProjectSectionTitle>
-          <TypographyP className="mt-1 text-sm text-muted-foreground">
+          <TypographyP className="mt-1" size="small" tone="subtle">
             <FormattedMessage {...projectSettingsPageContentMessages.sourceConnectionDescription} />
           </TypographyP>
         </div>
@@ -328,7 +334,7 @@ export function ProjectSettingsPageContent({
   if (projectQuery.isLoading || !values) {
     return (
       <ProjectPageShell>
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...projectSettingsPageContentMessages.loading} />
         </TypographyP>
       </ProjectPageShell>
@@ -338,7 +344,7 @@ export function ProjectSettingsPageContent({
   if (projectQuery.isError || !project) {
     return (
       <ProjectPageShell>
-        <TypographyP className="text-sm text-flame-100">
+        <TypographyP className="text-flame-100" size="small">
           <FormattedMessage {...projectSettingsPageContentMessages.loadError} />
         </TypographyP>
       </ProjectPageShell>
@@ -366,7 +372,7 @@ export function ProjectSettingsPageContent({
               <ProjectSectionTitle>
                 <FormattedMessage {...projectSettingsPageContentMessages.generalTitle} />
               </ProjectSectionTitle>
-              <TypographyP className="mt-1 text-sm text-muted-foreground">
+              <TypographyP className="mt-1" size="small" tone="subtle">
                 <FormattedMessage {...projectSettingsPageContentMessages.generalDescription} />
               </TypographyP>
             </div>
@@ -447,7 +453,7 @@ export function ProjectSettingsPageContent({
                   {...projectSettingsPageContentMessages.translationGuidanceTitle}
                 />
               </ProjectSectionTitle>
-              <TypographyP className="mt-1 text-sm text-muted-foreground">
+              <TypographyP className="mt-1" size="small" tone="subtle">
                 <FormattedMessage
                   {...projectSettingsPageContentMessages.translationGuidanceDescription}
                 />
@@ -485,7 +491,7 @@ export function ProjectSettingsPageContent({
               <ProjectSectionTitle>
                 <FormattedMessage {...projectSettingsPageContentMessages.localesTitle} />
               </ProjectSectionTitle>
-              <TypographyP className="mt-1 text-sm text-muted-foreground">
+              <TypographyP className="mt-1" size="small" tone="subtle">
                 {localesEditable ? (
                   <FormattedMessage
                     {...projectSettingsPageContentMessages.localesEditableDescription}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/page.tsx
@@ -32,7 +32,7 @@ export default async function ProjectSettingsPage({
   return (
     <Suspense
       fallback={
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           {intl.formatMessage({
             defaultMessage: "Loading settings...",
             id: "M1rJJm5ext",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -77,8 +77,12 @@ function useProjectSearch(projects: ProjectListRow[]) {
 function ProjectsSectionHeader({ title, description }: { title: string; description: string }) {
   return (
     <div className="space-y-1">
-      <TypographyP className="text-sm font-medium text-foreground">{title}</TypographyP>
-      <TypographyP className="text-sm leading-6 text-muted-foreground">{description}</TypographyP>
+      <TypographyP size="small" weight="medium" tone="content">
+        {title}
+      </TypographyP>
+      <TypographyP className="leading-6" size="small" tone="subtle">
+        {description}
+      </TypographyP>
     </div>
   );
 }
@@ -98,7 +102,13 @@ function RecentProjectsStrip({
 
   return (
     <section className="space-y-3">
-      <TypographyP className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+      <TypographyP
+        className="tracking-[0.08em]"
+        size="xsmall"
+        weight="medium"
+        tone="subtle"
+        capitalization="uppercase"
+      >
         <FormattedMessage {...projectsPageContentMessages.recentlyOpened} />
       </TypographyP>
       <div className="flex flex-wrap gap-2">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -78,7 +78,7 @@ function NativeEmptyState({
 }) {
   if (compact) {
     return (
-      <TypographyP className="text-sm leading-6 text-muted-foreground">
+      <TypographyP className="leading-6" size="small" tone="subtle">
         <FormattedMessage
           {...projectsTableMessages.nativeEmptyCompact}
           values={{
@@ -102,10 +102,10 @@ function NativeEmptyState({
 
   return (
     <div className="max-w-xl space-y-3 py-6">
-      <TypographyP className="text-sm font-medium text-foreground">
+      <TypographyP size="small" weight="medium" tone="content">
         <FormattedMessage {...projectsTableMessages.nativeEmptyTitle} />
       </TypographyP>
-      <TypographyP className="text-sm leading-6 text-muted-foreground">
+      <TypographyP className="leading-6" size="small" tone="subtle">
         <FormattedMessage {...projectsTableMessages.nativeEmptyDescription} />
       </TypographyP>
     </div>
@@ -152,7 +152,7 @@ function ProjectCard({
           <ProjectAvatar project={project} />
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
-              <TypographyH3 className="min-w-0 truncate text-base font-medium text-foreground">
+              <TypographyH3 className="min-w-0" lineClamp={1} weight="medium" tone="content">
                 {project.name}
               </TypographyH3>
               {!project.isActive ? (
@@ -161,10 +161,10 @@ function ProjectCard({
                 </Badge>
               ) : null}
             </div>
-            <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
+            <TypographyP className="mt-1" lineClamp={1} size="xsmall" tone="subtle">
               {providerName}
             </TypographyP>
-            <TypographyP className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+            <TypographyP className="mt-1" lineClamp={2} size="xsmall" tone="subtle">
               {project.descriptionValue ||
                 intl.formatMessage(projectsTableMessages.noDescriptionYet)}
             </TypographyP>
@@ -351,10 +351,10 @@ export function ProjectsTable({
             />
           ) : (
             <>
-              <TypographyP className="text-sm font-medium text-flame-100">
+              <TypographyP className="text-flame-100" size="small" weight="medium">
                 <FormattedMessage {...projectsTableMessages.loadFailedTitle} />
               </TypographyP>
-              <TypographyP className="mt-1 text-xs text-muted-foreground">
+              <TypographyP className="mt-1" size="xsmall" tone="subtle">
                 {projectsQuery.error instanceof Error
                   ? projectsQuery.error.message
                   : intl.formatMessage(projectsTableMessages.loadFailedFallback)}
@@ -368,10 +368,10 @@ export function ProjectsTable({
           <NativeEmptyState compact={compactEmptyNative} onCreateProject={onCreateProject} />
         ) : (
           <div className="max-w-xl space-y-3 py-4">
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...projectsTableMessages.emptyTmsTitle} />
             </TypographyP>
-            <TypographyP className="text-sm leading-6 text-muted-foreground">
+            <TypographyP className="leading-6" size="small" tone="subtle">
               <FormattedMessage {...projectsTableMessages.emptyTmsDescription} />
             </TypographyP>
           </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/api-keys-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/api-keys-page-content.tsx
@@ -164,15 +164,15 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
 
         <section aria-label={intl.formatMessage(apiKeysPageContentMessages.sectionAriaLabel)}>
           {apiKeysQuery.isLoading ? (
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               <FormattedMessage {...apiKeysPageContentMessages.loading} />
             </TypographyP>
           ) : apiKeysQuery.isError ? (
             <Rows spacing="0.5u">
-              <TypographyP className="text-sm font-medium text-destructive">
+              <TypographyP size="small" weight="medium" tone="critical">
                 <FormattedMessage {...apiKeysPageContentMessages.loadErrorTitle} />
               </TypographyP>
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 {apiKeysQuery.error instanceof Error
                   ? apiKeysQuery.error.message
                   : intl.formatMessage(apiKeysPageContentMessages.loadErrorFallback)}
@@ -180,10 +180,15 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
             </Rows>
           ) : activeKeys.length === 0 ? (
             <Rows spacing="1u">
-              <TypographyP className="text-sm font-medium text-foreground">
+              <TypographyP size="small" weight="medium" tone="content">
                 <FormattedMessage {...apiKeysPageContentMessages.emptyTitle} />
               </TypographyP>
-              <TypographyP className="max-w-xl text-pretty text-sm leading-6 text-muted-foreground">
+              <TypographyP
+                className="max-w-xl leading-6"
+                wrapStyle="pretty"
+                size="small"
+                tone="subtle"
+              >
                 <FormattedMessage {...apiKeysPageContentMessages.emptyDescription} />
               </TypographyP>
             </Rows>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
@@ -457,22 +457,24 @@ export function MembersPageView({
         className="min-w-0"
       >
         {isLoading ? (
-          <TypographyP className="py-8 text-sm text-muted-foreground">
+          <TypographyP className="py-8" size="small" tone="subtle">
             <FormattedMessage {...membersPageContentMessages.loading} />
           </TypographyP>
         ) : loadError ? (
           <div className="py-8">
-            <TypographyP className="text-sm font-medium text-flame-100">
+            <TypographyP className="text-flame-100" size="small" weight="medium">
               <FormattedMessage {...membersPageContentMessages.loadErrorTitle} />
             </TypographyP>
-            <TypographyP className="mt-1 text-xs text-muted-foreground">{loadError}</TypographyP>
+            <TypographyP className="mt-1" size="xsmall" tone="subtle">
+              {loadError}
+            </TypographyP>
           </div>
         ) : members.length === 0 ? (
           <div className="py-10">
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...membersPageContentMessages.emptyTitle} />
             </TypographyP>
-            <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+            <TypographyP className="mt-2 max-w-xl leading-6" size="small" tone="subtle">
               <FormattedMessage {...membersPageContentMessages.emptyDescription} />
             </TypographyP>
           </div>
@@ -492,7 +494,7 @@ export function MembersPageView({
                     <MemberAvatar displayName={member.displayName} avatarUrl={member.avatarUrl} />
                     <div className="min-w-0">
                       <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <TypographyP className="truncate text-sm font-medium text-foreground">
+                        <TypographyP lineClamp={1} size="small" weight="medium" tone="content">
                           {member.displayName}
                         </TypographyP>
                         {member.isCurrentUser ? (
@@ -501,7 +503,7 @@ export function MembersPageView({
                           </span>
                         ) : null}
                       </div>
-                      <TypographyP className="mt-0.5 truncate text-sm text-muted-foreground">
+                      <TypographyP className="mt-0.5" lineClamp={1} size="small" tone="subtle">
                         {member.email}
                       </TypographyP>
                     </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.tsx
@@ -70,7 +70,7 @@ export function NotificationPreferencesForm({
               <FieldLabel htmlFor="notification-email-enabled" className="text-sm font-medium">
                 <FormattedMessage {...messages.emailEnabledLabel} />
               </FieldLabel>
-              <TypographyP className="text-sm leading-tight text-muted-foreground">
+              <TypographyP className="leading-tight" size="small" tone="subtle">
                 <FormattedMessage {...messages.emailEnabledDescription} />
               </TypographyP>
             </Rows>
@@ -125,7 +125,7 @@ export function NotificationPreferencesForm({
       ) : null}
 
       {isSaving ? (
-        <TypographyP className="text-sm text-muted-foreground">
+        <TypographyP size="small" tone="subtle">
           <FormattedMessage {...messages.saving} />
         </TypographyP>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/personal-access-tokens-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/personal-access-tokens-page-content.tsx
@@ -211,15 +211,15 @@ export function PersonalAccessTokensPageContent({
 
         <section aria-label={intl.formatMessage(messages.sectionAriaLabel)}>
           {tokensQuery.isLoading ? (
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               <FormattedMessage {...messages.loading} />
             </TypographyP>
           ) : tokensQuery.isError ? (
             <Rows spacing="0.5u">
-              <TypographyP className="text-sm font-medium text-destructive">
+              <TypographyP size="small" weight="medium" tone="critical">
                 <FormattedMessage {...messages.loadErrorTitle} />
               </TypographyP>
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 {tokensQuery.error instanceof Error
                   ? tokensQuery.error.message
                   : intl.formatMessage(messages.loadErrorFallback)}
@@ -227,10 +227,15 @@ export function PersonalAccessTokensPageContent({
             </Rows>
           ) : tokens.length === 0 ? (
             <Rows spacing="1u">
-              <TypographyP className="text-sm font-medium text-foreground">
+              <TypographyP size="small" weight="medium" tone="content">
                 <FormattedMessage {...messages.emptyTitle} />
               </TypographyP>
-              <TypographyP className="max-w-xl text-pretty text-sm leading-6 text-muted-foreground">
+              <TypographyP
+                className="max-w-xl leading-6"
+                wrapStyle="pretty"
+                size="small"
+                tone="subtle"
+              >
                 <FormattedMessage {...messages.emptyDescription} />
               </TypographyP>
             </Rows>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-access-token-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-access-token-table.tsx
@@ -87,7 +87,13 @@ export function SettingsAccessTokenTable({
           <Columns spacing="2u" alignY="center" collapseBelow="medium" role="row">
             <Column width="3/12" role="cell">
               <Rows spacing="0.5u">
-                <TypographyP className="truncate text-sm leading-tight font-medium text-foreground">
+                <TypographyP
+                  className="leading-tight"
+                  lineClamp={1}
+                  size="small"
+                  weight="medium"
+                  tone="content"
+                >
                   {token.name}
                 </TypographyP>
                 {token.revokedAt ? <Badge variant="outline">{revokedLabel}</Badge> : null}
@@ -107,7 +113,7 @@ export function SettingsAccessTokenTable({
               </span>
             </Column>
             <Column width="2/12" role="cell">
-              <TypographyP className="text-sm leading-tight text-muted-foreground">
+              <TypographyP className="leading-tight" size="small" tone="subtle">
                 {formatAccessTokenDate(intl, token.lastUsedAt, neverUsedLabel)}
               </TypographyP>
             </Column>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-page-chrome.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-page-chrome.tsx
@@ -32,10 +32,10 @@ export function SettingsPageHeader({
       <span className="text-xs font-medium tracking-wider text-subtle-foreground uppercase">
         {eyebrow}
       </span>
-      <TypographyH1 className="font-sans text-2xl font-medium tracking-tight text-foreground md:text-2xl">
+      <TypographyH1 className="text-2xl tracking-tight md:text-2xl" weight="medium" tone="content">
         {title}
       </TypographyH1>
-      <TypographyP className="text-pretty text-sm leading-snug text-muted-foreground">
+      <TypographyP className="leading-snug" wrapStyle="pretty" size="small" tone="subtle">
         {description}
       </TypographyP>
     </Rows>
@@ -65,10 +65,10 @@ export function SettingsSectionHeader({
 }) {
   return (
     <Rows spacing="0.5u">
-      <TypographyP className="text-sm leading-tight font-medium text-foreground">
+      <TypographyP className="leading-tight" size="small" weight="medium" tone="content">
         {title}
       </TypographyP>
-      <TypographyP className="text-pretty text-sm leading-tight text-muted-foreground">
+      <TypographyP className="leading-tight" wrapStyle="pretty" size="small" tone="subtle">
         {description}
       </TypographyP>
     </Rows>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
@@ -53,8 +53,12 @@ const workspaceResourceUsageFeatureIds = new Set<string>(workspaceResourceFeatur
 function BillingNotice({ title, description }: { title: ReactNode; description: ReactNode }) {
   return (
     <Rows spacing="1u">
-      <TypographyP className="text-sm font-medium text-foreground">{title}</TypographyP>
-      <TypographyP className="text-pretty text-sm text-muted-foreground">{description}</TypographyP>
+      <TypographyP size="small" weight="medium" tone="content">
+        {title}
+      </TypographyP>
+      <TypographyP wrapStyle="pretty" size="small" tone="subtle">
+        {description}
+      </TypographyP>
     </Rows>
   );
 }
@@ -385,7 +389,7 @@ function ConfiguredBillingSettingsPanel({
         <Rows spacing="3u">
           <Rows spacing="1u">
             <Row spacing="1.5u" alignY="center">
-              <TypographyP className="text-sm leading-tight font-medium text-foreground">
+              <TypographyP className="leading-tight" size="small" weight="medium" tone="content">
                 {planName}
               </TypographyP>
               {activeSubscription ? (
@@ -405,7 +409,7 @@ function ConfiguredBillingSettingsPanel({
                 </Badge>
               ) : null}
             </Row>
-            <TypographyP className="text-sm leading-snug text-muted-foreground">
+            <TypographyP className="leading-snug" size="small" tone="subtle">
               {planCopy}
             </TypographyP>
           </Rows>
@@ -454,7 +458,7 @@ function ConfiguredBillingSettingsPanel({
             ) : null}
           </Row>
           {!canManageBilling ? (
-            <TypographyP className="text-xs text-muted-foreground">
+            <TypographyP size="xsmall" tone="subtle">
               <FormattedMessage {...billingSettingsContentMessages.adminOnlyPortal} />
             </TypographyP>
           ) : null}
@@ -466,17 +470,22 @@ function ConfiguredBillingSettingsPanel({
         className="scroll-mt-[calc(var(--app-shell-header-height)+1rem)]"
       >
         <Rows spacing="1u">
-          <TypographyP className="pb-2 text-sm leading-tight font-medium text-foreground">
+          <TypographyP className="pb-2 leading-tight" size="small" weight="medium" tone="content">
             <FormattedMessage {...billingSettingsContentMessages.planUsageTitle} />
           </TypographyP>
           {usageRows.map((row) => (
             <div key={row.featureId} className="min-h-12 border-t border-border py-3">
               <Row spacing="2u" align="spaceBetween" alignY="center">
                 <Rows spacing="0.5u">
-                  <TypographyP className="text-sm leading-tight font-medium text-foreground">
+                  <TypographyP
+                    className="leading-tight"
+                    size="small"
+                    weight="medium"
+                    tone="content"
+                  >
                     {row.label}
                   </TypographyP>
-                  <TypographyP className="text-xs leading-none text-subtle-foreground">
+                  <TypographyP className="leading-none" size="xsmall" tone="subtlest">
                     <FormattedMessage
                       {...billingSettingsContentMessages.resetsOn}
                       values={{ date: formatResetDate(intl, row.nextResetAt) }}
@@ -484,7 +493,12 @@ function ConfiguredBillingSettingsPanel({
                   </TypographyP>
                 </Rows>
                 <Rows spacing="0.5u" align="end">
-                  <TypographyP className="text-sm leading-tight font-medium text-foreground tabular-nums">
+                  <TypographyP
+                    className="leading-tight tabular-nums"
+                    size="small"
+                    weight="medium"
+                    tone="content"
+                  >
                     {row.usageUnavailable ? (
                       <FormattedMessage {...billingSettingsContentMessages.usageUnavailable} />
                     ) : row.unlimited ? (
@@ -500,14 +514,14 @@ function ConfiguredBillingSettingsPanel({
                     )}
                   </TypographyP>
                   {!row.unlimited && !row.usageUnavailable ? (
-                    <TypographyP className="text-xs leading-none text-subtle-foreground">
+                    <TypographyP className="leading-none" size="xsmall" tone="subtlest">
                       <FormattedMessage
                         {...billingSettingsContentMessages.usageRemaining}
                         values={{ remaining: formatUsageValue(intl, row.remaining) }}
                       />
                     </TypographyP>
                   ) : row.usageUnavailable ? (
-                    <TypographyP className="text-xs leading-none text-subtle-foreground">
+                    <TypographyP className="leading-none" size="xsmall" tone="subtlest">
                       <FormattedMessage
                         {...billingSettingsContentMessages.planLimit}
                         values={{ granted: formatUsageValue(intl, row.granted) }}
@@ -526,7 +540,7 @@ function ConfiguredBillingSettingsPanel({
         className="scroll-mt-[calc(var(--app-shell-header-height)+1rem)]"
       >
         <Rows spacing="1u">
-          <TypographyP className="pb-2 text-sm leading-tight font-medium text-foreground">
+          <TypographyP className="pb-2 leading-tight" size="small" weight="medium" tone="content">
             <FormattedMessage {...billingSettingsContentMessages.availablePlansTitle} />
           </TypographyP>
           {(plans ?? []).map((plan) => {
@@ -535,10 +549,15 @@ function ConfiguredBillingSettingsPanel({
               <div key={plan.id} className="border-t border-border py-3.5">
                 <Row spacing="2u" align="spaceBetween" alignY="center">
                   <Rows spacing="0.5u">
-                    <TypographyP className="text-sm leading-tight font-medium text-foreground">
+                    <TypographyP
+                      className="leading-tight"
+                      size="small"
+                      weight="medium"
+                      tone="content"
+                    >
                       {plan.name}
                     </TypographyP>
-                    <TypographyP className="text-sm leading-tight text-muted-foreground">
+                    <TypographyP className="leading-tight" size="small" tone="subtle">
                       {plan.description ?? (
                         <FormattedMessage
                           {...billingSettingsContentMessages.planDescriptionFallback}
@@ -569,7 +588,7 @@ function ConfiguredBillingSettingsPanel({
             );
           })}
           {!plans?.length ? (
-            <TypographyP className="border-t border-border py-3.5 text-sm text-muted-foreground">
+            <TypographyP className="border-t border-border py-3.5" size="small" tone="subtle">
               <FormattedMessage {...billingSettingsContentMessages.noPlansConfigured} />
             </TypographyP>
           ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
@@ -383,10 +383,10 @@ export function TeamDetailPageView({
       >
         <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...teamDetailPageViewMessages.membersHeading} />
             </TypographyP>
-            <TypographyP className="mt-1 text-sm text-muted-foreground">
+            <TypographyP className="mt-1" size="small" tone="subtle">
               <FormattedMessage
                 {...teamDetailPageViewMessages.membersDescription}
                 values={{
@@ -416,15 +416,15 @@ export function TeamDetailPageView({
         </div>
 
         {isLoading ? (
-          <TypographyP className="py-8 text-sm text-muted-foreground">
+          <TypographyP className="py-8" size="small" tone="subtle">
             <FormattedMessage {...teamDetailPageViewMessages.loading} />
           </TypographyP>
         ) : error ? (
           <div className="py-8">
-            <TypographyP className="text-sm font-medium text-flame-100">
+            <TypographyP className="text-flame-100" size="small" weight="medium">
               <FormattedMessage {...teamDetailPageViewMessages.loadFailed} />
             </TypographyP>
-            <TypographyP className="mt-1 text-xs text-muted-foreground">
+            <TypographyP className="mt-1" size="xsmall" tone="subtle">
               {error instanceof Error
                 ? error.message
                 : intl.formatMessage(teamDetailPageViewMessages.loadFailedFallback)}
@@ -432,10 +432,10 @@ export function TeamDetailPageView({
           </div>
         ) : pageState.members.length === 0 ? (
           <div className="py-10">
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...teamDetailPageViewMessages.emptyTitle} />
             </TypographyP>
-            <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+            <TypographyP className="mt-2 max-w-xl leading-6" size="small" tone="subtle">
               <FormattedMessage {...teamDetailPageViewMessages.emptyDescription} />
             </TypographyP>
           </div>
@@ -468,7 +468,7 @@ export function TeamDetailPageView({
                 >
                   <div role="cell" className="min-w-0">
                     <div className="flex min-w-0 flex-wrap items-center gap-2">
-                      <TypographyP className="truncate text-sm font-medium text-foreground">
+                      <TypographyP lineClamp={1} size="small" weight="medium" tone="content">
                         {member.email}
                       </TypographyP>
                       {isCurrentUser ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
@@ -257,15 +257,15 @@ export function TeamsPageView({
         className="min-w-0"
       >
         {isLoading ? (
-          <TypographyP className="py-8 text-sm text-muted-foreground">
+          <TypographyP className="py-8" size="small" tone="subtle">
             <FormattedMessage {...teamsPageViewMessages.loading} />
           </TypographyP>
         ) : error ? (
           <div className="py-8">
-            <TypographyP className="text-sm font-medium text-flame-100">
+            <TypographyP className="text-flame-100" size="small" weight="medium">
               <FormattedMessage {...teamsPageViewMessages.loadFailed} />
             </TypographyP>
-            <TypographyP className="mt-1 text-xs text-muted-foreground">
+            <TypographyP className="mt-1" size="xsmall" tone="subtle">
               {error instanceof Error
                 ? error.message
                 : intl.formatMessage(teamsPageViewMessages.loadFailedFallback)}
@@ -273,10 +273,10 @@ export function TeamsPageView({
           </div>
         ) : pageState.teams.length === 0 ? (
           <div className="py-10">
-            <TypographyP className="text-sm font-medium text-foreground">
+            <TypographyP size="small" weight="medium" tone="content">
               <FormattedMessage {...teamsPageViewMessages.emptyTitle} />
             </TypographyP>
-            <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+            <TypographyP className="mt-2 max-w-xl leading-6" size="small" tone="subtle">
               <FormattedMessage
                 {...teamsPageViewMessages.emptyDescription}
                 values={{
@@ -314,10 +314,15 @@ export function TeamsPageView({
                           "block min-w-0 rounded-md transition-colors hover:text-foreground",
                         children: (
                           <>
-                            <TypographyP className="truncate text-sm font-medium text-foreground">
+                            <TypographyP lineClamp={1} size="small" weight="medium" tone="content">
                               {team.name}
                             </TypographyP>
-                            <TypographyP className="mt-0.5 truncate text-sm text-muted-foreground md:hidden">
+                            <TypographyP
+                              className="mt-0.5 md:hidden"
+                              lineClamp={1}
+                              size="small"
+                              tone="subtle"
+                            >
                               {team.slug}
                             </TypographyP>
                           </>
@@ -328,7 +333,7 @@ export function TeamsPageView({
                 </div>
 
                 <div role="cell" className="hidden min-w-0 md:block">
-                  <TypographyP className="truncate font-mono text-xs text-muted-foreground">
+                  <TypographyP className="font-mono" lineClamp={1} size="xsmall" tone="subtle">
                     {team.slug}
                   </TypographyP>
                 </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-detail-sheet.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-detail-sheet.tsx
@@ -110,16 +110,22 @@ function ProvenanceRow({
   if (!actor.at && !actor.displayName && !actor.userId) {
     return (
       <div className="grid gap-0.5">
-        <TypographyP className="text-xs font-medium text-muted-foreground">{label}</TypographyP>
-        <TypographyP className="text-sm text-muted-foreground">{empty}</TypographyP>
+        <TypographyP size="xsmall" weight="medium" tone="subtle">
+          {label}
+        </TypographyP>
+        <TypographyP size="small" tone="subtle">
+          {empty}
+        </TypographyP>
       </div>
     );
   }
 
   return (
     <div className="grid gap-0.5">
-      <TypographyP className="text-xs font-medium text-muted-foreground">{label}</TypographyP>
-      <TypographyP className="text-sm">
+      <TypographyP size="xsmall" weight="medium" tone="subtle">
+        {label}
+      </TypographyP>
+      <TypographyP size="small">
         {actor.displayName ?? empty}
         {actor.at ? (
           <>
@@ -283,14 +289,14 @@ export function TmEntryDetailSheet({
 
         <div className="grid gap-6 px-6 pb-6">
           {detailQuery.isLoading ? (
-            <TypographyP className="text-sm text-muted-foreground">
+            <TypographyP size="small" tone="subtle">
               <FormattedMessage {...messages.loading} />
             </TypographyP>
           ) : null}
 
           {detailQuery.isError ? (
             <div className="grid gap-3">
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage {...messages.error} />
               </TypographyP>
               <Button type="button" variant="outline" onClick={() => detailQuery.refetch()}>
@@ -321,7 +327,7 @@ export function TmEntryDetailSheet({
               ) : null}
 
               {!canEdit ? (
-                <TypographyP className="text-sm text-muted-foreground">
+                <TypographyP size="small" tone="subtle">
                   <FormattedMessage {...messages.readOnlyNotice} />
                 </TypographyP>
               ) : null}
@@ -425,28 +431,28 @@ export function TmEntryDetailSheet({
               ) : (
                 <div className="grid gap-3">
                   <div>
-                    <TypographyP className="text-xs font-medium text-muted-foreground">
+                    <TypographyP size="xsmall" weight="medium" tone="subtle">
                       <FormattedMessage {...messages.sourceTextLabel} />
                     </TypographyP>
-                    <TypographyP className="text-sm">{detail.memoryEntry.sourceText}</TypographyP>
-                    <TypographyP className="text-xs text-muted-foreground">
+                    <TypographyP size="small">{detail.memoryEntry.sourceText}</TypographyP>
+                    <TypographyP size="xsmall" tone="subtle">
                       {formatLocaleOptionLabel(intl, detail.memoryEntry.sourceLocale)}
                     </TypographyP>
                   </div>
                   <div>
-                    <TypographyP className="text-xs font-medium text-muted-foreground">
+                    <TypographyP size="xsmall" weight="medium" tone="subtle">
                       <FormattedMessage {...messages.targetTextLabel} />
                     </TypographyP>
-                    <TypographyP className="text-sm">{detail.memoryEntry.targetText}</TypographyP>
-                    <TypographyP className="text-xs text-muted-foreground">
+                    <TypographyP size="small">{detail.memoryEntry.targetText}</TypographyP>
+                    <TypographyP size="xsmall" tone="subtle">
                       {formatLocaleOptionLabel(intl, detail.memoryEntry.targetLocale)}
                     </TypographyP>
                   </div>
                   <div>
-                    <TypographyP className="text-xs font-medium text-muted-foreground">
+                    <TypographyP size="xsmall" weight="medium" tone="subtle">
                       <FormattedMessage {...messages.contextLabel} />
                     </TypographyP>
-                    <TypographyP className="text-sm">
+                    <TypographyP size="small">
                       {detail.provenance.context ?? intl.formatMessage(messages.contextEmpty)}
                     </TypographyP>
                   </div>
@@ -454,32 +460,30 @@ export function TmEntryDetailSheet({
               )}
 
               <section className="grid gap-3">
-                <TypographyP className="text-sm font-medium">
+                <TypographyP size="small" weight="medium">
                   <FormattedMessage {...messages.provenanceTitle} />
                 </TypographyP>
                 <div className="grid gap-3">
                   <div className="grid gap-0.5">
-                    <TypographyP className="text-xs font-medium text-muted-foreground">
+                    <TypographyP size="xsmall" weight="medium" tone="subtle">
                       <FormattedMessage {...messages.originLabel} />
                     </TypographyP>
-                    <TypographyP className="text-sm">{detail.provenance.origin}</TypographyP>
+                    <TypographyP size="small">{detail.provenance.origin}</TypographyP>
                   </div>
                   {detail.provenance.provider ? (
                     <div className="grid gap-0.5">
-                      <TypographyP className="text-xs font-medium text-muted-foreground">
+                      <TypographyP size="xsmall" weight="medium" tone="subtle">
                         <FormattedMessage {...messages.providerLabel} />
                       </TypographyP>
-                      <TypographyP className="text-sm">{detail.provenance.provider}</TypographyP>
+                      <TypographyP size="small">{detail.provenance.provider}</TypographyP>
                     </div>
                   ) : null}
                   {detail.provenance.importBatchId ? (
                     <div className="grid gap-0.5">
-                      <TypographyP className="text-xs font-medium text-muted-foreground">
+                      <TypographyP size="xsmall" weight="medium" tone="subtle">
                         <FormattedMessage {...messages.importBatchLabel} />
                       </TypographyP>
-                      <TypographyP className="text-sm">
-                        {detail.provenance.importBatchId}
-                      </TypographyP>
+                      <TypographyP size="small">{detail.provenance.importBatchId}</TypographyP>
                     </div>
                   ) : null}
                   <ProvenanceRow
@@ -512,15 +516,15 @@ export function TmEntryDetailSheet({
 
               {metadataEntries.length > 0 ? (
                 <section className="grid gap-2">
-                  <TypographyP className="text-sm font-medium">
+                  <TypographyP size="small" weight="medium">
                     <FormattedMessage {...messages.metadataTitle} />
                   </TypographyP>
                   {metadataEntries.map(([key, value]) => (
                     <div key={key} className="grid gap-0.5">
-                      <TypographyP className="text-xs font-medium text-muted-foreground">
+                      <TypographyP size="xsmall" weight="medium" tone="subtle">
                         {key}
                       </TypographyP>
-                      <TypographyP className="text-sm">
+                      <TypographyP size="small">
                         {typeof value === "string" ? value : JSON.stringify(value)}
                       </TypographyP>
                     </div>
@@ -529,11 +533,11 @@ export function TmEntryDetailSheet({
               ) : null}
 
               <section className="grid gap-2">
-                <TypographyP className="text-sm font-medium">
+                <TypographyP size="small" weight="medium">
                   <FormattedMessage {...messages.variantsTitle} />
                 </TypographyP>
                 {detail.variants.length === 0 ? (
-                  <TypographyP className="text-sm text-muted-foreground">
+                  <TypographyP size="small" tone="subtle">
                     <FormattedMessage {...messages.variantsEmpty} />
                   </TypographyP>
                 ) : (
@@ -544,7 +548,7 @@ export function TmEntryDetailSheet({
                       className="rounded-lg border border-border px-3 py-2 text-left"
                       onClick={() => onOpenVariant(variant.id)}
                     >
-                      <TypographyP className="text-sm font-medium">
+                      <TypographyP size="small" weight="medium">
                         <FormattedMessage
                           {...messages.openVariant}
                           values={{
@@ -552,7 +556,7 @@ export function TmEntryDetailSheet({
                           }}
                         />
                       </TypographyP>
-                      <TypographyP className="text-xs text-muted-foreground">
+                      <TypographyP size="xsmall" tone="subtle">
                         {variant.targetText}
                         {variant.context ? ` · ${variant.context}` : ""}
                       </TypographyP>
@@ -562,21 +566,21 @@ export function TmEntryDetailSheet({
               </section>
 
               <section className="grid gap-2">
-                <TypographyP className="text-sm font-medium">
+                <TypographyP size="small" weight="medium">
                   <FormattedMessage {...messages.auditTitle} />
                 </TypographyP>
                 {detail.auditEvents.length === 0 ? (
-                  <TypographyP className="text-sm text-muted-foreground">
+                  <TypographyP size="small" tone="subtle">
                     <FormattedMessage {...messages.auditEmpty} />
                   </TypographyP>
                 ) : (
                   <ol className="grid gap-3">
                     {detail.auditEvents.map((event) => (
                       <li key={event.id} className="grid gap-0.5">
-                        <TypographyP className="text-sm font-medium">
+                        <TypographyP size="small" weight="medium">
                           <FormattedMessage {...eventLabel(event)} />
                         </TypographyP>
-                        <TypographyP className="text-xs text-muted-foreground">
+                        <TypographyP size="xsmall" tone="subtle">
                           {event.actorDisplayName ?? intl.formatMessage(messages.unknownActor)}
                           {" · "}
                           <FormattedDate

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-entry-explorer.tsx
@@ -235,12 +235,14 @@ export function TmEntryExplorer({
         {statusMessage}
       </div>
       {cursorNotice ? (
-        <TypographyP className="text-sm text-muted-foreground">{cursorNotice}</TypographyP>
+        <TypographyP size="small" tone="subtle">
+          {cursorNotice}
+        </TypographyP>
       ) : null}
 
       {selectedEntry ? (
         <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-3 py-2">
-          <TypographyP className="text-sm font-medium">
+          <TypographyP size="small" weight="medium">
             <FormattedMessage {...messages.selectedEntry} />
           </TypographyP>
           <Button type="button" size="sm" variant="outline" onClick={closeEntry}>
@@ -270,7 +272,7 @@ export function TmEntryExplorer({
 
       {entriesQuery.isError && !isInvalidCursorError(entriesQuery.error) ? (
         <div className="grid gap-3 rounded-lg border border-border px-4 py-10 text-center">
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP size="small" tone="subtle">
             {entriesQuery.error instanceof Error
               ? entriesQuery.error.message
               : intl.formatMessage(messages.error)}
@@ -284,7 +286,11 @@ export function TmEntryExplorer({
       ) : null}
 
       {entriesQuery.isSuccess && entries.length === 0 ? (
-        <TypographyP className="rounded-lg border border-border px-4 py-6 text-sm text-muted-foreground">
+        <TypographyP
+          className="rounded-lg border border-border px-4 py-6"
+          size="small"
+          tone="subtle"
+        >
           <FormattedMessage {...(hasFilters ? messages.empty : messages.emptyNoFilters)} />
         </TypographyP>
       ) : null}
@@ -320,8 +326,10 @@ export function TmEntryExplorer({
                 }}
               >
                 <div>
-                  <TypographyP className="text-sm font-medium">{entry.sourceText}</TypographyP>
-                  <TypographyP className="text-xs text-muted-foreground">
+                  <TypographyP size="small" weight="medium">
+                    {entry.sourceText}
+                  </TypographyP>
+                  <TypographyP size="xsmall" tone="subtle">
                     <FormattedMessage
                       {...messages.localePair}
                       values={{
@@ -332,7 +340,7 @@ export function TmEntryExplorer({
                   </TypographyP>
                 </div>
                 <div className="grid gap-1">
-                  <TypographyP className="text-sm text-subtle-foreground">
+                  <TypographyP size="small" tone="subtlest">
                     {entry.targetText}
                   </TypographyP>
                   <div className="flex flex-wrap gap-1">
@@ -424,7 +432,9 @@ export function TmEntryExplorer({
 
       {entriesQuery.isSuccess && (hasMore || Boolean(state.cursor)) ? (
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <TypographyP className="text-xs text-muted-foreground">{statusMessage}</TypographyP>
+          <TypographyP size="xsmall" tone="subtle">
+            {statusMessage}
+          </TypographyP>
           <div className="flex gap-2">
             <Button
               type="button"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/tm-import-export-panel.tsx
@@ -323,14 +323,18 @@ function ImportReportBody({ report }: { report: MemoryImportResponse }) {
     <div className="grid gap-4">
       <div className="flex flex-wrap gap-2">
         {reportCounts(report.report).map((item) => (
-          <TypographyP key={item.key} className="rounded-md border border-border px-2 py-1 text-xs">
+          <TypographyP
+            key={item.key}
+            className="rounded-md border border-border px-2 py-1"
+            size="xsmall"
+          >
             <FormattedMessage {...item.message} values={{ count: item.count }} />
           </TypographyP>
         ))}
       </div>
       {report.preview.length > 0 ? (
         <div className="grid gap-2">
-          <TypographyP className="text-sm font-medium">
+          <TypographyP size="small" weight="medium">
             <FormattedMessage {...messages.previewEntriesTitle} />
           </TypographyP>
           <div className="max-h-48 overflow-auto rounded-md border border-border">
@@ -339,11 +343,11 @@ function ImportReportBody({ report }: { report: MemoryImportResponse }) {
                 key={`${entry.externalKey ?? entry.sourceText}-${index}`}
                 className="border-b border-border px-3 py-2 last:border-b-0"
               >
-                <TypographyP className="text-xs text-muted-foreground">
+                <TypographyP size="xsmall" tone="subtle">
                   {entry.sourceLocale} → {entry.targetLocale} · {entry.action}
                 </TypographyP>
-                <TypographyP className="text-sm">{entry.sourceText}</TypographyP>
-                <TypographyP className="text-sm text-muted-foreground">
+                <TypographyP size="small">{entry.sourceText}</TypographyP>
+                <TypographyP size="small" tone="subtle">
                   {entry.targetText}
                 </TypographyP>
               </div>
@@ -353,7 +357,7 @@ function ImportReportBody({ report }: { report: MemoryImportResponse }) {
       ) : null}
       {report.report.issues.length > 0 ? (
         <div className="grid gap-2">
-          <TypographyP className="text-sm font-medium">
+          <TypographyP size="small" weight="medium">
             <FormattedMessage {...messages.issuesTitle} />
           </TypographyP>
           <ul className="max-h-40 overflow-auto rounded-md border border-border px-3 py-2 text-xs">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -229,14 +229,14 @@ export function TranslationMemoryDetailPageContent({
 
   if (memoryQuery.isLoading) {
     return (
-      <TypographyP className="py-8 text-sm text-muted-foreground">
+      <TypographyP className="py-8" size="small" tone="subtle">
         <FormattedMessage {...messages.loading} />
       </TypographyP>
     );
   }
   if (!memory) {
     return (
-      <TypographyP className="py-8 text-sm text-muted-foreground">
+      <TypographyP className="py-8" size="small" tone="subtle">
         <FormattedMessage {...messages.notFound} />
       </TypographyP>
     );
@@ -254,7 +254,9 @@ export function TranslationMemoryDetailPageContent({
 
       <section className="flex flex-col gap-2">
         <div className="flex flex-wrap items-center gap-2">
-          <TypographyH1 className="font-sans text-2xl font-medium">{memory.name}</TypographyH1>
+          <TypographyH1 className="text-2xl" weight="medium">
+            {memory.name}
+          </TypographyH1>
           <Badge variant="outline">
             {memory.source === "native" ? (
               <FormattedMessage {...messages.sourceWorkspace} />
@@ -264,7 +266,7 @@ export function TranslationMemoryDetailPageContent({
           </Badge>
         </div>
         {memory.description ? (
-          <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          <TypographyP className="max-w-2xl leading-6" size="small" tone="subtle">
             {memory.description}
           </TypographyP>
         ) : null}
@@ -460,7 +462,7 @@ export function TranslationMemoryDetailPageContent({
               </div>
             ))}
             {attachedProjectsQuery.isSuccess && (attachedProjectsQuery.data ?? []).length === 0 ? (
-              <TypographyP className="text-sm text-muted-foreground">
+              <TypographyP size="small" tone="subtle">
                 <FormattedMessage {...messages.noProjectsAssigned} />
               </TypographyP>
             ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
@@ -381,10 +381,10 @@ export function TranslationMemoriesPageView({
 
       {liveProjectSelectionRequired ? (
         <div className="space-y-3 py-10">
-          <TypographyP className="text-sm font-medium text-foreground">
+          <TypographyP size="small" weight="medium" tone="content">
             <FormattedMessage {...translationMemoriesPageViewMessages.chooseTmsProjectTitle} />
           </TypographyP>
-          <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
+          <TypographyP className="max-w-xl leading-6" size="small" tone="subtle">
             <FormattedMessage
               {...translationMemoriesPageViewMessages.chooseTmsProjectDescription}
             />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
@@ -113,7 +113,9 @@ function MemoryRow({
           )}
           <SourceLabel memory={memory} />
         </div>
-        <TypographyP className="mt-1 text-xs text-muted-foreground">{sourceDetail}</TypographyP>
+        <TypographyP className="mt-1" size="xsmall" tone="subtle">
+          {sourceDetail}
+        </TypographyP>
         <div className="mt-2 flex flex-wrap items-center gap-2">
           {memory.projectLinkId ? (
             <Link
@@ -143,8 +145,10 @@ function MemoryRow({
           ) : null}
         </div>
       </div>
-      <TypographyP className="text-sm text-muted-foreground">{memory.localeSummary}</TypographyP>
-      <TypographyP className="text-sm text-muted-foreground">
+      <TypographyP size="small" tone="subtle">
+        {memory.localeSummary}
+      </TypographyP>
+      <TypographyP size="small" tone="subtle">
         <FormattedMessage
           {...translationMemoriesTableMessages.segmentCount}
           values={{ countLabel: memory.segmentCountLabel }}
@@ -183,17 +187,17 @@ export function TranslationMemoriesTable({
       className="min-w-0"
     >
       {memoriesQuery.isLoading ? (
-        <TypographyP className="py-8 text-sm text-muted-foreground">
+        <TypographyP className="py-8" size="small" tone="subtle">
           <FormattedMessage {...translationMemoriesTableMessages.loading} />
         </TypographyP>
       ) : null}
 
       {memoriesQuery.isError ? (
         <div className="py-8">
-          <TypographyP className="text-sm font-medium text-flame-100">
+          <TypographyP className="text-flame-100" size="small" weight="medium">
             <FormattedMessage {...translationMemoriesTableMessages.loadFailed} />
           </TypographyP>
-          <TypographyP className="mt-1 text-xs text-muted-foreground">
+          <TypographyP className="mt-1" size="xsmall" tone="subtle">
             {memoriesQuery.error instanceof Error
               ? memoriesQuery.error.message
               : intl.formatMessage(translationMemoriesTableMessages.loadFailedFallback)}
@@ -203,8 +207,10 @@ export function TranslationMemoriesTable({
 
       {memoriesQuery.isSuccess && memories.length === 0 ? (
         <div className="space-y-3 py-10">
-          <TypographyP className="text-sm font-medium text-foreground">{emptyTitle}</TypographyP>
-          <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
+          <TypographyP size="small" weight="medium" tone="content">
+            {emptyTitle}
+          </TypographyP>
+          <TypographyP className="max-w-xl leading-6" size="small" tone="subtle">
             {emptyDescription}
           </TypographyP>
           {emptyAction}

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/legal-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/legal-page.tsx
@@ -57,13 +57,22 @@ export function LegalPage({ locale, eyebrow, title, description, children }: Leg
               Back to home
             </Link>
             <div className="space-y-4">
-              <TypographyP className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+              <TypographyP
+                className="tracking-[0.22em] text-primary"
+                size="xsmall"
+                weight="bold"
+                capitalization="uppercase"
+              >
                 {eyebrow}
               </TypographyP>
-              <TypographyH1 className="font-heading text-4xl leading-tight font-semibold tracking-[-0.04em] text-balance sm:text-5xl md:text-5xl">
+              <TypographyH1
+                className="font-heading text-4xl leading-tight tracking-[-0.04em] sm:text-5xl md:text-5xl"
+                weight="bold"
+                wrapStyle="balance"
+              >
                 {title}
               </TypographyH1>
-              <TypographyP className="max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+              <TypographyP className="max-w-2xl sm:text-lg" tone="subtle">
                 {description}
               </TypographyP>
             </div>
@@ -80,7 +89,11 @@ export function LegalPage({ locale, eyebrow, title, description, children }: Leg
 export function LegalSection({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="space-y-3">
-      <TypographyH2 className="font-heading text-2xl font-semibold tracking-[-0.03em] text-foreground md:text-2xl">
+      <TypographyH2
+        className="font-heading text-2xl tracking-[-0.03em] md:text-2xl"
+        weight="bold"
+        tone="content"
+      >
         {title}
       </TypographyH2>
       <div className="space-y-4">{children}</div>

--- a/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
@@ -207,7 +207,9 @@ export default async function AccessDeniedPage({ searchParams }: AccessDeniedPag
           <CardDescription className="text-muted-foreground">{copy.description}</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
-          <TypographyP className="text-sm leading-6 text-muted-foreground">{copy.body}</TypographyP>
+          <TypographyP className="leading-6" size="small" tone="subtle">
+            {copy.body}
+          </TypographyP>
 
           <div className="flex flex-wrap gap-3">
             {reason === "pending-invite" ? (

--- a/apps/hyperlocalise-web/src/app/auth/onboarding/_components/onboarding-wizard.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/onboarding/_components/onboarding-wizard.tsx
@@ -69,7 +69,7 @@ export function OnboardingWizard() {
             <h1 className="font-heading text-xl font-semibold text-foreground">
               <FormattedMessage {...onboardingWizardMessages.title} />
             </h1>
-            <TypographyP className="text-sm leading-6 text-muted-foreground">
+            <TypographyP className="leading-6" size="small" tone="subtle">
               <FormattedMessage {...onboardingWizardMessages.description} />
             </TypographyP>
           </div>

--- a/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
@@ -79,13 +79,13 @@ export const ArtifactClose = ({
 export type ArtifactTitleProps = HTMLAttributes<HTMLParagraphElement>;
 
 export const ArtifactTitle = ({ className, ...props }: ArtifactTitleProps) => (
-  <TypographyP className={cn("font-medium text-foreground text-sm", className)} {...props} />
+  <TypographyP {...props} weight="medium" tone="content" size="small" />
 );
 
 export type ArtifactDescriptionProps = HTMLAttributes<HTMLParagraphElement>;
 
 export const ArtifactDescription = ({ className, ...props }: ArtifactDescriptionProps) => (
-  <TypographyP className={cn("text-muted-foreground text-sm", className)} {...props} />
+  <TypographyP {...props} tone="subtle" size="small" />
 );
 
 export type ArtifactActionsProps = HTMLAttributes<HTMLDivElement>;

--- a/apps/hyperlocalise-web/src/components/ai-elements/chain-of-thought.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/chain-of-thought.tsx
@@ -202,7 +202,11 @@ export const ChainOfThoughtImage = memo(
       <div className="relative flex max-h-[22rem] items-center justify-center overflow-hidden rounded-lg bg-muted p-3">
         {children}
       </div>
-      {caption && <TypographyP className="text-muted-foreground text-xs">{caption}</TypographyP>}
+      {caption && (
+        <TypographyP tone="subtle" size="xsmall">
+          {caption}
+        </TypographyP>
+      )}
     </div>
   ),
 );

--- a/apps/hyperlocalise-web/src/components/ai-elements/context.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/context.tsx
@@ -176,7 +176,9 @@ export const ContextContentHeader = ({
         <>
           <div className="flex items-center justify-between gap-3 text-xs">
             <TypographyP>{displayPct}</TypographyP>
-            <TypographyP className="font-mono text-muted-foreground">{usedOfTotal}</TypographyP>
+            <TypographyP className="font-mono" tone="subtle">
+              {usedOfTotal}
+            </TypographyP>
           </div>
           <div className="space-y-2">
             <Progress className="bg-muted" value={usedPercent * PERCENT_MAX} />

--- a/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
@@ -75,9 +75,11 @@ export const ConversationEmptyState = ({
         <>
           {icon && <div className="text-muted-foreground">{icon}</div>}
           <div className="space-y-1">
-            <TypographyH3 className="font-medium text-sm md:text-sm">{resolvedTitle}</TypographyH3>
+            <TypographyH3 className="md:text-sm" weight="medium" size="small">
+              {resolvedTitle}
+            </TypographyH3>
             {resolvedDescription && (
-              <TypographyP className="text-muted-foreground text-sm">
+              <TypographyP tone="subtle" size="small">
                 {resolvedDescription}
               </TypographyP>
             )}

--- a/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
@@ -106,7 +106,7 @@ export const EnvironmentVariablesTitle = ({
   const intl = useIntl();
 
   return (
-    <TypographyH3 className={cn("font-medium text-sm", className)} {...props}>
+    <TypographyH3 {...props} weight="medium" size="small">
       {children ?? intl.formatMessage(environmentVariablesMessages.title)}
     </TypographyH3>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/inline-citation.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/inline-citation.tsx
@@ -257,13 +257,17 @@ export const InlineCitationSource = ({
 }: InlineCitationSourceProps) => (
   <div className={cn("space-y-1", className)} {...props}>
     {title && (
-      <TypographyH4 className="truncate font-medium text-sm leading-tight">{title}</TypographyH4>
+      <TypographyH4 className="leading-tight" lineClamp={1} weight="medium">
+        {title}
+      </TypographyH4>
     )}
     {url && (
-      <TypographyP className="truncate break-all text-muted-foreground text-xs">{url}</TypographyP>
+      <TypographyP className="break-all" lineClamp={1} tone="subtle" size="xsmall">
+        {url}
+      </TypographyP>
     )}
     {description && (
-      <TypographyP className="line-clamp-3 text-muted-foreground text-sm leading-relaxed">
+      <TypographyP className="leading-relaxed" lineClamp={3} tone="subtle" size="small">
         {description}
       </TypographyP>
     )}

--- a/apps/hyperlocalise-web/src/components/ai-elements/package-info.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/package-info.tsx
@@ -187,7 +187,7 @@ export const PackageInfoDescription = ({
   children,
   ...props
 }: PackageInfoDescriptionProps) => (
-  <TypographyP className={cn("mt-2 text-muted-foreground text-sm", className)} {...props}>
+  <TypographyP className="mt-2" {...props} tone="subtle" size="small">
     {children}
   </TypographyP>
 );

--- a/apps/hyperlocalise-web/src/components/ai-elements/schema-display.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/schema-display.tsx
@@ -139,10 +139,7 @@ export const SchemaDisplayDescription = ({
   const { description } = useContext(SchemaDisplayContext);
 
   return (
-    <TypographyP
-      className={cn("border-b px-4 py-3 text-muted-foreground text-sm", className)}
-      {...props}
-    >
+    <TypographyP className="border-b px-4 py-3" {...props} tone="subtle" size="small">
       {children ?? description}
     </TypographyP>
   );
@@ -192,7 +189,9 @@ export const SchemaDisplayParameter = ({
       )}
     </div>
     {description && (
-      <TypographyP className="mt-1 text-muted-foreground text-sm">{description}</TypographyP>
+      <TypographyP className="mt-1" tone="subtle" size="small">
+        {description}
+      </TypographyP>
     )}
   </div>
 );
@@ -278,8 +277,10 @@ export const SchemaDisplayProperty = ({
         </CollapsibleTrigger>
         {description && (
           <TypographyP
-            className="pb-2 text-muted-foreground text-sm"
+            className="pb-2"
             style={{ paddingLeft: paddingLeft + 24 }}
+            tone="subtle"
+            size="small"
           >
             {description}
           </TypographyP>
@@ -315,7 +316,9 @@ export const SchemaDisplayProperty = ({
         )}
       </div>
       {description && (
-        <TypographyP className="mt-1 ps-6 text-muted-foreground text-sm">{description}</TypographyP>
+        <TypographyP className="mt-1 ps-6" tone="subtle" size="small">
+          {description}
+        </TypographyP>
       )}
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/sources.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/sources.tsx
@@ -36,7 +36,7 @@ export const SourcesTrigger = ({ className, count, children, ...props }: Sources
   <CollapsibleTrigger className={cn("flex items-center gap-2", className)} {...props}>
     {children ?? (
       <>
-        <TypographyP className="font-medium">
+        <TypographyP weight="medium">
           <FormattedMessage {...sourcesMessages.usedSources} values={{ count }} />
         </TypographyP>
         <HugeiconsIcon icon={ArrowDown01Icon} className="h-4 w-4" />

--- a/apps/hyperlocalise-web/src/components/ai-elements/task.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/task.tsx
@@ -56,7 +56,7 @@ export const TaskTrigger = ({ children, className, title, ...props }: TaskTrigge
     {children ?? (
       <div className="flex w-full cursor-pointer items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground">
         <HugeiconsIcon icon={SearchIcon} className="size-4" />
-        <TypographyP className="text-sm">{title}</TypographyP>
+        <TypographyP size="small">{title}</TypographyP>
         <HugeiconsIcon
           icon={ArrowDown01Icon}
           className="size-4 transition-transform group-data-[state=open]:rotate-180"

--- a/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
@@ -269,7 +269,7 @@ export const WebPreviewConsole = ({
       >
         <div className="max-h-48 space-y-1 overflow-y-auto">
           {logs.length === 0 ? (
-            <TypographyP className="text-muted-foreground">
+            <TypographyP tone="subtle">
               <FormattedMessage {...webPreviewMessages.noConsoleOutput} />
             </TypographyP>
           ) : (

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -129,7 +129,12 @@ export function AppShellClient({
                 className="size-7 shrink-0 rounded-lg"
               />
               <div className="min-w-0 group-data-[collapsible=icon]:hidden">
-                <TypographyP className="truncate text-sm font-medium text-sidebar-foreground">
+                <TypographyP
+                  className="text-sidebar-foreground"
+                  lineClamp={1}
+                  size="small"
+                  weight="medium"
+                >
                   <FormattedMessage {...appShellClientMessages.brandName} />
                 </TypographyP>
               </div>

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -337,7 +337,9 @@ export const ChatDockPanel = observer(function ChatDockPanel({
 
       {tab.lastError ? (
         <div className="border-b border-border bg-destructive/5 px-3 py-2">
-          <TypographyMuted className="text-xs text-destructive">{tab.lastError}</TypographyMuted>
+          <TypographyMuted size="xsmall" tone="critical">
+            {tab.lastError}
+          </TypographyMuted>
         </div>
       ) : null}
 

--- a/apps/hyperlocalise-web/src/components/billing/plan-usage-summary.tsx
+++ b/apps/hyperlocalise-web/src/components/billing/plan-usage-summary.tsx
@@ -81,9 +81,13 @@ export function PlanUsageSummaryContent({ summary }: { summary: ResolvedPlanUsag
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col gap-1">
-        <TypographyP className="text-sm font-medium text-foreground">{planName}</TypographyP>
+        <TypographyP size="small" weight="medium" tone="content">
+          {planName}
+        </TypographyP>
         {renewalCopy ? (
-          <TypographyP className="text-sm text-muted-foreground">{renewalCopy}</TypographyP>
+          <TypographyP size="small" tone="subtle">
+            {renewalCopy}
+          </TypographyP>
         ) : null}
       </div>
       {summary.usageProgressPercent !== null ? (
@@ -93,7 +97,7 @@ export function PlanUsageSummaryContent({ summary }: { summary: ResolvedPlanUsag
           className="[&_[data-slot=progress-track]]:h-2"
         />
       ) : null}
-      <TypographyP className="text-sm text-subtle-foreground tabular-nums">
+      <TypographyP className="tabular-nums" size="small" tone="subtlest">
         {summary.usageSummary}
       </TypographyP>
     </div>
@@ -168,7 +172,7 @@ export function PlanUsageFooterControl({ organizationSlug }: { organizationSlug:
 
         {isLoading ? <PlanUsageSummarySkeleton /> : null}
         {hasError ? (
-          <TypographyP className="text-sm text-destructive">
+          <TypographyP size="small" tone="critical">
             <FormattedMessage {...planUsageSummaryMessages.loadError} />
           </TypographyP>
         ) : null}

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.tsx
@@ -740,7 +740,7 @@ export function ProjectFileContentEditorWorkspace({
 
   if (showLocaleSelector && (targetLocales?.length ?? 0) === 0) {
     return (
-      <TypographyP className="text-sm text-muted-foreground">
+      <TypographyP size="small" tone="subtle">
         <FormattedMessage {...projectFileCatWorkspaceMessages.noTargetLocales} />
       </TypographyP>
     );
@@ -769,7 +769,7 @@ export function ProjectFileContentEditorWorkspace({
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-flame-100">
         <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
-        <TypographyP className="text-sm">
+        <TypographyP size="small">
           {contentEditorQuery.error instanceof Error
             ? contentEditorQuery.error.message
             : intl.formatMessage(projectFileCatWorkspaceMessages.failedToLoadWorkspace)}
@@ -792,7 +792,12 @@ export function ProjectFileContentEditorWorkspace({
     >
       {showLocaleSelector ? (
         <div className="flex w-full flex-col gap-1.5 sm:max-w-44">
-          <TypographyP className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+          <TypographyP
+            className="text-[10px]"
+            weight="medium"
+            tone="subtle"
+            capitalization="uppercase"
+          >
             <FormattedMessage {...projectFileCatWorkspaceMessages.targetLocaleLabel} />
           </TypographyP>
           <Select

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-cta-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-cta-panel.tsx
@@ -47,10 +47,10 @@ export function FeatureTeaserCtaPanel({
   return (
     <div className={cn("flex flex-col gap-6", className)}>
       <div className="space-y-3">
-        <TypographyH2 className="text-xl font-medium text-foreground md:text-2xl">
+        <TypographyH2 className="md:text-2xl" size="xlarge" weight="medium" tone="content">
           <FormattedMessage {...title} />
         </TypographyH2>
-        <TypographyP className="text-sm leading-6 text-muted-foreground sm:text-base">
+        <TypographyP className="leading-6 sm:text-base" size="small" tone="subtle">
           <FormattedMessage {...description} />
         </TypographyP>
       </div>

--- a/apps/hyperlocalise-web/src/components/marketing/blog/blog-index-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/blog/blog-index-page.tsx
@@ -32,10 +32,10 @@ export function BlogIndexPage({ posts, lang }: BlogIndexPageProps) {
     <div className="min-h-screen bg-background text-foreground">
       <main className="mx-auto max-w-7xl">
         <section className="px-5 pb-10 pt-12 text-center sm:px-8 lg:px-10 lg:pt-16">
-          <TypographyH1 className="text-4xl tracking-tight sm:text-5xl">
+          <TypographyH1 className="text-4xl sm:text-5xl">
             {intl.formatMessage(blogMessages.indexTitle)}
           </TypographyH1>
-          <TypographyMuted className="mx-auto mt-4 max-w-2xl text-base sm:text-lg">
+          <TypographyMuted className="mx-auto mt-4 max-w-2xl sm:text-lg" size="medium">
             {intl.formatMessage(blogMessages.indexTagline)}
           </TypographyMuted>
         </section>
@@ -48,7 +48,7 @@ export function BlogIndexPage({ posts, lang }: BlogIndexPageProps) {
               ))}
             </div>
           ) : (
-            <TypographyMuted className="text-center text-base">
+            <TypographyMuted className="text-center" size="medium">
               {intl.formatMessage(blogMessages.indexEmptyState)}
             </TypographyMuted>
           )}

--- a/apps/hyperlocalise-web/src/components/marketing/blog/blog-post-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/blog/blog-post-page.tsx
@@ -45,13 +45,11 @@ export function BlogPostPage({ post, lang, htmlContent, relatedPosts }: BlogPost
       <main className="mx-auto max-w-7xl">
         <article className="px-5 pb-20 pt-12 sm:px-8 lg:px-10 lg:pt-16">
           <header className="mx-auto max-w-3xl text-center">
-            <TypographyH1 className="text-3xl tracking-tight sm:text-4xl lg:text-5xl">
-              {post.title}
-            </TypographyH1>
-            <TypographyP className="mt-4 text-base text-muted-foreground sm:text-lg">
+            <TypographyH1 className="text-3xl sm:text-4xl lg:text-5xl">{post.title}</TypographyH1>
+            <TypographyP className="mt-4 sm:text-lg" tone="subtle">
               {post.excerpt}
             </TypographyP>
-            <TypographyMuted className="mt-4 text-sm">
+            <TypographyMuted className="mt-4">
               {formatBlogPostDate(intl, post.date)}
             </TypographyMuted>
           </header>

--- a/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
@@ -433,19 +433,27 @@ export function ChatDockMockSection({
 
         <aside className="flex flex-col justify-between gap-10 px-6 py-8 sm:px-8 sm:py-10 lg:py-12">
           <div className="space-y-4">
-            <TypographyMuted className="text-[0.72rem] font-medium tracking-[0.18em] uppercase">
+            <TypographyMuted
+              className="text-[0.72rem] tracking-[0.18em]"
+              weight="medium"
+              capitalization="uppercase"
+            >
               <FormattedMessage {...chatDockMockMessages.sectionEyebrow} />
             </TypographyMuted>
             <TypographyH2 className="pb-0 text-3xl leading-[1.04] tracking-[-0.045em] sm:text-4xl">
               <FormattedMessage {...chatDockMockMessages.sectionTitle} />
             </TypographyH2>
-            <TypographyP className="max-w-sm text-muted-foreground">
+            <TypographyP className="max-w-sm" tone="subtle">
               <FormattedMessage {...chatDockMockMessages.sectionBody} />
             </TypographyP>
           </div>
 
           <div className="space-y-4">
-            <TypographyMuted className="text-[0.72rem] font-medium tracking-[0.18em] uppercase">
+            <TypographyMuted
+              className="text-[0.72rem] tracking-[0.18em]"
+              weight="medium"
+              capitalization="uppercase"
+            >
               <FormattedMessage {...chatDockMockMessages.featuresLabel} />
             </TypographyMuted>
             <ul className="space-y-3 font-mono text-[0.78rem] tracking-[0.08em] text-muted-foreground uppercase">

--- a/apps/hyperlocalise-web/src/components/marketing/company/company-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/company/company-page.tsx
@@ -41,7 +41,7 @@ export function CompanyPage({ locale }: CompanyPageProps) {
         <section className="px-5 pt-16 pb-16 sm:px-8 sm:pt-20 sm:pb-20 lg:px-10">
           <div className="max-w-4xl space-y-6">
             <TypographyH1>{copy.headline}</TypographyH1>
-            <TypographyP className="max-w-2xl text-lg text-muted-foreground">
+            <TypographyP className="max-w-2xl" size="large" tone="subtle">
               {copy.subcopy}
             </TypographyP>
             <div className="pt-2">
@@ -71,7 +71,8 @@ export function CompanyPage({ locale }: CompanyPageProps) {
           <div className="px-5 py-16 sm:px-8 sm:py-20 lg:px-10">
             <TypographyH2
               id="company-backed-by-heading"
-              className="pb-0 text-3xl leading-tight tracking-[-0.03em] text-muted-foreground sm:text-4xl md:text-5xl"
+              className="pb-0 text-3xl leading-tight tracking-[-0.03em] sm:text-4xl md:text-5xl"
+              tone="subtle"
             >
               {copy.backedByHeading}
             </TypographyH2>
@@ -106,10 +107,7 @@ export function CompanyPage({ locale }: CompanyPageProps) {
             </TypographyH2>
             <div className="space-y-5">
               {copy.foundersNoteParagraphs.map((paragraph) => (
-                <TypographyP
-                  key={paragraph}
-                  className="text-base leading-7 text-muted-foreground sm:text-lg"
-                >
+                <TypographyP key={paragraph} className="sm:text-lg" tone="subtle">
                   {paragraph}
                 </TypographyP>
               ))}

--- a/apps/hyperlocalise-web/src/components/marketing/contact/contact-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/contact/contact-page.tsx
@@ -30,7 +30,7 @@ export function ContactPage({ locale }: ContactPageProps) {
         <section className="px-5 pt-16 pb-24 sm:px-8 sm:pt-20 sm:pb-28 lg:px-10">
           <div className="max-w-4xl space-y-6">
             <TypographyH1>{copy.headline}</TypographyH1>
-            <TypographyP className="max-w-2xl text-lg text-muted-foreground">
+            <TypographyP className="max-w-2xl" size="large" tone="subtle">
               {copy.subcopy}
             </TypographyP>
             <div className="pt-2">

--- a/apps/hyperlocalise-web/src/components/marketing/feature-mesh-cards-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/feature-mesh-cards-section.tsx
@@ -112,7 +112,10 @@ function FeatureMeshCard({
         )}
       >
         <div className="space-y-3">
-          <TypographyH3 className="pb-0 text-[1.35rem] leading-[1.15] font-semibold tracking-[-0.035em] text-white sm:text-[1.55rem]">
+          <TypographyH3
+            className="pb-0 text-[1.35rem] leading-[1.15] tracking-[-0.035em] text-white sm:text-[1.55rem]"
+            weight="bold"
+          >
             <FormattedMessage {...title} />
           </TypographyH3>
           <TypographyP className="max-w-md pb-0 text-[0.95rem] leading-relaxed text-white/85">
@@ -132,7 +135,8 @@ export function FeatureMeshCardsSection() {
     <section id="features" aria-labelledby="feature-mesh-cards-heading">
       <TypographyH2
         id="feature-mesh-cards-heading"
-        className="max-w-3xl pb-0 text-[1.85rem] leading-[1.12] font-semibold tracking-[-0.04em] sm:text-4xl md:text-5xl"
+        className="max-w-3xl pb-0 text-[1.85rem] leading-[1.12] tracking-[-0.04em] sm:text-4xl md:text-5xl"
+        weight="bold"
       >
         <FormattedMessage {...featureMeshCardsSectionMessages.headline} />
       </TypographyH2>

--- a/apps/hyperlocalise-web/src/components/marketing/final-cta-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/final-cta-section.tsx
@@ -22,7 +22,10 @@ import { TypographyH2 } from "@/components/ui/typography";
 export function FinalCtaSection() {
   return (
     <section id="waitlist" className="text-center">
-      <TypographyH2 className="pb-0 text-4xl leading-[1.04] font-semibold tracking-[-0.04em] normal-case sm:text-5xl">
+      <TypographyH2
+        className="pb-0 text-4xl leading-[1.04] tracking-[-0.04em] normal-case sm:text-5xl"
+        weight="bold"
+      >
         <FormattedMessage {...finalCtaSectionMessages.headline} />
       </TypographyH2>
       <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">

--- a/apps/hyperlocalise-web/src/components/marketing/hero-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-section.tsx
@@ -113,7 +113,7 @@ export function HeroSection() {
               }}
               transition={headlineTransition}
             >
-              <TypographyH1 className="text-balance text-white">
+              <TypographyH1 className="text-white" wrapStyle="balance">
                 <FormattedMessage {...heroSectionMessages.headline} />
               </TypographyH1>
             </motion.div>
@@ -127,7 +127,7 @@ export function HeroSection() {
                 delay: shouldReduceMotion ? 0 : 0.56,
               }}
             >
-              <TypographyP className="mx-auto max-w-2xl pb-0 text-base text-white/80 sm:text-lg">
+              <TypographyP className="mx-auto max-w-2xl pb-0 text-white/80 sm:text-lg">
                 <FormattedMessage
                   {...heroSectionMessages.body}
                   values={{

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-leaderboard.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-leaderboard.tsx
@@ -58,7 +58,7 @@ export function LocalisationAuditLeaderboard({
     return (
       <section className="border-t border-border px-5 py-16 sm:px-8 lg:px-10">
         <TypographyH2 className="pb-0">{copy.leaderboardHeading}</TypographyH2>
-        <TypographyP className="mt-4 max-w-2xl text-muted-foreground">
+        <TypographyP className="mt-4 max-w-2xl" tone="subtle">
           {copy.leaderboardEmpty}
         </TypographyP>
       </section>
@@ -68,7 +68,7 @@ export function LocalisationAuditLeaderboard({
   return (
     <section className="border-t border-border px-5 py-16 sm:px-8 lg:px-10">
       <TypographyH2 className="pb-0">{copy.leaderboardHeading}</TypographyH2>
-      <TypographyP className="mt-4 max-w-2xl text-muted-foreground">
+      <TypographyP className="mt-4 max-w-2xl" tone="subtle">
         {copy.leaderboardSubcopy}
       </TypographyP>
 

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.tsx
@@ -35,7 +35,7 @@ export function LocalisationAuditPage({ locale, leaderboard }: LocalisationAudit
         <section className="px-5 pt-16 pb-20 sm:px-8 sm:pt-20 sm:pb-24 lg:px-10">
           <div className="max-w-3xl space-y-5">
             <TypographyH1>{copy.headline}</TypographyH1>
-            <TypographyP className="max-w-2xl text-lg text-muted-foreground sm:text-xl">
+            <TypographyP className="max-w-2xl sm:text-xl" size="large" tone="subtle">
               {copy.subcopy}
             </TypographyP>
           </div>
@@ -64,7 +64,7 @@ export function LocalisationAuditPage({ locale, leaderboard }: LocalisationAudit
           <div className="mt-10 grid gap-10 md:grid-cols-3">
             {copy.notices.map((notice) => (
               <div key={notice.title} className="space-y-3">
-                <TypographyH3 className="pb-0 text-xl tracking-tight md:text-2xl">
+                <TypographyH3 className="pb-0 md:text-2xl" size="xlarge">
                   {notice.title}
                 </TypographyH3>
                 <p className="max-w-sm text-muted-foreground">{notice.body}</p>
@@ -89,10 +89,10 @@ export function LocalisationAuditPage({ locale, leaderboard }: LocalisationAudit
               </code>
             </p>
           </aside>
-          <TypographyP className="mt-12 max-w-2xl text-muted-foreground">
+          <TypographyP className="mt-12 max-w-2xl" tone="subtle">
             {copy.scopeNote}
           </TypographyP>
-          <TypographyP className="mt-3 max-w-2xl text-muted-foreground">
+          <TypographyP className="mt-3 max-w-2xl" tone="subtle">
             {copy.disclosure}
           </TypographyP>
           <div className="mt-10 max-w-2xl rounded-xl border border-border bg-muted/30 p-6">

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
@@ -419,7 +419,7 @@ function AuditCriteriaList({
 
   return (
     <div>
-      <TypographyP className="mt-4 max-w-2xl text-muted-foreground">
+      <TypographyP className="mt-4 max-w-2xl" tone="subtle">
         {copy.criteriaSummary({
           passed: passed.length,
           failed: failed.length,
@@ -759,7 +759,9 @@ export function LocalisationAuditResult({
     return (
       <MeshWash>
         <TypographyH1 className="border-none text-white">{copy.staleTitle}</TypographyH1>
-        <TypographyP className="mt-4 max-w-2xl text-lg text-white/80">{copy.staleBody}</TypographyP>
+        <TypographyP className="mt-4 max-w-2xl text-white/80" size="large">
+          {copy.staleBody}
+        </TypographyP>
         <p className="mt-6 text-sm text-white/65">{audit.domainKey}</p>
         {error ? <p className="mt-4 text-sm text-red-200">{error}</p> : null}
         <Button
@@ -779,7 +781,7 @@ export function LocalisationAuditResult({
       <>
         <MeshWash>
           <TypographyH1 className="border-none text-white">{copy.runningTitle}</TypographyH1>
-          <TypographyP className="mt-4 max-w-2xl text-lg text-white/80">
+          <TypographyP className="mt-4 max-w-2xl text-white/80" size="large">
             {copy.runningBody}
           </TypographyP>
           <p className="mt-2 text-sm text-white/65">{copy.expectedDuration}</p>
@@ -789,8 +791,10 @@ export function LocalisationAuditResult({
           <AuditProgressTrack activeIndex={activeIndex} copy={copy} />
 
           <div className="mt-12 max-w-md">
-            <TypographyH2 className="pb-0 text-xl">{copy.emailWhenReadyHeading}</TypographyH2>
-            <TypographyP className="mt-3 text-muted-foreground">
+            <TypographyH2 className="pb-0" size="xlarge">
+              {copy.emailWhenReadyHeading}
+            </TypographyH2>
+            <TypographyP className="mt-3" tone="subtle">
               {copy.emailWhenReadyBody}
             </TypographyP>
             <form onSubmit={requestReportEmail} className="mt-6 space-y-4">
@@ -824,7 +828,7 @@ export function LocalisationAuditResult({
     return (
       <MeshWash>
         <TypographyH1 className="border-none text-white">{copy.failedTitle}</TypographyH1>
-        <TypographyP className="mt-4 max-w-2xl text-lg text-white/80">
+        <TypographyP className="mt-4 max-w-2xl text-white/80" size="large">
           {copy.failedBody}
         </TypographyP>
         <TypographyP className="mt-2 max-w-2xl text-white/70">
@@ -846,7 +850,7 @@ export function LocalisationAuditResult({
     return (
       <MeshWash>
         <TypographyH1 className="border-none text-white">{copy.blockedTitle}</TypographyH1>
-        <TypographyP className="mt-4 max-w-2xl text-lg text-white/80">
+        <TypographyP className="mt-4 max-w-2xl text-white/80" size="large">
           {copy.blockedBody}
         </TypographyP>
         <TypographyP className="mt-2 max-w-2xl text-white/70">{copy.blockedGuidance}</TypographyP>
@@ -978,7 +982,7 @@ export function LocalisationAuditResult({
               {ratingLabel}
             </Badge>
           ) : null}
-          <TypographyP className="mt-4 max-w-2xl text-pretty text-lg text-white/80">
+          <TypographyP className="mt-4 max-w-2xl text-white/80" wrapStyle="pretty" size="large">
             {interpretation}
           </TypographyP>
           {dimensionScores ? (
@@ -1044,7 +1048,7 @@ export function LocalisationAuditResult({
       {standing && !isWorkspace ? (
         <section className={sectionClassName}>
           <TypographyH2 className="pb-0">{copy.standingHeading}</TypographyH2>
-          <TypographyP className="mt-4 max-w-2xl text-lg text-muted-foreground">
+          <TypographyP className="mt-4 max-w-2xl" size="large" tone="subtle">
             {copy.standingRank({ rank: standing.rank, total: standing.total })}
           </TypographyP>
           <div className="mt-4 flex flex-wrap gap-x-8 gap-y-2 text-sm text-muted-foreground">
@@ -1143,7 +1147,7 @@ export function LocalisationAuditResult({
       {isWorkspace ? null : (
         <section className={sectionClassName}>
           <TypographyH2 className="pb-0">{copy.unlockHeading}</TypographyH2>
-          <TypographyP className="mt-4 max-w-2xl text-muted-foreground">
+          <TypographyP className="mt-4 max-w-2xl" tone="subtle">
             {copy.unlockBody}
           </TypographyP>
           <form onSubmit={requestReportEmail} className="mt-8 max-w-md space-y-4">
@@ -1173,7 +1177,9 @@ export function LocalisationAuditResult({
       {isWorkspace ? null : (
         <section className={sectionClassName}>
           <TypographyH2 className="pb-0">{copy.reauditHeading}</TypographyH2>
-          <TypographyP className="mt-4 max-w-2xl text-muted-foreground">{ctaBody}</TypographyP>
+          <TypographyP className="mt-4 max-w-2xl" tone="subtle">
+            {ctaBody}
+          </TypographyP>
           <div className="mt-6 flex flex-wrap gap-3">
             {audit.rerunnable ? (
               <Button onClick={() => restartAudit(copy.rerunError)} disabled={rerunPending}>

--- a/apps/hyperlocalise-web/src/components/marketing/logo-strip-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/logo-strip-section.tsx
@@ -97,11 +97,14 @@ export function LogoStripSection() {
       <div className="mb-4 flex items-center justify-between gap-4">
         <TypographyP
           id="supported-llm-providers"
-          className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground"
+          className="text-[0.68rem] tracking-[0.22em]"
+          weight="bold"
+          capitalization="uppercase"
+          tone="subtle"
         >
           <FormattedMessage {...logoStripSectionMessages.title} />
         </TypographyP>
-        <TypographyP className="hidden text-xs text-muted-foreground sm:block">
+        <TypographyP className="hidden sm:block" size="xsmall" tone="subtle">
           <FormattedMessage {...logoStripSectionMessages.subtitle} />
         </TypographyP>
       </div>

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-ai-features-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-ai-features-section.tsx
@@ -34,7 +34,7 @@ export function PricingAiFeaturesSection({
         >
           {heading}
         </TypographyH2>
-        <TypographyP className="mt-3 text-base text-muted-foreground sm:text-lg">
+        <TypographyP className="mt-3 sm:text-lg" tone="subtle">
           {subcopy}
         </TypographyP>
       </div>

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-comparison-matrix.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-comparison-matrix.tsx
@@ -100,7 +100,7 @@ export function PricingComparisonMatrix({
         >
           {heading}
         </TypographyH2>
-        <TypographyP className="mt-3 text-base text-muted-foreground sm:text-lg">
+        <TypographyP className="mt-3 sm:text-lg" tone="subtle">
           {subcopy}
         </TypographyP>
       </div>
@@ -143,9 +143,11 @@ export function PricingComparisonMatrix({
                           <HugeiconsIcon icon={Icon} className="size-4" strokeWidth={1.75} />
                         </span>
                       ) : null}
-                      <TypographyH3 className="text-lg md:text-lg">{section.title}</TypographyH3>
+                      <TypographyH3 className="md:text-lg" size="large">
+                        {section.title}
+                      </TypographyH3>
                     </div>
-                    <TypographyP className="mt-2 text-sm text-muted-foreground">
+                    <TypographyP className="mt-2" size="small" tone="subtle">
                       {section.description}
                     </TypographyP>
                   </div>

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-page.tsx
@@ -44,7 +44,9 @@ export function PricingPage({ locale, faqItems }: PricingPageProps) {
         <section className="px-5 pt-16 pb-10 sm:px-8 sm:pt-20 sm:pb-12 lg:px-10">
           <div className="max-w-3xl space-y-5">
             <TypographyH1>{copy.headline}</TypographyH1>
-            <TypographyP className="text-lg text-muted-foreground">{copy.subcopy}</TypographyP>
+            <TypographyP size="large" tone="subtle">
+              {copy.subcopy}
+            </TypographyP>
           </div>
         </section>
 

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-plans-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-plans-section.tsx
@@ -73,7 +73,7 @@ export function PricingPlansSection({ plans, popularBadge }: PricingPlansSection
             ) : null}
           </div>
 
-          <TypographyP className="mt-4 text-sm text-muted-foreground">
+          <TypographyP className="mt-4" size="small" tone="subtle">
             {plan.description}
           </TypographyP>
 

--- a/apps/hyperlocalise-web/src/components/marketing/recent-blog-posts-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/recent-blog-posts-section.tsx
@@ -35,13 +35,27 @@ export function RecentBlogPostsSection({ posts, lang }: RecentBlogPostsSectionPr
     <section id="blog" className="relative">
       <div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
         <div className="max-w-2xl">
-          <TypographyP className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+          <TypographyP
+            className="text-[0.68rem] tracking-[0.22em]"
+            weight="bold"
+            capitalization="uppercase"
+            tone="subtle"
+          >
             <FormattedMessage {...recentBlogPostsSectionMessages.eyebrow} />
           </TypographyP>
-          <TypographyH2 className="pt-3 pb-0 text-4xl font-semibold tracking-[-0.04em] normal-case text-foreground sm:text-5xl md:text-5xl">
+          <TypographyH2
+            className="pt-3 pb-0 text-4xl tracking-[-0.04em] normal-case sm:text-5xl md:text-5xl"
+            weight="bold"
+            tone="content"
+          >
             <FormattedMessage {...recentBlogPostsSectionMessages.heading} />
           </TypographyH2>
-          <TypographyP className="mt-4 max-w-xl text-pretty text-sm leading-6 text-muted-foreground sm:text-[0.95rem]">
+          <TypographyP
+            className="mt-4 max-w-xl leading-6 sm:text-[0.95rem]"
+            wrapStyle="pretty"
+            size="small"
+            tone="subtle"
+          >
             <FormattedMessage {...recentBlogPostsSectionMessages.description} />
           </TypographyP>
         </div>
@@ -64,7 +78,7 @@ export function RecentBlogPostsSection({ posts, lang }: RecentBlogPostsSectionPr
             ))}
           </div>
         ) : (
-          <TypographyP className="text-center text-sm text-muted-foreground">
+          <TypographyP className="text-center" size="small" tone="subtle">
             {intl.formatMessage(blogMessages.indexEmptyState)}
           </TypographyP>
         )}

--- a/apps/hyperlocalise-web/src/components/marketing/slack-launch-intake-illustration.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/slack-launch-intake-illustration.tsx
@@ -312,12 +312,12 @@ export function SlackLaunchIntakeIllustration({
         >
           <SlackMark className="size-3.5 gap-px" />
         </div>
-        <TypographyP className="pb-0 text-[0.8rem] font-bold tracking-[-0.02em] text-foreground">
+        <TypographyP className="pb-0 text-[0.8rem] font-bold tracking-[-0.02em]" tone="content">
           <span className="text-[#4a154b] dark:text-[#e8b4f2]">#</span>
           <FormattedMessage {...slackLaunchIntakeIllustrationMessages.channelName} />
         </TypographyP>
         <div className="ms-auto flex items-center gap-2 text-muted-foreground">
-          <TypographySmall className="text-[0.72rem] text-muted-foreground">
+          <TypographySmall className="text-[0.72rem]" tone="subtle">
             <FormattedMessage {...slackLaunchIntakeIllustrationMessages.memberCount} />
           </TypographySmall>
           <HugeiconsIcon icon={SearchIcon} strokeWidth={1.8} className="size-4" />

--- a/apps/hyperlocalise-web/src/components/marketing/startups/startups-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/startups/startups-page.tsx
@@ -74,7 +74,9 @@ export function StartupsPage({ locale }: StartupsPageProps) {
           aria-hidden
         />
         <div className="relative z-10 mx-auto flex min-h-[100svh] max-w-5xl flex-col items-center justify-center px-5 py-28 text-center sm:px-8 lg:px-10">
-          <TypographyH1 className="max-w-3xl text-balance text-white">{copy.headline}</TypographyH1>
+          <TypographyH1 className="max-w-3xl text-white" wrapStyle="balance">
+            {copy.headline}
+          </TypographyH1>
           <p className="mt-5 text-lg text-white/80 sm:text-xl">{copy.offerLine}</p>
           <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Button
@@ -108,7 +110,9 @@ export function StartupsPage({ locale }: StartupsPageProps) {
               >
                 {copy.whyHeading}
               </TypographyH2>
-              <TypographyP className="text-lg text-muted-foreground">{copy.whySubcopy}</TypographyP>
+              <TypographyP size="large" tone="subtle">
+                {copy.whySubcopy}
+              </TypographyP>
             </div>
             <ol className="mt-14 grid gap-4 sm:gap-5 md:grid-cols-3 md:gap-6">
               {copy.benefits.map((benefit, index) => {
@@ -185,7 +189,7 @@ export function StartupsPage({ locale }: StartupsPageProps) {
                   </li>
                 ))}
               </ul>
-              <TypographyP className="max-w-2xl text-lg text-muted-foreground">
+              <TypographyP className="max-w-2xl" size="large" tone="subtle">
                 {copy.tourfinderResult}
               </TypographyP>
             </div>
@@ -251,7 +255,7 @@ export function StartupsPage({ locale }: StartupsPageProps) {
               >
                 {copy.programHeading}
               </TypographyH2>
-              <TypographyP className="max-w-xl text-lg text-muted-foreground">
+              <TypographyP className="max-w-xl" size="large" tone="subtle">
                 {copy.programSubcopy}
               </TypographyP>
               <div className="pt-2">
@@ -296,11 +300,12 @@ export function StartupsPage({ locale }: StartupsPageProps) {
           <div className="px-5 py-20 text-center sm:px-8 sm:py-24 lg:px-10">
             <TypographyH2
               id="startups-final-cta-heading"
-              className="pb-0 text-4xl leading-[1.04] font-semibold tracking-[-0.04em] normal-case sm:text-5xl"
+              className="pb-0 text-4xl leading-[1.04] tracking-[-0.04em] normal-case sm:text-5xl"
+              weight="bold"
             >
               {copy.finalHeading}
             </TypographyH2>
-            <TypographyP className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground">
+            <TypographyP className="mx-auto mt-4 max-w-xl" size="large" tone="subtle">
               {copy.finalSubcopy}
             </TypographyP>
             <div className="mt-8 flex justify-center">

--- a/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/tourfinder-testimonial-section.tsx
@@ -57,13 +57,19 @@ export function TourfinderTestimonialSection() {
 
             <TypographyH2
               id="tourfinder-testimonial-heading"
-              className="mt-8 pb-0 text-left text-[2.25rem] leading-[1.04] font-semibold tracking-[-0.045em] text-foreground normal-case sm:mt-10 sm:text-5xl md:text-[3.5rem] md:leading-[1.02]"
+              className="mt-8 pb-0 text-left text-[2.25rem] leading-[1.04] tracking-[-0.045em] normal-case sm:mt-10 sm:text-5xl md:text-[3.5rem] md:leading-[1.02]"
+              weight="bold"
+              tone="content"
             >
               <FormattedMessage {...tourfinderTestimonialSectionMessages.headline} />
             </TypographyH2>
 
             <blockquote className="mt-6 max-w-2xl border-l-2 border-border pl-6 sm:mt-8">
-              <TypographyP className="pb-0 text-pretty text-[1.15rem] leading-relaxed text-muted-foreground sm:text-[1.35rem] sm:leading-[1.4]">
+              <TypographyP
+                className="pb-0 text-[1.15rem] leading-relaxed sm:text-[1.35rem] sm:leading-[1.4]"
+                wrapStyle="pretty"
+                tone="subtle"
+              >
                 <FormattedMessage
                   {...tourfinderTestimonialSectionMessages.quote}
                   values={quoteRichTextValues}

--- a/apps/hyperlocalise-web/src/components/marketing/translation-flow-illustration.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/translation-flow-illustration.tsx
@@ -180,10 +180,10 @@ export function TranslationFlowIllustration({
               <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} className="size-5" />
             </div>
             <div>
-              <TypographyH4 className="text-foreground">
+              <TypographyH4 tone="content">
                 <FormattedMessage {...translationFlowIllustrationMessages.taskTitle} />
               </TypographyH4>
-              <TypographyMuted className="text-muted-foreground">
+              <TypographyMuted>
                 <FormattedMessage {...translationFlowIllustrationMessages.taskSubtitle} />
               </TypographyMuted>
             </div>
@@ -292,7 +292,10 @@ export function TranslationFlowIllustration({
                         <SelectorAvatar target={target} />
                         <div>
                           <div className="flex items-center gap-2.5">
-                            <TypographySmall className="text-[0.98rem] font-medium tracking-[-0.02em] text-foreground">
+                            <TypographySmall
+                              className="text-[0.98rem] tracking-[-0.02em]"
+                              tone="content"
+                            >
                               {target.name}
                             </TypographySmall>
                             {target.role ? (

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-sections.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-sections.tsx
@@ -40,10 +40,10 @@ export function UseCaseHero({ content }: UseCaseHeroProps) {
         <p className="text-sm font-medium tracking-[0.14em] text-muted-foreground uppercase">
           <UseCaseMessage messageKey={content.hero.eyebrowKey} />
         </p>
-        <TypographyH1 className="text-left text-balance">
+        <TypographyH1 className="text-left" wrapStyle="balance">
           <UseCaseMessage messageKey={content.hero.headlineKey} />
         </TypographyH1>
-        <TypographyP className="max-w-2xl text-muted-foreground">
+        <TypographyP className="max-w-2xl" tone="subtle">
           <UseCaseMessage messageKey={content.hero.subheadlineKey} />
         </TypographyP>
         <Button
@@ -57,7 +57,7 @@ export function UseCaseHero({ content }: UseCaseHeroProps) {
       <div className="mt-12 overflow-hidden rounded-[1.5rem] border border-border bg-background shadow-[0_20px_48px_rgba(0,0,0,0.14)] sm:rounded-[2rem]">
         <div className="grid divide-y divide-border lg:grid-cols-[1.05fr_1.7fr] lg:divide-x lg:divide-y-0">
           <div className="px-6 py-7 sm:px-8 sm:py-9">
-            <TypographyP className="text-[0.95rem] tracking-[-0.02em] text-muted-foreground">
+            <TypographyP className="text-[0.95rem] tracking-[-0.02em]" tone="subtle">
               <UseCaseMessage messageKey="problemPanelEyebrow" />
             </TypographyP>
             <TypographyH2 className="mt-8 max-w-xl text-3xl leading-[1.04] tracking-[-0.045em] sm:text-4xl">
@@ -67,10 +67,10 @@ export function UseCaseHero({ content }: UseCaseHeroProps) {
           <div className="grid divide-y divide-border sm:grid-cols-3 sm:divide-x sm:divide-y-0">
             {content.problem.painKeys.slice(0, 3).map((painKey, index) => (
               <article key={painKey} className="flex flex-col gap-8 px-6 py-7 sm:px-7 sm:py-8">
-                <TypographyP className="text-[0.95rem] tracking-[-0.02em] text-muted-foreground">
+                <TypographyP className="text-[0.95rem] tracking-[-0.02em]" tone="subtle">
                   {formatStepLabel(index)}
                 </TypographyP>
-                <TypographyP className="text-sm leading-relaxed text-muted-foreground">
+                <TypographyP className="leading-relaxed" size="small" tone="subtle">
                   <UseCaseMessage messageKey={painKey} />
                 </TypographyP>
               </article>
@@ -105,10 +105,10 @@ export function UseCaseOverviewSection({ content }: UseCaseOverviewSectionProps)
               <div className="text-xs font-medium tracking-[0.12em] text-muted-foreground uppercase">
                 {formatStepLabel(index)}
               </div>
-              <TypographyH3 className="mt-3 text-xl font-medium tracking-[-0.03em]">
+              <TypographyH3 className="mt-3 tracking-[-0.03em]" size="xlarge" weight="medium">
                 <UseCaseMessage messageKey={item.titleKey} />
               </TypographyH3>
-              <TypographyP className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              <TypographyP className="mt-3 leading-relaxed" size="small" tone="subtle">
                 <UseCaseMessage messageKey={item.descriptionKey} />
               </TypographyP>
             </article>
@@ -133,7 +133,7 @@ export function UseCaseWorkflowSection({ content }: UseCaseWorkflowSectionProps)
         <TypographyH2 className="text-4xl sm:text-5xl">
           <UseCaseMessage messageKey={content.titleKey} />
         </TypographyH2>
-        <TypographyP className="text-muted-foreground">
+        <TypographyP tone="subtle">
           <UseCaseMessage messageKey={content.descriptionKey} />
         </TypographyP>
       </div>
@@ -142,14 +142,19 @@ export function UseCaseWorkflowSection({ content }: UseCaseWorkflowSectionProps)
         <div className="grid divide-y divide-border sm:grid-cols-2 lg:grid-cols-3 lg:divide-x lg:divide-y-0">
           {content.steps.map((step, index) => (
             <article key={step.labelKey} className="flex flex-col gap-3 px-6 py-7 sm:px-7 sm:py-8">
-              <TypographyP className="text-[0.95rem] tracking-[-0.02em] text-muted-foreground">
+              <TypographyP className="text-[0.95rem] tracking-[-0.02em]" tone="subtle">
                 {formatStepLabel(index)}
               </TypographyP>
-              <TypographyH3 className="text-xl font-medium tracking-[-0.03em] text-foreground">
+              <TypographyH3
+                className="tracking-[-0.03em]"
+                size="xlarge"
+                weight="medium"
+                tone="content"
+              >
                 <UseCaseMessage messageKey={step.labelKey} />
               </TypographyH3>
               {step.descriptionKey ? (
-                <TypographyP className="text-sm leading-relaxed text-muted-foreground">
+                <TypographyP className="leading-relaxed" size="small" tone="subtle">
                   <UseCaseMessage messageKey={step.descriptionKey} />
                 </TypographyP>
               ) : null}
@@ -184,10 +189,10 @@ export function UseCaseCapabilitiesSection({ content }: UseCaseCapabilitiesSecti
               <div className="text-xs font-medium tracking-[0.12em] text-muted-foreground uppercase">
                 {formatStepLabel(index, 4)}
               </div>
-              <TypographyH3 className="mt-3 text-xl font-medium tracking-[-0.03em]">
+              <TypographyH3 className="mt-3 tracking-[-0.03em]" size="xlarge" weight="medium">
                 <UseCaseMessage messageKey={item.titleKey} />
               </TypographyH3>
-              <TypographyP className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              <TypographyP className="mt-3 leading-relaxed" size="small" tone="subtle">
                 <UseCaseMessage messageKey={item.descriptionKey} />
               </TypographyP>
             </article>
@@ -210,10 +215,10 @@ export function UseCaseDifferentiatorSection({ content }: UseCaseDifferentiatorS
           <div className="text-sm text-muted-foreground">
             <UseCaseMessage messageKey={content.labelKey} />
           </div>
-          <TypographyH2 className="text-4xl text-balance sm:text-5xl">
+          <TypographyH2 className="text-4xl sm:text-5xl" wrapStyle="balance">
             <UseCaseMessage messageKey={content.titleKey} />
           </TypographyH2>
-          <TypographyP className="max-w-2xl text-muted-foreground">
+          <TypographyP className="max-w-2xl" tone="subtle">
             <UseCaseMessage messageKey={content.descriptionKey} />
           </TypographyP>
         </div>
@@ -253,7 +258,11 @@ export function UseCaseScenarioSection({ content }: UseCaseScenarioSectionProps)
           </TypographyH2>
         </div>
 
-        <TypographyP className="max-w-3xl text-lg leading-relaxed text-muted-foreground sm:text-xl sm:leading-8">
+        <TypographyP
+          className="max-w-3xl leading-relaxed sm:text-xl sm:leading-8"
+          size="large"
+          tone="subtle"
+        >
           <UseCaseMessage messageKey={content.narrativeKey} />
         </TypographyP>
       </div>
@@ -268,10 +277,13 @@ type UseCaseCtaSectionProps = {
 export function UseCaseCtaSection({ content }: UseCaseCtaSectionProps) {
   return (
     <section id="waitlist" className="text-center">
-      <TypographyH2 className="pb-0 text-4xl leading-[1.04] font-semibold tracking-[-0.04em] normal-case sm:text-5xl">
+      <TypographyH2
+        className="pb-0 text-4xl leading-[1.04] tracking-[-0.04em] normal-case sm:text-5xl"
+        weight="bold"
+      >
         <UseCaseMessage messageKey={content.headlineKey} />
       </TypographyH2>
-      <TypographyP className="mx-auto mt-5 max-w-2xl text-muted-foreground">
+      <TypographyP className="mx-auto mt-5 max-w-2xl" tone="subtle">
         <UseCaseMessage messageKey={content.descriptionKey} />
       </TypographyP>
       <div className="mt-8 flex justify-center">

--- a/apps/hyperlocalise-web/src/components/ui/brand-theme.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/brand-theme.stories.tsx
@@ -42,7 +42,9 @@ function ThemeSpecimen({
         {theme}
       </p>
       <TypographyH1 className="text-3xl md:text-4xl">{title}</TypographyH1>
-      <TypographyH2 className="mt-3 text-xl md:text-2xl">{subtitle}</TypographyH2>
+      <TypographyH2 className="mt-3 md:text-2xl" size="xlarge">
+        {subtitle}
+      </TypographyH2>
       <TypographyP className="mt-3" tone="subtle">
         Headings use <code className="font-mono text-sm">font-heading</code>, which follows the
         brand theme.

--- a/apps/hyperlocalise-web/src/components/ui/typography.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/typography.tsx
@@ -152,7 +152,7 @@ export type TitleProps = SharedTypographyProps & {
   weight?: TypographyWeight;
 };
 
-const textSizeClassNames = {
+const textSizeClasses = {
   xxlarge: "font-sans text-2xl leading-8",
   xlarge: "font-sans text-xl",
   large: "font-sans text-lg",
@@ -161,7 +161,7 @@ const textSizeClassNames = {
   xsmall: "font-sans text-xs",
 } as const satisfies Record<TextTypographySize, string>;
 
-const titleSizeClassNames = {
+const titleSizeClasses = {
   xlarge: "font-heading scroll-m-20 text-3xl tracking-[-0.04em] font-semibold md:text-6xl",
   large: "font-heading scroll-m-20 text-2xl font-semibold md:text-5xl",
   medium: "scroll-m-20 font-sans text-xl font-semibold tracking-wide md:text-3xl",
@@ -170,20 +170,20 @@ const titleSizeClassNames = {
   xxsmall: "scroll-m-20 font-sans text-sm font-semibold",
 } as const satisfies Record<TitleTypographySize, string>;
 
-const weightClassNames = {
+const weightClasses = {
   regular: "font-normal",
   medium: "font-medium",
   bold: "font-semibold",
 } as const satisfies Record<TypographyWeight, string>;
 
-const alignmentClassNames = {
+const alignmentClasses = {
   start: "text-start",
   center: "text-center",
   end: "text-end",
   inherit: undefined,
 } as const satisfies Record<TypographyAlignment, string | undefined>;
 
-const toneClassNames = {
+const toneClasses = {
   content: "text-foreground",
   subtle: "text-muted-foreground",
   subtlest: "text-subtle-foreground",
@@ -194,13 +194,13 @@ const toneClassNames = {
   inherit: undefined,
 } as const satisfies Record<TypographyTone, string | undefined>;
 
-const wrapStyleClassNames = {
+const wrapStyleClasses = {
   unset: undefined,
   balance: "text-balance",
   pretty: "text-pretty",
 } as const satisfies Record<TypographyWrapStyle, string | undefined>;
 
-const lineClampClassNames = {
+const lineClampClasses = {
   1: "truncate",
   2: "line-clamp-2",
   3: "line-clamp-3",
@@ -226,13 +226,13 @@ function defaultTitleTagName(size: TitleTypographySize): TitleTagName {
   }
 }
 
-function lineClampClassName(lineClamp: number | undefined) {
+function lineClampClass(lineClamp: number | undefined) {
   if (lineClamp == null || lineClamp < 1) {
     return undefined;
   }
 
-  if (lineClamp in lineClampClassNames) {
-    return lineClampClassNames[lineClamp as keyof typeof lineClampClassNames];
+  if (lineClamp in lineClampClasses) {
+    return lineClampClasses[lineClamp as keyof typeof lineClampClasses];
   }
 
   return "overflow-hidden";
@@ -255,7 +255,7 @@ function lineClampStyle(
   };
 }
 
-function typographyUtilityClassName({
+function typographyUtilityClasses({
   alignment,
   capitalization = "default",
   lineClamp,
@@ -266,10 +266,10 @@ function typographyUtilityClassName({
   "alignment" | "capitalization" | "lineClamp" | "tone" | "wrapStyle"
 >) {
   return cn(
-    alignment ? alignmentClassNames[alignment] : undefined,
-    tone ? toneClassNames[tone] : undefined,
-    wrapStyle ? wrapStyleClassNames[wrapStyle] : undefined,
-    lineClampClassName(lineClamp),
+    alignment ? alignmentClasses[alignment] : undefined,
+    tone ? toneClasses[tone] : undefined,
+    wrapStyle ? wrapStyleClasses[wrapStyle] : undefined,
+    lineClampClass(lineClamp),
     capitalization === "uppercase" ? "uppercase" : undefined,
   );
 }
@@ -316,9 +316,9 @@ function Text({
       data-slot="text"
       data-size={size}
       className={cn(
-        textSizeClassNames[size],
-        weight ? weightClassNames[weight] : undefined,
-        typographyUtilityClassName({
+        textSizeClasses[size],
+        weight ? weightClasses[weight] : undefined,
+        typographyUtilityClasses({
           alignment,
           capitalization,
           lineClamp,
@@ -356,9 +356,9 @@ function Title({
       data-slot="title"
       data-size={size}
       className={cn(
-        titleSizeClassNames[size],
-        weight ? weightClassNames[weight] : undefined,
-        typographyUtilityClassName({
+        titleSizeClasses[size],
+        weight ? weightClasses[weight] : undefined,
+        typographyUtilityClasses({
           alignment,
           capitalization,
           lineClamp,
@@ -407,7 +407,7 @@ function TypographyBlockquote({
     <Text
       tagName={tagName}
       wrapStyle={wrapStyle}
-      className={cn("mt-6 border-l-2 pl-6 font-sans italic", className)}
+      className="mt-6 border-l-2 pl-6 italic"
       {...props}
     />
   );
@@ -428,7 +428,7 @@ function TypographyInlineCode({
       data-slot="inline-code"
       className={cn(
         "bg-muted relative rounded px-[0.3rem] py-[0.2rem] font-mono text-sm font-normal",
-        typographyUtilityClassName({
+        typographyUtilityClasses({
           alignment,
           capitalization,
           lineClamp,


### PR DESCRIPTION
## What changed

Migrates `Typography*` and `Text`/`Title` usage from repeated Tailwind typography utilities to the token props added in #2191 (`size`, `tone`, `weight`, `wrapStyle`, `lineClamp`, etc.) across 126 files in `apps/hyperlocalise-web`.

`className` is retained where there is no matching token prop, including layout spacing, `font-mono`, custom colors like `text-flame-100`, fixed `text-2xl` page titles, and structural wrapper styles in `typography.tsx`.

Internal typography style maps were renamed from `*ClassNames` to `*Classes`.

## How to test

- `cd apps/hyperlocalise-web && vp check --fix`
- `cd apps/hyperlocalise-web && vp test src/components/ui/typography.test.tsx`
- Spot-check settings, project overview, and dashboard for unchanged text sizing and muted tones.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review