### PR TITLE
feat(web): add breadcrumb selectors and loading states

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
@@ -27,16 +27,213 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
+import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
 import { cn } from "@/lib/primitives/cn";
 
-import { getAppShellBreadcrumbs } from "./app-shell-title";
-import { parseProjectRoute } from "./navigation-config";
+import {
+  getAppShellBreadcrumbs,
+  type AppShellBreadcrumb as AppShellBreadcrumbItem,
+} from "./app-shell-title";
+import { DomainBreadcrumbSelector } from "./domain-breadcrumb-selector";
+import {
+  buildOrganizationPath,
+  buildProjectPath,
+  parseDomainRoute,
+  parseProjectRoute,
+  parseTeamRoute,
+} from "./navigation-config";
+import { ProjectBreadcrumbSelector } from "./project-breadcrumb-selector";
 import { useAppShellStore } from "./store/app-shell-store-context";
+import { TeamBreadcrumbSelector } from "./team-breadcrumb-selector";
 
 type AppShellBreadcrumbProps = {
   organizationSlug: string;
 };
+
+type SelectorCrumbKind = "project" | "team" | "domain";
+
+function isProjectBreadcrumbCrumb(
+  crumb: AppShellBreadcrumbItem,
+  index: number,
+  breadcrumbs: readonly AppShellBreadcrumbItem[],
+  organizationSlug: string,
+  projectId: string,
+) {
+  if (index !== 1 || breadcrumbs.length < 2) {
+    return false;
+  }
+
+  const projectHref = buildProjectPath(organizationSlug, projectId);
+  return crumb.href === projectHref || crumb.href === undefined;
+}
+
+function isTeamBreadcrumbCrumb(
+  crumb: AppShellBreadcrumbItem,
+  index: number,
+  breadcrumbs: readonly AppShellBreadcrumbItem[],
+  organizationSlug: string,
+) {
+  if (index !== 1 || breadcrumbs.length !== 2 || crumb.href) {
+    return false;
+  }
+
+  return breadcrumbs[0]?.href === buildOrganizationPath(organizationSlug, "teams");
+}
+
+function isDomainBreadcrumbCrumb(
+  crumb: AppShellBreadcrumbItem,
+  index: number,
+  breadcrumbs: readonly AppShellBreadcrumbItem[],
+  organizationSlug: string,
+) {
+  if (index !== 1 || breadcrumbs.length !== 2 || crumb.href) {
+    return false;
+  }
+
+  return breadcrumbs[0]?.href === buildOrganizationPath(organizationSlug, "domains");
+}
+
+function resolveSelectorCrumbKind(
+  crumb: AppShellBreadcrumbItem,
+  index: number,
+  breadcrumbs: readonly AppShellBreadcrumbItem[],
+  organizationSlug: string,
+  projectRoute: ReturnType<typeof parseProjectRoute>,
+  teamRoute: ReturnType<typeof parseTeamRoute>,
+  domainRoute: ReturnType<typeof parseDomainRoute>,
+): SelectorCrumbKind | null {
+  if (
+    projectRoute?.projectId &&
+    isProjectBreadcrumbCrumb(crumb, index, breadcrumbs, organizationSlug, projectRoute.projectId)
+  ) {
+    return "project";
+  }
+
+  if (teamRoute?.teamId && isTeamBreadcrumbCrumb(crumb, index, breadcrumbs, organizationSlug)) {
+    return "team";
+  }
+
+  if (
+    domainRoute?.linkedDomainId &&
+    isDomainBreadcrumbCrumb(crumb, index, breadcrumbs, organizationSlug)
+  ) {
+    return "domain";
+  }
+
+  return null;
+}
+
+function BreadcrumbCrumbContent({
+  crumb,
+  isLast,
+}: {
+  crumb: AppShellBreadcrumbItem;
+  isLast: boolean;
+}) {
+  if (crumb.render) {
+    return <>{crumb.render()}</>;
+  }
+
+  if (crumb.isLoading) {
+    return <Skeleton aria-hidden className={cn("rounded-md", isLast ? "h-5 w-28" : "h-4 w-24")} />;
+  }
+
+  const tooltip = crumb.title ?? (isLast ? crumb.label : undefined);
+
+  if (isLast || !crumb.href) {
+    return (
+      <BreadcrumbPage
+        className={cn(
+          "block truncate font-semibold text-foreground",
+          isLast ? "text-base" : "text-sm",
+        )}
+        title={tooltip}
+      >
+        {crumb.label}
+      </BreadcrumbPage>
+    );
+  }
+
+  return (
+    <BreadcrumbLink
+      render={<Link href={crumb.href} />}
+      className="block truncate font-medium text-muted-foreground hover:text-foreground"
+      title={crumb.label}
+    >
+      {crumb.label}
+    </BreadcrumbLink>
+  );
+}
+
+function SelectorBreadcrumbCrumbContent({
+  crumb,
+  isLast,
+  selectorKind,
+  organizationSlug,
+  projectRoute,
+  teamRoute,
+  domainRoute,
+  projectName,
+  teamName,
+  domainName,
+}: {
+  crumb: AppShellBreadcrumbItem;
+  isLast: boolean;
+  selectorKind: SelectorCrumbKind;
+  organizationSlug: string;
+  projectRoute: ReturnType<typeof parseProjectRoute>;
+  teamRoute: ReturnType<typeof parseTeamRoute>;
+  domainRoute: ReturnType<typeof parseDomainRoute>;
+  projectName?: string;
+  teamName?: string;
+  domainName?: string;
+}) {
+  if (crumb.render) {
+    return <>{crumb.render()}</>;
+  }
+
+  if (crumb.isLoading) {
+    return <Skeleton aria-hidden className={cn("rounded-md", isLast ? "h-5 w-28" : "h-4 w-24")} />;
+  }
+
+  if (selectorKind === "project" && projectRoute) {
+    return (
+      <ProjectBreadcrumbSelector
+        organizationSlug={organizationSlug}
+        projectId={projectRoute.projectId}
+        projectName={projectName?.trim() || crumb.label || projectRoute.projectId}
+        section={projectRoute.section}
+        isLast={isLast}
+      />
+    );
+  }
+
+  if (selectorKind === "team" && teamRoute) {
+    return (
+      <TeamBreadcrumbSelector
+        organizationSlug={organizationSlug}
+        teamId={teamRoute.teamId}
+        teamName={teamName?.trim() || crumb.label || teamRoute.teamId}
+        isLast={isLast}
+      />
+    );
+  }
+
+  if (selectorKind === "domain" && domainRoute) {
+    return (
+      <DomainBreadcrumbSelector
+        organizationSlug={organizationSlug}
+        linkedDomainId={domainRoute.linkedDomainId}
+        domainName={domainName?.trim() || crumb.label || domainRoute.linkedDomainId}
+        isLast={isLast}
+      />
+    );
+  }
+
+  return <BreadcrumbCrumbContent crumb={crumb} isLast={isLast} />;
+}
 
 export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
   organizationSlug,
@@ -45,7 +242,13 @@ export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
   const store = useAppShellStore();
   const pathname = usePathname();
   const projectRoute = parseProjectRoute(pathname);
-  const resolvedOrganizationSlug = projectRoute?.organizationSlug ?? organizationSlug;
+  const teamRoute = parseTeamRoute(pathname);
+  const domainRoute = parseDomainRoute(pathname);
+  const resolvedOrganizationSlug =
+    projectRoute?.organizationSlug ??
+    teamRoute?.organizationSlug ??
+    domainRoute?.organizationSlug ??
+    organizationSlug;
 
   const projectQuery = useQuery({
     queryKey: ["translation-project", resolvedOrganizationSlug, projectRoute?.projectId],
@@ -65,16 +268,71 @@ export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
     },
   });
 
+  const teamQuery = useQuery({
+    queryKey: ["workspace-team", resolvedOrganizationSlug, teamRoute?.teamId],
+    enabled: Boolean(teamRoute?.teamId),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].teams[":teamId"].$get({
+        param: {
+          organizationSlug: resolvedOrganizationSlug,
+          teamId: teamRoute!.teamId,
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to load team (${response.status})`);
+      }
+      const body = (await response.json()) as { team: { name: string } };
+      return body.team;
+    },
+  });
+
+  const domainQuery = useQuery({
+    queryKey: ["linked-domain", resolvedOrganizationSlug, domainRoute?.linkedDomainId],
+    enabled: Boolean(domainRoute?.linkedDomainId),
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/orgs/${encodeURIComponent(resolvedOrganizationSlug)}/linked-domains/${encodeURIComponent(domainRoute!.linkedDomainId)}`,
+      );
+      const body = (await response.json().catch(() => ({}))) as {
+        linkedDomain?: LinkedDomainPublic;
+        message?: string;
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(body.message || body.error || "Failed to load domain");
+      }
+      if (!body.linkedDomain) {
+        throw new Error("Failed to load domain");
+      }
+      return body.linkedDomain;
+    },
+  });
+
   const breadcrumbs = store.breadcrumb.applyOverrides(
     getAppShellBreadcrumbs(pathname, intl, {
       projectName: projectQuery.data?.name,
+      projectNameLoading: projectQuery.isPending,
+      teamName: teamQuery.data?.name,
+      teamNameLoading: teamQuery.isPending,
+      domainName: domainQuery.data?.domainKey,
+      domainNameLoading: domainQuery.isPending,
     }),
   );
 
   if (breadcrumbs.length === 1) {
+    const crumb = breadcrumbs[0]!;
+
+    if (crumb.render) {
+      return <>{crumb.render()}</>;
+    }
+
+    if (crumb.isLoading) {
+      return <Skeleton aria-hidden className="h-5 w-28 rounded-md" />;
+    }
+
     return (
       <BreadcrumbPage className="truncate text-base font-semibold text-foreground">
-        {breadcrumbs[0]!.label}
+        {crumb.label}
       </BreadcrumbPage>
     );
   }
@@ -84,7 +342,15 @@ export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
       <BreadcrumbList className="flex-nowrap gap-1.5 text-sm sm:gap-2">
         {breadcrumbs.map((crumb, index) => {
           const isLast = index === breadcrumbs.length - 1;
-          const tooltip = crumb.title ?? (isLast ? crumb.label : undefined);
+          const selectorKind = resolveSelectorCrumbKind(
+            crumb,
+            index,
+            breadcrumbs,
+            resolvedOrganizationSlug,
+            projectRoute,
+            teamRoute,
+            domainRoute,
+          );
 
           return (
             <Fragment key={`${crumb.href ?? crumb.label}-${index}`}>
@@ -97,24 +363,21 @@ export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
                     : "max-w-[7rem] shrink-0 sm:max-w-[9rem]",
                 )}
               >
-                {isLast || !crumb.href ? (
-                  <BreadcrumbPage
-                    className={cn(
-                      "block truncate font-semibold text-foreground",
-                      isLast ? "text-base" : "text-sm",
-                    )}
-                    title={tooltip}
-                  >
-                    {crumb.label}
-                  </BreadcrumbPage>
+                {selectorKind ? (
+                  <SelectorBreadcrumbCrumbContent
+                    crumb={crumb}
+                    isLast={isLast}
+                    selectorKind={selectorKind}
+                    organizationSlug={resolvedOrganizationSlug}
+                    projectRoute={projectRoute}
+                    teamRoute={teamRoute}
+                    domainRoute={domainRoute}
+                    projectName={projectQuery.data?.name}
+                    teamName={teamQuery.data?.name}
+                    domainName={domainQuery.data?.domainKey}
+                  />
                 ) : (
-                  <BreadcrumbLink
-                    render={<Link href={crumb.href} />}
-                    className="block truncate font-medium text-muted-foreground hover:text-foreground"
-                    title={crumb.label}
-                  >
-                    {crumb.label}
-                  </BreadcrumbLink>
+                  <BreadcrumbCrumbContent crumb={crumb} isLast={isLast} />
                 )}
               </BreadcrumbItem>
             </Fragment>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -117,6 +117,15 @@ describe("getAppShellBreadcrumbs", () => {
       { label: "Teams", href: "/org/acme/teams" },
       { label: "team_1" },
     ]);
+    expect(
+      getAppShellBreadcrumbs("/org/acme/teams/team_1", intl, { teamName: "Engineering" }),
+    ).toEqual([{ label: "Teams", href: "/org/acme/teams" }, { label: "Engineering" }]);
+    expect(
+      getAppShellBreadcrumbs("/org/acme/teams/team_1", intl, { teamNameLoading: true }),
+    ).toEqual([
+      { label: "Teams", href: "/org/acme/teams" },
+      { label: "", isLoading: true },
+    ]);
   });
 
   it("returns domains breadcrumbs for domain detail pages", () => {
@@ -124,6 +133,15 @@ describe("getAppShellBreadcrumbs", () => {
     expect(getAppShellBreadcrumbs("/org/acme/domains/ld_1", intl)).toEqual([
       { label: "Domains", href: "/org/acme/domains" },
       { label: "ld_1" },
+    ]);
+    expect(
+      getAppShellBreadcrumbs("/org/acme/domains/ld_1", intl, { domainName: "example.com" }),
+    ).toEqual([{ label: "Domains", href: "/org/acme/domains" }, { label: "example.com" }]);
+    expect(
+      getAppShellBreadcrumbs("/org/acme/domains/ld_1", intl, { domainNameLoading: true }),
+    ).toEqual([
+      { label: "Domains", href: "/org/acme/domains" },
+      { label: "", isLoading: true },
     ]);
   });
 
@@ -149,6 +167,18 @@ describe("getAppShellBreadcrumbs", () => {
     expect(getAppShellBreadcrumbs("/org/acme/projects/proj_1/jobs", intl)).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "proj_1", href: "/org/acme/projects/proj_1" },
+      { label: "Jobs" },
+    ]);
+  });
+
+  it("marks the project crumb as loading while the project name is being fetched", () => {
+    expect(
+      getAppShellBreadcrumbs("/org/acme/projects/proj_1/jobs", intl, {
+        projectNameLoading: true,
+      }),
+    ).toEqual([
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "", href: "/org/acme/projects/proj_1", isLoading: true },
       { label: "Jobs" },
     ]);
   });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -10,12 +10,15 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import type { ReactNode } from "react";
 import type { IntlShape } from "react-intl";
 
 export type AppShellBreadcrumb = {
   label: string;
   href?: string;
   title?: string;
+  isLoading?: boolean;
+  render?: () => ReactNode;
 };
 
 type RouteTitleKey =
@@ -341,7 +344,14 @@ function formatProjectSectionTitle(intl: IntlShape, key: ProjectSectionKey): str
 export function getAppShellBreadcrumbs(
   pathname: string | null,
   intl: IntlShape,
-  options?: { projectName?: string },
+  options?: {
+    projectName?: string;
+    projectNameLoading?: boolean;
+    teamName?: string;
+    teamNameLoading?: boolean;
+    domainName?: string;
+    domainNameLoading?: boolean;
+  },
 ): AppShellBreadcrumb[] {
   const orgRoute = parseOrgRoute(pathname);
   if (!orgRoute) {
@@ -386,9 +396,17 @@ export function getAppShellBreadcrumbs(
       return [{ label: formatRouteTitle(intl, "teams") }];
     }
 
+    const teamId = decodePathSegment(subsection);
+    const resolvedTeamName = options?.teamName?.trim();
+    const teamNameLoading = options?.teamNameLoading && !resolvedTeamName;
+    const teamLabel = resolvedTeamName || (teamNameLoading ? "" : teamId);
+
     return [
       { label: formatRouteTitle(intl, "teams"), href: buildOrgPath(organizationSlug, "teams") },
-      { label: decodePathSegment(subsection) },
+      {
+        label: teamLabel,
+        ...(teamNameLoading ? { isLoading: true } : {}),
+      },
     ];
   }
 
@@ -397,12 +415,20 @@ export function getAppShellBreadcrumbs(
       return [{ label: formatRouteTitle(intl, "domains") }];
     }
 
+    const linkedDomainId = decodePathSegment(subsection);
+    const resolvedDomainName = options?.domainName?.trim();
+    const domainNameLoading = options?.domainNameLoading && !resolvedDomainName;
+    const domainLabel = resolvedDomainName || (domainNameLoading ? "" : linkedDomainId);
+
     return [
       {
         label: formatRouteTitle(intl, "domains"),
         href: buildOrgPath(organizationSlug, "domains"),
       },
-      { label: decodePathSegment(subsection) },
+      {
+        label: domainLabel,
+        ...(domainNameLoading ? { isLoading: true } : {}),
+      },
     ];
   }
 
@@ -422,8 +448,14 @@ export function getAppShellBreadcrumbs(
 
   if (section === "projects" && subsection) {
     const projectId = decodePathSegment(subsection);
-    const projectLabel = options?.projectName?.trim() || projectId;
+    const resolvedProjectName = options?.projectName?.trim();
+    const projectNameLoading = options?.projectNameLoading && !resolvedProjectName;
+    const projectLabel = resolvedProjectName || (projectNameLoading ? "" : projectId);
     const projectHref = buildOrgPath(organizationSlug, "projects", subsection);
+    const projectCrumb: AppShellBreadcrumb = {
+      label: projectLabel,
+      ...(projectNameLoading ? { isLoading: true } : {}),
+    };
     const issueIdSegment = routeSegments[3];
 
     if (projectSection && isProjectSectionKey(projectSection)) {
@@ -433,7 +465,7 @@ export function getAppShellBreadcrumbs(
           label: formatRouteTitle(intl, "projects"),
           href: buildOrgPath(organizationSlug, "projects"),
         },
-        { label: projectLabel, href: projectHref },
+        { ...projectCrumb, href: projectHref },
         {
           label: formatProjectSectionTitle(intl, projectSection),
           href: issueIdSegment ? sectionHref : undefined,
@@ -446,7 +478,7 @@ export function getAppShellBreadcrumbs(
         label: formatRouteTitle(intl, "projects"),
         href: buildOrgPath(organizationSlug, "projects"),
       },
-      { label: projectLabel },
+      projectCrumb,
     ];
   }
 

--- a/apps/hyperlocalise-web/src/components/app-shell/breadcrumb-crumb-selector.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/breadcrumb-crumb-selector.messages.ts
@@ -1,0 +1,68 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const breadcrumbCrumbSelectorMessages = defineMessages({
+  empty: {
+    defaultMessage: "No options available",
+    id: "Tb7h0w/7fY",
+    description: "Empty state when a breadcrumb selector has no items",
+  },
+  loadError: {
+    defaultMessage: "Unable to load options",
+    id: "XLYekd9yOT",
+    description: "Error state when a breadcrumb selector fails to load items",
+  },
+  selected: {
+    defaultMessage: "Selected",
+    id: "4mbEhalZi9",
+    description: "Hint shown beside the active item in a breadcrumb selector menu",
+  },
+  switchDomain: {
+    defaultMessage: "Switch domain",
+    id: "JBqUQN0+J0",
+    description: "Menu label for the domain switcher in the breadcrumb",
+  },
+  domainsLoadError: {
+    defaultMessage: "Unable to load domains",
+    id: "moPVcf3ylY",
+    description: "Error state when the domain breadcrumb selector fails to load domains",
+  },
+  switchTeam: {
+    defaultMessage: "Switch team",
+    id: "glmojNf0zj",
+    description: "Menu label for the team switcher in the breadcrumb",
+  },
+  teamsLoadError: {
+    defaultMessage: "Unable to load teams",
+    id: "GpJgVP/u6k",
+    description: "Error state when the team breadcrumb selector fails to load teams",
+  },
+  switchProject: {
+    defaultMessage: "Switch project",
+    id: "cDw6CT/CPx",
+    description: "Menu label for the project switcher in the breadcrumb",
+  },
+  projectsLoadError: {
+    defaultMessage: "Unable to load projects",
+    id: "Nf77AX5l7/",
+    description: "Error state when the project breadcrumb selector fails to load projects",
+  },
+  noProjects: {
+    defaultMessage: "No projects found",
+    id: "bimsDnjEKL",
+    description: "Empty state when the project breadcrumb selector has no projects",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/breadcrumb-crumb-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/breadcrumb-crumb-selector.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuHint,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/primitives/cn";
+
+import { breadcrumbCrumbSelectorMessages as messages } from "./breadcrumb-crumb-selector.messages";
+
+export type BreadcrumbCrumbSelectorOption = {
+  value: string;
+  label: string;
+};
+
+type BreadcrumbCrumbSelectorProps = {
+  value: string;
+  label: string;
+  options: readonly BreadcrumbCrumbSelectorOption[];
+  onSelect: (value: string) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+  menuLabel?: string;
+  isLast?: boolean;
+  disabled?: boolean;
+};
+
+export function BreadcrumbCrumbSelector({
+  value,
+  label,
+  options,
+  onSelect,
+  isLoading = false,
+  isError = false,
+  menuLabel,
+  isLast = false,
+  disabled = false,
+}: BreadcrumbCrumbSelectorProps) {
+  const hasMultipleOptions = options.length > 1;
+
+  if (!hasMultipleOptions && !isLoading) {
+    return (
+      <span
+        className={cn(
+          "block truncate font-semibold text-foreground",
+          isLast ? "text-base" : "text-sm",
+        )}
+        title={label}
+      >
+        {label}
+      </span>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        disabled={disabled || isLoading}
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            className={cn(
+              "h-auto max-w-full gap-1 px-0 py-0 font-semibold hover:bg-transparent",
+              isLast
+                ? "text-base text-foreground hover:text-foreground"
+                : "text-sm font-medium text-muted-foreground hover:text-foreground",
+            )}
+          />
+        }
+      >
+        {isLoading ? (
+          <Skeleton aria-hidden className={cn("rounded-md", isLast ? "h-5 w-28" : "h-4 w-24")} />
+        ) : (
+          <span className="truncate">{label}</span>
+        )}
+        <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5 shrink-0" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-56" align="start">
+        <DropdownMenuGroup>
+          {menuLabel ? <DropdownMenuLabel>{menuLabel}</DropdownMenuLabel> : null}
+          {isError ? (
+            <DropdownMenuItem disabled>
+              <FormattedMessage {...messages.loadError} />
+            </DropdownMenuItem>
+          ) : null}
+          {!isLoading && !isError && options.length === 0 ? (
+            <DropdownMenuItem disabled>
+              <FormattedMessage {...messages.empty} />
+            </DropdownMenuItem>
+          ) : null}
+          {options.map((option) => (
+            <DropdownMenuItem key={option.value} onClick={() => onSelect(option.value)}>
+              <span className="truncate">{option.label}</span>
+              {option.value === value ? (
+                <DropdownMenuHint>
+                  <FormattedMessage {...messages.selected} />
+                </DropdownMenuHint>
+              ) : null}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/domain-breadcrumb-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/domain-breadcrumb-selector.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
+
+import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
+
+import { BreadcrumbCrumbSelector } from "./breadcrumb-crumb-selector";
+import { breadcrumbCrumbSelectorMessages as messages } from "./breadcrumb-crumb-selector.messages";
+import { buildDomainPath } from "./navigation-config";
+
+const organizationDomainsQueryKey = (organizationSlug: string) =>
+  ["linked-domains", organizationSlug, "breadcrumb"] as const;
+
+type DomainBreadcrumbSelectorProps = {
+  organizationSlug: string;
+  linkedDomainId: string;
+  domainName: string;
+  isLast?: boolean;
+};
+
+export function DomainBreadcrumbSelector({
+  organizationSlug,
+  linkedDomainId,
+  domainName,
+  isLast = false,
+}: DomainBreadcrumbSelectorProps) {
+  const intl = useIntl();
+  const router = useRouter();
+  const domainsQuery = useQuery({
+    queryKey: organizationDomainsQueryKey(organizationSlug),
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/orgs/${encodeURIComponent(organizationSlug)}/linked-domains`,
+      );
+      const body = (await response.json().catch(() => ({}))) as {
+        linkedDomains?: LinkedDomainPublic[];
+        message?: string;
+        error?: string;
+      };
+
+      if (!response.ok) {
+        throw new Error(
+          body.message || body.error || intl.formatMessage(messages.domainsLoadError),
+        );
+      }
+
+      return (body.linkedDomains ?? []).map((domain) => ({
+        value: domain.id,
+        label: domain.domainKey,
+      }));
+    },
+  });
+
+  function handleSelect(nextLinkedDomainId: string) {
+    if (nextLinkedDomainId === linkedDomainId) {
+      return;
+    }
+
+    router.push(buildDomainPath(organizationSlug, nextLinkedDomainId));
+  }
+
+  return (
+    <BreadcrumbCrumbSelector
+      value={linkedDomainId}
+      label={domainName}
+      options={domainsQuery.data ?? []}
+      onSelect={handleSelect}
+      isLoading={domainsQuery.isPending}
+      isError={domainsQuery.isError}
+      menuLabel={intl.formatMessage(messages.switchDomain)}
+      isLast={isLast}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -30,10 +30,14 @@ import {
   buildOrganizationPath,
   buildProjectNavigationItems,
   buildProjectPath,
+  buildTeamPath,
+  buildDomainPath,
   isInboxNewRequestPath,
   isNavigationItemActive,
   isOrganizationSettingsPath,
+  parseDomainRoute,
   parseProjectRoute,
+  parseTeamRoute,
   stripAppLocalePrefix,
 } from "./navigation-config";
 
@@ -289,6 +293,56 @@ describe("parseProjectRoute", () => {
       projectId: "proj_1",
       section: "jobs",
     });
+  });
+});
+
+describe("parseTeamRoute", () => {
+  it("returns null for empty and non-team routes", () => {
+    expect(parseTeamRoute(null)).toBeNull();
+    expect(parseTeamRoute("/org/acme/teams")).toBeNull();
+    expect(parseTeamRoute("/org/acme/projects/proj_1")).toBeNull();
+  });
+
+  it("parses team detail routes", () => {
+    expect(parseTeamRoute("/org/acme/teams/team_1")).toEqual({
+      organizationSlug: "acme",
+      teamId: "team_1",
+    });
+    expect(parseTeamRoute("/en/org/acme/teams/team_1")).toEqual({
+      organizationSlug: "acme",
+      teamId: "team_1",
+    });
+  });
+});
+
+describe("parseDomainRoute", () => {
+  it("returns null for empty and non-domain routes", () => {
+    expect(parseDomainRoute(null)).toBeNull();
+    expect(parseDomainRoute("/org/acme/domains")).toBeNull();
+    expect(parseDomainRoute("/org/acme/projects/proj_1")).toBeNull();
+  });
+
+  it("parses domain detail routes", () => {
+    expect(parseDomainRoute("/org/acme/domains/ld_1")).toEqual({
+      organizationSlug: "acme",
+      linkedDomainId: "ld_1",
+    });
+    expect(parseDomainRoute("/en/org/acme/domains/ld_1")).toEqual({
+      organizationSlug: "acme",
+      linkedDomainId: "ld_1",
+    });
+  });
+});
+
+describe("buildTeamPath", () => {
+  it("encodes team ids in the path", () => {
+    expect(buildTeamPath("acme", "team_1")).toBe("/org/acme/teams/team_1");
+  });
+});
+
+describe("buildDomainPath", () => {
+  it("encodes linked domain ids in the path", () => {
+    expect(buildDomainPath("acme", "ld_1")).toBe("/org/acme/domains/ld_1");
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -79,6 +79,14 @@ export function buildProjectPath(organizationSlug: string, projectId: string, se
   return section ? `${base}/${section}` : base;
 }
 
+export function buildTeamPath(organizationSlug: string, teamId: string) {
+  return `/org/${organizationSlug}/teams/${encodeURIComponent(teamId)}`;
+}
+
+export function buildDomainPath(organizationSlug: string, linkedDomainId: string) {
+  return `/org/${organizationSlug}/domains/${encodeURIComponent(linkedDomainId)}`;
+}
+
 export function buildAutomationsPath(
   organizationSlug: string,
   options?: {
@@ -455,6 +463,34 @@ export function parseProjectRoute(pathname: string | null) {
     organizationSlug,
     projectId: decodePathSegment(projectIdSegment),
     section,
+  };
+}
+
+export function parseTeamRoute(pathname: string | null) {
+  if (!pathname) return null;
+
+  const match = stripAppLocalePrefix(pathname).match(/^\/org\/([^/]+)\/teams\/([^/]+)$/);
+  if (!match) return null;
+
+  const [, organizationSlug, teamIdSegment] = match;
+
+  return {
+    organizationSlug,
+    teamId: decodePathSegment(teamIdSegment),
+  };
+}
+
+export function parseDomainRoute(pathname: string | null) {
+  if (!pathname) return null;
+
+  const match = stripAppLocalePrefix(pathname).match(/^\/org\/([^/]+)\/domains\/([^/]+)$/);
+  if (!match) return null;
+
+  const [, organizationSlug, linkedDomainIdSegment] = match;
+
+  return {
+    organizationSlug,
+    linkedDomainId: decodePathSegment(linkedDomainIdSegment),
   };
 }
 

--- a/apps/hyperlocalise-web/src/components/app-shell/project-breadcrumb-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/project-breadcrumb-selector.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
+
+import { apiClient } from "@/lib/api-client-instance";
+import { readApiResponseError } from "@/lib/api-error";
+
+import { BreadcrumbCrumbSelector } from "./breadcrumb-crumb-selector";
+import { breadcrumbCrumbSelectorMessages as messages } from "./breadcrumb-crumb-selector.messages";
+import { buildProjectPath } from "./navigation-config";
+
+const organizationProjectsQueryKey = (organizationSlug: string) =>
+  ["translation-projects", organizationSlug, "breadcrumb"] as const;
+
+type ProjectBreadcrumbSelectorProps = {
+  organizationSlug: string;
+  projectId: string;
+  projectName: string;
+  section: string | null;
+  isLast?: boolean;
+};
+
+export function ProjectBreadcrumbSelector({
+  organizationSlug,
+  projectId,
+  projectName,
+  section,
+  isLast = false,
+}: ProjectBreadcrumbSelectorProps) {
+  const intl = useIntl();
+  const router = useRouter();
+  const projectsQuery = useQuery({
+    queryKey: organizationProjectsQueryKey(organizationSlug),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+
+      if (response.status !== 200) {
+        throw await readApiResponseError(response, intl.formatMessage(messages.projectsLoadError));
+      }
+
+      const body = await response.json();
+      return body.projects.map((project) => ({
+        value: project.id,
+        label: project.name,
+      }));
+    },
+  });
+
+  function handleSelect(nextProjectId: string) {
+    if (nextProjectId === projectId) {
+      return;
+    }
+
+    const nextPath = section
+      ? buildProjectPath(organizationSlug, nextProjectId, section)
+      : buildProjectPath(organizationSlug, nextProjectId);
+    router.push(nextPath);
+  }
+
+  return (
+    <BreadcrumbCrumbSelector
+      value={projectId}
+      label={projectName}
+      options={projectsQuery.data ?? []}
+      onSelect={handleSelect}
+      isLoading={projectsQuery.isPending}
+      isError={projectsQuery.isError}
+      menuLabel={intl.formatMessage(messages.switchProject)}
+      isLast={isLast}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/breadcrumb-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/breadcrumb-store.ts
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import { makeAutoObservable } from "mobx";
+import type { ReactNode } from "react";
 
 import type { AppShellBreadcrumb } from "@/components/app-shell/app-shell-title";
 
@@ -20,6 +21,8 @@ export type BreadcrumbOverride = {
   matchSegment?: string;
   label: string;
   href?: string;
+  isLoading?: boolean;
+  render?: () => ReactNode;
 };
 
 export type BreadcrumbAppend = {
@@ -27,6 +30,8 @@ export type BreadcrumbAppend = {
   label: string;
   href?: string;
   title?: string;
+  isLoading?: boolean;
+  render?: () => ReactNode;
 };
 
 export class BreadcrumbStore {
@@ -65,6 +70,8 @@ export class BreadcrumbStore {
           return {
             label: override.label,
             href: override.href ?? crumb.href,
+            isLoading: override.isLoading,
+            render: override.render ?? crumb.render,
           };
         }
 
@@ -75,6 +82,8 @@ export class BreadcrumbStore {
             return {
               label: override.label,
               href: override.href ?? crumb.href,
+              isLoading: override.isLoading,
+              render: override.render ?? crumb.render,
             };
           }
         }
@@ -87,6 +96,8 @@ export class BreadcrumbStore {
       label: append.label,
       href: append.href,
       title: append.title,
+      isLoading: append.isLoading,
+      render: append.render,
     }));
 
     return [...overridden, ...appended];

--- a/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-breadcrumb.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-breadcrumb.ts
@@ -12,7 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import type { ReactNode } from "react";
 
 import type { BreadcrumbAppend, BreadcrumbOverride } from "./breadcrumb-store";
 import { useAppShellStore } from "./app-shell-store-context";
@@ -21,34 +22,57 @@ type BreadcrumbOverrideConfig = Omit<BreadcrumbOverride, "id"> & { id: string };
 type BreadcrumbAppendConfig = Omit<BreadcrumbAppend, "id" | "label"> & {
   id: string;
   label?: string;
+  isLoading?: boolean;
+  render?: () => ReactNode;
 };
 
 export function useAppShellBreadcrumbOverride(config: BreadcrumbOverrideConfig) {
   const store = useAppShellStore();
-  const { id, index, matchSegment, label, href } = config;
+  const renderRef = useRef(config.render);
+  renderRef.current = config.render;
+  const { id, index, matchSegment, label, href, isLoading } = config;
+  const hasRender = Boolean(config.render);
 
   useEffect(() => {
-    store.breadcrumb.registerOverride({ id, index, matchSegment, label, href });
+    store.breadcrumb.registerOverride({
+      id,
+      index,
+      matchSegment,
+      label,
+      href,
+      isLoading,
+      render: hasRender ? () => renderRef.current?.() : undefined,
+    });
 
     return () => {
       store.breadcrumb.unregisterOverride(id);
     };
-  }, [store, id, index, matchSegment, label, href]);
+  }, [store, id, index, matchSegment, label, href, isLoading, hasRender]);
 }
 
 export function useAppShellBreadcrumbAppend(config: BreadcrumbAppendConfig) {
   const store = useAppShellStore();
-  const { id, label, href, title } = config;
+  const renderRef = useRef(config.render);
+  renderRef.current = config.render;
+  const { id, label, href, title, isLoading } = config;
+  const hasRender = Boolean(config.render);
 
   useEffect(() => {
-    if (label === undefined) {
+    if (label === undefined && !isLoading && !hasRender) {
       return;
     }
 
-    store.breadcrumb.registerAppend({ id, label, href, title });
+    store.breadcrumb.registerAppend({
+      id,
+      label: label ?? "",
+      href,
+      title,
+      isLoading,
+      render: hasRender ? () => renderRef.current?.() : undefined,
+    });
 
     return () => {
       store.breadcrumb.unregisterAppend(id);
     };
-  }, [store, id, label, href, title]);
+  }, [store, id, label, href, title, isLoading, hasRender]);
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/team-breadcrumb-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/team-breadcrumb-selector.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
+
+import { apiClient } from "@/lib/api-client-instance";
+import { readApiResponseError } from "@/lib/api-error";
+
+import { BreadcrumbCrumbSelector } from "./breadcrumb-crumb-selector";
+import { breadcrumbCrumbSelectorMessages as messages } from "./breadcrumb-crumb-selector.messages";
+import { buildTeamPath } from "./navigation-config";
+
+const organizationTeamsQueryKey = (organizationSlug: string) =>
+  ["workspace-teams", organizationSlug, "breadcrumb"] as const;
+
+type TeamBreadcrumbSelectorProps = {
+  organizationSlug: string;
+  teamId: string;
+  teamName: string;
+  isLast?: boolean;
+};
+
+export function TeamBreadcrumbSelector({
+  organizationSlug,
+  teamId,
+  teamName,
+  isLast = false,
+}: TeamBreadcrumbSelectorProps) {
+  const intl = useIntl();
+  const router = useRouter();
+  const teamsQuery = useQuery({
+    queryKey: organizationTeamsQueryKey(organizationSlug),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].teams.$get({
+        param: { organizationSlug },
+      });
+
+      if (!response.ok) {
+        throw await readApiResponseError(response, intl.formatMessage(messages.teamsLoadError));
+      }
+
+      const body = await response.json();
+      return body.teams.map((team) => ({
+        value: team.id,
+        label: team.name,
+      }));
+    },
+  });
+
+  function handleSelect(nextTeamId: string) {
+    if (nextTeamId === teamId) {
+      return;
+    }
+
+    router.push(buildTeamPath(organizationSlug, nextTeamId));
+  }
+
+  return (
+    <BreadcrumbCrumbSelector
+      value={teamId}
+      label={teamName}
+      options={teamsQuery.data ?? []}
+      onSelect={handleSelect}
+      isLoading={teamsQuery.isPending}
+      isError={teamsQuery.isError}
+      menuLabel={intl.formatMessage(messages.switchTeam)}
+      isLast={isLast}
+    />
+  );
+}


### PR DESCRIPTION
## What changed

App shell breadcrumbs now show loading skeletons instead of raw entity IDs while data is fetched, and expose dropdown switchers for projects, teams, and domains when multiple items are available.

- Add `BreadcrumbCrumbSelector` plus project/team/domain selector components
- Extend MobX `BreadcrumbStore` with `isLoading` and `render` slots for custom selectors
- Add route parsers/builders for team and domain detail pages

## How to test

1. Open a project detail page (e.g. `/org/{org}/projects/{id}/files`) and confirm the project crumb shows a skeleton while loading, then a dropdown when multiple projects exist.
2. Open a team detail page (`/org/{org}/teams/{id}`) and confirm the team name loads with a switcher dropdown.
3. Open a domain detail page (`/org/{org}/domains/{id}`) and confirm the domain key loads with a switcher dropdown.
4. Run `cd apps/hyperlocalise-web && vp test src/components/app-shell/` and `vp check`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review