### PR TITLE
feat(mcp): add list_translations CAT queue tool

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-translations.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-translations.test.ts
@@ -418,9 +418,9 @@ describe("MCP list_translations", () => {
     );
     expect(scoped.output.total).toBe(2);
     expect(scoped.output.translations?.map((row) => row.key)).toEqual(["cta", "hero"]);
-    expect(scoped.output.translations?.every((row) => row.sourcePath === "locales/marketing.json")).toBe(
-      true,
-    );
+    expect(
+      scoped.output.translations?.every((row) => row.sourcePath === "locales/marketing.json"),
+    ).toBe(true);
 
     const firstPage = await readToolResult(
       await callMcpTool(headers, {
@@ -596,7 +596,10 @@ describe("MCP list_translations", () => {
 
   it("lets a read-only member list keys", async () => {
     const stored = await fixture.createStoredProjectFixture();
-    const member = fixture.createWorkosIdentityForOrganization(stored.identity.organization, "member");
+    const member = fixture.createWorkosIdentityForOrganization(
+      stored.identity.organization,
+      "member",
+    );
 
     if (!stored.project.teamId) {
       throw new Error("expected project team");

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-translations.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-translations.test.ts
@@ -1,0 +1,724 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { generateMcpToken, hashMcpToken } from "@/api/auth/mcp";
+import { createMcpTestApp } from "@/api/routes/mcp/mcp.fixture";
+import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
+import { db, schema } from "@/lib/database/client";
+import { ensureRepositorySourceFile } from "@/lib/file-storage/records";
+import {
+  setProjectTranslationKeysHidden,
+  upsertProjectTranslationKeysFromEntries,
+} from "@/lib/projects/translations/project-translation-service";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const mcpApp = createMcpTestApp();
+const fixture = createProjectTestFixture();
+
+type McpTranslationRow = {
+  id: string;
+  key: string;
+  sourcePath: string;
+  sourceText: string;
+  targetLocale: string | null;
+  targetText: string | null;
+  status: string | null;
+  maxLength: number | null;
+  isHidden: boolean;
+};
+
+type McpListTranslationsOutput = {
+  error?: string;
+  total?: number;
+  coverageSource?: string;
+  pagination?: {
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+    nextOffset: number | null;
+  };
+  translations?: McpTranslationRow[];
+};
+
+async function authenticatedMcpHeaders(identity = fixture.createWorkosIdentity()) {
+  const headers = await fixture.authHeadersFor(identity);
+
+  const accessToken = generateMcpToken();
+  const refreshToken = generateMcpToken();
+
+  const auth = globalThis.__testApiAuthContext;
+  if (!auth) {
+    throw new Error("expected test auth context");
+  }
+
+  await db.insert(schema.mcpSessions).values({
+    userId: auth.user.localUserId,
+    organizationId: auth.organization.localOrganizationId,
+    scope: "mcp",
+    accessTokenHash: hashMcpToken(accessToken),
+    refreshTokenHash: hashMcpToken(refreshToken),
+    expiresAt: new Date(Date.now() + 60_000),
+    refreshExpiresAt: new Date(Date.now() + 120_000),
+  });
+
+  return {
+    ...headers,
+    authorization: `Bearer ${accessToken}`,
+  };
+}
+
+async function callMcpTool(headers: Record<string, string>, args: Record<string, unknown>) {
+  return mcpApp.request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      ...headers,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "list_translations",
+        arguments: args,
+      },
+    }),
+  });
+}
+
+async function readToolResult(response: Response) {
+  expect(response.status).toBe(200);
+
+  const body = (await response.json()) as {
+    result?: {
+      isError?: boolean;
+      content?: Array<{ type: string; text?: string }>;
+    };
+  };
+
+  const text = body.result?.content?.[0]?.text;
+  expect(text).toBeDefined();
+
+  return {
+    isError: body.result?.isError === true,
+    output: JSON.parse(text!) as McpListTranslationsOutput,
+  };
+}
+
+async function seedFileKeys(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  entries: Array<{ key: string; text: string; maxLength?: number }>;
+}) {
+  const sourceFile = await ensureRepositorySourceFile({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+  });
+
+  await upsertProjectTranslationKeysFromEntries({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    repositorySourceFileId: sourceFile.id,
+    entries: input.entries.map((entry) => ({
+      key: entry.key,
+      text: entry.text,
+      context: null,
+      maxLength: entry.maxLength,
+    })),
+  });
+
+  const keys = await db
+    .select({
+      id: schema.projectTranslationKeys.id,
+      key: schema.projectTranslationKeys.key,
+      maxLength: schema.projectTranslationKeys.maxLength,
+      isHidden: schema.projectTranslationKeys.isHidden,
+    })
+    .from(schema.projectTranslationKeys)
+    .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id));
+
+  return { sourceFile, keys };
+}
+
+async function insertTranslation(input: {
+  organizationId: string;
+  projectId: string;
+  translationKeyId: string;
+  targetLocale: string;
+  text: string;
+  status: "draft" | "needs_review" | "approved" | "rejected";
+}) {
+  await db.insert(schema.projectTranslations).values(input);
+}
+
+describe("MCP list_translations", () => {
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  it("advertises list_translations with CAT filters and pagination", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpApp.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "list_translations");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("native key overlay");
+    expect(tool?.inputSchema?.required).toEqual(["projectId"]);
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      sourcePath: {
+        type: "string",
+        minLength: 1,
+        maxLength: 2048,
+      },
+      targetLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 32,
+      },
+      search: {
+        type: "string",
+        maxLength: 256,
+      },
+      queueFilter: {
+        type: "string",
+      },
+      queueSort: {
+        type: "string",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+        default: 20,
+      },
+      offset: {
+        type: "integer",
+        minimum: 0,
+        default: 0,
+      },
+    });
+  });
+
+  it("returns an empty page for a project with no keys", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toMatchObject({
+      total: 0,
+      coverageSource: "native_overlay",
+      pagination: {
+        limit: 20,
+        offset: 0,
+        hasMore: false,
+        nextOffset: null,
+      },
+      translations: [],
+    });
+  });
+
+  it("filters untranslated keys and matches CAT search on key, source, and target text", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const { keys } = await seedFileKeys({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/home.json",
+      entries: [
+        { key: "hello", text: "Hello world" },
+        { key: "checkout", text: "Checkout" },
+        { key: "save", text: "Save" },
+      ],
+    });
+
+    const hello = keys.find((row) => row.key === "hello");
+    const checkout = keys.find((row) => row.key === "checkout");
+    expect(hello).toBeDefined();
+    expect(checkout).toBeDefined();
+
+    await insertTranslation({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      translationKeyId: hello!.id,
+      targetLocale: "fr-FR",
+      text: "Bonjour le monde",
+      status: "approved",
+    });
+    await insertTranslation({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      translationKeyId: checkout!.id,
+      targetLocale: "fr-FR",
+      text: "Paiement",
+      status: "needs_review",
+    });
+
+    const untranslated = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        queueFilter: "untranslated",
+      }),
+    );
+    expect(untranslated.output.translations?.map((row) => row.key)).toEqual(["save"]);
+    expect(untranslated.output.translations?.[0]).toMatchObject({
+      sourcePath: "locales/home.json",
+      sourceText: "Save",
+      targetLocale: "fr-FR",
+      targetText: null,
+      status: null,
+      isHidden: false,
+    });
+
+    const needsReview = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        queueFilter: "needs_review",
+      }),
+    );
+    expect(needsReview.output.translations?.map((row) => row.key)).toEqual(["checkout"]);
+    expect(needsReview.output.translations?.[0]).toMatchObject({
+      targetText: "Paiement",
+      status: "needs_review",
+    });
+
+    const byKey = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        search: "checkout",
+      }),
+    );
+    expect(byKey.output.translations?.map((row) => row.key)).toEqual(["checkout"]);
+
+    const bySource = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        search: "Hello world",
+      }),
+    );
+    expect(bySource.output.translations?.map((row) => row.key)).toEqual(["hello"]);
+
+    const byTarget = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        search: "Paiement",
+      }),
+    );
+    expect(byTarget.output.translations?.map((row) => row.key)).toEqual(["checkout"]);
+  });
+
+  it("scopes rows to sourcePath and paginates without duplicates or omissions", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await seedFileKeys({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/marketing.json",
+      entries: [
+        { key: "cta", text: "Start" },
+        { key: "hero", text: "Hero" },
+      ],
+    });
+    await seedFileKeys({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/settings.json",
+      entries: [{ key: "save", text: "Save" }],
+    });
+
+    const scoped = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        sourcePath: "locales/marketing.json",
+        targetLocale: "fr-FR",
+      }),
+    );
+    expect(scoped.output.total).toBe(2);
+    expect(scoped.output.translations?.map((row) => row.key)).toEqual(["cta", "hero"]);
+    expect(scoped.output.translations?.every((row) => row.sourcePath === "locales/marketing.json")).toBe(
+      true,
+    );
+
+    const firstPage = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        limit: 2,
+        offset: 0,
+      }),
+    );
+    const secondPage = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        limit: 2,
+        offset: 2,
+      }),
+    );
+
+    expect(firstPage.output.pagination).toEqual({
+      limit: 2,
+      offset: 0,
+      hasMore: true,
+      nextOffset: 2,
+    });
+    expect(secondPage.output.pagination).toEqual({
+      limit: 2,
+      offset: 2,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    const keys = [
+      ...(firstPage.output.translations ?? []),
+      ...(secondPage.output.translations ?? []),
+    ].map((row) => `${row.sourcePath}:${row.key}`);
+    expect(keys).toEqual([
+      "locales/marketing.json:cta",
+      "locales/marketing.json:hero",
+      "locales/settings.json:save",
+    ]);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("expands omitted targetLocale across project locales without duplicating rows", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    await db
+      .update(schema.projects)
+      .set({ targetLocales: ["de-DE", "fr-FR"] })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const { keys } = await seedFileKeys({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/home.json",
+      entries: [
+        { key: "hello", text: "Hello" },
+        { key: "bye", text: "Goodbye" },
+      ],
+    });
+
+    const hello = keys.find((row) => row.key === "hello");
+    expect(hello).toBeDefined();
+    await insertTranslation({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      translationKeyId: hello!.id,
+      targetLocale: "de-DE",
+      text: "Hallo",
+      status: "approved",
+    });
+
+    const firstPage = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        limit: 3,
+        offset: 0,
+      }),
+    );
+    const secondPage = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        limit: 3,
+        offset: 3,
+      }),
+    );
+
+    expect(firstPage.output.total).toBe(4);
+    expect(firstPage.output.pagination).toEqual({
+      limit: 3,
+      offset: 0,
+      hasMore: true,
+      nextOffset: 3,
+    });
+    expect(secondPage.output.pagination?.hasMore).toBe(false);
+
+    const rows = [
+      ...(firstPage.output.translations ?? []),
+      ...(secondPage.output.translations ?? []),
+    ];
+    expect(rows.map((row) => `${row.targetLocale}:${row.key}`)).toEqual([
+      "de-DE:bye",
+      "de-DE:hello",
+      "fr-FR:bye",
+      "fr-FR:hello",
+    ]);
+    expect(rows.find((row) => row.targetLocale === "de-DE" && row.key === "hello")).toMatchObject({
+      targetText: "Hallo",
+      status: "approved",
+    });
+  });
+
+  it("maps approved to the CAT reviewed filter and keeps hidden flags", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const { keys } = await seedFileKeys({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/home.json",
+      entries: [
+        { key: "done", text: "Done", maxLength: 24 },
+        { key: "hidden", text: "Internal" },
+      ],
+    });
+
+    const done = keys.find((row) => row.key === "done");
+    const hidden = keys.find((row) => row.key === "hidden");
+    expect(done).toBeDefined();
+    expect(hidden).toBeDefined();
+
+    await insertTranslation({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      translationKeyId: done!.id,
+      targetLocale: "fr-FR",
+      text: "Fait",
+      status: "approved",
+    });
+    await setProjectTranslationKeysHidden({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      translationKeyIds: [hidden!.id],
+      isHidden: true,
+    });
+
+    const approved = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        queueFilter: "approved",
+      }),
+    );
+    expect(approved.output.translations).toEqual([
+      expect.objectContaining({
+        key: "done",
+        targetText: "Fait",
+        status: "approved",
+        maxLength: 24,
+        isHidden: false,
+      }),
+    ]);
+
+    const hiddenRows = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+        queueFilter: "hidden",
+      }),
+    );
+    expect(hiddenRows.output.translations?.map((row) => row.key)).toEqual(["hidden"]);
+    expect(hiddenRows.output.translations?.[0]?.isHidden).toBe(true);
+  });
+
+  it("lets a read-only member list keys", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const member = fixture.createWorkosIdentityForOrganization(stored.identity.organization, "member");
+
+    if (!stored.project.teamId) {
+      throw new Error("expected project team");
+    }
+
+    await fixture.authHeadersFor(member);
+    const memberAuth = globalThis.__testApiAuthContext;
+    if (!memberAuth) {
+      throw new Error("expected member auth context");
+    }
+
+    await db.insert(schema.teamMemberships).values({
+      teamId: stored.project.teamId,
+      userId: memberAuth.user.localUserId,
+      role: "member",
+    });
+
+    const headers = await authenticatedMcpHeaders(member);
+
+    await seedFileKeys({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/home.json",
+      entries: [{ key: "hello", text: "Hello" }],
+    });
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output.translations?.map((row) => row.key)).toEqual(["hello"]);
+  });
+
+  it("returns native overlay rows for TMS-backed projects", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    await db
+      .update(schema.projects)
+      .set({ source: "external_tms" })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    await seedFileKeys({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      sourcePath: "locales/overlay.json",
+      entries: [{ key: "overlay", text: "Overlay" }],
+    });
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: stored.project.id,
+        targetLocale: "fr-FR",
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output.coverageSource).toBe("native_overlay");
+    expect(result.output.translations?.map((row) => row.key)).toEqual(["overlay"]);
+  });
+
+  it("returns project_not_found for missing and cross-organization projects", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const external = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await seedFileKeys({
+      organizationId: external.organization.id,
+      projectId: external.project.id,
+      sourcePath: "locales/secret.json",
+      entries: [{ key: "secret", text: "Secret" }],
+    });
+
+    const missing = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: "project_does_not_exist",
+      }),
+    );
+    const otherOrg = await readToolResult(
+      await callMcpTool(headers, {
+        projectId: external.project.id,
+      }),
+    );
+
+    expect(missing.isError).toBe(true);
+    expect(missing.output).toMatchObject({
+      error: "project_not_found",
+    });
+    expect(otherOrg.isError).toBe(true);
+    expect(otherOrg.output).toMatchObject({
+      error: "project_not_found",
+    });
+    expect(otherOrg.output.translations).toBeUndefined();
+  });
+
+  it.each([
+    ["an over-limit page size", { limit: 51 }],
+    ["a zero page size", { limit: 0 }],
+    ["a negative offset", { offset: -1 }],
+    ["an overlong search", { search: "x".repeat(257) }],
+  ])("rejects %s", async (_label, args) => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await callMcpTool(headers, {
+      projectId: stored.project.id,
+      ...args,
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ type: string; text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toBeDefined();
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-translations.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-translations.ts
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type {
+  ProjectFileContentEditorQueueFilter,
+  ProjectFileContentEditorQueueSort,
+} from "@/api/routes/project/project.schema";
+import { isContentEditorAllFilesSourcePath } from "@/lib/projects/content-editor-all-files";
+import {
+  countProjectTranslationKeysForFile,
+  countProjectTranslationKeysForProject,
+  getProjectTranslationsByKeyIds,
+  getRepositorySourceFileByPath,
+  listProjectTranslationKeysForFile,
+  listProjectTranslationKeysForProject,
+} from "@/lib/projects/translations/project-translation-service";
+
+export const MCP_LIST_TRANSLATIONS_COVERAGE_SOURCE = "native_overlay" as const;
+
+export const mcpListTranslationsQueueFilters = [
+  "all",
+  "untranslated",
+  "needs_review",
+  "approved",
+  "reviewed",
+  "has_issues",
+  "hidden",
+  "qa_issues",
+  "machine_translated",
+  "with_comments",
+] as const;
+
+export type McpListTranslationsQueueFilter = (typeof mcpListTranslationsQueueFilters)[number];
+
+export type McpTranslationRow = {
+  id: string;
+  key: string;
+  sourcePath: string;
+  sourceText: string;
+  targetLocale: string | null;
+  targetText: string | null;
+  status: string | null;
+  maxLength: number | null;
+  isHidden: boolean;
+};
+
+export type McpListTranslationsResult = {
+  total: number;
+  coverageSource: typeof MCP_LIST_TRANSLATIONS_COVERAGE_SOURCE;
+  pagination: {
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+    nextOffset: number | null;
+  };
+  translations: McpTranslationRow[];
+};
+
+type ListedKey = {
+  id: string;
+  key: string;
+  sourceText: string;
+  sourcePath: string;
+  maxLength: number | null;
+  isHidden: boolean;
+};
+
+export function toCatQueueFilter(
+  queueFilter?: McpListTranslationsQueueFilter,
+): ProjectFileContentEditorQueueFilter | undefined {
+  if (!queueFilter || queueFilter === "approved") {
+    return queueFilter === "approved" ? "reviewed" : undefined;
+  }
+
+  return queueFilter;
+}
+
+function scopedSourcePath(sourcePath?: string) {
+  if (!sourcePath || isContentEditorAllFilesSourcePath(sourcePath)) {
+    return undefined;
+  }
+
+  return sourcePath;
+}
+
+async function countKeysForLocale(input: {
+  organizationId: string;
+  projectId: string;
+  targetLocale?: string;
+  search?: string;
+  queueFilter?: ProjectFileContentEditorQueueFilter;
+  sourcePath?: string;
+}) {
+  const sourcePath = scopedSourcePath(input.sourcePath);
+  if (sourcePath) {
+    const sourceFile = await getRepositorySourceFileByPath({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath,
+    });
+
+    if (!sourceFile) {
+      return 0;
+    }
+
+    return countProjectTranslationKeysForFile({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      repositorySourceFileId: sourceFile.id,
+      targetLocale: input.targetLocale,
+      search: input.search,
+      queueFilter: input.queueFilter,
+    });
+  }
+
+  return countProjectTranslationKeysForProject({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    targetLocale: input.targetLocale,
+    search: input.search,
+    queueFilter: input.queueFilter,
+    sourcePaths: undefined,
+  });
+}
+
+async function listKeysForLocale(input: {
+  organizationId: string;
+  projectId: string;
+  targetLocale?: string;
+  search?: string;
+  queueFilter?: ProjectFileContentEditorQueueFilter;
+  queueSort?: ProjectFileContentEditorQueueSort;
+  sourcePath?: string;
+  limit: number;
+  offset: number;
+}): Promise<ListedKey[]> {
+  const sourcePath = scopedSourcePath(input.sourcePath);
+  if (sourcePath) {
+    const sourceFile = await getRepositorySourceFileByPath({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath,
+    });
+
+    if (!sourceFile) {
+      return [];
+    }
+
+    const keys = await listProjectTranslationKeysForFile({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      repositorySourceFileId: sourceFile.id,
+      targetLocale: input.targetLocale,
+      search: input.search,
+      queueFilter: input.queueFilter,
+      queueSort: input.queueSort,
+      limit: input.limit,
+      offset: input.offset,
+    });
+
+    return keys.map((key) => ({
+      id: key.id,
+      key: key.key,
+      sourceText: key.sourceText,
+      sourcePath,
+      maxLength: key.maxLength,
+      isHidden: key.isHidden,
+    }));
+  }
+
+  const keys = await listProjectTranslationKeysForProject({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    targetLocale: input.targetLocale,
+    search: input.search,
+    queueFilter: input.queueFilter,
+    queueSort: input.queueSort,
+    limit: input.limit,
+    offset: input.offset,
+  });
+
+  return keys.map((key) => ({
+    id: key.id,
+    key: key.key,
+    sourceText: key.sourceText,
+    sourcePath: key.sourcePath,
+    maxLength: key.maxLength,
+    isHidden: key.isHidden,
+  }));
+}
+
+async function attachTranslations(input: {
+  organizationId: string;
+  projectId: string;
+  targetLocale?: string;
+  keys: ListedKey[];
+}): Promise<McpTranslationRow[]> {
+  if (!input.targetLocale || input.keys.length === 0) {
+    return input.keys.map((key) => ({
+      id: key.id,
+      key: key.key,
+      sourcePath: key.sourcePath,
+      sourceText: key.sourceText,
+      targetLocale: input.targetLocale ?? null,
+      targetText: null,
+      status: null,
+      maxLength: key.maxLength,
+      isHidden: key.isHidden,
+    }));
+  }
+
+  const translations = await getProjectTranslationsByKeyIds({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    translationKeyIds: input.keys.map((key) => key.id),
+    targetLocale: input.targetLocale,
+  });
+  const translationByKeyId = new Map(
+    translations.map((translation) => [translation.translationKeyId, translation]),
+  );
+
+  return input.keys.map((key) => {
+    const translation = translationByKeyId.get(key.id);
+
+    return {
+      id: key.id,
+      key: key.key,
+      sourcePath: key.sourcePath,
+      sourceText: key.sourceText,
+      targetLocale: input.targetLocale ?? null,
+      targetText: translation?.text ?? null,
+      status: translation?.status ?? null,
+      maxLength: key.maxLength,
+      isHidden: key.isHidden,
+    };
+  });
+}
+
+export async function loadMcpListTranslations(input: {
+  organizationId: string;
+  projectId: string;
+  projectTargetLocales: readonly string[];
+  sourcePath?: string;
+  targetLocale?: string;
+  search?: string;
+  queueFilter?: McpListTranslationsQueueFilter;
+  queueSort?: ProjectFileContentEditorQueueSort;
+  limit: number;
+  offset: number;
+}): Promise<McpListTranslationsResult> {
+  const queueFilter = toCatQueueFilter(input.queueFilter);
+  const locales = input.targetLocale
+    ? [input.targetLocale]
+    : input.projectTargetLocales.length > 0
+      ? [...input.projectTargetLocales]
+      : [undefined];
+
+  const counts = await Promise.all(
+    locales.map((targetLocale) =>
+      countKeysForLocale({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetLocale,
+        search: input.search,
+        queueFilter,
+        sourcePath: input.sourcePath,
+      }),
+    ),
+  );
+  const total = counts.reduce((sum, count) => sum + count, 0);
+
+  let skip = input.offset;
+  let remaining = input.limit;
+  const translations: McpTranslationRow[] = [];
+
+  for (let index = 0; index < locales.length; index += 1) {
+    const localeTotal = counts[index] ?? 0;
+    if (remaining <= 0) {
+      break;
+    }
+
+    if (skip >= localeTotal) {
+      skip -= localeTotal;
+      continue;
+    }
+
+    const keys = await listKeysForLocale({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      targetLocale: locales[index],
+      search: input.search,
+      queueFilter,
+      queueSort: input.queueSort,
+      sourcePath: input.sourcePath,
+      limit: remaining,
+      offset: skip,
+    });
+
+    translations.push(
+      ...(await attachTranslations({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetLocale: locales[index],
+        keys,
+      })),
+    );
+    remaining -= keys.length;
+    skip = 0;
+  }
+
+  const nextOffset = input.offset + translations.length;
+  const hasMore = nextOffset < total;
+
+  return {
+    total,
+    coverageSource: MCP_LIST_TRANSLATIONS_COVERAGE_SOURCE,
+    pagination: {
+      limit: input.limit,
+      offset: input.offset,
+      hasMore,
+      nextOffset: hasMore ? nextOffset : null,
+    },
+    translations,
+  };
+}

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-translations.unit.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-list-translations.unit.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { toCatQueueFilter } from "@/api/routes/mcp/mcp-list-translations";
+
+describe("toCatQueueFilter", () => {
+  it("maps approved to the CAT reviewed filter", () => {
+    expect(toCatQueueFilter("approved")).toBe("reviewed");
+  });
+
+  it("passes through CAT filters and leaves all unset", () => {
+    expect(toCatQueueFilter()).toBeUndefined();
+    expect(toCatQueueFilter("all")).toBe("all");
+    expect(toCatQueueFilter("untranslated")).toBe("untranslated");
+    expect(toCatQueueFilter("needs_review")).toBe("needs_review");
+    expect(toCatQueueFilter("reviewed")).toBe("reviewed");
+    expect(toCatQueueFilter("has_issues")).toBe("has_issues");
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-team-access.test.ts
@@ -527,6 +527,34 @@ describe("MCP team-scoped access", () => {
       error: "project_not_found",
     });
 
+    const accessibleTranslationsResponse = await callMcpTool(accessToken, "list_translations", {
+      projectId: alphaProjectBody.project.id,
+    });
+    expect(accessibleTranslationsResponse.status).toBe(200);
+    expect(parseToolResultText(await accessibleTranslationsResponse.json())).toMatchObject({
+      total: 0,
+      translations: [],
+    });
+
+    for (const lookup of inaccessibleFileLookups) {
+      const response = await callMcpTool(accessToken, "list_translations", {
+        projectId: lookup.projectId,
+      });
+
+      expect(response.status, lookup.label).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(
+        (responseBody as { result?: { isError?: boolean } }).result?.isError,
+        lookup.label,
+      ).toBe(true);
+
+      expect(parseToolResultText(responseBody), lookup.label).toMatchObject({
+        error: "project_not_found",
+      });
+    }
+
     const createDeniedResponse = await callMcpTool(accessToken, "create_issue", {
       projectId: alphaProjectBody.project.id,
       title: "Member must not create this issue",

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -435,9 +435,7 @@ const mcpListTranslationsInputSchema = z.object({
     .min(1)
     .max(32)
     .optional()
-    .describe(
-      "Optional target locale. When omitted, returns one row per project target locale.",
-    ),
+    .describe("Optional target locale. When omitted, returns one row per project target locale."),
   search: z
     .string()
     .trim()

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -80,12 +80,19 @@ import {
 } from "@/lib/projects/issue-sheet/issue-sheet-service";
 import type { IssueSheetComment } from "@/lib/projects/issue-sheet/issue-sheet-comment-service";
 import { isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
-import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import {
+  projectFileCatQueueSortSchema,
+  type ProjectFileRecord,
+} from "@/api/routes/project/project.schema";
 import {
   filterProjectFiles,
   listProjectFilesForProject,
 } from "@/lib/projects/files/project-file-service";
 import { loadMcpProjectStatus } from "@/api/routes/mcp/mcp-project-status";
+import {
+  loadMcpListTranslations,
+  mcpListTranslationsQueueFilters,
+} from "@/api/routes/mcp/mcp-list-translations";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -407,6 +414,58 @@ const mcpListFilesInputSchema = z.object({
     .max(256)
     .optional()
     .describe("Optional case-insensitive filter on source path or filename."),
+});
+
+const mcpListTranslationsInputSchema = z.object({
+  projectId: projectIdSchema.describe(
+    "ID of the accessible Hyperlocalise project whose translation keys to list.",
+  ),
+  sourcePath: z
+    .string()
+    .trim()
+    .min(1)
+    .max(2048)
+    .optional()
+    .describe(
+      "Optional source file path. Use * for every file. When omitted, lists keys across the project.",
+    ),
+  targetLocale: z
+    .string()
+    .trim()
+    .min(1)
+    .max(32)
+    .optional()
+    .describe(
+      "Optional target locale. When omitted, returns one row per project target locale.",
+    ),
+  search: z
+    .string()
+    .trim()
+    .max(256)
+    .optional()
+    .describe("Optional case-insensitive match on key, source text, context, or target text."),
+  queueFilter: z
+    .enum(mcpListTranslationsQueueFilters)
+    .optional()
+    .describe(
+      "CAT queue filter: all, untranslated, needs_review, approved (same as reviewed), has_issues, or other Content Editor filters.",
+    ),
+  queueSort: projectFileCatQueueSortSchema
+    .optional()
+    .describe("CAT queue sort: file_order (default) or untranslated_first."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe("Maximum number of translation rows to return."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe("Number of translation rows to skip before returning results."),
 });
 
 const mcpGetIssueInputSchema = z.object({
@@ -826,6 +885,55 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
             }),
           },
         ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "list_translations",
+    {
+      description:
+        "List translation keys in an accessible Hyperlocalise project. Returns compact CAT queue rows (id, key, sourcePath, sourceText, targetLocale, targetText, status, maxLength, isHidden) with total and pagination. Filters match the Content Editor queue. Read-only roles may list. Results use the native key overlay; live TMS provider listing is out of scope.",
+      inputSchema: mcpListTranslationsInputSchema,
+    },
+    async ({
+      projectId,
+      sourcePath,
+      targetLocale,
+      search,
+      queueFilter,
+      queueSort,
+      limit,
+      offset,
+    }) => {
+      const [project] = await db
+        .select({
+          id: schema.projects.id,
+          targetLocales: schema.projects.targetLocales,
+        })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      const result = await loadMcpListTranslations({
+        organizationId: apiAuth.organization.localOrganizationId,
+        projectId: project.id,
+        projectTargetLocales: project.targetLocales,
+        sourcePath,
+        targetLocale,
+        search,
+        queueFilter,
+        queueSort,
+        limit,
+        offset,
+      });
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result) }],
       };
     },
   );
@@ -1411,12 +1519,7 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
     },
   );
 
-  for (const name of [
-    "list_translations",
-    "upload_sources",
-    "download_translations",
-    "run_workflow",
-  ] as const) {
+  for (const name of ["upload_sources", "download_translations", "run_workflow"] as const) {
     server.registerTool(
       name,
       {

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -3,7 +3,7 @@ title: "MCP server"
 description: "Connect coding agents to Hyperlocalise Cloud over the Model Context Protocol."
 ---
 
-Hyperlocalise hosts an MCP (Model Context Protocol) server so agents such as Claude Code, Codex, and Cursor can read projects, source files, glossaries, jobs, and Board items from your workspace.
+Hyperlocalise hosts an MCP (Model Context Protocol) server so agents such as Claude Code, Codex, and Cursor can read projects, source files, translation keys, glossaries, jobs, and Board items from your workspace.
 
 The server uses OAuth with PKCE. After you approve access, the agent receives a bearer token scoped to one organization and your current membership role.
 
@@ -47,11 +47,26 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | `list_projects` | List accessible projects (`limit`, default 20, max 50) |
 | `get_project` | Project details by `projectId` |
 | `list_files` | List source files in a project (`projectId`, `limit` default 20 max 50, `offset`, optional `search`) |
+| `list_translations` | Paginated CAT queue of translation keys (`projectId`, optional `sourcePath`, `targetLocale`, `search`, `queueFilter`, `queueSort`, `limit` default 20 max 50, `offset`) |
 | `get_project_status` | Locale coverage counts by `projectId`, with optional `sourcePath` |
 | `list_glossaries` | List glossaries linked to accessible projects |
 | `get_glossary_entries` | Concept-linked terms for a `glossaryId` (`limit`, default 50, max 100) |
 
 `list_files` returns metadata only: `id` (stored file or source-file id), `sourcePath`, `filename`, `contentType`, `byteSize`, `updatedAt`, and `sourceLocale` when known. Pagination includes `total`, `limit`, `offset`, `hasMore`, and `nextOffset`. The tool does not return file contents. Inaccessible projects return `project_not_found`. Use the listed `sourcePath` values for later upload, download, or `run_workflow` calls.
+
+`list_translations` is the CAT queue for agents. It lists native overlay keys so you can find untranslated, needs-review, or matching strings without opening the Content Editor. Each row is compact: `id`, `key`, `sourcePath`, `sourceText`, `targetLocale`, `targetText`, `status`, `maxLength`, and `isHidden`. The response includes `total`, pagination (`hasMore`, `nextOffset`), and `coverageSource: "native_overlay"`. It does not include TM or glossary hits.
+
+Optional filters match the Content Editor queue:
+
+- `sourcePath` — one file. Use `*` or omit it to list every file in the project.
+- `targetLocale` — one locale. When omitted, the tool returns one row per project target locale.
+- `search` — case-insensitive match on key, source text, context, or target text.
+- `queueFilter` — `all`, `untranslated`, `needs_review`, `approved` (same as CAT `reviewed`), `has_issues`, plus the other Content Editor filters.
+- `queueSort` — `file_order` (default) or `untranslated_first`.
+
+Read-only roles may list. Writes stay on `update_translation` when that tool is wired. Missing or inaccessible projects, including cross-team and cross-organization reads, return `project_not_found`.
+
+For TMS-backed projects the tool still returns native overlay keys (`coverageSource: "native_overlay"`). Live Crowdin, Phrase, Lokalise, or Smartling listing is out of scope. Use the provider CAT or CLI for live provider strings.
 
 `get_project_status` answers “how done is French?” without paging translations. It returns `sourceLocale`, `targetLocales`, and per-locale counts: `total`, `translated`, `untranslated`, `needsReview`, `approved`, and `hidden`. Counts match Content Editor queue filters on the native key overlay. Hidden keys stay in `total` and, when they have no target text, in `untranslated`, because that is how the native CAT server filter counts them.
 
@@ -104,7 +119,6 @@ Missing or inaccessible jobs, including jobs from another organization, return `
 
 These tools are advertised but return `not_implemented` today:
 
-- `list_translations`
 - `upload_sources`
 - `download_translations`
 - `run_workflow`
@@ -137,7 +151,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `issue_not_found` | Wrong `projectId`, issue id, or missing project access |
 | `invalid_comment_cursor` | Stale or malformed `cursor` on `list_issue_comments` |
 | `job_not_found` | Wrong `jobId`, missing project access, or a job from another organization |
-| `project_not_found` | Wrong `projectId` or missing project access on `list_files`, `get_project_status`, or `list_jobs` |
+| `project_not_found` | Wrong `projectId` or missing project access on `list_files`, `list_translations`, `get_project_status`, or `list_jobs` |
 | Agent cannot reach local Cloud | Use `http://localhost:3000/mcp` and ensure the dev server is running |
 
 ## Next


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Replaces the reserved `list_translations` stub with a real paginated CAT queue search over project translation keys (HL-676).

Agents can find untranslated, needs-review, approved, or matching strings without opening the Content Editor. The tool:

- Reuses `listKeysForProject` / `listKeysForFile` and CAT `queueFilter` / `queueSort` / `search` semantics
- Respects `ownedProjectWhere` (cross-team and cross-org reads return `project_not_found`)
- Allows read-only roles to list
- Returns compact rows plus `total` and pagination
- Lists native overlay keys only for TMS-backed projects (`coverageSource: "native_overlay"`)

## How to test

- `vp test src/api/routes/mcp/mcp-list-translations.test.ts src/api/routes/mcp/mcp-list-translations.unit.test.ts src/api/routes/mcp/mcp-team-access.test.ts` — 18 passed
- Related MCP tests (`list_files`, `get_project_status`, `list_jobs`) — 23 passed
- `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-676](https://linear.app/hyperlocalise/issue/HL-676/add-list-translations-tool-to-the-hosted-mcp-server)

<div><a href="https://cursor.com/agents/bc-3dd1df7f-1e96-407d-9ef8-a94f55f6329f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dd1df7f-1e96-407d-9ef8-a94f55f6329f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

