### PR TITLE
feat(activity-log): define workspace activity contract

### DIFF
--- a/apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.test.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  ACTIVITY_ACTOR_KINDS,
+  ACTIVITY_TARGET_KINDS,
+  assertSafeActivityLogPayload,
+  isV1ActivityEventType,
+  LATER_ACTIVITY_EVENT_TYPES,
+  RESERVED_ACTIVITY_EVENT_TYPES,
+  V1_ACTIVITY_EVENT_TYPES,
+} from "./activity-log-contract";
+
+describe("activity log contract", () => {
+  it("defines the four supported actor kinds", () => {
+    expect(ACTIVITY_ACTOR_KINDS).toEqual(["user", "system", "agent", "api_key"]);
+  });
+
+  it("defines organization and resource targets", () => {
+    expect(ACTIVITY_TARGET_KINDS).toEqual([
+      "organization",
+      "invitation",
+      "membership",
+      "personal_access_token",
+      "organization_api_key",
+      "integration",
+      "project",
+      "glossary",
+      "translation_memory",
+    ]);
+  });
+
+  it("keeps the v1 catalog separate from reserved and later events", () => {
+    expect(V1_ACTIVITY_EVENT_TYPES).toContain("personal_access_token_created");
+    expect(V1_ACTIVITY_EVENT_TYPES).toContain("glossary_project_attached");
+    expect(V1_ACTIVITY_EVENT_TYPES).not.toContain("organization_api_key_created");
+    expect(RESERVED_ACTIVITY_EVENT_TYPES).toEqual([
+      "organization_api_key_created",
+      "organization_api_key_revoked",
+    ]);
+    expect(LATER_ACTIVITY_EVENT_TYPES).toEqual([
+      "job_created",
+      "job_cancelled",
+      "job_failed",
+      "automation_run_started",
+      "automation_enabled",
+      "automation_disabled",
+    ]);
+  });
+
+  it("recognizes only v1 event types for current writers", () => {
+    expect(isV1ActivityEventType("member_invited")).toBe(true);
+    expect(isV1ActivityEventType("organization_api_key_created")).toBe(false);
+    expect(isV1ActivityEventType("job_created")).toBe(false);
+  });
+
+  it("rejects forbidden fields at any payload depth", () => {
+    expect(() =>
+      assertSafeActivityLogPayload({
+        safe: { nested: [{ keyHash: "secret" }] },
+      }),
+    ).toThrow("activity_log_payload_contains_forbidden_field");
+
+    expect(() =>
+      assertSafeActivityLogPayload({
+        email: "owner@example.com",
+      }),
+    ).toThrow("activity_log_payload_contains_forbidden_field");
+  });
+
+  it("allows approved opaque and safe metadata", () => {
+    expect(() =>
+      assertSafeActivityLogPayload({
+        batchId: "batch_123",
+        changedFields: ["name"],
+        keyPrefix: "hl_AbCd",
+        name: "Native TM",
+        resourceId: "resource_123",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const ACTIVITY_ACTOR_KINDS = ["user", "system", "agent", "api_key"] as const;
+export type ActivityActorKind = (typeof ACTIVITY_ACTOR_KINDS)[number];
+
+export const ACTIVITY_TARGET_KINDS = [
+  "organization",
+  "invitation",
+  "membership",
+  "personal_access_token",
+  "organization_api_key",
+  "integration",
+  "project",
+  "glossary",
+  "translation_memory",
+] as const;
+export type ActivityTargetKind = (typeof ACTIVITY_TARGET_KINDS)[number];
+
+export const V1_ACTIVITY_EVENT_TYPES = [
+  "member_invited",
+  "member_invite_resent",
+  "member_role_changed",
+  "member_removed",
+  "workspace_updated",
+  "personal_access_token_created",
+  "personal_access_token_revoked",
+  "integration_connected",
+  "integration_disconnected",
+  "project_created",
+  "project_archived",
+  "project_deleted",
+  "project_settings_changed",
+  "glossary_created",
+  "glossary_deleted",
+  "glossary_imported",
+  "glossary_exported",
+  "glossary_ownership_changed",
+  "glossary_project_attached",
+  "glossary_project_detached",
+  "translation_memory_created",
+  "translation_memory_deleted",
+  "translation_memory_imported",
+  "translation_memory_exported",
+  "translation_memory_project_attached",
+  "translation_memory_project_detached",
+] as const;
+export type V1ActivityEventType = (typeof V1_ACTIVITY_EVENT_TYPES)[number];
+
+/** Reserved until the data model distinguishes organization API keys from PATs. */
+export const RESERVED_ACTIVITY_EVENT_TYPES = [
+  "organization_api_key_created",
+  "organization_api_key_revoked",
+] as const;
+export type ReservedActivityEventType = (typeof RESERVED_ACTIVITY_EVENT_TYPES)[number];
+
+export const LATER_ACTIVITY_EVENT_TYPES = [
+  "job_created",
+  "job_cancelled",
+  "job_failed",
+  "automation_run_started",
+  "automation_enabled",
+  "automation_disabled",
+] as const;
+export type LaterActivityEventType = (typeof LATER_ACTIVITY_EVENT_TYPES)[number];
+
+export type ActivityEventType =
+  | V1ActivityEventType
+  | ReservedActivityEventType
+  | LaterActivityEventType;
+
+export type ActivityMembershipRole =
+  | "admin"
+  | "localization_manager"
+  | "developer"
+  | "reviewer"
+  | "translator"
+  | "member";
+
+type SafeResourcePayload = {
+  resourceId: string;
+  name?: string;
+  source?: string;
+  providerKind?: string;
+};
+
+type ImportExportPayload = {
+  resourceId: string;
+  batchId?: string;
+  itemCount?: number;
+  fileName?: string;
+};
+
+type AttachmentPayload = {
+  projectId: string;
+  resourceId: string;
+};
+
+export type ActivityPayloadByEventType = {
+  member_invited: {
+    invitationId: string;
+    membershipId: string;
+  };
+  member_invite_resent: {
+    invitationId: string;
+  };
+  member_role_changed: {
+    memberUserId: string;
+    membershipId: string;
+    previousRole: ActivityMembershipRole;
+    nextRole: ActivityMembershipRole;
+  };
+  member_removed: {
+    memberUserId: string;
+    membershipId: string;
+  };
+  workspace_updated: {
+    changedFields: readonly string[];
+    previousName?: string;
+    nextName?: string;
+  };
+  personal_access_token_created: {
+    keyPrefix: string;
+    permissions: readonly string[];
+    tokenId: string;
+  };
+  personal_access_token_revoked: {
+    keyPrefix: string;
+    reason: "manual" | "membership_removed";
+    tokenId: string;
+  };
+  integration_connected: {
+    connectionId: string;
+    integrationKind: string;
+  };
+  integration_disconnected: {
+    connectionId: string;
+    integrationKind: string;
+  };
+  project_created: SafeResourcePayload;
+  project_archived: SafeResourcePayload;
+  project_deleted: SafeResourcePayload;
+  project_settings_changed: {
+    changedFields: readonly string[];
+    nextProviderKind?: string;
+    nextVisibility?: string;
+    previousProviderKind?: string;
+    previousVisibility?: string;
+    projectId: string;
+  };
+  glossary_created: SafeResourcePayload;
+  glossary_deleted: SafeResourcePayload;
+  glossary_imported: ImportExportPayload;
+  glossary_exported: ImportExportPayload;
+  glossary_ownership_changed: {
+    glossaryId: string;
+    nextControlLevel: string;
+    nextTeamId?: string | null;
+    previousControlLevel: string;
+    previousTeamId?: string | null;
+  };
+  glossary_project_attached: AttachmentPayload;
+  glossary_project_detached: AttachmentPayload;
+  translation_memory_created: SafeResourcePayload;
+  translation_memory_deleted: SafeResourcePayload;
+  translation_memory_imported: ImportExportPayload;
+  translation_memory_exported: ImportExportPayload;
+  translation_memory_project_attached: AttachmentPayload;
+  translation_memory_project_detached: AttachmentPayload;
+};
+
+export type ActivityTargetKindByEventType = {
+  member_invited: "invitation";
+  member_invite_resent: "invitation";
+  member_role_changed: "membership";
+  member_removed: "membership";
+  workspace_updated: "organization";
+  personal_access_token_created: "personal_access_token";
+  personal_access_token_revoked: "personal_access_token";
+  integration_connected: "integration";
+  integration_disconnected: "integration";
+  project_created: "project";
+  project_archived: "project";
+  project_deleted: "project";
+  project_settings_changed: "project";
+  glossary_created: "glossary";
+  glossary_deleted: "glossary";
+  glossary_imported: "glossary";
+  glossary_exported: "glossary";
+  glossary_ownership_changed: "glossary";
+  glossary_project_attached: "project";
+  glossary_project_detached: "project";
+  translation_memory_created: "translation_memory";
+  translation_memory_deleted: "translation_memory";
+  translation_memory_imported: "translation_memory";
+  translation_memory_exported: "translation_memory";
+  translation_memory_project_attached: "project";
+  translation_memory_project_detached: "project";
+};
+
+type ActivityLogEventBase = {
+  actorCredentialId: string | null;
+  actorKind: ActivityActorKind;
+  actorUserId: string | null;
+  organizationId: string;
+  targetId: string;
+};
+
+export type ActivityLogEventInput = {
+  [EventType in V1ActivityEventType]: ActivityLogEventBase & {
+    eventType: EventType;
+    payload: ActivityPayloadByEventType[EventType];
+    targetKind: ActivityTargetKindByEventType[EventType];
+  };
+}[V1ActivityEventType];
+
+export type ActivityLogEventRecord = ActivityLogEventInput & {
+  createdAt: Date;
+  id: string;
+};
+
+export type ActivityLogCursor = {
+  createdAt: Date;
+  id: string;
+};
+
+export type ActivityLogWriteError = { code: "activity_log_write_failed" };
+
+export const FORBIDDEN_ACTIVITY_PAYLOAD_KEYS = [
+  "authorization",
+  "body",
+  "ciphertext",
+  "email",
+  "emailAddress",
+  "fileBody",
+  "fileContents",
+  "hash",
+  "keyHash",
+  "key_hash",
+  "prompt",
+  "rawSecret",
+  "rawToken",
+  "requestBody",
+  "request_body",
+  "secret",
+  "sourceText",
+  "targetText",
+  "token",
+  "transcript",
+  "x-api-key",
+] as const;
+
+const forbiddenActivityPayloadKeys = new Set<string>(FORBIDDEN_ACTIVITY_PAYLOAD_KEYS);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Rejects payload keys that could persist secrets or customer content. */
+export function assertSafeActivityLogPayload(payload: unknown): void {
+  if (!isRecord(payload)) {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (forbiddenActivityPayloadKeys.has(key)) {
+      throw new Error("activity_log_payload_contains_forbidden_field");
+    }
+
+    if (isRecord(value)) {
+      assertSafeActivityLogPayload(value);
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        assertSafeActivityLogPayload(item);
+      }
+    }
+  }
+}
+
+export function isV1ActivityEventType(value: string): value is V1ActivityEventType {
+  return (V1_ACTIVITY_EVENT_TYPES as readonly string[]).includes(value);
+}

--- a/docs/adr/2026-09-04-workspace-activity-log-contract.md
+++ b/docs/adr/2026-09-04-workspace-activity-log-contract.md
@@ -1,0 +1,122 @@
+# Workspace activity log contract
+
+## Status
+
+Accepted. This document defines the contract for HL-695. Follow-up issues implement storage, the
+writer, permissions, API access, and event instrumentation.
+
+## Context
+
+Hyperlocalise already stores resource-scoped history in `issue_sheet_activities`,
+`memory_entry_events`, and glossary history. The workspace activity log serves a different purpose:
+it records high-signal organization changes so an operator can answer who changed workspace access
+or configuration, when the change happened, and which resource it affected.
+
+The log is an organization audit trail, not a second copy of issue, CAT, translation-memory-entry,
+or glossary-term history.
+
+## Decision
+
+The shared contract lives in
+`apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.ts`. It contains the v1 event
+catalog, typed payload mappings, actor and target kinds, the writer input shape, the persisted record
+shape, and the safe-payload guard. It remains independent of Drizzle so the storage ticket can map
+these types to columns without creating a schema-layer dependency on application code.
+
+### Event catalog
+
+V1 includes the following event types:
+
+| Area | Event types |
+| --- | --- |
+| Membership | `member_invited`, `member_invite_resent`, `member_role_changed`, `member_removed` |
+| Workspace | `workspace_updated` |
+| Credentials | `personal_access_token_created`, `personal_access_token_revoked` |
+| Integrations | `integration_connected`, `integration_disconnected` |
+| Projects | `project_created`, `project_archived`, `project_deleted`, `project_settings_changed` |
+| Glossaries | `glossary_created`, `glossary_deleted`, `glossary_imported`, `glossary_exported`, `glossary_ownership_changed`, `glossary_project_attached`, `glossary_project_detached` |
+| Translation memory | `translation_memory_created`, `translation_memory_deleted`, `translation_memory_imported`, `translation_memory_exported`, `translation_memory_project_attached`, `translation_memory_project_detached` |
+
+The current `organization_api_keys` table is the implementation behind personal access tokens. The
+contract reserves `organization_api_key_created` and `organization_api_key_revoked`, but current
+writers emit the personal-access-token events until the data model distinguishes the two resources.
+
+Job and automation events are later additions: `job_created`, `job_cancelled`, `job_failed`,
+`automation_run_started`, `automation_enabled`, and `automation_disabled`.
+
+The log excludes issue comments and field changes, CAT edits, TM entry text, glossary term text,
+emails, file contents, prompts, agent transcripts, request bodies, raw tokens, token hashes,
+authorization headers, and provider secrets. Existing resource timelines continue to own their
+history.
+
+### Actor and target
+
+Each event has these fields:
+
+| Field | Contract |
+| --- | --- |
+| `organizationId` | Internal organization ID; every event is tenant-scoped. |
+| `actorKind` | `user`, `system`, `agent`, or `api_key`. |
+| `actorUserId` | Nullable internal user ID. Set for a human session and when an API credential owner is known. |
+| `actorCredentialId` | Nullable opaque credential ID. Set for `api_key`; never store the credential secret or hash. |
+| `eventType` | Stable snake_case event name from the catalog. |
+| `targetKind` | Organization, invitation, membership, credential, integration, project, glossary, or translation memory. |
+| `targetId` | Opaque ID of the affected target. |
+| `payload` | Event-specific safe metadata defined by the typed contract. |
+| `createdAt` | PostgreSQL timestamp supplied with `clock_timestamp()`. |
+
+Human session mutations use `actorKind: user`. WorkOS-driven membership removal uses
+`actorKind: system`. Agent and API-key actors are reserved for paths that already identify those
+actors; API-key events carry the credential ID and resolved owner ID when available.
+
+### Payload rules
+
+Payloads may contain opaque IDs, safe display names, provider or resource kinds, statuses, counts,
+batch IDs, safe filenames, and old/new values that are not secrets or linguistic content.
+
+Membership events use membership, invitation, and member-user IDs. Role changes carry the previous
+and next role slugs. Workspace and project settings changes carry changed field names and only
+approved safe old/new values. Credential events carry the token ID, existing display prefix,
+permissions, and revocation reason. Import/export events carry resource ID, optional batch ID,
+count, and a filename only when it is safe metadata; omit filenames that may contain customer copy.
+Attachment events carry both project and resource IDs.
+
+The shared guard rejects forbidden sensitive or content-bearing keys at any nesting depth. Typed
+payloads remain the primary restriction; the guard is a defensive boundary for future writers.
+
+### Ordering and query shape
+
+The writer supplies `clock_timestamp()` for every insert. PostgreSQL provides the authoritative
+clock and allows sequential inserts in one transaction to receive advancing timestamps.
+
+The future list API reads only the requested organization and orders newest first by
+`created_at DESC, id DESC`. Its opaque cursor represents the `(created_at, id)` tuple, so events
+with identical timestamps remain stable. Actor, event-type, and time-range filters are applied
+server-side by the API follow-up.
+
+### Permission, retention, and failure
+
+`activity_logs:read` is granted only to `admin` and `localization_manager`. Permission enforcement
+belongs in the list API and Settings page tickets; this contract does not change the role matrix.
+
+V1 keeps events indefinitely. Export and external retention controls are later work.
+
+Activity writes are best effort. A failed insert never fails the user mutation. The writer returns
+the typed `activity_log_write_failed` result and logs a safe correlation ID with event and target
+status. It never logs the payload, request body, secret, hash, token, email, or provider content.
+
+## Follow-up boundaries
+
+- HL-696 maps this contract to append-only storage and the single writer.
+- HL-697 adds `activity_logs:read` and the organization-scoped list API.
+- HL-698 instruments membership and workspace-admin mutations.
+- HL-699 instruments credential and integration lifecycle mutations.
+- HL-700 instruments project, glossary, and translation-memory lifecycle mutations.
+- HL-701 defines and instruments the later job and automation catalog.
+
+## Testing
+
+The contract module tests cover the actor and target constants, v1 versus reserved/later catalogs,
+event-type recognition, and recursive rejection of forbidden payload keys. Follow-up tests must
+cover database ordering, organization isolation, writer failure behavior, permission checks, and
+each instrumented mutation.


### PR DESCRIPTION
## Summary

- Define the v1 workspace activity-log event catalog and typed actor, target, and payload contracts.
- Reserve organization API-key events while current writers use the existing personal access token model.
- Document exclusions, timestamp/order semantics, permissions, retention, and best-effort failure policy.
- Add recursive safe-payload validation and focused contract tests.

## Verification

- Focused activity-log contract test: passed
- vp check --fix: passed
- Full vp test remains red because of unrelated database/fixture failures (129 failed, 728 passed).

Closes HL-695