### PR TITLE
feat(mcp): add list_jobs tool for recent translation jobs

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-jobs.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-jobs.test.ts
@@ -1,0 +1,534 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { generateMcpToken, hashMcpToken } from "@/api/auth/mcp";
+import { createMcpTestApp } from "@/api/routes/mcp/mcp.fixture";
+import { COMPACT_JOB_LAST_ERROR_MAX_LENGTH } from "@/api/routes/public-jobs/public-jobs.read";
+import {
+  insertCompletedPublicFileJob,
+  insertPublicTranslationJob,
+  insertRepositoryPublicFileJob,
+} from "@/api/routes/public-jobs/public-jobs.fixture";
+import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
+import { db, schema } from "@/lib/database/client";
+import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/test-project-identifier";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const mcpApp = createMcpTestApp();
+const fixture = createProjectTestFixture();
+
+type CompactMcpJob = {
+  id: string;
+  projectId: string | null;
+  type: string | null;
+  status: string;
+  createdAt: string;
+  completedAt: string | null;
+  lastError: string | null;
+};
+
+type McpListJobsOutput = {
+  error?: string;
+  total?: number;
+  pagination?: {
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+    nextOffset: number | null;
+  };
+  jobs?: CompactMcpJob[];
+};
+
+async function authenticatedMcpHeaders(identity = fixture.createWorkosIdentity()) {
+  const headers = await fixture.authHeadersFor(identity);
+
+  const accessToken = generateMcpToken();
+  const refreshToken = generateMcpToken();
+
+  const auth = globalThis.__testApiAuthContext;
+  if (!auth) {
+    throw new Error("expected test auth context");
+  }
+
+  await db.insert(schema.mcpSessions).values({
+    userId: auth.user.localUserId,
+    organizationId: auth.organization.localOrganizationId,
+    scope: "mcp",
+    accessTokenHash: hashMcpToken(accessToken),
+    refreshTokenHash: hashMcpToken(refreshToken),
+    expiresAt: new Date(Date.now() + 60_000),
+    refreshExpiresAt: new Date(Date.now() + 120_000),
+  });
+
+  return {
+    ...headers,
+    authorization: `Bearer ${accessToken}`,
+  };
+}
+
+async function callMcpTool(headers: Record<string, string>, args: Record<string, unknown> = {}) {
+  return mcpApp.request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      ...headers,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "list_jobs",
+        arguments: args,
+      },
+    }),
+  });
+}
+
+async function readToolResult(response: Response) {
+  expect(response.status).toBe(200);
+
+  const body = (await response.json()) as {
+    result?: {
+      isError?: boolean;
+      content?: Array<{ type: string; text?: string }>;
+    };
+  };
+
+  const text = body.result?.content?.[0]?.text;
+  expect(text).toBeDefined();
+
+  return {
+    isError: body.result?.isError === true,
+    output: JSON.parse(text!) as McpListJobsOutput,
+  };
+}
+
+async function insertSecondProject(input: {
+  organizationId: string;
+  createdByUserId: string;
+  teamId: string | null;
+}) {
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      id: `project_${randomUUID()}`,
+      identifier: uniqueTestProjectIdentifier(),
+      organizationId: input.organizationId,
+      teamId: input.teamId,
+      createdByUserId: input.createdByUserId,
+      name: "Second project",
+      description: "",
+      translationContext: "",
+      sourceLocale: "en-US",
+      targetLocales: ["de-DE"],
+    })
+    .returning();
+
+  if (!project) {
+    throw new Error("expected second project");
+  }
+
+  return project;
+}
+
+describe("MCP list_jobs", () => {
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  it("advertises list_jobs with bounded filters and pagination", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpApp.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "list_jobs");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("translation jobs");
+    expect(tool?.inputSchema?.required).toBeUndefined();
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      sourcePath: {
+        type: "string",
+        minLength: 1,
+        maxLength: 2048,
+      },
+      status: {
+        type: "string",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+        default: 20,
+      },
+      offset: {
+        type: "integer",
+        minimum: 0,
+        default: 0,
+      },
+    });
+  });
+
+  it("lists accessible translation jobs without a projectId and hides other organizations", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const secondProject = await insertSecondProject({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      teamId: stored.project.teamId,
+    });
+    const external = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const [visibleJob, otherProjectJob, hiddenJob] = await Promise.all([
+      insertPublicTranslationJob({
+        organizationId: stored.organization.id,
+        projectId: stored.project.id,
+        status: "queued",
+      }),
+      insertPublicTranslationJob({
+        organizationId: stored.organization.id,
+        projectId: secondProject.id,
+        status: "running",
+      }),
+      insertPublicTranslationJob({
+        organizationId: external.organization.id,
+        projectId: external.project.id,
+        status: "succeeded",
+      }),
+    ]);
+
+    await db.insert(schema.jobs).values({
+      id: `job_${randomUUID()}`,
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      kind: "research",
+      status: "succeeded",
+      inputPayload: { query: "ignored" },
+    });
+
+    const result = await readToolResult(await callMcpTool(headers));
+
+    expect(result.isError).toBe(false);
+    expect(result.output.total).toBe(2);
+    expect(result.output.jobs?.map((job) => job.id).sort()).toEqual(
+      [visibleJob.id, otherProjectJob.id].sort(),
+    );
+    expect(result.output.jobs?.map((job) => job.id)).not.toContain(hiddenJob.id);
+    expect(result.output.jobs?.every((job) => job.type === "string")).toBe(true);
+    expect(result.output.jobs?.[0]).not.toHaveProperty("outputFiles");
+    expect(result.output.jobs?.[0]).not.toHaveProperty("outcomePayload");
+    expect(result.output.jobs?.[0]).not.toHaveProperty("inputPayload");
+  });
+
+  it("filters by projectId, status, and pagination", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const secondProject = await insertSecondProject({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      teamId: stored.project.teamId,
+    });
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const queued = await insertPublicTranslationJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      status: "queued",
+    });
+    const succeeded = await insertPublicTranslationJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      status: "succeeded",
+      completedAt: new Date("2026-03-01T12:00:00.000Z"),
+    });
+    await insertPublicTranslationJob({
+      organizationId: stored.organization.id,
+      projectId: secondProject.id,
+      status: "failed",
+      lastError: "other project",
+    });
+
+    const byProject = await readToolResult(
+      await callMcpTool(headers, { projectId: stored.project.id }),
+    );
+    const byStatus = await readToolResult(
+      await callMcpTool(headers, { projectId: stored.project.id, status: "queued" }),
+    );
+    const firstPage = await readToolResult(
+      await callMcpTool(headers, { projectId: stored.project.id, limit: 1, offset: 0 }),
+    );
+    const secondPage = await readToolResult(
+      await callMcpTool(headers, { projectId: stored.project.id, limit: 1, offset: 1 }),
+    );
+
+    expect(byProject.output.jobs?.map((job) => job.id).sort()).toEqual(
+      [queued.id, succeeded.id].sort(),
+    );
+    expect(byStatus.output).toMatchObject({
+      total: 1,
+      jobs: [{ id: queued.id, status: "queued" }],
+    });
+    expect(firstPage.output).toMatchObject({
+      total: 2,
+      pagination: { limit: 1, offset: 0, hasMore: true, nextOffset: 1 },
+    });
+    expect(secondPage.output).toMatchObject({
+      total: 2,
+      pagination: { limit: 1, offset: 1, hasMore: false, nextOffset: null },
+    });
+    expect([
+      ...(firstPage.output.jobs ?? []).map((job) => job.id),
+      ...(secondPage.output.jobs ?? []).map((job) => job.id),
+    ].sort()).toEqual([queued.id, succeeded.id].sort());
+  });
+
+  it("maps sourcePath to the latest succeeded file job for that path", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const olderJob = await insertRepositoryPublicFileJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/en/source.xliff",
+      sourceHash: "sha256:older",
+      status: "succeeded",
+      versionCreatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      jobCreatedAt: new Date("2026-01-01T00:01:00.000Z"),
+      completedAt: new Date("2026-01-04T00:00:00.000Z"),
+      outputFiles: [
+        {
+          fileId: "file_output_older_fr",
+          locale: "fr-FR",
+          filename: "source.older.fr-FR.xliff",
+        },
+      ],
+    });
+    const newerJob = await insertRepositoryPublicFileJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/en/source.xliff",
+      sourceHash: "sha256:newer",
+      status: "succeeded",
+      versionCreatedAt: new Date("2026-01-02T00:00:00.000Z"),
+      jobCreatedAt: new Date("2026-01-02T00:01:00.000Z"),
+      completedAt: new Date("2026-01-03T00:00:00.000Z"),
+      outputFiles: [
+        {
+          fileId: "file_output_newer_fr",
+          locale: "fr-FR",
+          filename: "source.newer.fr-FR.xliff",
+        },
+      ],
+    });
+    const queuedJob = await insertRepositoryPublicFileJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/en/source.xliff",
+      sourceHash: "sha256:queued",
+      status: "queued",
+      versionCreatedAt: new Date("2026-01-03T00:00:00.000Z"),
+      jobCreatedAt: new Date("2026-01-03T00:01:00.000Z"),
+    });
+    await insertRepositoryPublicFileJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/fr/other.xliff",
+      sourceHash: "sha256:other",
+      status: "succeeded",
+      versionCreatedAt: new Date("2026-01-04T00:00:00.000Z"),
+      jobCreatedAt: new Date("2026-01-04T00:01:00.000Z"),
+      completedAt: new Date("2026-01-04T00:02:00.000Z"),
+      outputFiles: [
+        {
+          fileId: "file_output_other_fr",
+          locale: "fr-FR",
+          filename: "other.fr-FR.xliff",
+        },
+      ],
+    });
+
+    const latestForPath = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        sourcePath: "./locales/en/source.xliff",
+      }),
+    );
+    const queuedForPath = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        sourcePath: "locales/en/source.xliff",
+        status: "queued",
+      }),
+    );
+
+    expect(latestForPath.isError).toBe(false);
+    expect(latestForPath.output.jobs?.map((job) => job.id)).toEqual([newerJob.id, olderJob.id]);
+    expect(latestForPath.output.jobs?.[0]).toMatchObject({
+      id: newerJob.id,
+      type: "file",
+      status: "succeeded",
+    });
+    expect(latestForPath.output.jobs?.[0]).not.toHaveProperty("outputFiles");
+    expect(queuedForPath.output.jobs?.map((job) => job.id)).toEqual([queuedJob.id]);
+  });
+
+  it("truncates lastError and omits output file bodies", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const lastError = "x".repeat(COMPACT_JOB_LAST_ERROR_MAX_LENGTH + 40);
+
+    const failed = await insertPublicTranslationJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      status: "failed",
+      lastError,
+    });
+    await insertCompletedPublicFileJob({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      outputFiles: [
+        {
+          fileId: "file_output_fr",
+          locale: "fr-FR",
+          filename: "source.fr-FR.xliff",
+        },
+      ],
+    });
+
+    const result = await readToolResult(
+      await callMcpTool(headers, { projectId: stored.project.id, status: "failed" }),
+    );
+
+    expect(result.output.jobs).toEqual([
+      {
+        id: failed.id,
+        projectId: stored.project.id,
+        type: "string",
+        status: "failed",
+        createdAt: expect.any(String),
+        completedAt: null,
+        lastError: "x".repeat(COMPACT_JOB_LAST_ERROR_MAX_LENGTH),
+      },
+    ]);
+  });
+
+  it("returns project_not_found for inaccessible projects", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const external = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await insertPublicTranslationJob({
+      organizationId: external.organization.id,
+      projectId: external.project.id,
+      status: "succeeded",
+    });
+
+    const missing = await readToolResult(
+      await callMcpTool(headers, { projectId: "project_does_not_exist" }),
+    );
+    const otherOrg = await readToolResult(
+      await callMcpTool(headers, { projectId: external.project.id }),
+    );
+
+    expect(missing.isError).toBe(true);
+    expect(missing.output).toMatchObject({ error: "project_not_found" });
+    expect(otherOrg.isError).toBe(true);
+    expect(otherOrg.output).toMatchObject({ error: "project_not_found" });
+  });
+
+  it.each([
+    ["an over-limit page size", { limit: 51 }],
+    ["a zero page size", { limit: 0 }],
+    ["a negative offset", { offset: -1 }],
+    ["an unknown status", { status: "not-a-status" }],
+  ])("rejects %s", async (_label, args) => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await callMcpTool(headers, {
+      projectId: stored.project.id,
+      ...args,
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ type: string; text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toBeDefined();
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-jobs.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-jobs.test.ts
@@ -345,10 +345,12 @@ describe("MCP list_jobs", () => {
       total: 2,
       pagination: { limit: 1, offset: 1, hasMore: false, nextOffset: null },
     });
-    expect([
-      ...(firstPage.output.jobs ?? []).map((job) => job.id),
-      ...(secondPage.output.jobs ?? []).map((job) => job.id),
-    ].sort()).toEqual([queued.id, succeeded.id].sort());
+    expect(
+      [
+        ...(firstPage.output.jobs ?? []).map((job) => job.id),
+        ...(secondPage.output.jobs ?? []).map((job) => job.id),
+      ].sort(),
+    ).toEqual([queued.id, succeeded.id].sort());
   });
 
   it("maps sourcePath to the latest succeeded file job for that path", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -822,4 +822,130 @@ describe("MCP team-scoped access", () => {
       });
     }
   });
+
+  it("scopes list_jobs to accessible projects and hides other organizations", async () => {
+    const admin = projectFixture.createWorkosIdentityWithRole("admin");
+    const member = projectFixture.createWorkosIdentityForOrganization(admin.organization, "member");
+
+    await projectFixture.authHeadersFor(admin);
+    const adminAuth = globalThis.__testApiAuthContext;
+    if (!adminAuth) {
+      throw new Error("expected admin auth context");
+    }
+
+    await projectFixture.authHeadersFor(member);
+    const memberAuth = globalThis.__testApiAuthContext;
+    if (!memberAuth) {
+      throw new Error("expected member auth context");
+    }
+
+    const teamAlphaResponse = await teamFixture.createTeamViaApi(admin, {
+      name: "MCP List Jobs Alpha",
+    });
+    const teamAlphaBody = (await teamAlphaResponse.json()) as TeamResponse;
+    const teamBetaResponse = await teamFixture.createTeamViaApi(admin, {
+      name: "MCP List Jobs Beta",
+    });
+    const teamBetaBody = (await teamBetaResponse.json()) as TeamResponse;
+
+    trackedMemberLocalUserId = await projectFixture.getLocalUserId(member.user.workosUserId);
+    await db.insert(schema.teamMemberships).values({
+      teamId: teamAlphaBody.team.id,
+      userId: trackedMemberLocalUserId,
+      role: "member",
+    });
+
+    const alphaProjectResponse = await client.api.orgs[":organizationSlug"].projects.$post(
+      {
+        param: { organizationSlug: admin.organization.slug ?? "missing-slug" },
+        json: {
+          name: "MCP List Jobs Alpha Project",
+          teamId: teamAlphaBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(admin) },
+    );
+    expect(alphaProjectResponse.status).toBe(201);
+    const alphaProjectBody = (await alphaProjectResponse.json()) as ProjectResponse;
+
+    const betaProjectResponse = await client.api.orgs[":organizationSlug"].projects.$post(
+      {
+        param: { organizationSlug: admin.organization.slug ?? "missing-slug" },
+        json: {
+          name: "MCP List Jobs Beta Project",
+          teamId: teamBetaBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["de-DE"],
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(admin) },
+    );
+    expect(betaProjectResponse.status).toBe(201);
+    const betaProjectBody = (await betaProjectResponse.json()) as ProjectResponse;
+
+    const { organization: externalOrganization, project: externalProject } =
+      await projectFixture.createStoredProjectFixture();
+
+    const [alphaJob, betaJob, externalJob] = await Promise.all([
+      insertPublicTranslationJob({
+        organizationId: memberAuth.organization.localOrganizationId,
+        projectId: alphaProjectBody.project.id,
+        status: "queued",
+      }),
+      insertPublicTranslationJob({
+        organizationId: memberAuth.organization.localOrganizationId,
+        projectId: betaProjectBody.project.id,
+        status: "running",
+      }),
+      insertPublicTranslationJob({
+        organizationId: externalOrganization.id,
+        projectId: externalProject.id,
+        status: "succeeded",
+      }),
+    ]);
+
+    const accessToken = await mcpAccessTokenForAuth(memberAuth);
+    const adminAccessToken = await mcpAccessTokenForAuth(adminAuth);
+
+    const memberList = await callMcpTool(accessToken, "list_jobs", {});
+    expect(memberList.status).toBe(200);
+    expect(parseToolResultText(await memberList.json())).toMatchObject({
+      total: 1,
+      jobs: [{ id: alphaJob.id, projectId: alphaProjectBody.project.id, status: "queued" }],
+    });
+
+    const adminList = await callMcpTool(adminAccessToken, "list_jobs", {});
+    expect(adminList.status).toBe(200);
+    const adminOutput = parseToolResultText(await adminList.json()) as {
+      jobs?: Array<{ id: string }>;
+    };
+    expect(adminOutput.jobs?.map((job) => job.id).sort()).toEqual(
+      [alphaJob.id, betaJob.id].sort(),
+    );
+
+    const inaccessibleProject = await callMcpTool(accessToken, "list_jobs", {
+      projectId: betaProjectBody.project.id,
+    });
+    expect(inaccessibleProject.status).toBe(200);
+    const inaccessibleBody = await inaccessibleProject.json();
+    expect((inaccessibleBody as { result?: { isError?: boolean } }).result?.isError).toBe(true);
+    expect(parseToolResultText(inaccessibleBody)).toMatchObject({
+      error: "project_not_found",
+    });
+
+    const externalProjectList = await callMcpTool(accessToken, "list_jobs", {
+      projectId: externalProject.id,
+    });
+    expect(externalProjectList.status).toBe(200);
+    const externalBody = await externalProjectList.json();
+    expect((externalBody as { result?: { isError?: boolean } }).result?.isError).toBe(true);
+    expect(parseToolResultText(externalBody)).toMatchObject({
+      error: "project_not_found",
+    });
+    expect(parseToolResultText(externalBody)).not.toMatchObject({
+      jobs: expect.arrayContaining([{ id: externalJob.id }]),
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -921,9 +921,7 @@ describe("MCP team-scoped access", () => {
     const adminOutput = parseToolResultText(await adminList.json()) as {
       jobs?: Array<{ id: string }>;
     };
-    expect(adminOutput.jobs?.map((job) => job.id).sort()).toEqual(
-      [alphaJob.id, betaJob.id].sort(),
-    );
+    expect(adminOutput.jobs?.map((job) => job.id).sort()).toEqual([alphaJob.id, betaJob.id].sort());
 
     const inaccessibleProject = await callMcpTool(accessToken, "list_jobs", {
       projectId: betaProjectBody.project.id,

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -42,6 +42,7 @@ import {
 import { jobIdParamsSchema } from "@/api/routes/public-jobs/public-jobs.schema";
 import {
   findAccessiblePublicJob,
+  listAccessiblePublicJobs,
   toMcpJobEnvelope,
 } from "@/api/routes/public-jobs/public-jobs.read";
 import {
@@ -548,6 +549,38 @@ const mcpCreateIssueInputSchema = z.object({
     .describe(
       "Caller-generated retry key. Reusing it with an equivalent payload returns the existing issue.",
     ),
+});
+
+const mcpListJobsInputSchema = z.object({
+  projectId: projectIdSchema
+    .optional()
+    .describe("Optional ID of an accessible Hyperlocalise project to list jobs for."),
+  sourcePath: z
+    .string()
+    .trim()
+    .min(1)
+    .max(2048)
+    .optional()
+    .describe(
+      "Optional source file path. When set, returns the latest file translation jobs for that path, matching GET /v1/jobs/latest.",
+    ),
+  status: z
+    .enum(schema.jobStatusEnum.enumValues)
+    .optional()
+    .describe("Optional job status filter such as queued, running, succeeded, or failed."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe("Maximum number of jobs to return."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe("Number of jobs to skip before returning results."),
 });
 
 const mcpGetJobInputSchema = z.object({
@@ -1253,6 +1286,49 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
 
       return {
         content: [{ type: "text", text: JSON.stringify({ glossaries }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "list_jobs",
+    {
+      description:
+        "List recent translation jobs visible to the caller. Use this to find a job id, then call get_job. Defaults to translation jobs. Optional sourcePath uses the latest-job-for-path lookup.",
+      inputSchema: mcpListJobsInputSchema,
+    },
+    async ({ projectId, sourcePath, status, limit, offset }) => {
+      const result = await listAccessiblePublicJobs(apiAuth, {
+        projectId,
+        sourcePath,
+        status,
+        limit,
+        offset,
+      });
+
+      if (isErr(result)) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      const nextOffset = offset + result.value.jobs.length;
+      const hasMore = nextOffset < result.value.total;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              total: result.value.total,
+              pagination: {
+                limit,
+                offset,
+                hasMore,
+                nextOffset: hasMore ? nextOffset : null,
+              },
+              jobs: result.value.jobs,
+            }),
+          },
+        ],
       };
     },
   );

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -568,13 +568,7 @@ const mcpListJobsInputSchema = z.object({
     .enum(schema.jobStatusEnum.enumValues)
     .optional()
     .describe("Optional job status filter such as queued, running, succeeded, or failed."),
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(50)
-    .default(20)
-    .describe("Maximum number of jobs to return."),
+  limit: z.number().int().min(1).max(50).default(20).describe("Maximum number of jobs to return."),
   offset: z
     .number()
     .int()

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.read.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.read.ts
@@ -10,11 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, eq } from "drizzle-orm";
+import { and, count, desc, eq, type SQL } from "drizzle-orm";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
-import { buildAccessibleJobsWhere } from "@/api/auth/team-access";
+import { buildAccessibleJobsWhere, canAccessProject } from "@/api/auth/team-access";
 import { db, schema } from "@/lib/database/client";
+import { normalizeSourcePath } from "@/lib/file-storage/records";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 export type PublicJobOutputFile = {
   fileId: string;
@@ -121,4 +123,173 @@ export async function findAccessiblePublicJob(
     .limit(1);
 
   return job ?? null;
+}
+
+export const COMPACT_JOB_LAST_ERROR_MAX_LENGTH = 500;
+
+export type ListAccessiblePublicJobsQuery = {
+  projectId?: string;
+  sourcePath?: string;
+  status?: AccessiblePublicJob["status"];
+  limit: number;
+  offset: number;
+};
+
+export type CompactPublicJob = {
+  id: string;
+  projectId: string | null;
+  type: AccessiblePublicJob["type"];
+  status: AccessiblePublicJob["status"];
+  createdAt: Date;
+  completedAt: Date | null;
+  lastError: string | null;
+};
+
+export function truncatePublicJobLastError(lastError: string | null) {
+  if (!lastError || lastError.length <= COMPACT_JOB_LAST_ERROR_MAX_LENGTH) {
+    return lastError;
+  }
+
+  return lastError.slice(0, COMPACT_JOB_LAST_ERROR_MAX_LENGTH);
+}
+
+function compactPublicJob(job: {
+  id: string;
+  projectId: string | null;
+  type: AccessiblePublicJob["type"];
+  status: AccessiblePublicJob["status"];
+  createdAt: Date;
+  completedAt: Date | null;
+  lastError: string | null;
+}): CompactPublicJob {
+  return {
+    id: job.id,
+    projectId: job.projectId,
+    type: job.type,
+    status: job.status,
+    createdAt: job.createdAt,
+    completedAt: job.completedAt,
+    lastError: truncatePublicJobLastError(job.lastError),
+  };
+}
+
+/**
+ * List compact translation jobs visible to the caller.
+ *
+ * Access matches `createListJobsTool` / `buildAccessibleJobsWhere`. When
+ * `sourcePath` is set, the query uses the same repository-file join as
+ * `GET /v1/jobs/latest` so agents can find the latest job for a path.
+ */
+export async function listAccessiblePublicJobs(
+  auth: ApiAuthContext,
+  query: ListAccessiblePublicJobsQuery,
+): Promise<Result<{ jobs: CompactPublicJob[]; total: number }, { code: "project_not_found" }>> {
+  if (query.projectId) {
+    const project = await canAccessProject(auth, query.projectId);
+    if (!project) {
+      return err({ code: "project_not_found" });
+    }
+  }
+
+  const accessibleJobsWhere = await buildAccessibleJobsWhere(auth);
+  const sourcePath = query.sourcePath ? normalizeSourcePath(query.sourcePath) : undefined;
+
+  const compactSelect = {
+    id: schema.jobs.id,
+    projectId: schema.jobs.projectId,
+    type: schema.translationJobDetails.type,
+    status: schema.jobs.status,
+    createdAt: schema.jobs.createdAt,
+    completedAt: schema.jobs.completedAt,
+    lastError: schema.jobs.lastError,
+  };
+
+  if (sourcePath) {
+    const filters: SQL[] = [
+      eq(schema.repositorySourceFileVersions.organizationId, auth.organization.localOrganizationId),
+      eq(schema.repositorySourceFileVersions.sourcePath, sourcePath),
+      accessibleJobsWhere,
+      eq(schema.jobs.kind, "translation"),
+      eq(schema.translationJobDetails.type, "file"),
+    ];
+
+    if (query.projectId) {
+      filters.push(eq(schema.repositorySourceFileVersions.projectId, query.projectId));
+    }
+
+    if (query.status) {
+      filters.push(eq(schema.jobs.status, query.status));
+    } else {
+      filters.push(eq(schema.jobs.status, "succeeded"));
+      filters.push(eq(schema.translationJobDetails.outcomeKind, "file_result"));
+    }
+
+    const where = and(...filters);
+    const [jobs, [totalRow]] = await Promise.all([
+      db
+        .select(compactSelect)
+        .from(schema.repositorySourceFileVersions)
+        .innerJoin(
+          schema.translationJobDetails,
+          eq(
+            schema.translationJobDetails.sourceFileVersionId,
+            schema.repositorySourceFileVersions.id,
+          ),
+        )
+        .innerJoin(schema.jobs, eq(schema.jobs.id, schema.translationJobDetails.jobId))
+        .where(where)
+        .orderBy(desc(schema.repositorySourceFileVersions.createdAt), desc(schema.jobs.createdAt))
+        .limit(query.limit)
+        .offset(query.offset),
+      db
+        .select({ value: count() })
+        .from(schema.repositorySourceFileVersions)
+        .innerJoin(
+          schema.translationJobDetails,
+          eq(
+            schema.translationJobDetails.sourceFileVersionId,
+            schema.repositorySourceFileVersions.id,
+          ),
+        )
+        .innerJoin(schema.jobs, eq(schema.jobs.id, schema.translationJobDetails.jobId))
+        .where(where),
+    ]);
+
+    return ok({
+      jobs: jobs.map(compactPublicJob),
+      total: totalRow?.value ?? 0,
+    });
+  }
+
+  const filters: SQL[] = [accessibleJobsWhere, eq(schema.jobs.kind, "translation")];
+
+  if (query.projectId) {
+    filters.push(eq(schema.jobs.projectId, query.projectId));
+  }
+
+  if (query.status) {
+    filters.push(eq(schema.jobs.status, query.status));
+  }
+
+  const where = and(...filters);
+  const [jobs, [totalRow]] = await Promise.all([
+    db
+      .select(compactSelect)
+      .from(schema.jobs)
+      .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+      .where(where)
+      .orderBy(desc(schema.jobs.createdAt))
+      .limit(query.limit)
+      .offset(query.offset),
+    db
+      .select({ value: count() })
+      .from(schema.jobs)
+      .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+      .where(where),
+  ]);
+
+  return ok({
+    jobs: jobs.map(compactPublicJob),
+    total: totalRow?.value ?? 0,
+  });
 }

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.read.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.read.ts
@@ -276,7 +276,10 @@ export async function listAccessiblePublicJobs(
     db
       .select(compactSelect)
       .from(schema.jobs)
-      .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+      .leftJoin(
+        schema.translationJobDetails,
+        eq(schema.translationJobDetails.jobId, schema.jobs.id),
+      )
       .where(where)
       .orderBy(desc(schema.jobs.createdAt))
       .limit(query.limit)
@@ -284,7 +287,10 @@ export async function listAccessiblePublicJobs(
     db
       .select({ value: count() })
       .from(schema.jobs)
-      .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+      .leftJoin(
+        schema.translationJobDetails,
+        eq(schema.translationJobDetails.jobId, schema.jobs.id),
+      )
       .where(where),
   ]);
 

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -3,7 +3,7 @@ title: "MCP server"
 description: "Connect coding agents to Hyperlocalise Cloud over the Model Context Protocol."
 ---
 
-Hyperlocalise hosts an MCP (Model Context Protocol) server so agents such as Claude Code, Codex, and Cursor can read projects, source files, glossaries, and Board items from your workspace.
+Hyperlocalise hosts an MCP (Model Context Protocol) server so agents such as Claude Code, Codex, and Cursor can read projects, source files, glossaries, jobs, and Board items from your workspace.
 
 The server uses OAuth with PKCE. After you approve access, the agent receives a bearer token scoped to one organization and your current membership role.
 
@@ -83,7 +83,18 @@ Inaccessible projects return `project_not_found`.
 
 | Tool | Description |
 | --- | --- |
+| `list_jobs` | Recent translation jobs (`projectId`, `sourcePath`, `status`, `limit` default 20 max 50, `offset`) |
 | `get_job` | Job status by `jobId`. Poll after `run_workflow` until the job is terminal. |
+
+`list_jobs` finds recent translation jobs so you can call `get_job` without already knowing a job id. It defaults to `kind = translation`. Optional filters:
+
+- `projectId` — jobs on one accessible project. An inaccessible or missing project returns `project_not_found`.
+- `sourcePath` — latest file translation jobs for that path, using the same lookup as `GET /v1/jobs/latest`. Without `status`, this returns succeeded file jobs for the path, newest first.
+- `status` — `queued`, `running`, `succeeded`, `failed`, `waiting_for_review`, or `cancelled`.
+
+Omit `projectId` to list jobs across every project you can access. Organization-wide roles see every project in the workspace. Team members only see jobs on their teams' projects.
+
+Each job is compact: `id`, `projectId`, `type`, `status`, `createdAt`, `completedAt`, and a truncated `lastError`. The list does not include input, outcome, or output file bodies. Pagination includes `total`, `limit`, `offset`, `hasMore`, and `nextOffset`.
 
 `get_job` returns the public job envelope: `id`, `projectId`, `type`, `kind`, `status`, timestamps, and `lastError`. Status values include `queued`, `running`, `succeeded`, and `failed`. Completed file jobs also include `outputFiles` with `{ fileId, locale, filename }` so you can pass those ids to `download_translations` or file reads.
 
@@ -126,7 +137,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `issue_not_found` | Wrong `projectId`, issue id, or missing project access |
 | `invalid_comment_cursor` | Stale or malformed `cursor` on `list_issue_comments` |
 | `job_not_found` | Wrong `jobId`, missing project access, or a job from another organization |
-| `project_not_found` | Wrong `projectId` or missing project access on `list_files` or `get_project_status` |
+| `project_not_found` | Wrong `projectId` or missing project access on `list_files`, `get_project_status`, or `list_jobs` |
 | Agent cannot reach local Cloud | Use `http://localhost:3000/mcp` and ensure the dev server is running |
 
 ## Next


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a hosted MCP `list_jobs` tool so agents can find recent translation jobs without already knowing a job id, then call `get_job`.

- Optional `projectId`, `sourcePath`, and `status`
- `limit` 1–50 (default 20) and `offset`
- Defaults to translation jobs
- `sourcePath` uses the same latest-job-for-path join as `GET /v1/jobs/latest`
- Compact rows: `id`, `projectId`, `type`, `status`, `createdAt`, `completedAt`, truncated `lastError`
- Inaccessible `projectId` returns `project_not_found`
- Organization-wide vs team access matches the Jobs UI
- Docs in `docs/platform/mcp.mdx`

Fixes HL-684.

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/api/routes/mcp/mcp-list-jobs.test.ts src/api/routes/mcp/mcp-team-access.test.ts src/api/routes/mcp/mcp.route.test.ts
vp check --fix
```

Local results: 10 `list_jobs` tests, team isolation, and the existing MCP/public-jobs suites all passed. `vp check --fix` passed.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-684](https://linear.app/hyperlocalise/issue/HL-684/add-list-jobs-tool-to-the-hosted-mcp-server)

<div><a href="https://cursor.com/agents/bc-14c85ff3-5949-4672-a876-8ec5c9885a58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14c85ff3-5949-4672-a876-8ec5c9885a58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

