### PR TITLE
feat(mcp): add query_glossary tool

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-query-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-query-glossary.test.ts
@@ -1,0 +1,522 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { generateMcpToken, hashMcpToken } from "@/api/auth/mcp";
+import { createMcpTestApp } from "@/api/routes/mcp/mcp.fixture";
+import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
+import { db, schema } from "@/lib/database/client";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const mcpApp = createMcpTestApp();
+const fixture = createProjectTestFixture();
+
+type McpGlossaryHit = {
+  glossaryId: string;
+  conceptId: string;
+  sourceTerm: string;
+  targetTerm: string;
+  forbidden: boolean;
+  status: string;
+  partOfSpeech: string;
+  description: string;
+};
+
+type McpQueryGlossaryOutput = {
+  error?: string;
+  message?: string;
+  terms?: McpGlossaryHit[];
+};
+
+async function authenticatedMcpHeaders(identity = fixture.createWorkosIdentity()) {
+  const headers = await fixture.authHeadersFor(identity);
+
+  const accessToken = generateMcpToken();
+  const refreshToken = generateMcpToken();
+
+  const auth = globalThis.__testApiAuthContext;
+  if (!auth) {
+    throw new Error("expected test auth context");
+  }
+
+  await db.insert(schema.mcpSessions).values({
+    userId: auth.user.localUserId,
+    organizationId: auth.organization.localOrganizationId,
+    scope: "mcp",
+    accessTokenHash: hashMcpToken(accessToken),
+    refreshTokenHash: hashMcpToken(refreshToken),
+    expiresAt: new Date(Date.now() + 60_000),
+    refreshExpiresAt: new Date(Date.now() + 120_000),
+  });
+
+  return {
+    ...headers,
+    authorization: `Bearer ${accessToken}`,
+  };
+}
+
+async function callMcpTool(headers: Record<string, string>, args: Record<string, unknown> = {}) {
+  return mcpApp.request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      ...headers,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "query_glossary",
+        arguments: args,
+      },
+    }),
+  });
+}
+
+async function readToolResult(response: Response) {
+  expect(response.status).toBe(200);
+
+  const body = (await response.json()) as {
+    result?: {
+      isError?: boolean;
+      content?: Array<{ type: string; text?: string }>;
+    };
+  };
+
+  const text = body.result?.content?.[0]?.text;
+  expect(text).toBeDefined();
+
+  return {
+    isError: body.result?.isError === true,
+    output: JSON.parse(text!) as McpQueryGlossaryOutput,
+  };
+}
+
+async function insertNativeGlossaryPair(input: {
+  organizationId: string;
+  createdByUserId?: string;
+  name: string;
+  sourceTerm: string;
+  targetTerm: string;
+  targetStatus?: string;
+  description?: string;
+  partOfSpeech?: string;
+}) {
+  const [glossary] = await db
+    .insert(schema.glossaries)
+    .values({
+      organizationId: input.organizationId,
+      createdByUserId: input.createdByUserId,
+      name: input.name,
+      description: "",
+      sourceLocale: "en",
+      targetLocale: null,
+      status: "active",
+    })
+    .returning();
+
+  const [concept] = await db
+    .insert(schema.glossaryConcepts)
+    .values({
+      glossaryId: glossary.id,
+      primaryTerm: input.sourceTerm,
+    })
+    .returning();
+
+  await db.insert(schema.glossaryTerms).values({
+    glossaryId: glossary.id,
+    conceptId: concept.id,
+    locale: "en",
+    term: input.sourceTerm,
+    sourceTerm: input.sourceTerm,
+    targetTerm: input.sourceTerm,
+    description: input.description ?? "",
+    partOfSpeech: input.partOfSpeech ?? "",
+    status: "preferred",
+    reviewStatus: "approved",
+  });
+
+  await db.insert(schema.glossaryTerms).values({
+    glossaryId: glossary.id,
+    conceptId: concept.id,
+    locale: "fr",
+    term: input.targetTerm,
+    sourceTerm: input.targetTerm,
+    targetTerm: input.targetTerm,
+    description: "",
+    partOfSpeech: input.partOfSpeech ?? "",
+    status: input.targetStatus ?? "preferred",
+    reviewStatus: "approved",
+  });
+
+  return { glossary, concept };
+}
+
+describe("MCP query_glossary", () => {
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  it("advertises query_glossary with a bounded locale search schema", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpApp.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "query_glossary");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("concept-linked");
+    expect(tool?.inputSchema?.required).toEqual(["sourceText", "sourceLocale", "targetLocale"]);
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      sourceText: {
+        type: "string",
+      },
+      sourceLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 50,
+      },
+      targetLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 50,
+      },
+      projectId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      glossaryId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 20,
+        default: 10,
+      },
+    });
+  });
+
+  it("returns no terms for an empty query", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "   ",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output.terms).toEqual([]);
+  });
+
+  it("marks forbidden hits so agents can avoid them", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const { glossary, concept } = await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+      targetStatus: "not_recommended",
+      description: "Payment step in the cart",
+      partOfSpeech: "noun",
+    });
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output.terms).toEqual([
+      {
+        glossaryId: glossary.id,
+        conceptId: concept.id,
+        sourceTerm: "checkout",
+        targetTerm: "caisse",
+        forbidden: true,
+        status: "not_recommended",
+        partOfSpeech: "noun",
+        description: "Payment step in the cart",
+      },
+    ]);
+  });
+
+  it("does not leak unlinked glossaries when a project ID is set", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const linked = await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Linked",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+    await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Unlinked",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+    });
+
+    await db.insert(schema.projectGlossaries).values({
+      organizationId: stored.organization.id,
+      projectId: stored.project.id,
+      glossaryId: linked.glossary.id,
+    });
+
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        projectId: stored.project.id,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output.terms).toEqual([
+      expect.objectContaining({
+        glossaryId: linked.glossary.id,
+        targetTerm: "paiement",
+        forbidden: false,
+      }),
+    ]);
+  });
+
+  it("returns glossary_not_found for an explicit inaccessible glossary", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const other = await fixture.createStoredProjectFixture();
+    const hidden = await insertNativeGlossaryPair({
+      organizationId: other.organization.id,
+      createdByUserId: other.user.id,
+      name: "Other org",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+    });
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        glossaryId: hidden.glossary.id,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "glossary_not_found",
+    });
+  });
+
+  it("returns glossary_not_found for provider glossary IDs", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        glossaryId: "smartling:glossary:term-base-1",
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "glossary_not_found",
+    });
+  });
+
+  it("returns no terms for an inaccessible project ID", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const other = await fixture.createStoredProjectFixture();
+    await insertNativeGlossaryPair({
+      organizationId: other.organization.id,
+      createdByUserId: other.user.id,
+      name: "Other org",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+    });
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        projectId: other.project.id,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output.terms).toEqual([]);
+  });
+
+  it("truncates long descriptions and ignores leftover term-based rows", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const longDescription = `${"context ".repeat(80)}end`;
+    const { glossary } = await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+      description: longDescription,
+    });
+
+    await db.insert(schema.glossaryTerms).values({
+      glossaryId: glossary.id,
+      conceptId: null,
+      locale: null,
+      term: null,
+      sourceTerm: "invoice",
+      targetTerm: "facture-legacy",
+      description: "should not appear",
+      reviewStatus: "approved",
+    });
+
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const leftoverResult = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "invoice",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+    const conceptResult = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+
+    expect(leftoverResult.output.terms).toEqual([]);
+    expect(conceptResult.output.terms).toHaveLength(1);
+    expect(conceptResult.output.terms?.[0]?.description).toHaveLength(500);
+    expect(longDescription.length).toBeGreaterThan(500);
+    expect(conceptResult.output.terms?.[0]?.description).toBe(longDescription.slice(0, 500));
+  });
+
+  it("does not return glossary terms from another organization without an explicit ID", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Current",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+    await fixture.createStoredProjectFixture().then(async (other) => {
+      await insertNativeGlossaryPair({
+        organizationId: other.organization.id,
+        createdByUserId: other.user.id,
+        name: "Other",
+        sourceTerm: "checkout",
+        targetTerm: "caisse",
+      });
+    });
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output.terms).toEqual([
+      expect.objectContaining({
+        targetTerm: "paiement",
+      }),
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-query-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-query-glossary.test.ts
@@ -47,6 +47,7 @@ type McpGlossaryHit = {
   forbidden: boolean;
   status: string;
   partOfSpeech: string;
+  caseSensitive: boolean;
   description: string;
 };
 
@@ -131,6 +132,8 @@ async function insertNativeGlossaryPair(input: {
   targetStatus?: string;
   description?: string;
   partOfSpeech?: string;
+  caseSensitive?: boolean;
+  targetForbidden?: boolean;
 }) {
   const [glossary] = await db
     .insert(schema.glossaries)
@@ -163,6 +166,7 @@ async function insertNativeGlossaryPair(input: {
     description: input.description ?? "",
     partOfSpeech: input.partOfSpeech ?? "",
     status: "preferred",
+    caseSensitive: input.caseSensitive ?? false,
     reviewStatus: "approved",
   });
 
@@ -176,6 +180,7 @@ async function insertNativeGlossaryPair(input: {
     description: "",
     partOfSpeech: input.partOfSpeech ?? "",
     status: input.targetStatus ?? "preferred",
+    forbidden: input.targetForbidden ?? false,
     reviewStatus: "approved",
   });
 
@@ -317,9 +322,144 @@ describe("MCP query_glossary", () => {
         forbidden: true,
         status: "not_recommended",
         partOfSpeech: "noun",
+        caseSensitive: false,
         description: "Payment step in the cart",
       },
     ]);
+  });
+
+  it("matches a glossary term contained in a longer source string", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const { glossary } = await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "Proceed to checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output.terms).toEqual([
+      expect.objectContaining({
+        glossaryId: glossary.id,
+        sourceTerm: "checkout",
+        targetTerm: "paiement",
+      }),
+    ]);
+  });
+
+  it("does not return a case-sensitive term for a differently cased query", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Brand",
+      sourceTerm: "NASA",
+      targetTerm: "NASA",
+      caseSensitive: true,
+    });
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const missed = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "nasa",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+    const matched = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "NASA launches today",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+
+    expect(missed.output.terms).toEqual([]);
+    expect(matched.output.terms).toEqual([
+      expect.objectContaining({
+        sourceTerm: "NASA",
+        targetTerm: "NASA",
+        caseSensitive: true,
+      }),
+    ]);
+  });
+
+  it("marks an explicit forbidden flag even when status is preferred", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+      targetStatus: "preferred",
+      targetForbidden: true,
+    });
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+
+    expect(result.output.terms).toEqual([
+      expect.objectContaining({
+        targetTerm: "caisse",
+        forbidden: true,
+        status: "preferred",
+      }),
+    ]);
+  });
+
+  it("returns glossary_not_found for a non-UUID glossary ID without querying", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        glossaryId: "missing",
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "glossary_not_found",
+    });
+  });
+
+  it("returns glossary_not_found for a Crowdin live glossary ID", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        glossaryId: "crowdin:glossary:42",
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "glossary_not_found",
+    });
   });
 
   it("does not leak unlinked glossaries when a project ID is set", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-query-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-query-glossary.test.ts
@@ -129,10 +129,12 @@ async function insertNativeGlossaryPair(input: {
   name: string;
   sourceTerm: string;
   targetTerm: string;
+  sourceStatus?: string;
   targetStatus?: string;
   description?: string;
   partOfSpeech?: string;
   caseSensitive?: boolean;
+  sourceForbidden?: boolean;
   targetForbidden?: boolean;
 }) {
   const [glossary] = await db
@@ -165,8 +167,9 @@ async function insertNativeGlossaryPair(input: {
     targetTerm: input.sourceTerm,
     description: input.description ?? "",
     partOfSpeech: input.partOfSpeech ?? "",
-    status: "preferred",
+    status: input.sourceStatus ?? "preferred",
     caseSensitive: input.caseSensitive ?? false,
+    forbidden: input.sourceForbidden ?? false,
     reviewStatus: "approved",
   });
 
@@ -390,6 +393,35 @@ describe("MCP query_glossary", () => {
         sourceTerm: "NASA",
         targetTerm: "NASA",
         caseSensitive: true,
+      }),
+    ]);
+  });
+
+  it("marks a preferred target forbidden when the matched source term is prohibited", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    await insertNativeGlossaryPair({
+      organizationId: stored.organization.id,
+      createdByUserId: stored.user.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+      sourceStatus: "not_recommended",
+    });
+
+    const result = await readToolResult(
+      await callMcpTool(headers, {
+        sourceText: "Proceed to checkout",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }),
+    );
+
+    expect(result.output.terms).toEqual([
+      expect.objectContaining({
+        sourceTerm: "checkout",
+        targetTerm: "paiement",
+        forbidden: true,
       }),
     ]);
   });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -95,7 +95,11 @@ import {
 } from "@/api/routes/mcp/mcp-list-translations";
 import { glossaryIdParamsSchema } from "@/api/routes/glossary/glossary.schema";
 import type { ApiAuthContext } from "@/api/auth/workos";
-import { queryGlossaryTerms, type QueryGlossaryHit } from "@/lib/tools/asset-tools";
+import {
+  isQueryableNativeGlossaryId,
+  queryGlossaryTerms,
+  type QueryGlossaryHit,
+} from "@/lib/tools/asset-tools";
 import type { ToolContext } from "@/lib/tools/types";
 
 const authorizationQuerySchema = z.object({
@@ -687,6 +691,7 @@ function compactMcpGlossaryHit(hit: QueryGlossaryHit) {
     forbidden: hit.forbidden,
     status: hit.status,
     partOfSpeech: hit.partOfSpeech,
+    caseSensitive: hit.caseSensitive,
     description: truncateMcpGlossaryDescription(hit.description),
   };
 }
@@ -1583,6 +1588,10 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
     },
     async ({ sourceText, sourceLocale, targetLocale, projectId, glossaryId, limit }) => {
       if (glossaryId) {
+        if (!isQueryableNativeGlossaryId(glossaryId)) {
+          return mcpToolError("glossary_not_found", "Glossary not found or inaccessible");
+        }
+
         const glossary = await canAccessGlossary(apiAuth, glossaryId);
 
         if (!glossary) {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -93,6 +93,10 @@ import {
   loadMcpListTranslations,
   mcpListTranslationsQueueFilters,
 } from "@/api/routes/mcp/mcp-list-translations";
+import { glossaryIdParamsSchema } from "@/api/routes/glossary/glossary.schema";
+import type { ApiAuthContext } from "@/api/auth/workos";
+import { queryGlossaryTerms, type QueryGlossaryHit } from "@/lib/tools/asset-tools";
+import type { ToolContext } from "@/lib/tools/types";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -633,6 +637,59 @@ const mcpListJobsInputSchema = z.object({
     .default(0)
     .describe("Number of jobs to skip before returning results."),
 });
+
+const MCP_GLOSSARY_DESCRIPTION_MAX_LENGTH = 500;
+
+const mcpQueryGlossaryInputSchema = z.object({
+  sourceText: z.string().describe("Source string to look up in accessible glossaries."),
+  sourceLocale: z.string().min(1).max(50).describe("BCP-47 source locale tag."),
+  targetLocale: z.string().min(1).max(50).describe("BCP-47 target locale tag."),
+  projectId: projectIdSchema
+    .optional()
+    .describe("Optional project ID. When set, search only glossaries linked to that project."),
+  glossaryId: glossaryIdParamsSchema.shape.glossaryId
+    .optional()
+    .describe("Optional glossary ID. Inaccessible glossaries return glossary_not_found."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .default(10)
+    .describe("Maximum number of ranked hits to return."),
+});
+
+function mcpToolContext(apiAuth: ApiAuthContext): ToolContext {
+  return {
+    conversationId: "mcp",
+    organizationId: apiAuth.organization.localOrganizationId,
+    localUserId: apiAuth.user.localUserId,
+    membershipRole: apiAuth.membership.role,
+    projectId: null,
+    db,
+  };
+}
+
+function truncateMcpGlossaryDescription(description: string) {
+  if (description.length <= MCP_GLOSSARY_DESCRIPTION_MAX_LENGTH) {
+    return description;
+  }
+
+  return description.slice(0, MCP_GLOSSARY_DESCRIPTION_MAX_LENGTH);
+}
+
+function compactMcpGlossaryHit(hit: QueryGlossaryHit) {
+  return {
+    glossaryId: hit.glossaryId,
+    conceptId: hit.conceptId,
+    sourceTerm: hit.sourceTerm,
+    targetTerm: hit.targetTerm,
+    forbidden: hit.forbidden,
+    status: hit.status,
+    partOfSpeech: hit.partOfSpeech,
+    description: truncateMcpGlossaryDescription(hit.description),
+  };
+}
 
 const mcpGetJobInputSchema = z.object({
   jobId: jobIdParamsSchema.shape.jobId.describe(
@@ -1513,6 +1570,42 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
 
       return {
         content: [{ type: "text", text: JSON.stringify({ entries }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "query_glossary",
+    {
+      description:
+        "Search concept-linked glossary terms for a source string and locale pair. Prefer this over get_glossary_entries when you need a hit while translating. Forbidden terms are marked so agents can avoid them.",
+      inputSchema: mcpQueryGlossaryInputSchema,
+    },
+    async ({ sourceText, sourceLocale, targetLocale, projectId, glossaryId, limit }) => {
+      if (glossaryId) {
+        const glossary = await canAccessGlossary(apiAuth, glossaryId);
+
+        if (!glossary) {
+          return mcpToolError("glossary_not_found", "Glossary not found or inaccessible");
+        }
+      }
+
+      const result = await queryGlossaryTerms(mcpToolContext(apiAuth), {
+        sourceText,
+        sourceLocale,
+        targetLocale,
+        projectId,
+        glossaryId,
+        limit,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ terms: result.terms.map(compactMcpGlossaryHit) }),
+          },
+        ],
       };
     },
   );

--- a/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.test.ts
@@ -237,4 +237,40 @@ describe("flattenNativeConceptTermsToPairs", () => {
 
     expect(pairs.map((pair) => pair.targetTerm)).toEqual(["paiement", "caisse"]);
   });
+
+  it("marks a stored forbidden flag even when status is preferred", () => {
+    const concepts: NativeConceptGroup[] = [
+      {
+        conceptId: "concept-1",
+        glossaryId: "glossary-1",
+        glossaryName: "Commerce",
+        translatable: true,
+        terms: [
+          baseTerm({ id: "source-1", locale: "en", term: "checkout", status: "preferred" }),
+          baseTerm({
+            id: "target-preferred",
+            locale: "fr",
+            term: "caisse",
+            status: "preferred",
+            forbidden: true,
+          }),
+        ],
+      },
+    ];
+
+    const pairs = flattenNativeConceptTermsToPairs({
+      concepts,
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+    });
+
+    expect(pairs).toEqual([
+      expect.objectContaining({
+        sourceTerm: "checkout",
+        targetTerm: "caisse",
+        status: "preferred",
+        forbidden: true,
+      }),
+    ]);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.test.ts
@@ -121,7 +121,7 @@ describe("flattenNativeConceptTermsToPairs", () => {
     ]);
   });
 
-  it("does not forbid preferred targets because a source synonym is not_recommended", () => {
+  it("does not mark a preferred source pair forbidden because a synonym is not_recommended", () => {
     const concepts: NativeConceptGroup[] = [
       {
         conceptId: "concept-1",
@@ -156,12 +156,53 @@ describe("flattenNativeConceptTermsToPairs", () => {
       expect.objectContaining({
         sourceTerm: "cart",
         targetTerm: "paiement",
-        forbidden: false,
+        forbidden: true,
       }),
       expect.objectContaining({
         sourceTerm: "checkout",
         targetTerm: "paiement",
         forbidden: false,
+      }),
+    ]);
+  });
+
+  it("marks a preferred target forbidden when the matched source term is prohibited", () => {
+    const concepts: NativeConceptGroup[] = [
+      {
+        conceptId: "concept-1",
+        glossaryId: "glossary-1",
+        glossaryName: "Commerce",
+        translatable: true,
+        terms: [
+          baseTerm({
+            id: "source-1",
+            locale: "en",
+            term: "checkout",
+            status: "preferred",
+            forbidden: true,
+          }),
+          baseTerm({
+            id: "target-preferred",
+            locale: "fr",
+            term: "paiement",
+            status: "preferred",
+          }),
+        ],
+      },
+    ];
+
+    const pairs = flattenNativeConceptTermsToPairs({
+      concepts,
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+    });
+
+    expect(pairs).toEqual([
+      expect.objectContaining({
+        sourceTerm: "checkout",
+        targetTerm: "paiement",
+        status: "preferred",
+        forbidden: true,
       }),
     ]);
   });

--- a/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.test.ts
@@ -70,15 +70,19 @@ describe("flattenNativeConceptTermsToPairs", () => {
 
     expect(pairs).toEqual([
       expect.objectContaining({
+        conceptId: "concept-1",
         sourceTerm: "checkout",
         targetTerm: "paiement",
         targetLocale: "fr",
+        status: "preferred",
         forbidden: false,
       }),
       expect.objectContaining({
+        conceptId: "concept-1",
         sourceTerm: "checkout",
         targetTerm: "caisse",
         targetLocale: "fr",
+        status: "not_recommended",
         forbidden: true,
       }),
     ]);

--- a/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.ts
@@ -20,6 +20,7 @@ import { pickPreferredTermForLocale } from "./native-glossary";
 
 export type GlossaryTermQueryRow = {
   id: string;
+  conceptId: string;
   glossaryId: string;
   glossaryName: string;
   sourceTerm: string;
@@ -27,6 +28,7 @@ export type GlossaryTermQueryRow = {
   targetLocale: string;
   description: string;
   partOfSpeech: string;
+  status: string;
   forbidden: boolean;
   caseSensitive: boolean;
   provenance: string;
@@ -71,15 +73,18 @@ function toNormalizedConceptTerm(row: NativeConceptTermRow): NormalizedGlossaryC
 
 function buildPairRow(input: {
   id: string;
+  conceptId: string;
   glossaryId: string;
   glossaryName: string;
   sourceTerm: NativeConceptTermRow;
   targetTerm: string;
   targetLocale: string;
+  status: string;
   forbidden: boolean;
 }): GlossaryTermQueryRow {
   return {
     id: input.id,
+    conceptId: input.conceptId,
     glossaryId: input.glossaryId,
     glossaryName: input.glossaryName,
     sourceTerm: input.sourceTerm.term,
@@ -87,6 +92,7 @@ function buildPairRow(input: {
     targetLocale: input.targetLocale,
     description: input.sourceTerm.description,
     partOfSpeech: input.sourceTerm.partOfSpeech,
+    status: input.status,
     forbidden: input.forbidden,
     caseSensitive: input.sourceTerm.caseSensitive,
     provenance: input.sourceTerm.provenance,
@@ -119,11 +125,13 @@ export function flattenNativeConceptTermsToPairs(input: {
           pairs.push(
             buildPairRow({
               id: sourceTerm.id,
+              conceptId: concept.conceptId,
               glossaryId: concept.glossaryId,
               glossaryName: concept.glossaryName,
               sourceTerm,
               targetTerm: sourceTerm.term,
               targetLocale,
+              status: sourceTerm.status,
               forbidden: sourceStatus.forbidden,
             }),
           );
@@ -140,11 +148,13 @@ export function flattenNativeConceptTermsToPairs(input: {
             pairs.push(
               buildPairRow({
                 id: preferredRow.id,
+                conceptId: concept.conceptId,
                 glossaryId: concept.glossaryId,
                 glossaryName: concept.glossaryName,
                 sourceTerm,
                 targetTerm: preferred.text,
                 targetLocale,
+                status: preferredRow.status,
                 forbidden: targetStatus.forbidden,
               }),
             );
@@ -161,11 +171,13 @@ export function flattenNativeConceptTermsToPairs(input: {
           pairs.push(
             buildPairRow({
               id: targetRow.id,
+              conceptId: concept.conceptId,
               glossaryId: concept.glossaryId,
               glossaryName: concept.glossaryName,
               sourceTerm,
               targetTerm: targetRow.term,
               targetLocale,
+              status: targetRow.status,
               forbidden: true,
             }),
           );

--- a/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.ts
@@ -160,7 +160,11 @@ export function flattenNativeConceptTermsToPairs(input: {
                 targetTerm: preferred.text,
                 targetLocale,
                 status: preferredRow.status,
-                forbidden: pairIsForbidden(targetStatus.forbidden, preferredRow.forbidden),
+                forbidden: pairIsForbidden(
+                  sourceStatus.forbidden || targetStatus.forbidden,
+                  sourceTerm.forbidden,
+                  preferredRow.forbidden,
+                ),
               }),
             );
           }

--- a/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/flatten-native-glossary-pairs.ts
@@ -46,7 +46,12 @@ export type NativeConceptTermRow = {
   caseSensitive: boolean;
   provenance: string;
   reviewStatus: string;
+  forbidden?: boolean;
 };
+
+function pairIsForbidden(statusForbidden: boolean, ...storedFlags: Array<boolean | undefined>) {
+  return statusForbidden || storedFlags.some((flag) => flag === true);
+}
 
 export type NativeConceptGroup = {
   conceptId: string;
@@ -132,7 +137,7 @@ export function flattenNativeConceptTermsToPairs(input: {
               targetTerm: sourceTerm.term,
               targetLocale,
               status: sourceTerm.status,
-              forbidden: sourceStatus.forbidden,
+              forbidden: pairIsForbidden(sourceStatus.forbidden, sourceTerm.forbidden),
             }),
           );
           continue;
@@ -155,7 +160,7 @@ export function flattenNativeConceptTermsToPairs(input: {
                 targetTerm: preferred.text,
                 targetLocale,
                 status: preferredRow.status,
-                forbidden: targetStatus.forbidden,
+                forbidden: pairIsForbidden(targetStatus.forbidden, preferredRow.forbidden),
               }),
             );
           }

--- a/apps/hyperlocalise-web/src/lib/glossary/query-glossary-terms.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/query-glossary-terms.ts
@@ -74,6 +74,7 @@ export function groupConceptTerms(
     caseSensitive: boolean;
     provenance: string;
     reviewStatus: string;
+    forbidden?: boolean;
   }>,
 ): NativeConceptGroup[] {
   const concepts = new Map<string, NativeConceptGroup>();
@@ -94,6 +95,7 @@ export function groupConceptTerms(
       caseSensitive: row.caseSensitive,
       provenance: row.provenance,
       reviewStatus: row.reviewStatus,
+      forbidden: row.forbidden ?? false,
     };
 
     if (existing) {
@@ -282,6 +284,7 @@ async function fetchNativeConceptTermRows(
       caseSensitive: schema.glossaryTerms.caseSensitive,
       provenance: schema.glossaryTerms.provenance,
       reviewStatus: schema.glossaryTerms.reviewStatus,
+      forbidden: schema.glossaryTerms.forbidden,
     })
     .from(schema.glossaryTerms)
     .innerJoin(
@@ -411,6 +414,7 @@ export async function listNativeGlossaryTermPairs(
       caseSensitive: schema.glossaryTerms.caseSensitive,
       provenance: schema.glossaryTerms.provenance,
       reviewStatus: schema.glossaryTerms.reviewStatus,
+      forbidden: schema.glossaryTerms.forbidden,
     })
     .from(schema.glossaryTerms)
     .innerJoin(

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.test.ts
@@ -76,6 +76,8 @@ async function createGlossaryWithTerm(input: {
   name: string;
   sourceTerm: string;
   targetTerm: string;
+  targetStatus?: string;
+  description?: string;
 }) {
   const [glossary] = await db
     .insert(schema.glossaries)
@@ -106,7 +108,7 @@ async function createGlossaryWithTerm(input: {
       term: input.sourceTerm,
       sourceTerm: input.sourceTerm,
       targetTerm: input.sourceTerm,
-      description: "",
+      description: input.description ?? "",
       reviewStatus: "approved",
     })
     .returning();
@@ -119,6 +121,7 @@ async function createGlossaryWithTerm(input: {
     sourceTerm: input.targetTerm,
     targetTerm: input.targetTerm,
     description: "",
+    status: input.targetStatus ?? "preferred",
     reviewStatus: "approved",
   });
 
@@ -174,6 +177,7 @@ async function executeGlossarySearch(input: {
   organizationId: string;
   sourceText: string;
   projectId?: string;
+  glossaryId?: string;
 }): Promise<Extract<GlossarySearchResult, { terms: unknown }>> {
   const queryGlossary = createQueryGlossaryTool(toolContext(input.organizationId));
 
@@ -187,6 +191,7 @@ async function executeGlossarySearch(input: {
       sourceLocale: "en",
       targetLocale: "fr",
       projectId: input.projectId,
+      glossaryId: input.glossaryId,
       limit: 10,
     },
     { toolCallId: "test-tool-call", messages: [], context: {} },
@@ -247,6 +252,9 @@ afterEach(async () => {
     await db
       .delete(schema.glossaryTerms)
       .where(inArray(schema.glossaryTerms.glossaryId, glossaryIds));
+    await db
+      .delete(schema.glossaryConcepts)
+      .where(inArray(schema.glossaryConcepts.glossaryId, glossaryIds));
   }
 
   const memoryIds = memories.map((memory) => memory.id);
@@ -368,6 +376,131 @@ describe("createQueryGlossaryTool", () => {
         glossaryName: "Brand Glossary",
       }),
     ]);
+  });
+
+  it("returns no terms for an empty query", async () => {
+    const organization = await createOrganization();
+    await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+
+    const result = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "   &&&   ",
+    });
+
+    expect(result.terms).toEqual([]);
+  });
+
+  it("marks forbidden target terms so callers can avoid them", async () => {
+    const organization = await createOrganization();
+    await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+      targetStatus: "not_recommended",
+    });
+
+    const result = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "checkout",
+    });
+
+    expect(result.terms).toEqual([
+      expect.objectContaining({
+        sourceTerm: "checkout",
+        targetTerm: "caisse",
+        forbidden: true,
+        status: "not_recommended",
+      }),
+    ]);
+  });
+
+  it("does not search an unlinked glossary when a project ID is set", async () => {
+    const organization = await createOrganization();
+    const project = await createProject(organization.id);
+    const linked = await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Linked Glossary",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+    await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Unlinked Glossary",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+    });
+
+    await db.insert(schema.projectGlossaries).values({
+      organizationId: organization.id,
+      projectId: project.id,
+      glossaryId: linked.glossary.id,
+    });
+
+    const result = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "checkout",
+      projectId: project.id,
+    });
+
+    expect(result.terms).toEqual([
+      expect.objectContaining({
+        glossaryId: linked.glossary.id,
+        targetTerm: "paiement",
+      }),
+    ]);
+  });
+
+  it("does not return leftover term-based rows without a concept", async () => {
+    const organization = await createOrganization();
+    const { glossary } = await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Commerce",
+      sourceTerm: "invoice",
+      targetTerm: "facture",
+    });
+
+    await db.insert(schema.glossaryTerms).values({
+      glossaryId: glossary.id,
+      conceptId: null,
+      locale: null,
+      term: null,
+      sourceTerm: "checkout",
+      targetTerm: "caisse-legacy",
+      description: "",
+      reviewStatus: "approved",
+    });
+
+    const result = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "checkout",
+    });
+
+    expect(result.terms).toEqual([]);
+  });
+
+  it("returns no terms for an inaccessible glossary ID", async () => {
+    const currentOrganization = await createOrganization();
+    const otherOrganization = await createOrganization();
+    const { glossary } = await createGlossaryWithTerm({
+      organizationId: otherOrganization.id,
+      name: "Other Glossary",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+    });
+
+    const result = await executeGlossarySearch({
+      organizationId: currentOrganization.id,
+      sourceText: "checkout",
+      glossaryId: glossary.id,
+    });
+
+    expect(result.terms).toEqual([]);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.test.ts
@@ -76,9 +76,11 @@ async function createGlossaryWithTerm(input: {
   name: string;
   sourceTerm: string;
   targetTerm: string;
+  sourceStatus?: string;
   targetStatus?: string;
   description?: string;
   caseSensitive?: boolean;
+  sourceForbidden?: boolean;
   targetForbidden?: boolean;
 }) {
   const [glossary] = await db
@@ -111,7 +113,9 @@ async function createGlossaryWithTerm(input: {
       sourceTerm: input.sourceTerm,
       targetTerm: input.sourceTerm,
       description: input.description ?? "",
+      status: input.sourceStatus ?? "preferred",
       caseSensitive: input.caseSensitive ?? false,
+      forbidden: input.sourceForbidden ?? false,
       reviewStatus: "approved",
     })
     .returning();
@@ -553,6 +557,30 @@ describe("createQueryGlossaryTool", () => {
       expect.objectContaining({
         sourceTerm: "NASA",
         caseSensitive: true,
+      }),
+    ]);
+  });
+
+  it("marks a preferred target forbidden when the matched source term is prohibited", async () => {
+    const organization = await createOrganization();
+    await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+      sourceStatus: "not_recommended",
+    });
+
+    const result = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "Proceed to checkout",
+    });
+
+    expect(result.terms).toEqual([
+      expect.objectContaining({
+        sourceTerm: "checkout",
+        targetTerm: "paiement",
+        forbidden: true,
       }),
     ]);
   });

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.test.ts
@@ -78,6 +78,8 @@ async function createGlossaryWithTerm(input: {
   targetTerm: string;
   targetStatus?: string;
   description?: string;
+  caseSensitive?: boolean;
+  targetForbidden?: boolean;
 }) {
   const [glossary] = await db
     .insert(schema.glossaries)
@@ -109,6 +111,7 @@ async function createGlossaryWithTerm(input: {
       sourceTerm: input.sourceTerm,
       targetTerm: input.sourceTerm,
       description: input.description ?? "",
+      caseSensitive: input.caseSensitive ?? false,
       reviewStatus: "approved",
     })
     .returning();
@@ -122,6 +125,7 @@ async function createGlossaryWithTerm(input: {
     targetTerm: input.targetTerm,
     description: "",
     status: input.targetStatus ?? "preferred",
+    forbidden: input.targetForbidden ?? false,
     reviewStatus: "approved",
   });
 
@@ -501,6 +505,104 @@ describe("createQueryGlossaryTool", () => {
     });
 
     expect(result.terms).toEqual([]);
+  });
+
+  it("matches a glossary term contained in a longer source string", async () => {
+    const organization = await createOrganization();
+    await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+
+    const result = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "Proceed to checkout",
+    });
+
+    expect(result.terms).toEqual([
+      expect.objectContaining({
+        sourceTerm: "checkout",
+        targetTerm: "paiement",
+      }),
+    ]);
+  });
+
+  it("does not return a case-sensitive term for a differently cased query", async () => {
+    const organization = await createOrganization();
+    await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Brand",
+      sourceTerm: "NASA",
+      targetTerm: "NASA",
+      caseSensitive: true,
+    });
+
+    const missed = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "nasa",
+    });
+    const matched = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "NASA launches today",
+    });
+
+    expect(missed.terms).toEqual([]);
+    expect(matched.terms).toEqual([
+      expect.objectContaining({
+        sourceTerm: "NASA",
+        caseSensitive: true,
+      }),
+    ]);
+  });
+
+  it("marks an explicit forbidden flag even when status is preferred", async () => {
+    const organization = await createOrganization();
+    await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "caisse",
+      targetForbidden: true,
+    });
+
+    const result = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "checkout",
+    });
+
+    expect(result.terms).toEqual([
+      expect.objectContaining({
+        targetTerm: "caisse",
+        forbidden: true,
+        status: "preferred",
+      }),
+    ]);
+  });
+
+  it("returns no terms for a non-UUID or provider glossary ID", async () => {
+    const organization = await createOrganization();
+    await createGlossaryWithTerm({
+      organizationId: organization.id,
+      name: "Commerce",
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+
+    const missing = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "checkout",
+      glossaryId: "missing",
+    });
+    const provider = await executeGlossarySearch({
+      organizationId: organization.id,
+      sourceText: "checkout",
+      glossaryId: "crowdin:glossary:42",
+    });
+
+    expect(missing.terms).toEqual([]);
+    expect(provider.terms).toEqual([]);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
@@ -21,6 +21,7 @@ import { groupConceptTerms } from "@/lib/glossary/query-glossary-terms";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
 import {
+  toolCanAccessGlossary,
   toolCanAccessProject,
   toolProjectLinkedGlossaryWhere,
   toolProjectLinkedMemoryWhere,
@@ -44,6 +45,221 @@ function buildTsQuery(input: string): string {
   return sanitized;
 }
 
+export const queryGlossaryInputSchema = z.object({
+  sourceText: z.string().describe("The source text to look up in glossaries."),
+  sourceLocale: z.string().describe("BCP-47 source locale tag."),
+  targetLocale: z.string().describe("BCP-47 target locale tag."),
+  projectId: z
+    .string()
+    .optional()
+    .describe("Optional project ID to restrict to attached glossaries."),
+  glossaryId: z.string().optional().describe("Optional glossary ID to search a single glossary."),
+  limit: z.number().min(1).max(20).default(10).describe("Maximum results to return."),
+});
+
+export type QueryGlossaryInput = z.infer<typeof queryGlossaryInputSchema>;
+
+export type QueryGlossaryHit = {
+  id: string;
+  conceptId: string;
+  sourceTerm: string;
+  targetTerm: string;
+  description: string;
+  partOfSpeech: string;
+  status: string;
+  caseSensitive: boolean;
+  forbidden: boolean;
+  glossaryId: string;
+  glossaryName: string;
+  rank: number;
+};
+
+export type QueryGlossaryResult = {
+  terms: QueryGlossaryHit[];
+};
+
+/**
+ * Search glossary terms for a given source text and locale pair.
+ *
+ * Uses the existing Postgres full-text search vector (GIN index) on
+ * `glossaryTerms.searchVector` for fast lexical retrieval. Results are
+ * ranked so that matches in the source term rank higher than matches in
+ * the target term or description. Native pairs come from concept-linked
+ * terms, not leftover `source_term` / `target_term` columns.
+ */
+export async function queryGlossaryTerms(
+  ctx: ToolContext,
+  input: QueryGlossaryInput,
+): Promise<QueryGlossaryResult> {
+  const { sourceText, sourceLocale, targetLocale, projectId, glossaryId } = input;
+  const limit = input.limit ?? 10;
+  const db = ctx.db;
+  const tsQuery = buildTsQuery(sourceText);
+
+  if (!tsQuery) {
+    return { terms: [] };
+  }
+
+  let glossaryIds: string[] | undefined;
+  if (projectId) {
+    const accessibleProject = await toolCanAccessProject(ctx, projectId);
+    if (!accessibleProject) {
+      return { terms: [] };
+    }
+
+    const attached = await db
+      .select({ glossaryId: schema.projectGlossaries.glossaryId })
+      .from(schema.projectGlossaries)
+      .where(
+        and(
+          eq(schema.projectGlossaries.projectId, projectId),
+          eq(schema.projectGlossaries.organizationId, ctx.organizationId),
+        ),
+      );
+    glossaryIds = attached.map((row) => row.glossaryId);
+    if (glossaryIds.length === 0) {
+      return { terms: [] };
+    }
+  }
+
+  if (glossaryId) {
+    const accessibleGlossary = await toolCanAccessGlossary(ctx, glossaryId);
+    if (!accessibleGlossary) {
+      return { terms: [] };
+    }
+
+    if (glossaryIds && !glossaryIds.includes(glossaryId)) {
+      return { terms: [] };
+    }
+
+    glossaryIds = [glossaryId];
+  }
+
+  const glossarySourceTerms = alias(schema.glossaryTerms, "glossary_source_terms");
+
+  const sharedConditions = [
+    sql`${glossarySourceTerms.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
+    await toolProjectLinkedGlossaryWhere(ctx),
+    eq(schema.glossaries.sourceLocale, sourceLocale),
+    eq(schema.glossaries.status, "active"),
+    eq(schema.glossaries.source, "native"),
+    eq(glossarySourceTerms.locale, sourceLocale),
+    isNotNull(glossarySourceTerms.conceptId),
+    isNotNull(glossarySourceTerms.term),
+    eq(glossarySourceTerms.reviewStatus, "approved"),
+  ];
+
+  if (glossaryIds) {
+    sharedConditions.push(inArray(glossarySourceTerms.glossaryId, glossaryIds));
+  }
+
+  const rank =
+    sql<number>`ts_rank(${glossarySourceTerms.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
+      "rank",
+    );
+
+  const matchingSources = await db
+    .select({
+      conceptId: glossarySourceTerms.conceptId,
+      glossaryId: glossarySourceTerms.glossaryId,
+      sourceTerm: glossarySourceTerms.term,
+      rank,
+    })
+    .from(glossarySourceTerms)
+    .innerJoin(schema.glossaries, eq(glossarySourceTerms.glossaryId, schema.glossaries.id))
+    .where(and(...sharedConditions))
+    .orderBy(desc(rank))
+    .limit(limit * 5);
+
+  const conceptIds = [
+    ...new Set(
+      matchingSources
+        .map((row) => row.conceptId)
+        .filter((conceptId): conceptId is string => conceptId !== null),
+    ),
+  ];
+
+  if (conceptIds.length === 0) {
+    return { terms: [] };
+  }
+
+  const rankByGlossarySource = new Map<string, number>();
+  for (const row of matchingSources) {
+    if (!row.sourceTerm) {
+      continue;
+    }
+    const key = `${row.glossaryId}:${row.sourceTerm}`;
+    rankByGlossarySource.set(key, Math.max(rankByGlossarySource.get(key) ?? 0, row.rank));
+  }
+
+  const conceptRows = await db
+    .select({
+      id: schema.glossaryTerms.id,
+      conceptId: schema.glossaryTerms.conceptId,
+      glossaryId: schema.glossaryTerms.glossaryId,
+      glossaryName: schema.glossaries.name,
+      translatable: schema.glossaryConcepts.translatable,
+      locale: schema.glossaryTerms.locale,
+      term: schema.glossaryTerms.term,
+      status: schema.glossaryTerms.status,
+      description: schema.glossaryTerms.description,
+      partOfSpeech: schema.glossaryTerms.partOfSpeech,
+      caseSensitive: schema.glossaryTerms.caseSensitive,
+      provenance: schema.glossaryTerms.provenance,
+      reviewStatus: schema.glossaryTerms.reviewStatus,
+    })
+    .from(schema.glossaryTerms)
+    .innerJoin(
+      schema.glossaryConcepts,
+      eq(schema.glossaryTerms.conceptId, schema.glossaryConcepts.id),
+    )
+    .innerJoin(schema.glossaries, eq(schema.glossaryTerms.glossaryId, schema.glossaries.id))
+    .where(
+      and(
+        inArray(schema.glossaryTerms.conceptId, conceptIds),
+        eq(schema.glossaries.organizationId, ctx.organizationId),
+        eq(schema.glossaries.source, "native"),
+        eq(schema.glossaries.sourceLocale, sourceLocale),
+        eq(schema.glossaries.status, "active"),
+        isNotNull(schema.glossaryTerms.term),
+        isNotNull(schema.glossaryTerms.locale),
+        eq(schema.glossaryTerms.reviewStatus, "approved"),
+      ),
+    );
+
+  const pairs = flattenNativeConceptTermsToPairs({
+    concepts: groupConceptTerms(
+      conceptRows.map((row) => ({
+        ...row,
+        conceptId: row.conceptId!,
+      })),
+    ),
+    sourceLocale,
+    targetLocales: [targetLocale],
+  });
+
+  const terms = pairs
+    .filter((pair) => rankByGlossarySource.has(`${pair.glossaryId}:${pair.sourceTerm}`))
+    .map((pair) => ({
+      id: pair.id,
+      conceptId: pair.conceptId,
+      sourceTerm: pair.sourceTerm,
+      targetTerm: pair.targetTerm,
+      description: pair.description,
+      partOfSpeech: pair.partOfSpeech,
+      status: pair.status,
+      caseSensitive: pair.caseSensitive,
+      forbidden: pair.forbidden,
+      glossaryId: pair.glossaryId,
+      glossaryName: pair.glossaryName,
+      rank: rankByGlossarySource.get(`${pair.glossaryId}:${pair.sourceTerm}`) ?? 0,
+    }))
+    .toSorted((left, right) => right.rank - left.rank)
+    .slice(0, limit);
+
+  return { terms };
+}
+
 /**
  * Search glossary terms for a given source text and locale pair.
  *
@@ -56,181 +272,8 @@ export function createQueryGlossaryTool(ctx: ToolContext) {
   return tool({
     description:
       "Search glossary terms for a source text and locale pair. Returns matching terms with preferred translations.",
-    inputSchema: z.object({
-      sourceText: z.string().describe("The source text to look up in glossaries."),
-      sourceLocale: z.string().describe("BCP-47 source locale tag."),
-      targetLocale: z.string().describe("BCP-47 target locale tag."),
-      projectId: z
-        .string()
-        .optional()
-        .describe("Optional project ID to restrict to attached glossaries."),
-      limit: z.number().min(1).max(20).default(10).describe("Maximum results to return."),
-    }),
-    execute: async ({ sourceText, sourceLocale, targetLocale, projectId, limit }) => {
-      const db = ctx.db;
-      const tsQuery = buildTsQuery(sourceText);
-
-      if (!tsQuery) {
-        return { terms: [] };
-      }
-
-      let glossaryIds: string[] | undefined;
-      if (projectId) {
-        const accessibleProject = await toolCanAccessProject(ctx, projectId);
-        if (!accessibleProject) {
-          return { terms: [] };
-        }
-
-        const attached = await db
-          .select({ glossaryId: schema.projectGlossaries.glossaryId })
-          .from(schema.projectGlossaries)
-          .where(
-            and(
-              eq(schema.projectGlossaries.projectId, projectId),
-              eq(schema.projectGlossaries.organizationId, ctx.organizationId),
-            ),
-          );
-        glossaryIds = attached.map((a) => a.glossaryId);
-        if (glossaryIds.length === 0) {
-          return { terms: [] };
-        }
-      }
-
-      const glossarySourceTerms = alias(schema.glossaryTerms, "glossary_source_terms");
-
-      const sharedConditions = [
-        sql`${glossarySourceTerms.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
-        await toolProjectLinkedGlossaryWhere(ctx),
-        eq(schema.glossaries.sourceLocale, sourceLocale),
-        eq(schema.glossaries.status, "active"),
-        eq(schema.glossaries.source, "native"),
-        eq(glossarySourceTerms.locale, sourceLocale),
-        isNotNull(glossarySourceTerms.conceptId),
-        isNotNull(glossarySourceTerms.term),
-        eq(glossarySourceTerms.reviewStatus, "approved"),
-      ];
-
-      if (glossaryIds) {
-        sharedConditions.push(inArray(glossarySourceTerms.glossaryId, glossaryIds));
-      }
-
-      const rank =
-        sql<number>`ts_rank(${glossarySourceTerms.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
-          "rank",
-        );
-
-      const matchingSources = await db
-        .select({
-          conceptId: glossarySourceTerms.conceptId,
-          glossaryId: glossarySourceTerms.glossaryId,
-          sourceTerm: glossarySourceTerms.term,
-          rank,
-        })
-        .from(glossarySourceTerms)
-        .innerJoin(schema.glossaries, eq(glossarySourceTerms.glossaryId, schema.glossaries.id))
-        .where(and(...sharedConditions))
-        .orderBy(desc(rank))
-        .limit(limit * 5);
-
-      const conceptIds = [
-        ...new Set(
-          matchingSources
-            .map((row) => row.conceptId)
-            .filter((conceptId): conceptId is string => conceptId !== null),
-        ),
-      ];
-
-      if (conceptIds.length === 0) {
-        return { terms: [] };
-      }
-
-      const rankByGlossarySource = new Map<string, number>();
-      for (const row of matchingSources) {
-        if (!row.sourceTerm) {
-          continue;
-        }
-        const key = `${row.glossaryId}:${row.sourceTerm}`;
-        rankByGlossarySource.set(key, Math.max(rankByGlossarySource.get(key) ?? 0, row.rank));
-      }
-
-      const conceptRows = await db
-        .select({
-          id: schema.glossaryTerms.id,
-          conceptId: schema.glossaryTerms.conceptId,
-          glossaryId: schema.glossaryTerms.glossaryId,
-          glossaryName: schema.glossaries.name,
-          translatable: schema.glossaryConcepts.translatable,
-          locale: schema.glossaryTerms.locale,
-          term: schema.glossaryTerms.term,
-          status: schema.glossaryTerms.status,
-          description: schema.glossaryTerms.description,
-          partOfSpeech: schema.glossaryTerms.partOfSpeech,
-          caseSensitive: schema.glossaryTerms.caseSensitive,
-          provenance: schema.glossaryTerms.provenance,
-          reviewStatus: schema.glossaryTerms.reviewStatus,
-        })
-        .from(schema.glossaryTerms)
-        .innerJoin(
-          schema.glossaryConcepts,
-          eq(schema.glossaryTerms.conceptId, schema.glossaryConcepts.id),
-        )
-        .innerJoin(schema.glossaries, eq(schema.glossaryTerms.glossaryId, schema.glossaries.id))
-        .where(
-          and(
-            inArray(schema.glossaryTerms.conceptId, conceptIds),
-            eq(schema.glossaries.organizationId, ctx.organizationId),
-            eq(schema.glossaries.source, "native"),
-            eq(schema.glossaries.sourceLocale, sourceLocale),
-            eq(schema.glossaries.status, "active"),
-            isNotNull(schema.glossaryTerms.term),
-            isNotNull(schema.glossaryTerms.locale),
-            eq(schema.glossaryTerms.reviewStatus, "approved"),
-          ),
-        );
-
-      const pairs = flattenNativeConceptTermsToPairs({
-        concepts: groupConceptTerms(
-          conceptRows.map((row) => ({
-            ...row,
-            conceptId: row.conceptId!,
-          })),
-        ),
-        sourceLocale,
-        targetLocales: [targetLocale],
-      });
-
-      const terms = pairs
-        .filter((pair) => rankByGlossarySource.has(`${pair.glossaryId}:${pair.sourceTerm}`))
-        .map((pair) => ({
-          id: pair.id,
-          sourceTerm: pair.sourceTerm,
-          targetTerm: pair.targetTerm,
-          description: pair.description,
-          partOfSpeech: pair.partOfSpeech,
-          caseSensitive: pair.caseSensitive,
-          forbidden: pair.forbidden,
-          glossaryId: pair.glossaryId,
-          glossaryName: pair.glossaryName,
-          rank: rankByGlossarySource.get(`${pair.glossaryId}:${pair.sourceTerm}`) ?? 0,
-        }))
-        .toSorted((left, right) => right.rank - left.rank)
-        .slice(0, limit);
-
-      return {
-        terms: terms.map((term) => ({
-          id: term.id,
-          sourceTerm: term.sourceTerm,
-          targetTerm: term.targetTerm,
-          description: term.description,
-          partOfSpeech: term.partOfSpeech,
-          caseSensitive: term.caseSensitive,
-          forbidden: term.forbidden,
-          glossaryId: term.glossaryId,
-          glossaryName: term.glossaryName,
-          rank: term.rank,
-        })),
-      };
-    },
+    inputSchema: queryGlossaryInputSchema,
+    execute: async (input) => queryGlossaryTerms(ctx, input),
   });
 }
 

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
@@ -17,7 +17,10 @@ import { z } from "zod";
 
 import * as schema from "@/lib/database/schema";
 import { flattenNativeConceptTermsToPairs } from "@/lib/glossary/flatten-native-glossary-pairs";
+import { buildGlossaryTsQuery } from "@/lib/glossary/glossary";
+import { concordanceSourceContainsTerm } from "@/lib/glossary/native-glossary";
 import { groupConceptTerms } from "@/lib/glossary/query-glossary-terms";
+import { parseLiveProviderGlossaryId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
 import {
@@ -43,6 +46,16 @@ function buildTsQuery(input: string): string {
     .map((w) => `${w}:*`)
     .join(" & ");
   return sanitized;
+}
+
+const QUERY_GLOSSARY_CANDIDATE_PAGE_SIZE = 200;
+
+function isNativeGlossaryId(value: string) {
+  return z.uuid().safeParse(value).success;
+}
+
+export function isQueryableNativeGlossaryId(value: string) {
+  return isNativeGlossaryId(value) && parseLiveProviderGlossaryId(value) === null;
 }
 
 export const queryGlossaryInputSchema = z.object({
@@ -94,7 +107,7 @@ export async function queryGlossaryTerms(
   const { sourceText, sourceLocale, targetLocale, projectId, glossaryId } = input;
   const limit = input.limit ?? 10;
   const db = ctx.db;
-  const tsQuery = buildTsQuery(sourceText);
+  const tsQuery = buildGlossaryTsQuery(sourceText);
 
   if (!tsQuery) {
     return { terms: [] };
@@ -123,6 +136,10 @@ export async function queryGlossaryTerms(
   }
 
   if (glossaryId) {
+    if (!isQueryableNativeGlossaryId(glossaryId)) {
+      return { terms: [] };
+    }
+
     const accessibleGlossary = await toolCanAccessGlossary(ctx, glossaryId);
     if (!accessibleGlossary) {
       return { terms: [] };
@@ -158,18 +175,57 @@ export async function queryGlossaryTerms(
       "rank",
     );
 
-  const matchingSources = await db
-    .select({
-      conceptId: glossarySourceTerms.conceptId,
-      glossaryId: glossarySourceTerms.glossaryId,
-      sourceTerm: glossarySourceTerms.term,
-      rank,
-    })
-    .from(glossarySourceTerms)
-    .innerJoin(schema.glossaries, eq(glossarySourceTerms.glossaryId, schema.glossaries.id))
-    .where(and(...sharedConditions))
-    .orderBy(desc(rank))
-    .limit(limit * 5);
+  const matchingSources: Array<{
+    conceptId: string | null;
+    glossaryId: string;
+    sourceTerm: string | null;
+    caseSensitive: boolean;
+    rank: number;
+  }> = [];
+  let candidateOffset = 0;
+  const neededCandidates = Math.max(limit * 5, limit);
+
+  while (matchingSources.length < neededCandidates) {
+    const page = await db
+      .select({
+        conceptId: glossarySourceTerms.conceptId,
+        glossaryId: glossarySourceTerms.glossaryId,
+        sourceTerm: glossarySourceTerms.term,
+        caseSensitive: glossarySourceTerms.caseSensitive,
+        rank,
+      })
+      .from(glossarySourceTerms)
+      .innerJoin(schema.glossaries, eq(glossarySourceTerms.glossaryId, schema.glossaries.id))
+      .where(and(...sharedConditions))
+      .orderBy(desc(rank))
+      .limit(QUERY_GLOSSARY_CANDIDATE_PAGE_SIZE)
+      .offset(candidateOffset);
+
+    if (page.length === 0) {
+      break;
+    }
+
+    candidateOffset += page.length;
+    for (const row of page) {
+      if (
+        !row.sourceTerm ||
+        !concordanceSourceContainsTerm(sourceText, {
+          sourceTerm: row.sourceTerm,
+          caseSensitive: row.caseSensitive,
+        })
+      ) {
+        continue;
+      }
+      matchingSources.push(row);
+      if (matchingSources.length >= neededCandidates) {
+        break;
+      }
+    }
+
+    if (page.length < QUERY_GLOSSARY_CANDIDATE_PAGE_SIZE) {
+      break;
+    }
+  }
 
   const conceptIds = [
     ...new Set(
@@ -207,6 +263,7 @@ export async function queryGlossaryTerms(
       caseSensitive: schema.glossaryTerms.caseSensitive,
       provenance: schema.glossaryTerms.provenance,
       reviewStatus: schema.glossaryTerms.reviewStatus,
+      forbidden: schema.glossaryTerms.forbidden,
     })
     .from(schema.glossaryTerms)
     .innerJoin(

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { tool } from "ai";
 import { z } from "zod";
@@ -197,7 +197,7 @@ export async function queryGlossaryTerms(
       .from(glossarySourceTerms)
       .innerJoin(schema.glossaries, eq(glossarySourceTerms.glossaryId, schema.glossaries.id))
       .where(and(...sharedConditions))
-      .orderBy(desc(rank))
+      .orderBy(desc(rank), asc(glossarySourceTerms.id))
       .limit(QUERY_GLOSSARY_CANDIDATE_PAGE_SIZE)
       .offset(candidateOffset);
 

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -79,9 +79,11 @@ Inaccessible projects return `project_not_found`.
 
 `query_glossary` looks up a source string instead of paging a whole glossary. Pass `sourceText`, `sourceLocale`, and `targetLocale`. Optional `projectId` limits the search to glossaries linked to that project. Optional `glossaryId` searches one glossary. `limit` defaults to 10 and maxes at 20.
 
-Each hit includes `glossaryId`, `conceptId`, `sourceTerm`, `targetTerm`, `forbidden`, `status`, `partOfSpeech`, and a description truncated to 500 characters. Use `forbidden` to avoid rejected terms.
+Each hit includes `glossaryId`, `conceptId`, `sourceTerm`, `targetTerm`, `forbidden`, `status`, `partOfSpeech`, `caseSensitive`, and a description truncated to 500 characters. Use `forbidden` to avoid rejected terms. Case-sensitive entries only match the stored casing.
 
-Native pairs come from concept-linked terms. Leftover `source_term` / `target_term` rows are ignored. Provider glossaries stay read-only; an inaccessible or provider `glossaryId` returns `glossary_not_found`. An inaccessible `projectId` returns `{ "terms": [] }`.
+The search is the same native concordance path used in-app: an OR candidate query, then a source-text containment filter. A sentence such as `Proceed to checkout` still matches a `checkout` term.
+
+Native pairs come from concept-linked terms. Leftover `source_term` / `target_term` rows are ignored. Provider glossaries stay read-only; an inaccessible, non-UUID, or provider `glossaryId` returns `glossary_not_found`. An inaccessible `projectId` returns `{ "terms": [] }`.
 
 ### Board (issues)
 

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -51,6 +51,7 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | `get_project_status` | Locale coverage counts by `projectId`, with optional `sourcePath` |
 | `list_glossaries` | List glossaries linked to accessible projects |
 | `get_glossary_entries` | Concept-linked terms for a `glossaryId` (`limit`, default 50, max 100) |
+| `query_glossary` | Ranked concept-linked hits for a source string and locale pair |
 
 `list_files` returns metadata only: `id` (stored file or source-file id), `sourcePath`, `filename`, `contentType`, `byteSize`, `updatedAt`, and `sourceLocale` when known. Pagination includes `total`, `limit`, `offset`, `hasMore`, and `nextOffset`. The tool does not return file contents. Inaccessible projects return `project_not_found`. Use the listed `sourcePath` values for later upload, download, or `run_workflow` calls.
 
@@ -75,6 +76,12 @@ When you pass `sourcePath`, the tool still returns project-wide locale totals an
 For TMS-backed projects the tool still returns native overlay counts (`coverageSource: "native_overlay"`). It does not fetch live provider statistics. Use the provider CAT or CLI for Crowdin, Phrase, Lokalise, or Smartling progress.
 
 Inaccessible projects return `project_not_found`.
+
+`query_glossary` looks up a source string instead of paging a whole glossary. Pass `sourceText`, `sourceLocale`, and `targetLocale`. Optional `projectId` limits the search to glossaries linked to that project. Optional `glossaryId` searches one glossary. `limit` defaults to 10 and maxes at 20.
+
+Each hit includes `glossaryId`, `conceptId`, `sourceTerm`, `targetTerm`, `forbidden`, `status`, `partOfSpeech`, and a description truncated to 500 characters. Use `forbidden` to avoid rejected terms.
+
+Native pairs come from concept-linked terms. Leftover `source_term` / `target_term` rows are ignored. Provider glossaries stay read-only; an inaccessible or provider `glossaryId` returns `glossary_not_found`. An inaccessible `projectId` returns `{ "terms": [] }`.
 
 ### Board (issues)
 
@@ -152,6 +159,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `invalid_comment_cursor` | Stale or malformed `cursor` on `list_issue_comments` |
 | `job_not_found` | Wrong `jobId`, missing project access, or a job from another organization |
 | `project_not_found` | Wrong `projectId` or missing project access on `list_files`, `list_translations`, `get_project_status`, or `list_jobs` |
+| `glossary_not_found` | Wrong `glossaryId`, missing glossary access, or a provider glossary on `query_glossary` |
 | Agent cannot reach local Cloud | Use `http://localhost:3000/mcp` and ensure the dev server is running |
 
 ## Next

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -79,7 +79,7 @@ Inaccessible projects return `project_not_found`.
 
 `query_glossary` looks up a source string instead of paging a whole glossary. Pass `sourceText`, `sourceLocale`, and `targetLocale`. Optional `projectId` limits the search to glossaries linked to that project. Optional `glossaryId` searches one glossary. `limit` defaults to 10 and maxes at 20.
 
-Each hit includes `glossaryId`, `conceptId`, `sourceTerm`, `targetTerm`, `forbidden`, `status`, `partOfSpeech`, `caseSensitive`, and a description truncated to 500 characters. Use `forbidden` to avoid rejected terms. Case-sensitive entries only match the stored casing.
+Each hit includes `glossaryId`, `conceptId`, `sourceTerm`, `targetTerm`, `forbidden`, `status`, `partOfSpeech`, `caseSensitive`, and a description truncated to 500 characters. `forbidden` is true when the matched source term or the preferred target is prohibited. Case-sensitive entries only match the stored casing.
 
 The search is the same native concordance path used in-app: an OR candidate query, then a source-text containment filter. A sentence such as `Proceed to checkout` still matches a `checkout` term.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a hosted MCP `query_glossary` tool so agents can look up a source string and locale pair instead of paging `get_glossary_entries`.

The tool reuses the native concordance path: OR candidate FTS, then `concordanceSourceContainsTerm` (including case-sensitive terms). Hits are concept-linked pairs and include:

- `glossaryId`, `conceptId`, `sourceTerm`, `targetTerm`
- `forbidden` (matched source or preferred target, including stored flags), `status`, `partOfSpeech`, `caseSensitive`
- truncated `description` (500 chars)

`projectId` limits the search to glossaries linked to that project. Non-UUID, provider, or inaccessible `glossaryId` values return `glossary_not_found` without hitting Postgres with an invalid UUID. Inaccessible projects return empty `terms`.

## Codex review follow-up

- Sentence lookups such as `Proceed to checkout` now match contained terms
- Case-sensitive entries no longer match the wrong casing
- Stored `forbidden = true` is preserved even when status is `preferred`
- A prohibited source term marks the pair forbidden even when the preferred target is allowed
- FTS candidate pages order by rank, then term id, so OFFSET paging stays stable
- `missing` and `crowdin:glossary:42` return `glossary_not_found` instead of a Postgres error

## How to test

- `vp test src/api/routes/mcp/mcp-query-glossary.test.ts src/lib/tools/asset-tools.test.ts src/lib/glossary/flatten-native-glossary-pairs.test.ts src/lib/glossary/query-glossary-terms.test.ts`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-685](https://linear.app/hyperlocalise/issue/HL-685/add-query-glossary-tool-to-the-hosted-mcp-server)

<div><a href="https://cursor.com/agents/bc-48e84bb2-49c2-4bc0-bd06-0f4e3b8460b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48e84bb2-49c2-4bc0-bd06-0f4e3b8460b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

