### PR TITLE
feat(web): enable instant navigation for org workspace

### DIFF
--- a/apps/hyperlocalise-web/next.config.ts
+++ b/apps/hyperlocalise-web/next.config.ts
@@ -18,10 +18,15 @@ import { AGENT_MARKDOWN_TRACE_GLOB } from "./src/agents/_runtime/paths";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  cacheComponents: true,
+  partialPrefetching: true,
   reactCompiler: true,
   typescript: {
     // Exclude tests and typed-app.ts so next build does not instantiate AppType (TS2589).
     tsconfigPath: "tsconfig.build.json",
+  },
+  experimental: {
+    exposeTestingApiInProductionBuild: true,
   },
   // View transitions work without config in Next.js 16.3+ (experimental.viewTransition removed).
   // Agent prompts load from src/agents/**/*.md at runtime via process.cwd() (see paths.ts).

--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -161,6 +161,7 @@
     "zod": "4.5.4"
   },
   "devDependencies": {
+    "@next/playwright": "16.3.4",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-mcp": "^0.7.0",

--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -162,7 +162,7 @@
   },
   "devDependencies": {
     "@next/playwright": "16.3.4",
-    "@storybook/addon-a11y": "^10.4.6",
+    "@storybook/addon-a11y": "10.5.10",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-mcp": "^0.7.0",
     "@storybook/addon-vitest": "^10.4.6",

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -456,9 +456,12 @@ importers:
         specifier: 4.5.4
         version: 4.5.4
     devDependencies:
+      '@next/playwright':
+        specifier: 16.3.4
+        version: 16.3.4
       '@storybook/addon-a11y':
         specifier: ^10.4.6
-        version: 10.5.10(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))
+        version: 10.6.0(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))
       '@storybook/addon-docs':
         specifier: ^10.4.6
         version: 10.5.10(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -1781,6 +1784,14 @@ packages:
 
   '@next/env@16.3.4':
     resolution: {integrity: sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==}
+
+  '@next/playwright@16.3.4':
+    resolution: {integrity: sha512-3kY/r//YJutrG1JTV7bAe1RNraRmwDjI19lzPrNPmq0mdYvEVTASXPyAqhRW6auQiyWS8FG75TyMHXUkn78tVw==}
+    peerDependencies:
+      '@playwright/test': '>=1.0.0'
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
 
   '@next/swc-darwin-arm64@16.3.4':
     resolution: {integrity: sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==}
@@ -3689,10 +3700,10 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@storybook/addon-a11y@10.5.10':
-    resolution: {integrity: sha512-RpRQV5xUbrl6hCiNrd5FSMIo6pnRZ0VZxWvEW/ASLcreGkKUW5jl2AeLCe5YROE2i80s/dU+6VPzOYKrwWNFbQ==}
+  '@storybook/addon-a11y@10.6.0':
+    resolution: {integrity: sha512-Z/CZor/F8H74/+IoeLroEQXQoVxvmjVtUgATJ95KPBolHxMaHLXLsYU0wosIiiORxmfRCnpen5pQl1n4+pBWQw==}
     peerDependencies:
-      storybook: ^10.5.10
+      storybook: ^10.6.0
 
   '@storybook/addon-docs@10.5.10':
     resolution: {integrity: sha512-06JoK3/a7FWI/6GzuidJP9iHp1/Vejboe6lzS1jW+d8ItpecriBt+oXh1VNmUM7i7PjI6pZnet+j51QnLyeOoQ==}
@@ -12215,6 +12226,8 @@ snapshots:
 
   '@next/env@16.3.4': {}
 
+  '@next/playwright@16.3.4': {}
+
   '@next/swc-darwin-arm64@16.3.4':
     optional: true
 
@@ -13749,7 +13762,7 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-a11y@10.5.10(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))':
+  '@storybook/addon-a11y@10.6.0(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.13.0

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -460,8 +460,8 @@ importers:
         specifier: 16.3.4
         version: 16.3.4
       '@storybook/addon-a11y':
-        specifier: ^10.4.6
-        version: 10.6.0(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))
+        specifier: 10.5.10
+        version: 10.5.10(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))
       '@storybook/addon-docs':
         specifier: ^10.4.6
         version: 10.5.10(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -3700,10 +3700,10 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@storybook/addon-a11y@10.6.0':
-    resolution: {integrity: sha512-Z/CZor/F8H74/+IoeLroEQXQoVxvmjVtUgATJ95KPBolHxMaHLXLsYU0wosIiiORxmfRCnpen5pQl1n4+pBWQw==}
+  '@storybook/addon-a11y@10.5.10':
+    resolution: {integrity: sha512-RpRQV5xUbrl6hCiNrd5FSMIo6pnRZ0VZxWvEW/ASLcreGkKUW5jl2AeLCe5YROE2i80s/dU+6VPzOYKrwWNFbQ==}
     peerDependencies:
-      storybook: ^10.6.0
+      storybook: ^10.5.10
 
   '@storybook/addon-docs@10.5.10':
     resolution: {integrity: sha512-06JoK3/a7FWI/6GzuidJP9iHp1/Vejboe6lzS1jW+d8ItpecriBt+oXh1VNmUM7i7PjI6pZnet+j51QnLyeOoQ==}
@@ -13762,7 +13762,7 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-a11y@10.6.0(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))':
+  '@storybook/addon-a11y@10.5.10(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.3.0(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.21.0)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.13.0

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/layout.tsx
@@ -14,6 +14,6 @@ import type { ReactNode } from "react";
 
 import { BrandThemeProvider } from "@/components/ui/brand-theme";
 
-export default async function AuthenticatedLayout({ children }: { children: ReactNode }) {
+export default function AuthenticatedLayout({ children }: { children: ReactNode }) {
   return <BrandThemeProvider theme="product">{children}</BrandThemeProvider>;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-page-suspense.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-page-suspense.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Suspense, type ReactNode } from "react";
+
+import { OrganizationRouteLoading } from "./organization-route-loading";
+
+type OrgPageSuspenseProps = {
+  children: ReactNode;
+};
+
+export function OrgPageSuspense({ children }: OrgPageSuspenseProps) {
+  return <Suspense fallback={<OrganizationRouteLoading />}>{children}</Suspense>;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/page.tsx
@@ -14,12 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AiEnginePageContent } from "./_components/ai-engine-page-content";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function AiEnginePage({
+export default function AiEnginePage({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
+  return (
+    <OrgPageSuspense>
+      <AiEnginePageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function AiEnginePageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
@@ -10,8 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import {
@@ -22,8 +20,21 @@ import {
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationDetailPageContent } from "../_components/automation-detail-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function AutomationDetailPage({
+export default function AutomationDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; automationId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <AutomationDetailPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function AutomationDetailPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; automationId: string }>;
@@ -39,13 +50,11 @@ export default async function AutomationDetailPage({
   const flags = await evaluateWorkspaceFeatureFlags(auth);
 
   return (
-    <Suspense fallback={null}>
-      <AutomationDetailPageContent
-        organizationSlug={organizationSlug}
-        automationId={automationId}
-        knowledgeAvailable={flags.knowledge}
-        canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
-      />
-    </Suspense>
+    <AutomationDetailPageContent
+      organizationSlug={organizationSlug}
+      automationId={automationId}
+      knowledgeAvailable={flags.knowledge}
+      canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
@@ -10,8 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import {
@@ -27,8 +25,23 @@ import {
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationsNewPageContent } from "../_components/automations-new-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function NewAutomationPage({
+export default function NewAutomationPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+  searchParams: Promise<{ template?: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <NewAutomationPageLoader params={params} searchParams={searchParams} />
+    </OrgPageSuspense>
+  );
+}
+
+async function NewAutomationPageLoader({
   params,
   searchParams,
 }: {
@@ -52,13 +65,11 @@ export default async function NewAutomationPage({
     : createDefaultWorkspaceAutomationFormState();
 
   return (
-    <Suspense fallback={null}>
-      <AutomationsNewPageContent
-        organizationSlug={organizationSlug}
-        initialForm={initialForm}
-        knowledgeAvailable={flags.knowledge}
-        canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
-      />
-    </Suspense>
+    <AutomationsNewPageContent
+      organizationSlug={organizationSlug}
+      initialForm={initialForm}
+      knowledgeAvailable={flags.knowledge}
+      canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/page.tsx
@@ -10,8 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
 import {
@@ -21,9 +19,22 @@ import {
 } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 import { AutomationsPageContent } from "./_components/automations-page-content";
 
-export default async function AutomationsPage({
+export default function AutomationsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <AutomationsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function AutomationsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
@@ -42,12 +53,10 @@ export default async function AutomationsPage({
   const templates = getMergedWorkspaceAutomationTemplates();
 
   return (
-    <Suspense fallback={null}>
-      <AutomationsPageContent
-        organizationSlug={organizationSlug}
-        templates={templates}
-        visualWorkflowsEnabled={visualWorkflowsEnabled}
-      />
-    </Suspense>
+    <AutomationsPageContent
+      organizationSlug={organizationSlug}
+      templates={templates}
+      visualWorkflowsEnabled={visualWorkflowsEnabled}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/visual-workflows/[visualWorkflowId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/visual-workflows/[visualWorkflowId]/page.tsx
@@ -24,8 +24,21 @@ import { getVisualWorkflowById } from "@/lib/visual-workflows/visual-workflows";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { VisualWorkflowEditorPageContent } from "../../_components/visual-workflow-editor-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function VisualWorkflowEditorPage({
+export default function VisualWorkflowEditorPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; visualWorkflowId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <VisualWorkflowEditorPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function VisualWorkflowEditorPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; visualWorkflowId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/visual-workflows/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/visual-workflows/page.tsx
@@ -10,7 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
 import { notFound } from "next/navigation";
 
 import { isWorkspaceOperatorRole } from "@/api/auth/policy";
@@ -23,8 +22,21 @@ import {
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { VisualWorkflowsPageContent } from "../_components/visual-workflows-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function VisualWorkflowsPage({
+export default function VisualWorkflowsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <VisualWorkflowsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function VisualWorkflowsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
@@ -48,9 +60,5 @@ export default async function VisualWorkflowsPage({
     notFound();
   }
 
-  return (
-    <Suspense fallback={null}>
-      <VisualWorkflowsPageContent organizationSlug={organizationSlug} />
-    </Suspense>
-  );
+  return <VisualWorkflowsPageContent organizationSlug={organizationSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/page.tsx
@@ -11,12 +11,17 @@
  * Version 2.0 or later.
  */
 import { redirect } from "next/navigation";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function ChatPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
+export default function ChatPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  return (
+    <OrgPageSuspense>
+      <ChatPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ChatPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
-  redirect(`/org/${organizationSlug}/inbox/new`);
+  return redirect(`/org/${organizationSlug}/inbox/new`);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/page.tsx
@@ -14,9 +14,22 @@ import { isWorkspaceOperatorRole } from "@/api/auth/policy";
 import { evaluateWorkspaceFeatureFlags } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 import { DashboardPageContent } from "./_components/dashboard-page-content";
 
-export default async function OrganizationDashboardPage({
+export default function OrganizationDashboardPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <OrganizationDashboardPageContent params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function OrganizationDashboardPageContent({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/page.tsx
@@ -15,8 +15,21 @@ import { getWorkspaceFeatureFlagEnabled, workspaceDomainsFlag } from "@/lib/flag
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { DomainDetailPageContent } from "./_components/domain-detail-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function DomainDetailPage({
+export default function DomainDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <DomainDetailPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function DomainDetailPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; linkedDomainId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/page.tsx
@@ -15,12 +15,17 @@ import { getWorkspaceFeatureFlagEnabled, workspaceDomainsFlag } from "@/lib/flag
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { DomainsPageContent } from "./_components/domains-page-content";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function DomainsPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
+export default function DomainsPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  return (
+    <OrgPageSuspense>
+      <DomainsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function DomainsPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   const auth = await requireAppCapability("projects:read", { organizationSlug });
   const domainsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceDomainsFlag, auth);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/concepts/[conceptId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/concepts/[conceptId]/page.tsx
@@ -10,13 +10,28 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { GlossaryDetailPageContent } from "../../_components/glossary-detail-page-content";
+import { OrgPageSuspense } from "../../../../_components/org-page-suspense";
 
-export default async function GlossaryConceptPage({
+export default function GlossaryConceptPage({
+  params,
+}: {
+  params: Promise<{
+    organizationSlug: string;
+    glossaryId: string;
+    conceptId: string;
+  }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <GlossaryConceptPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function GlossaryConceptPageLoader({
   params,
 }: {
   params: Promise<{
@@ -29,13 +44,11 @@ export default async function GlossaryConceptPage({
   const auth = await requireAppAuthContext({ organizationSlug });
 
   return (
-    <Suspense fallback={null}>
-      <GlossaryDetailPageContent
-        organizationSlug={organizationSlug}
-        glossaryId={glossaryId}
-        conceptId={conceptId}
-        canManageGlossaries={hasCapability(auth.membership.role, "glossaries:write")}
-      />
-    </Suspense>
+    <GlossaryDetailPageContent
+      organizationSlug={organizationSlug}
+      glossaryId={glossaryId}
+      conceptId={conceptId}
+      canManageGlossaries={hasCapability(auth.membership.role, "glossaries:write")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/page.tsx
@@ -10,13 +10,24 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { GlossaryDetailPageContent } from "./_components/glossary-detail-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function GlossaryDetailPage({
+export default function GlossaryDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; glossaryId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <GlossaryDetailPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function GlossaryDetailPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; glossaryId: string }>;
@@ -25,12 +36,10 @@ export default async function GlossaryDetailPage({
   const auth = await requireAppAuthContext({ organizationSlug });
 
   return (
-    <Suspense fallback={null}>
-      <GlossaryDetailPageContent
-        organizationSlug={organizationSlug}
-        glossaryId={glossaryId}
-        canManageGlossaries={hasCapability(auth.membership.role, "glossaries:write")}
-      />
-    </Suspense>
+    <GlossaryDetailPageContent
+      organizationSlug={organizationSlug}
+      glossaryId={glossaryId}
+      canManageGlossaries={hasCapability(auth.membership.role, "glossaries:write")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -297,6 +297,7 @@ function GlossaryRow({
           {detailId ? (
             <Link
               href={`/org/${organizationSlug}/glossaries/${detailId}`}
+              prefetch
               className="min-w-0 truncate text-[15px] font-semibold tracking-[-0.01em] text-foreground underline-offset-2 hover:underline"
             >
               {glossary.name}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/page.tsx
@@ -10,26 +10,32 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 import { GlossariesPageContent } from "./_components/glossaries-page-content";
 
-export default async function GlossariesPage({
+export default function GlossariesPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
+  return (
+    <OrgPageSuspense>
+      <GlossariesPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function GlossariesPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
 
   return (
-    <Suspense fallback={null}>
-      <GlossariesPageContent
-        organizationSlug={organizationSlug}
-        canManageGlossaries={hasCapability(auth.membership.role, "glossaries:write")}
-      />
-    </Suspense>
+    <GlossariesPageContent
+      organizationSlug={organizationSlug}
+      canManageGlossaries={hasCapability(auth.membership.role, "glossaries:write")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/audiences/[audienceId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/audiences/[audienceId]/page.tsx
@@ -14,8 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { HyperlabAudienceDetail } from "../../_components/hyperlab-audience-detail";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function HyperlabAudienceDetailRoute({
+export default function HyperlabAudienceDetailRoute({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; audienceId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabAudienceDetailRouteLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabAudienceDetailRouteLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; audienceId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/audiences/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/audiences/page.tsx
@@ -14,8 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { HyperlabAudiencesPage } from "../_components/hyperlab-audiences-page";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function HyperlabAudiencesRoute({
+export default function HyperlabAudiencesRoute({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabAudiencesRouteLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabAudiencesRouteLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/experiments/[experimentId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/experiments/[experimentId]/page.tsx
@@ -14,8 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { HyperlabExperimentDetail } from "../../_components/hyperlab-experiment-detail";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function HyperlabExperimentDetailRoute({
+export default function HyperlabExperimentDetailRoute({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; experimentId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabExperimentDetailRouteLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabExperimentDetailRouteLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; experimentId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/experiments/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/experiments/page.tsx
@@ -14,8 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { HyperlabExperimentsPage } from "../_components/hyperlab-experiments-page";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function HyperlabExperimentsRoute({
+export default function HyperlabExperimentsRoute({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabExperimentsRouteLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabExperimentsRouteLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/flags/[flagId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/flags/[flagId]/page.tsx
@@ -14,8 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { HyperlabFlagDetail } from "../../_components/hyperlab-flag-detail";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function HyperlabFlagDetailRoute({
+export default function HyperlabFlagDetailRoute({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; flagId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabFlagDetailRouteLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabFlagDetailRouteLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; flagId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/flags/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/flags/page.tsx
@@ -14,8 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { HyperlabFlagsPage } from "../_components/hyperlab-flags-page";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function HyperlabFlagsRoute({
+export default function HyperlabFlagsRoute({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabFlagsRouteLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabFlagsRouteLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/keys/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/keys/page.tsx
@@ -14,8 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { HyperlabKeysPage } from "../_components/hyperlab-keys-page";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function HyperlabKeysRoute({
+export default function HyperlabKeysRoute({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabKeysRouteLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabKeysRouteLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/layout.tsx
@@ -16,7 +16,23 @@ import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-pa
 import { getWorkspaceFeatureFlagEnabled, workspaceHyperlabFlag } from "@/lib/flags/workspace-flags";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
-export default async function HyperlabLayout({
+import { OrgPageSuspense } from "../_components/org-page-suspense";
+
+export default function HyperlabLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabLayoutLoader params={params}>{children}</HyperlabLayoutLoader>
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabLayoutLoader({
   children,
   params,
 }: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/page.tsx
@@ -11,12 +11,21 @@
  * Version 2.0 or later.
  */
 import { HyperlabOverview } from "./_components/hyperlab-overview";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function HyperlabPage({
+export default function HyperlabPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
+  return (
+    <OrgPageSuspense>
+      <HyperlabPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function HyperlabPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   return <HyperlabOverview organizationSlug={organizationSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/[conversationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/[conversationId]/page.tsx
@@ -13,8 +13,21 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { InboxPageContent } from "../_components/inbox-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function InboxConversationPage({
+export default function InboxConversationPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; conversationId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <InboxConversationPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function InboxConversationPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; conversationId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/new/page.tsx
@@ -13,8 +13,21 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { InboxPageContent } from "../_components/inbox-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function InboxNewRequestPage({
+export default function InboxNewRequestPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <InboxNewRequestPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function InboxNewRequestPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/notifications/[notificationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/notifications/[notificationId]/page.tsx
@@ -13,8 +13,21 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { InboxPageContent } from "../../_components/inbox-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function InboxNotificationPage({
+export default function InboxNotificationPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; notificationId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <InboxNotificationPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function InboxNotificationPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; notificationId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/page.tsx
@@ -13,12 +13,17 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { InboxPageContent } from "./_components/inbox-page-content";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function InboxPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
+export default function InboxPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  return (
+    <OrgPageSuspense>
+      <InboxPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function InboxPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
   const currentUserName =

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/canva/claim/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/canva/claim/page.tsx
@@ -14,8 +14,23 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { CanvaClaimPageContent } from "./canva-claim-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function CanvaClaimPage({
+export default function CanvaClaimPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+  searchParams: Promise<{ claimId?: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <CanvaClaimPageLoader params={params} searchParams={searchParams} />
+    </OrgPageSuspense>
+  );
+}
+
+async function CanvaClaimPageLoader({
   params,
   searchParams,
 }: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/github/repositories/[githubRepositoryId]/automation/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/github/repositories/[githubRepositoryId]/automation/page.tsx
@@ -22,8 +22,21 @@ import { getIntlShape } from "@/lib/app-i18n/intl";
 import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import { db, schema } from "@/lib/database/client";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { OrgPageSuspense } from "../../../../../_components/org-page-suspense";
 
-export default async function GithubRepositoryAutomationPage({
+export default function GithubRepositoryAutomationPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; githubRepositoryId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <GithubRepositoryAutomationPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function GithubRepositoryAutomationPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; githubRepositoryId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/page.tsx
@@ -13,8 +13,23 @@
 import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { IntegrationsPageContent } from "./_components/integrations-page-content";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function IntegrationsPage({
+export default function IntegrationsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+  searchParams: Promise<{ error?: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <IntegrationsPageLoader params={params} searchParams={searchParams} />
+    </OrgPageSuspense>
+  );
+}
+
+async function IntegrationsPageLoader({
   params,
   searchParams,
 }: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
@@ -10,39 +10,24 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
-import { TypographyP } from "@/components/ui/typography";
-import { getIntlShape } from "@/lib/app-i18n/intl";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { IssuesPageContent } from "./_components/issues-page-content";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function IssuesPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
+export default function IssuesPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  return (
+    <OrgPageSuspense>
+      <IssuesPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function IssuesPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  const intl = getIntlShape(await getAppLocale());
   const canEditIssues = hasCapability(auth.membership.role, "write_back:translation");
 
-  return (
-    <Suspense
-      fallback={
-        <TypographyP size="small" tone="subtle">
-          {intl.formatMessage({
-            defaultMessage: "Loading board...",
-            id: "wZsNKEWooe",
-            description: "Suspense fallback while workspace board content loads",
-          })}
-        </TypographyP>
-      }
-    >
-      <IssuesPageContent organizationSlug={organizationSlug} canEditIssues={canEditIssues} />
-    </Suspense>
-  );
+  return <IssuesPageContent organizationSlug={organizationSlug} canEditIssues={canEditIssues} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/page.tsx
@@ -10,20 +10,18 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 import { JobsPageContent } from "./_components/jobs-page-content";
 
-export default async function JobsPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
-  const { organizationSlug } = await params;
-
+export default function JobsPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
   return (
-    <Suspense fallback={null}>
-      <JobsPageContent organizationSlug={organizationSlug} />
-    </Suspense>
+    <OrgPageSuspense>
+      <JobsPageLoader params={params} />
+    </OrgPageSuspense>
   );
+}
+
+async function JobsPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  const { organizationSlug } = await params;
+  return <JobsPageContent organizationSlug={organizationSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/page.tsx
@@ -19,12 +19,21 @@ import {
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { KnowledgePageContent } from "./_components/knowledge-page-content";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function KnowledgePage({
+export default function KnowledgePage({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
+  return (
+    <OrgPageSuspense>
+      <KnowledgePageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function KnowledgePageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
   const knowledgeEnabled = await getWorkspaceFeatureFlagEnabled(workspaceKnowledgeFlag, auth);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/layout.tsx
@@ -10,9 +10,10 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 
 import { AppShell } from "@/components/app-shell/app-shell";
+import { AppShellSkeleton } from "@/components/app-shell/app-shell-skeleton";
 import { AutumnBillingProvider } from "@/lib/billing/autumn-billing-provider";
 import { isAutumnConfigured } from "@/lib/billing/autumn-config";
 
@@ -23,9 +24,32 @@ type OrganizationLayoutProps = {
   }>;
 };
 
-export default async function OrganizationLayout({ children, params }: OrganizationLayoutProps) {
-  const { organizationSlug } = await params;
+export default function OrganizationLayout({ children, params }: OrganizationLayoutProps) {
   const autumnConfigured = isAutumnConfigured();
+
+  return (
+    <Suspense fallback={<AppShellSkeleton>{children}</AppShellSkeleton>}>
+      <OrganizationLayoutContent autumnConfigured={autumnConfigured} params={params}>
+        {children}
+      </OrganizationLayoutContent>
+    </Suspense>
+  );
+}
+
+type OrganizationLayoutContentProps = {
+  autumnConfigured: boolean;
+  children: ReactNode;
+  params: Promise<{
+    organizationSlug: string;
+  }>;
+};
+
+async function OrganizationLayoutContent({
+  autumnConfigured,
+  children,
+  params,
+}: OrganizationLayoutContentProps) {
+  const { organizationSlug } = await params;
   const appShell = (
     <AppShell autumnConfigured={autumnConfigured} organizationSlug={organizationSlug}>
       {children}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/link-domain/[domainSlug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/link-domain/[domainSlug]/page.tsx
@@ -15,8 +15,21 @@ import { getWorkspaceFeatureFlagEnabled, workspaceDomainsFlag } from "@/lib/flag
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { LinkDomainPageContent } from "./_components/link-domain-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function LinkDomainPage({
+export default function LinkDomainPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; domainSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <LinkDomainPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function LinkDomainPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; domainSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/members/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/members/page.tsx
@@ -13,12 +13,17 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { MembersPageContent } from "../settings/_components/members-page-content";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function MembersPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
+export default function MembersPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  return (
+    <OrgPageSuspense>
+      <MembersPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function MembersPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   await requireAppAuthContext({ organizationSlug });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/members/permissions/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/members/permissions/page.tsx
@@ -13,8 +13,21 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { RolePermissionsPageView } from "../../settings/_components/role-permissions-page-view";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function RolePermissionsPage({
+export default function RolePermissionsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <RolePermissionsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function RolePermissionsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/my-jobs/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/my-jobs/page.tsx
@@ -10,20 +10,18 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 import { JobsPageContent } from "../jobs/_components/jobs-page-content";
 
-export default async function MyJobsPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
-  const { organizationSlug } = await params;
-
+export default function MyJobsPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
   return (
-    <Suspense fallback={null}>
-      <JobsPageContent organizationSlug={organizationSlug} scope="personal" />
-    </Suspense>
+    <OrgPageSuspense>
+      <MyJobsPageLoader params={params} />
+    </OrgPageSuspense>
   );
+}
+
+async function MyJobsPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  const { organizationSlug } = await params;
+  return <JobsPageContent organizationSlug={organizationSlug} scope="personal" />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/my-work/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/my-work/page.tsx
@@ -11,12 +11,17 @@
  * Version 2.0 or later.
  */
 import { redirect } from "next/navigation";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function MyWorkPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
+export default function MyWorkPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  return (
+    <OrgPageSuspense>
+      <MyWorkPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function MyWorkPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
-  redirect(`/org/${organizationSlug}/my-jobs`);
+  return redirect(`/org/${organizationSlug}/my-jobs`);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/[automationId]/page.tsx
@@ -10,8 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import {
@@ -22,8 +20,21 @@ import {
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationDetailPageContent } from "../../../../automations/_components/automation-detail-page-content";
+import { OrgPageSuspense } from "../../../../_components/org-page-suspense";
 
-export default async function ProjectAutomationDetailPage({
+export default function ProjectAutomationDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string; automationId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectAutomationDetailPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectAutomationDetailPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string; automationId: string }>;
@@ -39,14 +50,12 @@ export default async function ProjectAutomationDetailPage({
   const flags = await evaluateWorkspaceFeatureFlags(auth);
 
   return (
-    <Suspense fallback={null}>
-      <AutomationDetailPageContent
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        automationId={automationId}
-        knowledgeAvailable={flags.knowledge}
-        canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
-      />
-    </Suspense>
+    <AutomationDetailPageContent
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      automationId={automationId}
+      knowledgeAvailable={flags.knowledge}
+      canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/new/page.tsx
@@ -10,8 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import {
@@ -27,8 +25,23 @@ import {
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationsNewPageContent } from "../../../../automations/_components/automations-new-page-content";
+import { OrgPageSuspense } from "../../../../_components/org-page-suspense";
 
-export default async function ProjectNewAutomationPage({
+export default function ProjectNewAutomationPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+  searchParams: Promise<{ template?: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectNewAutomationPageLoader params={params} searchParams={searchParams} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectNewAutomationPageLoader({
   params,
   searchParams,
 }: {
@@ -55,14 +68,12 @@ export default async function ProjectNewAutomationPage({
   };
 
   return (
-    <Suspense fallback={null}>
-      <AutomationsNewPageContent
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        initialForm={initialForm}
-        knowledgeAvailable={flags.knowledge}
-        canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
-      />
-    </Suspense>
+    <AutomationsNewPageContent
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      initialForm={initialForm}
+      knowledgeAvailable={flags.knowledge}
+      canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/page.tsx
@@ -10,8 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
 import {
@@ -21,8 +19,21 @@ import {
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationsPageContent } from "../../../automations/_components/automations-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function ProjectAutomationsPage({
+export default function ProjectAutomationsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectAutomationsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectAutomationsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string }>;
@@ -38,12 +49,10 @@ export default async function ProjectAutomationsPage({
   const templates = getMergedWorkspaceAutomationTemplates();
 
   return (
-    <Suspense fallback={null}>
-      <AutomationsPageContent
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        templates={templates}
-      />
-    </Suspense>
+    <AutomationsPageContent
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      templates={templates}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/content-editor/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/content-editor/page.tsx
@@ -24,8 +24,34 @@ import {
 } from "@/api/routes/project/project.shared";
 
 import { ProjectFileContentEditorPageContent } from "../_components/project-file-content-editor-page-content";
+import { OrgPageSuspense } from "../../../../_components/org-page-suspense";
 
-export default async function ProjectFileContentEditorPage({
+export default function ProjectFileContentEditorPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+  searchParams: Promise<{
+    sourcePath?: string;
+    locale?: string;
+    segment?: string;
+    externalResourceId?: string;
+    resourceType?: string;
+    branch?: string;
+    sourcePaths?: string;
+    queueFilter?: string;
+    queueSort?: string;
+    search?: string;
+  }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectFileContentEditorPageLoader params={params} searchParams={searchParams} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectFileContentEditorPageLoader({
   params,
   searchParams,
 }: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/page.tsx
@@ -10,37 +10,30 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
-import { TypographyP } from "@/components/ui/typography";
-import { getIntlShape } from "@/lib/app-i18n/intl";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { ProjectFilesPageContent } from "./_components/project-files-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function ProjectFilesPage({
+export default function ProjectFilesPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectFilesPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectFilesPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
   await requireAppAuthContext({ organizationSlug });
-  const intl = getIntlShape(await getAppLocale());
 
-  return (
-    <Suspense
-      fallback={
-        <TypographyP size="small" tone="subtle">
-          {intl.formatMessage({
-            defaultMessage: "Loading files...",
-            id: "KWzlpvb4xC",
-            description: "Suspense fallback while project files content loads",
-          })}
-        </TypographyP>
-      }
-    >
-      <ProjectFilesPageContent organizationSlug={organizationSlug} projectId={projectId} />
-    </Suspense>
-  );
+  return <ProjectFilesPageContent organizationSlug={organizationSlug} projectId={projectId} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/[issueId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/[issueId]/page.tsx
@@ -10,17 +10,25 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
-import { TypographyP } from "@/components/ui/typography";
-import { getIntlShape } from "@/lib/app-i18n/intl";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { IssueDetailPageContent } from "./_components/issue-detail-page-content";
+import { OrgPageSuspense } from "../../../../_components/org-page-suspense";
 
-export default async function IssueDetailPage({
+export default function IssueDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string; issueId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <IssueDetailPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function IssueDetailPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string; issueId: string }>;
@@ -28,25 +36,12 @@ export default async function IssueDetailPage({
   const { organizationSlug, projectId: rawProjectId, issueId } = await params;
   const projectId = normalizeProjectId(rawProjectId);
   await requireAppAuthContext({ organizationSlug });
-  const intl = getIntlShape(await getAppLocale());
 
   return (
-    <Suspense
-      fallback={
-        <TypographyP size="small" tone="subtle">
-          {intl.formatMessage({
-            defaultMessage: "Loading issue...",
-            id: "JxSxJmFns3",
-            description: "Suspense fallback while the issue detail page loads",
-          })}
-        </TypographyP>
-      }
-    >
-      <IssueDetailPageContent
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        issueId={issueId}
-      />
-    </Suspense>
+    <IssueDetailPageContent
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      issueId={issueId}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
@@ -10,43 +10,38 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
-import { TypographyP } from "@/components/ui/typography";
-import { getIntlShape } from "@/lib/app-i18n/intl";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { IssueSheetPageContent } from "./_components/issue-sheet-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function IssueSheetPage({
+export default function IssueSheetPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <IssueSheetPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function IssueSheetPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  const intl = getIntlShape(await getAppLocale());
   const canEditIssues = hasCapability(auth.membership.role, "write_back:translation");
 
   return (
-    <Suspense
-      fallback={
-        <TypographyP size="small" tone="subtle">
-          {intl.formatMessage({
-            defaultMessage: "Loading board...",
-            id: "LGF0oZcJpk",
-            description: "Suspense fallback while Board content loads",
-          })}
-        </TypographyP>
-      }
-    >
-      <IssueSheetPageContent
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        canEditIssues={canEditIssues}
-      />
-    </Suspense>
+    <IssueSheetPageContent
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      canEditIssues={canEditIssues}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/page.tsx
@@ -15,8 +15,21 @@ import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { JobDetailPageContent } from "./_components/job-detail-page-content";
+import { OrgPageSuspense } from "../../../../_components/org-page-suspense";
 
-export default async function ProjectJobDetailPage({
+export default function ProjectJobDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string; jobId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectJobDetailPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectJobDetailPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string; jobId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -23,8 +23,32 @@ import {
 } from "@/api/routes/project/project.shared";
 
 import { JobContentEditorPageContent } from "./_components/job-content-editor-page-content";
+import { OrgPageSuspense } from "../../../../../_components/org-page-suspense";
 
-export default async function ProjectJobStringsPage({
+export default function ProjectJobStringsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string; jobId: string }>;
+  searchParams: Promise<{
+    sourcePath?: string;
+    storedFileId?: string;
+    sourcePaths?: string;
+    targetLocale?: string;
+    segment?: string;
+    queueFilter?: string;
+    queueSort?: string;
+    search?: string;
+  }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectJobStringsPageLoader params={params} searchParams={searchParams} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectJobStringsPageLoader({
   params,
   searchParams,
 }: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/page.tsx
@@ -10,20 +10,27 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { JobsPageContent } from "../../../jobs/_components/jobs-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function ProjectJobsPage({
+export default function ProjectJobsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectJobsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectJobsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
 
-  return (
-    <Suspense fallback={null}>
-      <JobsPageContent organizationSlug={organizationSlug} projectId={projectId} />
-    </Suspense>
-  );
+  return <JobsPageContent organizationSlug={organizationSlug} projectId={projectId} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/knowledge/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/knowledge/page.tsx
@@ -18,8 +18,21 @@ import {
   workspaceKnowledgeFlag,
 } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function ProjectKnowledgePage({
+export default function ProjectKnowledgePage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectKnowledgePageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectKnowledgePageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/page.tsx
@@ -10,34 +10,27 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { ProjectOverviewPageContent } from "./_components/project-overview-page-content";
-import { TypographyP } from "@/components/ui/typography";
-import { getIntlShape } from "@/lib/app-i18n/intl";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function ProjectOverviewPage({
+export default function ProjectOverviewPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectOverviewPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectOverviewPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
-  const intl = getIntlShape(await getAppLocale());
 
-  return (
-    <Suspense
-      fallback={
-        <TypographyP size="small" tone="subtle">
-          {intl.formatMessage({
-            defaultMessage: "Loading project…",
-            id: "PtTtkKUG7c",
-            description: "Suspense fallback while project overview content loads",
-          })}
-        </TypographyP>
-      }
-    >
-      <ProjectOverviewPageContent organizationSlug={organizationSlug} projectId={projectId} />
-    </Suspense>
-  );
+  return <ProjectOverviewPageContent organizationSlug={organizationSlug} projectId={projectId} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/page.tsx
@@ -10,42 +10,37 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
-import { TypographyP } from "@/components/ui/typography";
-import { getIntlShape } from "@/lib/app-i18n/intl";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import { isWorkspaceOperatorRole } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { ProjectSettingsPageContent } from "./_components/project-settings-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function ProjectSettingsPage({
+export default function ProjectSettingsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectSettingsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectSettingsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
-  const intl = getIntlShape(await getAppLocale());
 
   return (
-    <Suspense
-      fallback={
-        <TypographyP size="small" tone="subtle">
-          {intl.formatMessage({
-            defaultMessage: "Loading settings...",
-            id: "M1rJJm5ext",
-            description: "Suspense fallback while project settings content loads",
-          })}
-        </TypographyP>
-      }
-    >
-      <ProjectSettingsPageContent
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        canManageCatBehavior={isWorkspaceOperatorRole(auth.membership.role)}
-      />
-    </Suspense>
+    <ProjectSettingsPageContent
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      canManageCatBehavior={isWorkspaceOperatorRole(auth.membership.role)}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
@@ -25,8 +25,34 @@ import {
 } from "@/api/routes/project/project.shared";
 
 import { ProjectFileContentEditorPageContent } from "../files/_components/project-file-content-editor-page-content";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
 
-export default async function ProjectStringsPage({
+export default function ProjectStringsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+  searchParams: Promise<{
+    sourcePath?: string;
+    locale?: string;
+    segment?: string;
+    externalResourceId?: string;
+    resourceType?: string;
+    branch?: string;
+    sourcePaths?: string;
+    queueFilter?: string;
+    queueSort?: string;
+    search?: string;
+  }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ProjectStringsPageLoader params={params} searchParams={searchParams} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ProjectStringsPageLoader({
   params,
   searchParams,
 }: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -146,6 +146,7 @@ function ProjectCard({
       <div className="flex items-start justify-between gap-4">
         <Link
           href={projectHref}
+          prefetch
           onClick={() => onOpenProject?.(project.id)}
           className="min-w-0 flex flex-1 items-start gap-3"
         >
@@ -225,7 +226,7 @@ function ProjectCard({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-48">
                 <DropdownMenuGroup>
-                  <DropdownMenuItem render={<Link href={projectHref} />}>
+                  <DropdownMenuItem render={<Link href={projectHref} prefetch />}>
                     <FormattedMessage {...projectsTableMessages.openProject} />
                   </DropdownMenuItem>
                   <DropdownMenuItem
@@ -273,6 +274,7 @@ function ProjectCard({
             {project.openJobCount > 0 ? (
               <Link
                 href={`/org/${organizationSlug}/projects/${project.id}/jobs`}
+                prefetch
                 className="text-subtle-foreground hover:text-foreground hover:underline"
               >
                 {intl.formatMessage(projectsTableMessages.openJobsCount, {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/page.tsx
@@ -10,20 +10,22 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 import { ProjectsPageContent } from "./_components/projects-page-content";
 
-export default async function ProjectsPage({
+export default function ProjectsPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
-  const { organizationSlug } = await params;
-
   return (
-    <Suspense fallback={null}>
-      <ProjectsPageContent organizationSlug={organizationSlug} />
-    </Suspense>
+    <OrgPageSuspense>
+      <ProjectsPageLoader params={params} />
+    </OrgPageSuspense>
   );
+}
+
+async function ProjectsPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  const { organizationSlug } = await params;
+  return <ProjectsPageContent organizationSlug={organizationSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/account/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/account/page.tsx
@@ -12,8 +12,21 @@
  */
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { AccountSettingsPageContent } from "../_components/settings-pages";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function AccountSettingsPage({
+export default function AccountSettingsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <AccountSettingsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function AccountSettingsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/activity-logs/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/activity-logs/page.tsx
@@ -13,8 +13,21 @@
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { ActivityLogsPageContent } from "../_components/activity-logs-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function ActivityLogsSettingsPage({
+export default function ActivityLogsSettingsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ActivityLogsSettingsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ActivityLogsSettingsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/api-keys/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/api-keys/page.tsx
@@ -12,8 +12,21 @@
  */
 import { requireAppCapability } from "@/lib/workos/app-auth";
 import { ApiKeySettingsPageContent } from "../_components/api-keys-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function ApiKeySettingsPage({
+export default function ApiKeySettingsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <ApiKeySettingsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function ApiKeySettingsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/page.tsx
@@ -15,8 +15,21 @@ import { isAutumnConfigured } from "@/lib/billing/autumn-config";
 import { requireAppAuthContext, requireAppCapability } from "@/lib/workos/app-auth";
 
 import { BillingSettingsPageContent } from "./_components/billing-settings-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function BillingSettingsPage({
+export default function BillingSettingsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <BillingSettingsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function BillingSettingsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/layout.tsx
@@ -14,9 +14,24 @@ import type { ReactNode } from "react";
 
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 import { SettingsLayoutClient } from "./_components/settings-layout-client";
 
-export default async function SettingsLayout({
+export default function SettingsLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <SettingsLayoutLoader params={params}>{children}</SettingsLayoutLoader>
+    </OrgPageSuspense>
+  );
+}
+
+async function SettingsLayoutLoader({
   children,
   params,
 }: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/linked-domains/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/linked-domains/page.tsx
@@ -11,12 +11,25 @@
  * Version 2.0 or later.
  */
 import { redirect } from "next/navigation";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function LinkedDomainsSettingsPage({
+export default function LinkedDomainsSettingsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <LinkedDomainsSettingsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function LinkedDomainsSettingsPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  redirect(`/org/${organizationSlug}/domains`);
+  return redirect(`/org/${organizationSlug}/domains`);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/members/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/members/page.tsx
@@ -11,12 +11,25 @@
  * Version 2.0 or later.
  */
 import { redirect } from "next/navigation";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function MembersSettingsRedirectPage({
+export default function MembersSettingsRedirectPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <MembersSettingsRedirectPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function MembersSettingsRedirectPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  redirect(`/org/${organizationSlug}/members`);
+  return redirect(`/org/${organizationSlug}/members`);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/page.tsx
@@ -12,12 +12,21 @@
  */
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { GeneralSettingsPageContent } from "./_components/settings-pages";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function SettingsPage({
+export default function SettingsPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
+  return (
+    <OrgPageSuspense>
+      <SettingsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function SettingsPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/[teamId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/[teamId]/page.tsx
@@ -14,8 +14,21 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { TeamDetailPageContent } from "../_components/team-detail-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function TeamDetailPage({
+export default function TeamDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; teamId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <TeamDetailPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function TeamDetailPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; teamId: string }>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/page.tsx
@@ -14,12 +14,17 @@ import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { TeamsPageContent } from "./_components/teams-page-content";
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 
-export default async function TeamsPage({
-  params,
-}: {
-  params: Promise<{ organizationSlug: string }>;
-}) {
+export default function TeamsPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
+  return (
+    <OrgPageSuspense>
+      <TeamsPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function TeamsPageLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/page.tsx
@@ -10,13 +10,24 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { TranslationMemoryDetailPageContent } from "./_components/translation-memory-detail-page-content";
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
 
-export default async function TranslationMemoryDetailPage({
+export default function TranslationMemoryDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; memoryId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <TranslationMemoryDetailPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function TranslationMemoryDetailPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; memoryId: string }>;
@@ -25,12 +36,10 @@ export default async function TranslationMemoryDetailPage({
   const auth = await requireAppAuthContext({ organizationSlug });
 
   return (
-    <Suspense fallback={null}>
-      <TranslationMemoryDetailPageContent
-        organizationSlug={organizationSlug}
-        memoryId={memoryId}
-        canManageMemories={hasCapability(auth.membership.role, "memories:write")}
-      />
-    </Suspense>
+    <TranslationMemoryDetailPageContent
+      organizationSlug={organizationSlug}
+      memoryId={memoryId}
+      canManageMemories={hasCapability(auth.membership.role, "memories:write")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
@@ -106,6 +106,7 @@ function MemoryRow({
           ) : (
             <Link
               href={`/org/${organizationSlug}/translation-memories/${memory.id}`}
+              prefetch
               className="truncate text-sm font-medium text-foreground underline-offset-2 hover:underline"
             >
               {memory.name}
@@ -120,6 +121,7 @@ function MemoryRow({
           {memory.projectLinkId ? (
             <Link
               href={`/org/${organizationSlug}/projects/${memory.projectLinkId}`}
+              prefetch
               className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
             >
               <FormattedMessage {...translationMemoriesTableMessages.viewLinkedProject} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/page.tsx
@@ -10,13 +10,25 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Suspense } from "react";
-
 import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { OrgPageSuspense } from "../_components/org-page-suspense";
 import { TranslationMemoriesPageContent } from "./_components/translation-memories-page-content";
 
-export default async function TranslationMemoriesPage({
+export default function TranslationMemoriesPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <TranslationMemoriesPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function TranslationMemoriesPageLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
@@ -25,11 +37,9 @@ export default async function TranslationMemoriesPage({
   const auth = await requireAppAuthContext({ organizationSlug });
 
   return (
-    <Suspense fallback={null}>
-      <TranslationMemoriesPageContent
-        organizationSlug={organizationSlug}
-        canCreateMemories={hasCapability(auth.membership.role, "memories:write")}
-      />
-    </Suspense>
+    <TranslationMemoriesPageContent
+      organizationSlug={organizationSlug}
+      canCreateMemories={hasCapability(auth.membership.role, "memories:write")}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/disavow.txt/route.ts
+++ b/apps/hyperlocalise-web/src/app/disavow.txt/route.ts
@@ -12,8 +12,6 @@
  */
 import { buildDisavowFile } from "@/lib/seo/disavow-file";
 
-export const dynamic = "force-static";
-
 export function GET() {
   return new Response(buildDisavowFile(), {
     headers: {

--- a/apps/hyperlocalise-web/src/app/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/layout.tsx
@@ -12,62 +12,16 @@
  */
 import { Analytics } from "@vercel/analytics/next";
 import type { Metadata } from "next";
-import { Domine, Geist_Mono, Inter, Noto_Serif, Noto_Serif_SC } from "next/font/google";
-import { withAuth } from "@/lib/workos/server-auth";
-import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
-import { I18nProvider } from "@/components/i18n/i18n-provider";
-import { QueryProvider } from "@/components/query-provider";
-import { ThemeProvider } from "@/components/theme-provider";
-import { Toaster } from "@/components/ui/sonner";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
-import type { AppLocale } from "@/lib/app-i18n/locales";
-import { SITE_URL } from "@/lib/seo/site-url";
 import { GoogleAnalytics } from "@next/third-parties/google";
+
+import { RootLayoutProviders } from "@/components/root-layout/root-layout-providers";
+import { rootHtmlClassName } from "@/components/root-layout/root-layout-fonts";
 import { GA_MEASUREMENT_ID } from "@/lib/analytics/google-analytics";
-import { cn } from "@/lib/primitives/cn";
+import { DEFAULT_APP_LOCALE } from "@/lib/app-i18n/locales";
 import { PRIVATE_ROBOTS } from "@/lib/seo/robots-metadata";
+import { SITE_URL } from "@/lib/seo/site-url";
+
 import "./globals.css";
-
-const inter = Inter({
-  subsets: ["latin", "latin-ext", "vietnamese"],
-  variable: "--font-sans",
-});
-
-/** Domine only ships latin + latin-ext (covers en / de-DE / fr-FR). */
-const domine = Domine({
-  subsets: ["latin", "latin-ext"],
-  variable: "--font-heading-marketing",
-});
-
-/** Fallback heading face when Domine lacks Vietnamese glyphs. */
-const notoSerif = Noto_Serif({
-  subsets: ["latin", "latin-ext", "vietnamese"],
-  variable: "--font-heading-marketing",
-});
-
-/** Fallback heading face when Domine lacks CJK glyphs. */
-const notoSerifSc = Noto_Serif_SC({
-  subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
-  preload: false,
-  variable: "--font-heading-marketing",
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-function headingFontForLocale(locale: AppLocale) {
-  if (locale === "vi-VN") {
-    return notoSerif;
-  }
-  if (locale === "zh-CN") {
-    return notoSerifSc;
-  }
-  return domine;
-}
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -77,47 +31,16 @@ export const metadata: Metadata = {
   robots: PRIVATE_ROBOTS,
 };
 
-async function getInitialAuth(): Promise<
-  React.ComponentProps<typeof AuthKitProvider>["initialAuth"]
-> {
-  const { accessToken: _accessToken, ...initialAuth } = await withAuth();
-  return initialAuth;
-}
-
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [locale, initialAuth] = await Promise.all([getAppLocale(), getInitialAuth()]);
-  const headingFont = headingFontForLocale(locale);
-
   return (
-    <html
-      lang={locale}
-      className={cn(
-        "antialiased",
-        "font-sans",
-        geistMono.variable,
-        inter.variable,
-        headingFont.variable,
-      )}
-      suppressHydrationWarning
-    >
+    <html lang={DEFAULT_APP_LOCALE} className={rootHtmlClassName()} suppressHydrationWarning>
       <body>
         <Analytics />
-        <AuthKitProvider initialAuth={initialAuth}>
-          <I18nProvider locale={locale}>
-            <QueryProvider>
-              <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-                <TooltipProvider>
-                  {children}
-                  <Toaster richColors closeButton />
-                </TooltipProvider>
-              </ThemeProvider>
-            </QueryProvider>
-          </I18nProvider>
-        </AuthKitProvider>
+        <RootLayoutProviders>{children}</RootLayoutProviders>
       </body>
 
       <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.ts
@@ -12,8 +12,6 @@
  */
 import { SITE_URL } from "@/lib/seo/site-url";
 
-export const dynamic = "force-static";
-
 type LlmsLink = {
   title: string;
   href: string;

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-skeleton.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-skeleton.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { CSSProperties, ReactNode } from "react";
+import Image from "next/image";
+import { useIntl } from "react-intl";
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarInset,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyP } from "@/components/ui/typography";
+
+import { appShellClientMessages } from "./app-shell-client.messages";
+
+type AppShellSkeletonProps = {
+  children: ReactNode;
+};
+
+export function AppShellSkeleton({ children }: AppShellSkeletonProps) {
+  const intl = useIntl();
+
+  return (
+    <SidebarProvider
+      defaultOpen
+      style={
+        {
+          "--app-shell-content-height":
+            "calc(100svh - var(--app-shell-header-height) - var(--app-shell-footer-height))",
+          "--app-shell-plan-footer-height": "calc(3rem + env(safe-area-inset-bottom))",
+          "--app-shell-footer-height":
+            "calc(var(--app-shell-plan-footer-height) + var(--app-shell-dock-height, 0px))",
+          "--sidebar-width": "15rem",
+        } as CSSProperties
+      }
+      className="min-h-svh bg-background text-foreground"
+    >
+      <Sidebar variant="sidebar" collapsible="icon">
+        <SidebarHeader className="gap-3 border-b border-sidebar-border px-3 py-3 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-0">
+          <div className="flex items-center gap-2.5 rounded-xl px-1 py-1 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+            <Image
+              src="/images/logo.png"
+              width={28}
+              height={28}
+              sizes="28px"
+              alt={intl.formatMessage(appShellClientMessages.logoAlt)}
+              className="size-7 shrink-0 rounded-lg"
+            />
+            <div className="min-w-0 group-data-[collapsible=icon]:hidden">
+              <TypographyP
+                className="text-sidebar-foreground"
+                lineClamp={1}
+                size="small"
+                weight="medium"
+              >
+                {intl.formatMessage(appShellClientMessages.brandName)}
+              </TypographyP>
+            </div>
+          </div>
+        </SidebarHeader>
+
+        <SidebarContent className="gap-3 px-2 pt-2 pb-[var(--app-shell-footer-height)]">
+          <div className="space-y-2 px-1">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-4/5" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-3/4" />
+          </div>
+        </SidebarContent>
+
+        <SidebarRail />
+      </Sidebar>
+
+      <SidebarInset className="h-svh max-h-svh min-h-0 overflow-hidden bg-background pb-[var(--app-shell-footer-height)]">
+        <div className="sticky top-0 z-20 shrink-0 border-b border-border bg-background/96 backdrop-blur">
+          <div className="flex h-(--app-shell-header-height) items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
+            <div className="flex min-w-0 items-center gap-3">
+              <SidebarTrigger className="-ms-1" />
+              <Separator
+                orientation="vertical"
+                className="me-2 data-vertical:h-4 data-vertical:self-auto"
+              />
+              <Skeleton className="h-4 w-32" />
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Skeleton className="size-8 rounded-full" />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-5 sm:px-6 lg:px-8">
+          {children}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -10,10 +10,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 
 import { hasCapability } from "@/api/auth/policy";
 import { AppShellClient } from "@/components/app-shell/app-shell-client";
+import { AppShellSkeleton } from "@/components/app-shell/app-shell-skeleton";
 import { buildGlobalNavigationGroups } from "@/components/app-shell/navigation-config";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 import { getAppLocale } from "@/lib/app-i18n/server-locale";
@@ -36,11 +37,27 @@ export type AppShellProps = {
   organizationSlug: string;
 };
 
-export async function AppShell({
-  autumnConfigured = false,
+export function AppShell({ autumnConfigured = false, children, organizationSlug }: AppShellProps) {
+  return (
+    <Suspense fallback={<AppShellSkeleton>{children}</AppShellSkeleton>}>
+      <AppShellWithData autumnConfigured={autumnConfigured} organizationSlug={organizationSlug}>
+        {children}
+      </AppShellWithData>
+    </Suspense>
+  );
+}
+
+type AppShellWithDataProps = {
+  autumnConfigured: boolean;
+  children: ReactNode;
+  organizationSlug: string;
+};
+
+async function AppShellWithData({
+  autumnConfigured,
   children,
   organizationSlug,
-}: AppShellProps) {
+}: AppShellWithDataProps) {
   const auth = await requireAppAuthContext({ organizationSlug });
   const activeOrganizationSlug = auth.activeOrganization.slug ?? organizationSlug;
   const intl = getIntlShape(await getAppLocale()) as IntlShape;

--- a/apps/hyperlocalise-web/src/components/root-layout/root-document-locale.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-document-locale.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useLayoutEffect } from "react";
+
+import type { AppLocale } from "@/lib/app-i18n/locales";
+
+type RootDocumentLocaleProps = {
+  locale: AppLocale;
+};
+
+export function RootDocumentLocale({ locale }: RootDocumentLocaleProps) {
+  useLayoutEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-fonts.ts
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-fonts.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Domine, Geist_Mono, Inter, Noto_Serif, Noto_Serif_SC } from "next/font/google";
+
+import { DEFAULT_APP_LOCALE, type AppLocale } from "@/lib/app-i18n/locales";
+import { cn } from "@/lib/primitives/cn";
+
+export const inter = Inter({
+  subsets: ["latin", "latin-ext", "vietnamese"],
+  variable: "--font-sans",
+});
+
+/** Domine only ships latin + latin-ext (covers en / de-DE / fr-FR). */
+export const domine = Domine({
+  subsets: ["latin", "latin-ext"],
+  variable: "--font-heading-marketing",
+});
+
+/** Fallback heading face when Domine lacks Vietnamese glyphs. */
+export const notoSerif = Noto_Serif({
+  subsets: ["latin", "latin-ext", "vietnamese"],
+  variable: "--font-heading-marketing",
+});
+
+/** Fallback heading face when Domine lacks CJK glyphs. */
+export const notoSerifSc = Noto_Serif_SC({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  preload: false,
+  variable: "--font-heading-marketing",
+});
+
+export const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export function headingFontForLocale(locale: AppLocale) {
+  if (locale === "vi-VN") {
+    return notoSerif;
+  }
+  if (locale === "zh-CN") {
+    return notoSerifSc;
+  }
+  return domine;
+}
+
+export function rootHtmlClassName(locale: AppLocale = DEFAULT_APP_LOCALE) {
+  const headingFont = headingFontForLocale(locale);
+
+  return cn("antialiased", "font-sans", geistMono.variable, inter.variable, headingFont.variable);
+}

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
@@ -29,8 +29,12 @@ describe("root layout cacheComponents boundary", () => {
       path.join(import.meta.dirname, "root-layout-providers.tsx"),
       "utf8",
     );
+    const fallbackFn = source.match(
+      /function RootLayoutProvidersFallback\(\) \{[\s\S]*?\n\}/,
+    )?.[0];
 
-    expect(source).toMatch(/fallback=\{<RootLayoutProvidersFallback/);
-    expect(source).not.toMatch(/fallback=\{[\s\S]*\{children\}/);
+    expect(source).toContain("<Suspense fallback={<RootLayoutProvidersFallback />}>");
+    expect(fallbackFn).toBeDefined();
+    expect(fallbackFn).not.toContain("{children}");
   });
 });

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vite-plus/test";
+
+describe("root layout cacheComponents boundary", () => {
+  it("does not read request data in the root layout module", () => {
+    const source = readFileSync(path.join(import.meta.dirname, "../../app/layout.tsx"), "utf8");
+
+    expect(source).toMatch(/export default function RootLayout/);
+    expect(source).not.toMatch(/\bgetAppLocale\b|\bgetInitialAuth\b|\bwithAuth\b/);
+    expect(source).not.toMatch(/\bheaders\s*\(|\bcookies\s*\(/);
+  });
+
+  it("keeps the root Suspense fallback free of route children", () => {
+    const source = readFileSync(
+      path.join(import.meta.dirname, "root-layout-providers.tsx"),
+      "utf8",
+    );
+
+    expect(source).toMatch(/fallback=\{<RootLayoutProvidersFallback/);
+    expect(source).not.toMatch(/fallback=\{[\s\S]*\{children\}/);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
@@ -29,9 +29,7 @@ describe("root layout cacheComponents boundary", () => {
       path.join(import.meta.dirname, "root-layout-providers.tsx"),
       "utf8",
     );
-    const fallbackFn = source.match(
-      /function RootLayoutProvidersFallback\(\) \{[\s\S]*?\n\}/,
-    )?.[0];
+    const fallbackFn = source.match(/function RootLayoutProvidersFallback\(\) \{[\s\S]*?\n\}/)?.[0];
 
     expect(source).toContain("<Suspense fallback={<RootLayoutProvidersFallback />}>");
     expect(fallbackFn).toBeDefined();

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Suspense, type ReactNode } from "react";
+import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
+
+import { I18nProvider } from "@/components/i18n/i18n-provider";
+import { QueryProvider } from "@/components/query-provider";
+import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { DEFAULT_APP_LOCALE, type AppLocale } from "@/lib/app-i18n/locales";
+import { getAppLocale } from "@/lib/app-i18n/server-locale";
+import { withAuth } from "@/lib/workos/server-auth";
+
+import { headingFontForLocale } from "./root-layout-fonts";
+import { RootDocumentLocale } from "./root-document-locale";
+
+type RootLayoutProvidersProps = {
+  children: ReactNode;
+};
+
+type RootLayoutProvidersInnerProps = RootLayoutProvidersProps & {
+  initialAuth: React.ComponentProps<typeof AuthKitProvider>["initialAuth"];
+  locale: AppLocale;
+};
+
+export function RootLayoutProviders({ children }: RootLayoutProvidersProps) {
+  return (
+    <Suspense
+      fallback={
+        <RootLayoutProvidersInner initialAuth={undefined} locale={DEFAULT_APP_LOCALE}>
+          {children}
+        </RootLayoutProvidersInner>
+      }
+    >
+      <RootLayoutProvidersContent>{children}</RootLayoutProvidersContent>
+    </Suspense>
+  );
+}
+
+async function RootLayoutProvidersContent({ children }: RootLayoutProvidersProps) {
+  const [locale, initialAuth] = await Promise.all([getAppLocale(), getInitialAuth()]);
+
+  return (
+    <RootLayoutProvidersInner initialAuth={initialAuth} locale={locale}>
+      {children}
+    </RootLayoutProvidersInner>
+  );
+}
+
+function RootLayoutProvidersInner({
+  children,
+  initialAuth,
+  locale,
+}: RootLayoutProvidersInnerProps) {
+  const headingFontClassName = headingFontForLocale(locale).variable;
+
+  return (
+    <>
+      <RootDocumentLocale locale={locale} />
+      <div className={headingFontClassName}>
+        <AuthKitProvider initialAuth={initialAuth}>
+          <I18nProvider locale={locale}>
+            <QueryProvider>
+              <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+                <TooltipProvider>
+                  {children}
+                  <Toaster richColors closeButton />
+                </TooltipProvider>
+              </ThemeProvider>
+            </QueryProvider>
+          </I18nProvider>
+        </AuthKitProvider>
+      </div>
+    </>
+  );
+}
+
+async function getInitialAuth(): Promise<
+  React.ComponentProps<typeof AuthKitProvider>["initialAuth"]
+> {
+  const { accessToken: _accessToken, ...initialAuth } = await withAuth();
+  return initialAuth;
+}

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.tsx
@@ -29,23 +29,24 @@ type RootLayoutProvidersProps = {
   children: ReactNode;
 };
 
-type RootLayoutProvidersInnerProps = RootLayoutProvidersProps & {
+type RootLayoutProvidersInnerProps = {
+  children?: ReactNode;
   initialAuth: React.ComponentProps<typeof AuthKitProvider>["initialAuth"];
   locale: AppLocale;
 };
 
 export function RootLayoutProviders({ children }: RootLayoutProvidersProps) {
   return (
-    <Suspense
-      fallback={
-        <RootLayoutProvidersInner initialAuth={undefined} locale={DEFAULT_APP_LOCALE}>
-          {children}
-        </RootLayoutProvidersInner>
-      }
-    >
+    <Suspense fallback={<RootLayoutProvidersFallback />}>
       <RootLayoutProvidersContent>{children}</RootLayoutProvidersContent>
     </Suspense>
   );
+}
+
+function RootLayoutProvidersFallback() {
+  // Keep route children out of the fallback. Including them would prerender
+  // uncached page data (cookies, headers, auth) into the static shell.
+  return <RootLayoutProvidersInner initialAuth={undefined} locale={DEFAULT_APP_LOCALE} />;
 }
 
 async function RootLayoutProvidersContent({ children }: RootLayoutProvidersProps) {

--- a/apps/hyperlocalise-web/src/e2e/flows/instant-navigation.e2e.ts
+++ b/apps/hyperlocalise-web/src/e2e/flows/instant-navigation.e2e.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { instant } from "@next/playwright";
+import { describe, it } from "vite-plus/test";
+
+import { E2E_BASE_URL, organizationDashboardPath } from "../constants";
+import { getE2ePage, loginAsAdmin, useE2eBrowser } from "../fixtures/browser";
+
+describe("instant navigation", () => {
+  useE2eBrowser();
+
+  it("dashboard is instant on an initial page load", async () => {
+    const page = getE2ePage();
+    const identity = await loginAsAdmin(page);
+    const dashboardPath = organizationDashboardPath(identity.organizationSlug);
+
+    await instant(
+      page,
+      async () => {
+        await page.goto(new URL(dashboardPath, E2E_BASE_URL).toString(), {
+          waitUntil: "domcontentloaded",
+        });
+        await page.getByRole("heading", { name: "Overview" }).waitFor({ state: "visible" });
+      },
+      { baseURL: E2E_BASE_URL },
+    );
+  });
+
+  it("projects nav is instant on a client navigation", async () => {
+    const page = getE2ePage();
+    await loginAsAdmin(page);
+
+    await instant(page, async () => {
+      await page.getByRole("link", { name: "Projects", exact: true }).click();
+      await page.waitForURL((url) => url.pathname.endsWith("/projects"));
+      await page.getByRole("heading", { name: "Projects" }).waitFor({ state: "visible" });
+    });
+  });
+
+  it("jobs nav is instant on a client navigation", async () => {
+    const page = getE2ePage();
+    await loginAsAdmin(page);
+
+    await instant(page, async () => {
+      await page.getByRole("link", { name: "Jobs", exact: true }).click();
+      await page.waitForURL((url) => url.pathname.endsWith("/jobs"));
+      await page.getByRole("heading", { name: "Jobs" }).waitFor({ state: "visible" });
+    });
+  });
+});


### PR DESCRIPTION
## What changed
Enable Next.js 16.3 instant navigation for the org workspace (`/org/[organizationSlug]/*`):
- Turn on `cacheComponents` and `partialPrefetching` in `next.config.ts`
- Stream `AppShell` auth/flags/TMS behind `Suspense` with a skeleton fallback
- Refactor org layout and all org routes to use sync page shells + async loaders via `OrgPageSuspense`
- Add `prefetch` on high-value detail links in projects, glossaries, and translation-memories tables
- Add `@next/playwright` `instant()` e2e coverage for dashboard, projects, and jobs navigation
## How to test
- `cd apps/hyperlocalise-web && vp check --fix`
- `cd apps/hyperlocalise-web && vp test`
- Start dev server (`vp run dev`) and navigate between org sidebar routes — shell should paint immediately with loading fallbacks
- Use Next.js DevTools Navigation Inspector to verify client navigations show prefetched shell content
- E2E (requires WorkOS emulator + dev server): `vp run test:e2e` and run `instant-navigation.e2e.ts`
## Checklist
- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review