### PR TITLE
feat(web): polish inbox list, issue rows, app shell footer, and file view layout

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.stories.tsx
@@ -153,7 +153,7 @@ export const NarrowRow: Story = {
   args: {
     issues: [
       createOrganizationIssue({
-        updatedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+        updatedAt: new Date(Date.now() - 60 * 86_400_000).toISOString(),
       }),
     ],
     summary: {
@@ -164,9 +164,10 @@ export const NarrowRow: Story = {
     },
   },
   play: async ({ canvas }) => {
-    const date = canvas.getByText("30m");
+    const date = canvas.getByRole("time");
     await expect(date).toBeVisible();
     await expect(date.scrollWidth).toBeLessThanOrEqual(date.clientWidth);
-    await expect(date.getAttribute("title")).toMatch(/30 minutes ago/i);
+    await expect(date.textContent?.length).toBeGreaterThan(0);
+    await expect(date.getAttribute("title")).toBeTruthy();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.tsx
@@ -144,51 +144,56 @@ export function IssueListRow({
         onClick={() => onActivate(issue)}
         onKeyDown={(event) => onActivateKeyDown(event, issue)}
       >
-        <IssuePriorityIcon priority={issue.priority} size="sm" />
-        <Link
-          href={buildIssueDetailHref({
-            organizationSlug,
-            projectId: issue.projectId,
-            issueId: issue.identifier,
-          })}
-          className="min-w-0 flex-1 truncate font-medium text-foreground hover:underline"
-          onClick={stopPropagation}
-          onKeyDown={stopPropagation}
-        >
-          <span className="mr-2 font-mono text-xs text-muted-foreground tabular-nums">
-            {issue.identifier}
-          </span>
-          {issue.title}
-        </Link>
-        {showProject && issue.projectName ? (
+        <IssuePriorityIcon priority={issue.priority} size="sm" className="shrink-0" />
+        <div className="min-w-0 flex-1 overflow-hidden">
           <Link
-            href={`/org/${organizationSlug}/projects/${encodeURIComponent(issue.projectId)}`}
-            className="hidden max-w-[10rem] truncate text-muted-foreground hover:text-foreground hover:underline md:inline"
+            href={buildIssueDetailHref({
+              organizationSlug,
+              projectId: issue.projectId,
+              issueId: issue.identifier,
+            })}
+            className="block truncate font-medium text-foreground hover:underline"
             onClick={stopPropagation}
             onKeyDown={stopPropagation}
           >
-            {issue.projectName}
+            <span className="mr-2 font-mono text-xs text-muted-foreground tabular-nums">
+              {issue.identifier}
+            </span>
+            {issue.title}
           </Link>
-        ) : null}
-        <span className="hidden w-16 shrink-0 truncate text-muted-foreground sm:inline">
-          {issue.targetLocale ?? emptyValue}
-        </span>
-        <div className="shrink-0" onClick={stopPropagation} onKeyDown={stopPropagation}>
-          <IssueAssigneeTableCell
-            organizationSlug={organizationSlug}
-            projectId={issue.projectId}
-            issueId={issue.identifier}
-            assigneeUserId={issue.assigneeUserId}
-            assigneeLabel={issue.assignee}
-            disabled={disableInlineEdits}
-          />
         </div>
-        <span
-          className="w-10 shrink-0 text-end text-muted-foreground tabular-nums"
-          title={formatRelativeTimestamp(issue.updatedAt)}
-        >
-          {formatCompactRelativeTimestamp(issue.updatedAt)}
-        </span>
+        <div className="flex shrink-0 items-center gap-3">
+          {showProject && issue.projectName ? (
+            <Link
+              href={`/org/${organizationSlug}/projects/${encodeURIComponent(issue.projectId)}`}
+              className="hidden max-w-[7rem] min-w-0 truncate text-muted-foreground hover:text-foreground hover:underline md:inline"
+              onClick={stopPropagation}
+              onKeyDown={stopPropagation}
+            >
+              {issue.projectName}
+            </Link>
+          ) : null}
+          <span className="hidden w-14 shrink-0 truncate text-muted-foreground sm:inline">
+            {issue.targetLocale ?? emptyValue}
+          </span>
+          <div onClick={stopPropagation} onKeyDown={stopPropagation}>
+            <IssueAssigneeTableCell
+              organizationSlug={organizationSlug}
+              projectId={issue.projectId}
+              issueId={issue.identifier}
+              assigneeUserId={issue.assigneeUserId}
+              assigneeLabel={issue.assignee}
+              disabled={disableInlineEdits}
+            />
+          </div>
+          <time
+            className="min-w-[4.75rem] shrink-0 text-end text-muted-foreground tabular-nums"
+            dateTime={issue.updatedAt}
+            title={formatRelativeTimestamp(issue.updatedAt)}
+          >
+            {formatCompactRelativeTimestamp(issue.updatedAt)}
+          </time>
+        </div>
       </div>
     </div>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -21,6 +21,9 @@ import { ChatDockEmptyState } from "@/components/app-shell/chat-dock/chat-dock-e
 import { chatDockMessages } from "@/components/app-shell/chat-dock/chat-dock.messages";
 import { UpgradePlanButton } from "@/components/billing/upgrade-plan-button";
 import { Badge } from "@/components/ui/badge";
+import { Box } from "@/components/ui/layout/box";
+import { Row } from "@/components/ui/layout/row";
+import { Rows } from "@/components/ui/layout/rows";
 import { TypographyH4, TypographyMuted } from "@/components/ui/typography";
 import { useAiFeaturesAccess } from "@/lib/billing/use-ai-features-access";
 
@@ -55,8 +58,10 @@ function InboxAiComposer({
 
   if (access.status === "denied") {
     return (
-      <div className="border-t border-border px-4 py-3 sm:px-6">
-        <UpgradePlanButton organizationSlug={organizationSlug} size="sm" />
+      <div className="border-t border-border">
+        <Box paddingX="3u" paddingY="1.5u">
+          <UpgradePlanButton organizationSlug={organizationSlug} size="sm" />
+        </Box>
       </div>
     );
   }
@@ -110,22 +115,24 @@ export function ConversationPanel({
         ref={panelRef}
         className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background"
       >
-        <header className="flex min-h-16 items-center border-b border-border px-4 py-3 sm:px-6">
-          <div className="flex min-w-0 flex-1 items-start gap-3">
-            <HugeiconsIcon
-              icon={Chat01Icon}
-              strokeWidth={1.8}
-              className="mt-0.5 size-5 shrink-0 text-muted-foreground"
-            />
-            <div className="min-w-0">
-              <TypographyH4 lineClamp={1} size="medium">
-                <FormattedMessage {...conversationPanelMessages.newRequestTitle} />
-              </TypographyH4>
-              <TypographyMuted className="mt-1.5" size="xsmall">
-                <FormattedMessage {...conversationPanelMessages.newRequestSubtitle} />
-              </TypographyMuted>
-            </div>
-          </div>
+        <header className="border-b border-border">
+          <Box paddingX="3u" paddingY="1.5u" display="flex" alignItems="center">
+            <Row spacing="1.5u" alignY="center">
+              <HugeiconsIcon
+                icon={Chat01Icon}
+                strokeWidth={1.8}
+                className="size-5 shrink-0 text-muted-foreground"
+              />
+              <Rows spacing="0.5u">
+                <TypographyH4 lineClamp={1} size="medium">
+                  <FormattedMessage {...conversationPanelMessages.newRequestTitle} />
+                </TypographyH4>
+                <TypographyMuted size="xsmall">
+                  <FormattedMessage {...conversationPanelMessages.newRequestSubtitle} />
+                </TypographyMuted>
+              </Rows>
+            </Row>
+          </Box>
         </header>
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -164,11 +171,17 @@ export function ConversationPanel({
   if (!conversation) {
     return (
       <section className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-background">
-        <div className="flex flex-1 items-center justify-center text-muted-foreground">
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          height="full"
+          background="canvas"
+        >
           <TypographyMuted>
             <FormattedMessage {...conversationPanelMessages.selectConversation} />
           </TypographyMuted>
-        </div>
+        </Box>
       </section>
     );
   }
@@ -229,46 +242,48 @@ function ConversationHeader({
   const intl = useIntl();
 
   return (
-    <header className="flex min-h-16 items-center border-b border-border px-4 py-3 sm:px-6">
-      <div className="flex min-w-0 flex-1 items-start gap-3">
-        <HugeiconsIcon
-          icon={BubbleChatNotificationIcon}
-          strokeWidth={1.8}
-          className="mt-0.5 size-5 shrink-0 text-muted-foreground"
-        />
-        <div className="min-w-0">
-          <TypographyH4 lineClamp={1} size="medium">
-            {conversation.title}
-          </TypographyH4>
-          <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            <Badge variant="outline" className="border-border bg-muted text-foreground">
-              {getSourceLabel(conversation.source, intl)}
-            </Badge>
-            <Badge variant="outline" className={statusStyles[conversation.status]}>
-              {getStatusLabel(conversation.status, intl)}
-            </Badge>
-            <span>
-              <FormattedMessage
-                {...conversationPanelMessages.createdAt}
-                values={{ relativeTime: formatRelativeTime(conversation.createdAt, intl) }}
-              />
-            </span>
-            {jobsIsLoading ? (
-              <span>
-                <FormattedMessage {...conversationPanelMessages.checkingLinkedJobs} />
-              </span>
-            ) : null}
-            {!jobsIsLoading && jobs.length > 0 ? (
-              <span>
+    <header className="border-b border-border">
+      <Box paddingX="3u" paddingY="1.5u" display="flex" alignItems="center">
+        <Row spacing="1.5u" alignY="start">
+          <HugeiconsIcon
+            icon={BubbleChatNotificationIcon}
+            strokeWidth={1.8}
+            className="mt-0.5 size-5 shrink-0 text-muted-foreground"
+          />
+          <Rows spacing="1u">
+            <TypographyH4 lineClamp={1} size="medium">
+              {conversation.title}
+            </TypographyH4>
+            <Box display="flex" flexWrap="wrap" alignItems="center" gap="1u">
+              <Badge variant="outline" className="border-border bg-muted text-foreground">
+                {getSourceLabel(conversation.source, intl)}
+              </Badge>
+              <Badge variant="outline" className={statusStyles[conversation.status]}>
+                {getStatusLabel(conversation.status, intl)}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
                 <FormattedMessage
-                  {...conversationPanelMessages.linkedJobsCount}
-                  values={{ count: jobs.length }}
+                  {...conversationPanelMessages.createdAt}
+                  values={{ relativeTime: formatRelativeTime(conversation.createdAt, intl) }}
                 />
               </span>
-            ) : null}
-          </div>
-        </div>
-      </div>
+              {jobsIsLoading ? (
+                <span className="text-xs text-muted-foreground">
+                  <FormattedMessage {...conversationPanelMessages.checkingLinkedJobs} />
+                </span>
+              ) : null}
+              {!jobsIsLoading && jobs.length > 0 ? (
+                <span className="text-xs text-muted-foreground">
+                  <FormattedMessage
+                    {...conversationPanelMessages.linkedJobsCount}
+                    values={{ count: jobs.length }}
+                  />
+                </span>
+              ) : null}
+            </Box>
+          </Rows>
+        </Row>
+      </Box>
     </header>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list-item-visuals.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list-item-visuals.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getConversationListItemVisual,
+  getNotificationListItemVisual,
+} from "./inbox-list-item-visuals";
+
+const intl = {
+  formatMessage: (descriptor: { defaultMessage?: string }, values?: Record<string, string>) => {
+    let message = descriptor.defaultMessage ?? "";
+    if (values) {
+      for (const [key, value] of Object.entries(values)) {
+        message = message.replace(`{${key}}`, value);
+      }
+    }
+    return message;
+  },
+} as never;
+
+describe("getConversationListItemVisual", () => {
+  it("maps each conversation source to a type label", () => {
+    expect(getConversationListItemVisual("chat_ui", intl).typeIconLabel).toBe("Chat");
+    expect(getConversationListItemVisual("email_agent", intl).typeIconLabel).toBe("Email");
+    expect(getConversationListItemVisual("github_agent", intl).typeIconLabel).toBe("GitHub");
+    expect(getConversationListItemVisual("slack_agent", intl).typeIconLabel).toBe("Slack");
+    expect(getConversationListItemVisual("web_chat", intl).typeIconLabel).toBe("Web chat");
+  });
+});
+
+describe("getNotificationListItemVisual", () => {
+  it("maps each notification type to a short label", () => {
+    expect(getNotificationListItemVisual("assigned", intl).typeIconLabel).toBe("Assignment");
+    expect(getNotificationListItemVisual("mentioned", intl).typeIconLabel).toBe("Mention");
+    expect(getNotificationListItemVisual("comment", intl).typeIconLabel).toBe("Comment");
+    expect(getNotificationListItemVisual("status_changed", intl).typeIconLabel).toBe(
+      "Status change",
+    );
+    expect(getNotificationListItemVisual("assignee_changed", intl).typeIconLabel).toBe(
+      "Assignee change",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list-item-visuals.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list-item-visuals.ts
@@ -1,0 +1,133 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ComponentProps } from "react";
+import {
+  Chat01Icon,
+  Comment01Icon,
+  Flag01Icon,
+  Mail01Icon,
+  Message01Icon,
+  SlackIcon,
+  SourceCodeIcon,
+  UserIcon,
+  UserMultiple02Icon,
+} from "@hugeicons/core-free-icons";
+import type { HugeiconsIcon } from "@hugeicons/react";
+import type { IntlShape } from "react-intl";
+
+import { assertNever } from "@/lib/primitives/assert-never/assert-never";
+
+import { inboxNotificationsMessages } from "./inbox-notifications.messages";
+import type { InboxIssueNotification } from "./inbox-notifications-api";
+import { getSourceLabel, type Conversation } from "./inbox-types";
+
+type Icon = ComponentProps<typeof HugeiconsIcon>["icon"];
+
+/** Icon colors tuned for `bg-card` badge backgrounds in light and dark themes. */
+const inboxBadgeIconBlue = "text-blue-800 dark:text-blue-900";
+const inboxBadgeIconPurple = "text-purple-800 dark:text-purple-900";
+const inboxBadgeIconAmber = "text-amber-900 dark:text-amber-700";
+const inboxBadgeIconGreen = "text-green-900 dark:text-green-900";
+const inboxBadgeIconNeutral = "text-foreground";
+const inboxBadgeIconPrimary = "text-primary";
+
+export type InboxListItemVisual = {
+  typeIcon: Icon;
+  typeIconLabel: string;
+  /** Tailwind color classes applied directly to the badge icon. */
+  badgeClassName: string;
+};
+
+export function getConversationListItemVisual(
+  source: Conversation["source"],
+  intl: IntlShape,
+): InboxListItemVisual {
+  const typeIconLabel = getSourceLabel(source, intl);
+
+  switch (source) {
+    case "chat_ui":
+      return {
+        typeIcon: Chat01Icon,
+        typeIconLabel,
+        badgeClassName: inboxBadgeIconBlue,
+      };
+    case "web_chat":
+      return {
+        typeIcon: Message01Icon,
+        typeIconLabel,
+        badgeClassName: inboxBadgeIconPurple,
+      };
+    case "email_agent":
+      return {
+        typeIcon: Mail01Icon,
+        typeIconLabel,
+        badgeClassName: inboxBadgeIconAmber,
+      };
+    case "github_agent":
+      return {
+        typeIcon: SourceCodeIcon,
+        typeIconLabel,
+        badgeClassName: inboxBadgeIconNeutral,
+      };
+    case "slack_agent":
+      return {
+        typeIcon: SlackIcon,
+        typeIconLabel,
+        badgeClassName: inboxBadgeIconGreen,
+      };
+    default:
+      return assertNever(source);
+  }
+}
+
+export function getNotificationListItemVisual(
+  type: InboxIssueNotification["type"],
+  intl: IntlShape,
+): InboxListItemVisual {
+  switch (type) {
+    case "assigned":
+      return {
+        typeIcon: UserIcon,
+        typeIconLabel: intl.formatMessage(inboxNotificationsMessages.assignedType),
+        badgeClassName: inboxBadgeIconPrimary,
+      };
+    case "mentioned":
+      return {
+        typeIcon: Message01Icon,
+        typeIconLabel: intl.formatMessage(inboxNotificationsMessages.mentionedType),
+        badgeClassName: inboxBadgeIconBlue,
+      };
+    case "comment":
+      return {
+        typeIcon: Comment01Icon,
+        typeIconLabel: intl.formatMessage(inboxNotificationsMessages.commentType),
+        badgeClassName: inboxBadgeIconNeutral,
+      };
+    case "status_changed":
+      return {
+        typeIcon: Flag01Icon,
+        typeIconLabel: intl.formatMessage(inboxNotificationsMessages.statusChangedType),
+        badgeClassName: inboxBadgeIconAmber,
+      };
+    case "assignee_changed":
+      return {
+        typeIcon: UserMultiple02Icon,
+        typeIconLabel: intl.formatMessage(inboxNotificationsMessages.assigneeChangedType),
+        badgeClassName: inboxBadgeIconPurple,
+      };
+    default:
+      return assertNever(type);
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.stories.tsx
@@ -73,7 +73,6 @@ export const WithIssueNotifications: Story = {
     ).toBeInTheDocument();
     await expect(canvas.getByText("Checkout CTA tone feels off")).toBeInTheDocument();
     await expect(canvas.getByText("Can you review the CTA wording?")).toBeInTheDocument();
-    await expect(canvas.getAllByText("Issue").length).toBeGreaterThan(0);
     await expect(canvas.getByRole("button", { name: "Mark all as read" })).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -12,8 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { memo, useMemo } from "react";
-import { Chat01Icon } from "@hugeicons/core-free-icons";
+import { memo, useMemo, type ReactNode } from "react";
+import { Chat01Icon, SparklesIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl, type MessageDescriptor } from "react-intl";
 
@@ -24,13 +24,17 @@ import { TypographyMuted, TypographySmall } from "@/components/ui/typography";
 import { stripMarkdown } from "@/lib/markdown/strip-markdown";
 import { cn } from "@/lib/primitives/cn";
 
+import {
+  getConversationListItemVisual,
+  getNotificationListItemVisual,
+  type InboxListItemVisual,
+} from "./inbox-list-item-visuals";
 import { inboxListMessages } from "./inbox-list.messages";
 import type { InboxIssueNotification } from "./inbox-notifications-api";
 import { inboxNotificationsMessages } from "./inbox-notifications.messages";
 import {
   formatRelativeTime,
   getConversationParticipantAvatar,
-  getSourceLabel,
   type Conversation,
   type InboxCurrentUser,
 } from "./inbox-types";
@@ -223,30 +227,95 @@ export const InboxList = memo(function InboxList({
   );
 });
 
-function listItemClassName(isSelected: boolean) {
+function listItemClassName(isSelected: boolean, isUnread = false) {
   return cn(
-    "grid w-full text-left transition-colors",
-    "grid-cols-[2rem_minmax(0,1fr)] gap-2 rounded-md px-2 py-2.5",
+    "grid w-full grid-cols-[auto_minmax(0,1fr)] gap-3 rounded-md px-2 py-2.5 text-left transition-colors",
     isSelected
       ? "bg-accent text-foreground"
       : "text-foreground hover:bg-muted hover:text-foreground",
+    isUnread && !isSelected && "bg-muted/40",
+  );
+}
+
+function InboxListItemAvatar({
+  visual,
+  children,
+}: {
+  visual: InboxListItemVisual;
+  children: ReactNode;
+}) {
+  return (
+    <div className="relative shrink-0">
+      <Avatar className="bg-muted">{children}</Avatar>
+      <span
+        className="absolute -end-0.5 -bottom-0.5 z-10 flex size-[18px] items-center justify-center rounded-full bg-card shadow-sm ring-2 ring-background"
+        aria-label={visual.typeIconLabel}
+      >
+        <HugeiconsIcon
+          icon={visual.typeIcon}
+          strokeWidth={2}
+          size={12}
+          className={cn("shrink-0", visual.badgeClassName)}
+        />
+      </span>
+    </div>
+  );
+}
+
+function InboxListItemContent({
+  title,
+  subtitle,
+  timestamp,
+  titleWeight = "regular",
+  showMeta = true,
+}: {
+  title: ReactNode;
+  subtitle: ReactNode;
+  timestamp: string;
+  titleWeight?: "regular" | "bold";
+  showMeta?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="flex items-start justify-between gap-2">
+        <TypographySmall lineClamp={1} weight={titleWeight === "bold" ? "bold" : undefined}>
+          {title}
+        </TypographySmall>
+        {showMeta && timestamp ? (
+          <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+            {timestamp}
+          </span>
+        ) : null}
+      </div>
+      <TypographyMuted className="mt-0.5" lineClamp={1}>
+        {subtitle}
+      </TypographyMuted>
+    </div>
   );
 }
 
 const NewRequestListItem = memo(function NewRequestListItem() {
+  const intl = useIntl();
+  const visual: InboxListItemVisual = {
+    typeIcon: SparklesIcon,
+    typeIconLabel: intl.formatMessage(inboxListMessages.newRequestTitle),
+    badgeClassName: "text-primary",
+  };
+
   return (
     <div aria-current="page" className={listItemClassName(true)}>
-      <div className="flex size-8 items-center justify-center rounded-full bg-muted text-muted-foreground">
-        <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} className="size-4" />
-      </div>
-      <div className="min-w-0">
-        <TypographySmall lineClamp={1}>
-          <FormattedMessage {...inboxListMessages.newRequestTitle} />
-        </TypographySmall>
-        <TypographyMuted className="mt-1" lineClamp={1}>
-          <FormattedMessage {...inboxListMessages.newRequestPreview} />
-        </TypographyMuted>
-      </div>
+      <InboxListItemAvatar visual={visual}>
+        <AvatarFallback className="bg-muted text-xs font-medium text-foreground">
+          <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} className="size-4" />
+        </AvatarFallback>
+      </InboxListItemAvatar>
+      <InboxListItemContent
+        title={<FormattedMessage {...inboxListMessages.newRequestTitle} />}
+        subtitle={<FormattedMessage {...inboxListMessages.newRequestPreview} />}
+        timestamp=""
+        titleWeight="bold"
+        showMeta={false}
+      />
     </div>
   );
 });
@@ -255,11 +324,17 @@ function ConversationListSkeleton() {
   return (
     <div className="flex flex-col gap-2">
       {Array.from({ length: 5 }).map((_, index) => (
-        <div key={index} className="flex gap-3 rounded-lg px-3 py-3">
-          <Skeleton className="size-10 shrink-0 rounded-full bg-muted" />
+        <div
+          key={index}
+          className="grid grid-cols-[auto_minmax(0,1fr)] gap-3 rounded-md px-2 py-2.5"
+        >
+          <Skeleton className="size-8 shrink-0 rounded-full bg-muted" />
           <div className="flex min-w-0 flex-1 flex-col gap-2">
-            <Skeleton className="h-4 w-3/4 bg-muted" />
-            <Skeleton className="h-3 w-1/2 bg-muted" />
+            <div className="flex items-center justify-between gap-2">
+              <Skeleton className="h-4 w-3/4 bg-muted" />
+              <Skeleton className="h-3 w-10 bg-muted" />
+            </div>
+            <Skeleton className="h-3 w-full bg-muted" />
           </div>
         </div>
       ))}
@@ -287,6 +362,7 @@ const ConversationListItem = memo(function ConversationListItem({
   const preview = conversation.lastMessage
     ? stripMarkdown(conversation.lastMessage.text) || conversation.lastMessage.text
     : intl.formatMessage(inboxListMessages.noMessagesYet);
+  const visual = getConversationListItemVisual(conversation.source, intl);
 
   return (
     <button
@@ -295,27 +371,19 @@ const ConversationListItem = memo(function ConversationListItem({
       onClick={() => onSelect(conversation.id)}
       className={listItemClassName(isSelected)}
     >
-      <Avatar className="size-8 bg-muted">
+      <InboxListItemAvatar visual={visual}>
         {participantAvatar.imageUrl ? (
           <AvatarImage src={participantAvatar.imageUrl} alt={participantAvatar.alt} />
         ) : null}
         <AvatarFallback className="bg-muted text-xs font-medium text-foreground">
           {participantAvatar.label}
         </AvatarFallback>
-      </Avatar>
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-center gap-2">
-          <TypographySmall lineClamp={1}>{conversation.title}</TypographySmall>
-        </div>
-        <TypographyMuted className="mt-1" lineClamp={1}>
-          {preview}
-        </TypographyMuted>
-        <div className="mt-2 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-          <span className="truncate">{getSourceLabel(conversation.source, intl)}</span>
-          <span className="size-1 rounded-full bg-muted" />
-          <span>{formatRelativeTime(conversation.lastMessageAt, intl)}</span>
-        </div>
-      </div>
+      </InboxListItemAvatar>
+      <InboxListItemContent
+        title={conversation.title}
+        subtitle={preview}
+        timestamp={formatRelativeTime(conversation.lastMessageAt, intl)}
+      />
     </button>
   );
 });
@@ -339,47 +407,29 @@ const NotificationListItem = memo(function NotificationListItem({
   const secondary = notificationSecondaryText(notification.payload.commentExcerpt, preview);
   const isUnread = !notification.readAt;
   const avatarLabel = actorName.slice(0, 1).toUpperCase() || "?";
+  const visual = getNotificationListItemVisual(notification.type, intl);
 
   return (
     <button
       type="button"
       aria-pressed={isSelected}
       onClick={() => onSelect(notification.id)}
-      className={cn(
-        "grid w-full text-left transition-colors",
-        "grid-cols-[2rem_minmax(0,1fr)] gap-2 rounded-md px-2 py-2.5",
-        isSelected
-          ? "bg-accent text-foreground"
-          : "text-foreground hover:bg-muted hover:text-foreground",
-        isUnread && !isSelected && "bg-muted/40",
-      )}
+      className={listItemClassName(isSelected, isUnread)}
     >
-      <Avatar className="size-8 bg-muted">
+      <InboxListItemAvatar visual={visual}>
         {notification.actor?.avatarUrl ? (
           <AvatarImage src={notification.actor.avatarUrl} alt={actorName} />
         ) : null}
         <AvatarFallback className="bg-muted text-xs font-medium text-foreground">
           {avatarLabel}
         </AvatarFallback>
-      </Avatar>
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-center gap-2">
-          <TypographySmall lineClamp={1} weight="bold">
-            {notification.payload.issueTitle}
-          </TypographySmall>
-          {isUnread ? <span className="size-1.5 shrink-0 rounded-full bg-primary" /> : null}
-        </div>
-        <TypographyMuted className="mt-1" lineClamp={1}>
-          {secondary}
-        </TypographyMuted>
-        <div className="mt-2 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-          <span className="truncate">
-            <FormattedMessage {...inboxNotificationsMessages.issueNotification} />
-          </span>
-          <span className="size-1 rounded-full bg-muted" />
-          <span>{formatRelativeTime(notification.createdAt, intl)}</span>
-        </div>
-      </div>
+      </InboxListItemAvatar>
+      <InboxListItemContent
+        title={notification.payload.issueTitle}
+        subtitle={secondary}
+        timestamp={formatRelativeTime(notification.createdAt, intl)}
+        titleWeight={isUnread ? "bold" : "regular"}
+      />
     </button>
   );
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-notifications.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-notifications.messages.ts
@@ -65,6 +65,31 @@ export const inboxNotificationsMessages = defineMessages({
     id: "Vm1k8EkL8L",
     description: "Source label for issue notification rows in the inbox list",
   },
+  assignedType: {
+    defaultMessage: "Assignment",
+    id: "Y+HVGLFFig",
+    description: "Short label for assignment notification type icon in the inbox list",
+  },
+  mentionedType: {
+    defaultMessage: "Mention",
+    id: "TE4yzOvouE",
+    description: "Short label for mention notification type icon in the inbox list",
+  },
+  commentType: {
+    defaultMessage: "Comment",
+    id: "xz22Pvfb9j",
+    description: "Short label for comment notification type icon in the inbox list",
+  },
+  statusChangedType: {
+    defaultMessage: "Status change",
+    id: "/xLTphGoSI",
+    description: "Short label for status-change notification type icon in the inbox list",
+  },
+  assigneeChangedType: {
+    defaultMessage: "Assignee change",
+    id: "IHSPoPMGG7",
+    description: "Short label for assignee-change notification type icon in the inbox list",
+  },
   issuePanelLoading: {
     defaultMessage: "Loading issue",
     id: "EOpyg02xLN",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
@@ -14,7 +14,9 @@
  */
 import { FormattedMessage } from "react-intl";
 
-import { cn } from "@/lib/primitives/cn";
+import { Box } from "@/components/ui/layout/box";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
 
 import { ConversationPanel } from "./conversation-panel";
 import { InboxIssuePanel } from "./inbox-issue-panel";
@@ -108,84 +110,87 @@ export function InboxPageView({
           ? "new"
           : "none";
 
+  const listColumnWidth = isSparseInbox ? "1/5" : "1/4";
+
   return (
     <main
       data-organization={organizationSlug}
       className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background text-foreground sm:-mx-6 lg:-mx-8"
     >
-      <div
-        className={cn(
-          "grid h-full min-h-0 grid-cols-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden lg:grid-rows-1",
-          isSparseInbox
-            ? "lg:grid-cols-[minmax(14rem,17rem)_minmax(0,1fr)]"
-            : "lg:grid-cols-[minmax(20rem,24rem)_minmax(0,1fr)] xl:grid-cols-[minmax(22rem,26rem)_minmax(0,1fr)]",
-        )}
-      >
-        <InboxPanelErrorBoundary
-          scope="list"
-          className="max-h-[40svh] min-h-0 shrink-0 lg:h-full lg:max-h-none lg:shrink"
-          resetKeys={[
-            selectionKey,
-            conversations.length,
-            notifications.length,
-            conversationsIsLoading,
-            notificationsIsLoading,
-          ]}
-        >
-          <InboxList
-            conversations={conversations}
-            currentUser={currentUser}
-            hasMoreNotifications={hasMoreNotifications}
-            isError={listIsError}
-            isLoading={listIsLoading}
-            isLoadingMoreNotifications={isLoadingMoreNotifications}
-            notifications={notifications}
-            onLoadMoreNotifications={onLoadMoreNotifications}
-            onMarkAllRead={onMarkAllRead}
-            onSelectConversation={onSelectConversation}
-            onSelectNotification={onSelectNotification}
-            selection={selection}
-            unreadNotificationCount={unreadNotificationCount}
-          />
-        </InboxPanelErrorBoundary>
-
-        {selection?.kind === "notification" ? (
-          selectedNotification ? (
-            <InboxIssuePanel
-              organizationSlug={organizationSlug}
-              projectId={selectedNotification.projectId}
-              issueId={selectedNotification.issueId}
+      <Columns spacing="0" height="full" collapseBelow="large">
+        <Column width={listColumnWidth}>
+          <InboxPanelErrorBoundary
+            scope="list"
+            className="max-h-[40svh] min-h-0 shrink-0 lg:h-full lg:max-h-none lg:shrink"
+            resetKeys={[
+              selectionKey,
+              conversations.length,
+              notifications.length,
+              conversationsIsLoading,
+              notificationsIsLoading,
+            ]}
+          >
+            <InboxList
+              conversations={conversations}
+              currentUser={currentUser}
+              hasMoreNotifications={hasMoreNotifications}
+              isError={listIsError}
+              isLoading={listIsLoading}
+              isLoadingMoreNotifications={isLoadingMoreNotifications}
+              notifications={notifications}
+              onLoadMoreNotifications={onLoadMoreNotifications}
+              onMarkAllRead={onMarkAllRead}
+              onSelectConversation={onSelectConversation}
+              onSelectNotification={onSelectNotification}
+              selection={selection}
+              unreadNotificationCount={unreadNotificationCount}
             />
-          ) : selectedNotificationIsLoading ? (
-            <section
-              className="flex min-h-0 flex-1 items-center justify-center p-6"
-              aria-busy="true"
-              aria-label="Loading notification"
-            >
-              <span className="text-sm text-muted-foreground">
-                <FormattedMessage {...inboxNotificationsMessages.issuePanelLoading} />
-              </span>
-            </section>
-          ) : null
-        ) : (
-          <ConversationPanel
-            conversation={selectedConversation}
-            currentUser={currentUser}
-            draft={draft}
-            isComposingNew={selection?.kind === "new"}
-            isSending={isSending}
-            isStreaming={isStreaming}
-            jobs={jobs}
-            jobsIsLoading={jobsIsLoading}
-            messages={messages}
-            messagesIsLoading={messagesIsLoading}
-            onDraftChange={onDraftChange}
-            onSendMessage={onSendMessage}
-            organizationSlug={organizationSlug}
-            streamedAssistant={streamedAssistant}
-          />
-        )}
-      </div>
+          </InboxPanelErrorBoundary>
+        </Column>
+
+        <Column width="fluid">
+          {selection?.kind === "notification" ? (
+            selectedNotification ? (
+              <InboxIssuePanel
+                organizationSlug={organizationSlug}
+                projectId={selectedNotification.projectId}
+                issueId={selectedNotification.issueId}
+              />
+            ) : selectedNotificationIsLoading ? (
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                padding="3u"
+                height="full"
+                aria-busy="true"
+                aria-label="Loading notification"
+              >
+                <span className="text-sm text-muted-foreground">
+                  <FormattedMessage {...inboxNotificationsMessages.issuePanelLoading} />
+                </span>
+              </Box>
+            ) : null
+          ) : (
+            <ConversationPanel
+              conversation={selectedConversation}
+              currentUser={currentUser}
+              draft={draft}
+              isComposingNew={selection?.kind === "new"}
+              isSending={isSending}
+              isStreaming={isStreaming}
+              jobs={jobs}
+              jobsIsLoading={jobsIsLoading}
+              messages={messages}
+              messagesIsLoading={messagesIsLoading}
+              onDraftChange={onDraftChange}
+              onSendMessage={onSendMessage}
+              organizationSlug={organizationSlug}
+              streamedAssistant={streamedAssistant}
+            />
+          )}
+        </Column>
+      </Columns>
     </main>
   );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -108,7 +108,7 @@ export function AppShellClient({
           {
             "--app-shell-content-height":
               "calc(100svh - var(--app-shell-header-height) - var(--app-shell-footer-height))",
-            "--app-shell-plan-footer-height": "calc(2.5rem + env(safe-area-inset-bottom))",
+            "--app-shell-plan-footer-height": "calc(3rem + env(safe-area-inset-bottom))",
             "--app-shell-footer-height":
               "calc(var(--app-shell-plan-footer-height) + var(--app-shell-dock-height, 0px))",
             "--sidebar-width": "15rem",

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, type ReactNode } from "react";
+import { useEffect, type CSSProperties, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
 
@@ -39,7 +39,10 @@ const currentUser: InboxCurrentUser = {
 function FooterStoryFrame({ children }: { children: ReactNode }) {
   return (
     <AppShellStoreProvider defaultNavigationGroups={[]}>
-      <div className="min-h-screen bg-muted/20 text-foreground">
+      <div
+        className="min-h-screen bg-muted/20 text-foreground"
+        style={{ "--app-shell-plan-footer-height": "3rem" } as CSSProperties}
+      >
         <div className="mx-auto max-w-5xl px-6 py-10">
           <p className="text-sm text-muted-foreground">
             App shell content placeholder so the fixed footer is shown in context.

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -134,42 +134,60 @@ export function AppShellFooter({
                       <span className="tabular-nums">
                         {glossaryGuidanceStatus.notRecommendedCount}
                       </span>
-                    </span>
-                  ) : null}
-                </Button>
-              ) : null}
-              {showIssueGuidance && issueGuidanceStatus.available ? (
+                    ) : null}
+                    {glossaryGuidanceStatus.notRecommendedCount > 0 ? (
+                      <span className="inline-flex items-center gap-0.5 text-xs font-medium text-rose-500">
+                        <HugeiconsIcon
+                          icon={MinusSignCircleIcon}
+                          strokeWidth={2}
+                          className="size-4"
+                          aria-hidden="true"
+                        />
+                        <span className="tabular-nums">
+                          {glossaryGuidanceStatus.notRecommendedCount}
+                        </span>
+                      </span>
+                    ) : null}
+                  </Button>
+                ) : null}
+                {showIssueGuidance && issueGuidanceStatus.available ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={requestCatIssueGuidance}
+                    aria-label={intl.formatMessage(
+                      issueGuidanceStatus.openIssueCount > 0
+                        ? appShellFooterMessages.issueGuidanceAvailableAriaLabel
+                        : appShellFooterMessages.issueGuidanceAriaLabel,
+                      issueGuidanceStatus.openIssueCount > 0
+                        ? { count: issueGuidanceStatus.openIssueCount }
+                        : undefined,
+                    )}
+                  >
+                    <HugeiconsIcon icon={Copy01Icon} strokeWidth={2} data-icon="inline-start" />
+                    <FormattedMessage {...appShellFooterMessages.issueGuidanceLabel} />
+                    {issueGuidanceStatus.openIssueCount > 0 ? (
+                      <span className="tabular-nums text-xs font-medium text-flame-900 dark:text-flame-100">
+                        {issueGuidanceStatus.openIssueCount}
+                      </span>
+                    ) : null}
+                  </Button>
+                ) : null}
+                {showChatDock ? (
+                  <ChatDockFooterControls organizationSlug={organizationSlug} />
+                ) : null}
                 <Button
-                  type="button"
                   variant="ghost"
-                  onClick={requestCatIssueGuidance}
-                  aria-label={intl.formatMessage(
-                    issueGuidanceStatus.openIssueCount > 0
-                      ? appShellFooterMessages.issueGuidanceAvailableAriaLabel
-                      : appShellFooterMessages.issueGuidanceAriaLabel,
-                    issueGuidanceStatus.openIssueCount > 0
-                      ? { count: issueGuidanceStatus.openIssueCount }
-                      : undefined,
-                  )}
+                  render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+                  aria-label={intl.formatMessage(appShellFooterMessages.emailSupportAriaLabel)}
                 >
-                  <HugeiconsIcon icon={Copy01Icon} strokeWidth={2} data-icon="inline-start" />
-                  <FormattedMessage {...appShellFooterMessages.issueGuidanceLabel} />
-                  {issueGuidanceStatus.openIssueCount > 0 ? (
-                    <span className="tabular-nums text-xs font-medium text-flame-900 dark:text-flame-100">
-                      {issueGuidanceStatus.openIssueCount}
-                    </span>
-                  ) : null}
+                  <HugeiconsIcon
+                    icon={CustomerSupportIcon}
+                    strokeWidth={2}
+                    data-icon="inline-start"
+                  />
+                  <FormattedMessage {...appShellFooterMessages.supportLabel} />
                 </Button>
-              ) : null}
-              {showChatDock ? <ChatDockFooterControls organizationSlug={organizationSlug} /> : null}
-              <Button
-                variant="ghost"
-                render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
-                aria-label={intl.formatMessage(appShellFooterMessages.emailSupportAriaLabel)}
-              >
-                <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} data-icon="inline-start" />
-                <FormattedMessage {...appShellFooterMessages.supportLabel} />
-              </Button>
               </Row>
             </Column>
           </Columns>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -97,42 +97,36 @@ export function AppShellFooter({
             ) : null}
             <Column width="content">
               <Row spacing="1u" alignY="center">
-              {showGlossaryGuidance ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={requestCatGlossaryGuidance}
-                  aria-label={intl.formatMessage(
-                    glossaryGuidanceStatus.matchCount > 0 ||
-                      glossaryGuidanceStatus.preferredCount > 0 ||
-                      glossaryGuidanceStatus.notRecommendedCount > 0
-                      ? appShellFooterMessages.glossaryGuidanceAvailableAriaLabel
-                      : appShellFooterMessages.glossaryGuidanceAriaLabel,
-                  )}
-                >
-                  <HugeiconsIcon icon={BookOpenTextIcon} strokeWidth={2} data-icon="inline-start" />
-                  <FormattedMessage {...appShellFooterMessages.glossaryGuidanceLabel} />
-                  {glossaryGuidanceStatus.preferredCount > 0 ? (
-                    <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-500">
-                      <HugeiconsIcon
-                        icon={CheckmarkCircle02Icon}
-                        strokeWidth={2}
-                        className="size-4"
-                        aria-hidden="true"
-                      />
-                      <span className="tabular-nums">{glossaryGuidanceStatus.preferredCount}</span>
-                    </span>
-                  ) : null}
-                  {glossaryGuidanceStatus.notRecommendedCount > 0 ? (
-                    <span className="inline-flex items-center gap-0.5 text-xs font-medium text-rose-500">
-                      <HugeiconsIcon
-                        icon={MinusSignCircleIcon}
-                        strokeWidth={2}
-                        className="size-4"
-                        aria-hidden="true"
-                      />
-                      <span className="tabular-nums">
-                        {glossaryGuidanceStatus.notRecommendedCount}
+                {showGlossaryGuidance ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={requestCatGlossaryGuidance}
+                    aria-label={intl.formatMessage(
+                      glossaryGuidanceStatus.matchCount > 0 ||
+                        glossaryGuidanceStatus.preferredCount > 0 ||
+                        glossaryGuidanceStatus.notRecommendedCount > 0
+                        ? appShellFooterMessages.glossaryGuidanceAvailableAriaLabel
+                        : appShellFooterMessages.glossaryGuidanceAriaLabel,
+                    )}
+                  >
+                    <HugeiconsIcon
+                      icon={BookOpenTextIcon}
+                      strokeWidth={2}
+                      data-icon="inline-start"
+                    />
+                    <FormattedMessage {...appShellFooterMessages.glossaryGuidanceLabel} />
+                    {glossaryGuidanceStatus.preferredCount > 0 ? (
+                      <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-500">
+                        <HugeiconsIcon
+                          icon={CheckmarkCircle02Icon}
+                          strokeWidth={2}
+                          className="size-4"
+                          aria-hidden="true"
+                        />
+                        <span className="tabular-nums">
+                          {glossaryGuidanceStatus.preferredCount}
+                        </span>
                       </span>
                     ) : null}
                     {glossaryGuidanceStatus.notRecommendedCount > 0 ? (

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -44,6 +44,10 @@ import {
   subscribeCatIssueGuidance,
 } from "@/components/content-editor/issues/content-editor-issue-guidance-event";
 import { Button } from "@/components/ui/button";
+import { Box } from "@/components/ui/layout/box";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
+import { Row } from "@/components/ui/layout/row";
 import { SUPPORT_EMAIL } from "@/lib/support-contact";
 
 import { appShellFooterMessages } from "./app-shell-footer.messages";
@@ -83,91 +87,93 @@ export function AppShellFooter({
         </ChatDockErrorBoundary>
       ) : null}
 
-      <div className="flex h-(--app-shell-plan-footer-height) shrink-0 items-stretch px-2">
-        <div className="flex h-10 w-full items-center gap-2">
-          {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
-          <div className="ms-auto flex min-w-0 items-center gap-2">
-            {showGlossaryGuidance ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                className="gap-1.5 px-2"
-                onClick={requestCatGlossaryGuidance}
-                aria-label={intl.formatMessage(
-                  glossaryGuidanceStatus.matchCount > 0 ||
-                    glossaryGuidanceStatus.preferredCount > 0 ||
-                    glossaryGuidanceStatus.notRecommendedCount > 0
-                    ? appShellFooterMessages.glossaryGuidanceAvailableAriaLabel
-                    : appShellFooterMessages.glossaryGuidanceAriaLabel,
-                )}
-              >
-                <HugeiconsIcon icon={BookOpenTextIcon} strokeWidth={2} className="size-3.5" />
-                <FormattedMessage {...appShellFooterMessages.glossaryGuidanceLabel} />
-                {glossaryGuidanceStatus.preferredCount > 0 ? (
-                  <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-500">
-                    <HugeiconsIcon
-                      icon={CheckmarkCircle02Icon}
-                      strokeWidth={2}
-                      className="size-4"
-                      aria-hidden="true"
-                    />
-                    <span className="tabular-nums">{glossaryGuidanceStatus.preferredCount}</span>
-                  </span>
-                ) : null}
-                {glossaryGuidanceStatus.notRecommendedCount > 0 ? (
-                  <span className="inline-flex items-center gap-0.5 text-xs font-medium text-rose-500">
-                    <HugeiconsIcon
-                      icon={MinusSignCircleIcon}
-                      strokeWidth={2}
-                      className="size-4"
-                      aria-hidden="true"
-                    />
-                    <span className="tabular-nums">
-                      {glossaryGuidanceStatus.notRecommendedCount}
+      <div className="h-(--app-shell-plan-footer-height) shrink-0">
+        <Box paddingX="1u" display="flex" alignItems="center" height="full" width="full">
+          <Columns spacing="1u" alignY="center" align={showPlan ? "spaceBetween" : "end"}>
+            {showPlan ? (
+              <Column width="content">
+                <PlanUsageFooterControl organizationSlug={organizationSlug} />
+              </Column>
+            ) : null}
+            <Column width="content">
+              <Row spacing="1u" alignY="center">
+              {showGlossaryGuidance ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={requestCatGlossaryGuidance}
+                  aria-label={intl.formatMessage(
+                    glossaryGuidanceStatus.matchCount > 0 ||
+                      glossaryGuidanceStatus.preferredCount > 0 ||
+                      glossaryGuidanceStatus.notRecommendedCount > 0
+                      ? appShellFooterMessages.glossaryGuidanceAvailableAriaLabel
+                      : appShellFooterMessages.glossaryGuidanceAriaLabel,
+                  )}
+                >
+                  <HugeiconsIcon icon={BookOpenTextIcon} strokeWidth={2} data-icon="inline-start" />
+                  <FormattedMessage {...appShellFooterMessages.glossaryGuidanceLabel} />
+                  {glossaryGuidanceStatus.preferredCount > 0 ? (
+                    <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-500">
+                      <HugeiconsIcon
+                        icon={CheckmarkCircle02Icon}
+                        strokeWidth={2}
+                        className="size-4"
+                        aria-hidden="true"
+                      />
+                      <span className="tabular-nums">{glossaryGuidanceStatus.preferredCount}</span>
                     </span>
-                  </span>
-                ) : null}
-              </Button>
-            ) : null}
-            {showIssueGuidance && issueGuidanceStatus.available ? (
+                  ) : null}
+                  {glossaryGuidanceStatus.notRecommendedCount > 0 ? (
+                    <span className="inline-flex items-center gap-0.5 text-xs font-medium text-rose-500">
+                      <HugeiconsIcon
+                        icon={MinusSignCircleIcon}
+                        strokeWidth={2}
+                        className="size-4"
+                        aria-hidden="true"
+                      />
+                      <span className="tabular-nums">
+                        {glossaryGuidanceStatus.notRecommendedCount}
+                      </span>
+                    </span>
+                  ) : null}
+                </Button>
+              ) : null}
+              {showIssueGuidance && issueGuidanceStatus.available ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={requestCatIssueGuidance}
+                  aria-label={intl.formatMessage(
+                    issueGuidanceStatus.openIssueCount > 0
+                      ? appShellFooterMessages.issueGuidanceAvailableAriaLabel
+                      : appShellFooterMessages.issueGuidanceAriaLabel,
+                    issueGuidanceStatus.openIssueCount > 0
+                      ? { count: issueGuidanceStatus.openIssueCount }
+                      : undefined,
+                  )}
+                >
+                  <HugeiconsIcon icon={Copy01Icon} strokeWidth={2} data-icon="inline-start" />
+                  <FormattedMessage {...appShellFooterMessages.issueGuidanceLabel} />
+                  {issueGuidanceStatus.openIssueCount > 0 ? (
+                    <span className="tabular-nums text-xs font-medium text-flame-900 dark:text-flame-100">
+                      {issueGuidanceStatus.openIssueCount}
+                    </span>
+                  ) : null}
+                </Button>
+              ) : null}
+              {showChatDock ? <ChatDockFooterControls organizationSlug={organizationSlug} /> : null}
               <Button
-                type="button"
                 variant="ghost"
-                size="xs"
-                className="gap-1.5 px-2"
-                onClick={requestCatIssueGuidance}
-                aria-label={intl.formatMessage(
-                  issueGuidanceStatus.openIssueCount > 0
-                    ? appShellFooterMessages.issueGuidanceAvailableAriaLabel
-                    : appShellFooterMessages.issueGuidanceAriaLabel,
-                  issueGuidanceStatus.openIssueCount > 0
-                    ? { count: issueGuidanceStatus.openIssueCount }
-                    : undefined,
-                )}
+                render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+                aria-label={intl.formatMessage(appShellFooterMessages.emailSupportAriaLabel)}
               >
-                <HugeiconsIcon icon={Copy01Icon} strokeWidth={2} className="size-3.5" />
-                <FormattedMessage {...appShellFooterMessages.issueGuidanceLabel} />
-                {issueGuidanceStatus.openIssueCount > 0 ? (
-                  <span className="tabular-nums text-xs font-medium text-flame-900 dark:text-flame-100">
-                    {issueGuidanceStatus.openIssueCount}
-                  </span>
-                ) : null}
+                <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} data-icon="inline-start" />
+                <FormattedMessage {...appShellFooterMessages.supportLabel} />
               </Button>
-            ) : null}
-            {showChatDock ? <ChatDockFooterControls organizationSlug={organizationSlug} /> : null}
-            <Button
-              variant="ghost"
-              size="xs"
-              className="gap-1.5 px-2"
-              render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
-              aria-label={intl.formatMessage(appShellFooterMessages.emailSupportAriaLabel)}
-            >
-              <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} className="size-3.5" />
-              <FormattedMessage {...appShellFooterMessages.supportLabel} />
-            </Button>
-          </div>
-        </div>
+              </Row>
+            </Column>
+          </Columns>
+        </Box>
       </div>
     </footer>
   );

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
@@ -18,6 +18,8 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, type MessageDescriptor, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
+import { Box } from "@/components/ui/layout/box";
+import { Rows } from "@/components/ui/layout/rows";
 
 import { chatDockMessages } from "./chat-dock.messages";
 import type { ChatDockPageContext } from "./chat-dock-store";
@@ -98,35 +100,64 @@ export function ChatDockEmptyState({
   const suggestions = buildChatDockSuggestions(pageContext, intl.formatMessage);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-5 overflow-y-auto px-5 py-8 text-center">
-      <div className="flex size-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-        <HugeiconsIcon icon={Chat01Icon} strokeWidth={1.8} className="size-5" />
-      </div>
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        gap="3u"
+        paddingX="3u"
+        paddingY="4u"
+        height="full"
+      >
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          background="muted"
+          borderRadius="standard"
+          padding="1u"
+        >
+          <HugeiconsIcon
+            icon={Chat01Icon}
+            strokeWidth={1.8}
+            className="size-5 text-muted-foreground"
+          />
+        </Box>
 
-      <div className="max-w-sm space-y-1">
-        <h2 className="text-balance text-sm font-semibold text-foreground">
-          <FormattedMessage {...chatDockMessages.emptyTitle} />
-        </h2>
-        <p className="text-pretty text-sm text-muted-foreground">
-          <FormattedMessage {...chatDockMessages.emptySubtitle} />
-        </p>
-      </div>
+        <Rows spacing="0.5u" align="center">
+          <h2 className="max-w-sm text-balance text-sm font-semibold text-foreground">
+            <FormattedMessage {...chatDockMessages.emptyTitle} />
+          </h2>
+          <p className="max-w-sm text-pretty text-sm text-muted-foreground">
+            <FormattedMessage {...chatDockMessages.emptySubtitle} />
+          </p>
+        </Rows>
 
-      <div className="flex max-w-sm flex-wrap justify-center gap-2">
-        {suggestions.map((suggestion) => (
-          <Button
-            key={suggestion.id}
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-8 gap-1.5 rounded-full bg-background text-xs font-medium"
-            onClick={() => onSelectSuggestion(suggestion.prompt)}
-          >
-            <HugeiconsIcon icon={suggestion.icon} strokeWidth={1.8} className="size-3.5" />
-            {suggestion.label}
-          </Button>
-        ))}
-      </div>
+        <Box
+          display="flex"
+          flexWrap="wrap"
+          alignItems="center"
+          justifyContent="center"
+          gap="1u"
+          width="full"
+        >
+          {suggestions.map((suggestion) => (
+            <Button
+              key={suggestion.id}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5 rounded-full bg-background text-xs font-medium"
+              onClick={() => onSelectSuggestion(suggestion.prompt)}
+            >
+              <HugeiconsIcon icon={suggestion.icon} strokeWidth={1.8} className="size-3.5" />
+              {suggestion.label}
+            </Button>
+          ))}
+        </Box>
+      </Box>
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -32,6 +32,8 @@ import type {
 import { ReplyComposer } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer";
 import { UpgradePlanButton } from "@/components/billing/upgrade-plan-button";
 import { Button } from "@/components/ui/button";
+import { Box } from "@/components/ui/layout/box";
+import { Row } from "@/components/ui/layout/row";
 import { TypographyMuted } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { useAiFeaturesAccess } from "@/lib/billing/use-ai-features-access";
@@ -296,50 +298,56 @@ export const ChatDockPanel = observer(function ChatDockPanel({
       className="fixed inset-x-2 bottom-[calc(var(--app-shell-plan-footer-height)+0.5rem)] z-50 flex h-[min(44rem,calc(100svh-var(--app-shell-plan-footer-height)-1rem))] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15 sm:inset-x-auto sm:right-3 sm:w-[30rem]"
       aria-label={tab.title}
     >
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-foreground">{tab.title}</p>
-        </div>
-        {!tab.isPending ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1 px-2 text-xs"
-            render={<Link href={`/org/${organizationSlug}/inbox/${tab.id}`} />}
-          >
-            <FormattedMessage {...chatDockMessages.openInInbox} />
-            <HugeiconsIcon icon={ArrowUpRight01Icon} strokeWidth={2} className="size-3.5" />
-          </Button>
-        ) : null}
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          aria-label={intl.formatMessage(chatDockMessages.collapsePanel)}
-          onClick={() => store.setPanelOpen(false)}
-        >
-          <span aria-hidden className="text-base leading-none">
-            {COLLAPSE_GLYPH}
-          </span>
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          aria-label={intl.formatMessage(chatDockMessages.closeTab)}
-          onClick={() => {
-            store.closeTab(tab.id);
-          }}
-        >
-          <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
-        </Button>
+      <header className="h-12 shrink-0 border-b border-border">
+        <Box paddingX="1.5u" display="flex" alignItems="center" height="full">
+          <Row spacing="1u" alignY="center">
+            <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+              {tab.title}
+            </p>
+            {!tab.isPending ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1 px-2 text-xs"
+                render={<Link href={`/org/${organizationSlug}/inbox/${tab.id}`} />}
+              >
+                <FormattedMessage {...chatDockMessages.openInInbox} />
+                <HugeiconsIcon icon={ArrowUpRight01Icon} strokeWidth={2} className="size-3.5" />
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={intl.formatMessage(chatDockMessages.collapsePanel)}
+              onClick={() => store.setPanelOpen(false)}
+            >
+              <span aria-hidden className="text-base leading-none">
+                {COLLAPSE_GLYPH}
+              </span>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={intl.formatMessage(chatDockMessages.closeTab)}
+              onClick={() => {
+                store.closeTab(tab.id);
+              }}
+            >
+              <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+            </Button>
+          </Row>
+        </Box>
       </header>
 
       {tab.lastError ? (
-        <div className="border-b border-border bg-destructive/5 px-3 py-2">
-          <TypographyMuted size="xsmall" tone="critical">
-            {tab.lastError}
-          </TypographyMuted>
+        <div className="border-b border-border bg-destructive/5">
+          <Box paddingX="1.5u" paddingY="1u">
+            <TypographyMuted size="xsmall" tone="critical">
+              {tab.lastError}
+            </TypographyMuted>
+          </Box>
         </div>
       ) : null}
 
@@ -372,8 +380,10 @@ export const ChatDockPanel = observer(function ChatDockPanel({
         )}
 
         {aiFeaturesAccess.status === "denied" ? (
-          <div className="border-t border-border px-3 py-2">
-            <UpgradePlanButton organizationSlug={organizationSlug} size="sm" />
+          <div className="border-t border-border">
+            <Box paddingX="1.5u" paddingY="1u">
+              <UpgradePlanButton organizationSlug={organizationSlug} size="sm" />
+            </Box>
           </div>
         ) : aiFeaturesAccess.status === "allowed" ? (
           <ReplyComposer

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
@@ -93,21 +93,14 @@ export const ChatDockTabBar = observer(function ChatDockTabBar({
         })}
       </div>
 
-      <AiFeatureAction
-        organizationSlug={organizationSlug}
-        variant="ghost"
-        size="xs"
-        className="shrink-0 gap-1.5 px-2"
-      >
+      <AiFeatureAction organizationSlug={organizationSlug} variant="ghost">
         <Button
           type="button"
           variant="ghost"
-          size="xs"
-          className="shrink-0 gap-1.5 px-2"
           aria-label={intl.formatMessage(chatDockMessages.newChat)}
           onClick={onNewTab}
         >
-          <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} className="size-3.5" />
+          <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} data-icon="inline-start" />
           <FormattedMessage {...chatDockMessages.newChat} />
         </Button>
       </AiFeatureAction>

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
@@ -164,21 +164,14 @@ export const ChatDockFooterControls = observer(function ChatDockFooterControls({
 
   if (!chatDock.hasTabs) {
     return (
-      <AiFeatureAction
-        organizationSlug={organizationSlug}
-        variant="ghost"
-        size="xs"
-        className="gap-1.5 px-2"
-      >
+      <AiFeatureAction organizationSlug={organizationSlug} variant="ghost">
         <Button
           type="button"
           variant="ghost"
-          size="xs"
-          className="gap-1.5 px-2"
           aria-label={intl.formatMessage(chatDockMessages.newChat)}
           onClick={() => chatDock.openNewTab()}
         >
-          <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} className="size-3.5" />
+          <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} data-icon="inline-start" />
           <FormattedMessage {...chatDockMessages.newChat} />
         </Button>
       </AiFeatureAction>

--- a/apps/hyperlocalise-web/src/components/billing/plan-usage-summary.tsx
+++ b/apps/hyperlocalise-web/src/components/billing/plan-usage-summary.tsx
@@ -147,7 +147,6 @@ export function PlanUsageFooterControl({ organizationSlug }: { organizationSlug:
         render={
           <Button
             variant="outline"
-            size="xs"
             aria-label={intl.formatMessage(planUsageSummaryMessages.openPlanUsageAriaLabel, {
               planName,
             })}

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-file-viewer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-file-viewer.test.tsx
@@ -139,11 +139,14 @@ Translate this paragraph.
     );
 
     const titleField = await screen.findByLabelText("title");
+    const saveButton = screen.getByRole("button", { name: /save edits/i });
+    expect(saveButton).toBeDisabled();
     expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
     await screen.findByRole("heading", { level: 1, name: "Guide" });
     await user.clear(titleField);
     await user.type(titleField, "Updated Guide");
-    await user.click(screen.getByRole("button", { name: /save edits/i }));
+    expect(saveButton).toBeEnabled();
+    await user.click(saveButton);
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledTimes(1);
@@ -177,10 +180,13 @@ Translate this paragraph.
     );
 
     const editor = await screen.findByLabelText("Translated document");
+    const saveButton = screen.getByRole("button", { name: /save edits/i });
     expect(editor).toHaveValue(mdxBody);
+    expect(saveButton).toBeDisabled();
 
     await user.type(editor, " Updated.");
-    await user.click(screen.getByRole("button", { name: /save edits/i }));
+    expect(saveButton).toBeEnabled();
+    await user.click(saveButton);
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledTimes(1);
@@ -193,6 +199,40 @@ Translate this paragraph.
     expect(savedText).not.toContain("&lt;Callout");
     expect(savedText).not.toContain("&lt;kbd");
     expect(savedText).toContain("Updated.");
+  });
+
+  it("collapses and expands document frontmatter fields", async () => {
+    const user = userEvent.setup();
+    const markdownBody = `---
+title: Guide
+description: Intro
+---
+
+# Guide
+`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(markdownBody, { status: 200 })),
+    );
+
+    render(
+      <ContentEditorTestProviders>
+        <ContentEditorDocumentFileViewerPane
+          role="target"
+          src="https://example.com/guide.md"
+          filename="guide.md"
+        />
+      </ContentEditorTestProviders>,
+    );
+
+    const titleField = await screen.findByLabelText("title");
+    expect(titleField).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: /Document properties/i }));
+    expect(titleField).not.toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: /Document properties/i }));
+    expect(screen.getByLabelText("title")).toBeVisible();
   });
 
   it("renders read-only panes as a formatted preview instead of raw markup", async () => {

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-file-viewer.tsx
@@ -12,9 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { FloppyDiskIcon, Loading03Icon } from "@hugeicons/core-free-icons";
+import { ArrowDown01Icon, FloppyDiskIcon, Loading03Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import {
@@ -23,11 +23,15 @@ import {
   type ContentEditorDocumentFrontmatterField,
 } from "@/components/content-editor/file-view/content-editor-document-frontmatter";
 import { contentEditorFileViewMessages } from "@/components/content-editor/file-view/content-editor-file-view.messages";
+import { FileViewPaneState } from "@/components/content-editor/file-view/content-editor-file-view-layout";
 import { MarkdownEditor, MarkdownPreview } from "@/components/markdown-editor/markdown-editor";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Row } from "@/components/ui/layout/row";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/primitives/cn";
 
 export const CONTENT_EDITOR_DOCUMENT_FILE_UPLOAD_ACCEPT = ".md,.markdown,.mdx";
 
@@ -61,6 +65,7 @@ export function ContentEditorDocumentFileViewerPane({
   canEdit = true,
   isBusy = false,
   onSave,
+  footerActions,
 }: {
   role: "source" | "target";
   src?: string | null;
@@ -70,6 +75,7 @@ export function ContentEditorDocumentFileViewerPane({
   canEdit?: boolean;
   isBusy?: boolean;
   onSave?: (file: File) => void | Promise<void>;
+  footerActions?: ReactNode;
 }) {
   const intl = useIntl();
   const readOnly = role === "source" || !canEdit;
@@ -80,11 +86,45 @@ export function ContentEditorDocumentFileViewerPane({
   const [error, setError] = useState<string | null>(null);
   const [isFetching, setIsFetching] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [frontmatterOpen, setFrontmatterOpen] = useState(true);
+  const [savedSnapshot, setSavedSnapshot] = useState<{
+    fields: ContentEditorDocumentFrontmatterField[];
+    body: string;
+    hasFrontmatter: boolean;
+    rawFrontmatter: string;
+  } | null>(null);
+  const editorBaselineSyncedRef = useRef(false);
+
+  function currentDocumentText() {
+    return joinContentEditorDocument({ fields, body, hasFrontmatter, rawFrontmatter });
+  }
+
+  function snapshotDocumentText(snapshot: NonNullable<typeof savedSnapshot>) {
+    return joinContentEditorDocument(snapshot);
+  }
+
+  const hasUnsavedChanges =
+    savedSnapshot !== null && currentDocumentText() !== snapshotDocumentText(savedSnapshot);
+
+  function handleMarkdownBodyChange(next: string) {
+    setBody(next);
+    if (!editorBaselineSyncedRef.current) {
+      editorBaselineSyncedRef.current = true;
+      setSavedSnapshot({
+        fields,
+        body: next,
+        hasFrontmatter,
+        rawFrontmatter,
+      });
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
     setError(null);
     setIsFetching(true);
+    setSavedSnapshot(null);
+    editorBaselineSyncedRef.current = false;
     void (async () => {
       try {
         const primary = await loadDocumentText(src);
@@ -119,6 +159,13 @@ export function ContentEditorDocumentFileViewerPane({
         setBody(split.body);
         setHasFrontmatter(split.hasFrontmatter);
         setRawFrontmatter(split.rawFrontmatter);
+        setSavedSnapshot({
+          fields: split.fields,
+          body: split.body,
+          hasFrontmatter: split.hasFrontmatter,
+          rawFrontmatter: split.rawFrontmatter,
+        });
+        editorBaselineSyncedRef.current = isMdxDocumentFilename(filename);
       } catch {
         if (!cancelled) {
           setError(
@@ -149,9 +196,11 @@ export function ContentEditorDocumentFileViewerPane({
     }
     setIsSaving(true);
     try {
-      const text = joinContentEditorDocument({ fields, body, hasFrontmatter, rawFrontmatter });
+      const text = currentDocumentText();
       const file = new File([text], filename, { type: "text/markdown" });
       await onSave(file);
+      setSavedSnapshot({ fields, body, hasFrontmatter, rawFrontmatter });
+      editorBaselineSyncedRef.current = true;
     } finally {
       setIsSaving(false);
     }
@@ -160,105 +209,130 @@ export function ContentEditorDocumentFileViewerPane({
   const showSpinner = isLoading || isFetching;
 
   return (
-    <div className="flex min-h-56 flex-col gap-3 rounded-lg border border-border bg-background p-3">
-      {showSpinner ? (
-        <div className="flex min-h-56 items-center justify-center text-muted-foreground">
-          <HugeiconsIcon icon={Loading03Icon} className="size-5 animate-spin" aria-hidden />
-        </div>
-      ) : error ? (
-        <div className="flex min-h-56 items-center justify-center px-4 text-center text-sm text-muted-foreground">
-          {error}
-        </div>
-      ) : !src && role === "source" ? (
-        <div className="flex min-h-56 items-center justify-center px-4 text-center text-sm text-muted-foreground">
-          {emptyLabel}
-        </div>
-      ) : (
-        <>
-          {hasFrontmatter ? (
-            <div className="space-y-2">
-              <h4 className="text-xs font-medium text-muted-foreground">
-                <FormattedMessage {...contentEditorFileViewMessages.documentFrontmatter} />
-              </h4>
-              <div className="grid gap-2">
-                {fields.map((field, index) => (
-                  <div key={`${field.key}-${index}`} className="grid gap-1">
-                    <Label
-                      htmlFor={`content-editor-document-field-${role}-${field.key}`}
-                      className="text-xs"
-                    >
-                      {field.key}
-                    </Label>
-                    <Input
-                      id={`content-editor-document-field-${role}-${field.key}`}
-                      value={field.value}
-                      disabled={readOnly}
-                      onChange={(event) => {
-                        const value = event.currentTarget.value;
-                        setFields((current) =>
-                          current.map((entry, entryIndex) =>
-                            entryIndex === index ? { ...entry, value } : entry,
-                          ),
-                        );
-                      }}
-                    />
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          <div className="flex min-h-0 flex-1 flex-col gap-2">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 py-8 md:px-10 md:py-10">
+        {showSpinner ? (
+          <div className="flex flex-1 items-center justify-center text-muted-foreground">
+            <HugeiconsIcon icon={Loading03Icon} className="size-5 animate-spin" aria-hidden />
+          </div>
+        ) : error ? (
+          <FileViewPaneState>{error}</FileViewPaneState>
+        ) : !src && role === "source" ? (
+          <FileViewPaneState>{emptyLabel}</FileViewPaneState>
+        ) : (
+          <>
             {hasFrontmatter ? (
-              <h4 className="text-xs font-medium text-muted-foreground">
-                <FormattedMessage {...contentEditorFileViewMessages.documentBody} />
-              </h4>
+              <Collapsible
+                open={frontmatterOpen}
+                onOpenChange={setFrontmatterOpen}
+                className="border-b border-border/60 pb-6"
+              >
+                <CollapsibleTrigger className="flex w-full items-center justify-between gap-2 rounded-md py-1 text-start hover:text-foreground">
+                  <h4 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                    <FormattedMessage {...contentEditorFileViewMessages.documentFrontmatter} />
+                  </h4>
+                  <HugeiconsIcon
+                    icon={ArrowDown01Icon}
+                    className={cn(
+                      "size-4 shrink-0 text-muted-foreground transition-transform",
+                      frontmatterOpen && "rotate-180",
+                    )}
+                    aria-hidden
+                  />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="pt-3">
+                  <div className="grid gap-3">
+                    {fields.map((field, index) => (
+                      <div key={`${field.key}-${index}`} className="grid gap-1.5">
+                        <Label
+                          htmlFor={`content-editor-document-field-${role}-${field.key}`}
+                          className="text-xs text-muted-foreground"
+                        >
+                          {field.key}
+                        </Label>
+                        <Input
+                          id={`content-editor-document-field-${role}-${field.key}`}
+                          value={field.value}
+                          disabled={readOnly}
+                          onChange={(event) => {
+                            const value = event.currentTarget.value;
+                            setFields((current) =>
+                              current.map((entry, entryIndex) =>
+                                entryIndex === index ? { ...entry, value } : entry,
+                              ),
+                            );
+                          }}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
             ) : null}
-            {readOnly ? (
-              <MarkdownPreview value={body} className="min-h-[16rem]" emptyMessage={emptyLabel} />
-            ) : isMdxDocumentFilename(filename) ? (
-              /*
+
+            <div className="flex min-h-0 flex-1 flex-col gap-3">
+              {hasFrontmatter ? (
+                <h4 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                  <FormattedMessage {...contentEditorFileViewMessages.documentBody} />
+                </h4>
+              ) : null}
+              {readOnly ? (
+                <MarkdownPreview
+                  value={body}
+                  chrome="minimal"
+                  className="min-h-[16rem] flex-1"
+                  contentClassName="prose prose-sm max-w-none dark:prose-invert"
+                  emptyMessage={emptyLabel}
+                />
+              ) : isMdxDocumentFilename(filename) ? (
+                /*
                 MDX keeps a raw textarea: TipTap getMarkdown() HTML-escapes angle brackets,
                 which corrupts JSX and raw HTML on save (e.g. <Callout> → &lt;Callout&gt;).
               */
-              <Textarea
-                value={body}
-                onChange={(event) => setBody(event.currentTarget.value)}
-                aria-label={intl.formatMessage(contentEditorFileViewMessages.documentEditorAria)}
-                className="min-h-[16rem] resize-y font-mono text-sm leading-relaxed"
-              />
-            ) : (
-              <MarkdownEditor
-                key={`${role}-${src ?? seedSrc ?? "missing"}-${filename}`}
-                value={body}
-                onChange={setBody}
-                disabled={isBusy || isSaving}
-                ariaLabel={intl.formatMessage(contentEditorFileViewMessages.documentEditorAria)}
-                className="min-h-[16rem]"
-              />
-            )}
-          </div>
+                <Textarea
+                  value={body}
+                  onChange={(event) => setBody(event.currentTarget.value)}
+                  aria-label={intl.formatMessage(contentEditorFileViewMessages.documentEditorAria)}
+                  className="min-h-[16rem] resize-y font-mono text-sm leading-relaxed"
+                />
+              ) : (
+                <MarkdownEditor
+                  key={`${role}-${src ?? seedSrc ?? "missing"}-${filename}`}
+                  value={body}
+                  onChange={handleMarkdownBodyChange}
+                  disabled={isBusy || isSaving}
+                  ariaLabel={intl.formatMessage(contentEditorFileViewMessages.documentEditorAria)}
+                  className="min-h-[20rem] flex-1 border-0 bg-transparent shadow-none"
+                />
+              )}
+            </div>
+          </>
+        )}
+      </div>
 
-          {onSave && !readOnly ? (
-            <div className="flex justify-end">
+      {!readOnly && (footerActions || onSave) ? (
+        <div className="shrink-0 border-t border-border/60 px-6 py-3 md:px-10">
+          <Row spacing="1u" align="end" alignY="center">
+            {footerActions}
+            {onSave ? (
               <Button
                 type="button"
-                size="sm"
-                variant="outline"
-                disabled={isBusy || isSaving}
+                variant="default"
+                size="xs"
+                disabled={!hasUnsavedChanges || isBusy || isSaving}
                 onClick={() => void handleSave()}
               >
                 {isBusy || isSaving ? (
-                  <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin" aria-hidden />
+                  <HugeiconsIcon icon={Loading03Icon} className="animate-spin" aria-hidden />
                 ) : (
-                  <HugeiconsIcon icon={FloppyDiskIcon} className="size-3" aria-hidden />
+                  <HugeiconsIcon icon={FloppyDiskIcon} data-icon="inline-start" aria-hidden />
                 )}
                 <FormattedMessage {...contentEditorFileViewMessages.saveEdits} />
               </Button>
-            </div>
-          ) : null}
-        </>
-      )}
+            ) : null}
+          </Row>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-layout.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-layout.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { Box } from "@/components/ui/layout/box";
+import { Row } from "@/components/ui/layout/row";
+import { Text, Title } from "@/components/ui/typography";
+
+import { contentEditorFileViewMessages } from "./content-editor-file-view.messages";
+
+export function FileViewHeader({ children }: { children: ReactNode }) {
+  return (
+    <header className="flex h-12 shrink-0 items-center border-b border-border/50 bg-background/90 backdrop-blur-md">
+      <Box display="flex" alignItems="center" height="full" paddingX="2u" width="full">
+        {children}
+      </Box>
+    </header>
+  );
+}
+
+export function FileViewLocalePill({ children }: { children: ReactNode }) {
+  return (
+    <span className="hidden shrink-0 sm:inline-flex">
+      <Box
+        display="inline-flex"
+        borderRadius="full"
+        background="muted"
+        paddingX="1u"
+        paddingY="0.5u"
+      >
+        <Text size="xsmall" weight="medium" tone="subtle" tagName="span">
+          {children}
+        </Text>
+      </Box>
+    </span>
+  );
+}
+
+export function FileViewWorkspace({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-muted/30 dark:bg-muted/15">
+      <div className="flex min-h-0 flex-1 flex-col p-4 lg:p-6">{children}</div>
+    </div>
+  );
+}
+
+export function FileViewWorkspaceContent({
+  layout,
+  children,
+}: {
+  layout: "split" | "single";
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={
+        layout === "split"
+          ? "mx-auto flex min-h-0 w-full max-w-[96rem] flex-1 flex-col"
+          : "mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+export function FileViewPaneColumn({ children }: { children: ReactNode }) {
+  return <div className="flex h-full min-h-0 flex-1 flex-col">{children}</div>;
+}
+
+export function FileViewPane({
+  title,
+  toolbar,
+  footer,
+  children,
+}: {
+  title: ReactNode;
+  toolbar?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <FileViewPaneLabel>{title}</FileViewPaneLabel>
+      <FileViewPage toolbar={toolbar} footer={footer}>
+        {children}
+      </FileViewPage>
+    </div>
+  );
+}
+
+function FileViewPaneLabel({ children }: { children: ReactNode }) {
+  return (
+    <Title tagName="h3" size="xxsmall" weight="medium" tone="subtle">
+      {children}
+    </Title>
+  );
+}
+
+export function FileViewPage({
+  toolbar,
+  footer,
+  children,
+}: {
+  toolbar?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      {toolbar ? (
+        <div className="shrink-0 border-b border-border/60 bg-muted/20 px-3 py-1.5">
+          <Row spacing="1u" alignY="center">
+            {toolbar}
+          </Row>
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+      {footer ? (
+        <div className="shrink-0 border-t border-border/60 px-3 py-3">
+          <Row spacing="1u" align="end" alignY="center">
+            {footer}
+          </Row>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function FileViewPaneState({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full min-h-[16rem] flex-1 items-center justify-center p-8">
+      <Text size="small" tone="subtle" alignment="center">
+        {children}
+      </Text>
+    </div>
+  );
+}
+
+export function FileViewUnsupportedPreview() {
+  return (
+    <FileViewPaneState>
+      <FormattedMessage {...contentEditorFileViewMessages.previewUnsupported} />
+    </FileViewPaneState>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.test.tsx
@@ -14,12 +14,13 @@
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { ContentEditorTestProviders } from "@/components/content-editor/shared/content-editor-test-utils";
 import type { ContentEditorSegment } from "@/components/content-editor/shared/types";
 
 import { ContentEditorFileViewPanel } from "./content-editor-file-view-panel";
+import { writeCatFileViewSourcePaneVisible } from "./content-editor-file-view-source-pane";
 
 function imageSegment(overrides: Partial<ContentEditorSegment> = {}): ContentEditorSegment {
   return {
@@ -40,6 +41,10 @@ function imageSegment(overrides: Partial<ContentEditorSegment> = {}): ContentEdi
 }
 
 describe("ContentEditorFileViewPanel", () => {
+  beforeEach(() => {
+    writeCatFileViewSourcePaneVisible(true);
+  });
+
   it("renders source pane before translated pane", () => {
     render(
       <ContentEditorTestProviders>
@@ -137,5 +142,27 @@ describe("ContentEditorFileViewPanel", () => {
 
     expect(onPrevious).toHaveBeenCalledTimes(1);
     expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles the source pane visibility", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ContentEditorTestProviders>
+        <ContentEditorFileViewPanel segment={imageSegment()} viewerId="image" filename="hero.png" />
+      </ContentEditorTestProviders>,
+    );
+
+    expect(screen.getByRole("heading", { name: /Source \(en\)/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Hide source/i }));
+    expect(screen.queryByRole("heading", { name: /Source \(en\)/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Show source/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    await user.click(screen.getByRole("button", { name: /Show source/i }));
+    expect(screen.getByRole("heading", { name: /Source \(en\)/i })).toBeInTheDocument();
   });
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-panel.tsx
@@ -12,8 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useState } from "react";
-import type { ReactNode } from "react";
+import { useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import {
   ArrowLeft01Icon,
@@ -21,6 +20,8 @@ import {
   Loading03Icon,
   SparklesIcon,
   Upload01Icon,
+  ViewIcon,
+  ViewOffSlashIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -35,11 +36,28 @@ import {
 import type { ContentEditorSegment } from "@/components/content-editor/shared/types";
 import type { ContentEditorFileViewerId } from "@/components/content-editor/workspace/content-editor-file-view-capabilities";
 import { Button } from "@/components/ui/button";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
+import { Row } from "@/components/ui/layout/row";
 import { Spinner } from "@/components/ui/spinner";
+import { Title } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
 import { contentEditorFileViewMessages } from "./content-editor-file-view.messages";
+import {
+  readCatFileViewSourcePaneVisible,
+  writeCatFileViewSourcePaneVisible,
+} from "./content-editor-file-view-source-pane";
 import { ContentEditorFileGenerateDialog } from "./content-editor-file-generate-dialog";
+import {
+  FileViewHeader,
+  FileViewLocalePill,
+  FileViewPane,
+  FileViewPaneColumn,
+  FileViewUnsupportedPreview,
+  FileViewWorkspace,
+  FileViewWorkspaceContent,
+} from "./content-editor-file-view-layout";
 import {
   CAT_IMAGE_FILE_UPLOAD_ACCEPT,
   ContentEditorImageFileViewerPane,
@@ -63,8 +81,8 @@ const ContentEditorOfficeFileViewerPane = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="flex min-h-56 items-center justify-center border border-dashed border-border text-sm text-muted-foreground">
-        <span className="size-5 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+      <div className="flex min-h-56 items-center justify-center border border-dashed border-border">
+        <Spinner className="size-5 text-muted-foreground" />
       </div>
     ),
   },
@@ -114,7 +132,11 @@ export function ContentEditorFileViewPanel({
   className?: string;
 }) {
   const intl = useIntl();
+  const uploadInputRef = useRef<HTMLInputElement>(null);
   const [generateDialogOpen, setGenerateDialogOpen] = useState(false);
+  const [sourcePaneVisible, setSourcePaneVisible] = useState(() =>
+    readCatFileViewSourcePaneVisible(),
+  );
   const resolvedPrimaryActionLabel =
     primaryActionLabel ?? intl.formatMessage(contentEditorFileViewMessages.approve);
   const hasTarget = Boolean(segment.targetAssetUrl || segment.targetText.trim());
@@ -154,189 +176,258 @@ export function ContentEditorFileViewPanel({
     }
   }
 
+  function toggleSourcePane() {
+    setSourcePaneVisible((current) => {
+      const next = !current;
+      writeCatFileViewSourcePaneVisible(next);
+      return next;
+    });
+  }
+
+  const targetFileActions = (
+    <>
+      {onRegenerate ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          disabled={!canEdit || isImageBusy}
+          onClick={() => setGenerateDialogOpen(true)}
+        >
+          {isImageBusy ? (
+            <HugeiconsIcon icon={Loading03Icon} className="animate-spin" aria-hidden />
+          ) : (
+            <HugeiconsIcon icon={SparklesIcon} data-icon="inline-start" aria-hidden />
+          )}
+          <FormattedMessage
+            {...(hasTarget
+              ? contentEditorFileViewMessages.regenerate
+              : contentEditorFileViewMessages.generate)}
+          />
+        </Button>
+      ) : null}
+      {onUpload && uploadAccept ? (
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            disabled={!canEdit || isImageBusy}
+            onClick={() => uploadInputRef.current?.click()}
+          >
+            <HugeiconsIcon icon={Upload01Icon} data-icon="inline-start" aria-hidden />
+            <FormattedMessage {...contentEditorFileViewMessages.uploadFile} />
+          </Button>
+          <input
+            ref={uploadInputRef}
+            type="file"
+            accept={uploadAccept}
+            className="sr-only"
+            disabled={!canEdit || isImageBusy}
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) {
+                onUpload(file);
+              }
+              event.currentTarget.value = "";
+            }}
+          />
+        </>
+      ) : null}
+    </>
+  );
+
+  const hasTargetFileActions = Boolean(onRegenerate || (onUpload && uploadAccept));
+
+  const sourcePane = (
+    <FileViewPane
+      title={
+        <FormattedMessage
+          {...contentEditorFileViewMessages.sourceHeading}
+          values={{ locale: segment.sourceLocale }}
+        />
+      }
+    >
+      {viewerId === "image" ? (
+        <ContentEditorImageFileViewerPane role="source" src={sourceSrc} />
+      ) : viewerId === "video" ? (
+        <ContentEditorVideoFileViewerPane role="source" src={sourceSrc} />
+      ) : officeKind ? (
+        <ContentEditorOfficeFileViewerPane
+          kind={officeKind}
+          role="source"
+          src={sourceSrc}
+          filename={displayName}
+          canEdit={false}
+        />
+      ) : isDocumentViewer ? (
+        <ContentEditorDocumentFileViewerPane
+          role="source"
+          src={sourceSrc}
+          filename={displayName}
+          canEdit={false}
+        />
+      ) : (
+        <FileViewUnsupportedPreview />
+      )}
+    </FileViewPane>
+  );
+
   return (
     <div className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3 lg:px-5">
-        <div className="min-w-0 space-y-1">
-          <div className="flex flex-wrap items-center gap-2">
-            {shouldShowSegmentStatusBadge(segment.status, segment.isHidden) ? (
-              <SegmentStatusBadge status={segment.status} />
-            ) : null}
-            {segment.isHidden ? <ContentEditorHiddenStringBadge /> : null}
-            {segment.isLocked ? <ContentEditorLockedStringBadge /> : null}
-            <p className="truncate font-mono text-xs text-muted-foreground">{displayName}</p>
-          </div>
-          <p className="text-sm text-muted-foreground">
-            {segment.sourceLocale} → {segment.targetLocale}
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
+      <FileViewHeader>
+        <Row spacing="1.5u" alignY="center">
           {onPrevious || onNext ? (
-            <div className="flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={onPrevious}
-                disabled={!hasPreviousSegment || !onPrevious}
-                aria-label={intl.formatMessage(contentEditorFileViewMessages.previousFileAria)}
-              >
-                <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={onNext}
-                disabled={!hasNextSegment || !onNext}
-                aria-label={intl.formatMessage(contentEditorFileViewMessages.nextFileAria)}
-              >
-                <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
-              </Button>
-            </div>
+            <Column width="content">
+              <Row spacing="1u" alignY="center">
+                <Button
+                  variant="outline"
+                  size="icon-xs"
+                  onClick={onPrevious}
+                  disabled={!hasPreviousSegment || !onPrevious}
+                  aria-label={intl.formatMessage(contentEditorFileViewMessages.previousFileAria)}
+                >
+                  <HugeiconsIcon icon={ArrowLeft01Icon} aria-hidden />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="icon-xs"
+                  onClick={onNext}
+                  disabled={!hasNextSegment || !onNext}
+                  aria-label={intl.formatMessage(contentEditorFileViewMessages.nextFileAria)}
+                >
+                  <HugeiconsIcon icon={ArrowRight01Icon} aria-hidden />
+                </Button>
+              </Row>
+            </Column>
           ) : null}
-          <ContentEditorWorkspaceViewSwitcherConnected />
-          {onApprove ? (
-            <Button variant="default" size="sm" disabled={!canTriggerApprove} onClick={onApprove}>
-              {isApproving ? <Spinner className="size-4 text-primary-foreground" /> : null}
-              {resolvedPrimaryActionLabel}
-            </Button>
-          ) : null}
-        </div>
-      </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="grid h-full min-h-0 gap-4 p-4 lg:grid-cols-2 lg:gap-6 lg:p-6">
-          <FileViewPane
-            title={
-              <FormattedMessage
-                {...contentEditorFileViewMessages.sourceHeading}
-                values={{ locale: segment.sourceLocale }}
-              />
-            }
-          >
-            {viewerId === "image" ? (
-              <ContentEditorImageFileViewerPane role="source" src={sourceSrc} />
-            ) : viewerId === "video" ? (
-              <ContentEditorVideoFileViewerPane role="source" src={sourceSrc} />
-            ) : officeKind ? (
-              <ContentEditorOfficeFileViewerPane
-                kind={officeKind}
-                role="source"
-                src={sourceSrc}
-                filename={displayName}
-                canEdit={false}
-              />
-            ) : isDocumentViewer ? (
-              <ContentEditorDocumentFileViewerPane
-                role="source"
-                src={sourceSrc}
-                filename={displayName}
-                canEdit={false}
-              />
-            ) : (
-              <UnsupportedPreview />
-            )}
-          </FileViewPane>
+          <Column width="fluid">
+            <Row spacing="1u" alignY="center">
+              <Title tagName="h1" size="xxsmall" weight="medium" lineClamp={1} title={displayName}>
+                {displayName}
+              </Title>
+              <FileViewLocalePill>
+                {segment.sourceLocale} → {segment.targetLocale}
+              </FileViewLocalePill>
+              {shouldShowSegmentStatusBadge(segment.status, segment.isHidden) ? (
+                <SegmentStatusBadge status={segment.status} />
+              ) : null}
+              {segment.isHidden ? <ContentEditorHiddenStringBadge /> : null}
+              {segment.isLocked ? <ContentEditorLockedStringBadge /> : null}
+            </Row>
+          </Column>
 
-          <FileViewPane
-            title={
-              <FormattedMessage
-                {...contentEditorFileViewMessages.targetHeading}
-                values={{ locale: segment.targetLocale }}
-              />
-            }
-            toolbar={
-              <div className="flex flex-wrap items-center gap-2">
-                {onRegenerate ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="xs"
-                    disabled={!canEdit || isImageBusy}
-                    onClick={() => setGenerateDialogOpen(true)}
+          <Column width="content">
+            <Row spacing="1u" alignY="center">
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                aria-pressed={sourcePaneVisible}
+                onClick={toggleSourcePane}
+              >
+                <HugeiconsIcon
+                  icon={sourcePaneVisible ? ViewOffSlashIcon : ViewIcon}
+                  data-icon="inline-start"
+                  aria-hidden
+                />
+                <FormattedMessage
+                  {...(sourcePaneVisible
+                    ? contentEditorFileViewMessages.hideSource
+                    : contentEditorFileViewMessages.showSource)}
+                />
+              </Button>
+              <ContentEditorWorkspaceViewSwitcherConnected size="xs" variant="outline" />
+              {onApprove ? (
+                <Button
+                  variant="default"
+                  size="xs"
+                  disabled={!canTriggerApprove}
+                  onClick={onApprove}
+                >
+                  {isApproving ? <Spinner className="size-3 text-primary-foreground" /> : null}
+                  {resolvedPrimaryActionLabel}
+                </Button>
+              ) : null}
+            </Row>
+          </Column>
+        </Row>
+      </FileViewHeader>
+
+      <FileViewWorkspace>
+        <FileViewWorkspaceContent layout={sourcePaneVisible ? "split" : "single"}>
+          <div className="flex min-h-0 flex-1 flex-col">
+            <Columns
+              spacing="3u"
+              height="full"
+              alignY="stretch"
+              align={sourcePaneVisible ? "start" : "center"}
+              collapseBelow="large"
+            >
+              {sourcePaneVisible ? (
+                <Column width="1/2">
+                  <FileViewPaneColumn>{sourcePane}</FileViewPaneColumn>
+                </Column>
+              ) : null}
+              <Column width={sourcePaneVisible ? "1/2" : "containedContent"}>
+                <FileViewPaneColumn>
+                  <FileViewPane
+                    title={
+                      <FormattedMessage
+                        {...contentEditorFileViewMessages.targetHeading}
+                        values={{ locale: segment.targetLocale }}
+                      />
+                    }
+                    footer={
+                      !isDocumentViewer && hasTargetFileActions ? targetFileActions : undefined
+                    }
                   >
-                    {isImageBusy ? (
-                      <HugeiconsIcon
-                        icon={Loading03Icon}
-                        className="size-3 animate-spin"
-                        aria-hidden
+                    {viewerId === "image" ? (
+                      <ContentEditorImageFileViewerPane
+                        role="target"
+                        src={targetSrc}
+                        isLoading={isSegmentTargetLoading}
+                      />
+                    ) : viewerId === "video" ? (
+                      <ContentEditorVideoFileViewerPane
+                        role="target"
+                        src={targetSrc}
+                        isLoading={isSegmentTargetLoading}
+                      />
+                    ) : officeKind ? (
+                      <ContentEditorOfficeFileViewerPane
+                        kind={officeKind}
+                        role="target"
+                        src={targetSrc}
+                        filename={displayName}
+                        isLoading={isSegmentTargetLoading}
+                        canEdit={canEdit}
+                        isBusy={isImageBusy}
+                        onSave={onUpload}
+                      />
+                    ) : isDocumentViewer ? (
+                      <ContentEditorDocumentFileViewerPane
+                        role="target"
+                        src={targetSrc}
+                        seedSrc={sourceSrc}
+                        filename={displayName}
+                        isLoading={isSegmentTargetLoading}
+                        canEdit={canEdit}
+                        isBusy={isImageBusy}
+                        onSave={onUpload}
+                        footerActions={hasTargetFileActions ? targetFileActions : undefined}
                       />
                     ) : (
-                      <HugeiconsIcon icon={SparklesIcon} className="size-3" aria-hidden />
+                      <FileViewUnsupportedPreview />
                     )}
-                    <FormattedMessage
-                      {...(hasTarget
-                        ? contentEditorFileViewMessages.regenerate
-                        : contentEditorFileViewMessages.generate)}
-                    />
-                  </Button>
-                ) : null}
-                {onUpload && uploadAccept ? (
-                  <label
-                    className={cn(
-                      "inline-flex h-6 cursor-pointer items-center gap-1 rounded border border-input bg-background px-2.5 text-xs font-medium shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground",
-                      !canEdit || isImageBusy ? "pointer-events-none opacity-50" : "",
-                    )}
-                  >
-                    <HugeiconsIcon icon={Upload01Icon} className="size-3" aria-hidden />
-                    <FormattedMessage {...contentEditorFileViewMessages.uploadFile} />
-                    <input
-                      type="file"
-                      accept={uploadAccept}
-                      className="sr-only"
-                      disabled={!canEdit || isImageBusy}
-                      onChange={(event) => {
-                        const file = event.target.files?.[0];
-                        if (file) {
-                          onUpload(file);
-                        }
-                        event.currentTarget.value = "";
-                      }}
-                    />
-                  </label>
-                ) : null}
-              </div>
-            }
-          >
-            {viewerId === "image" ? (
-              <ContentEditorImageFileViewerPane
-                role="target"
-                src={targetSrc}
-                isLoading={isSegmentTargetLoading}
-              />
-            ) : viewerId === "video" ? (
-              <ContentEditorVideoFileViewerPane
-                role="target"
-                src={targetSrc}
-                isLoading={isSegmentTargetLoading}
-              />
-            ) : officeKind ? (
-              <ContentEditorOfficeFileViewerPane
-                kind={officeKind}
-                role="target"
-                src={targetSrc}
-                filename={displayName}
-                isLoading={isSegmentTargetLoading}
-                canEdit={canEdit}
-                isBusy={isImageBusy}
-                onSave={onUpload}
-              />
-            ) : isDocumentViewer ? (
-              <ContentEditorDocumentFileViewerPane
-                role="target"
-                src={targetSrc}
-                seedSrc={sourceSrc}
-                filename={displayName}
-                isLoading={isSegmentTargetLoading}
-                canEdit={canEdit}
-                isBusy={isImageBusy}
-                onSave={onUpload}
-              />
-            ) : (
-              <UnsupportedPreview />
-            )}
-          </FileViewPane>
-        </div>
-      </div>
+                  </FileViewPane>
+                </FileViewPaneColumn>
+              </Column>
+            </Columns>
+          </div>
+        </FileViewWorkspaceContent>
+      </FileViewWorkspace>
       {onRegenerate ? (
         <ContentEditorFileGenerateDialog
           open={generateDialogOpen}
@@ -347,34 +438,6 @@ export function ContentEditorFileViewPanel({
           onSubmit={handleGenerateSubmit}
         />
       ) : null}
-    </div>
-  );
-}
-
-function FileViewPane({
-  title,
-  toolbar,
-  children,
-}: {
-  title: ReactNode;
-  toolbar?: ReactNode;
-  children: ReactNode;
-}) {
-  return (
-    <section className="flex min-h-0 flex-col gap-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-xs font-medium text-muted-foreground">{title}</h3>
-        {toolbar}
-      </div>
-      {children}
-    </section>
-  );
-}
-
-function UnsupportedPreview() {
-  return (
-    <div className="flex min-h-56 items-center justify-center border border-dashed border-border bg-muted/30 px-4 text-center text-sm text-muted-foreground">
-      <FormattedMessage {...contentEditorFileViewMessages.previewUnsupported} />
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-source-pane.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-source-pane.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  readCatFileViewSourcePaneVisible,
+  writeCatFileViewSourcePaneVisible,
+} from "./content-editor-file-view-source-pane";
+
+describe("content-editor-file-view-source-pane", () => {
+  it("defaults to visible and persists hidden state", () => {
+    const setItem = vi.fn();
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem,
+    });
+
+    expect(readCatFileViewSourcePaneVisible()).toBe(true);
+
+    writeCatFileViewSourcePaneVisible(false);
+    expect(setItem).toHaveBeenCalledWith("content-editor-file-view:source-pane:v1", "false");
+
+    vi.stubGlobal("localStorage", undefined);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-source-pane.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view-source-pane.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  readBrowserLocalStorageItem,
+  writeBrowserLocalStorageItem,
+} from "@/lib/primitives/browser-local-storage/browser-local-storage";
+
+export const CAT_FILE_VIEW_SOURCE_PANE_STORAGE_KEY = "content-editor-file-view:source-pane:v1";
+
+export function readCatFileViewSourcePaneVisible() {
+  const stored = readBrowserLocalStorageItem(CAT_FILE_VIEW_SOURCE_PANE_STORAGE_KEY);
+  if (stored === "false") {
+    return false;
+  }
+  return true;
+}
+
+export function writeCatFileViewSourcePaneVisible(visible: boolean) {
+  writeBrowserLocalStorageItem(CAT_FILE_VIEW_SOURCE_PANE_STORAGE_KEY, String(visible));
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.messages.ts
@@ -174,6 +174,26 @@ export const contentEditorFileViewMessages = defineMessages({
     id: "ShnGyATeRG",
     description: "Accessible label for next-file navigation in CAT File view",
   },
+  showSource: {
+    defaultMessage: "Show source",
+    id: "PugY2uNCND",
+    description: "Button to show the source file pane in CAT File view",
+  },
+  hideSource: {
+    defaultMessage: "Hide source",
+    id: "hGlGhqryiM",
+    description: "Button to hide the source file pane in CAT File view",
+  },
+  showSourceAria: {
+    defaultMessage: "Show source file",
+    id: "VFeDyBNEpt",
+    description: "Accessible label for showing the source pane in CAT File view",
+  },
+  hideSourceAria: {
+    defaultMessage: "Hide source file",
+    id: "U2RIqLyDQ1",
+    description: "Accessible label for hiding the source pane in CAT File view",
+  },
 });
 
 export function contentEditorFileGeneratePromptPlaceholderMessage(

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-image-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-image-file-viewer.tsx
@@ -15,6 +15,7 @@
 import { useIntl } from "react-intl";
 
 import { ContentEditorImagePreview } from "@/components/content-editor/editor/content-editor-image-preview";
+import { Spinner } from "@/components/ui/spinner";
 
 import { contentEditorFileViewMessages } from "./content-editor-file-view.messages";
 
@@ -41,13 +42,20 @@ export function ContentEditorImageFileViewerPane({
 
   if (isLoading) {
     return (
-      <div className="flex min-h-56 items-center justify-center border border-dashed border-border text-sm text-muted-foreground">
-        <span className="size-5 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+      <div className="flex h-full min-h-full flex-1 items-center justify-center p-6">
+        <Spinner className="size-5 text-muted-foreground" />
       </div>
     );
   }
 
   return (
-    <ContentEditorImagePreview src={src} alt={alt} emptyLabel={emptyLabel} className="min-h-56" />
+    <div className="flex h-full min-h-full flex-1 flex-col p-6">
+      <ContentEditorImagePreview
+        src={src}
+        alt={alt}
+        emptyLabel={emptyLabel}
+        className="h-full min-h-full flex-1"
+      />
+    </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-video-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-video-file-viewer.tsx
@@ -15,6 +15,7 @@
 import { useIntl } from "react-intl";
 
 import { ContentEditorVideoPreview } from "@/components/content-editor/editor/content-editor-video-preview";
+import { Spinner } from "@/components/ui/spinner";
 
 import { contentEditorFileViewMessages } from "./content-editor-file-view.messages";
 
@@ -37,11 +38,19 @@ export function ContentEditorVideoFileViewerPane({
 
   if (isLoading) {
     return (
-      <div className="flex min-h-56 items-center justify-center border border-dashed border-border text-sm text-muted-foreground">
-        <span className="size-5 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+      <div className="flex h-full min-h-full flex-1 items-center justify-center p-6">
+        <Spinner className="size-5 text-muted-foreground" />
       </div>
     );
   }
 
-  return <ContentEditorVideoPreview src={src} emptyLabel={emptyLabel} className="min-h-56" />;
+  return (
+    <div className="flex h-full min-h-full flex-1 flex-col p-6">
+      <ContentEditorVideoPreview
+        src={src}
+        emptyLabel={emptyLabel}
+        className="h-full min-h-full flex-1"
+      />
+    </div>
+  );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.stories.tsx
@@ -60,7 +60,7 @@ const meta = {
     (Story) => (
       <div
         className="min-h-screen bg-muted/20 text-foreground"
-        style={{ "--app-shell-plan-footer-height": "2.5rem" } as CSSProperties}
+        style={{ "--app-shell-plan-footer-height": "3rem" } as CSSProperties}
       >
         <Story />
       </div>

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-view-switcher-connected.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-view-switcher-connected.tsx
@@ -25,11 +25,15 @@ export const ContentEditorWorkspaceViewSwitcherConnected = observer(
     onChange,
     availableViews,
     className,
+    size,
+    variant,
   }: {
     value?: ContentEditorWorkspaceViewMode;
     onChange?: (mode: ContentEditorWorkspaceViewMode) => void;
     availableViews?: readonly ContentEditorWorkspaceViewMode[];
     className?: string;
+    size?: "sm" | "xs";
+    variant?: "outline" | "ghost";
   }) {
     const store = useOptionalCatWorkspace();
     const selectedSegment = store?.selectedSegmentView ?? null;
@@ -53,6 +57,8 @@ export const ContentEditorWorkspaceViewSwitcherConnected = observer(
         onChange={resolvedOnChange}
         availableViews={resolvedAvailableViews}
         className={className}
+        size={size}
+        variant={variant}
       />
     );
   },

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-view-switcher.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-view-switcher.tsx
@@ -60,28 +60,33 @@ export function ContentEditorWorkspaceViewSwitcher({
   onChange,
   availableViews = DEFAULT_AVAILABLE_VIEWS,
   className,
+  size = "sm",
+  variant = "outline",
 }: {
   value: ContentEditorWorkspaceViewMode;
   onChange: (mode: ContentEditorWorkspaceViewMode) => void;
   availableViews?: readonly ContentEditorWorkspaceViewMode[];
   className?: string;
+  size?: "sm" | "xs";
+  variant?: "outline" | "ghost";
 }) {
   const intl = useIntl();
   const modes = availableViews.length > 0 ? availableViews : DEFAULT_AVAILABLE_VIEWS;
+  const compact = size === "xs";
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
           <Button
-            variant="outline"
-            size="sm"
-            className={cn("size-8 shrink-0 px-0 font-normal", className)}
+            variant={variant}
+            size={compact ? "icon-xs" : "sm"}
+            className={cn(compact ? "shrink-0" : "size-8 shrink-0 px-0", "font-normal", className)}
             aria-label={intl.formatMessage(contentEditorWorkspaceViewModeMessages.viewModeAria)}
           />
         }
       >
-        <HugeiconsIcon icon={viewModeIcon(value)} className="size-4" />
+        <HugeiconsIcon icon={viewModeIcon(value)} className={compact ? "size-3" : "size-4"} />
         <span className="sr-only">
           <FormattedMessage {...viewModeLabel(value)} />
         </span>


### PR DESCRIPTION
## What changed

Polishes several authenticated web surfaces for clearer hierarchy, better overflow handling, and more consistent layout primitives.

**Inbox**
- Redesign inbox list items with accessible badge icons and a shared `inbox-list-item-visuals` helper (conversation vs. notification icon, color, and label)
- Simplify inbox page layout and conversation panel structure
- Fix issue-grouped list row overflow

**App shell**
- Align footer actions to the right and adopt layout primitives (`Box`, `Row`, `Columns`)
- Refresh chat dock empty state, panel, and tab bar for consistent spacing

**Content editor file view**
- Extract shared file-view layout primitives (`FileViewHeader`, `FileViewWorkspace`, pane columns, etc.)
- Refactor document/image/video viewers and the file-view panel around the new layout
- Add source-pane helper and wire workspace view switcher for file view

## How to test

- `cd apps/hyperlocalise-web && vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list-item-visuals.test.ts src/components/content-editor/file-view/`
- Inbox: open org inbox — verify list badges, icons, and selection states; confirm long issue titles don’t overflow grouped rows
- App shell: check footer alignment (plan usage, glossary/issue guidance, chat dock) in light and dark themes
- Content editor: open a document/image/video file — verify header, locale pill, split vs. single layout, and workspace view switcher
- Storybook: `InboxList`, `AppShellFooter`, `IssueGroupedList`, `ContentEditorEditorIssuesSection`

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review