### PR TITLE
feat(web): enrich integration pages and refresh content ops mock

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-flow-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-flow-panel.tsx
@@ -35,7 +35,7 @@ import { cn } from "@/lib/primitives/cn";
 import { CONTENT_OPS_MOCK_INNER_CLASSNAME } from "./content-ops-mock-stage.constants";
 import { contentOpsMockStageMessages } from "./content-ops-mock-stage.messages";
 
-type FlowTemplateId = "brief" | "campaign" | "seo";
+type FlowTemplateId = "brief" | "campaign";
 
 type FlowNodeKind = "trigger" | "action";
 
@@ -102,6 +102,32 @@ function buildLayout(templateId: FlowTemplateId, labels: string[]): FlowLayoutNo
   const baseY = 0;
   const centerX = 0;
 
+  if (templateId === "brief") {
+    return labels.map((label, index) => {
+      if (index <= 4) {
+        return {
+          label,
+          kind: index === 0 ? "trigger" : "action",
+          position: { x: centerX, y: baseY + index * NODE_GAP_Y },
+        };
+      }
+
+      if (index === 5) {
+        return {
+          label,
+          kind: "action",
+          position: { x: centerX - 112, y: baseY + 5 * NODE_GAP_Y },
+        };
+      }
+
+      return {
+        label,
+        kind: "action",
+        position: { x: centerX + 112, y: baseY + 5 * NODE_GAP_Y },
+      };
+    });
+  }
+
   if (templateId === "campaign") {
     return labels.map((label, index) => {
       if (index <= 2) {
@@ -133,7 +159,18 @@ function buildLayout(templateId: FlowTemplateId, labels: string[]): FlowLayoutNo
   }));
 }
 
-function buildEdges(templateId: FlowTemplateId, templateKey: string): Edge[] {
+function buildEdges(templateId: FlowTemplateId, templateKey: string, nodeCount: number): Edge[] {
+  if (templateId === "brief") {
+    return [
+      { id: `${templateKey}-e-0`, source: `${templateKey}-0`, target: `${templateKey}-1` },
+      { id: `${templateKey}-e-1`, source: `${templateKey}-1`, target: `${templateKey}-2` },
+      { id: `${templateKey}-e-2`, source: `${templateKey}-2`, target: `${templateKey}-3` },
+      { id: `${templateKey}-e-3`, source: `${templateKey}-3`, target: `${templateKey}-4` },
+      { id: `${templateKey}-e-4`, source: `${templateKey}-4`, target: `${templateKey}-5` },
+      { id: `${templateKey}-e-5`, source: `${templateKey}-4`, target: `${templateKey}-6` },
+    ];
+  }
+
   if (templateId === "campaign") {
     return [
       { id: `${templateKey}-e-0`, source: `${templateKey}-0`, target: `${templateKey}-1` },
@@ -143,7 +180,7 @@ function buildEdges(templateId: FlowTemplateId, templateKey: string): Edge[] {
     ];
   }
 
-  return [0, 1, 2, 3].map((index) => ({
+  return Array.from({ length: nodeCount - 1 }, (_, index) => ({
     id: `${templateKey}-e-${index}`,
     source: `${templateKey}-${index}`,
     target: `${templateKey}-${index + 1}`,
@@ -211,10 +248,12 @@ export function ContentOpsFlowPanel({
   const templateLabels = useMemo(
     () => ({
       brief: [
-        intl.formatMessage(contentOpsMockStageMessages.flowNodeBrief),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeSchedule),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeKeywords),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeCreateContent),
         intl.formatMessage(contentOpsMockStageMessages.flowNodeLocalise),
-        intl.formatMessage(contentOpsMockStageMessages.flowNodeBrandQa),
         intl.formatMessage(contentOpsMockStageMessages.flowNodeReview),
+        intl.formatMessage(contentOpsMockStageMessages.flowNodeSlack),
         intl.formatMessage(contentOpsMockStageMessages.flowNodeCms),
       ],
       campaign: [
@@ -222,13 +261,6 @@ export function ContentOpsFlowPanel({
         intl.formatMessage(contentOpsMockStageMessages.flowNodeLocalise),
         intl.formatMessage(contentOpsMockStageMessages.flowNodeReview),
         intl.formatMessage(contentOpsMockStageMessages.flowNodeStaging),
-        intl.formatMessage(contentOpsMockStageMessages.flowNodeSlack),
-      ],
-      seo: [
-        intl.formatMessage(contentOpsMockStageMessages.flowNodeSchedule),
-        intl.formatMessage(contentOpsMockStageMessages.flowNodeKeywords),
-        intl.formatMessage(contentOpsMockStageMessages.flowNodeLocalise),
-        intl.formatMessage(contentOpsMockStageMessages.flowNodeDraft),
         intl.formatMessage(contentOpsMockStageMessages.flowNodeSlack),
       ],
     }),
@@ -245,10 +277,6 @@ export function ContentOpsFlowPanel({
         title: contentOpsMockStageMessages.flowTemplateCampaign,
         description: contentOpsMockStageMessages.flowCampaignDescription,
       },
-      seo: {
-        title: contentOpsMockStageMessages.flowTemplateSeo,
-        description: contentOpsMockStageMessages.flowSeoDescription,
-      },
     }),
     [],
   );
@@ -259,8 +287,8 @@ export function ContentOpsFlowPanel({
     [activeIndex, kindLabels, labels, templateId],
   );
   const initialEdges = useMemo(
-    () => styleEdges(buildEdges(templateId, templateId), activeIndex),
-    [activeIndex, templateId],
+    () => styleEdges(buildEdges(templateId, templateId, labels.length), activeIndex),
+    [activeIndex, labels.length, templateId],
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
@@ -270,7 +298,9 @@ export function ContentOpsFlowPanel({
     (nextTemplateId: FlowTemplateId, nextActiveIndex: number) => {
       const nextLabels = templateLabels[nextTemplateId];
       setNodes(buildFlowNodes(nextTemplateId, nextLabels, kindLabels, nextActiveIndex));
-      setEdges(styleEdges(buildEdges(nextTemplateId, nextTemplateId), nextActiveIndex));
+      setEdges(
+        styleEdges(buildEdges(nextTemplateId, nextTemplateId, nextLabels.length), nextActiveIndex),
+      );
     },
     [kindLabels, setEdges, setNodes, templateLabels],
   );
@@ -315,7 +345,6 @@ export function ContentOpsFlowPanel({
   }[] = [
     { id: "brief", label: contentOpsMockStageMessages.flowTemplateBrief },
     { id: "campaign", label: contentOpsMockStageMessages.flowTemplateCampaign },
-    { id: "seo", label: contentOpsMockStageMessages.flowTemplateSeo },
   ];
 
   const meta = templateMeta[templateId];
@@ -355,7 +384,7 @@ export function ContentOpsFlowPanel({
         </div>
       </div>
 
-      <div className="relative min-h-0 min-h-[22rem] flex-1 w-full">
+      <div className="relative min-h-0 min-h-[28rem] flex-1 w-full">
         <Canvas
           nodes={nodes}
           edges={edges}
@@ -372,7 +401,7 @@ export function ContentOpsFlowPanel({
           preventScrolling={false}
           proOptions={{ hideAttribution: true }}
           fitView
-          fitViewOptions={{ padding: 0.45, minZoom: 0.85, maxZoom: 1.1 }}
+          fitViewOptions={{ padding: 0.35, minZoom: 0.75, maxZoom: 1.05 }}
           minZoom={0.75}
           maxZoom={1.25}
           defaultEdgeOptions={{

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-app-shell.tsx
@@ -68,7 +68,6 @@ const ACTIVE_NAV_BY_TAB: Record<ContentOpsMockTabId, MockNavId> = {
   campaign: "automations",
   "seo-blog": "automations",
   brand: "knowledge",
-  "brief-to-publish": "automations",
   editor: "projects",
 };
 
@@ -78,7 +77,6 @@ const BREADCRUMB_KEY_BY_TAB: Record<ContentOpsMockTabId, keyof typeof contentOps
     campaign: "mockBreadcrumbCampaign",
     "seo-blog": "mockBreadcrumbSeo",
     brand: "mockBreadcrumbBrand",
-    "brief-to-publish": "mockBreadcrumbWorkflow",
     editor: "mockBreadcrumbEditor",
   };
 

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -77,18 +77,13 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Header breadcrumb in marketing app shell mock",
   },
   mockBreadcrumbSeo: {
-    defaultMessage: "Acme · SEO blog run",
-    id: "Iu1s0Q/uDs",
+    defaultMessage: "Acme · Multilingual blog workflow",
+    id: "k5tXS6aCpT",
     description: "Header breadcrumb in marketing app shell mock",
   },
   mockBreadcrumbBrand: {
     defaultMessage: "Acme · Brand review",
     id: "nn0iMJAwx4",
-    description: "Header breadcrumb in marketing app shell mock",
-  },
-  mockBreadcrumbWorkflow: {
-    defaultMessage: "Acme · Workflows",
-    id: "O8WdOBz8MN",
     description: "Header breadcrumb in marketing app shell mock",
   },
   mockBreadcrumbEditor: {
@@ -132,14 +127,9 @@ export const contentOpsMockStageMessages = defineMessages({
     id: "Cef/Y5xN6Q",
     description: "Content ops mock tab label for brand governance",
   },
-  tabBriefToPublish: {
-    defaultMessage: "Automate brief to publish",
-    id: "h/nQhr+VQ1",
-    description: "Content ops mock tab label for brief-to-publish workflow",
-  },
   tabEditor: {
-    defaultMessage: "Editor",
-    id: "rQDAKZnTf9",
+    defaultMessage: "Content Studio",
+    id: "B5P0vwqbH1",
     description: "Content ops mock tab label for the CAT file content editor",
   },
 
@@ -689,8 +679,8 @@ export const contentOpsMockStageMessages = defineMessages({
   },
 
   flowTitle: {
-    defaultMessage: "Brief to publish · workflow",
-    id: "+TDSJ1bdrZ",
+    defaultMessage: "Multilingual blog · workflow",
+    id: "7DodroC7Kp",
     description: "Flow panel title",
   },
   flowNodeKindTrigger: {
@@ -704,9 +694,10 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Workflow node type label for actions in content ops flow mock",
   },
   flowBriefDescription: {
-    defaultMessage: "From approved brief to CMS publish across every market.",
-    id: "M4wiL9knTM",
-    description: "Workflow description for brief-to-publish template in content ops mock",
+    defaultMessage:
+      "On schedule, research keywords, draft content, localise, review, then notify Slack and publish to CMS.",
+    id: "zVfLTcACWy",
+    description: "Workflow description for multilingual blog template in content ops mock",
   },
   flowCampaignDescription: {
     defaultMessage: "Launch copy to staging and notify the team when review clears.",
@@ -734,9 +725,9 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Flow template pill for SEO blog",
   },
   flowTemplateBrief: {
-    defaultMessage: "Brief to publish",
-    id: "Unt4qWzIK1",
-    description: "Flow template pill for brief to publish",
+    defaultMessage: "Multilingual blog",
+    id: "1rvztL9O9G",
+    description: "Flow template pill for multilingual blog publishing",
   },
   flowNodeBrief: {
     defaultMessage: "GTM brief",
@@ -773,6 +764,11 @@ export const contentOpsMockStageMessages = defineMessages({
     id: "3wOLsPOjf5",
     description: "Flow node label",
   },
+  flowNodeCreateContent: {
+    defaultMessage: "Create content draft",
+    id: "B5M7/Y7enl",
+    description: "Flow node label for content creation in brief-to-publish workflow",
+  },
   flowNodeDraft: {
     defaultMessage: "CMS draft",
     id: "DN35BCM/UE",
@@ -790,10 +786,4 @@ export const contentOpsMockStageMessages = defineMessages({
   },
 });
 
-export type ContentOpsMockTabId =
-  | "triage"
-  | "campaign"
-  | "seo-blog"
-  | "brand"
-  | "brief-to-publish"
-  | "editor";
+export type ContentOpsMockTabId = "triage" | "campaign" | "seo-blog" | "brand" | "editor";

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.tsx
@@ -14,13 +14,11 @@
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Clock01Icon,
   File01Icon,
   LanguageSquareIcon,
   PauseIcon,
   PlayIcon,
   Rocket01Icon,
-  Search01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -49,21 +47,13 @@ import {
 } from "./content-ops-mock-stage.messages";
 
 const TAB_HOLD_MS = 9000;
-const TAB_ORDER: ContentOpsMockTabId[] = [
-  "triage",
-  "campaign",
-  "seo-blog",
-  "brand",
-  "brief-to-publish",
-  "editor",
-];
+const TAB_ORDER: ContentOpsMockTabId[] = ["triage", "campaign", "seo-blog", "brand", "editor"];
 
 const MESH_BY_TAB: Record<ContentOpsMockTabId, string> = {
   triage: SAGE_MESH_GRADIENT_SRC,
   campaign: LAVENDER_MESH_GRADIENT_SRC,
   "seo-blog": SAGE_MESH_GRADIENT_SRC,
   brand: LAVENDER_MESH_GRADIENT_SRC,
-  "brief-to-publish": SAGE_MESH_GRADIENT_SRC,
   editor: LAVENDER_MESH_GRADIENT_SRC,
 };
 
@@ -77,7 +67,6 @@ const TABS: TabConfig[] = [
   { id: "campaign", labelKey: "tabCampaign" },
   { id: "seo-blog", labelKey: "tabSeoBlog" },
   { id: "brand", labelKey: "tabBrand" },
-  { id: "brief-to-publish", labelKey: "tabBriefToPublish" },
   { id: "editor", labelKey: "tabEditor" },
 ];
 
@@ -135,55 +124,6 @@ export function ContentOpsMockStage({
     }),
     [intl],
   );
-
-  const seoScene: ContentOpsTerminalScene = useMemo(() => {
-    const highlightStep = intl.formatMessage(contentOpsMockStageMessages.stepSeo3);
-    return {
-      id: "seo-blog",
-      automationName: intl.formatMessage(contentOpsMockStageMessages.seoAutomationName),
-      triggerIcon: <HugeiconsIcon icon={Clock01Icon} strokeWidth={1.8} className="size-3.5" />,
-      triggerLabel: intl.formatMessage(contentOpsMockStageMessages.triggerSeoSchedule),
-      instructions: intl.formatMessage(contentOpsMockStageMessages.seoInstructions),
-      tools: [
-        {
-          icon: <HugeiconsIcon icon={Search01Icon} strokeWidth={1.8} className="size-3.5" />,
-          label: intl.formatMessage(contentOpsMockStageMessages.toolSearch),
-          description: intl.formatMessage(contentOpsMockStageMessages.toolSearchDescription),
-        },
-        {
-          icon: <HugeiconsIcon icon={Search01Icon} strokeWidth={1.8} className="size-3.5" />,
-          label: intl.formatMessage(contentOpsMockStageMessages.toolAhrefs),
-          description: intl.formatMessage(contentOpsMockStageMessages.toolAhrefsDescription),
-        },
-        {
-          icon: <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} className="size-3.5" />,
-          label: intl.formatMessage(contentOpsMockStageMessages.toolCms),
-          description: intl.formatMessage(contentOpsMockStageMessages.toolCmsDescription),
-        },
-        {
-          icon: (
-            <Image
-              src="/images/slack-logo.svg"
-              alt=""
-              width={14}
-              height={14}
-              className="size-3.5"
-            />
-          ),
-          label: intl.formatMessage(contentOpsMockStageMessages.toolSlack),
-          description: intl.formatMessage(contentOpsMockStageMessages.toolSlackSeoDescription),
-        },
-      ],
-      steps: [
-        intl.formatMessage(contentOpsMockStageMessages.stepSeo1),
-        intl.formatMessage(contentOpsMockStageMessages.stepSeo2),
-        highlightStep,
-        intl.formatMessage(contentOpsMockStageMessages.stepSeo4),
-        intl.formatMessage(contentOpsMockStageMessages.stepSeo5),
-      ],
-      highlightSteps: new Set([highlightStep]),
-    };
-  }, [intl]);
 
   const handleTabSelect = useCallback((tabId: ContentOpsMockTabId) => {
     setAutoplayEnabled(false);
@@ -278,11 +218,10 @@ export function ContentOpsMockStage({
                 <ContentOpsInboxPanel highlightedIndex={triageHighlightIndex % 3} />
               ) : null}
               {activeTab === "campaign" ? <ContentOpsAgentTerminal scene={campaignScene} /> : null}
-              {activeTab === "seo-blog" ? <ContentOpsAgentTerminal scene={seoScene} /> : null}
-              {activeTab === "brand" ? <ContentOpsBrandPanel /> : null}
-              {activeTab === "brief-to-publish" ? (
+              {activeTab === "seo-blog" ? (
                 <ContentOpsFlowPanel pauseAutoplay={pauseAutoplay} />
               ) : null}
+              {activeTab === "brand" ? <ContentOpsBrandPanel /> : null}
               {activeTab === "editor" ? (
                 <ContentOpsEditorPanel pauseAutoplay={pauseAutoplay} />
               ) : null}

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integration-cta-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integration-cta-section.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { Box } from "@/components/ui/layout/box";
+import { Rows } from "@/components/ui/layout/rows";
+import { TypographyH2, TypographyP } from "@/components/ui/typography";
+
+type IntegrationCtaSectionProps = {
+  headline: string;
+  description: string;
+  primaryCtaLabel: string;
+  secondaryCtaLabel: string;
+};
+
+export function IntegrationCtaSection({
+  headline,
+  description,
+  primaryCtaLabel,
+  secondaryCtaLabel,
+}: IntegrationCtaSectionProps) {
+  return (
+    <Box paddingX="3u" paddingY="8u">
+      <div className="mx-auto max-w-4xl">
+        <Box background="surface" border="standard" borderRadius="large" padding="6u">
+          <div className="text-center">
+            <Rows spacing="3u" align="center">
+              <TypographyH2 alignment="center" size="medium">
+                {headline}
+              </TypographyH2>
+              <TypographyP alignment="center" tone="subtle">
+                {description}
+              </TypographyP>
+              <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button
+                  nativeButton={false}
+                  render={<a href={REQUEST_DEMO_URL} rel="noopener noreferrer" target="_blank" />}
+                >
+                  {primaryCtaLabel}
+                </Button>
+                <Button
+                  nativeButton={false}
+                  render={<a href="/auth/sign-in" rel="noopener noreferrer" />}
+                  variant="outline"
+                >
+                  {secondaryCtaLabel}
+                </Button>
+              </div>
+            </Rows>
+          </div>
+        </Box>
+      </div>
+    </Box>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integration-detail-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integration-detail-page.tsx
@@ -12,17 +12,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { ArrowLeft01Icon, ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useMemo } from "react";
 
 import type { MarketingIntegration } from "@/components/marketing/integrations/integrations-page-content";
 import {
   getCategoryLabelForIntegration,
+  getIntegrationCtaCopy,
   getIntegrationDetailCopy,
+  getIntegrationNamesBySlug,
+  getRelatedIntegrations,
 } from "@/components/marketing/integrations/integrations-page-content";
+import { IntegrationCard } from "@/components/marketing/integrations/integration-card";
+import { IntegrationCtaSection } from "@/components/marketing/integrations/integration-cta-section";
 import { IntegrationLogoMark } from "@/components/marketing/integrations/integration-logo-mark";
-import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
@@ -37,9 +43,25 @@ import { Separator } from "@/components/ui/separator";
 import {
   TypographyH1,
   TypographyH2,
+  TypographyH3,
   TypographyMuted,
   TypographyP,
 } from "@/components/ui/typography";
+
+const IntegrationWorkflowPreview = dynamic(
+  () =>
+    import("@/components/marketing/integrations/integration-workflow-preview").then(
+      (module) => module.IntegrationWorkflowPreview,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex min-h-[22rem] items-center justify-center rounded-2xl border border-border bg-background">
+        <TypographyMuted>Loading workflow preview…</TypographyMuted>
+      </div>
+    ),
+  },
+);
 
 type IntegrationDetailPageProps = {
   integration: MarketingIntegration;
@@ -60,14 +82,37 @@ function getStatusLabel(
   return copy.statusAvailable;
 }
 
+function formatStepLabel(index: number) {
+  return `0${index + 1}`;
+}
+
 export function IntegrationDetailPage({ integration }: IntegrationDetailPageProps) {
   const appLocale = useAppLocale();
   const copy = getIntegrationDetailCopy(appLocale);
+  const ctaCopy = getIntegrationCtaCopy(appLocale, integration.name);
   const integrationsIndexHref = rewriteAppLocalePath("/integrations", appLocale);
   const categoryLabel = getCategoryLabelForIntegration(appLocale, integration.category);
   const statusLabel = getStatusLabel(integration, copy);
   const typeLabel = integration.type === "native" ? copy.typeNative : copy.typePartner;
   const canConnect = integration.status === "available" || integration.status === "native";
+  const relatedIntegrations = getRelatedIntegrations(appLocale, integration);
+  const integrationNamesBySlug = useMemo(
+    () => ({
+      ...getIntegrationNamesBySlug(appLocale),
+      hyperlocalise: "Hyperlocalise",
+    }),
+    [appLocale],
+  );
+  const workflowPreviewCopy = useMemo(
+    () => ({
+      triggerLabel: copy.workflowTriggerLabel,
+      actionLabel: copy.workflowActionLabel,
+      previewHint: copy.workflowPreviewHint,
+      playLabel: copy.workflowPlayLabel,
+      pauseLabel: copy.workflowPauseLabel,
+    }),
+    [copy],
+  );
 
   return (
     <Box background="canvas" width="full">
@@ -94,9 +139,7 @@ export function IntegrationDetailPage({ integration }: IntegrationDetailPageProp
                     />
 
                     <Rows spacing="1u">
-                      <TypographyH1 className="text-3xl sm:text-4xl">
-                        {integration.name}
-                      </TypographyH1>
+                      <TypographyH1>{integration.name}</TypographyH1>
                       <TypographyP tone="subtle">{integration.tagline}</TypographyP>
                     </Rows>
 
@@ -163,11 +206,9 @@ export function IntegrationDetailPage({ integration }: IntegrationDetailPageProp
                 </Column>
 
                 <Column width="2/3">
-                  <Rows spacing="6u">
+                  <Rows spacing="8u">
                     <Rows spacing="2u">
-                      <TypographyH2 className="text-2xl tracking-tight">
-                        {copy.overviewHeading}
-                      </TypographyH2>
+                      <TypographyH2 size="medium">{copy.overviewHeading}</TypographyH2>
                       {integration.overview.map((paragraph) => (
                         <TypographyP key={paragraph} tone="subtle">
                           {paragraph}
@@ -175,27 +216,111 @@ export function IntegrationDetailPage({ integration }: IntegrationDetailPageProp
                       ))}
                     </Rows>
 
-                    <Rows spacing="3u">
-                      <TypographyH2 className="text-2xl tracking-tight">
-                        {copy.productsHeading}
-                      </TypographyH2>
-                      <Rows spacing="2u">
-                        {integration.products.map((product) => (
-                          <Box
-                            key={product.name}
-                            background="surface"
-                            border="standard"
-                            borderRadius="large"
-                            padding="3u"
-                          >
-                            <Rows spacing="1u">
-                              <TypographyP weight="medium">{product.name}</TypographyP>
-                              <TypographyMuted size="small">{product.description}</TypographyMuted>
-                            </Rows>
-                          </Box>
-                        ))}
+                    {integration.capabilities.length > 0 ? (
+                      <Rows spacing="3u">
+                        <TypographyH2 size="medium">{copy.capabilitiesHeading}</TypographyH2>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          {integration.capabilities.map((capability) => (
+                            <Box
+                              key={capability.title}
+                              background="surface"
+                              border="standard"
+                              borderRadius="large"
+                              padding="3u"
+                            >
+                              <Rows spacing="1u">
+                                <TypographyH3 size="medium" weight="medium">
+                                  {capability.title}
+                                </TypographyH3>
+                                <TypographyMuted size="small">
+                                  {capability.description}
+                                </TypographyMuted>
+                              </Rows>
+                            </Box>
+                          ))}
+                        </div>
                       </Rows>
-                    </Rows>
+                    ) : null}
+
+                    {integration.products.length > 0 ? (
+                      <Rows spacing="3u">
+                        <TypographyH2 size="medium">{copy.productsHeading}</TypographyH2>
+                        <div className="grid gap-3 sm:grid-cols-2">
+                          {integration.products.map((product) => (
+                            <Box
+                              key={product.name}
+                              background="surface"
+                              border="standard"
+                              borderRadius="large"
+                              padding="3u"
+                            >
+                              <Rows spacing="1u">
+                                <TypographyP weight="medium">{product.name}</TypographyP>
+                                <TypographyMuted size="small">
+                                  {product.description}
+                                </TypographyMuted>
+                              </Rows>
+                            </Box>
+                          ))}
+                        </div>
+                      </Rows>
+                    ) : null}
+
+                    {integration.workflows.length > 0 ? (
+                      <Rows spacing="3u">
+                        <Rows spacing="1u">
+                          <TypographyH2 size="medium">{copy.workflowsHeading}</TypographyH2>
+                          <TypographyMuted>{copy.workflowsDescription}</TypographyMuted>
+                        </Rows>
+                        <IntegrationWorkflowPreview
+                          copy={workflowPreviewCopy}
+                          integrationNamesBySlug={integrationNamesBySlug}
+                          integrationSlug={integration.slug}
+                          workflows={integration.workflows}
+                        />
+                      </Rows>
+                    ) : null}
+
+                    {integration.setupSteps.length > 0 ? (
+                      <Rows spacing="3u">
+                        <TypographyH2 size="medium">{copy.setupHeading}</TypographyH2>
+                        <Rows spacing="0">
+                          {integration.setupSteps.map((step, index) => (
+                            <div
+                              key={step.title}
+                              className="flex gap-4 border-t border-border py-5 first:border-t-0 first:pt-0"
+                            >
+                              <div className="min-w-8 shrink-0 tabular-nums">
+                                <TypographyMuted>{formatStepLabel(index)}</TypographyMuted>
+                              </div>
+                              <Rows spacing="1u">
+                                <TypographyP weight="medium">{step.title}</TypographyP>
+                                <TypographyMuted size="small">{step.description}</TypographyMuted>
+                              </Rows>
+                            </div>
+                          ))}
+                        </Rows>
+                      </Rows>
+                    ) : null}
+
+                    {relatedIntegrations.length > 0 ? (
+                      <Rows spacing="3u">
+                        <TypographyH2 size="medium">{copy.relatedHeading}</TypographyH2>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          {relatedIntegrations.map((related) => (
+                            <IntegrationCard
+                              key={related.slug}
+                              categoryLabel={getCategoryLabelForIntegration(
+                                appLocale,
+                                related.category,
+                              )}
+                              integration={related}
+                              lang={appLocale}
+                            />
+                          ))}
+                        </div>
+                      </Rows>
+                    ) : null}
                   </Rows>
                 </Column>
               </Columns>
@@ -203,24 +328,12 @@ export function IntegrationDetailPage({ integration }: IntegrationDetailPageProp
           </Box>
 
           <Separator />
-          <Box paddingX="3u" paddingY="8u">
-            <div className="mx-auto max-w-3xl text-center">
-              <Rows spacing="2u" align="center">
-                <TypographyH2 className="text-3xl tracking-tight">
-                  {copy.finalCtaHeadline}
-                </TypographyH2>
-                <TypographyP className="max-w-2xl text-center" tone="subtle">
-                  {copy.finalCtaDescription}
-                </TypographyP>
-                <Button
-                  nativeButton={false}
-                  render={<a href={REQUEST_DEMO_URL} rel="noopener noreferrer" target="_blank" />}
-                >
-                  {copy.connectCta}
-                </Button>
-              </Rows>
-            </div>
-          </Box>
+          <IntegrationCtaSection
+            description={ctaCopy.description}
+            headline={ctaCopy.headline}
+            primaryCtaLabel={ctaCopy.primaryCtaLabel}
+            secondaryCtaLabel={ctaCopy.secondaryCtaLabel}
+          />
 
           <Separator />
           <Box paddingX="3u" paddingTop="6u">

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integration-workflow-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integration-workflow-preview.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useCallback, useEffect, useMemo, useState, type MouseEvent } from "react";
+import {
+  Background,
+  Handle,
+  Position,
+  useEdgesState,
+  useNodesState,
+  type Node,
+  type NodeProps,
+  type OnEdgesChange,
+  type OnNodesChange,
+} from "@xyflow/react";
+import { PauseIcon, PlayIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Canvas } from "@/components/ai-elements/canvas";
+import { IntegrationLogoMark } from "@/components/marketing/integrations/integration-logo-mark";
+import { getIntegrationCatalogEntry } from "@/lib/integrations/integration-catalog";
+import type {
+  IntegrationIconKey,
+  ResolvedIntegrationWorkflow,
+} from "@/lib/integrations/integration-catalog.types";
+import {
+  buildWorkflowEdges,
+  buildWorkflowNodes,
+  styleWorkflowEdges,
+  type IntegrationWorkflowNodeData,
+} from "@/lib/integrations/integration-workflow-graph";
+import { Button } from "@/components/ui/button";
+import { TypographyMuted, TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+type IntegrationWorkflowPreviewCopy = {
+  triggerLabel: string;
+  actionLabel: string;
+  previewHint: string;
+  playLabel: string;
+  pauseLabel: string;
+};
+
+type IntegrationWorkflowPreviewProps = {
+  workflows: ResolvedIntegrationWorkflow[];
+  integrationSlug: string;
+  integrationNamesBySlug: Readonly<Record<string, string>>;
+  copy: IntegrationWorkflowPreviewCopy;
+};
+
+const KIND_HEADER_CLASS = {
+  trigger: "border-rose-500/25 bg-rose-500/12 text-rose-900 dark:text-rose-100",
+  action: "border-sky-500/25 bg-sky-500/12 text-sky-950 dark:text-sky-100",
+} as const;
+
+function getActorBranding(actorSlug: string) {
+  if (actorSlug === "hyperlocalise") {
+    return {
+      name: "Hyperlocalise",
+      logoSrc: "/images/logo.png",
+      iconKey: undefined as IntegrationIconKey | undefined,
+    };
+  }
+
+  const entry = getIntegrationCatalogEntry(actorSlug);
+  return {
+    name: entry?.slug ?? actorSlug,
+    logoSrc: entry?.logoSrc,
+    iconKey: entry?.iconKey,
+  };
+}
+
+function IntegrationWorkflowNode({ data }: NodeProps<Node<IntegrationWorkflowNodeData>>) {
+  const branding = getActorBranding(data.actorSlug);
+
+  return (
+    <div
+      className={cn(
+        "w-[14rem] overflow-hidden rounded-xl border border-border/80 bg-background text-left shadow-md shadow-black/8 transition-shadow",
+        data.active && "ring-2 ring-primary/35 shadow-lg shadow-primary/10",
+      )}
+    >
+      <Handle
+        className="!size-2 !border-border !bg-background"
+        position={Position.Top}
+        type="target"
+      />
+
+      <div
+        className={cn(
+          "flex items-center justify-between gap-2 border-b px-3 py-1.5 text-[10px] font-semibold tracking-[0.06em] uppercase",
+          KIND_HEADER_CLASS[data.kind],
+        )}
+      >
+        <span>{data.kindLabel}</span>
+        <IntegrationLogoMark
+          iconKey={branding.iconKey}
+          logoSrc={branding.logoSrc}
+          name={branding.name}
+          size="sm"
+        />
+      </div>
+
+      <div className="space-y-1 px-3 py-2.5">
+        <p className="text-[0.8rem] font-medium leading-snug text-foreground">{data.label}</p>
+        {data.description ? (
+          <p className="text-[0.7rem] leading-snug text-muted-foreground">{data.description}</p>
+        ) : null}
+      </div>
+
+      <Handle
+        className="!size-2 !border-border !bg-background"
+        position={Position.Bottom}
+        type="source"
+      />
+    </div>
+  );
+}
+
+const nodeTypes = { integrationWorkflow: IntegrationWorkflowNode };
+
+function buildFlowState(
+  workflow: ResolvedIntegrationWorkflow,
+  workflowKey: string,
+  integrationSlug: string,
+  integrationNamesBySlug: Readonly<Record<string, string>>,
+  kindLabels: { trigger: string; action: string },
+  activeIndex: number,
+) {
+  const nodes = buildWorkflowNodes(
+    workflow,
+    workflowKey,
+    integrationSlug,
+    integrationNamesBySlug,
+    kindLabels,
+    activeIndex,
+  );
+  const edges = styleWorkflowEdges(
+    buildWorkflowEdges(workflowKey, workflow.steps.length),
+    activeIndex,
+  );
+
+  return { nodes, edges };
+}
+
+export function IntegrationWorkflowPreview({
+  workflows,
+  integrationSlug,
+  integrationNamesBySlug,
+  copy,
+}: IntegrationWorkflowPreviewProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(true);
+
+  const selectedWorkflow = workflows[selectedIndex] ?? workflows[0];
+  const workflowKey = `workflow-${selectedIndex}`;
+
+  const kindLabels = useMemo(
+    () => ({
+      trigger: copy.triggerLabel,
+      action: copy.actionLabel,
+    }),
+    [copy.actionLabel, copy.triggerLabel],
+  );
+
+  const initialFlow = useMemo(
+    () =>
+      buildFlowState(
+        selectedWorkflow,
+        workflowKey,
+        integrationSlug,
+        integrationNamesBySlug,
+        kindLabels,
+        activeIndex,
+      ),
+    [
+      activeIndex,
+      integrationNamesBySlug,
+      integrationSlug,
+      kindLabels,
+      selectedWorkflow,
+      workflowKey,
+    ],
+  );
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialFlow.nodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialFlow.edges);
+
+  const resetFlow = useCallback(
+    (
+      nextWorkflow: ResolvedIntegrationWorkflow,
+      nextWorkflowKey: string,
+      nextActiveIndex: number,
+    ) => {
+      const nextFlow = buildFlowState(
+        nextWorkflow,
+        nextWorkflowKey,
+        integrationSlug,
+        integrationNamesBySlug,
+        kindLabels,
+        nextActiveIndex,
+      );
+      setNodes(nextFlow.nodes);
+      setEdges(nextFlow.edges);
+    },
+    [integrationNamesBySlug, integrationSlug, kindLabels, setEdges, setNodes],
+  );
+
+  useEffect(() => {
+    setActiveIndex(0);
+    setIsPlaying(true);
+    resetFlow(selectedWorkflow, workflowKey, 0);
+  }, [resetFlow, selectedWorkflow, workflowKey]);
+
+  useEffect(() => {
+    setNodes((current) =>
+      current.map((node, index) => ({
+        ...node,
+        data: {
+          ...node.data,
+          active: index === activeIndex,
+        },
+      })),
+    );
+    setEdges((current) => styleWorkflowEdges(current, activeIndex));
+  }, [activeIndex, setEdges, setNodes]);
+
+  useEffect(() => {
+    if (!isPlaying || selectedWorkflow.steps.length <= 1) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setActiveIndex((index) => (index + 1) % selectedWorkflow.steps.length);
+    }, 1600);
+
+    return () => clearInterval(timer);
+  }, [isPlaying, selectedWorkflow.steps.length]);
+
+  const handleNodeClick = useCallback(
+    (_event: MouseEvent, node: Node<IntegrationWorkflowNodeData>) => {
+      const nodeIndex = Number(node.id.split("-").at(-1));
+      if (Number.isNaN(nodeIndex)) {
+        return;
+      }
+
+      setIsPlaying(false);
+      setActiveIndex(nodeIndex);
+    },
+    [],
+  );
+
+  if (!selectedWorkflow) {
+    return null;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-border bg-background shadow-[0_20px_48px_rgba(0,0,0,0.08)]">
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border/60 px-5 py-4">
+        <div className="min-w-0 space-y-1">
+          <TypographyP weight="medium">{selectedWorkflow.title}</TypographyP>
+          <TypographyMuted size="small">{copy.previewHint}</TypographyMuted>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            aria-label={isPlaying ? copy.pauseLabel : copy.playLabel}
+            onClick={() => setIsPlaying((playing) => !playing)}
+            size="icon-sm"
+            type="button"
+            variant="outline"
+          >
+            <HugeiconsIcon icon={isPlaying ? PauseIcon : PlayIcon} className="size-4" />
+          </Button>
+
+          <div className="flex flex-wrap gap-1.5">
+            {workflows.map((workflow, index) => (
+              <button
+                key={workflow.title}
+                className={cn(
+                  "cursor-pointer rounded-full border px-2.5 py-1 text-[10px] font-medium transition-colors",
+                  selectedIndex === index
+                    ? "border-primary/40 bg-primary/10 text-foreground"
+                    : "border-border/60 text-muted-foreground hover:border-border hover:text-foreground",
+                )}
+                onClick={() => setSelectedIndex(index)}
+                type="button"
+              >
+                {workflow.title}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="relative min-h-[22rem] w-full">
+        <Canvas
+          defaultEdgeOptions={{
+            type: "smoothstep",
+            style: { strokeWidth: 1.5, stroke: "var(--border)" },
+          }}
+          edges={edges}
+          elementsSelectable
+          fitView
+          fitViewOptions={{ padding: 0.45, minZoom: 0.85, maxZoom: 1.1 }}
+          maxZoom={1.25}
+          minZoom={0.75}
+          nodeTypes={nodeTypes}
+          nodes={nodes}
+          nodesConnectable={false}
+          nodesDraggable
+          onEdgesChange={onEdgesChange as OnEdgesChange}
+          onNodeClick={handleNodeClick}
+          onNodesChange={onNodesChange as OnNodesChange}
+          panOnDrag
+          panOnScroll={false}
+          preventScrolling={false}
+          proOptions={{ hideAttribution: true }}
+          selectionOnDrag={false}
+          zoomOnScroll={false}
+        >
+          <Background color="var(--border)" gap={18} size={1} />
+        </Canvas>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-index-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-index-page.tsx
@@ -20,9 +20,11 @@ import type {
 } from "@/components/marketing/integrations/integrations-page-content";
 import {
   getCategoryLabelForIntegration,
+  getIntegrationCtaCopy,
   getIntegrationsIndexCopy,
 } from "@/components/marketing/integrations/integrations-page-content";
 import { IntegrationCard } from "@/components/marketing/integrations/integration-card";
+import { IntegrationCtaSection } from "@/components/marketing/integrations/integration-cta-section";
 import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { Box } from "@/components/ui/layout/box";
@@ -58,6 +60,7 @@ export function IntegrationsIndexPage({
   categoryLabels,
 }: IntegrationsIndexPageProps) {
   const copy = getIntegrationsIndexCopy(lang);
+  const ctaCopy = getIntegrationCtaCopy(lang);
   const [query, setQuery] = useState("");
   const [activeCategory, setActiveCategory] = useState<IntegrationCategory | "all">("all");
   const deferredQuery = useDeferredValue(query.trim().toLowerCase());
@@ -148,11 +151,19 @@ export function IntegrationsIndexPage({
                 ))}
               </Rows>
             ) : (
-              <TypographyMuted className="text-center" size="medium">
+              <TypographyMuted alignment="center" size="medium">
                 {copy.emptyState}
               </TypographyMuted>
             )}
           </Box>
+
+          <Separator />
+          <IntegrationCtaSection
+            description={ctaCopy.description}
+            headline={ctaCopy.headline}
+            primaryCtaLabel={ctaCopy.primaryCtaLabel}
+            secondaryCtaLabel={ctaCopy.secondaryCtaLabel}
+          />
 
           <Separator />
           <Box paddingX="3u" paddingTop="6u">

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-page-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-page-content.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   getMarketingIntegrationBySlug,
   getMarketingIntegrations,
+  getRelatedIntegrations,
   integrationSlugs,
 } from "@/components/marketing/integrations/integrations-page-content";
 import { getIntegrationPath } from "@/lib/integrations/integration-path";
@@ -43,7 +44,19 @@ describe("integrations-page-content", () => {
     const integration = getMarketingIntegrationBySlug("en", "github");
 
     expect(integration?.name).toBe("GitHub");
-    expect(integration?.products).toHaveLength(1);
+    expect(integration?.products.length).toBeGreaterThan(0);
     expect(integration?.overview.length).toBeGreaterThan(0);
+    expect(integration?.capabilities.length).toBeGreaterThan(0);
+    expect(integration?.workflows.length).toBeGreaterThan(0);
+    expect(integration?.setupSteps.length).toBeGreaterThan(0);
+  });
+
+  it("returns related integrations for catalog entries with relatedSlugs", () => {
+    const integration = getMarketingIntegrationBySlug("en", "github");
+    expect(integration).not.toBeNull();
+
+    const related = getRelatedIntegrations("en", integration!);
+    expect(related.length).toBeGreaterThan(0);
+    expect(related.every((item) => item.slug !== "github")).toBe(true);
   });
 });

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-page-content.ts
@@ -25,6 +25,7 @@ import {
   getMarketingIntegrationCategoryLabels,
   resolveIntegrationBySlug,
   resolveMarketingIntegrations,
+  resolveRelatedIntegrations,
 } from "@/lib/integrations/resolve-integration-catalog";
 
 export type { IntegrationCategory, IntegrationIconKey, IntegrationStatus, IntegrationType };
@@ -41,6 +42,14 @@ export function getMarketingIntegrations(locale: string) {
 
 export function getMarketingIntegrationBySlug(locale: string, slug: string) {
   return resolveIntegrationBySlug(locale, slug);
+}
+
+export function getRelatedIntegrations(locale: string, integration: MarketingIntegration) {
+  return resolveRelatedIntegrations(locale, integration);
+}
+
+export function getIntegrationNamesBySlug(locale: string) {
+  return Object.fromEntries(getMarketingIntegrations(locale).map((item) => [item.slug, item.name]));
 }
 
 export function getIntegrationCategoryLabels(locale: string) {
@@ -136,6 +145,57 @@ export function getIntegrationDetailCopy(locale: string) {
       id: "+yckLBiVoH",
       description: "Heading for the integration products section",
     }),
+    capabilitiesHeading: intl.formatMessage({
+      defaultMessage: "Capabilities",
+      id: "oUdwcZdkjG",
+      description: "Heading for the integration capabilities section",
+    }),
+    workflowsHeading: intl.formatMessage({
+      defaultMessage: "Example workflows",
+      id: "BNs8waALWE",
+      description: "Heading for the integration workflow examples section",
+    }),
+    workflowsDescription: intl.formatMessage({
+      defaultMessage:
+        "See how teams connect this integration to Hyperlocalise for localization workflows.",
+      id: "2i4QuyVvsX",
+      description: "Supporting copy for the integration workflow examples section",
+    }),
+    workflowTriggerLabel: intl.formatMessage({
+      defaultMessage: "Trigger",
+      id: "MsnNcIq3o0",
+      description: "Label for workflow trigger nodes in the preview canvas",
+    }),
+    workflowActionLabel: intl.formatMessage({
+      defaultMessage: "Action",
+      id: "q9W62WYB+b",
+      description: "Label for workflow action nodes in the preview canvas",
+    }),
+    workflowPreviewHint: intl.formatMessage({
+      defaultMessage: "Click a step or use play to preview how the automation runs.",
+      id: "WCvOhYUxHY",
+      description: "Hint text above the interactive workflow preview canvas",
+    }),
+    workflowPlayLabel: intl.formatMessage({
+      defaultMessage: "Play workflow preview",
+      id: "HnLFJWChXa",
+      description: "Accessible label for playing the workflow preview animation",
+    }),
+    workflowPauseLabel: intl.formatMessage({
+      defaultMessage: "Pause workflow preview",
+      id: "Go2Z9TjTft",
+      description: "Accessible label for pausing the workflow preview animation",
+    }),
+    setupHeading: intl.formatMessage({
+      defaultMessage: "Getting started",
+      id: "0rhtNVSwNB",
+      description: "Heading for the integration setup instructions section",
+    }),
+    relatedHeading: intl.formatMessage({
+      defaultMessage: "Related integrations",
+      id: "MvleTlgom0",
+      description: "Heading for related integrations on the detail page",
+    }),
     websiteLink: intl.formatMessage({
       defaultMessage: "Website",
       id: "DbC71eoMLw",
@@ -182,15 +242,47 @@ export function getIntegrationDetailCopy(locale: string) {
       description: "Integration status label for built-in Hyperlocalise capabilities",
     }),
     finalCtaHeadline: intl.formatMessage({
-      defaultMessage: "Get started with Hyperlocalise",
-      id: "EA4eYo/c8H",
-      description: "Headline for the bottom CTA on integration detail pages",
+      defaultMessage: "Get started with Hyperlocalise today",
+      id: "vAwILOzBUa",
+      description: "Headline for the bottom CTA on integration pages",
     }),
     finalCtaDescription: intl.formatMessage({
       defaultMessage:
-        "Connect integrations from your workspace settings once you are onboarded to Hyperlocalise.",
-      id: "+LauXjmWs2",
-      description: "Supporting copy for the bottom CTA on integration detail pages",
+        "Connect your stack and run agent-native localization workflows with reviewers, automations, and launch tools in one workspace.",
+      id: "JRwdGo2HxU",
+      description: "Supporting copy for the bottom CTA on integration pages",
     }),
+    finalCtaPrimaryLabel: intl.formatMessage({
+      defaultMessage: "Request a demo",
+      id: "S2P95qzM5L",
+      description: "Primary CTA button on integration pages",
+    }),
+    finalCtaSecondaryLabel: intl.formatMessage({
+      defaultMessage: "Sign in to workspace",
+      id: "b6B/tBg1a5",
+      description: "Secondary CTA button on integration pages",
+    }),
+  };
+}
+
+export function getIntegrationCtaCopy(locale: string, integrationName?: string) {
+  const intl = getIntlShape(locale);
+  const copy = getIntegrationDetailCopy(locale);
+
+  return {
+    headline: copy.finalCtaHeadline,
+    description: integrationName
+      ? intl.formatMessage(
+          {
+            defaultMessage:
+              "Connect {integrationName} to Hyperlocalise and start running localization workflows with agents, reviewers, and automations in one workspace.",
+            id: "eZMddlPk0j",
+            description: "Supporting copy for the bottom CTA on integration detail pages",
+          },
+          { integrationName },
+        )
+      : copy.finalCtaDescription,
+    primaryCtaLabel: copy.finalCtaPrimaryLabel,
+    secondaryCtaLabel: copy.finalCtaSecondaryLabel,
   };
 }

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
@@ -17,8 +17,8 @@ import { defineMessages } from "react-intl";
 export const principlesSectionMessages = defineMessages({
   headline: {
     defaultMessage:
-      "Multilingual content operations, unified. <muted>From GTM brief to market release — generate more multilingual content without adding headcount.</muted>",
-    id: "3DgHaZOLH3",
+      "Multilingual content operations, unified. <muted>Less operational overhead, faster market entry, and more revenue from every language you ship.</muted>",
+    id: "qZPWtL4H2F",
     description:
       "Marketing homepage principles section headline; muted wraps the supporting sentence",
   },

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.detail.copy.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.detail.copy.ts
@@ -1,0 +1,3027 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { IntegrationCatalogSlug } from "@/lib/integrations/integration-catalog.copy";
+import type { IntegrationDetailCopyDescriptors } from "@/lib/integrations/integration-catalog.types";
+
+export const integrationDetailCopy = {
+  github: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Repository sync",
+          id: "intGitHubCapRepoTitle",
+          description: "GitHub capability title for repository sync",
+        },
+        description: {
+          defaultMessage:
+            "Connect repositories and branches so Hyperlocalise always works from the code your team is shipping.",
+          id: "intGitHubCapRepoDesc",
+          description: "GitHub capability description for repository sync",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Localization-aware PR review",
+          id: "intGitHubCapPrTitle",
+          description: "GitHub capability title for PR review",
+        },
+        description: {
+          defaultMessage:
+            "Inspect string changes in pull requests and flag missing translations before code merges.",
+          id: "intGitHubCapPrDesc",
+          description: "GitHub capability description for PR review",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Agent fix proposals",
+          id: "intGitHubCapAgentTitle",
+          description: "GitHub capability title for agent fixes",
+        },
+        description: {
+          defaultMessage:
+            "Let agents propose localization fixes and open pull requests directly from review findings.",
+          id: "intGitHubCapAgentDesc",
+          description: "GitHub capability description for agent fixes",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Automation triggers",
+          id: "intGitHubCapAutoTitle",
+          description: "GitHub capability title for automation triggers",
+        },
+        description: {
+          defaultMessage:
+            "Kick off translation workflows when branches are pushed or pull requests are opened.",
+          id: "intGitHubCapAutoDesc",
+          description: "GitHub capability description for automation triggers",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Catch missing translations before merge",
+          id: "intGitHubWf1Title",
+          description: "GitHub workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "PR opened on GitHub",
+              id: "intGitHubWf1Step1",
+              description: "GitHub workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Hyperlocalise scans strings",
+              id: "intGitHubWf1Step2",
+              description: "GitHub workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Reviewer notified in Slack",
+              id: "intGitHubWf1Step3",
+              description: "GitHub workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Ship localization fixes from review findings",
+          id: "intGitHubWf2Title",
+          description: "GitHub workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Agent flags untranslated keys",
+              id: "intGitHubWf2Step1",
+              description: "GitHub workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Translations drafted in Hyperlocalise",
+              id: "intGitHubWf2Step2",
+              description: "GitHub workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Fix PR opened on GitHub",
+              id: "intGitHubWf2Step3",
+              description: "GitHub workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Sync release branches to your TMS",
+          id: "intGitHubWf3Title",
+          description: "GitHub workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Release branch pushed",
+              id: "intGitHubWf3Step1",
+              description: "GitHub workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Strings exported to Crowdin",
+              id: "intGitHubWf3Step2",
+              description: "GitHub workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Locale files updated via PR",
+              id: "intGitHubWf3Step3",
+              description: "GitHub workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Install the GitHub App",
+          id: "intGitHubSetup1Title",
+          description: "GitHub setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Open Integrations in your workspace, find GitHub, and click Connect to install the app on your organization.",
+          id: "intGitHubSetup1Desc",
+          description: "GitHub setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select repositories and branches",
+          id: "intGitHubSetup2Title",
+          description: "GitHub setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Choose which repositories Hyperlocalise can access and set the default branch for each repo.",
+          id: "intGitHubSetup2Desc",
+          description: "GitHub setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Enable automation triggers",
+          id: "intGitHubSetup3Title",
+          description: "GitHub setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Turn on push and pull request triggers in Automations so workflows run when your team ships code.",
+          id: "intGitHubSetup3Desc",
+          description: "GitHub setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Repository connections",
+          id: "intGitHubProd1Name",
+          description: "GitHub product name",
+        },
+        description: {
+          defaultMessage: "Sync repos, branches, and file context for agent-native localization.",
+          id: "intGitHubProd1Desc",
+          description: "GitHub product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "PR review",
+          id: "intGitHubProd2Name",
+          description: "GitHub product name",
+        },
+        description: {
+          defaultMessage:
+            "Surface string changes and translation gaps inside merge request workflows.",
+          id: "intGitHubProd2Desc",
+          description: "GitHub product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Agent fix PRs",
+          id: "intGitHubProd3Name",
+          description: "GitHub product name",
+        },
+        description: {
+          defaultMessage: "Open pull requests with proposed localization fixes from agent review.",
+          id: "intGitHubProd3Desc",
+          description: "GitHub product description",
+        },
+      },
+    ],
+  },
+  gitlab: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Merge request review",
+          id: "intGitLabCapMrTitle",
+          description: "GitLab capability title",
+        },
+        description: {
+          defaultMessage:
+            "Review localized strings inside GitLab merge requests without switching tools.",
+          id: "intGitLabCapMrDesc",
+          description: "GitLab capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Repository context",
+          id: "intGitLabCapRepoTitle",
+          description: "GitLab capability title",
+        },
+        description: {
+          defaultMessage:
+            "Give agents product context from GitLab repos so translation work stays tied to code.",
+          id: "intGitLabCapRepoDesc",
+          description: "GitLab capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Localization fix proposals",
+          id: "intGitLabCapFixTitle",
+          description: "GitLab capability title",
+        },
+        description: {
+          defaultMessage:
+            "Propose and open merge requests with localization fixes from Hyperlocalise reviews.",
+          id: "intGitLabCapFixDesc",
+          description: "GitLab capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "CI/CD integration",
+          id: "intGitLabCapCiTitle",
+          description: "GitLab capability title",
+        },
+        description: {
+          defaultMessage:
+            "Trigger localization checks and translation workflows from GitLab pipeline events.",
+          id: "intGitLabCapCiDesc",
+          description: "GitLab capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Block releases with missing translations",
+          id: "intGitLabWf1Title",
+          description: "GitLab workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "MR updated on GitLab",
+              id: "intGitLabWf1Step1",
+              description: "GitLab workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Hyperlocalise checks locales",
+              id: "intGitLabWf1Step2",
+              description: "GitLab workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Blocker posted to MR",
+              id: "intGitLabWf1Step3",
+              description: "GitLab workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Route review blockers to Jira",
+          id: "intGitLabWf2Title",
+          description: "GitLab workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Translation gap found",
+              id: "intGitLabWf2Step1",
+              description: "GitLab workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Jira issue created",
+              id: "intGitLabWf2Step2",
+              description: "GitLab workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Fix MR linked to issue",
+              id: "intGitLabWf2Step3",
+              description: "GitLab workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect your GitLab group",
+          id: "intGitLabSetup1Title",
+          description: "GitLab setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Authorize Hyperlocalise to access your GitLab group or namespace from workspace Integrations.",
+          id: "intGitLabSetup1Desc",
+          description: "GitLab setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select projects",
+          id: "intGitLabSetup2Title",
+          description: "GitLab setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Choose which projects to sync and set the default branch for localization context.",
+          id: "intGitLabSetup2Desc",
+          description: "GitLab setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Project sync",
+          id: "intGitLabProd1Name",
+          description: "GitLab product name",
+        },
+        description: {
+          defaultMessage:
+            "Connect GitLab projects and branches for localization-aware development.",
+          id: "intGitLabProd1Desc",
+          description: "GitLab product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "MR review",
+          id: "intGitLabProd2Name",
+          description: "GitLab product name",
+        },
+        description: {
+          defaultMessage: "Inspect string changes and flag translation gaps in merge requests.",
+          id: "intGitLabProd2Desc",
+          description: "GitLab product description",
+        },
+      },
+    ],
+  },
+  slack: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Review notifications",
+          id: "intSlackCapNotifyTitle",
+          description: "Slack capability title",
+        },
+        description: {
+          defaultMessage:
+            "Route translation review requests and status updates to the channels that own the work.",
+          id: "intSlackCapNotifyDesc",
+          description: "Slack capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Thread-based coordination",
+          id: "intSlackCapThreadTitle",
+          description: "Slack capability title",
+        },
+        description: {
+          defaultMessage:
+            "Discuss string changes, approve translations, and resolve blockers without leaving Slack.",
+          id: "intSlackCapThreadDesc",
+          description: "Slack capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Launch alerts",
+          id: "intSlackCapAlertTitle",
+          description: "Slack capability title",
+        },
+        description: {
+          defaultMessage:
+            "Get notified when locales are ready, blockers appear, or launch deadlines approach.",
+          id: "intSlackCapAlertDesc",
+          description: "Slack capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Agent mentions",
+          id: "intSlackCapAgentTitle",
+          description: "Slack capability title",
+        },
+        description: {
+          defaultMessage:
+            "Mention the localization bot to ask about project status, string context, or review queues.",
+          id: "intSlackCapAgentDesc",
+          description: "Slack capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Notify reviewers when strings change",
+          id: "intSlackWf1Title",
+          description: "Slack workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "New strings submitted",
+              id: "intSlackWf1Step1",
+              description: "Slack workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Review posted to #localization",
+              id: "intSlackWf1Step2",
+              description: "Slack workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Reviewer approves in thread",
+              id: "intSlackWf1Step3",
+              description: "Slack workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Escalate launch blockers",
+          id: "intSlackWf2Title",
+          description: "Slack workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Locale fails QA check",
+              id: "intSlackWf2Step1",
+              description: "Slack workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Alert sent to #launch",
+              id: "intSlackWf2Step2",
+              description: "Slack workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Owner assigned in thread",
+              id: "intSlackWf2Step3",
+              description: "Slack workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Celebrate locale launches",
+          id: "intSlackWf3Title",
+          description: "Slack workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "All locales approved",
+              id: "intSlackWf3Step1",
+              description: "Slack workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Launch summary posted",
+              id: "intSlackWf3Step2",
+              description: "Slack workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Team notified in channel",
+              id: "intSlackWf3Step3",
+              description: "Slack workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Install the Slack app",
+          id: "intSlackSetup1Title",
+          description: "Slack setup step title",
+        },
+        description: {
+          defaultMessage:
+            "From workspace Integrations, click Connect on Slack and authorize the app for your workspace.",
+          id: "intSlackSetup1Desc",
+          description: "Slack setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Choose notification channels",
+          id: "intSlackSetup2Title",
+          description: "Slack setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Select which channels receive review requests, launch alerts, and agent notifications.",
+          id: "intSlackSetup2Desc",
+          description: "Slack setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Configure automations",
+          id: "intSlackSetup3Title",
+          description: "Slack setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Set up Automations to post to Slack when translation events occur in your projects.",
+          id: "intSlackSetup3Desc",
+          description: "Slack setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Channel notifications",
+          id: "intSlackProd1Name",
+          description: "Slack product name",
+        },
+        description: {
+          defaultMessage: "Post review requests and status updates to team channels.",
+          id: "intSlackProd1Desc",
+          description: "Slack product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Thread reviews",
+          id: "intSlackProd2Name",
+          description: "Slack product name",
+        },
+        description: {
+          defaultMessage: "Approve translations and resolve blockers directly in Slack threads.",
+          id: "intSlackProd2Desc",
+          description: "Slack product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Localization bot",
+          id: "intSlackProd3Name",
+          description: "Slack product name",
+        },
+        description: {
+          defaultMessage: "Ask the bot about project status, string context, and review queues.",
+          id: "intSlackProd3Desc",
+          description: "Slack product description",
+        },
+      },
+    ],
+  },
+  crowdin: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Live project browsing",
+          id: "intCrowdinCapBrowseTitle",
+          description: "Crowdin capability title",
+        },
+        description: {
+          defaultMessage:
+            "Browse Crowdin projects, jobs, and translation data alongside native Hyperlocalise work.",
+          id: "intCrowdinCapBrowseDesc",
+          description: "Crowdin capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "OAuth and PAT setup",
+          id: "intCrowdinCapAuthTitle",
+          description: "Crowdin capability title",
+        },
+        description: {
+          defaultMessage:
+            "Connect with user OAuth or personal access tokens depending on your team's security policy.",
+          id: "intCrowdinCapAuthDesc",
+          description: "Crowdin capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Agent TMS context",
+          id: "intCrowdinCapAgentTitle",
+          description: "Crowdin capability title",
+        },
+        description: {
+          defaultMessage:
+            "Give agents access to Crowdin project structure, strings, and job status for smarter workflows.",
+          id: "intCrowdinCapAgentDesc",
+          description: "Crowdin capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Bidirectional sync",
+          id: "intCrowdinCapSyncTitle",
+          description: "Crowdin capability title",
+        },
+        description: {
+          defaultMessage:
+            "Keep Hyperlocalise and Crowdin aligned so translation work does not drift between systems.",
+          id: "intCrowdinCapSyncDesc",
+          description: "Crowdin capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Pull latest strings from Crowdin",
+          id: "intCrowdinWf1Title",
+          description: "Crowdin workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Crowdin job completed",
+              id: "intCrowdinWf1Step1",
+              description: "Crowdin workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Strings synced to Hyperlocalise",
+              id: "intCrowdinWf1Step2",
+              description: "Crowdin workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Review queue updated",
+              id: "intCrowdinWf1Step3",
+              description: "Crowdin workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Push approved translations back",
+          id: "intCrowdinWf2Title",
+          description: "Crowdin workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Translations approved",
+              id: "intCrowdinWf2Step1",
+              description: "Crowdin workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Strings pushed to Crowdin",
+              id: "intCrowdinWf2Step2",
+              description: "Crowdin workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "GitHub PR opened with locale files",
+              id: "intCrowdinWf2Step3",
+              description: "Crowdin workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Crowdin",
+          id: "intCrowdinSetup1Title",
+          description: "Crowdin setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Open Integrations, find Crowdin, and connect with OAuth or a personal access token.",
+          id: "intCrowdinSetup1Desc",
+          description: "Crowdin setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select projects",
+          id: "intCrowdinSetup2Title",
+          description: "Crowdin setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Choose which Crowdin projects to link so agents and reviewers can browse live TMS data.",
+          id: "intCrowdinSetup2Desc",
+          description: "Crowdin setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Project browser",
+          id: "intCrowdinProd1Name",
+          description: "Crowdin product name",
+        },
+        description: {
+          defaultMessage: "Browse Crowdin projects, files, and jobs from Hyperlocalise.",
+          id: "intCrowdinProd1Desc",
+          description: "Crowdin product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "String sync",
+          id: "intCrowdinProd2Name",
+          description: "Crowdin product name",
+        },
+        description: {
+          defaultMessage: "Import and export translation data between Crowdin and your workspace.",
+          id: "intCrowdinProd2Desc",
+          description: "Crowdin product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Agent context",
+          id: "intCrowdinProd3Name",
+          description: "Crowdin product name",
+        },
+        description: {
+          defaultMessage: "Give localization agents live TMS context for smarter translation work.",
+          id: "intCrowdinProd3Desc",
+          description: "Crowdin product description",
+        },
+      },
+    ],
+  },
+  lokalise: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "OAuth project access",
+          id: "intLokaliseCapOAuthTitle",
+          description: "Lokalise capability title",
+        },
+        description: {
+          defaultMessage:
+            "Connect with user OAuth to browse Lokalise projects, tasks, and linguistic assets securely.",
+          id: "intLokaliseCapOAuthDesc",
+          description: "Lokalise capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Glossary and TM access",
+          id: "intLokaliseCapGlossaryTitle",
+          description: "Lokalise capability title",
+        },
+        description: {
+          defaultMessage:
+            "Surface glossaries and translation memories so agents apply consistent terminology.",
+          id: "intLokaliseCapGlossaryDesc",
+          description: "Lokalise capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Task visibility",
+          id: "intLokaliseCapTaskTitle",
+          description: "Lokalise capability title",
+        },
+        description: {
+          defaultMessage:
+            "See Lokalise tasks and assignment status alongside Hyperlocalise review workflows.",
+          id: "intLokaliseCapTaskDesc",
+          description: "Lokalise capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Hybrid TMS workflows",
+          id: "intLokaliseCapHybridTitle",
+          description: "Lokalise capability title",
+        },
+        description: {
+          defaultMessage:
+            "Run agent-native localization on top of Lokalise without forcing teams to switch tools.",
+          id: "intLokaliseCapHybridDesc",
+          description: "Lokalise capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Assign Lokalise tasks from agent review",
+          id: "intLokaliseWf1Title",
+          description: "Lokalise workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Agent flags terminology issue",
+              id: "intLokaliseWf1Step1",
+              description: "Lokalise workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Lokalise task created",
+              id: "intLokaliseWf1Step2",
+              description: "Lokalise workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Translator notified",
+              id: "intLokaliseWf1Step3",
+              description: "Lokalise workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Import glossary for agent context",
+          id: "intLokaliseWf2Title",
+          description: "Lokalise workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Glossary updated in Lokalise",
+              id: "intLokaliseWf2Step1",
+              description: "Lokalise workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Terms synced to Hyperlocalise",
+              id: "intLokaliseWf2Step2",
+              description: "Lokalise workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Agents apply brand terms",
+              id: "intLokaliseWf2Step3",
+              description: "Lokalise workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Authorize with OAuth",
+          id: "intLokaliseSetup1Title",
+          description: "Lokalise setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Connect Lokalise from workspace Integrations using your Lokalise account OAuth flow.",
+          id: "intLokaliseSetup1Desc",
+          description: "Lokalise setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Link projects",
+          id: "intLokaliseSetup2Title",
+          description: "Lokalise setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Select Lokalise projects to expose in Hyperlocalise for browsing and agent workflows.",
+          id: "intLokaliseSetup2Desc",
+          description: "Lokalise setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Project browser",
+          id: "intLokaliseProd1Name",
+          description: "Lokalise product name",
+        },
+        description: {
+          defaultMessage: "Browse Lokalise projects, keys, and tasks from your workspace.",
+          id: "intLokaliseProd1Desc",
+          description: "Lokalise product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Linguistic assets",
+          id: "intLokaliseProd2Name",
+          description: "Lokalise product name",
+        },
+        description: {
+          defaultMessage: "Access glossaries and translation memories for consistent agent output.",
+          id: "intLokaliseProd2Desc",
+          description: "Lokalise product description",
+        },
+      },
+    ],
+  },
+  phrase: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Enterprise project access",
+          id: "intPhraseCapProjectTitle",
+          description: "Phrase capability title",
+        },
+        description: {
+          defaultMessage:
+            "Browse Phrase projects and jobs with OAuth-backed access for enterprise TMS programs.",
+          id: "intPhraseCapProjectDesc",
+          description: "Phrase capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Job status visibility",
+          id: "intPhraseCapJobTitle",
+          description: "Phrase capability title",
+        },
+        description: {
+          defaultMessage:
+            "See translation job progress and assignment status inside Hyperlocalise launch workflows.",
+          id: "intPhraseCapJobDesc",
+          description: "Phrase capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Agent TMS context",
+          id: "intPhraseCapAgentTitle",
+          description: "Phrase capability title",
+        },
+        description: {
+          defaultMessage:
+            "Give agents Phrase project structure and string data for context-aware translation.",
+          id: "intPhraseCapAgentDesc",
+          description: "Phrase capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Launch coordination",
+          id: "intPhraseCapLaunchTitle",
+          description: "Phrase capability title",
+        },
+        description: {
+          defaultMessage:
+            "Coordinate enterprise localization launches with Phrase jobs visible to your whole team.",
+          id: "intPhraseCapLaunchDesc",
+          description: "Phrase capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Track Phrase job completion",
+          id: "intPhraseWf1Title",
+          description: "Phrase workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Phrase job assigned",
+              id: "intPhraseWf1Step1",
+              description: "Phrase workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Progress synced to Hyperlocalise",
+              id: "intPhraseWf1Step2",
+              description: "Phrase workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Launch owner notified",
+              id: "intPhraseWf1Step3",
+              description: "Phrase workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Route blockers to Slack",
+          id: "intPhraseWf2Title",
+          description: "Phrase workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Phrase job overdue",
+              id: "intPhraseWf2Step1",
+              description: "Phrase workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Alert posted to Slack",
+              id: "intPhraseWf2Step2",
+              description: "Phrase workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "PM escalates in thread",
+              id: "intPhraseWf2Step3",
+              description: "Phrase workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect with OAuth",
+          id: "intPhraseSetup1Title",
+          description: "Phrase setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Authorize Hyperlocalise to access your Phrase account from workspace Integrations.",
+          id: "intPhraseSetup1Desc",
+          description: "Phrase setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select projects and jobs",
+          id: "intPhraseSetup2Title",
+          description: "Phrase setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Link Phrase projects so job status and string data appear in your localization workspace.",
+          id: "intPhraseSetup2Desc",
+          description: "Phrase setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Project browser",
+          id: "intPhraseProd1Name",
+          description: "Phrase product name",
+        },
+        description: {
+          defaultMessage: "Browse Phrase projects and localization jobs from Hyperlocalise.",
+          id: "intPhraseProd1Desc",
+          description: "Phrase product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Job tracking",
+          id: "intPhraseProd2Name",
+          description: "Phrase product name",
+        },
+        description: {
+          defaultMessage: "Monitor translation job progress alongside launch workflows.",
+          id: "intPhraseProd2Desc",
+          description: "Phrase product description",
+        },
+      },
+    ],
+  },
+  smartling: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Enterprise program visibility",
+          id: "intSmartlingCapProgramTitle",
+          description: "Smartling capability title",
+        },
+        description: {
+          defaultMessage:
+            "Bring large-scale Smartling programs into the same workspace your launch team uses.",
+          id: "intSmartlingCapProgramDesc",
+          description: "Smartling capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Agent workflows on TMS data",
+          id: "intSmartlingCapAgentTitle",
+          description: "Smartling capability title",
+        },
+        description: {
+          defaultMessage:
+            "Run agent-native localization reviews on top of existing Smartling infrastructure.",
+          id: "intSmartlingCapAgentDesc",
+          description: "Smartling capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Launch coordination",
+          id: "intSmartlingCapLaunchTitle",
+          description: "Smartling capability title",
+        },
+        description: {
+          defaultMessage:
+            "Coordinate multi-locale launches with Smartling job status visible to stakeholders.",
+          id: "intSmartlingCapLaunchDesc",
+          description: "Smartling capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Review layer",
+          id: "intSmartlingCapReviewTitle",
+          description: "Smartling capability title",
+        },
+        description: {
+          defaultMessage: "Add Hyperlocalise review and QA on top of Smartling translation output.",
+          id: "intSmartlingCapReviewDesc",
+          description: "Smartling capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "QA Smartling output before launch",
+          id: "intSmartlingWf1Title",
+          description: "Smartling workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Smartling job completed",
+              id: "intSmartlingWf1Step1",
+              description: "Smartling workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Strings imported for review",
+              id: "intSmartlingWf1Step2",
+              description: "Smartling workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "QA findings routed to reviewers",
+              id: "intSmartlingWf1Step3",
+              description: "Smartling workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Smartling",
+          id: "intSmartlingSetup1Title",
+          description: "Smartling setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Link your Smartling account from workspace Integrations to enable program visibility.",
+          id: "intSmartlingSetup1Desc",
+          description: "Smartling setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Program browser",
+          id: "intSmartlingProd1Name",
+          description: "Smartling product name",
+        },
+        description: {
+          defaultMessage: "Browse Smartling projects and jobs from your Hyperlocalise workspace.",
+          id: "intSmartlingProd1Desc",
+          description: "Smartling product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Review layer",
+          id: "intSmartlingProd2Name",
+          description: "Smartling product name",
+        },
+        description: {
+          defaultMessage: "Add agent-native QA and review on top of Smartling translations.",
+          id: "intSmartlingProd2Desc",
+          description: "Smartling product description",
+        },
+      },
+    ],
+  },
+  contentful: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Space and environment targeting",
+          id: "intContentfulCapSpaceTitle",
+          description: "Contentful capability title",
+        },
+        description: {
+          defaultMessage:
+            "Connect specific Contentful spaces and environments for precise content localization.",
+          id: "intContentfulCapSpaceDesc",
+          description: "Contentful capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Agentic article translation",
+          id: "intContentfulCapAgentTitle",
+          description: "Contentful capability title",
+        },
+        description: {
+          defaultMessage:
+            "Let agents translate structured content entries while preserving field types and relationships.",
+          id: "intContentfulCapAgentDesc",
+          description: "Contentful capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Draft writeback",
+          id: "intContentfulCapWritebackTitle",
+          description: "Contentful capability title",
+        },
+        description: {
+          defaultMessage:
+            "Write localized drafts back to Contentful so editors can review before publishing.",
+          id: "intContentfulCapWritebackDesc",
+          description: "Contentful capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Content-type aware",
+          id: "intContentfulCapTypeTitle",
+          description: "Contentful capability title",
+        },
+        description: {
+          defaultMessage:
+            "Target specific content types so agents only translate the fields that need localization.",
+          id: "intContentfulCapTypeDesc",
+          description: "Contentful capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Translate blog posts to new locales",
+          id: "intContentfulWf1Title",
+          description: "Contentful workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Article published in English",
+              id: "intContentfulWf1Step1",
+              description: "Contentful workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Agent drafts German version",
+              id: "intContentfulWf1Step2",
+              description: "Contentful workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Draft saved to Contentful",
+              id: "intContentfulWf1Step3",
+              description: "Contentful workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Localize product pages for launch",
+          id: "intContentfulWf2Title",
+          description: "Contentful workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "New product entry created",
+              id: "intContentfulWf2Step1",
+              description: "Contentful workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Translations drafted for 5 locales",
+              id: "intContentfulWf2Step2",
+              description: "Contentful workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Editor reviews drafts in Contentful",
+              id: "intContentfulWf2Step3",
+              description: "Contentful workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Keep SEO metadata localized",
+          id: "intContentfulWf3Title",
+          description: "Contentful workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "SEO fields updated",
+              id: "intContentfulWf3Step1",
+              description: "Contentful workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Ahrefs keywords applied per locale",
+              id: "intContentfulWf3Step2",
+              description: "Contentful workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Localized meta written back",
+              id: "intContentfulWf3Step3",
+              description: "Contentful workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect your space",
+          id: "intContentfulSetup1Title",
+          description: "Contentful setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Authorize Hyperlocalise to access your Contentful space from workspace Integrations.",
+          id: "intContentfulSetup1Desc",
+          description: "Contentful setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select environment and content types",
+          id: "intContentfulSetup2Title",
+          description: "Contentful setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Choose the environment and content types agents should translate and write back to.",
+          id: "intContentfulSetup2Desc",
+          description: "Contentful setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Configure writeback",
+          id: "intContentfulSetup3Title",
+          description: "Contentful setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Set whether agents write drafts or published entries, and which locales to target.",
+          id: "intContentfulSetup3Desc",
+          description: "Contentful setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Space connections",
+          id: "intContentfulProd1Name",
+          description: "Contentful product name",
+        },
+        description: {
+          defaultMessage: "Link Contentful spaces and environments for targeted localization.",
+          id: "intContentfulProd1Desc",
+          description: "Contentful product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Entry translation",
+          id: "intContentfulProd2Name",
+          description: "Contentful product name",
+        },
+        description: {
+          defaultMessage: "Translate structured entries while preserving field types and links.",
+          id: "intContentfulProd2Desc",
+          description: "Contentful product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Draft writeback",
+          id: "intContentfulProd3Name",
+          description: "Contentful product name",
+        },
+        description: {
+          defaultMessage: "Write localized drafts back for editor review before publishing.",
+          id: "intContentfulProd3Desc",
+          description: "Contentful product description",
+        },
+      },
+    ],
+  },
+  canva: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Design asset localization",
+          id: "intCanvaCapAssetTitle",
+          description: "Canva capability title",
+        },
+        description: {
+          defaultMessage:
+            "Localize text layers and campaign creative in Canva designs without rebuilding layouts.",
+          id: "intCanvaCapAssetDesc",
+          description: "Canva capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Campaign creative workflows",
+          id: "intCanvaCapCampaignTitle",
+          description: "Canva capability title",
+        },
+        description: {
+          defaultMessage:
+            "Adapt marketing campaigns for new markets while keeping brand visuals consistent.",
+          id: "intCanvaCapCampaignDesc",
+          description: "Canva capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Brand consistency",
+          id: "intCanvaCapBrandTitle",
+          description: "Canva capability title",
+        },
+        description: {
+          defaultMessage:
+            "Apply glossary and style guide terms to design copy for on-brand localized creative.",
+          id: "intCanvaCapBrandDesc",
+          description: "Canva capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Visual launch coordination",
+          id: "intCanvaCapLaunchTitle",
+          description: "Canva capability title",
+        },
+        description: {
+          defaultMessage:
+            "Keep visual launch assets in the same localization operating system as product copy.",
+          id: "intCanvaCapLaunchDesc",
+          description: "Canva capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Localize campaign banners for new markets",
+          id: "intCanvaWf1Title",
+          description: "Canva workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Campaign design approved",
+              id: "intCanvaWf1Step1",
+              description: "Canva workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Text layers translated per locale",
+              id: "intCanvaWf1Step2",
+              description: "Canva workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Localized versions saved in Canva",
+              id: "intCanvaWf1Step3",
+              description: "Canva workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Adapt social posts for regional launch",
+          id: "intCanvaWf2Title",
+          description: "Canva workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Social template selected",
+              id: "intCanvaWf2Step1",
+              description: "Canva workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Copy localized with brand glossary",
+              id: "intCanvaWf2Step2",
+              description: "Canva workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Regional variants ready to publish",
+              id: "intCanvaWf2Step3",
+              description: "Canva workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Canva",
+          id: "intCanvaSetup1Title",
+          description: "Canva setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Authorize Hyperlocalise to access your Canva account from workspace Integrations.",
+          id: "intCanvaSetup1Desc",
+          description: "Canva setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select brand kits and folders",
+          id: "intCanvaSetup2Title",
+          description: "Canva setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Choose which Canva brand kits and design folders to include in localization workflows.",
+          id: "intCanvaSetup2Desc",
+          description: "Canva setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Design localization",
+          id: "intCanvaProd1Name",
+          description: "Canva product name",
+        },
+        description: {
+          defaultMessage: "Translate text layers in Canva designs for market-specific creative.",
+          id: "intCanvaProd1Desc",
+          description: "Canva product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Campaign adaptation",
+          id: "intCanvaProd2Name",
+          description: "Canva product name",
+        },
+        description: {
+          defaultMessage:
+            "Adapt marketing campaigns for new locales while preserving brand visuals.",
+          id: "intCanvaProd2Desc",
+          description: "Canva product description",
+        },
+      },
+    ],
+  },
+  intercom: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Help center localization",
+          id: "intIntercomCapHelpTitle",
+          description: "Intercom capability title",
+        },
+        description: {
+          defaultMessage:
+            "Translate support articles and help center content for global customer bases.",
+          id: "intIntercomCapHelpDesc",
+          description: "Intercom capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "In-product messaging",
+          id: "intIntercomCapMessageTitle",
+          description: "Intercom capability title",
+        },
+        description: {
+          defaultMessage:
+            "Localize tours, banners, and in-app messages so onboarding feels native in every market.",
+          id: "intIntercomCapMessageDesc",
+          description: "Intercom capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Consistent review process",
+          id: "intIntercomCapReviewTitle",
+          description: "Intercom capability title",
+        },
+        description: {
+          defaultMessage:
+            "Run support content through the same review workflow as product strings.",
+          id: "intIntercomCapReviewDesc",
+          description: "Intercom capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Launch alignment",
+          id: "intIntercomCapLaunchTitle",
+          description: "Intercom capability title",
+        },
+        description: {
+          defaultMessage:
+            "Ship localized support content alongside product launches in new markets.",
+          id: "intIntercomCapLaunchDesc",
+          description: "Intercom capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Localize help articles for market launch",
+          id: "intIntercomWf1Title",
+          description: "Intercom workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "New feature ships",
+              id: "intIntercomWf1Step1",
+              description: "Intercom workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Help articles drafted in 4 locales",
+              id: "intIntercomWf1Step2",
+              description: "Intercom workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Articles published in Intercom",
+              id: "intIntercomWf1Step3",
+              description: "Intercom workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Translate onboarding tours",
+          id: "intIntercomWf2Title",
+          description: "Intercom workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Tour copy updated in English",
+              id: "intIntercomWf2Step1",
+              description: "Intercom workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Translations reviewed in Hyperlocalise",
+              id: "intIntercomWf2Step2",
+              description: "Intercom workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Localized tour pushed to Intercom",
+              id: "intIntercomWf2Step3",
+              description: "Intercom workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Intercom",
+          id: "intIntercomSetup1Title",
+          description: "Intercom setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Authorize Hyperlocalise to access your Intercom workspace from Integrations.",
+          id: "intIntercomSetup1Desc",
+          description: "Intercom setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select content types",
+          id: "intIntercomSetup2Title",
+          description: "Intercom setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Choose which Intercom content types to localize: articles, messages, or tours.",
+          id: "intIntercomSetup2Desc",
+          description: "Intercom setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Help center",
+          id: "intIntercomProd1Name",
+          description: "Intercom product name",
+        },
+        description: {
+          defaultMessage: "Translate support articles and documentation for global customers.",
+          id: "intIntercomProd1Desc",
+          description: "Intercom product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "In-product messaging",
+          id: "intIntercomProd2Name",
+          description: "Intercom product name",
+        },
+        description: {
+          defaultMessage: "Localize tours, banners, and onboarding messages per market.",
+          id: "intIntercomProd2Desc",
+          description: "Intercom product description",
+        },
+      },
+    ],
+  },
+  ahrefs: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Keyword research per locale",
+          id: "intAhrefsCapKeywordTitle",
+          description: "Ahrefs capability title",
+        },
+        description: {
+          defaultMessage:
+            "Feed locale-specific keyword data into content planning and translation prioritization.",
+          id: "intAhrefsCapKeywordDesc",
+          description: "Ahrefs capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Ranking context",
+          id: "intAhrefsCapRankTitle",
+          description: "Ahrefs capability title",
+        },
+        description: {
+          defaultMessage:
+            "See how pages rank in target markets to prioritize which content to localize first.",
+          id: "intAhrefsCapRankDesc",
+          description: "Ahrefs capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Content planning",
+          id: "intAhrefsCapPlanTitle",
+          description: "Ahrefs capability title",
+        },
+        description: {
+          defaultMessage:
+            "Use search data to decide which pages and topics deserve localization investment.",
+          id: "intAhrefsCapPlanDesc",
+          description: "Ahrefs capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "SEO-informed translation",
+          id: "intAhrefsCapTranslateTitle",
+          description: "Ahrefs capability title",
+        },
+        description: {
+          defaultMessage:
+            "Give agents keyword context so localized content targets real search intent.",
+          id: "intAhrefsCapTranslateDesc",
+          description: "Ahrefs capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Prioritize pages for localization",
+          id: "intAhrefsWf1Title",
+          description: "Ahrefs workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Ahrefs ranking data imported",
+              id: "intAhrefsWf1Step1",
+              description: "Ahrefs workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "High-traffic pages flagged",
+              id: "intAhrefsWf1Step2",
+              description: "Ahrefs workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Localization queue prioritized",
+              id: "intAhrefsWf1Step3",
+              description: "Ahrefs workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Optimize localized meta descriptions",
+          id: "intAhrefsWf2Title",
+          description: "Ahrefs workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Target keywords identified",
+              id: "intAhrefsWf2Step1",
+              description: "Ahrefs workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Agent drafts SEO-aware copy",
+              id: "intAhrefsWf2Step2",
+              description: "Ahrefs workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Meta written to Contentful",
+              id: "intAhrefsWf2Step3",
+              description: "Ahrefs workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Ahrefs",
+          id: "intAhrefsSetup1Title",
+          description: "Ahrefs setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Link your Ahrefs account from workspace Integrations to import keyword and ranking data.",
+          id: "intAhrefsSetup1Desc",
+          description: "Ahrefs setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select target markets",
+          id: "intAhrefsSetup2Title",
+          description: "Ahrefs setup step title",
+        },
+        description: {
+          defaultMessage: "Choose which country and language combinations to pull search data for.",
+          id: "intAhrefsSetup2Desc",
+          description: "Ahrefs setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Keyword research",
+          id: "intAhrefsProd1Name",
+          description: "Ahrefs product name",
+        },
+        description: {
+          defaultMessage: "Import locale-specific keyword data for content planning.",
+          id: "intAhrefsProd1Desc",
+          description: "Ahrefs product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Ranking insights",
+          id: "intAhrefsProd2Name",
+          description: "Ahrefs product name",
+        },
+        description: {
+          defaultMessage: "See page rankings per market to prioritize localization work.",
+          id: "intAhrefsProd2Desc",
+          description: "Ahrefs product description",
+        },
+      },
+    ],
+  },
+  semrush: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Competitive research",
+          id: "intSemrushCapCompTitle",
+          description: "Semrush capability title",
+        },
+        description: {
+          defaultMessage:
+            "Understand competitor content strategies in target markets before localizing.",
+          id: "intSemrushCapCompDesc",
+          description: "Semrush capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Keyword intelligence",
+          id: "intSemrushCapKeywordTitle",
+          description: "Semrush capability title",
+        },
+        description: {
+          defaultMessage:
+            "Pull keyword and ranking data into Hyperlocalise for search-informed translation.",
+          id: "intSemrushCapKeywordDesc",
+          description: "Semrush capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Market prioritization",
+          id: "intSemrushCapMarketTitle",
+          description: "Semrush capability title",
+        },
+        description: {
+          defaultMessage: "Use SEO signals to decide which markets and pages to localize first.",
+          id: "intSemrushCapMarketDesc",
+          description: "Semrush capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Content optimization",
+          id: "intSemrushCapOptimizeTitle",
+          description: "Semrush capability title",
+        },
+        description: {
+          defaultMessage: "Optimize localized content for search intent in each target language.",
+          id: "intSemrushCapOptimizeDesc",
+          description: "Semrush capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Plan multilingual content calendar",
+          id: "intSemrushWf1Title",
+          description: "Semrush workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Semrush keyword gaps identified",
+              id: "intSemrushWf1Step1",
+              description: "Semrush workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Content briefs created per locale",
+              id: "intSemrushWf1Step2",
+              description: "Semrush workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Translation queue populated",
+              id: "intSemrushWf1Step3",
+              description: "Semrush workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Benchmark competitor localization",
+          id: "intSemrushWf2Title",
+          description: "Semrush workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Competitor pages analyzed",
+              id: "intSemrushWf2Step1",
+              description: "Semrush workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Gap report generated",
+              id: "intSemrushWf2Step2",
+              description: "Semrush workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Priority pages added to queue",
+              id: "intSemrushWf2Step3",
+              description: "Semrush workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Semrush",
+          id: "intSemrushSetup1Title",
+          description: "Semrush setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Link your Semrush account from workspace Integrations to import SEO intelligence.",
+          id: "intSemrushSetup1Desc",
+          description: "Semrush setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Keyword intelligence",
+          id: "intSemrushProd1Name",
+          description: "Semrush product name",
+        },
+        description: {
+          defaultMessage: "Import keyword and ranking data for locale-aware content planning.",
+          id: "intSemrushProd1Desc",
+          description: "Semrush product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Competitive analysis",
+          id: "intSemrushProd2Name",
+          description: "Semrush product name",
+        },
+        description: {
+          defaultMessage: "Benchmark competitor content strategies in target markets.",
+          id: "intSemrushProd2Desc",
+          description: "Semrush product description",
+        },
+      },
+    ],
+  },
+  hyperlab: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Controlled experiments",
+          id: "intHyperlabCapExperimentTitle",
+          description: "Hyperlab capability title",
+        },
+        description: {
+          defaultMessage:
+            "Test localized copy, layouts, or market-specific variants with a subset of users first.",
+          id: "intHyperlabCapExperimentDesc",
+          description: "Hyperlab capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "No separate feature flags",
+          id: "intHyperlabCapFlagsTitle",
+          description: "Hyperlab capability title",
+        },
+        description: {
+          defaultMessage:
+            "Run experiments inside Hyperlocalise without bolting on a separate feature-flag stack.",
+          id: "intHyperlabCapFlagsDesc",
+          description: "Hyperlab capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Locale-aware variants",
+          id: "intHyperlabCapLocaleTitle",
+          description: "Hyperlab capability title",
+        },
+        description: {
+          defaultMessage:
+            "Test different translations or market-specific messaging before global rollout.",
+          id: "intHyperlabCapLocaleDesc",
+          description: "Hyperlab capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Launch confidence",
+          id: "intHyperlabCapLaunchTitle",
+          description: "Hyperlab capability title",
+        },
+        description: {
+          defaultMessage:
+            "Validate localized experiences with real users before committing to a full market launch.",
+          id: "intHyperlabCapLaunchDesc",
+          description: "Hyperlab capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "A/B test translated headlines",
+          id: "intHyperlabWf1Title",
+          description: "Hyperlab workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Two headline variants created",
+              id: "intHyperlabWf1Step1",
+              description: "Hyperlab workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Experiment shown to 10% of users",
+              id: "intHyperlabWf1Step2",
+              description: "Hyperlab workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Winning variant rolled out",
+              id: "intHyperlabWf1Step3",
+              description: "Hyperlab workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Validate new market copy before launch",
+          id: "intHyperlabWf2Title",
+          description: "Hyperlab workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "German copy drafted",
+              id: "intHyperlabWf2Step1",
+              description: "Hyperlab workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Shown to German beta users",
+              id: "intHyperlabWf2Step2",
+              description: "Hyperlab workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Full DE launch approved",
+              id: "intHyperlabWf2Step3",
+              description: "Hyperlab workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Enable Hyperlab",
+          id: "intHyperlabSetup1Title",
+          description: "Hyperlab setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Hyperlab is included with Hyperlocalise. Enable it from your workspace Experiments settings.",
+          id: "intHyperlabSetup1Desc",
+          description: "Hyperlab setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Create your first experiment",
+          id: "intHyperlabSetup2Title",
+          description: "Hyperlab setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Define variants, set audience targeting, and choose which localized content to test.",
+          id: "intHyperlabSetup2Desc",
+          description: "Hyperlab setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "A/B experiments",
+          id: "intHyperlabProd1Name",
+          description: "Hyperlab product name",
+        },
+        description: {
+          defaultMessage: "Test localized copy and layouts with a subset of users before rollout.",
+          id: "intHyperlabProd1Desc",
+          description: "Hyperlab product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Market validation",
+          id: "intHyperlabProd2Name",
+          description: "Hyperlab product name",
+        },
+        description: {
+          defaultMessage: "Validate new market experiences with real users before full launch.",
+          id: "intHyperlabProd2Desc",
+          description: "Hyperlab product description",
+        },
+      },
+    ],
+  },
+  jira: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Issue creation from blockers",
+          id: "intJiraCapIssueTitle",
+          description: "Jira capability title",
+        },
+        description: {
+          defaultMessage:
+            "Turn translation blockers into Jira issues so engineering can track and resolve them.",
+          id: "intJiraCapIssueDesc",
+          description: "Jira capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Workflow sync",
+          id: "intJiraCapSyncTitle",
+          description: "Jira capability title",
+        },
+        description: {
+          defaultMessage:
+            "Keep localization tasks synchronized with your existing Jira boards and sprints.",
+          id: "intJiraCapSyncDesc",
+          description: "Jira capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Launch tracking",
+          id: "intJiraCapLaunchTitle",
+          description: "Jira capability title",
+        },
+        description: {
+          defaultMessage:
+            "Track locale launch milestones alongside engineering deliverables in Jira.",
+          id: "intJiraCapLaunchDesc",
+          description: "Jira capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Cross-team visibility",
+          id: "intJiraCapVisibilityTitle",
+          description: "Jira capability title",
+        },
+        description: {
+          defaultMessage:
+            "Give product and engineering teams visibility into localization blockers.",
+          id: "intJiraCapVisibilityDesc",
+          description: "Jira capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Create Jira ticket from translation blocker",
+          id: "intJiraWf1Title",
+          description: "Jira workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Missing string flagged",
+              id: "intJiraWf1Step1",
+              description: "Jira workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Jira issue auto-created",
+              id: "intJiraWf1Step2",
+              description: "Jira workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Engineer assigned and notified",
+              id: "intJiraWf1Step3",
+              description: "Jira workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Track locale launch in sprint",
+          id: "intJiraWf2Title",
+          description: "Jira workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Launch epic created",
+              id: "intJiraWf2Step1",
+              description: "Jira workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Locale tasks added to sprint",
+              id: "intJiraWf2Step2",
+              description: "Jira workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Progress synced to Hyperlocalise",
+              id: "intJiraWf2Step3",
+              description: "Jira workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Jira",
+          id: "intJiraSetup1Title",
+          description: "Jira setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Authorize Hyperlocalise to access your Jira workspace from Integrations.",
+          id: "intJiraSetup1Desc",
+          description: "Jira setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Map projects and issue types",
+          id: "intJiraSetup2Title",
+          description: "Jira setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Select which Jira projects and issue types to use for localization blockers.",
+          id: "intJiraSetup2Desc",
+          description: "Jira setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Issue creation",
+          id: "intJiraProd1Name",
+          description: "Jira product name",
+        },
+        description: {
+          defaultMessage: "Create Jira issues automatically from translation blockers.",
+          id: "intJiraProd1Desc",
+          description: "Jira product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Workflow sync",
+          id: "intJiraProd2Name",
+          description: "Jira product name",
+        },
+        description: {
+          defaultMessage: "Keep localization tasks synchronized with Jira boards and sprints.",
+          id: "intJiraProd2Desc",
+          description: "Jira product description",
+        },
+      },
+    ],
+  },
+  linear: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Issue sync",
+          id: "intLinearCapIssueTitle",
+          description: "Linear capability title",
+        },
+        description: {
+          defaultMessage:
+            "Turn translation blockers into Linear issues without losing product context.",
+          id: "intLinearCapIssueDesc",
+          description: "Linear capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Launch coordination",
+          id: "intLinearCapLaunchTitle",
+          description: "Linear capability title",
+        },
+        description: {
+          defaultMessage: "Track localization launch tasks alongside product delivery in Linear.",
+          id: "intLinearCapLaunchDesc",
+          description: "Linear capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Team visibility",
+          id: "intLinearCapVisibilityTitle",
+          description: "Linear capability title",
+        },
+        description: {
+          defaultMessage:
+            "Give product teams visibility into localization blockers in their existing workflow.",
+          id: "intLinearCapVisibilityDesc",
+          description: "Linear capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Fast issue creation",
+          id: "intLinearCapFastTitle",
+          description: "Linear capability title",
+        },
+        description: {
+          defaultMessage:
+            "Create Linear issues from review findings with one click from Hyperlocalise.",
+          id: "intLinearCapFastDesc",
+          description: "Linear capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "File Linear issue from review finding",
+          id: "intLinearWf1Title",
+          description: "Linear workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "QA issue found in review",
+              id: "intLinearWf1Step1",
+              description: "Linear workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Linear issue created",
+              id: "intLinearWf1Step2",
+              description: "Linear workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Owner notified in Linear",
+              id: "intLinearWf1Step3",
+              description: "Linear workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Linear",
+          id: "intLinearSetup1Title",
+          description: "Linear setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Authorize Hyperlocalise to access your Linear workspace from Integrations.",
+          id: "intLinearSetup1Desc",
+          description: "Linear setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Issue creation",
+          id: "intLinearProd1Name",
+          description: "Linear product name",
+        },
+        description: {
+          defaultMessage: "Create Linear issues from translation blockers and review findings.",
+          id: "intLinearProd1Desc",
+          description: "Linear product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Launch tracking",
+          id: "intLinearProd2Name",
+          description: "Linear product name",
+        },
+        description: {
+          defaultMessage: "Track localization launch tasks in your product delivery pipeline.",
+          id: "intLinearProd2Desc",
+          description: "Linear product description",
+        },
+      },
+    ],
+  },
+  notion: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Style guide import",
+          id: "intNotionCapStyleTitle",
+          description: "Notion capability title",
+        },
+        description: {
+          defaultMessage:
+            "Import brand style guides and writing rules from Notion for agent context.",
+          id: "intNotionCapStyleDesc",
+          description: "Notion capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Glossary sync",
+          id: "intNotionCapGlossaryTitle",
+          description: "Notion capability title",
+        },
+        description: {
+          defaultMessage:
+            "Pull glossary terms and market notes from Notion so agents apply consistent terminology.",
+          id: "intNotionCapGlossaryDesc",
+          description: "Notion capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Market guidance",
+          id: "intNotionCapMarketTitle",
+          description: "Notion capability title",
+        },
+        description: {
+          defaultMessage:
+            "Give agents locale-specific market notes and cultural guidance from your knowledge base.",
+          id: "intNotionCapMarketDesc",
+          description: "Notion capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Living documentation",
+          id: "intNotionCapDocsTitle",
+          description: "Notion capability title",
+        },
+        description: {
+          defaultMessage:
+            "Keep agent context in sync with your team's living docs without manual copy-paste.",
+          id: "intNotionCapDocsDesc",
+          description: "Notion capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Sync brand glossary to agents",
+          id: "intNotionWf1Title",
+          description: "Notion workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Glossary updated in Notion",
+              id: "intNotionWf1Step1",
+              description: "Notion workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Terms synced to Hyperlocalise",
+              id: "intNotionWf1Step2",
+              description: "Notion workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Agents apply brand terms",
+              id: "intNotionWf1Step3",
+              description: "Notion workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Import market launch briefs",
+          id: "intNotionWf2Title",
+          description: "Notion workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Launch brief published in Notion",
+              id: "intNotionWf2Step1",
+              description: "Notion workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Context imported for agents",
+              id: "intNotionWf2Step2",
+              description: "Notion workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Translations follow market guidance",
+              id: "intNotionWf2Step3",
+              description: "Notion workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Notion",
+          id: "intNotionSetup1Title",
+          description: "Notion setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Authorize Hyperlocalise to access your Notion workspace from Integrations.",
+          id: "intNotionSetup1Desc",
+          description: "Notion setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Select pages to import",
+          id: "intNotionSetup2Title",
+          description: "Notion setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Choose which Notion pages contain style guides, glossaries, or market notes.",
+          id: "intNotionSetup2Desc",
+          description: "Notion setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Style guide import",
+          id: "intNotionProd1Name",
+          description: "Notion product name",
+        },
+        description: {
+          defaultMessage: "Import brand and writing guidelines from Notion for agent context.",
+          id: "intNotionProd1Desc",
+          description: "Notion product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Glossary sync",
+          id: "intNotionProd2Name",
+          description: "Notion product name",
+        },
+        description: {
+          defaultMessage: "Keep glossary terms in sync between Notion and Hyperlocalise.",
+          id: "intNotionProd2Desc",
+          description: "Notion product description",
+        },
+      },
+    ],
+  },
+  resend: {
+    capabilities: [
+      {
+        title: {
+          defaultMessage: "Transactional email localization",
+          id: "intResendCapEmailTitle",
+          description: "Resend capability title",
+        },
+        description: {
+          defaultMessage:
+            "Send localized transactional emails from the same workspace where copy is reviewed.",
+          id: "intResendCapEmailDesc",
+          description: "Resend capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Template management",
+          id: "intResendCapTemplateTitle",
+          description: "Resend capability title",
+        },
+        description: {
+          defaultMessage:
+            "Manage email templates per locale with translation memory and review history behind them.",
+          id: "intResendCapTemplateDesc",
+          description: "Resend capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Launch-ready emails",
+          id: "intResendCapLaunchTitle",
+          description: "Resend capability title",
+        },
+        description: {
+          defaultMessage:
+            "Ship localized welcome, reset, and notification emails alongside product launches.",
+          id: "intResendCapLaunchDesc",
+          description: "Resend capability description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Review before send",
+          id: "intResendCapReviewTitle",
+          description: "Resend capability title",
+        },
+        description: {
+          defaultMessage:
+            "Run email copy through the same review process as product strings before sending.",
+          id: "intResendCapReviewDesc",
+          description: "Resend capability description",
+        },
+      },
+    ],
+    workflows: [
+      {
+        title: {
+          defaultMessage: "Localize welcome email for new market",
+          id: "intResendWf1Title",
+          description: "Resend workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Welcome template drafted",
+              id: "intResendWf1Step1",
+              description: "Resend workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Translated and reviewed",
+              id: "intResendWf1Step2",
+              description: "Resend workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Sent via Resend per locale",
+              id: "intResendWf1Step3",
+              description: "Resend workflow step label",
+            },
+          },
+        ],
+      },
+      {
+        title: {
+          defaultMessage: "Update password reset copy globally",
+          id: "intResendWf2Title",
+          description: "Resend workflow example title",
+        },
+        steps: [
+          {
+            label: {
+              defaultMessage: "Reset email copy updated",
+              id: "intResendWf2Step1",
+              description: "Resend workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "All locale variants synced",
+              id: "intResendWf2Step2",
+              description: "Resend workflow step label",
+            },
+          },
+          {
+            label: {
+              defaultMessage: "Templates pushed to Resend",
+              id: "intResendWf2Step3",
+              description: "Resend workflow step label",
+            },
+          },
+        ],
+      },
+    ],
+    setupSteps: [
+      {
+        title: {
+          defaultMessage: "Connect Resend",
+          id: "intResendSetup1Title",
+          description: "Resend setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Add your Resend API key from workspace Integrations to enable email delivery.",
+          id: "intResendSetup1Desc",
+          description: "Resend setup step description",
+        },
+      },
+      {
+        title: {
+          defaultMessage: "Configure email templates",
+          id: "intResendSetup2Title",
+          description: "Resend setup step title",
+        },
+        description: {
+          defaultMessage:
+            "Set up email templates per locale and link them to your localization projects.",
+          id: "intResendSetup2Desc",
+          description: "Resend setup step description",
+        },
+      },
+    ],
+    products: [
+      {
+        name: {
+          defaultMessage: "Transactional email",
+          id: "intResendProd1Name",
+          description: "Resend product name",
+        },
+        description: {
+          defaultMessage: "Send localized transactional emails through Resend.",
+          id: "intResendProd1Desc",
+          description: "Resend product description",
+        },
+      },
+      {
+        name: {
+          defaultMessage: "Template localization",
+          id: "intResendProd2Name",
+          description: "Resend product name",
+        },
+        description: {
+          defaultMessage: "Manage and review email templates per locale before sending.",
+          id: "intResendProd2Desc",
+          description: "Resend product description",
+        },
+      },
+    ],
+  },
+} as const satisfies Partial<Record<IntegrationCatalogSlug, IntegrationDetailCopyDescriptors>>;
+
+export function getIntegrationDetailCopyDescriptors(
+  slug: string,
+): IntegrationDetailCopyDescriptors | null {
+  if (!(slug in integrationDetailCopy)) {
+    return null;
+  }
+
+  return integrationDetailCopy[slug as keyof typeof integrationDetailCopy];
+}

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.ts
@@ -24,6 +24,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     iconKey: "github",
     websiteUrl: "https://github.com",
+    relatedSlugs: ["gitlab", "slack", "crowdin"],
     keywords: ["GitHub localization", "GitHub translation workflow", "Hyperlocalise GitHub"],
   },
   {
@@ -35,6 +36,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     iconKey: "gitlab",
     websiteUrl: "https://gitlab.com",
+    relatedSlugs: ["github", "slack", "jira"],
     keywords: ["GitLab localization", "GitLab translation workflow"],
   },
   {
@@ -46,6 +48,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     logoSrc: "/images/slack-logo.svg",
     websiteUrl: "https://slack.com",
+    relatedSlugs: ["github", "jira", "linear"],
     keywords: ["Slack localization", "translation review Slack", "Hyperlocalise Slack"],
   },
   {
@@ -67,6 +70,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     iconKey: "jira",
     websiteUrl: "https://www.atlassian.com/software/jira",
+    relatedSlugs: ["linear", "slack", "github"],
     keywords: ["Jira localization", "translation issue tracking"],
   },
   {
@@ -78,6 +82,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     iconKey: "linear",
     websiteUrl: "https://linear.app",
+    relatedSlugs: ["jira", "slack", "github"],
     keywords: ["Linear localization", "translation workflow Linear"],
   },
   {
@@ -100,6 +105,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     logoSrc: "/images/tms/crowdin.png",
     websiteUrl: "https://crowdin.com",
     tmsProviderKind: "crowdin",
+    relatedSlugs: ["lokalise", "phrase", "github"],
     keywords: ["Crowdin integration", "Crowdin Hyperlocalise", "TMS connector"],
   },
   {
@@ -112,6 +118,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     logoSrc: "/images/tms/lokalise.webp",
     websiteUrl: "https://lokalise.com",
     tmsProviderKind: "lokalise",
+    relatedSlugs: ["crowdin", "phrase", "notion"],
     keywords: ["Lokalise integration", "Lokalise Hyperlocalise"],
   },
   {
@@ -124,6 +131,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     logoSrc: "/images/tms/phrase.png",
     websiteUrl: "https://phrase.com",
     tmsProviderKind: "phrase",
+    relatedSlugs: ["crowdin", "lokalise", "smartling"],
     keywords: ["Phrase integration", "Phrase TMS Hyperlocalise"],
   },
   {
@@ -136,6 +144,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     logoSrc: "/images/tms/smartling.png",
     websiteUrl: "https://www.smartling.com",
     tmsProviderKind: "smartling",
+    relatedSlugs: ["phrase", "crowdin"],
     keywords: ["Smartling integration", "enterprise localization TMS"],
   },
   {
@@ -147,6 +156,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     logoSrc: "/images/contentful-logo.svg",
     websiteUrl: "https://www.contentful.com",
+    relatedSlugs: ["canva", "ahrefs", "semrush"],
     keywords: ["Contentful localization", "CMS translation connector"],
   },
   {
@@ -158,6 +168,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     logoSrc: "/images/canva-logo.svg",
     websiteUrl: "https://www.canva.com",
+    relatedSlugs: ["contentful", "intercom"],
     keywords: ["Canva localization", "design localization connector"],
   },
   {
@@ -198,6 +209,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     iconKey: "notion",
     websiteUrl: "https://www.notion.so",
+    relatedSlugs: ["lokalise", "contentful"],
     keywords: ["Notion localization guidelines", "style guide import"],
   },
   {
@@ -209,6 +221,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     logoSrc: "/images/intercom-logo.svg",
     websiteUrl: "https://www.intercom.com",
+    relatedSlugs: ["contentful", "resend", "slack"],
     keywords: ["Intercom localization", "customer support translation"],
   },
   {
@@ -289,6 +302,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     iconKey: "resend",
     websiteUrl: "https://resend.com",
+    relatedSlugs: ["intercom", "slack"],
     keywords: ["Resend localization", "transactional email translation"],
   },
   {
@@ -299,6 +313,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     marketing: true,
     workspace: true,
     logoSrc: "/images/logo.png",
+    relatedSlugs: ["github", "contentful"],
     keywords: ["localization experiments", "Hyperlab", "feature testing localization"],
   },
   {
@@ -319,6 +334,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     logoSrc: "/images/ahrefs-logo.svg",
     websiteUrl: "https://ahrefs.com",
+    relatedSlugs: ["semrush", "contentful"],
     keywords: ["Ahrefs localization", "SEO localization workflow"],
   },
   {
@@ -330,6 +346,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
     workspace: true,
     logoSrc: "/images/semrush-logo.svg",
     websiteUrl: "https://www.semrush.com",
+    relatedSlugs: ["ahrefs", "contentful"],
     keywords: ["Semrush localization", "SEO translation workflow"],
   },
 ];

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.types.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.types.ts
@@ -41,6 +41,38 @@ export type IntegrationIconKey =
   | "loops"
   | "googledrive";
 
+export type IntegrationCapabilityDescriptor = {
+  title: MessageDescriptor;
+  description: MessageDescriptor;
+};
+
+export type IntegrationWorkflowStepDescriptor = {
+  label: MessageDescriptor;
+  description?: MessageDescriptor;
+};
+
+export type IntegrationWorkflowDescriptor = {
+  title: MessageDescriptor;
+  steps: readonly IntegrationWorkflowStepDescriptor[];
+};
+
+export type IntegrationSetupStepDescriptor = {
+  title: MessageDescriptor;
+  description: MessageDescriptor;
+};
+
+export type IntegrationProductDescriptor = {
+  name: MessageDescriptor;
+  description: MessageDescriptor;
+};
+
+export type IntegrationDetailCopyDescriptors = {
+  capabilities?: readonly IntegrationCapabilityDescriptor[];
+  workflows?: readonly IntegrationWorkflowDescriptor[];
+  setupSteps?: readonly IntegrationSetupStepDescriptor[];
+  products?: readonly IntegrationProductDescriptor[];
+};
+
 export type IntegrationCopyDescriptors = {
   name: MessageDescriptor;
   tagline: MessageDescriptor;
@@ -63,14 +95,43 @@ export type IntegrationCatalogEntry = {
   websiteUrl?: string;
   docsUrl?: string;
   keywords?: readonly string[];
+  relatedSlugs?: readonly string[];
   tmsProviderKind?: ExternalTmsProviderKind | "native";
+};
+
+export type ResolvedIntegrationCapability = {
+  title: string;
+  description: string;
+};
+
+export type ResolvedIntegrationWorkflowStep = {
+  label: string;
+  description?: string;
+};
+
+export type ResolvedIntegrationWorkflow = {
+  title: string;
+  steps: ResolvedIntegrationWorkflowStep[];
+};
+
+export type ResolvedIntegrationSetupStep = {
+  title: string;
+  description: string;
+};
+
+export type ResolvedIntegrationProduct = {
+  name: string;
+  description: string;
 };
 
 export type ResolvedIntegrationCopy = {
   name: string;
   tagline: string;
   overview: string[];
-  products: { name: string; description: string }[];
+  capabilities: ResolvedIntegrationCapability[];
+  workflows: ResolvedIntegrationWorkflow[];
+  setupSteps: ResolvedIntegrationSetupStep[];
+  products: ResolvedIntegrationProduct[];
   metadata: {
     title: string;
     description: string;

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.test.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildWorkflowEdges,
+  buildWorkflowNodes,
+  inferWorkflowStepActor,
+} from "@/lib/integrations/integration-workflow-graph";
+
+const integrationNames = {
+  github: "GitHub",
+  slack: "Slack",
+  crowdin: "Crowdin",
+  hyperlocalise: "Hyperlocalise",
+};
+
+describe("integration-workflow-graph", () => {
+  it("infers hyperlocalise actors from labels", () => {
+    expect(
+      inferWorkflowStepActor("Hyperlocalise scans strings", 1, "github", integrationNames),
+    ).toBe("hyperlocalise");
+  });
+
+  it("infers related integrations from labels", () => {
+    expect(
+      inferWorkflowStepActor("Reviewer notified in Slack", 2, "github", integrationNames),
+    ).toBe("slack");
+  });
+
+  it("builds linear workflow edges", () => {
+    expect(buildWorkflowEdges("github-wf-0", 3)).toEqual([
+      { id: "github-wf-0-edge-0", source: "github-wf-0-node-0", target: "github-wf-0-node-1" },
+      { id: "github-wf-0-edge-1", source: "github-wf-0-node-1", target: "github-wf-0-node-2" },
+    ]);
+  });
+
+  it("builds workflow nodes with trigger and action kinds", () => {
+    const nodes = buildWorkflowNodes(
+      {
+        title: "Catch missing translations before merge",
+        steps: [
+          { label: "PR opened on GitHub" },
+          { label: "Hyperlocalise scans strings" },
+          { label: "Reviewer notified in Slack" },
+        ],
+      },
+      "github-wf-0",
+      "github",
+      integrationNames,
+      { trigger: "Trigger", action: "Action" },
+      1,
+    );
+
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0]?.data.kind).toBe("trigger");
+    expect(nodes[1]?.data.kind).toBe("action");
+    expect(nodes[1]?.data.active).toBe(true);
+    expect(nodes[1]?.data.actorSlug).toBe("hyperlocalise");
+    expect(nodes[2]?.data.actorSlug).toBe("slack");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Edge, Node } from "@xyflow/react";
+
+import type { ResolvedIntegrationWorkflow } from "@/lib/integrations/integration-catalog.types";
+
+export type WorkflowNodeKind = "trigger" | "action";
+
+export type IntegrationWorkflowNodeData = {
+  label: string;
+  description?: string;
+  kind: WorkflowNodeKind;
+  kindLabel: string;
+  actorSlug: string;
+  actorName: string;
+  active?: boolean;
+};
+
+const NODE_GAP_Y = 108;
+const HYPERLOCALISE_SLUG = "hyperlocalise";
+
+export function inferWorkflowStepActor(
+  label: string,
+  stepIndex: number,
+  primaryIntegrationSlug: string,
+  integrationNamesBySlug: Readonly<Record<string, string>>,
+): string {
+  if (/hyperlocalise/i.test(label)) {
+    return HYPERLOCALISE_SLUG;
+  }
+
+  for (const [slug, name] of Object.entries(integrationNamesBySlug)) {
+    if (slug === primaryIntegrationSlug) {
+      continue;
+    }
+
+    if (name && label.toLowerCase().includes(name.toLowerCase())) {
+      return slug;
+    }
+  }
+
+  const primaryName = integrationNamesBySlug[primaryIntegrationSlug];
+  if (primaryName && label.toLowerCase().includes(primaryName.toLowerCase())) {
+    return primaryIntegrationSlug;
+  }
+
+  if (stepIndex === 0) {
+    return primaryIntegrationSlug;
+  }
+
+  return HYPERLOCALISE_SLUG;
+}
+
+export function buildWorkflowEdges(workflowKey: string, stepCount: number): Edge[] {
+  return Array.from({ length: stepCount - 1 }, (_, index) => ({
+    id: `${workflowKey}-edge-${index}`,
+    source: `${workflowKey}-node-${index}`,
+    target: `${workflowKey}-node-${index + 1}`,
+  }));
+}
+
+export function buildWorkflowNodes(
+  workflow: ResolvedIntegrationWorkflow,
+  workflowKey: string,
+  primaryIntegrationSlug: string,
+  integrationNamesBySlug: Readonly<Record<string, string>>,
+  kindLabels: { trigger: string; action: string },
+  activeIndex: number,
+): Node<IntegrationWorkflowNodeData>[] {
+  return workflow.steps.map((step, index) => {
+    const actorSlug = inferWorkflowStepActor(
+      step.label,
+      index,
+      primaryIntegrationSlug,
+      integrationNamesBySlug,
+    );
+
+    return {
+      id: `${workflowKey}-node-${index}`,
+      type: "integrationWorkflow",
+      position: { x: 0, y: index * NODE_GAP_Y },
+      data: {
+        label: step.label,
+        description: step.description,
+        kind: index === 0 ? "trigger" : "action",
+        kindLabel: index === 0 ? kindLabels.trigger : kindLabels.action,
+        actorSlug,
+        actorName: integrationNamesBySlug[actorSlug] ?? "Hyperlocalise",
+        active: index === activeIndex,
+      },
+      draggable: true,
+    };
+  });
+}
+
+export function styleWorkflowEdges(edges: Edge[], activeIndex: number): Edge[] {
+  return edges.map((edge) => {
+    const sourceIndex = Number(edge.source.split("-").at(-1));
+    const isActivePath = sourceIndex === activeIndex;
+    const isCompletePath = sourceIndex < activeIndex;
+
+    return {
+      ...edge,
+      animated: isActivePath,
+      style: {
+        strokeWidth: isCompletePath || isActivePath ? 2 : 1.5,
+        stroke: isCompletePath || isActivePath ? "var(--primary)" : "var(--border)",
+      },
+    };
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/integrations/resolve-integration-catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/resolve-integration-catalog.ts
@@ -16,6 +16,7 @@ import {
   getIntegrationCopyDescriptors,
   type IntegrationCatalogSlug,
 } from "@/lib/integrations/integration-catalog.copy";
+import { getIntegrationDetailCopyDescriptors } from "@/lib/integrations/integration-catalog.detail.copy";
 import {
   integrationCatalogEntries,
   marketingIntegrationSlugs,
@@ -25,6 +26,10 @@ import type {
   IntegrationCategory,
   ResolvedIntegration,
   ResolvedIntegrationCopy,
+  ResolvedIntegrationCapability,
+  ResolvedIntegrationProduct,
+  ResolvedIntegrationSetupStep,
+  ResolvedIntegrationWorkflow,
 } from "@/lib/integrations/integration-catalog.types";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 
@@ -33,12 +38,16 @@ function resolveIntegrationCopy(
   entry: IntegrationCatalogEntry,
 ): ResolvedIntegrationCopy {
   const descriptors = getIntegrationCopyDescriptors(entry.slug);
+  const detailDescriptors = getIntegrationDetailCopyDescriptors(entry.slug);
 
   if (!descriptors) {
     return {
       name: entry.slug,
       tagline: "",
       overview: [],
+      capabilities: [],
+      workflows: [],
+      setupSteps: [],
       products: [],
       metadata: {
         title: entry.slug,
@@ -56,11 +65,42 @@ function resolveIntegrationCopy(
     ? intl.formatMessage(descriptors.productDescription)
     : tagline;
 
+  const capabilities: ResolvedIntegrationCapability[] =
+    detailDescriptors?.capabilities?.map((capability) => ({
+      title: intl.formatMessage(capability.title),
+      description: intl.formatMessage(capability.description),
+    })) ?? [];
+
+  const workflows: ResolvedIntegrationWorkflow[] =
+    detailDescriptors?.workflows?.map((workflow) => ({
+      title: intl.formatMessage(workflow.title),
+      steps: workflow.steps.map((step) => ({
+        label: intl.formatMessage(step.label),
+        description: step.description ? intl.formatMessage(step.description) : undefined,
+      })),
+    })) ?? [];
+
+  const setupSteps: ResolvedIntegrationSetupStep[] =
+    detailDescriptors?.setupSteps?.map((step) => ({
+      title: intl.formatMessage(step.title),
+      description: intl.formatMessage(step.description),
+    })) ?? [];
+
+  const products: ResolvedIntegrationProduct[] = detailDescriptors?.products?.length
+    ? detailDescriptors.products.map((product) => ({
+        name: intl.formatMessage(product.name),
+        description: intl.formatMessage(product.description),
+      }))
+    : [{ name: productName, description: productDescription }];
+
   return {
     name,
     tagline,
     overview,
-    products: [{ name: productName, description: productDescription }],
+    capabilities,
+    workflows,
+    setupSteps,
+    products,
     metadata: {
       title: descriptors.metadataTitle
         ? intl.formatMessage(descriptors.metadataTitle)
@@ -97,6 +137,23 @@ export function resolveMarketingIntegrations(locale: string): ResolvedIntegratio
 
   return integrationCatalogEntries
     .filter((entry) => entry.marketing)
+    .map((entry) => resolveIntegration(intl, entry));
+}
+
+export function resolveRelatedIntegrations(
+  locale: string,
+  integration: ResolvedIntegration,
+): ResolvedIntegration[] {
+  const relatedSlugs = integration.relatedSlugs ?? [];
+  if (relatedSlugs.length === 0) {
+    return [];
+  }
+
+  const intl = getIntlShape(locale);
+
+  return relatedSlugs
+    .map((slug) => integrationCatalogEntries.find((entry) => entry.slug === slug))
+    .filter((entry): entry is IntegrationCatalogEntry => entry !== undefined && entry.marketing)
     .map((entry) => resolveIntegration(intl, entry));
 }
 


### PR DESCRIPTION
## What changed

- Enriched marketing integration detail pages with capabilities, workflows, setup steps, related integrations, and a get-started CTA
- Added an interactive React Flow workflow preview for integration workflow examples
- Moved the multilingual blog workflow mock into the **Publish Multilingual Blog** tab and removed the separate brief-to-publish tab
- Updated the workflow mock to use a scheduled trigger and renamed the editor tab pill to **Content Studio**
- Refreshed homepage principles copy to emphasize operational efficiency and revenue

## How to test

- [ ] Open `/integrations` and verify the index page CTA and layout
- [ ] Open several integration detail pages (e.g. GitHub, Contentful, Ahrefs) and check capabilities, workflow preview stepping, setup steps, related integrations, and CTA
- [ ] On the homepage principles section, open **Publish Multilingual Blog** and confirm the workflow canvas shows the scheduled multilingual blog flow
- [ ] Confirm the **Automate brief to publish** tab is gone and the editor pill reads **Content Studio**
- [ ] Run `vp test src/components/marketing/integrations/integrations-page-content.test.ts src/lib/integrations/integration-workflow-graph.test.ts`
- [ ] Run `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review