### PR TITLE
feat(web): add Hyperlab preview mock UI for feature teaser

### DIFF
--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.stories.tsx
@@ -147,3 +147,29 @@ export const ProjectGuideline: Story = {
     ).toBeInTheDocument();
   },
 };
+
+export const Hyperlab: Story = {
+  args: {
+    feature: "hyperlab",
+    scope: "workspace",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/hyperlab",
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Hyperlab" })).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Target, split, and ship without another vendor"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("checkout-cta")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Create experiment and config flags unique to your workspace"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Request a demo" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Contact us" })).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.tsx
@@ -22,6 +22,7 @@ import {
 import { AutomationsMockUI } from "@/components/marketing/product/automations-mock-ui";
 import { DomainsMockUI } from "@/components/marketing/product/domains-mock-ui";
 import { GuidelineMockUI } from "@/components/marketing/product/guideline-mock-ui";
+import { HyperlabMockUI } from "@/components/marketing/product/hyperlab-mock-ui";
 import type { MarketingMockMeshPosition } from "@/components/marketing/product/marketing-mock-shell";
 
 import { FeatureTeaserCtaPanel } from "./feature-teaser-cta-panel";
@@ -48,6 +49,8 @@ function FeatureTeaserShowcase({ feature, aside }: { feature: FeatureTeaserId; a
       return <GuidelineMockUI {...teaserMockProps} aside={aside} />;
     case "domains":
       return <DomainsMockUI {...teaserMockProps} aside={aside} />;
+    case "hyperlab":
+      return <HyperlabMockUI {...teaserMockProps} aside={aside} />;
   }
 }
 

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.messages.ts
@@ -1,0 +1,208 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const hyperlabMockMessages = defineMessages({
+  eyebrow: {
+    defaultMessage: "Hyperlab",
+    id: "BWPiMioFAx",
+    description: "Hyperlab mock UI eyebrow label",
+  },
+  headline: {
+    defaultMessage: "Flags, experiments, and live evaluation in one workspace",
+    id: "gwEqR0+wNr",
+    description: "Hyperlab mock UI section heading",
+  },
+  requestDemo: {
+    defaultMessage: "Request a Demo",
+    id: "ZnyV6xQJFB",
+    description: "Hyperlab mock UI call-to-action button",
+  },
+
+  useCaseFlagsTitle: {
+    defaultMessage: "Feature flags",
+    id: "m17mlZ3/Yb",
+    description: "Hyperlab mock UI flags use case title",
+  },
+  useCaseFlagsDescription: {
+    defaultMessage: "Experiment and config flags scoped to your workspace",
+    id: "Lnk8DKi9bA",
+    description: "Hyperlab mock UI flags use case description",
+  },
+  useCaseExperimentsTitle: {
+    defaultMessage: "A/B experiments",
+    id: "Jg5QWOEhGR",
+    description: "Hyperlab mock UI experiments use case title",
+  },
+  useCaseExperimentsDescription: {
+    defaultMessage: "Split traffic, set rollout %, and activate when ready",
+    id: "JoFuLmCZ9Z",
+    description: "Hyperlab mock UI experiments use case description",
+  },
+  useCaseAudiencesTitle: {
+    defaultMessage: "Audience targeting",
+    id: "t7vmy3s2y1",
+    description: "Hyperlab mock UI audiences use case title",
+  },
+  useCaseAudiencesDescription: {
+    defaultMessage: "Attribute rules evaluated live on every request",
+    id: "bBNT4RDo7G",
+    description: "Hyperlab mock UI audiences use case description",
+  },
+
+  navOverview: {
+    defaultMessage: "Overview",
+    id: "spEEMpmq/e",
+    description: "Hyperlab mock UI nav tab",
+  },
+  navFlags: {
+    defaultMessage: "Flags",
+    id: "du55QFnCON",
+    description: "Hyperlab mock UI nav tab",
+  },
+  navExperiments: {
+    defaultMessage: "Experiments",
+    id: "r3TGVfZPDe",
+    description: "Hyperlab mock UI nav tab",
+  },
+  navAudiences: {
+    defaultMessage: "Audiences",
+    id: "jEVZfFEPYx",
+    description: "Hyperlab mock UI nav tab",
+  },
+  navKeys: {
+    defaultMessage: "Keys",
+    id: "0tIFgw5ysH",
+    description: "Hyperlab mock UI nav tab",
+  },
+
+  flagsPanelTitle: {
+    defaultMessage: "Flags",
+    id: "KS/H7AoEPP",
+    description: "Hyperlab mock UI flags panel title",
+  },
+  flagsPanelSubtitle: {
+    defaultMessage: "3 flags · 2 experiment, 1 config",
+    id: "PNw9tng+1C",
+    description: "Hyperlab mock UI flags panel subtitle",
+  },
+  flagCheckoutCta: {
+    defaultMessage: "checkout-cta",
+    id: "V/sRu8J8dR",
+    description: "Hyperlab mock UI sample flag key",
+  },
+  flagThemePalette: {
+    defaultMessage: "theme.palette",
+    id: "JM0AnSPCmK",
+    description: "Hyperlab mock UI sample flag key",
+  },
+  flagOnboardingFlow: {
+    defaultMessage: "onboarding.flow",
+    id: "a4wQu11D5D",
+    description: "Hyperlab mock UI sample flag key",
+  },
+  kindExperiment: {
+    defaultMessage: "Experiment",
+    id: "QT9sZSgQql",
+    description: "Hyperlab mock UI flag kind badge",
+  },
+  kindConfig: {
+    defaultMessage: "Config",
+    id: "QZTQDCT8kY",
+    description: "Hyperlab mock UI flag kind badge",
+  },
+
+  experimentsPanelTitle: {
+    defaultMessage: "Experiments",
+    id: "/BDbP6ag0g",
+    description: "Hyperlab mock UI experiments panel title",
+  },
+  experimentsPanelSubtitle: {
+    defaultMessage: "checkout-cta-test · A/B · Active",
+    id: "bLqYNXsXHH",
+    description: "Hyperlab mock UI experiments panel subtitle",
+  },
+  statusActive: {
+    defaultMessage: "Active",
+    id: "lIN1Ui+fCv",
+    description: "Hyperlab mock UI experiment status badge",
+  },
+  variantControl: {
+    defaultMessage: "control",
+    id: "EoS+At6qci",
+    description: "Hyperlab mock UI experiment variant label",
+  },
+  variantTreatment: {
+    defaultMessage: "treatment",
+    id: "jQ86ApxA97",
+    description: "Hyperlab mock UI experiment variant label",
+  },
+  rolloutLabel: {
+    defaultMessage: "Rollout",
+    id: "V5bvOi6wCN",
+    description: "Hyperlab mock UI rollout section label",
+  },
+
+  audiencesPanelTitle: {
+    defaultMessage: "Audiences",
+    id: "gDPRQKf6Ay",
+    description: "Hyperlab mock UI audiences panel title",
+  },
+  audiencesPanelSubtitle: {
+    defaultMessage: "Pro users · 1 rule",
+    id: "75wQzkw69+",
+    description: "Hyperlab mock UI audiences panel subtitle",
+  },
+  audienceProUsers: {
+    defaultMessage: "Pro users",
+    id: "GMgwhbm+0k",
+    description: "Hyperlab mock UI audience name",
+  },
+  criterionAttribute: {
+    defaultMessage: "plan",
+    id: "x1FhjXZK5S",
+    description: "Hyperlab mock UI criterion attribute",
+  },
+  criterionMatch: {
+    defaultMessage: "exact",
+    id: "Jr30TY5iBo",
+    description: "Hyperlab mock UI criterion match operator",
+  },
+  criterionValue: {
+    defaultMessage: "pro",
+    id: "cVva7Hlu9m",
+    description: "Hyperlab mock UI criterion value",
+  },
+  evaluateTitle: {
+    defaultMessage: "OFREP evaluate",
+    id: "UEAwre36YT",
+    description: "Hyperlab mock UI evaluate response section title",
+  },
+  evaluateEnabled: {
+    defaultMessage: '"enabled": true',
+    id: "ezlEf15Nuz",
+    description: "Hyperlab mock UI evaluate response field",
+  },
+  evaluateVariant: {
+    defaultMessage: '"variant": "treatment"',
+    id: "aTqbNUoZhT",
+    description: "Hyperlab mock UI evaluate response field",
+  },
+  evaluateReason: {
+    defaultMessage: '"reason": "TARGETING_MATCH"',
+    id: "aAxceYKye/",
+    description: "Hyperlab mock UI evaluate response field",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { HyperlabMockUI } from "./hyperlab-mock-ui";
+
+function HyperlabMockShowcase({ variant = "full" }: { variant?: "full" | "embedded" }) {
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <HyperlabMockUI variant={variant} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Marketing/Product/HyperlabMock",
+  component: HyperlabMockShowcase,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof HyperlabMockShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Flags, experiments, and live evaluation in one workspace",
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Feature flags" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "A/B experiments" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Audience targeting" })).toBeInTheDocument();
+    await expect(canvas.getByText("checkout-cta")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Request a Demo" })).toBeInTheDocument();
+  },
+};
+
+export const Embedded: Story = {
+  render: () => <HyperlabMockShowcase variant="embedded" />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("checkout-cta")).toBeInTheDocument();
+    await expect(canvas.getByText("theme.palette")).toBeInTheDocument();
+    await expect(canvas.queryByRole("link", { name: "Request a Demo" })).not.toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { LAVENDER_MESH_GRADIENT_SRC } from "@/components/marketing/hero-frame-mesh-stage";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { hyperlabMockMessages } from "./hyperlab-mock-ui.messages";
+import {
+  MarketingMockShell,
+  type MarketingMockMeshPosition,
+  type MarketingMockVariant,
+} from "./marketing-mock-shell";
+import { MarketingMockUseCaseSelector } from "./marketing-mock-use-case-selector";
+
+type SceneId = "flags" | "experiments" | "audiences";
+
+const SCENE_HOLD_MS = 3200;
+const ROLLOUT_STEP_MS = 700;
+
+function MockNav({ active }: { active: SceneId }) {
+  const tabs = useMemo(
+    () =>
+      [
+        ["overview", hyperlabMockMessages.navOverview, false],
+        ["flags", hyperlabMockMessages.navFlags, active === "flags"],
+        ["experiments", hyperlabMockMessages.navExperiments, active === "experiments"],
+        ["audiences", hyperlabMockMessages.navAudiences, active === "audiences"],
+        ["keys", hyperlabMockMessages.navKeys, false],
+      ] as const,
+    [active],
+  );
+
+  return (
+    <div className="flex flex-wrap gap-1 border-b border-border/50 px-4 py-2">
+      {tabs.map(([id, message, isActive]) => (
+        <span
+          key={id}
+          className={cn(
+            "rounded-sm px-2.5 py-1 text-xs",
+            isActive ? "font-medium text-foreground" : "text-muted-foreground/70",
+          )}
+        >
+          <FormattedMessage {...message} />
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function FlagsPanel() {
+  const intl = useIntl();
+
+  const flags = useMemo(
+    () => [
+      {
+        key: intl.formatMessage(hyperlabMockMessages.flagCheckoutCta),
+        kind: intl.formatMessage(hyperlabMockMessages.kindExperiment),
+        tone: "experiment" as const,
+      },
+      {
+        key: intl.formatMessage(hyperlabMockMessages.flagThemePalette),
+        kind: intl.formatMessage(hyperlabMockMessages.kindConfig),
+        tone: "config" as const,
+      },
+      {
+        key: intl.formatMessage(hyperlabMockMessages.flagOnboardingFlow),
+        kind: intl.formatMessage(hyperlabMockMessages.kindExperiment),
+        tone: "experiment" as const,
+      },
+    ],
+    [intl],
+  );
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="border-b border-border/50 px-4 py-3">
+        <div className="text-sm font-semibold text-foreground">
+          <FormattedMessage {...hyperlabMockMessages.flagsPanelTitle} />
+        </div>
+        <div className="text-xs text-muted-foreground">
+          <FormattedMessage {...hyperlabMockMessages.flagsPanelSubtitle} />
+        </div>
+      </div>
+
+      <MockNav active="flags" />
+
+      <div className="space-y-2 p-4">
+        {flags.map((flag, index) => (
+          <motion.div
+            key={flag.key}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.08, duration: 0.25 }}
+            className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/80 px-3 py-2.5"
+          >
+            <span className="font-mono text-xs text-foreground">{flag.key}</span>
+            <span
+              className={cn(
+                "rounded-full px-2 py-0.5 text-[10px] font-medium",
+                flag.tone === "experiment"
+                  ? "bg-primary/10 text-primary"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              {flag.kind}
+            </span>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ExperimentsPanel({ rolloutPercent }: { rolloutPercent: number }) {
+  const intl = useIntl();
+
+  const variants = useMemo(
+    () => [
+      {
+        label: intl.formatMessage(hyperlabMockMessages.variantControl),
+        percent: 100 - rolloutPercent,
+      },
+      {
+        label: intl.formatMessage(hyperlabMockMessages.variantTreatment),
+        percent: rolloutPercent,
+      },
+    ],
+    [intl, rolloutPercent],
+  );
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="flex items-start justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <div>
+          <div className="text-sm font-semibold text-foreground">
+            <FormattedMessage {...hyperlabMockMessages.experimentsPanelTitle} />
+          </div>
+          <div className="text-xs text-muted-foreground">
+            <FormattedMessage {...hyperlabMockMessages.experimentsPanelSubtitle} />
+          </div>
+        </div>
+        <span className="rounded-full bg-grove-100 px-2.5 py-1 text-[10px] font-medium text-grove-900">
+          <FormattedMessage {...hyperlabMockMessages.statusActive} />
+        </span>
+      </div>
+
+      <MockNav active="experiments" />
+
+      <div className="space-y-4 p-4">
+        <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          <FormattedMessage {...hyperlabMockMessages.rolloutLabel} />
+        </div>
+
+        {variants.map((variant) => (
+          <div key={variant.label} className="space-y-1.5">
+            <div className="flex items-center justify-between text-xs">
+              <span className="font-mono text-foreground">{variant.label}</span>
+              <span className="text-muted-foreground">{variant.percent}%</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-border/50">
+              <motion.div
+                className="h-full rounded-full bg-primary/70"
+                initial={false}
+                animate={{ width: `${variant.percent}%` }}
+                transition={{ duration: 0.4, ease: "easeOut" }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AudiencesPanel({ showEvaluate }: { showEvaluate: boolean }) {
+  const intl = useIntl();
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="border-b border-border/50 px-4 py-3">
+        <div className="text-sm font-semibold text-foreground">
+          <FormattedMessage {...hyperlabMockMessages.audiencesPanelTitle} />
+        </div>
+        <div className="text-xs text-muted-foreground">
+          <FormattedMessage {...hyperlabMockMessages.audiencesPanelSubtitle} />
+        </div>
+      </div>
+
+      <MockNav active="audiences" />
+
+      <div className="space-y-4 p-4">
+        <div className="rounded-lg border border-primary/25 bg-primary/5 px-3 py-2.5">
+          <div className="mb-2 text-sm font-medium text-foreground">
+            <FormattedMessage {...hyperlabMockMessages.audienceProUsers} />
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
+            <span className="rounded border border-border/60 bg-background px-1.5 py-0.5">
+              {intl.formatMessage(hyperlabMockMessages.criterionAttribute)}
+            </span>
+            <span>{intl.formatMessage(hyperlabMockMessages.criterionMatch)}</span>
+            <span className="rounded border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-primary">
+              {intl.formatMessage(hyperlabMockMessages.criterionValue)}
+            </span>
+          </div>
+        </div>
+
+        <AnimatePresence>
+          {showEvaluate ? (
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -4 }}
+              transition={{ duration: 0.28 }}
+              className="rounded-lg border border-border/60 bg-muted/30 p-3"
+            >
+              <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <FormattedMessage {...hyperlabMockMessages.evaluateTitle} />
+              </div>
+              <pre className="overflow-x-auto font-mono text-[11px] leading-relaxed text-foreground/90">
+                {`{\n  ${intl.formatMessage(hyperlabMockMessages.evaluateEnabled)},\n  ${intl.formatMessage(hyperlabMockMessages.evaluateVariant)},\n  ${intl.formatMessage(hyperlabMockMessages.evaluateReason)}\n}`}
+              </pre>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+export function HyperlabMockUI({
+  priority = false,
+  pauseAutoplay = false,
+  renderCta,
+  variant = "full",
+  aside,
+  meshPosition = "left",
+}: {
+  priority?: boolean;
+  pauseAutoplay?: boolean;
+  renderCta?: () => ReactNode;
+  variant?: MarketingMockVariant;
+  aside?: ReactNode;
+  meshPosition?: MarketingMockMeshPosition;
+}) {
+  const intl = useIntl();
+  const shouldReduceMotion = useReducedMotion();
+
+  const useCases = useMemo(
+    () => [
+      {
+        id: "flags",
+        title: intl.formatMessage(hyperlabMockMessages.useCaseFlagsTitle),
+        description: intl.formatMessage(hyperlabMockMessages.useCaseFlagsDescription),
+      },
+      {
+        id: "experiments",
+        title: intl.formatMessage(hyperlabMockMessages.useCaseExperimentsTitle),
+        description: intl.formatMessage(hyperlabMockMessages.useCaseExperimentsDescription),
+      },
+      {
+        id: "audiences",
+        title: intl.formatMessage(hyperlabMockMessages.useCaseAudiencesTitle),
+        description: intl.formatMessage(hyperlabMockMessages.useCaseAudiencesDescription),
+      },
+    ],
+    [intl],
+  );
+
+  const sceneByUseCase: Record<string, SceneId> = {
+    flags: "flags",
+    experiments: "experiments",
+    audiences: "audiences",
+  };
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [rolloutPercent, setRolloutPercent] = useState(30);
+  const [showEvaluate, setShowEvaluate] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+
+  const activeUseCase = useCases[activeIndex]!;
+  const activeScene = sceneByUseCase[activeUseCase.id] ?? "flags";
+
+  useEffect(() => {
+    if (isPaused || pauseAutoplay || shouldReduceMotion) {
+      return;
+    }
+
+    if (activeScene === "experiments" && rolloutPercent < 50) {
+      const timer = setTimeout(() => setRolloutPercent((value) => value + 10), ROLLOUT_STEP_MS);
+      return () => clearTimeout(timer);
+    }
+
+    if (activeScene === "audiences" && !showEvaluate) {
+      const timer = setTimeout(() => setShowEvaluate(true), ROLLOUT_STEP_MS);
+      return () => clearTimeout(timer);
+    }
+
+    const timer = setTimeout(() => {
+      setActiveIndex((index) => (index + 1) % useCases.length);
+      setRolloutPercent(30);
+      setShowEvaluate(false);
+    }, SCENE_HOLD_MS);
+
+    return () => clearTimeout(timer);
+  }, [
+    activeScene,
+    rolloutPercent,
+    showEvaluate,
+    isPaused,
+    pauseAutoplay,
+    shouldReduceMotion,
+    useCases.length,
+  ]);
+
+  function handleSelect(id: string) {
+    const index = useCases.findIndex((useCase) => useCase.id === id);
+    if (index === -1) {
+      return;
+    }
+
+    setIsPaused(true);
+    setActiveIndex(index);
+    setRolloutPercent(30);
+    setShowEvaluate(false);
+    setTimeout(() => setIsPaused(false), 500);
+  }
+
+  const visual = (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={activeUseCase.id}
+        initial={{ opacity: 0, x: -12 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: 12 }}
+        transition={{ duration: 0.32, ease: [0.19, 1, 0.22, 1] }}
+        className="w-full"
+      >
+        {activeScene === "flags" ? <FlagsPanel /> : null}
+        {activeScene === "experiments" ? (
+          <ExperimentsPanel rolloutPercent={rolloutPercent} />
+        ) : null}
+        {activeScene === "audiences" ? <AudiencesPanel showEvaluate={showEvaluate} /> : null}
+      </motion.div>
+    </AnimatePresence>
+  );
+
+  const sidebar =
+    variant === "full" ? (
+      <MarketingMockUseCaseSelector
+        eyebrow={hyperlabMockMessages.eyebrow}
+        headline={hyperlabMockMessages.headline}
+        useCases={useCases}
+        activeId={activeUseCase.id}
+        onSelect={handleSelect}
+        cta={
+          renderCta === undefined ? (
+            <Button
+              variant="outline"
+              size="lg"
+              nativeButton={false}
+              render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+              className="cursor-pointer rounded-sm"
+            >
+              <FormattedMessage {...hyperlabMockMessages.requestDemo} />
+            </Button>
+          ) : (
+            renderCta()
+          )
+        }
+      />
+    ) : undefined;
+
+  return (
+    <MarketingMockShell
+      visual={visual}
+      sidebar={sidebar}
+      aside={aside}
+      meshSrc={LAVENDER_MESH_GRADIENT_SRC}
+      priority={priority}
+      variant={variant}
+      meshPosition={meshPosition}
+    />
+  );
+}


### PR DESCRIPTION
## What changed

Add an animated Hyperlab product mock to the feature teaser page so gated visitors see a convincing preview instead of only the early-access CTA.

- New `HyperlabMockUI` with three cycling scenes: feature flags, A/B experiments, and audience targeting with OFREP evaluate
- Wire the mock into `FeatureTeaserShowcase` for the `hyperlab` feature
- Add Storybook coverage for the mock and teaser page

## How to test

- Open Storybook: `Marketing/Product/HyperlabMock` and `App/FeatureTeaser → Hyperlab`
- Visit `/org/{slug}/hyperlab` with `workspace-hyperlab` disabled and confirm the animated preview appears beside the CTA panel
- Run `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review