### PR TITLE
feat(web): expand visual workflows and add Storybook playground

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/nodes/visual-workflow-compact-node.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/nodes/visual-workflow-compact-node.tsx
@@ -24,6 +24,7 @@ import {
   resolveNodeSubtitle,
   TRIGGER_BADGE_ICON,
 } from "@/lib/visual-workflows/catalog/node-catalog";
+import { nodeSupportsErrorBranch } from "@/lib/visual-workflows/runtime/node-options";
 import type { VisualWorkflowRfNode } from "@/lib/visual-workflows/schema/types";
 import { cn } from "@/lib/primitives/cn";
 
@@ -38,9 +39,22 @@ export function VisualWorkflowCompactNode({ id, data, selected }: NodeProps<Visu
   const catalog = catalogItemByType(data.catalogType);
   const isTrigger = isTriggerType(data.catalogType);
   const isIf = data.catalogType === "logic.if";
+  const isSwitch = data.catalogType === "logic.switch";
   const isAi = data.catalogType === "ai.agent";
+  const showErrorHandle = nodeSupportsErrorBranch(data.config);
   const title = intl.formatMessage(titleMessage(data.catalogType));
   const subtitle = resolveNodeSubtitle(data.config);
+
+  const switchHandles =
+    isSwitch && data.config.kind === "logic.switch"
+      ? [
+          ...data.config.cases.map((_, index) => ({
+            id: String(index),
+            label: intl.formatMessage(messages.switchCaseHandle, { index: index + 1 }),
+          })),
+          { id: "default", label: intl.formatMessage(messages.switchDefaultHandle) },
+        ]
+      : [];
 
   return (
     <Card
@@ -79,8 +93,31 @@ export function VisualWorkflowCompactNode({ id, data, selected }: NodeProps<Visu
             type="source"
           />
         </>
+      ) : isSwitch ? (
+        switchHandles.map((handle, index) => (
+          <Handle
+            key={handle.id}
+            className={cn(HANDLE_CLASS, handle.id === "default" ? "bg-muted-foreground" : null)}
+            id={handle.id}
+            position={Position.Right}
+            type="source"
+            style={{
+              top: `${((index + 1) / (switchHandles.length + 1)) * 100}%`,
+            }}
+          />
+        ))
       ) : (
-        <Handle className={HANDLE_CLASS} position={Position.Right} type="source" />
+        <>
+          <Handle className={HANDLE_CLASS} position={Position.Right} type="source" />
+          {showErrorHandle ? (
+            <Handle
+              className={cn(HANDLE_CLASS, "top-[75%]! bg-destructive")}
+              id="error"
+              position={Position.Right}
+              type="source"
+            />
+          ) : null}
+        </>
       )}
 
       <div className="flex flex-col items-center gap-1.5 pt-1 text-center">
@@ -100,6 +137,20 @@ export function VisualWorkflowCompactNode({ id, data, selected }: NodeProps<Visu
         </div>
       ) : null}
 
+      {isSwitch ? (
+        <div className="pointer-events-none absolute inset-y-0 right-[-2.8rem] flex flex-col justify-evenly py-2 text-[10px] font-medium text-muted-foreground">
+          {switchHandles.map((handle) => (
+            <span key={handle.id}>{handle.label}</span>
+          ))}
+        </div>
+      ) : null}
+
+      {showErrorHandle && !isIf && !isSwitch ? (
+        <div className="pointer-events-none absolute top-[72%] right-[-2.6rem] text-[10px] font-medium text-destructive">
+          <FormattedMessage {...messages.errorHandle} />
+        </div>
+      ) : null}
+
       {isAi ? (
         <div className="mt-2 grid gap-1 border-t border-border pt-2 text-left text-[11px] text-muted-foreground">
           <span>
@@ -111,6 +162,12 @@ export function VisualWorkflowCompactNode({ id, data, selected }: NodeProps<Visu
         </div>
       ) : null}
 
+      {data.lastOutput && Object.keys(data.lastOutput).length > 0 ? (
+        <div className="mt-2 max-h-16 overflow-hidden border-t border-border pt-2 text-left text-[10px] text-muted-foreground">
+          <p className="line-clamp-3 font-mono break-all">{JSON.stringify(data.lastOutput)}</p>
+        </div>
+      ) : null}
+
       <button
         type="button"
         data-visual-workflow-add=""
@@ -118,7 +175,10 @@ export function VisualWorkflowCompactNode({ id, data, selected }: NodeProps<Visu
         aria-label={intl.formatMessage(messages.addNode)}
         onClick={(event) => {
           event.stopPropagation();
-          onAddFromNode({ nodeId: id, handleId: isIf ? "true" : undefined });
+          onAddFromNode({
+            nodeId: id,
+            handleId: isIf ? "true" : isSwitch ? "0" : undefined,
+          });
         }}
       >
         <HugeiconsIcon icon={Add01Icon} className="size-3.5" strokeWidth={2} />
@@ -143,6 +203,10 @@ function titleMessage(type: VisualWorkflowRfNode["data"]["catalogType"]) {
       return messages.nodeNotifySlack;
     case "logic.if":
       return messages.nodeIf;
+    case "logic.switch":
+      return messages.nodeSwitch;
+    case "logic.set":
+      return messages.nodeSet;
     case "ai.agent":
       return messages.nodeAi;
     case "logic.for_each":

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-canvas.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-canvas.tsx
@@ -142,7 +142,7 @@ export function applyVisualWorkflowConnection(
   return addEdge(
     {
       ...connection,
-      label: sourceHandle === "true" || sourceHandle === "false" ? sourceHandle : undefined,
+      label: sourceHandle ?? undefined,
     },
     edges,
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-chrome.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-chrome.tsx
@@ -34,6 +34,7 @@ export function VisualWorkflowChrome({
   isSaving = false,
   saveDisabled = false,
   previewMode = false,
+  playgroundMode = false,
   activeTab = "editor",
   onTabChange,
   workflowStatus = "draft",
@@ -49,6 +50,7 @@ export function VisualWorkflowChrome({
   isSaving?: boolean;
   saveDisabled?: boolean;
   previewMode?: boolean;
+  playgroundMode?: boolean;
   activeTab?: "editor" | "executions";
   onTabChange?: (tab: "editor" | "executions") => void;
   workflowStatus?: VisualWorkflowStatus;
@@ -69,7 +71,11 @@ export function VisualWorkflowChrome({
           variant="inline"
           className="max-w-xs px-2 font-medium"
         />
-        {previewMode ? (
+        {playgroundMode ? (
+          <Badge variant="outline" className="rounded-full">
+            <FormattedMessage {...messages.playgroundBadge} />
+          </Badge>
+        ) : previewMode ? (
           <Badge variant="outline" className="rounded-full">
             <FormattedMessage {...messages.previewBadge} />
           </Badge>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.tsx
@@ -12,11 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import { ArrowLeft01Icon, Delete02Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -30,8 +31,12 @@ import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 import { assertNever } from "@/lib/primitives/assert-never/assert-never";
 import type {
+  HttpAuthType,
   HttpMethod,
+  VisualKeyValuePair,
   VisualNodeConfig,
+  VisualNodeErrorBehavior,
+  VisualWorkflowGithubTriggerEvent,
   VisualWorkflowRfNode,
   VisualWorkflowValidationIssue,
 } from "@/lib/visual-workflows/schema/types";
@@ -39,6 +44,9 @@ import type {
 import { visualWorkflowEditorMessages as messages } from "./visual-workflow-editor.messages";
 
 const HTTP_METHODS: HttpMethod[] = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+const ERROR_BEHAVIORS: VisualNodeErrorBehavior[] = ["stop", "continue", "branch"];
+const GITHUB_EVENTS: VisualWorkflowGithubTriggerEvent[] = ["push", "pull_request"];
+const TIMEZONES = ["UTC", "America/New_York", "America/Los_Angeles", "Europe/London", "Asia/Tokyo"];
 
 export function VisualWorkflowConfigPanel({
   node,
@@ -68,143 +76,312 @@ export function VisualWorkflowConfigPanel({
         </h2>
         {config.kind === "action.http" ? (
           <>
-            <div className="grid gap-1.5">
-              <Label htmlFor="vw-http-method">
-                <FormattedMessage {...messages.httpMethod} />
-              </Label>
-              <Select
-                value={config.method}
-                items={HTTP_METHODS.map((method) => ({ value: method, label: method }))}
-                onValueChange={(value) => {
-                  if (!value || !isHttpMethod(value)) {
-                    return;
-                  }
-                  onChangeConfig({ ...config, method: value });
-                }}
-              >
-                <SelectTrigger id="vw-http-method" className="w-full">
-                  <SelectValue>{config.method}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {HTTP_METHODS.map((method) => (
-                    <SelectItem key={method} value={method} label={method}>
-                      {method}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="grid gap-1.5">
-              <Label htmlFor="vw-http-url">
-                <FormattedMessage {...messages.httpUrl} />
-              </Label>
-              <Input
-                id="vw-http-url"
-                value={config.url}
-                onChange={(event) => onChangeConfig({ ...config, url: event.target.value })}
-                placeholder="https://"
+            <SelectField
+              id="vw-http-method"
+              label={intl.formatMessage(messages.httpMethod)}
+              value={config.method}
+              items={HTTP_METHODS.map((method) => ({ value: method, label: method }))}
+              onValueChange={(value) => {
+                if (!value || !isHttpMethod(value)) {
+                  return;
+                }
+                onChangeConfig({ ...config, method: value });
+              }}
+            />
+            <TextField
+              id="vw-http-url"
+              label={intl.formatMessage(messages.httpUrl)}
+              value={config.url}
+              onChange={(value) => onChangeConfig({ ...config, url: value })}
+              placeholder="https://"
+            />
+            <KeyValueEditor
+              label={intl.formatMessage(messages.httpQueryParams)}
+              pairs={config.queryParams ?? []}
+              onChange={(pairs) => onChangeConfig({ ...config, queryParams: pairs })}
+            />
+            <KeyValueEditor
+              label={intl.formatMessage(messages.httpHeaders)}
+              pairs={config.headers ?? []}
+              onChange={(pairs) => onChangeConfig({ ...config, headers: pairs })}
+            />
+            <SelectField
+              id="vw-http-body-type"
+              label={intl.formatMessage(messages.httpBodyType)}
+              value={config.bodyType ?? "none"}
+              items={[
+                { value: "none", label: intl.formatMessage(messages.httpBodyNone) },
+                { value: "json", label: intl.formatMessage(messages.httpBodyJson) },
+                { value: "text", label: intl.formatMessage(messages.httpBodyText) },
+              ]}
+              onValueChange={(value) => {
+                if (value !== "none" && value !== "json" && value !== "text") {
+                  return;
+                }
+                onChangeConfig({ ...config, bodyType: value });
+              }}
+            />
+            {(config.bodyType ?? "none") !== "none" ? (
+              <TextAreaField
+                id="vw-http-body"
+                label={intl.formatMessage(messages.httpBody)}
+                value={config.body ?? ""}
+                onChange={(value) => onChangeConfig({ ...config, body: value })}
+                placeholder='{"key": "{{trigger.id}}"}'
               />
-            </div>
+            ) : null}
+            <SelectField
+              id="vw-http-auth-type"
+              label={intl.formatMessage(messages.httpAuthType)}
+              value={config.auth?.type ?? "none"}
+              items={[
+                { value: "none", label: intl.formatMessage(messages.httpAuthNone) },
+                { value: "bearer", label: intl.formatMessage(messages.httpAuthBearer) },
+                { value: "api_key", label: intl.formatMessage(messages.httpAuthApiKey) },
+              ]}
+              onValueChange={(value) => {
+                if (!value || !isHttpAuthType(value)) {
+                  return;
+                }
+                onChangeConfig({
+                  ...config,
+                  auth: { ...config.auth, type: value, token: config.auth?.token ?? "" },
+                });
+              }}
+            />
+            {(config.auth?.type ?? "none") !== "none" ? (
+              <>
+                <TextField
+                  id="vw-http-auth-token"
+                  label={intl.formatMessage(messages.httpAuthToken)}
+                  value={config.auth?.token ?? ""}
+                  onChange={(value) =>
+                    onChangeConfig({
+                      ...config,
+                      auth: {
+                        type: config.auth?.type ?? "bearer",
+                        token: value,
+                        headerName: config.auth?.headerName,
+                      },
+                    })
+                  }
+                />
+                {config.auth?.type === "api_key" ? (
+                  <TextField
+                    id="vw-http-auth-header"
+                    label={intl.formatMessage(messages.httpAuthHeaderName)}
+                    value={config.auth?.headerName ?? "X-API-Key"}
+                    onChange={(value) =>
+                      onChangeConfig({
+                        ...config,
+                        auth: {
+                          type: "api_key",
+                          token: config.auth?.token ?? "",
+                          headerName: value,
+                        },
+                      })
+                    }
+                  />
+                ) : null}
+              </>
+            ) : null}
+            <CheckboxField
+              id="vw-http-parse-json"
+              label={intl.formatMessage(messages.httpParseJson)}
+              checked={config.parseJsonBody ?? true}
+              onCheckedChange={(checked) =>
+                onChangeConfig({ ...config, parseJsonBody: checked === true })
+              }
+            />
+            <CheckboxField
+              id="vw-http-fail-on-error"
+              label={intl.formatMessage(messages.httpFailOnError)}
+              checked={config.failOnHttpError ?? true}
+              onCheckedChange={(checked) =>
+                onChangeConfig({ ...config, failOnHttpError: checked === true })
+              }
+            />
+            <ErrorBehaviorField
+              value={config.onError ?? "stop"}
+              onChange={(onError) => onChangeConfig({ ...config, onError })}
+            />
           </>
         ) : null}
         {config.kind === "logic.if" ? (
-          <div className="grid gap-1.5">
-            <Label htmlFor="vw-if-condition">
-              <FormattedMessage {...messages.ifCondition} />
-            </Label>
-            <Textarea
-              id="vw-if-condition"
-              value={config.condition}
-              onChange={(event) => onChangeConfig({ ...config, condition: event.target.value })}
+          <TextAreaField
+            id="vw-if-condition"
+            label={intl.formatMessage(messages.ifCondition)}
+            value={config.condition}
+            onChange={(value) => onChangeConfig({ ...config, condition: value })}
+          />
+        ) : null}
+        {config.kind === "logic.switch" ? (
+          <>
+            <TextAreaField
+              id="vw-switch-expression"
+              label={intl.formatMessage(messages.switchExpression)}
+              value={config.expression}
+              onChange={(value) => onChangeConfig({ ...config, expression: value })}
+              placeholder="{{nodes.http.json.status}}"
             />
-          </div>
+            <div className="grid gap-2">
+              <Label>
+                <FormattedMessage {...messages.switchCases} />
+              </Label>
+              {config.cases.map((caseEntry, index) => (
+                <div key={`case-${index}`} className="flex items-center gap-2">
+                  <Input
+                    value={caseEntry.value}
+                    onChange={(event) => {
+                      const cases = config.cases.map((entry, caseIndex) =>
+                        caseIndex === index ? { value: event.target.value } : entry,
+                      );
+                      onChangeConfig({ ...config, cases });
+                    }}
+                    placeholder={intl.formatMessage(messages.switchCaseValue, {
+                      index: index + 1,
+                    })}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={config.cases.length <= 1}
+                    onClick={() => {
+                      onChangeConfig({
+                        ...config,
+                        cases: config.cases.filter((_, caseIndex) => caseIndex !== index),
+                      });
+                    }}
+                  >
+                    <HugeiconsIcon icon={Delete02Icon} className="size-4" strokeWidth={2} />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={config.cases.length >= 12}
+                onClick={() =>
+                  onChangeConfig({
+                    ...config,
+                    cases: [...config.cases, { value: "" }],
+                  })
+                }
+              >
+                <HugeiconsIcon icon={PlusSignIcon} className="size-4" strokeWidth={2} />
+                <FormattedMessage {...messages.addSwitchCase} />
+              </Button>
+            </div>
+          </>
+        ) : null}
+        {config.kind === "logic.set" ? (
+          <KeyValueEditor
+            label={intl.formatMessage(messages.setAssignments)}
+            keyLabel={intl.formatMessage(messages.setFieldName)}
+            valueLabel={intl.formatMessage(messages.setFieldValue)}
+            pairs={config.assignments}
+            onChange={(assignments) => onChangeConfig({ ...config, assignments })}
+          />
         ) : null}
         {config.kind === "logic.for_each" ? (
-          <div className="grid gap-1.5">
-            <Label htmlFor="vw-for-each-collection">
-              <FormattedMessage {...messages.forEachCollection} />
-            </Label>
-            <Textarea
-              id="vw-for-each-collection"
-              value={config.collection}
-              onChange={(event) => onChangeConfig({ ...config, collection: event.target.value })}
-              placeholder="{{trigger.items}}"
-            />
-          </div>
+          <TextAreaField
+            id="vw-for-each-collection"
+            label={intl.formatMessage(messages.forEachCollection)}
+            value={config.collection}
+            onChange={(value) => onChangeConfig({ ...config, collection: value })}
+            placeholder="{{trigger.items}}"
+          />
         ) : null}
         {config.kind === "action.notify_slack" ? (
           <>
-            <div className="grid gap-1.5">
-              <Label htmlFor="vw-slack-channel">
-                <FormattedMessage {...messages.slackChannelId} />
-              </Label>
-              <Input
-                id="vw-slack-channel"
-                value={config.channelId}
-                onChange={(event) => onChangeConfig({ ...config, channelId: event.target.value })}
-              />
-            </div>
-            <div className="grid gap-1.5">
-              <Label htmlFor="vw-slack-message">
-                <FormattedMessage {...messages.slackMessage} />
-              </Label>
-              <Textarea
-                id="vw-slack-message"
-                value={config.message}
-                onChange={(event) => onChangeConfig({ ...config, message: event.target.value })}
-              />
-            </div>
+            <TextField
+              id="vw-slack-channel"
+              label={intl.formatMessage(messages.slackChannelId)}
+              value={config.channelId}
+              onChange={(value) => onChangeConfig({ ...config, channelId: value })}
+            />
+            <TextAreaField
+              id="vw-slack-message"
+              label={intl.formatMessage(messages.slackMessage)}
+              value={config.message}
+              onChange={(value) => onChangeConfig({ ...config, message: value })}
+            />
+            <ErrorBehaviorField
+              value={config.onError ?? "stop"}
+              onChange={(onError) => onChangeConfig({ ...config, onError })}
+            />
           </>
         ) : null}
         {config.kind === "trigger.github" ? (
           <>
-            <div className="grid gap-1.5">
-              <Label htmlFor="vw-github-repo">
-                <FormattedMessage {...messages.githubRepositoryId} />
+            <TextField
+              id="vw-github-repo"
+              label={intl.formatMessage(messages.githubRepositoryId)}
+              value={config.githubInstallationRepositoryId}
+              onChange={(value) =>
+                onChangeConfig({
+                  ...config,
+                  githubInstallationRepositoryId: value,
+                })
+              }
+            />
+            <TextField
+              id="vw-github-branches"
+              label={intl.formatMessage(messages.githubBranches)}
+              value={config.branches.join(", ")}
+              onChange={(value) =>
+                onChangeConfig({
+                  ...config,
+                  branches: value
+                    .split(",")
+                    .map((entry) => entry.trim())
+                    .filter(Boolean),
+                })
+              }
+              placeholder="main, release/*"
+            />
+            <div className="grid gap-2">
+              <Label>
+                <FormattedMessage {...messages.githubEvents} />
               </Label>
-              <Input
-                id="vw-github-repo"
-                value={config.githubInstallationRepositoryId}
-                onChange={(event) =>
-                  onChangeConfig({
-                    ...config,
-                    githubInstallationRepositoryId: event.target.value,
-                  })
-                }
-              />
-            </div>
-            <div className="grid gap-1.5">
-              <Label htmlFor="vw-github-branches">
-                <FormattedMessage {...messages.githubBranches} />
-              </Label>
-              <Input
-                id="vw-github-branches"
-                value={config.branches.join(", ")}
-                onChange={(event) =>
-                  onChangeConfig({
-                    ...config,
-                    branches: event.target.value
-                      .split(",")
-                      .map((entry) => entry.trim())
-                      .filter(Boolean),
-                  })
-                }
-                placeholder="main, release/*"
-              />
+              {GITHUB_EVENTS.map((event) => {
+                const events = config.events ?? ["push"];
+                const checked = events.includes(event);
+                return (
+                  <CheckboxField
+                    key={event}
+                    id={`vw-github-event-${event}`}
+                    label={intl.formatMessage(
+                      event === "push" ? messages.githubEventPush : messages.githubEventPullRequest,
+                    )}
+                    checked={checked}
+                    onCheckedChange={(isChecked) => {
+                      const nextEvents = isChecked
+                        ? [...new Set([...events, event])]
+                        : events.filter((entry) => entry !== event);
+                      onChangeConfig({
+                        ...config,
+                        events: nextEvents.length > 0 ? nextEvents : ["push"],
+                      });
+                    }}
+                  />
+                );
+              })}
             </div>
           </>
         ) : null}
         {config.kind === "trigger.scheduled" ? (
-          <div className="grid gap-1.5">
-            <Label htmlFor="vw-schedule-cadence">
-              <FormattedMessage {...messages.scheduleCadence} />
-            </Label>
-            <Select
+          <>
+            <SelectField
+              id="vw-schedule-cadence"
+              label={intl.formatMessage(messages.scheduleCadence)}
               value={config.schedule.cadence}
               items={[
-                { value: "hourly", label: "Hourly" },
-                { value: "daily", label: "Daily" },
-                { value: "weekly", label: "Weekly" },
+                { value: "hourly", label: intl.formatMessage(messages.scheduleHourly) },
+                { value: "daily", label: intl.formatMessage(messages.scheduleDaily) },
+                { value: "weekly", label: intl.formatMessage(messages.scheduleWeekly) },
               ]}
               onValueChange={(value) => {
                 if (value !== "hourly" && value !== "daily" && value !== "weekly") {
@@ -215,53 +392,94 @@ export function VisualWorkflowConfigPanel({
                   schedule: { ...config.schedule, cadence: value },
                 });
               }}
-            >
-              <SelectTrigger id="vw-schedule-cadence" className="w-full">
-                <SelectValue>{config.schedule.cadence}</SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="hourly" label="Hourly">
-                  Hourly
-                </SelectItem>
-                <SelectItem value="daily" label="Daily">
-                  Daily
-                </SelectItem>
-                <SelectItem value="weekly" label="Weekly">
-                  Weekly
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        ) : null}
-        {config.kind === "trigger.source_upload" ? (
-          <div className="grid gap-1.5">
-            <Label htmlFor="vw-source-project">
-              <FormattedMessage {...messages.sourceUploadProjectId} />
-            </Label>
-            <Input
-              id="vw-source-project"
-              value={config.projectId ?? ""}
-              onChange={(event) =>
+            />
+            {config.schedule.cadence !== "hourly" ? (
+              <SelectField
+                id="vw-schedule-hour"
+                label={intl.formatMessage(messages.scheduleHour)}
+                value={String(config.schedule.hourUtc ?? 9)}
+                items={Array.from({ length: 24 }, (_, hour) => ({
+                  value: String(hour),
+                  label: `${String(hour).padStart(2, "0")}:00 UTC`,
+                }))}
+                onValueChange={(value) => {
+                  if (!value) {
+                    return;
+                  }
+                  onChangeConfig({
+                    ...config,
+                    schedule: { ...config.schedule, hourUtc: Number(value) },
+                  });
+                }}
+              />
+            ) : null}
+            {config.schedule.cadence === "weekly" ? (
+              <SelectField
+                id="vw-schedule-day"
+                label={intl.formatMessage(messages.scheduleDayOfWeek)}
+                value={String(config.schedule.dayOfWeek ?? 1)}
+                items={[
+                  { value: "0", label: intl.formatMessage(messages.scheduleSunday) },
+                  { value: "1", label: intl.formatMessage(messages.scheduleMonday) },
+                  { value: "2", label: intl.formatMessage(messages.scheduleTuesday) },
+                  { value: "3", label: intl.formatMessage(messages.scheduleWednesday) },
+                  { value: "4", label: intl.formatMessage(messages.scheduleThursday) },
+                  { value: "5", label: intl.formatMessage(messages.scheduleFriday) },
+                  { value: "6", label: intl.formatMessage(messages.scheduleSaturday) },
+                ]}
+                onValueChange={(value) => {
+                  if (!value) {
+                    return;
+                  }
+                  onChangeConfig({
+                    ...config,
+                    schedule: { ...config.schedule, dayOfWeek: Number(value) },
+                  });
+                }}
+              />
+            ) : null}
+            <SelectField
+              id="vw-schedule-timezone"
+              label={intl.formatMessage(messages.scheduleTimezone)}
+              value={config.schedule.timezone ?? "UTC"}
+              items={TIMEZONES.map((timezone) => ({ value: timezone, label: timezone }))}
+              onValueChange={(value) => {
+                if (!value) {
+                  return;
+                }
                 onChangeConfig({
                   ...config,
-                  projectId: event.target.value.trim() || undefined,
-                })
-              }
+                  schedule: { ...config.schedule, timezone: value },
+                });
+              }}
             />
-          </div>
+          </>
+        ) : null}
+        {config.kind === "trigger.source_upload" ? (
+          <TextField
+            id="vw-source-project"
+            label={intl.formatMessage(messages.sourceUploadProjectId)}
+            value={config.projectId ?? ""}
+            onChange={(value) =>
+              onChangeConfig({
+                ...config,
+                projectId: value.trim() || undefined,
+              })
+            }
+          />
         ) : null}
         {config.kind === "ai.agent" ? (
           <>
-            <div className="grid gap-1.5">
-              <Label htmlFor="vw-ai-prompt">
-                <FormattedMessage {...messages.aiPrompt} />
-              </Label>
-              <Textarea
-                id="vw-ai-prompt"
-                value={config.prompt}
-                onChange={(event) => onChangeConfig({ ...config, prompt: event.target.value })}
-              />
-            </div>
+            <TextAreaField
+              id="vw-ai-prompt"
+              label={intl.formatMessage(messages.aiPrompt)}
+              value={config.prompt}
+              onChange={(value) => onChangeConfig({ ...config, prompt: value })}
+            />
+            <ErrorBehaviorField
+              value={config.onError ?? "stop"}
+              onChange={(onError) => onChangeConfig({ ...config, onError })}
+            />
             <div className="rounded-lg border border-dashed border-border px-3 py-2 text-sm text-muted-foreground">
               <p>
                 <FormattedMessage {...messages.aiModelSlot} />
@@ -275,15 +493,20 @@ export function VisualWorkflowConfigPanel({
             </div>
           </>
         ) : null}
-        {config.kind === "trigger.manual" ||
-        config.kind === "trigger.scheduled" ||
-        config.kind === "trigger.github" ||
-        config.kind === "trigger.source_upload" ? (
-          config.kind === "trigger.manual" ? (
-            <TypographyP size="small" tone="subtle">
-              <FormattedMessage {...messages.noConfig} />
-            </TypographyP>
-          ) : null
+        {config.kind === "trigger.manual" ? (
+          <TypographyP size="small" tone="subtle">
+            <FormattedMessage {...messages.noConfig} />
+          </TypographyP>
+        ) : null}
+        {node.data.lastOutput || node.data.lastError ? (
+          <div className="grid gap-1.5 border-t border-border pt-4">
+            <Label>
+              <FormattedMessage {...messages.nodeOutputTitle} />
+            </Label>
+            <pre className="max-h-48 overflow-auto rounded-md bg-muted p-2 text-xs">
+              {JSON.stringify(node.data.lastOutput ?? node.data.lastError, null, 2)}
+            </pre>
+          </div>
         ) : null}
       </div>
       {issues.length > 0 ? (
@@ -299,8 +522,231 @@ export function VisualWorkflowConfigPanel({
   );
 }
 
+function KeyValueEditor({
+  label,
+  keyLabel,
+  valueLabel,
+  pairs,
+  onChange,
+}: {
+  label: string;
+  keyLabel?: string;
+  valueLabel?: string;
+  pairs: VisualKeyValuePair[];
+  onChange: (pairs: VisualKeyValuePair[]) => void;
+}) {
+  const intl = useIntl();
+  const resolvedKeyLabel = keyLabel ?? intl.formatMessage(messages.keyValueKey);
+  const resolvedValueLabel = valueLabel ?? intl.formatMessage(messages.keyValueValue);
+
+  return (
+    <div className="grid gap-2">
+      <Label>{label}</Label>
+      {pairs.map((pair, index) => (
+        <div key={`kv-${index}`} className="grid gap-1.5">
+          <Input
+            value={pair.key}
+            placeholder={resolvedKeyLabel}
+            onChange={(event) => {
+              onChange(
+                pairs.map((entry, entryIndex) =>
+                  entryIndex === index ? { ...entry, key: event.target.value } : entry,
+                ),
+              );
+            }}
+          />
+          <div className="flex items-center gap-2">
+            <Input
+              value={pair.value}
+              placeholder={resolvedValueLabel}
+              onChange={(event) => {
+                onChange(
+                  pairs.map((entry, entryIndex) =>
+                    entryIndex === index ? { ...entry, value: event.target.value } : entry,
+                  ),
+                );
+              }}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onChange(pairs.filter((_, entryIndex) => entryIndex !== index))}
+            >
+              <HugeiconsIcon icon={Delete02Icon} className="size-4" strokeWidth={2} />
+            </Button>
+          </div>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onChange([...pairs, { key: "", value: "" }])}
+      >
+        <HugeiconsIcon icon={PlusSignIcon} className="size-4" strokeWidth={2} />
+        <FormattedMessage {...messages.addKeyValuePair} />
+      </Button>
+    </div>
+  );
+}
+
+function ErrorBehaviorField({
+  value,
+  onChange,
+}: {
+  value: VisualNodeErrorBehavior;
+  onChange: (value: VisualNodeErrorBehavior) => void;
+}) {
+  const intl = useIntl();
+  return (
+    <SelectField
+      id="vw-error-behavior"
+      label={intl.formatMessage(messages.onErrorLabel)}
+      value={value}
+      items={ERROR_BEHAVIORS.map((behavior) => ({
+        value: behavior,
+        label: intl.formatMessage(errorBehaviorMessage(behavior)),
+      }))}
+      onValueChange={(nextValue) => {
+        if (!nextValue || !isErrorBehavior(nextValue)) {
+          return;
+        }
+        onChange(nextValue);
+      }}
+    />
+  );
+}
+
+function SelectField({
+  id,
+  label,
+  value,
+  items,
+  onValueChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  items: { value: string; label: string }[];
+  onValueChange: (value: string | null) => void;
+}) {
+  const selected = items.find((item) => item.value === value);
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Select value={value} items={items} onValueChange={onValueChange}>
+        <SelectTrigger id={id} className="w-full">
+          <SelectValue>{selected?.label ?? value}</SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {items.map((item) => (
+            <SelectItem key={item.value} value={item.value} label={item.label}>
+              {item.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function TextField({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}
+
+function TextAreaField({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Textarea
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}
+
+function CheckboxField({
+  id,
+  label,
+  checked,
+  onCheckedChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(value) => onCheckedChange(value === true)}
+      />
+      <Label htmlFor={id}>{label}</Label>
+    </div>
+  );
+}
+
 function isHttpMethod(value: string): value is HttpMethod {
   return HTTP_METHODS.includes(value as HttpMethod);
+}
+
+function isHttpAuthType(value: string): value is HttpAuthType {
+  return value === "none" || value === "bearer" || value === "api_key";
+}
+
+function isErrorBehavior(value: string): value is VisualNodeErrorBehavior {
+  return ERROR_BEHAVIORS.includes(value as VisualNodeErrorBehavior);
+}
+
+function errorBehaviorMessage(behavior: VisualNodeErrorBehavior) {
+  switch (behavior) {
+    case "stop":
+      return messages.onErrorStop;
+    case "continue":
+      return messages.onErrorContinue;
+    case "branch":
+      return messages.onErrorBranch;
+  }
 }
 
 function issueMessage(code: VisualWorkflowValidationIssue["code"]) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages.ts
@@ -25,6 +25,11 @@ export const visualWorkflowEditorMessages = defineMessages({
     id: "4LzDIQaYVP",
     description: "Badge indicating the visual editor is a prototype",
   },
+  playgroundBadge: {
+    defaultMessage: "Playground",
+    id: "TzH92UpIsI",
+    description: "Badge indicating the visual editor is an interactive playground",
+  },
   editorTab: {
     defaultMessage: "Editor",
     id: "sHEScxEFix",
@@ -205,6 +210,26 @@ export const visualWorkflowEditorMessages = defineMessages({
     id: "N80yyF08UZ",
     description: "Catalog description for the if/else node",
   },
+  nodeSwitch: {
+    defaultMessage: "Switch",
+    id: "Qb8e9HBTwT",
+    description: "Catalog title for the switch node",
+  },
+  nodeSwitchHint: {
+    defaultMessage: "Route to one of several branches.",
+    id: "eGggF69cbr",
+    description: "Catalog description for the switch node",
+  },
+  nodeSet: {
+    defaultMessage: "Set fields",
+    id: "DQLb5tVkm8",
+    description: "Catalog title for the set fields node",
+  },
+  nodeSetHint: {
+    defaultMessage: "Assign values into the workflow context.",
+    id: "ZXPdUvtPkF",
+    description: "Catalog description for the set fields node",
+  },
   nodeAi: {
     defaultMessage: "AI Agent",
     id: "mHug8Cyl7z",
@@ -289,6 +314,171 @@ export const visualWorkflowEditorMessages = defineMessages({
     defaultMessage: "URL",
     id: "k66v97xuuE",
     description: "HTTP node URL field label",
+  },
+  httpQueryParams: {
+    defaultMessage: "Query parameters",
+    id: "ZlYq8eSzg2",
+    description: "HTTP node query parameters label",
+  },
+  httpHeaders: {
+    defaultMessage: "Headers",
+    id: "UPSrigC8qi",
+    description: "HTTP node headers label",
+  },
+  httpBodyType: {
+    defaultMessage: "Body type",
+    id: "gXUXFoSBuO",
+    description: "HTTP node body type label",
+  },
+  httpBodyNone: {
+    defaultMessage: "None",
+    id: "jtMuzhGEyo",
+    description: "HTTP node body type none option",
+  },
+  httpBodyJson: {
+    defaultMessage: "JSON",
+    id: "n5goMj2vzm",
+    description: "HTTP node body type json option",
+  },
+  httpBodyText: {
+    defaultMessage: "Text",
+    id: "8Xv6VRwnt8",
+    description: "HTTP node body type text option",
+  },
+  httpBody: {
+    defaultMessage: "Body",
+    id: "Ajr/yjqPyf",
+    description: "HTTP node body field label",
+  },
+  httpAuthType: {
+    defaultMessage: "Authentication",
+    id: "YHVrBzelKI",
+    description: "HTTP node auth type label",
+  },
+  httpAuthNone: {
+    defaultMessage: "None",
+    id: "LfRnarhSYl",
+    description: "HTTP node auth none option",
+  },
+  httpAuthBearer: {
+    defaultMessage: "Bearer token",
+    id: "VaBWbObFr8",
+    description: "HTTP node bearer auth option",
+  },
+  httpAuthApiKey: {
+    defaultMessage: "API key",
+    id: "JxY8wqGfw1",
+    description: "HTTP node api key auth option",
+  },
+  httpAuthToken: {
+    defaultMessage: "Token",
+    id: "M872sYIDd7",
+    description: "HTTP node auth token label",
+  },
+  httpAuthHeaderName: {
+    defaultMessage: "Header name",
+    id: "GYOEi48Bxv",
+    description: "HTTP node api key header name label",
+  },
+  httpParseJson: {
+    defaultMessage: "Parse JSON response",
+    id: "2tQhE9LloD",
+    description: "HTTP node parse json checkbox label",
+  },
+  httpFailOnError: {
+    defaultMessage: "Fail on HTTP error status",
+    id: "HCpKchokfS",
+    description: "HTTP node fail on error checkbox label",
+  },
+  onErrorLabel: {
+    defaultMessage: "On error",
+    id: "NFSiCA4x/F",
+    description: "Label for node error behavior select",
+  },
+  onErrorStop: {
+    defaultMessage: "Stop workflow",
+    id: "lPNvi3t9/d",
+    description: "Stop workflow on node error",
+  },
+  onErrorContinue: {
+    defaultMessage: "Continue workflow",
+    id: "1GLSyoUT4Z",
+    description: "Continue workflow on node error",
+  },
+  onErrorBranch: {
+    defaultMessage: "Error branch",
+    id: "UJFX+3Y3fz",
+    description: "Route to error branch on node error",
+  },
+  errorHandle: {
+    defaultMessage: "error",
+    id: "nYOxYYV5jF",
+    description: "Label on error output handle",
+  },
+  switchExpression: {
+    defaultMessage: "Expression",
+    id: "vKVR+7LwqC",
+    description: "Switch node expression field label",
+  },
+  switchCases: {
+    defaultMessage: "Cases",
+    id: "0vaHgLAQkS",
+    description: "Switch node cases section label",
+  },
+  switchCaseValue: {
+    defaultMessage: "Case {index}",
+    id: "bE+/1fvD7l",
+    description: "Placeholder for switch case value input",
+  },
+  addSwitchCase: {
+    defaultMessage: "Add case",
+    id: "n4hpRZLl37",
+    description: "Button to add a switch case",
+  },
+  switchCaseHandle: {
+    defaultMessage: "Case {index}",
+    id: "04QgRuZsOk",
+    description: "Label for numbered switch output handle",
+  },
+  switchDefaultHandle: {
+    defaultMessage: "default",
+    id: "F9TbntyBsV",
+    description: "Label for switch default output handle",
+  },
+  setAssignments: {
+    defaultMessage: "Field assignments",
+    id: "VMyrNr9Y/C",
+    description: "Set node assignments section label",
+  },
+  setFieldName: {
+    defaultMessage: "Field name",
+    id: "UWp9ixlYUw",
+    description: "Set node field name placeholder",
+  },
+  setFieldValue: {
+    defaultMessage: "Value",
+    id: "B6FNmz1hFv",
+    description: "Set node field value placeholder",
+  },
+  keyValueKey: {
+    defaultMessage: "Key",
+    id: "Is9VBW0Pl3",
+    description: "Key placeholder for key-value editor",
+  },
+  keyValueValue: {
+    defaultMessage: "Value",
+    id: "umK6yIapNV",
+    description: "Value placeholder for key-value editor",
+  },
+  addKeyValuePair: {
+    defaultMessage: "Add row",
+    id: "fYm7crAvvb",
+    description: "Button to add key-value row",
+  },
+  nodeOutputTitle: {
+    defaultMessage: "Last output",
+    id: "I4MDdItT7N",
+    description: "Heading for inline node output inspector",
   },
   ifCondition: {
     defaultMessage: "Condition",
@@ -430,10 +620,90 @@ export const visualWorkflowEditorMessages = defineMessages({
     id: "IsFQvqwJAO",
     description: "Label for GitHub branch patterns on trigger node",
   },
+  githubEvents: {
+    defaultMessage: "Events",
+    id: "BFGbjLDQqh",
+    description: "Label for GitHub events on trigger node",
+  },
+  githubEventPush: {
+    defaultMessage: "Push",
+    id: "h+QA+7BAPb",
+    description: "GitHub push event checkbox label",
+  },
+  githubEventPullRequest: {
+    defaultMessage: "Pull request",
+    id: "qxdCTJo5wL",
+    description: "GitHub pull request event checkbox label",
+  },
   scheduleCadence: {
     defaultMessage: "Cadence",
     id: "+KX/fjdtO4",
     description: "Label for schedule cadence on scheduled trigger node",
+  },
+  scheduleHourly: {
+    defaultMessage: "Hourly",
+    id: "fB8k9m+qMa",
+    description: "Hourly schedule cadence option",
+  },
+  scheduleDaily: {
+    defaultMessage: "Daily",
+    id: "yoc2jz/v8a",
+    description: "Daily schedule cadence option",
+  },
+  scheduleWeekly: {
+    defaultMessage: "Weekly",
+    id: "xM1UVGq/9v",
+    description: "Weekly schedule cadence option",
+  },
+  scheduleHour: {
+    defaultMessage: "Hour (UTC)",
+    id: "f30lOJsKLX",
+    description: "Label for schedule hour field",
+  },
+  scheduleDayOfWeek: {
+    defaultMessage: "Day of week",
+    id: "2HD/xUOuDn",
+    description: "Label for weekly schedule day field",
+  },
+  scheduleTimezone: {
+    defaultMessage: "Timezone",
+    id: "TQPbZg8LsO",
+    description: "Label for schedule timezone field",
+  },
+  scheduleSunday: {
+    defaultMessage: "Sunday",
+    id: "IDmuYPzcIE",
+    description: "Sunday option for weekly schedule",
+  },
+  scheduleMonday: {
+    defaultMessage: "Monday",
+    id: "vy+5ISEhNS",
+    description: "Monday option for weekly schedule",
+  },
+  scheduleTuesday: {
+    defaultMessage: "Tuesday",
+    id: "aewkbG6Jn7",
+    description: "Tuesday option for weekly schedule",
+  },
+  scheduleWednesday: {
+    defaultMessage: "Wednesday",
+    id: "QVQzu9FFdo",
+    description: "Wednesday option for weekly schedule",
+  },
+  scheduleThursday: {
+    defaultMessage: "Thursday",
+    id: "oF3U8SKzm3",
+    description: "Thursday option for weekly schedule",
+  },
+  scheduleFriday: {
+    defaultMessage: "Friday",
+    id: "JLv9f0uEE2",
+    description: "Friday option for weekly schedule",
+  },
+  scheduleSaturday: {
+    defaultMessage: "Saturday",
+    id: "yN3IaRAmIM",
+    description: "Saturday option for weekly schedule",
   },
   sourceUploadProjectId: {
     defaultMessage: "Project ID (optional)",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.stories.tsx
@@ -11,20 +11,22 @@
  * Version 2.0 or later.
  */
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect, userEvent } from "storybook/test";
 
-import { visualWorkflowDemoDraft } from "./visual-workflow-editor.fixture";
+import {
+  visualWorkflowDemoDraft,
+  visualWorkflowPlaygroundDraft,
+} from "./visual-workflow-editor.fixture";
 import { VisualWorkflowEditor } from "./visual-workflow-editor";
 
 const meta = {
-  title: "App/Automations/VisualWorkflowEditor",
+  title: "App/Automations/Visual Workflow",
   component: VisualWorkflowEditor,
   parameters: {
     layout: "fullscreen",
     docs: {
       description: {
         component:
-          "HL-626 visual workflow mock. Open Sample graph first — canvas, picker, Test workflow, and Export JSON. No auth or WorkOS flag required.",
+          "Interactive playground for visual workflows. Add nodes from the picker, connect steps, configure each node, and run **Test workflow** to execute the graph in the browser. Logic nodes run for real; HTTP, Slack, and AI steps return simulated outputs.",
       },
     },
   },
@@ -40,32 +42,24 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const SampleGraph: Story = {
-  name: "Sample graph (mentor demo)",
+export const Playground: Story = {
+  name: "Playground",
+  args: {
+    initialName: visualWorkflowPlaygroundDraft.name,
+    initialNodes: visualWorkflowPlaygroundDraft.nodes,
+    initialEdges: visualWorkflowPlaygroundDraft.edges,
+    previewMode: true,
+    playgroundMode: true,
+  },
+};
+
+export const SampleWorkflow: Story = {
+  name: "Sample workflow",
   args: {
     initialName: visualWorkflowDemoDraft.name,
     initialNodes: visualWorkflowDemoDraft.nodes,
     initialEdges: visualWorkflowDemoDraft.edges,
     previewMode: true,
-  },
-  play: async ({ canvas }) => {
-    await expect(canvas.getByDisplayValue("Lead ping")).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Export JSON" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Test workflow" })).toBeEnabled();
-  },
-};
-
-export const Empty: Story = {
-  args: {
-    previewMode: true,
-  },
-  play: async ({ canvas }) => {
-    await expect(canvas.getByRole("button", { name: "Add first step" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Load sample" })).toBeInTheDocument();
-    await expect(canvas.getByRole("heading", { name: "What happens next?" })).toBeInTheDocument();
-    await userEvent.click(canvas.getByRole("button", { name: "Add first step" }));
-    await userEvent.click(canvas.getByRole("button", { name: /Manual trigger/i }));
-    await expect(canvas.getByRole("heading", { name: "Configure step" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Test workflow" })).toBeEnabled();
+    playgroundMode: true,
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.tsx
@@ -25,6 +25,7 @@ import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { runFakeWorkflow } from "@/lib/visual-workflows/preview/fake-run";
+import { runPlaygroundWorkflow } from "@/lib/visual-workflows/preview/playground-run";
 import {
   createDefaultConfig,
   getVisualNodeDimensions,
@@ -65,6 +66,7 @@ export function VisualWorkflowEditor({
   initialEdges = [],
   initialName,
   previewMode = false,
+  playgroundMode = false,
   onSave,
   isSaving = false,
   organizationSlug,
@@ -79,6 +81,7 @@ export function VisualWorkflowEditor({
   initialEdges?: VisualWorkflowRfEdge[];
   initialName?: string;
   previewMode?: boolean;
+  playgroundMode?: boolean;
   onSave?: (definition: VisualWorkflowDefinition) => void | Promise<void>;
   isSaving?: boolean;
   organizationSlug?: string;
@@ -201,6 +204,30 @@ export function VisualWorkflowEditor({
     [selectedNodeId],
   );
 
+  const setNodeOutputSnapshot = useCallback(
+    (
+      nodeId: string,
+      output: Record<string, unknown> | null,
+      error: Record<string, unknown> | null,
+    ) => {
+      setNodes((current) =>
+        current.map((node) =>
+          node.id === nodeId
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  lastOutput: output,
+                  lastError: error,
+                },
+              }
+            : node,
+        ),
+      );
+    },
+    [],
+  );
+
   const setRunStatus = useCallback((nodeId: string, status: MockNodeRunStatus) => {
     setNodes((current) =>
       current.map((node) =>
@@ -210,25 +237,41 @@ export function VisualWorkflowEditor({
   }, []);
 
   const applyNodeRunStatuses = useCallback(
-    (nodeRuns: Array<{ nodeId: string; status: string }>) => {
-      const statusByNodeId = new Map(
-        nodeRuns.map((nodeRun) => [nodeRun.nodeId, nodeRun.status] as const),
-      );
+    (
+      nodeRuns: Array<{
+        nodeId: string;
+        status: string;
+        outputSnapshot?: Record<string, unknown>;
+        error?: Record<string, unknown> | null;
+      }>,
+    ) => {
+      const runByNodeId = new Map(nodeRuns.map((nodeRun) => [nodeRun.nodeId, nodeRun]));
       setNodes((current) =>
         current.map((node) => {
-          const status = statusByNodeId.get(node.id);
-          if (!status) {
+          const nodeRun = runByNodeId.get(node.id);
+          if (!nodeRun) {
             return node;
           }
           const mappedStatus: MockNodeRunStatus =
-            status === "running"
+            nodeRun.status === "running"
               ? "running"
-              : status === "succeeded"
+              : nodeRun.status === "succeeded"
                 ? "succeeded"
-                : status === "failed"
+                : nodeRun.status === "failed"
                   ? "failed"
                   : "idle";
-          return { ...node, data: { ...node.data, runStatus: mappedStatus } };
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              runStatus: mappedStatus,
+              lastOutput:
+                nodeRun.outputSnapshot && Object.keys(nodeRun.outputSnapshot).length > 0
+                  ? nodeRun.outputSnapshot
+                  : null,
+              lastError: nodeRun.error ?? null,
+            },
+          };
         }),
       );
     },
@@ -241,7 +284,10 @@ export function VisualWorkflowEditor({
     runAbortRef.current = controller;
     setIsRunning(true);
     setNodes((current) =>
-      current.map((node) => ({ ...node, data: { ...node.data, runStatus: "idle" } })),
+      current.map((node) => ({
+        ...node,
+        data: { ...node.data, runStatus: "idle", lastOutput: null, lastError: null },
+      })),
     );
 
     const definition = toVisualWorkflowDefinition({ name, nodes, edges });
@@ -275,6 +321,18 @@ export function VisualWorkflowEditor({
         if (latestRun.status === "failed") {
           toast.error(intl.formatMessage(messages.testRunFailed));
         }
+      } else if (playgroundMode) {
+        const result = await runPlaygroundWorkflow({
+          name,
+          nodes,
+          edges,
+          signal: controller.signal,
+          onStatus: setRunStatus,
+          onOutput: setNodeOutputSnapshot,
+        });
+        if (result === "failed") {
+          toast.error(intl.formatMessage(messages.testRunFailed));
+        }
       } else {
         await runFakeWorkflow({
           nodes,
@@ -296,6 +354,8 @@ export function VisualWorkflowEditor({
     nodes,
     onPersistBeforeTest,
     organizationSlug,
+    playgroundMode,
+    setNodeOutputSnapshot,
     setRunStatus,
     visualWorkflowId,
     visualWorkflowsApi,
@@ -350,6 +410,7 @@ export function VisualWorkflowEditor({
         isSaving={isSaving}
         saveDisabled={saveDisabled}
         previewMode={previewMode}
+        playgroundMode={playgroundMode}
         activeTab={activeTab}
         onTabChange={setActiveTab}
         workflowStatus={workflowStatus}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-node-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-node-picker.tsx
@@ -154,6 +154,10 @@ function titleFor(type: VisualCatalogType) {
       return messages.nodeNotifySlack;
     case "logic.if":
       return messages.nodeIf;
+    case "logic.switch":
+      return messages.nodeSwitch;
+    case "logic.set":
+      return messages.nodeSet;
     case "ai.agent":
       return messages.nodeAi;
     case "logic.for_each":
@@ -177,6 +181,10 @@ function hintFor(type: VisualCatalogType) {
       return messages.nodeNotifySlackHint;
     case "logic.if":
       return messages.nodeIfHint;
+    case "logic.switch":
+      return messages.nodeSwitchHint;
+    case "logic.set":
+      return messages.nodeSetHint;
     case "ai.agent":
       return messages.nodeAiHint;
     case "logic.for_each":

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/catalog/node-catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/catalog/node-catalog.ts
@@ -17,8 +17,10 @@ import {
   GitBranchIcon,
   Globe02Icon,
   Mail01Icon,
+  Route01Icon,
   Task01Icon,
   Upload04Icon,
+  VariableIcon,
 } from "@hugeicons/core-free-icons";
 import type { ComponentProps } from "react";
 import type { HugeiconsIcon } from "@hugeicons/react";
@@ -80,6 +82,18 @@ export const VISUAL_NODE_CATALOG: readonly VisualNodeCatalogItem[] = [
     icon: GitBranchIcon,
   },
   {
+    type: "logic.switch",
+    category: "logic",
+    enabled: true,
+    icon: Route01Icon,
+  },
+  {
+    type: "logic.set",
+    category: "logic",
+    enabled: true,
+    icon: VariableIcon,
+  },
+  {
     type: "ai.agent",
     category: "ai",
     enabled: true,
@@ -122,13 +136,32 @@ export function createDefaultConfig(type: VisualCatalogType): VisualNodeConfig {
     case "trigger.source_upload":
       return { kind: "trigger.source_upload" };
     case "action.http":
-      return { kind: "action.http", method: "GET", url: "" };
+      return {
+        kind: "action.http",
+        method: "GET",
+        url: "",
+        headers: [],
+        queryParams: [],
+        bodyType: "none",
+        auth: { type: "none" },
+        parseJsonBody: true,
+        failOnHttpError: true,
+        onError: "stop",
+      };
     case "action.notify_slack":
-      return { kind: "action.notify_slack", channelId: "", message: "" };
+      return { kind: "action.notify_slack", channelId: "", message: "", onError: "stop" };
     case "logic.if":
       return { kind: "logic.if", condition: "" };
+    case "logic.switch":
+      return {
+        kind: "logic.switch",
+        expression: "",
+        cases: [{ value: "" }, { value: "" }],
+      };
+    case "logic.set":
+      return { kind: "logic.set", assignments: [{ key: "", value: "" }] };
     case "ai.agent":
-      return { kind: "ai.agent", prompt: "" };
+      return { kind: "ai.agent", prompt: "", onError: "stop" };
     case "logic.for_each":
       return { kind: "logic.for_each", collection: "" };
     default:
@@ -145,6 +178,9 @@ export function getVisualNodeDimensions(type: VisualCatalogType): {
   }
   if (type === "logic.if") {
     return { width: 200, height: 120 };
+  }
+  if (type === "logic.switch") {
+    return { width: 200, height: 140 };
   }
   if (type.startsWith("trigger.")) {
     return { width: 200, height: 120 };
@@ -180,6 +216,12 @@ export function resolveNodeSubtitle(config: VisualNodeConfig): string {
       return config.channelId ? "Slack" : "Slack channel";
     case "logic.if":
       return config.condition.trim() ? "1 condition" : "No condition";
+    case "logic.switch":
+      return config.cases.length > 0 ? `${config.cases.length} cases` : "No cases";
+    case "logic.set":
+      return config.assignments.length > 0
+        ? `${config.assignments.length} fields`
+        : "No assignments";
     case "ai.agent":
       return "Tools agent";
     case "logic.for_each":

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/fixtures/playground-draft.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/fixtures/playground-draft.ts
@@ -10,5 +10,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-export { visualWorkflowDemoDraft } from "@/lib/visual-workflows/fixtures/demo-draft";
-export { visualWorkflowPlaygroundDraft } from "@/lib/visual-workflows/fixtures/playground-draft";
+import {
+  createEmptyVisualWorkflowDefinition,
+  fromVisualWorkflowDefinition,
+} from "../schema/serializers";
+
+export const visualWorkflowPlaygroundDraft = fromVisualWorkflowDefinition(
+  createEmptyVisualWorkflowDefinition("Playground workflow"),
+);

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/preview/playground-run.test.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/preview/playground-run.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { createDefaultConfig } from "../catalog/node-catalog";
+import { runPlaygroundWorkflow } from "./playground-run";
+import type { VisualWorkflowRfEdge, VisualWorkflowRfNode } from "../schema/types";
+
+function node(id: string, type: VisualWorkflowRfNode["data"]["catalogType"]): VisualWorkflowRfNode {
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: {
+      catalogType: type,
+      config: createDefaultConfig(type),
+      runStatus: "idle",
+    },
+  };
+}
+
+describe("playground workflow runner", () => {
+  it("executes branching logic with simulated action outputs", async () => {
+    const nodes: VisualWorkflowRfNode[] = [
+      node("trigger", "trigger.manual"),
+      {
+        ...node("set", "logic.set"),
+        data: {
+          ...node("set", "logic.set").data,
+          config: {
+            kind: "logic.set",
+            assignments: [{ key: "status", value: "ready" }],
+          },
+        },
+      },
+      {
+        ...node("switch", "logic.switch"),
+        data: {
+          ...node("switch", "logic.switch").data,
+          config: {
+            kind: "logic.switch",
+            expression: "{{nodes.set.status}}",
+            cases: [{ value: "ready" }, { value: "blocked" }],
+          },
+        },
+      },
+      {
+        ...node("taken", "action.notify_slack"),
+        data: {
+          ...node("taken", "action.notify_slack").data,
+          config: {
+            kind: "action.notify_slack",
+            channelId: "C123",
+            message: "Ready branch reached",
+            onError: "stop",
+          },
+        },
+      },
+    ];
+    const edges: VisualWorkflowRfEdge[] = [
+      { id: "e1", source: "trigger", target: "set" },
+      { id: "e2", source: "set", target: "switch" },
+      { id: "e3", source: "switch", target: "taken", sourceHandle: "0" },
+    ];
+
+    const statuses: string[] = [];
+    const outputs: Record<string, Record<string, unknown>> = {};
+
+    const result = await runPlaygroundWorkflow({
+      name: "Playground",
+      nodes,
+      edges,
+      onStatus: (nodeId, status) => {
+        statuses.push(`${nodeId}:${status}`);
+      },
+      onOutput: (nodeId, output) => {
+        if (output) {
+          outputs[nodeId] = output;
+        }
+      },
+    });
+
+    expect(result).toBe("completed");
+    expect(statuses).toContain("set:succeeded");
+    expect(statuses).toContain("taken:succeeded");
+    expect(outputs.set?.status).toBe("ready");
+    expect(outputs.taken?.simulated).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/preview/playground-run.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/preview/playground-run.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { toVisualWorkflowDefinition } from "../schema/serializers";
+import type {
+  MockNodeRunStatus,
+  VisualWorkflowRfEdge,
+  VisualWorkflowRfNode,
+} from "../schema/types";
+import { executeLogicVisualWorkflowNode } from "../runtime/execute-logic-node";
+import type { VisualWorkflowNodeExecutionResult } from "../runtime/execution-result";
+import { runVisualWorkflowInterpreter } from "../runtime/interpreter";
+import { resolveVisualWorkflowTemplate } from "../runtime/expressions";
+import type { CanonicalVisualWorkflowNode } from "../schema/types";
+import type { VisualWorkflowExecutionContext } from "../runtime/context";
+
+const PLAYGROUND_ORGANIZATION_ID = "00000000-0000-4000-8000-000000000099";
+
+async function executePlaygroundVisualWorkflowNode(input: {
+  node: CanonicalVisualWorkflowNode;
+  context: VisualWorkflowExecutionContext;
+  organizationId: string;
+}): Promise<VisualWorkflowNodeExecutionResult> {
+  const logicResult = executeLogicVisualWorkflowNode({
+    node: input.node,
+    context: input.context,
+  });
+  if (logicResult.ok || logicResult.error.code !== "not_logic_node") {
+    return logicResult;
+  }
+
+  switch (input.node.config.kind) {
+    case "action.http": {
+      const url = resolveVisualWorkflowTemplate(input.node.config.url, input.context).trim();
+      if (!url) {
+        return { ok: false, error: { code: "missing_url", message: "HTTP URL is required." } };
+      }
+
+      return {
+        ok: true,
+        output: {
+          status: 200,
+          statusText: "OK",
+          ok: true,
+          body: JSON.stringify({ playground: true, url }),
+          json: { playground: true, url },
+          simulated: true,
+        },
+      };
+    }
+    case "action.notify_slack": {
+      const channelId = resolveVisualWorkflowTemplate(
+        input.node.config.channelId,
+        input.context,
+      ).trim();
+      const message = resolveVisualWorkflowTemplate(
+        input.node.config.message,
+        input.context,
+      ).trim();
+      if (!channelId) {
+        return {
+          ok: false,
+          error: { code: "missing_channel", message: "Slack channel ID is required." },
+        };
+      }
+      if (!message) {
+        return {
+          ok: false,
+          error: { code: "missing_message", message: "Slack message is required." },
+        };
+      }
+
+      return {
+        ok: true,
+        output: {
+          sent: true,
+          channelId,
+          message,
+          simulated: true,
+        },
+      };
+    }
+    case "ai.agent": {
+      const prompt = resolveVisualWorkflowTemplate(input.node.config.prompt, input.context).trim();
+      if (!prompt) {
+        return { ok: false, error: { code: "missing_prompt", message: "AI prompt is required." } };
+      }
+
+      return {
+        ok: true,
+        output: {
+          text: `Playground response for: ${prompt.slice(0, 120)}`,
+          simulated: true,
+        },
+      };
+    }
+    default:
+      return {
+        ok: false,
+        error: {
+          code: "unsupported_node",
+          message: "Unsupported node type.",
+        },
+      };
+  }
+}
+
+export async function runPlaygroundWorkflow(options: {
+  name: string;
+  nodes: readonly VisualWorkflowRfNode[];
+  edges: readonly VisualWorkflowRfEdge[];
+  signal?: AbortSignal;
+  onStatus: (nodeId: string, status: MockNodeRunStatus) => void;
+  onOutput?: (
+    nodeId: string,
+    output: Record<string, unknown> | null,
+    error: Record<string, unknown> | null,
+  ) => void;
+}): Promise<"completed" | "aborted" | "failed"> {
+  if (options.signal?.aborted) {
+    return "aborted";
+  }
+
+  const definition = toVisualWorkflowDefinition({
+    name: options.name,
+    nodes: [...options.nodes],
+    edges: [...options.edges],
+  });
+
+  const result = await runVisualWorkflowInterpreter({
+    definition,
+    organizationId: PLAYGROUND_ORGANIZATION_ID,
+    triggerInput: {
+      playground: true,
+      triggeredAt: new Date().toISOString(),
+    },
+    executeNode: executePlaygroundVisualWorkflowNode,
+    onNodeUpdate: async (update) => {
+      if (options.signal?.aborted) {
+        return;
+      }
+
+      if (update.status === "running") {
+        options.onStatus(update.nodeId, "running");
+        return;
+      }
+
+      if (update.status === "succeeded") {
+        options.onStatus(update.nodeId, "succeeded");
+        options.onOutput?.(update.nodeId, update.outputSnapshot ?? null, null);
+        return;
+      }
+
+      if (update.status === "failed") {
+        options.onStatus(update.nodeId, "failed");
+        options.onOutput?.(update.nodeId, update.outputSnapshot ?? null, update.error ?? null);
+      }
+    },
+  });
+
+  if (options.signal?.aborted) {
+    return "aborted";
+  }
+
+  return result.ok ? "completed" : "failed";
+}

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execute-logic-node.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execute-logic-node.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { CanonicalVisualWorkflowNode } from "../schema/types";
+import type { VisualWorkflowExecutionContext } from "./context";
+import type { VisualWorkflowNodeExecutionResult } from "./execution-result";
+import {
+  evaluateVisualWorkflowCondition,
+  resolveVisualWorkflowCollection,
+  resolveVisualWorkflowTemplate,
+} from "./expressions";
+
+export function executeLogicVisualWorkflowNode(input: {
+  node: CanonicalVisualWorkflowNode;
+  context: VisualWorkflowExecutionContext;
+}): VisualWorkflowNodeExecutionResult {
+  const { node, context } = input;
+
+  switch (node.config.kind) {
+    case "trigger.manual":
+    case "trigger.scheduled":
+    case "trigger.github":
+    case "trigger.source_upload":
+      return {
+        ok: true,
+        output: {
+          ...context.trigger,
+        },
+      };
+    case "logic.if": {
+      const resolvedCondition = resolveVisualWorkflowTemplate(node.config.condition, context);
+      const branchResult = evaluateVisualWorkflowCondition(node.config.condition, context);
+      return {
+        ok: true,
+        output: {
+          condition: resolvedCondition,
+          result: branchResult,
+        },
+        branchResult,
+      };
+    }
+    case "logic.switch": {
+      const expressionValue = resolveVisualWorkflowTemplate(node.config.expression, context).trim();
+      let matchedCase = "default";
+
+      for (let index = 0; index < node.config.cases.length; index += 1) {
+        const caseValue = resolveVisualWorkflowTemplate(
+          node.config.cases[index]?.value ?? "",
+          context,
+        ).trim();
+        if (caseValue.length > 0 && expressionValue === caseValue) {
+          matchedCase = String(index);
+          break;
+        }
+      }
+
+      return {
+        ok: true,
+        output: {
+          expression: expressionValue,
+          matchedCase,
+        },
+        switchCase: matchedCase,
+      };
+    }
+    case "logic.set": {
+      const output: Record<string, unknown> = {};
+      for (const assignment of node.config.assignments) {
+        const key = assignment.key.trim();
+        if (!key) {
+          continue;
+        }
+        const resolved = resolveVisualWorkflowTemplate(assignment.value, context);
+        output[key] = coerceSetValue(resolved);
+      }
+
+      return {
+        ok: true,
+        output,
+      };
+    }
+    case "logic.for_each": {
+      const items = resolveVisualWorkflowCollection(node.config.collection, context);
+      return {
+        ok: true,
+        output: {
+          items,
+          count: items.length,
+        },
+      };
+    }
+    default:
+      return {
+        ok: false,
+        error: {
+          code: "not_logic_node",
+          message: "Node is not handled by the logic executor.",
+        },
+      };
+  }
+}
+
+function coerceSetValue(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed === "true") {
+    return true;
+  }
+  if (trimmed === "false") {
+    return false;
+  }
+  if (trimmed === "null") {
+    return null;
+  }
+  const asNumber = Number(trimmed);
+  if (Number.isFinite(asNumber) && trimmed === String(asNumber)) {
+    return asNumber;
+  }
+  if (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execute-node.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execute-node.ts
@@ -18,22 +18,18 @@ import { readBoundedResponseBody, withPublicHttpFetch } from "@/lib/security/pub
 
 import type { CanonicalVisualWorkflowNode } from "../schema/types";
 import type { VisualWorkflowExecutionContext } from "./context";
+import { executeLogicVisualWorkflowNode } from "./execute-logic-node";
+import type { VisualWorkflowNodeExecutionResult } from "./execution-result";
+import { resolveVisualWorkflowTemplate } from "./expressions";
 import {
-  evaluateVisualWorkflowCondition,
-  resolveVisualWorkflowCollection,
-  resolveVisualWorkflowTemplate,
-} from "./expressions";
+  appendQueryParams,
+  buildHttpRequestHeaders,
+  parseHttpResponseBody,
+  resolveHttpRequestBody,
+  resolveKeyValuePairs,
+} from "./http-request";
 
-export type VisualWorkflowNodeExecutionResult =
-  | {
-      ok: true;
-      output: Record<string, unknown>;
-      branchResult?: boolean;
-    }
-  | {
-      ok: false;
-      error: { message: string; code?: string };
-    };
+export type { VisualWorkflowNodeExecutionResult } from "./execution-result";
 
 const MAX_HTTP_BODY_CHARS = 8_000;
 
@@ -43,41 +39,69 @@ export async function executeVisualWorkflowNode(input: {
   organizationId: string;
 }): Promise<VisualWorkflowNodeExecutionResult> {
   const { node, context } = input;
+  const logicResult = executeLogicVisualWorkflowNode({ node, context });
+  if (logicResult.ok || logicResult.error.code !== "not_logic_node") {
+    return logicResult;
+  }
 
   switch (node.config.kind) {
-    case "trigger.manual":
-    case "trigger.scheduled":
-    case "trigger.github":
-    case "trigger.source_upload":
-      return {
-        ok: true,
-        output: {
-          ...context.trigger,
-        },
-      };
     case "action.http": {
-      const url = resolveVisualWorkflowTemplate(node.config.url, context).trim();
+      const httpConfig = node.config;
+      const url = resolveVisualWorkflowTemplate(httpConfig.url, context).trim();
       if (!url) {
         return { ok: false, error: { code: "missing_url", message: "HTTP URL is required." } };
       }
 
+      const queryParams = resolveKeyValuePairs(httpConfig.queryParams, context);
+      const resolvedUrl = appendQueryParams(url, queryParams);
+      const bodyType = httpConfig.bodyType ?? "none";
+      const requestBody = resolveHttpRequestBody({
+        body: httpConfig.body,
+        bodyType,
+        context,
+        method: httpConfig.method,
+      });
+      const headers = buildHttpRequestHeaders({
+        headers: resolveKeyValuePairs(httpConfig.headers, context),
+        auth: httpConfig.auth
+          ? {
+              type: httpConfig.auth.type,
+              token: httpConfig.auth.token
+                ? resolveVisualWorkflowTemplate(httpConfig.auth.token, context)
+                : undefined,
+              headerName: httpConfig.auth.headerName,
+            }
+          : undefined,
+        bodyType,
+        hasBody: Boolean(requestBody),
+      });
+      const parseJsonBody = httpConfig.parseJsonBody ?? true;
+
       try {
         const result = await withPublicHttpFetch(
-          url,
-          { method: node.config.method, redirect: "manual" },
+          resolvedUrl,
+          {
+            method: httpConfig.method,
+            redirect: "manual",
+            headers,
+            body: requestBody,
+          },
           async (response) => {
             const bodyBytes = await readBoundedResponseBody(response);
             const bodyText = new TextDecoder().decode(bodyBytes).slice(0, MAX_HTTP_BODY_CHARS);
+            const json = parseHttpResponseBody(bodyText, parseJsonBody);
             return {
               status: response.status,
               statusText: response.statusText,
               ok: response.ok,
               body: bodyText,
+              json,
             };
           },
         );
 
-        if (!result.ok) {
+        const failOnHttpError = httpConfig.failOnHttpError ?? true;
+        if (failOnHttpError && !result.ok) {
           return {
             ok: false,
             error: {
@@ -138,18 +162,6 @@ export async function executeVisualWorkflowNode(input: {
         },
       };
     }
-    case "logic.if": {
-      const resolvedCondition = resolveVisualWorkflowTemplate(node.config.condition, context);
-      const branchResult = evaluateVisualWorkflowCondition(node.config.condition, context);
-      return {
-        ok: true,
-        output: {
-          condition: resolvedCondition,
-          result: branchResult,
-        },
-        branchResult,
-      };
-    }
     case "ai.agent": {
       const prompt = resolveVisualWorkflowTemplate(node.config.prompt, context).trim();
       if (!prompt) {
@@ -179,16 +191,6 @@ export async function executeVisualWorkflowNode(input: {
           },
         };
       }
-    }
-    case "logic.for_each": {
-      const items = resolveVisualWorkflowCollection(node.config.collection, context);
-      return {
-        ok: true,
-        output: {
-          items,
-          count: items.length,
-        },
-      };
     }
     default:
       return {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execution-result.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execution-result.ts
@@ -10,5 +10,14 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-export { visualWorkflowDemoDraft } from "@/lib/visual-workflows/fixtures/demo-draft";
-export { visualWorkflowPlaygroundDraft } from "@/lib/visual-workflows/fixtures/playground-draft";
+export type VisualWorkflowNodeExecutionResult =
+  | {
+      ok: true;
+      output: Record<string, unknown>;
+      branchResult?: boolean;
+      switchCase?: string;
+    }
+  | {
+      ok: false;
+      error: { message: string; code?: string };
+    };

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/graph-index.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/graph-index.ts
@@ -61,16 +61,32 @@ export function buildVisualWorkflowGraphIndex(
 export function selectNextEdges(input: {
   nodeType: VisualCatalogType;
   branchResult: boolean | null;
+  switchCase: string | null;
+  useErrorBranch: boolean;
   outgoing: readonly CanonicalVisualWorkflowEdge[];
 }): CanonicalVisualWorkflowEdge[] {
+  if (input.useErrorBranch) {
+    return input.outgoing.filter((edge) => edge.sourceHandle === "error");
+  }
+
   if (input.nodeType === "logic.if") {
     const handle = input.branchResult ? "true" : "false";
     return input.outgoing.filter((edge) => edge.sourceHandle === handle);
   }
 
-  if (input.outgoing.length <= 1) {
-    return [...input.outgoing];
+  if (input.nodeType === "logic.switch") {
+    const handle = input.switchCase ?? "default";
+    const matched = input.outgoing.filter((edge) => edge.sourceHandle === handle);
+    if (matched.length > 0) {
+      return matched;
+    }
+    return input.outgoing.filter((edge) => edge.sourceHandle === "default");
   }
 
-  return [...input.outgoing].toSorted((left, right) => left.target.localeCompare(right.target));
+  const successEdges = input.outgoing.filter((edge) => edge.sourceHandle !== "error");
+  if (successEdges.length <= 1) {
+    return [...successEdges];
+  }
+
+  return [...successEdges].toSorted((left, right) => left.target.localeCompare(right.target));
 }

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/http-request.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/http-request.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { VisualKeyValuePair } from "../schema/types";
+import type { VisualWorkflowExecutionContext } from "./context";
+import { resolveVisualWorkflowTemplate } from "./expressions";
+
+export function resolveKeyValuePairs(
+  pairs: readonly VisualKeyValuePair[] | undefined,
+  context: VisualWorkflowExecutionContext,
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  for (const pair of pairs ?? []) {
+    const key = pair.key.trim();
+    if (!key) {
+      continue;
+    }
+    resolved[key] = resolveVisualWorkflowTemplate(pair.value, context);
+  }
+  return resolved;
+}
+
+export function appendQueryParams(url: string, queryParams: Record<string, string>): string {
+  const entries = Object.entries(queryParams).filter(([, value]) => value.length > 0);
+  if (entries.length === 0) {
+    return url;
+  }
+
+  const parsed = new URL(url);
+  for (const [key, value] of entries) {
+    parsed.searchParams.set(key, value);
+  }
+  return parsed.toString();
+}
+
+export function buildHttpRequestHeaders(input: {
+  headers: Record<string, string>;
+  auth?: {
+    type: "none" | "bearer" | "api_key";
+    token?: string;
+    headerName?: string;
+  };
+  bodyType?: "none" | "json" | "text";
+  hasBody: boolean;
+}): Record<string, string> {
+  const result = { ...input.headers };
+
+  if (input.auth?.type === "bearer" && input.auth.token?.trim()) {
+    result.Authorization = `Bearer ${input.auth.token.trim()}`;
+  }
+  if (input.auth?.type === "api_key" && input.auth.token?.trim()) {
+    const headerName = input.auth.headerName?.trim() || "X-API-Key";
+    result[headerName] = input.auth.token.trim();
+  }
+
+  if (input.hasBody && input.bodyType === "json" && !result["Content-Type"]) {
+    result["Content-Type"] = "application/json";
+  }
+  if (input.hasBody && input.bodyType === "text" && !result["Content-Type"]) {
+    result["Content-Type"] = "text/plain";
+  }
+
+  return result;
+}
+
+export function resolveHttpRequestBody(input: {
+  body?: string;
+  bodyType?: "none" | "json" | "text";
+  context: VisualWorkflowExecutionContext;
+  method: string;
+}): string | undefined {
+  if (input.method === "GET" || input.method === "DELETE") {
+    return undefined;
+  }
+  if (input.bodyType === "none" || !input.body?.trim()) {
+    return undefined;
+  }
+  return resolveVisualWorkflowTemplate(input.body, input.context);
+}
+
+export function parseHttpResponseBody(bodyText: string, parseJsonBody: boolean): unknown {
+  if (!parseJsonBody || !bodyText.trim()) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(bodyText) as unknown;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter-server.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter-server.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { executeVisualWorkflowNode } from "./execute-node";
+import {
+  getVisualWorkflowGraphIndex,
+  runVisualWorkflowInterpreter as runVisualWorkflowInterpreterCore,
+  type VisualWorkflowGraphIndex,
+  type VisualWorkflowInterpreterExecuteNode,
+  type VisualWorkflowInterpreterNodeUpdate,
+  type VisualWorkflowInterpreterResult,
+} from "./interpreter";
+import type { VisualWorkflowDefinition } from "../schema/types";
+
+export type {
+  VisualWorkflowGraphIndex,
+  VisualWorkflowInterpreterExecuteNode,
+  VisualWorkflowInterpreterNodeUpdate,
+  VisualWorkflowInterpreterResult,
+};
+
+export { getVisualWorkflowGraphIndex };
+
+export async function runVisualWorkflowInterpreter(input: {
+  definition: VisualWorkflowDefinition;
+  organizationId: string;
+  triggerInput?: Record<string, unknown>;
+  executeNode?: VisualWorkflowInterpreterExecuteNode;
+  onNodeUpdate?: (update: VisualWorkflowInterpreterNodeUpdate) => Promise<void> | void;
+}): Promise<VisualWorkflowInterpreterResult> {
+  return runVisualWorkflowInterpreterCore({
+    ...input,
+    executeNode: input.executeNode ?? executeVisualWorkflowNode,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter.ts
@@ -11,19 +11,21 @@
  * Version 2.0 or later.
  */
 import type { CanonicalVisualWorkflowEdge } from "../schema/types";
-import type { VisualWorkflowDefinition } from "../schema/types";
+import type { CanonicalVisualWorkflowNode, VisualWorkflowDefinition } from "../schema/types";
 import {
   createVisualWorkflowExecutionContext,
   setNodeOutput,
   type VisualWorkflowExecutionContext,
 } from "./context";
 import { executeVisualWorkflowNode } from "./execute-node";
+import type { VisualWorkflowNodeExecutionResult } from "./execution-result";
 import {
   buildVisualWorkflowGraphIndex,
   selectNextEdges,
   type VisualWorkflowGraphIndex,
 } from "./graph-index";
 import { findForEachLoopRegion, incomingEdgesForNode, sortLoopBodyNodes } from "./loop-region";
+import { resolveNodeErrorBehavior } from "./node-options";
 
 export type VisualWorkflowInterpreterNodeUpdate = {
   nodeId: string;
@@ -117,8 +119,93 @@ function releaseSkippedOutgoingEdge(input: {
 }
 
 type RunNodeResult =
-  | { ok: true; branchResult?: boolean; nodeType: string; executedNodeIds?: string[] }
+  | {
+      ok: true;
+      branchResult?: boolean;
+      switchCase?: string;
+      useErrorBranch?: boolean;
+      nodeType: string;
+      executedNodeIds?: string[];
+    }
   | { ok: false; error: Record<string, unknown> };
+
+function releaseBranchingOutgoingEdges(input: {
+  node: { type: string };
+  outgoing: readonly CanonicalVisualWorkflowEdge[];
+  nextEdges: readonly CanonicalVisualWorkflowEdge[];
+  graph: VisualWorkflowGraphIndex;
+  completed: Set<string>;
+  skipped: Set<string>;
+  pendingIncoming: Map<string, number>;
+  queue: string[];
+  scope?: Set<string>;
+}) {
+  if (input.node.type !== "logic.if" && input.node.type !== "logic.switch") {
+    return;
+  }
+
+  const selectedEdgeIds = new Set(input.nextEdges.map((edge) => edge.id));
+  for (const edge of input.outgoing) {
+    if (selectedEdgeIds.has(edge.id)) {
+      continue;
+    }
+    if (input.scope && !input.scope.has(edge.target)) {
+      continue;
+    }
+
+    releaseSkippedOutgoingEdge({
+      edge,
+      graph: input.graph,
+      completed: input.completed,
+      skipped: input.skipped,
+      pendingIncoming: input.pendingIncoming,
+      queue: input.queue,
+    });
+  }
+}
+
+function releaseNodeOutgoingEdges(input: {
+  node: { id: string; type: string };
+  execution: Extract<RunNodeResult, { ok: true }>;
+  graph: VisualWorkflowGraphIndex;
+  pendingIncoming: Map<string, number>;
+  queue: string[];
+  completed: Set<string>;
+  skipped: Set<string>;
+  scope?: Set<string>;
+}) {
+  const outgoing = input.graph.outgoingByNodeId.get(input.node.id) ?? [];
+  const nextEdges = selectNextEdges({
+    nodeType: input.node.type as import("../schema/types").VisualCatalogType,
+    branchResult: input.execution.branchResult ?? null,
+    switchCase: input.execution.switchCase ?? null,
+    useErrorBranch: input.execution.useErrorBranch ?? false,
+    outgoing,
+  });
+
+  for (const edge of nextEdges) {
+    if (input.scope && !input.scope.has(edge.target)) {
+      continue;
+    }
+    releasePredecessorEdge({
+      pendingIncoming: input.pendingIncoming,
+      queue: input.queue,
+      targetNodeId: edge.target,
+    });
+  }
+
+  releaseBranchingOutgoingEdges({
+    node: input.node,
+    outgoing,
+    nextEdges,
+    graph: input.graph,
+    completed: input.completed,
+    skipped: input.skipped,
+    pendingIncoming: input.pendingIncoming,
+    queue: input.queue,
+    scope: input.scope,
+  });
+}
 
 function clearLoopBodyState(input: {
   context: VisualWorkflowExecutionContext;
@@ -175,41 +262,16 @@ async function runScopedSubgraph(input: {
       continue;
     }
 
-    const outgoing = input.graph.outgoingByNodeId.get(nodeId) ?? [];
-    const nextEdges = selectNextEdges({
-      nodeType: node.type,
-      branchResult: execution.branchResult ?? null,
-      outgoing,
+    releaseNodeOutgoingEdges({
+      node,
+      execution,
+      graph: input.graph,
+      pendingIncoming,
+      queue,
+      completed,
+      skipped,
+      scope,
     });
-    const selectedEdgeIds = new Set(nextEdges.map((edge) => edge.id));
-
-    for (const edge of nextEdges) {
-      if (!scope.has(edge.target)) {
-        continue;
-      }
-      releasePredecessorEdge({
-        pendingIncoming,
-        queue,
-        targetNodeId: edge.target,
-      });
-    }
-
-    if (node.type === "logic.if") {
-      for (const edge of outgoing) {
-        if (selectedEdgeIds.has(edge.id) || !scope.has(edge.target)) {
-          continue;
-        }
-
-        releaseSkippedOutgoingEdge({
-          edge,
-          graph: input.graph,
-          completed,
-          skipped,
-          pendingIncoming,
-          queue,
-        });
-      }
-    }
   }
 
   return { ok: true, lastCompletedNodeId };
@@ -306,6 +368,11 @@ export async function runVisualWorkflowInterpreter(input: {
   definition: VisualWorkflowDefinition;
   organizationId: string;
   triggerInput?: Record<string, unknown>;
+  executeNode?: (args: {
+    node: CanonicalVisualWorkflowNode;
+    context: VisualWorkflowExecutionContext;
+    organizationId: string;
+  }) => Promise<VisualWorkflowNodeExecutionResult>;
   onNodeUpdate?: (update: VisualWorkflowInterpreterNodeUpdate) => Promise<void> | void;
 }): Promise<VisualWorkflowInterpreterResult> {
   const graph = buildVisualWorkflowGraphIndex(input.definition);
@@ -325,6 +392,7 @@ export async function runVisualWorkflowInterpreter(input: {
   const skipped = new Set<string>();
   const pendingIncoming = new Map(graph.incomingCountByNodeId);
   const queue = [graph.triggerNodeId];
+  const executeNodeFn = input.executeNode ?? executeVisualWorkflowNode;
 
   const runNode = async (nodeId: string): Promise<RunNodeResult> => {
     const node = graph.nodesById.get(nodeId);
@@ -341,13 +409,40 @@ export async function runVisualWorkflowInterpreter(input: {
       },
     });
 
-    const execution = await executeVisualWorkflowNode({
+    const execution = await executeNodeFn({
       node,
       context,
       organizationId: input.organizationId,
     });
 
     if (!execution.ok) {
+      const errorBehavior = resolveNodeErrorBehavior(node.config);
+      if (errorBehavior === "continue") {
+        const errorOutput = { failed: true, error: execution.error };
+        setNodeOutput(context, nodeId, errorOutput);
+        nodeResults[nodeId] = errorOutput;
+        await input.onNodeUpdate?.({
+          nodeId,
+          nodeType: node.type,
+          status: "succeeded",
+          outputSnapshot: errorOutput,
+        });
+        return { ok: true, nodeType: node.type };
+      }
+      if (errorBehavior === "branch") {
+        const errorOutput = { failed: true, error: execution.error };
+        setNodeOutput(context, nodeId, errorOutput);
+        nodeResults[nodeId] = errorOutput;
+        await input.onNodeUpdate?.({
+          nodeId,
+          nodeType: node.type,
+          status: "failed",
+          error: execution.error,
+          outputSnapshot: errorOutput,
+        });
+        return { ok: true, nodeType: node.type, useErrorBranch: true };
+      }
+
       await input.onNodeUpdate?.({
         nodeId,
         nodeType: node.type,
@@ -367,7 +462,12 @@ export async function runVisualWorkflowInterpreter(input: {
       outputSnapshot: execution.output,
     });
 
-    return { ok: true, branchResult: execution.branchResult, nodeType: node.type };
+    return {
+      ok: true,
+      branchResult: execution.branchResult,
+      switchCase: execution.switchCase,
+      nodeType: node.type,
+    };
   };
 
   const forEachContext: ForEachExecutionContext = {
@@ -438,38 +538,15 @@ export async function runVisualWorkflowInterpreter(input: {
       };
     }
 
-    const outgoing = graph.outgoingByNodeId.get(nodeId) ?? [];
-    const nextEdges = selectNextEdges({
-      nodeType: node.type,
-      branchResult: execution.branchResult ?? null,
-      outgoing,
+    releaseNodeOutgoingEdges({
+      node,
+      execution,
+      graph,
+      pendingIncoming,
+      queue,
+      completed,
+      skipped,
     });
-    const selectedEdgeIds = new Set(nextEdges.map((edge) => edge.id));
-
-    for (const edge of nextEdges) {
-      releasePredecessorEdge({
-        pendingIncoming,
-        queue,
-        targetNodeId: edge.target,
-      });
-    }
-
-    if (node.type === "logic.if") {
-      for (const edge of outgoing) {
-        if (selectedEdgeIds.has(edge.id)) {
-          continue;
-        }
-
-        releaseSkippedOutgoingEdge({
-          edge,
-          graph,
-          completed,
-          skipped,
-          pendingIncoming,
-          queue,
-        });
-      }
-    }
   }
 
   return {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter.ts
@@ -17,7 +17,6 @@ import {
   setNodeOutput,
   type VisualWorkflowExecutionContext,
 } from "./context";
-import { executeVisualWorkflowNode } from "./execute-node";
 import type { VisualWorkflowNodeExecutionResult } from "./execution-result";
 import {
   buildVisualWorkflowGraphIndex,
@@ -364,15 +363,17 @@ async function executeForEachLoop(
   };
 }
 
+export type VisualWorkflowInterpreterExecuteNode = (args: {
+  node: CanonicalVisualWorkflowNode;
+  context: VisualWorkflowExecutionContext;
+  organizationId: string;
+}) => Promise<VisualWorkflowNodeExecutionResult>;
+
 export async function runVisualWorkflowInterpreter(input: {
   definition: VisualWorkflowDefinition;
   organizationId: string;
   triggerInput?: Record<string, unknown>;
-  executeNode?: (args: {
-    node: CanonicalVisualWorkflowNode;
-    context: VisualWorkflowExecutionContext;
-    organizationId: string;
-  }) => Promise<VisualWorkflowNodeExecutionResult>;
+  executeNode: VisualWorkflowInterpreterExecuteNode;
   onNodeUpdate?: (update: VisualWorkflowInterpreterNodeUpdate) => Promise<void> | void;
 }): Promise<VisualWorkflowInterpreterResult> {
   const graph = buildVisualWorkflowGraphIndex(input.definition);
@@ -392,7 +393,7 @@ export async function runVisualWorkflowInterpreter(input: {
   const skipped = new Set<string>();
   const pendingIncoming = new Map(graph.incomingCountByNodeId);
   const queue = [graph.triggerNodeId];
-  const executeNodeFn = input.executeNode ?? executeVisualWorkflowNode;
+  const executeNodeFn = input.executeNode;
 
   const runNode = async (nodeId: string): Promise<RunNodeResult> => {
     const node = graph.nodesById.get(nodeId);

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/node-options.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/node-options.ts
@@ -10,5 +10,15 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-export { visualWorkflowDemoDraft } from "@/lib/visual-workflows/fixtures/demo-draft";
-export { visualWorkflowPlaygroundDraft } from "@/lib/visual-workflows/fixtures/playground-draft";
+import type { VisualNodeConfig, VisualNodeErrorBehavior } from "../schema/types";
+
+export function resolveNodeErrorBehavior(config: VisualNodeConfig): VisualNodeErrorBehavior {
+  if ("onError" in config && config.onError) {
+    return config.onError;
+  }
+  return "stop";
+}
+
+export function nodeSupportsErrorBranch(config: VisualNodeConfig): boolean {
+  return resolveNodeErrorBehavior(config) === "branch";
+}

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/runtime.test.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/runtime.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { createDefaultConfig } from "../catalog/node-catalog";
 import { createVisualWorkflowExecutionContext } from "./context";
 import { evaluateVisualWorkflowCondition, resolveVisualWorkflowTemplate } from "./expressions";
-import { runVisualWorkflowInterpreter } from "./interpreter";
+import { runVisualWorkflowInterpreter } from "./interpreter-server";
 import type { VisualWorkflowDefinition } from "../schema/types";
 
 describe("visual workflow expressions", () => {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/runtime.test.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/runtime.test.ts
@@ -89,13 +89,76 @@ describe("visual workflow node execution edges", () => {
       node: {
         id: "http",
         type: "action.http",
-        config: { kind: "action.http", method: "GET", url: "   " },
+        config: {
+          kind: "action.http",
+          method: "GET",
+          url: "   ",
+          onError: "stop",
+        },
       },
     });
 
     expect(result).toEqual({
       ok: false,
       error: { code: "missing_url", message: "HTTP URL is required." },
+    });
+  });
+
+  it("assigns fields in logic.set nodes", async () => {
+    const { executeVisualWorkflowNode } = await import("./execute-node");
+    const context = createVisualWorkflowExecutionContext({
+      triggerInput: { name: "Ada" },
+    });
+    const result = await executeVisualWorkflowNode({
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      context,
+      node: {
+        id: "set",
+        type: "logic.set",
+        config: {
+          kind: "logic.set",
+          assignments: [
+            { key: "greeting", value: "Hello {{trigger.name}}" },
+            { key: "count", value: "3" },
+          ],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        greeting: "Hello Ada",
+        count: 3,
+      },
+    });
+  });
+
+  it("routes switch nodes to the matching case", async () => {
+    const { executeVisualWorkflowNode } = await import("./execute-node");
+    const context = createVisualWorkflowExecutionContext({ triggerInput: {} });
+    context.nodes.http = { json: { status: "ready" } };
+    const result = await executeVisualWorkflowNode({
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      context,
+      node: {
+        id: "switch",
+        type: "logic.switch",
+        config: {
+          kind: "logic.switch",
+          expression: "{{nodes.http.json.status}}",
+          cases: [{ value: "pending" }, { value: "ready" }],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        expression: "ready",
+        matchedCase: "1",
+      },
+      switchCase: "1",
     });
   });
 });
@@ -382,6 +445,89 @@ describe("visual workflow interpreter", () => {
 
     expect(result.ok).toBe(true);
     expect(started.filter((nodeId) => nodeId === "join")).toHaveLength(1);
+  });
+
+  it("continues after a failed node when onError is continue", async () => {
+    const definition: VisualWorkflowDefinition = {
+      schemaVersion: 1,
+      name: "Continue on error",
+      nodes: [
+        { id: "t", type: "trigger.manual", config: createDefaultConfig("trigger.manual") },
+        {
+          id: "http",
+          type: "action.http",
+          config: {
+            kind: "action.http",
+            method: "GET",
+            url: "",
+            onError: "continue",
+          },
+        },
+        { id: "after", type: "logic.if", config: { kind: "logic.if", condition: "true" } },
+      ],
+      edges: [
+        { id: "e1", source: "t", target: "http", sourceHandle: null, targetHandle: null },
+        { id: "e2", source: "http", target: "after", sourceHandle: null, targetHandle: null },
+      ],
+      editor: { positions: {} },
+    };
+
+    const started: string[] = [];
+    const result = await runVisualWorkflowInterpreter({
+      definition,
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      onNodeUpdate: async (update) => {
+        if (update.status === "running") {
+          started.push(update.nodeId);
+        }
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(started).toContain("after");
+  });
+
+  it("follows error branches when onError is branch", async () => {
+    const definition: VisualWorkflowDefinition = {
+      schemaVersion: 1,
+      name: "Error branch",
+      nodes: [
+        { id: "t", type: "trigger.manual", config: createDefaultConfig("trigger.manual") },
+        {
+          id: "http",
+          type: "action.http",
+          config: {
+            kind: "action.http",
+            method: "GET",
+            url: "",
+            onError: "branch",
+          },
+        },
+        { id: "success", type: "logic.if", config: { kind: "logic.if", condition: "true" } },
+        { id: "error", type: "logic.if", config: { kind: "logic.if", condition: "true" } },
+      ],
+      edges: [
+        { id: "e1", source: "t", target: "http", sourceHandle: null, targetHandle: null },
+        { id: "e2", source: "http", target: "success", sourceHandle: null, targetHandle: null },
+        { id: "e3", source: "http", target: "error", sourceHandle: "error", targetHandle: null },
+      ],
+      editor: { positions: {} },
+    };
+
+    const started: string[] = [];
+    const result = await runVisualWorkflowInterpreter({
+      definition,
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      onNodeUpdate: async (update) => {
+        if (update.status === "running") {
+          started.push(update.nodeId);
+        }
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(started).toContain("error");
+    expect(started).not.toContain("success");
   });
 
   it("runs nested for-each loops for every outer and inner item", async () => {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/definition-schema.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/definition-schema.ts
@@ -16,6 +16,19 @@ import { VISUAL_WORKFLOW_SCHEMA_VERSION } from "./types";
 
 const httpMethodSchema = z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]);
 
+const visualKeyValuePairSchema = z.object({
+  key: z.string().max(256),
+  value: z.string().max(4000),
+});
+
+const visualNodeErrorBehaviorSchema = z.enum(["stop", "continue", "branch"]);
+
+const httpAuthSchema = z.object({
+  type: z.enum(["none", "bearer", "api_key"]),
+  token: z.string().max(4000).optional(),
+  headerName: z.string().trim().min(1).max(128).optional(),
+});
+
 const visualWorkflowScheduleSchema = z.object({
   cadence: z.enum(["hourly", "daily", "weekly"]),
   hourUtc: z.number().int().min(0).max(23).optional(),
@@ -38,6 +51,8 @@ const visualCatalogTypeSchema = z.enum([
   "action.http",
   "action.notify_slack",
   "logic.if",
+  "logic.switch",
+  "logic.set",
   "ai.agent",
   "logic.for_each",
 ]);
@@ -66,19 +81,41 @@ const visualNodeConfigSchema = z.discriminatedUnion("kind", [
     kind: z.literal("action.http"),
     method: httpMethodSchema,
     url: z.string().max(2048),
+    headers: z.array(visualKeyValuePairSchema).max(32).optional(),
+    queryParams: z.array(visualKeyValuePairSchema).max(32).optional(),
+    body: z.string().max(100_000).optional(),
+    bodyType: z.enum(["none", "json", "text"]).optional(),
+    auth: httpAuthSchema.optional(),
+    parseJsonBody: z.boolean().optional(),
+    failOnHttpError: z.boolean().optional(),
+    onError: visualNodeErrorBehaviorSchema.optional(),
   }),
   z.object({
     kind: z.literal("action.notify_slack"),
     channelId: z.string().trim().min(1).max(64),
     message: z.string().max(4000),
+    onError: visualNodeErrorBehaviorSchema.optional(),
   }),
   z.object({
     kind: z.literal("logic.if"),
     condition: z.string().max(2000),
   }),
   z.object({
+    kind: z.literal("logic.switch"),
+    expression: z.string().max(2000),
+    cases: z
+      .array(z.object({ value: z.string().max(2000) }))
+      .min(1)
+      .max(12),
+  }),
+  z.object({
+    kind: z.literal("logic.set"),
+    assignments: z.array(visualKeyValuePairSchema).max(32),
+  }),
+  z.object({
     kind: z.literal("ai.agent"),
     prompt: z.string().max(20_000),
+    onError: visualNodeErrorBehaviorSchema.optional(),
   }),
   z.object({
     kind: z.literal("logic.for_each"),

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/serializers.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/serializers.ts
@@ -28,6 +28,8 @@ const ENABLED_TYPES = new Set<VisualCatalogType>([
   "action.http",
   "action.notify_slack",
   "logic.if",
+  "logic.switch",
+  "logic.set",
   "ai.agent",
   "logic.for_each",
 ]);
@@ -89,11 +91,9 @@ export function fromVisualWorkflowDefinition(
     id: edge.id,
     source: edge.source,
     target: edge.target,
-    sourceHandle:
-      edge.sourceHandle === "true" || edge.sourceHandle === "false" ? edge.sourceHandle : null,
-    targetHandle: null,
-    label:
-      edge.sourceHandle === "true" || edge.sourceHandle === "false" ? edge.sourceHandle : undefined,
+    sourceHandle: edge.sourceHandle,
+    targetHandle: edge.targetHandle,
+    label: edge.sourceHandle ?? undefined,
   }));
 
   return {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/types.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/types.ts
@@ -22,12 +22,25 @@ export type VisualCatalogType =
   | "action.http"
   | "action.notify_slack"
   | "logic.if"
+  | "logic.switch"
+  | "logic.set"
   | "ai.agent"
   | "logic.for_each";
 
 export type VisualCatalogCategory = "trigger" | "action" | "logic" | "ai" | "flow";
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export type HttpBodyType = "none" | "json" | "text";
+
+export type HttpAuthType = "none" | "bearer" | "api_key";
+
+export type VisualNodeErrorBehavior = "stop" | "continue" | "branch";
+
+export type VisualKeyValuePair = {
+  key: string;
+  value: string;
+};
 
 export type VisualWorkflowScheduleCadence = "hourly" | "daily" | "weekly";
 
@@ -52,16 +65,48 @@ export type VisualNodeConfig =
       events?: VisualWorkflowGithubTriggerEvent[];
     }
   | { kind: "trigger.source_upload"; projectId?: string }
-  | { kind: "action.http"; method: HttpMethod; url: string }
-  | { kind: "action.notify_slack"; channelId: string; message: string }
+  | {
+      kind: "action.http";
+      method: HttpMethod;
+      url: string;
+      headers?: VisualKeyValuePair[];
+      queryParams?: VisualKeyValuePair[];
+      body?: string;
+      bodyType?: HttpBodyType;
+      auth?: {
+        type: HttpAuthType;
+        token?: string;
+        headerName?: string;
+      };
+      parseJsonBody?: boolean;
+      failOnHttpError?: boolean;
+      onError?: VisualNodeErrorBehavior;
+    }
+  | {
+      kind: "action.notify_slack";
+      channelId: string;
+      message: string;
+      onError?: VisualNodeErrorBehavior;
+    }
   | { kind: "logic.if"; condition: string }
-  | { kind: "ai.agent"; prompt: string }
+  | {
+      kind: "logic.switch";
+      expression: string;
+      cases: { value: string }[];
+    }
+  | {
+      kind: "logic.set";
+      assignments: VisualKeyValuePair[];
+    }
+  | { kind: "ai.agent"; prompt: string; onError?: VisualNodeErrorBehavior }
   | { kind: "logic.for_each"; collection: string };
 
 export type VisualWorkflowNodeData = {
   catalogType: VisualCatalogType;
   config: VisualNodeConfig;
   runStatus: MockNodeRunStatus;
+  lastOutput?: Record<string, unknown> | null;
+  lastError?: Record<string, unknown> | null;
 };
 
 export type VisualWorkflowRfNode = Node<VisualWorkflowNodeData, VisualCatalogType>;

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow-runs.ts
@@ -766,7 +766,7 @@ export async function executeVisualWorkflowRun(input: {
     });
   }
 
-  const { runVisualWorkflowInterpreter } = await import("./runtime/interpreter");
+  const { runVisualWorkflowInterpreter } = await import("./runtime/interpreter-server");
   const result = await runVisualWorkflowInterpreter({
     definition,
     organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow.test.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow.test.ts
@@ -57,7 +57,7 @@ describe("toVisualWorkflowDefinition", () => {
       {
         id: "b",
         type: "action.http",
-        config: { kind: "action.http", method: "GET", url: "" },
+        config: createDefaultConfig("action.http"),
       },
     ]);
     expect(draft.edges).toEqual([


### PR DESCRIPTION
## What changed
Expands visual workflows with Phase A capabilities and turns the Storybook story into an interactive playground.
- **Rich HTTP node**: headers, query params, body, auth, JSON parsing, fail-on-error toggle
- **New logic nodes**: `Switch` (multi-branch) and `Set fields` (assign values)
- **Error handling**: per-node `onError` with stop, continue, or error-branch routing
- **Trigger config UI**: GitHub events, schedule hour/day/timezone pickers
- **Inline output**: node output previews on canvas and in the config panel after test runs
- **Storybook playground**: renamed to `App/Automations/Visual Workflow` with a `Playground` story that runs the client-side interpreter (logic for real, actions simulated)
## How to test
- `cd apps/hyperlocalise-web && vp test src/lib/visual-workflows`
- `cd apps/hyperlocalise-web && vp check --fix`
- Open Storybook → **App/Automations/Visual Workflow → Playground**
  - Add nodes from the picker, connect them, configure steps
  - Click **Test workflow** and verify branching plus per-node outputs
## Checklist
- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review