### PR TITLE
feat(web): move header prefs to account menu and add app shell stories

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor-page-content.tsx
@@ -19,6 +19,7 @@ import { FormattedMessage } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
 import { fromVisualWorkflowDefinition } from "@/lib/visual-workflows/schema/serializers";
 import type { VisualWorkflowDefinition } from "@/lib/visual-workflows/schema/types";
 import type { VisualWorkflowRecord } from "@/lib/visual-workflows/visual-workflow-types";
@@ -39,6 +40,7 @@ export function VisualWorkflowEditorPageContent({
   visualWorkflowsApi?: VisualWorkflowsApi;
 }) {
   const router = useRouter();
+  useAppShellSidebar({ forceCollapsed: true });
   const editorState = fromVisualWorkflowDefinition({
     ...workflow.definition,
     name: workflow.name,

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -27,8 +27,6 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/primitives/cn";
-import LocaleToggle from "@/components/locale-toggle/locale-toggle";
-import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 import { AppShellBreadcrumb } from "./app-shell-breadcrumb";
 import { AppShellNavigation } from "./app-shell-navigation";
 import { TmsUserConnectButton } from "./tms-user-connect-button";
@@ -169,16 +167,17 @@ export function AppShellClient({
                     connectMethod={resolvedTmsUserConnectCta.connectMethod}
                   />
                 ) : null}
-                <LocaleToggle />
-                <ThemeToggle />
                 <NavUser
-                  organizationName={activeOrganization.name}
                   organizationSlug={activeOrganization.slug ?? ""}
                   organizations={organizations}
                   showApiKeysLink={showApiKeysLink}
                   showBillingLink={showBillingLink}
                   showMembersLink={showMembersLink}
-                  user={{ name: user.name, avatar: user.avatarUrl ?? "" }}
+                  user={{
+                    name: user.name,
+                    email: user.email,
+                    avatar: user.avatarUrl ?? "",
+                  }}
                 />
               </div>
             </div>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
@@ -16,6 +16,10 @@ import { expect, fn, userEvent, within } from "storybook/test";
 
 import { AppShellStoreProvider } from "@/components/app-shell/store/app-shell-store-context";
 import {
+  APP_SHELL_STORY_ORGANIZATION_SLUG,
+  appShellStoryUser,
+} from "@/components/app-shell/app-shell.stories.fixture";
+import {
   CAT_ISSUE_GUIDANCE_OPEN_EVENT,
   EMPTY_CAT_ISSUE_GUIDANCE_STATUS,
   setCatIssueGuidanceStatus,
@@ -27,13 +31,12 @@ import {
   type ContentEditorGlossaryGuidanceStatus,
 } from "@/components/content-editor/intelligence/content-editor-glossary-guidance-event";
 
-import type { InboxCurrentUser } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
 import { AppShellFooter } from "./app-shell-footer";
 
-const currentUser: InboxCurrentUser = {
+const currentUser = {
   avatarUrl: null,
-  email: "storybook@example.com",
-  name: "Storybook User",
+  email: appShellStoryUser.email,
+  name: appShellStoryUser.name,
 };
 
 function FooterStoryFrame({ children }: { children: ReactNode }) {
@@ -104,7 +107,7 @@ const meta = {
     ),
   ],
   args: {
-    organizationSlug: "acme",
+    organizationSlug: APP_SHELL_STORY_ORGANIZATION_SLUG,
     showPlan: false,
     showGlossaryGuidance: false,
     showIssueGuidance: false,

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-header.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-header.stories.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import {
+  APP_SHELL_STORY_ORGANIZATION_SLUG,
+  APP_SHELL_STORY_PROJECT_ID,
+  AppShellHeaderActionDemo,
+  AppShellHeaderStoryFrame,
+  appShellStoryUser,
+} from "./app-shell.stories.fixture";
+
+const meta = {
+  title: "App Shell/Header",
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/dashboard`,
+      },
+    },
+  },
+  render: () => <AppShellHeaderStoryFrame />,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DashboardBreadcrumb: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("navigation", { name: "breadcrumb" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /Account/i })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Save changes" })).not.toBeInTheDocument();
+  },
+};
+
+export const ProjectBreadcrumb: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/projects/${APP_SHELL_STORY_PROJECT_ID}/settings`,
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Settings")).toBeInTheDocument();
+    await expect(canvas.getByText(APP_SHELL_STORY_PROJECT_ID)).toBeInTheDocument();
+  },
+};
+
+export const WithHeaderAction: Story = {
+  render: () => (
+    <AppShellHeaderStoryFrame>
+      <AppShellHeaderActionDemo />
+    </AppShellHeaderStoryFrame>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeInTheDocument();
+  },
+};
+
+export const WithTmsConnect: Story = {
+  render: () => <AppShellHeaderStoryFrame showTmsConnect />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: /Connect Crowdin/i })).toBeInTheDocument();
+  },
+};
+
+export const AccountMenu: Story = {
+  play: async ({ canvas }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /Account/i }));
+
+    const menu = within(document.body);
+    await expect(menu.getByText(appShellStoryUser.email)).toBeInTheDocument();
+    await expect(menu.getByRole("menuitem", { name: "Members" })).toBeInTheDocument();
+    await expect(menu.getByRole("menuitem", { name: "Billing" })).toBeInTheDocument();
+    await expect(menu.getByRole("menuitem", { name: "Log out" })).toBeInTheDocument();
+  },
+};
+
+export const SwitchWorkspaceMenu: Story = {
+  play: async ({ canvas }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /Account/i }));
+
+    const menu = within(document.body);
+    await userEvent.click(menu.getByRole("menuitem", { name: "Switch workspace" }));
+
+    await expect(menu.getByText("Workspaces")).toBeInTheDocument();
+    await expect(menu.getByRole("menuitem", { name: "Acme Localization" })).toBeInTheDocument();
+    await expect(menu.getByRole("menuitem", { name: "Beta Workspace" })).toBeInTheDocument();
+    await expect(menu.getByRole("menuitem", { name: "View all workspaces" })).toBeInTheDocument();
+  },
+};
+
+export const MemberMenu: Story = {
+  render: () => <AppShellHeaderStoryFrame showAdminLinks={false} />,
+  play: async ({ canvas }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /Account/i }));
+
+    const menu = within(document.body);
+    await expect(menu.getByRole("menuitem", { name: "Account" })).toBeInTheDocument();
+    await expect(menu.queryByRole("menuitem", { name: "Members" })).not.toBeInTheDocument();
+    await expect(menu.queryByRole("menuitem", { name: "Billing" })).not.toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-sidebar.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-sidebar.stories.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent } from "storybook/test";
+
+import {
+  APP_SHELL_STORY_ORGANIZATION_SLUG,
+  APP_SHELL_STORY_PROJECT_ID,
+  AppShellSidebarStoryFrame,
+} from "./app-shell.stories.fixture";
+
+const meta = {
+  title: "App Shell/Sidebar",
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/dashboard`,
+      },
+    },
+  },
+  render: () => <AppShellSidebarStoryFrame />,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const GlobalNavigation: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("link", { name: "Overview" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Inbox" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Automations" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Projects" })).toBeInTheDocument();
+  },
+};
+
+export const InboxActive: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/inbox`,
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    const inboxLink = canvas.getByRole("link", { name: "Inbox" });
+    await expect(inboxLink.querySelector("[data-active]")).toBeTruthy();
+  },
+};
+
+export const ProjectNavigation: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/projects/${APP_SHELL_STORY_PROJECT_ID}/files`,
+      },
+    },
+  },
+  render: () => <AppShellSidebarStoryFrame variant="project" />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Website localization")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "All projects" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Files" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Overview" })).toBeInTheDocument();
+  },
+};
+
+export const Collapsed: Story = {
+  render: () => <AppShellSidebarStoryFrame collapsed />,
+  play: async () => {
+    const sidebar = document.querySelector('[data-slot="sidebar"]');
+    await expect(sidebar).toHaveAttribute("data-state", "collapsed");
+    await expect(sidebar).toHaveAttribute("data-collapsible", "icon");
+  },
+};
+
+export const ToggleCollapse: Story = {
+  play: async ({ canvas }) => {
+    const trigger = canvas.getByRole("button", { name: "Collapse Sidebar" });
+    await userEvent.click(trigger);
+
+    const sidebar = document.querySelector('[data-slot="sidebar"]');
+    await expect(sidebar).toHaveAttribute("data-state", "collapsed");
+
+    await userEvent.click(canvas.getByRole("button", { name: "Expand Sidebar" }));
+    await expect(sidebar).toHaveAttribute("data-state", "expanded");
+  },
+};

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.fixture.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.fixture.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { type CSSProperties, type ReactNode } from "react";
+import Image from "next/image";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarInset,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { Separator } from "@/components/ui/separator";
+import { TypographyP } from "@/components/ui/typography";
+import { getIntlShape } from "@/lib/app-i18n/intl";
+import { annotateNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
+import type { WorkspaceFeatureFlagState } from "@/lib/flags/workos-flag-entities";
+import type { TmsUserConnectCta } from "@/lib/providers/credentials/tms-user-connection-shared";
+
+import { appShellClientMessages } from "./app-shell-client.messages";
+import { AppShellClient } from "./app-shell-client";
+import { AppShellBreadcrumb } from "./app-shell-breadcrumb";
+import { AppShellNavigation } from "./app-shell-navigation";
+import { buildGlobalNavigationGroups, buildProjectNavigationItems } from "./navigation-config";
+import { NavUser } from "./nav-user";
+import { AppShellHeaderActions } from "./store/app-shell-header-actions";
+import { AppShellStoreProvider } from "./store/app-shell-store-context";
+import { SidebarStoreBridge } from "./store/sidebar-store-bridge";
+import { useAppShellHeaderAction } from "./store/use-app-shell-header-action";
+import { useAppShellNavigationCustom } from "./store/use-app-shell-navigation";
+import { TmsUserConnectButton } from "./tms-user-connect-button";
+
+export const APP_SHELL_STORY_ORGANIZATION_SLUG = "acme";
+export const APP_SHELL_STORY_PROJECT_ID = "project_website";
+
+export const appShellStoryUser = {
+  name: "Minh Cung",
+  email: "minh.cung@example.com",
+  avatarUrl: undefined,
+};
+
+export const appShellStoryOrganizations = [
+  { name: "Acme Localization", slug: APP_SHELL_STORY_ORGANIZATION_SLUG },
+  { name: "Beta Workspace", slug: "beta" },
+] as const;
+
+export const appShellStoryTmsConnectCta: TmsUserConnectCta = {
+  showConnectCta: true,
+  providerKind: "crowdin",
+  providerDisplayName: "Crowdin",
+  connectMethod: "oauth",
+};
+
+export const ALL_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
+  automations: true,
+  knowledge: true,
+  visualMock: true,
+  visualWorkflows: true,
+  domains: true,
+  glossarySearch: true,
+  hyperlab: true,
+};
+
+export function buildAppShellStoryNavigationGroups(locale: string = "en") {
+  const intl = getIntlShape(locale) as IntlShape;
+  return annotateNavigationByWorkspaceFlags(
+    buildGlobalNavigationGroups(APP_SHELL_STORY_ORGANIZATION_SLUG, intl),
+    ALL_WORKSPACE_FEATURE_FLAGS,
+  );
+}
+
+export function buildAppShellStoryProjectNavigationGroups(locale: string = "en") {
+  const intl = getIntlShape(locale) as IntlShape;
+  return [
+    {
+      items: buildProjectNavigationItems(
+        APP_SHELL_STORY_ORGANIZATION_SLUG,
+        APP_SHELL_STORY_PROJECT_ID,
+        intl,
+      ),
+    },
+  ];
+}
+
+const appShellStoryLayoutStyle = {
+  "--app-shell-content-height":
+    "calc(100svh - var(--app-shell-header-height) - var(--app-shell-footer-height))",
+  "--app-shell-plan-footer-height": "calc(3rem + env(safe-area-inset-bottom))",
+  "--app-shell-footer-height":
+    "calc(var(--app-shell-plan-footer-height) + var(--app-shell-dock-height, 0px))",
+  "--sidebar-width": "15rem",
+} as CSSProperties;
+
+export function AppShellStoryPlaceholder() {
+  return (
+    <div className="rounded-2xl border border-dashed border-border bg-muted/20 p-8">
+      <p className="text-sm text-muted-foreground">
+        Page content renders in this area. Use the shell chrome around it to preview navigation,
+        header actions, and footer states.
+      </p>
+    </div>
+  );
+}
+
+type AppShellStoryFrameProps = {
+  children?: ReactNode;
+  navigationGroups?: ReturnType<typeof buildAppShellStoryNavigationGroups>;
+  showApiKeysLink?: boolean;
+  showBillingLink?: boolean;
+  showMembersLink?: boolean;
+  autumnConfigured?: boolean;
+  tmsUserConnectCta?: TmsUserConnectCta;
+};
+
+export function AppShellStoryFrame({
+  children,
+  navigationGroups = buildAppShellStoryNavigationGroups(),
+  showApiKeysLink = true,
+  showBillingLink = true,
+  showMembersLink = true,
+  autumnConfigured = false,
+  tmsUserConnectCta = { showConnectCta: false },
+}: AppShellStoryFrameProps) {
+  return (
+    <AppShellClient
+      activeOrganization={{
+        name: "Acme Localization",
+        slug: APP_SHELL_STORY_ORGANIZATION_SLUG,
+      }}
+      navigationGroups={navigationGroups}
+      organizations={[...appShellStoryOrganizations]}
+      showApiKeysLink={showApiKeysLink}
+      showBillingLink={showBillingLink}
+      showMembersLink={showMembersLink}
+      autumnConfigured={autumnConfigured}
+      tmsUserConnectCta={tmsUserConnectCta}
+      user={appShellStoryUser}
+      workspaceFeatureFlags={ALL_WORKSPACE_FEATURE_FLAGS}
+    >
+      {children ?? <AppShellStoryPlaceholder />}
+    </AppShellClient>
+  );
+}
+
+function AppShellHeaderStoryBar({
+  showTmsConnect = false,
+  showAdminLinks = true,
+}: {
+  showTmsConnect?: boolean;
+  showAdminLinks?: boolean;
+}) {
+  return (
+    <div className="sticky top-0 z-20 shrink-0 border-b border-border bg-background/96 backdrop-blur">
+      <div className="flex h-(--app-shell-header-height) items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
+        <div className="flex min-w-0 items-center gap-3">
+          <SidebarTrigger className="-ms-1" />
+          <Separator
+            orientation="vertical"
+            className="me-2 data-vertical:h-4 data-vertical:self-auto"
+          />
+          <AppShellBreadcrumb organizationSlug={APP_SHELL_STORY_ORGANIZATION_SLUG} />
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <AppShellHeaderActions />
+          {showTmsConnect ? (
+            <TmsUserConnectButton
+              organizationSlug={APP_SHELL_STORY_ORGANIZATION_SLUG}
+              providerKind="crowdin"
+              providerDisplayName="Crowdin"
+              connectMethod="oauth"
+            />
+          ) : null}
+          <NavUser
+            organizationSlug={APP_SHELL_STORY_ORGANIZATION_SLUG}
+            organizations={[...appShellStoryOrganizations]}
+            showApiKeysLink={showAdminLinks}
+            showBillingLink={showAdminLinks}
+            showMembersLink={showAdminLinks}
+            user={{
+              name: appShellStoryUser.name,
+              email: appShellStoryUser.email,
+              avatar: appShellStoryUser.avatarUrl ?? "",
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AppShellHeaderStoryFrame({
+  children,
+  showTmsConnect = false,
+  showAdminLinks = true,
+}: {
+  children?: ReactNode;
+  showTmsConnect?: boolean;
+  showAdminLinks?: boolean;
+}) {
+  return (
+    <AppShellStoreProvider defaultNavigationGroups={buildAppShellStoryNavigationGroups()}>
+      <SidebarProvider
+        defaultOpen
+        style={appShellStoryLayoutStyle}
+        className="min-h-[16rem] bg-background"
+      >
+        <SidebarStoreBridge />
+        <Sidebar variant="sidebar" collapsible="icon" className="hidden" />
+        <SidebarInset className="min-h-[16rem] bg-background">
+          <AppShellHeaderStoryBar showTmsConnect={showTmsConnect} showAdminLinks={showAdminLinks} />
+          <div className="px-4 py-5 sm:px-6 lg:px-8">
+            {children ?? <AppShellStoryPlaceholder />}
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </AppShellStoreProvider>
+  );
+}
+
+function ProjectSidebarStorySetup() {
+  useAppShellNavigationCustom({
+    groups: buildAppShellStoryProjectNavigationGroups(),
+    projectContext: {
+      organizationSlug: APP_SHELL_STORY_ORGANIZATION_SLUG,
+      projectId: APP_SHELL_STORY_PROJECT_ID,
+      projectName: "Website localization",
+    },
+  });
+
+  return null;
+}
+
+export function AppShellSidebarStoryFrame({
+  collapsed = false,
+  variant = "global",
+}: {
+  collapsed?: boolean;
+  variant?: "global" | "project";
+}) {
+  const intl = useIntl();
+
+  return (
+    <AppShellStoreProvider defaultNavigationGroups={buildAppShellStoryNavigationGroups()}>
+      <SidebarProvider
+        defaultOpen={!collapsed}
+        style={appShellStoryLayoutStyle}
+        className="min-h-[36rem] rounded-2xl border bg-background text-foreground"
+      >
+        <SidebarStoreBridge />
+        {variant === "project" ? <ProjectSidebarStorySetup /> : null}
+        <Sidebar variant="sidebar" collapsible="icon">
+          <SidebarHeader className="gap-3 border-b border-sidebar-border px-3 py-3 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-0">
+            <div className="flex items-center gap-2.5 rounded-xl px-1 py-1 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+              <Image
+                src="/images/logo.png"
+                width={28}
+                height={28}
+                sizes="28px"
+                alt={intl.formatMessage(appShellClientMessages.logoAlt)}
+                className="size-7 shrink-0 rounded-lg"
+              />
+              <div className="min-w-0 group-data-[collapsible=icon]:hidden">
+                <TypographyP
+                  className="text-sidebar-foreground"
+                  lineClamp={1}
+                  size="small"
+                  weight="medium"
+                >
+                  <FormattedMessage {...appShellClientMessages.brandName} />
+                </TypographyP>
+              </div>
+            </div>
+          </SidebarHeader>
+          <SidebarContent className="gap-0 px-2 pt-2">
+            <AppShellNavigation organizationSlug={APP_SHELL_STORY_ORGANIZATION_SLUG} />
+          </SidebarContent>
+          <SidebarRail />
+        </Sidebar>
+        <SidebarInset className="p-6">
+          <SidebarTrigger />
+          <p className="mt-4 text-sm text-muted-foreground">
+            Sidebar preview. Toggle collapse with the trigger above or the rail on the left.
+          </p>
+        </SidebarInset>
+      </SidebarProvider>
+    </AppShellStoreProvider>
+  );
+}
+
+export function AppShellHeaderActionDemo() {
+  useAppShellHeaderAction({
+    id: "storybook-save",
+    render: () => (
+      <Button size="sm" type="button">
+        Save changes
+      </Button>
+    ),
+  });
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import {
+  APP_SHELL_STORY_ORGANIZATION_SLUG,
+  APP_SHELL_STORY_PROJECT_ID,
+  AppShellHeaderActionDemo,
+  AppShellStoryFrame,
+  appShellStoryTmsConnectCta,
+  appShellStoryUser,
+} from "./app-shell.stories.fixture";
+
+const meta = {
+  title: "App Shell/Shell",
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/dashboard`,
+      },
+    },
+  },
+  render: () => <AppShellStoryFrame />,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WorkspaceDashboard: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: /Account/i })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Email support" })).toBeInTheDocument();
+    await expect(canvas.getByText("Overview")).toBeInTheDocument();
+  },
+};
+
+export const ProjectSettings: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/projects/${APP_SHELL_STORY_PROJECT_ID}/settings`,
+      },
+    },
+  },
+  render: () => (
+    <AppShellStoryFrame>
+      <AppShellHeaderActionDemo />
+    </AppShellStoryFrame>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeInTheDocument();
+    await expect(canvas.getByText("Settings")).toBeInTheDocument();
+  },
+};
+
+export const TmsConnectPrompt: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/dashboard`,
+      },
+    },
+  },
+  render: () => <AppShellStoryFrame tmsUserConnectCta={appShellStoryTmsConnectCta} />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: /Connect Crowdin/i })).toBeInTheDocument();
+  },
+};
+
+export const ContentEditorFooter: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/projects/${APP_SHELL_STORY_PROJECT_ID}/strings`,
+      },
+    },
+  },
+  render: () => (
+    <AppShellStoryFrame autumnConfigured showBillingLink>
+      <p className="text-sm text-muted-foreground">
+        Content editor routes enable glossary and issue guidance controls in the footer.
+      </p>
+    </AppShellStoryFrame>
+  ),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("button", { name: "Open glossary guidance" }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Open board" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /Open plan usage:/i })).toBeInTheDocument();
+  },
+};
+
+export const LimitedAdminMenu: Story = {
+  render: () => (
+    <AppShellStoryFrame showApiKeysLink={false} showBillingLink={false} showMembersLink={false} />
+  ),
+  play: async ({ canvas, userEvent: storyUserEvent }) => {
+    await storyUserEvent.click(canvas.getByRole("button", { name: /Account/i }));
+
+    const menu = within(document.body);
+    await expect(menu.getByRole("menuitem", { name: "Account" })).toBeInTheDocument();
+    await expect(menu.queryByRole("menuitem", { name: "Members" })).not.toBeInTheDocument();
+    await expect(menu.queryByRole("menuitem", { name: "Billing" })).not.toBeInTheDocument();
+  },
+};
+
+export const AccountMenuOpen: Story = {
+  play: async ({ canvas }) => {
+    const accountButton = canvas.getByRole("button", { name: /Account/i });
+    await userEvent.click(accountButton);
+
+    const menu = within(document.body);
+    await expect(menu.getByText(appShellStoryUser.name)).toBeInTheDocument();
+    await expect(menu.getByText(appShellStoryUser.email)).toBeInTheDocument();
+    await expect(menu.getByRole("radio", { name: "Light" })).toBeInTheDocument();
+    await expect(menu.getByRole("radio", { name: "Dark" })).toBeInTheDocument();
+    await expect(menu.getByRole("radio", { name: "System" })).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
@@ -43,6 +43,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import LocaleToggle from "@/components/locale-toggle/locale-toggle";
 import ThemeToggle from "@/components/theme-toggle/theme-toggle";
+import { localeToggleMessages } from "@/components/locale-toggle/locale-toggle.messages";
+import { themeToggleMessages } from "@/components/theme-toggle/theme-toggle.messages";
 import { buildOrganizationSwitchHref } from "@/components/team-switcher";
 import { buildPlanUsageHref } from "@/lib/billing/plan-usage";
 
@@ -131,12 +133,18 @@ export function NavUser({
             </div>
           </DropdownMenuLabel>
         </DropdownMenuGroup>
-        <div className="px-1 py-1">
-          <div className="flex flex-col gap-1 rounded-lg bg-muted p-1">
-            <ThemeToggle variant="menu" />
-            <LocaleToggle variant="menu" />
-          </div>
-        </div>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            <FormattedMessage {...themeToggleMessages.changeTheme} />
+          </DropdownMenuLabel>
+          <ThemeToggle variant="menu" />
+        </DropdownMenuGroup>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            <FormattedMessage {...localeToggleMessages.changeLanguage} />
+          </DropdownMenuLabel>
+          <LocaleToggle variant="menu" />
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuItem render={<Link href={`/org/${organizationSlug}/settings/account`} />}>

--- a/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
@@ -41,6 +41,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import LocaleToggle from "@/components/locale-toggle/locale-toggle";
+import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 import { buildOrganizationSwitchHref } from "@/components/team-switcher";
 import { buildPlanUsageHref } from "@/lib/billing/plan-usage";
 
@@ -52,7 +54,6 @@ type OrganizationOption = {
 };
 
 export function NavUser({
-  organizationName,
   organizationSlug,
   organizations,
   showApiKeysLink = false,
@@ -60,7 +61,6 @@ export function NavUser({
   showMembersLink = false,
   user,
 }: {
-  organizationName: string;
   organizationSlug: string;
   organizations: OrganizationOption[];
   showApiKeysLink?: boolean;
@@ -68,6 +68,7 @@ export function NavUser({
   showMembersLink?: boolean;
   user: {
     name: string;
+    email: string;
     avatar: string;
   };
 }) {
@@ -115,21 +116,27 @@ export function NavUser({
           <FormattedMessage {...navUserMessages.accountTooltip} />
         </TooltipContent>
       </Tooltip>
-      <DropdownMenuContent className="min-w-56 rounded-lg" side="bottom" align="end" sideOffset={4}>
+      <DropdownMenuContent className="min-w-64 rounded-lg" side="bottom" align="end" sideOffset={4}>
         <DropdownMenuGroup>
           <DropdownMenuLabel className="p-0 font-normal">
             <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-              <Avatar className="h-8 w-8 rounded-lg">
+              <Avatar className="size-8 rounded-full">
                 <AvatarImage src={user.avatar} alt={user.name} />
-                <AvatarFallback className="rounded-lg">{initials}</AvatarFallback>
+                <AvatarFallback className="rounded-full">{initials}</AvatarFallback>
               </Avatar>
-              <div className="grid flex-1 text-left text-sm leading-tight">
+              <div className="grid min-w-0 flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{user.name}</span>
-                <span className="truncate text-xs text-muted-foreground">{organizationName}</span>
+                <span className="truncate text-xs text-muted-foreground">{user.email}</span>
               </div>
             </div>
           </DropdownMenuLabel>
         </DropdownMenuGroup>
+        <div className="px-1 py-1">
+          <div className="flex flex-col gap-1 rounded-lg bg-muted p-1">
+            <ThemeToggle variant="menu" />
+            <LocaleToggle variant="menu" />
+          </div>
+        </div>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuItem render={<Link href={`/org/${organizationSlug}/settings/account`} />}>
@@ -164,37 +171,39 @@ export function NavUser({
                 <FormattedMessage {...navUserMessages.switchWorkspace} />
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="min-w-56">
-                <DropdownMenuLabel className="text-xs text-muted-foreground">
-                  <FormattedMessage {...navUserMessages.workspaces} />
-                </DropdownMenuLabel>
-                {switchableOrganizations.map((organization) => {
-                  const isActive = organization.slug === organizationSlug;
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel className="text-xs text-muted-foreground">
+                    <FormattedMessage {...navUserMessages.workspaces} />
+                  </DropdownMenuLabel>
+                  {switchableOrganizations.map((organization) => {
+                    const isActive = organization.slug === organizationSlug;
 
-                  return (
-                    <DropdownMenuItem
-                      key={organization.slug}
-                      className="gap-2 p-2"
-                      render={
-                        <Link
-                          href={buildOrganizationSwitchHref(
-                            organization.slug,
-                            pathname,
-                            organizationSlug,
-                          )}
-                        />
-                      }
-                    >
-                      <span className="flex-1 truncate">{organization.name}</span>
-                      {isActive ? (
-                        <HugeiconsIcon
-                          icon={CheckmarkCircle01Icon}
-                          strokeWidth={1.8}
-                          className="size-4 text-bud-400"
-                        />
-                      ) : null}
-                    </DropdownMenuItem>
-                  );
-                })}
+                    return (
+                      <DropdownMenuItem
+                        key={organization.slug}
+                        className="gap-2 p-2"
+                        render={
+                          <Link
+                            href={buildOrganizationSwitchHref(
+                              organization.slug,
+                              pathname,
+                              organizationSlug,
+                            )}
+                          />
+                        }
+                      >
+                        <span className="flex-1 truncate">{organization.name}</span>
+                        {isActive ? (
+                          <HugeiconsIcon
+                            icon={CheckmarkCircle01Icon}
+                            strokeWidth={1.8}
+                            className="size-4 text-bud-400"
+                          />
+                        ) : null}
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem render={<Link href="/auth/select-organization" />}>
                   <FormattedMessage {...navUserMessages.viewAllWorkspaces} />

--- a/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
@@ -32,12 +32,68 @@ import {
   rewriteAppLocalePath,
 } from "@/lib/app-i18n/rewrite-app-locale-path";
 
+import { cn } from "@/lib/primitives/cn";
+
 import { localeToggleMessages } from "./locale-toggle.messages";
 
-export function LocaleToggle() {
+function LocaleMenuControl() {
   const intl = useIntl();
   const pathname = usePathname() ?? "/";
   const activeLocale = getAppLocaleFromPathname(pathname);
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={intl.formatMessage(localeToggleMessages.languageAria)}
+      className="flex gap-1"
+    >
+      {SUPPORTED_APP_LOCALES.map((locale) => {
+        const isActive = locale === activeLocale;
+        const label = getNativeLocaleDisplayName(locale);
+
+        return (
+          <button
+            key={locale}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            aria-label={label}
+            onClick={() => {
+              if (locale === activeLocale) {
+                return;
+              }
+
+              const search = window.location.search;
+              const hash = window.location.hash;
+              window.location.assign(rewriteAppLocalePath(`${pathname}${search}${hash}`, locale));
+            }}
+            className={cn(
+              "flex flex-1 items-center justify-center rounded-md p-2 text-base leading-none transition-colors",
+              isActive
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <span aria-hidden="true">{getAppLocaleFlagEmoji(locale)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+type LocaleToggleProps = {
+  variant?: "dropdown" | "menu";
+};
+
+export function LocaleToggle({ variant = "dropdown" }: LocaleToggleProps) {
+  const intl = useIntl();
+  const pathname = usePathname() ?? "/";
+  const activeLocale = getAppLocaleFromPathname(pathname);
+
+  if (variant === "menu") {
+    return <LocaleMenuControl />;
+  }
 
   return (
     <DropdownMenu>

--- a/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
@@ -32,53 +32,37 @@ import {
   rewriteAppLocalePath,
 } from "@/lib/app-i18n/rewrite-app-locale-path";
 
-import { cn } from "@/lib/primitives/cn";
-
 import { localeToggleMessages } from "./locale-toggle.messages";
 
-function LocaleMenuControl() {
+function LocaleMenuRadioGroup() {
   const intl = useIntl();
   const pathname = usePathname() ?? "/";
   const activeLocale = getAppLocaleFromPathname(pathname);
 
   return (
-    <div
-      role="radiogroup"
+    <DropdownMenuRadioGroup
       aria-label={intl.formatMessage(localeToggleMessages.languageAria)}
-      className="flex gap-1"
+      value={activeLocale}
+      onValueChange={(value) => {
+        const nextLocale = value as AppLocale;
+        if (nextLocale === activeLocale) {
+          return;
+        }
+
+        const search = window.location.search;
+        const hash = window.location.hash;
+        window.location.assign(rewriteAppLocalePath(`${pathname}${search}${hash}`, nextLocale));
+      }}
     >
-      {SUPPORTED_APP_LOCALES.map((locale) => {
-        const isActive = locale === activeLocale;
-        const label = getNativeLocaleDisplayName(locale);
-
-        return (
-          <button
-            key={locale}
-            type="button"
-            role="radio"
-            aria-checked={isActive}
-            aria-label={label}
-            onClick={() => {
-              if (locale === activeLocale) {
-                return;
-              }
-
-              const search = window.location.search;
-              const hash = window.location.hash;
-              window.location.assign(rewriteAppLocalePath(`${pathname}${search}${hash}`, locale));
-            }}
-            className={cn(
-              "flex flex-1 items-center justify-center rounded-md p-2 text-base leading-none transition-colors",
-              isActive
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
+      {SUPPORTED_APP_LOCALES.map((locale) => (
+        <DropdownMenuRadioItem key={locale} value={locale}>
+          <span className="flex items-center gap-2">
             <span aria-hidden="true">{getAppLocaleFlagEmoji(locale)}</span>
-          </button>
-        );
-      })}
-    </div>
+            <span>{getNativeLocaleDisplayName(locale)}</span>
+          </span>
+        </DropdownMenuRadioItem>
+      ))}
+    </DropdownMenuRadioGroup>
   );
 }
 
@@ -92,7 +76,7 @@ export function LocaleToggle({ variant = "dropdown" }: LocaleToggleProps) {
   const activeLocale = getAppLocaleFromPathname(pathname);
 
   if (variant === "menu") {
-    return <LocaleMenuControl />;
+    return <LocaleMenuRadioGroup />;
   }
 
   return (

--- a/apps/hyperlocalise-web/src/components/theme-toggle/theme-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/theme-toggle/theme-toggle.tsx
@@ -28,9 +28,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
+import { cn } from "@/lib/primitives/cn";
+
 import { themeToggleMessages } from "./theme-toggle.messages";
 
 type ThemeOption = "light" | "dark" | "system";
+
+const THEME_OPTIONS: ThemeOption[] = ["light", "dark", "system"];
 
 function ThemeToggleIcon({ theme }: { theme: ThemeOption }) {
   if (theme === "dark") {
@@ -44,8 +48,7 @@ function ThemeToggleIcon({ theme }: { theme: ThemeOption }) {
   return <HugeiconsIcon icon={Sun01Icon} strokeWidth={2} className="size-4" />;
 }
 
-export function ThemeToggle() {
-  const intl = useIntl();
+function useThemeToggleState() {
   const { resolvedTheme, setTheme, theme } = useTheme();
   const [mounted, setMounted] = React.useState(false);
 
@@ -61,6 +64,65 @@ export function ThemeToggle() {
       ? ((resolvedTheme as "light" | "dark" | undefined) ?? "light")
       : activeTheme
     : "system";
+
+  return { activeTheme, mounted, setTheme, triggerTheme };
+}
+
+function ThemeMenuControl() {
+  const intl = useIntl();
+  const { activeTheme, mounted, setTheme } = useThemeToggleState();
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={intl.formatMessage(themeToggleMessages.colorThemeAria)}
+      className="flex gap-1"
+    >
+      {THEME_OPTIONS.map((option) => {
+        const isActive = mounted && activeTheme === option;
+        const label = intl.formatMessage(
+          option === "light"
+            ? themeToggleMessages.light
+            : option === "dark"
+              ? themeToggleMessages.dark
+              : themeToggleMessages.system,
+        );
+
+        return (
+          <button
+            key={option}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            aria-label={label}
+            disabled={!mounted}
+            onClick={() => setTheme(option)}
+            className={cn(
+              "flex flex-1 items-center justify-center rounded-md p-2 transition-colors",
+              isActive
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <ThemeToggleIcon theme={option} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+type ThemeToggleProps = {
+  variant?: "dropdown" | "menu";
+};
+
+export function ThemeToggle({ variant = "dropdown" }: ThemeToggleProps) {
+  const intl = useIntl();
+  const { activeTheme, setTheme, triggerTheme } = useThemeToggleState();
+
+  if (variant === "menu") {
+    return <ThemeMenuControl />;
+  }
 
   return (
     <DropdownMenu>

--- a/apps/hyperlocalise-web/src/components/theme-toggle/theme-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/theme-toggle/theme-toggle.tsx
@@ -28,13 +28,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
-import { cn } from "@/lib/primitives/cn";
-
 import { themeToggleMessages } from "./theme-toggle.messages";
 
 type ThemeOption = "light" | "dark" | "system";
-
-const THEME_OPTIONS: ThemeOption[] = ["light", "dark", "system"];
 
 function ThemeToggleIcon({ theme }: { theme: ThemeOption }) {
   if (theme === "dark") {
@@ -68,47 +64,29 @@ function useThemeToggleState() {
   return { activeTheme, mounted, setTheme, triggerTheme };
 }
 
-function ThemeMenuControl() {
+function ThemeMenuRadioGroup() {
   const intl = useIntl();
-  const { activeTheme, mounted, setTheme } = useThemeToggleState();
+  const { activeTheme, setTheme } = useThemeToggleState();
 
   return (
-    <div
-      role="radiogroup"
+    <DropdownMenuRadioGroup
       aria-label={intl.formatMessage(themeToggleMessages.colorThemeAria)}
-      className="flex gap-1"
+      value={activeTheme}
+      onValueChange={(value) => setTheme(value as ThemeOption)}
     >
-      {THEME_OPTIONS.map((option) => {
-        const isActive = mounted && activeTheme === option;
-        const label = intl.formatMessage(
-          option === "light"
-            ? themeToggleMessages.light
-            : option === "dark"
-              ? themeToggleMessages.dark
-              : themeToggleMessages.system,
-        );
-
-        return (
-          <button
-            key={option}
-            type="button"
-            role="radio"
-            aria-checked={isActive}
-            aria-label={label}
-            disabled={!mounted}
-            onClick={() => setTheme(option)}
-            className={cn(
-              "flex flex-1 items-center justify-center rounded-md p-2 transition-colors",
-              isActive
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <ThemeToggleIcon theme={option} />
-          </button>
-        );
-      })}
-    </div>
+      <DropdownMenuRadioItem value="light">
+        <HugeiconsIcon icon={Sun01Icon} strokeWidth={2} className="size-4" />
+        <FormattedMessage {...themeToggleMessages.light} />
+      </DropdownMenuRadioItem>
+      <DropdownMenuRadioItem value="dark">
+        <HugeiconsIcon icon={Moon02Icon} strokeWidth={2} className="size-4" />
+        <FormattedMessage {...themeToggleMessages.dark} />
+      </DropdownMenuRadioItem>
+      <DropdownMenuRadioItem value="system">
+        <HugeiconsIcon icon={ComputerIcon} strokeWidth={2} className="size-4" />
+        <FormattedMessage {...themeToggleMessages.system} />
+      </DropdownMenuRadioItem>
+    </DropdownMenuRadioGroup>
   );
 }
 
@@ -121,7 +99,7 @@ export function ThemeToggle({ variant = "dropdown" }: ThemeToggleProps) {
   const { activeTheme, setTheme, triggerTheme } = useThemeToggleState();
 
   if (variant === "menu") {
-    return <ThemeMenuControl />;
+    return <ThemeMenuRadioGroup />;
   }
 
   return (


### PR DESCRIPTION
## What changed

- Moved theme and locale controls from the app shell header into the account menu as inline segmented toggles, showing the user's email in the profile section.
- Fixed the Switch workspace submenu Base UI error by wrapping workspace labels and items in `DropdownMenuGroup`.
- Collapsed the sidebar automatically when opening the visual workflow editor.
- Added Storybook stories for the full app shell, header, and sidebar (footer stories now share fixtures).

## How to test

- Open the account menu in the app shell and verify theme/locale toggles work and the header no longer shows separate locale/theme buttons.
- With multiple workspaces, open Switch workspace and confirm the submenu renders without Base UI errors; switching should route through `/auth/select-organization/{slug}`.
- Open a visual workflow editor and confirm the sidebar collapses.
- Run `cd apps/hyperlocalise-web && vp check --fix` and browse Storybook under **App Shell/**.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review