### PR TITLE
Visual workflows: rename, delete, change trigger, and fix integration examples

### DIFF
--- a/apps/hyperlocalise-web/lang/de-DE.json
+++ b/apps/hyperlocalise-web/lang/de-DE.json
@@ -2283,7 +2283,7 @@
     "defaultMessage": "Offen"
   },
   "5Q7wl9b9ir": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "5QymJ2ZjS2": {
     "defaultMessage": "Cache"
@@ -2451,7 +2451,7 @@
     "defaultMessage": "Nur Workspace-Administratoren können das Abrechnungsportal öffnen."
   },
   "68KxHHw2pe": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "68oR+M/HhK": {
     "defaultMessage": "Laden Sie den vollständigen Speicher herunter oder beschränken Sie die Datei auf ein Quell- und Zielsprachenpaar."
@@ -4071,7 +4071,7 @@
     "defaultMessage": "Bestandene Prüfungen anzeigen"
   },
   "BU34xLZuIV": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "BUGP6fk/PM": {
     "defaultMessage": "In Prüfung"
@@ -13986,7 +13986,7 @@
     "defaultMessage": "Arbeitsbereich"
   },
   "jq/3JKwWN0": {
-    "defaultMessage": "No advanced workflows yet. Create one to start building on the canvas."
+    "defaultMessage": "No visual workflows yet. Create one to start building on the canvas."
   },
   "jqb6LSQ7FV": {
     "defaultMessage": "Die Automatisierung kann derzeit nicht gelöscht werden."

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -4887,9 +4887,9 @@
     "defaultMessage": "Blog",
     "description": "Title for the marketing blog index page"
   },
-  "BNs8waALWE": {
+  "p/CGM67hkK": {
     "defaultMessage": "Visual workflow examples",
-    "description": "Heading for the integration visual workflow examples section"
+    "description": "Heading for the integration workflow examples section"
   },
   "BOD7YPsYm8": {
     "defaultMessage": "Issues",

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -4888,8 +4888,8 @@
     "description": "Title for the marketing blog index page"
   },
   "BNs8waALWE": {
-    "defaultMessage": "Example workflows",
-    "description": "Heading for the integration workflow examples section"
+    "defaultMessage": "Visual workflow examples",
+    "description": "Heading for the integration visual workflow examples section"
   },
   "BOD7YPsYm8": {
     "defaultMessage": "Issues",

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -2708,7 +2708,7 @@
     "description": "Issue status filter option when an issue is open"
   },
   "5Q7wl9b9ir": {
-    "defaultMessage": "Advanced workflows",
+    "defaultMessage": "Visual workflows",
     "description": "Link from automations list to visual workflows"
   },
   "5QymJ2ZjS2": {
@@ -2904,7 +2904,7 @@
     "description": "Note shown when the user cannot open the billing portal"
   },
   "68KxHHw2pe": {
-    "defaultMessage": "Advanced workflows",
+    "defaultMessage": "Visual workflows",
     "description": "Title for the visual workflows list page"
   },
   "68oR+M/HhK": {
@@ -4916,7 +4916,7 @@
     "description": "Control to expand passed localisation audit criteria"
   },
   "BU34xLZuIV": {
-    "defaultMessage": "Advanced workflows",
+    "defaultMessage": "Visual workflows",
     "description": "Breadcrumb label for the visual workflows list page"
   },
   "BUGP6fk/PM": {
@@ -16888,7 +16888,7 @@
     "description": "Eyebrow label above the translation memories page title"
   },
   "jq/3JKwWN0": {
-    "defaultMessage": "No advanced workflows yet. Create one to start building on the canvas.",
+    "defaultMessage": "No visual workflows yet. Create one to start building on the canvas.",
     "description": "Empty state on the visual workflows list page"
   },
   "jqb6LSQ7FV": {
@@ -22666,5 +22666,49 @@
   "zztNzAuBoJ": {
     "defaultMessage": "Enabled",
     "description": "Screen reader label for the repository enabled checkbox column"
+  },
+  "vwDelBtn01": {
+    "defaultMessage": "Delete",
+    "description": "Button that deletes a visual workflow"
+  },
+  "vwDelTtl02": {
+    "defaultMessage": "Delete workflow?",
+    "description": "Title of the delete visual workflow confirmation dialog"
+  },
+  "vwDelDsc03": {
+    "defaultMessage": "{workflowName} will be removed from this workspace and will no longer run.",
+    "description": "Delete visual workflow confirmation describing the selected workflow"
+  },
+  "vwDelCan04": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel button in the delete visual workflow dialog"
+  },
+  "vwDelIng05": {
+    "defaultMessage": "Deleting...",
+    "description": "Delete button label while a visual workflow is being deleted"
+  },
+  "vwDelCfm06": {
+    "defaultMessage": "Delete",
+    "description": "Confirm button to delete a visual workflow"
+  },
+  "vwDelOk07": {
+    "defaultMessage": "Workflow deleted",
+    "description": "Toast when a visual workflow is deleted successfully"
+  },
+  "vwDelErr08": {
+    "defaultMessage": "Could not delete this workflow.",
+    "description": "Toast when visual workflow deletion fails"
+  },
+  "vwTrigTyp09": {
+    "defaultMessage": "Trigger",
+    "description": "Label for changing the selected visual workflow trigger type"
+  },
+  "vwDelStp10": {
+    "defaultMessage": "Delete step",
+    "description": "Button that removes the selected node from the visual workflow canvas"
+  },
+  "vwDelWf11": {
+    "defaultMessage": "Delete",
+    "description": "Button that deletes the current visual workflow"
   }
 }

--- a/apps/hyperlocalise-web/lang/fr-FR.json
+++ b/apps/hyperlocalise-web/lang/fr-FR.json
@@ -2283,7 +2283,7 @@
     "defaultMessage": "Open"
   },
   "5Q7wl9b9ir": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "5QymJ2ZjS2": {
     "defaultMessage": "Cache"
@@ -2451,7 +2451,7 @@
     "defaultMessage": "Seuls les administrateurs de l’espace de travail peuvent ouvrir le portail de facturation."
   },
   "68KxHHw2pe": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "68oR+M/HhK": {
     "defaultMessage": "Téléchargez la mémoire complète ou limitez le fichier à une seule paire de paramètres régionaux source et cible."
@@ -4071,7 +4071,7 @@
     "defaultMessage": "Afficher les audits réussis"
   },
   "BU34xLZuIV": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "BUGP6fk/PM": {
     "defaultMessage": "En cours de révision"
@@ -13986,7 +13986,7 @@
     "defaultMessage": "Workspace"
   },
   "jq/3JKwWN0": {
-    "defaultMessage": "No advanced workflows yet. Create one to start building on the canvas."
+    "defaultMessage": "No visual workflows yet. Create one to start building on the canvas."
   },
   "jqb6LSQ7FV": {
     "defaultMessage": "Impossible de supprimer l’automatisation pour le moment"

--- a/apps/hyperlocalise-web/lang/vi-VN.json
+++ b/apps/hyperlocalise-web/lang/vi-VN.json
@@ -2283,7 +2283,7 @@
     "defaultMessage": "Open"
   },
   "5Q7wl9b9ir": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "5QymJ2ZjS2": {
     "defaultMessage": "Bộ nhớ đệm"
@@ -2451,7 +2451,7 @@
     "defaultMessage": "Chỉ quản trị viên không gian làm việc mới có thể mở cổng thanh toán."
   },
   "68KxHHw2pe": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "68oR+M/HhK": {
     "defaultMessage": "Tải xuống toàn bộ bộ nhớ hoặc giới hạn tệp ở một cặp ngôn ngữ nguồn và đích."
@@ -4071,7 +4071,7 @@
     "defaultMessage": "Hiển thị các đợt kiểm tra đã đạt"
   },
   "BU34xLZuIV": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "BUGP6fk/PM": {
     "defaultMessage": "Đang xem xét"
@@ -13986,7 +13986,7 @@
     "defaultMessage": "Workspace"
   },
   "jq/3JKwWN0": {
-    "defaultMessage": "No advanced workflows yet. Create one to start building on the canvas."
+    "defaultMessage": "No visual workflows yet. Create one to start building on the canvas."
   },
   "jqb6LSQ7FV": {
     "defaultMessage": "Hiện không thể xóa tự động hóa."

--- a/apps/hyperlocalise-web/lang/zh-CN.json
+++ b/apps/hyperlocalise-web/lang/zh-CN.json
@@ -2283,7 +2283,7 @@
     "defaultMessage": "Open"
   },
   "5Q7wl9b9ir": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "5QymJ2ZjS2": {
     "defaultMessage": "缓存"
@@ -2451,7 +2451,7 @@
     "defaultMessage": "只有工作区管理员才能打开账单门户。"
   },
   "68KxHHw2pe": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "68oR+M/HhK": {
     "defaultMessage": "下载完整记忆，或将文件限制为一个源语言和目标语言区域设置对。"
@@ -4071,7 +4071,7 @@
     "defaultMessage": "显示已通过的审核"
   },
   "BU34xLZuIV": {
-    "defaultMessage": "Advanced workflows"
+    "defaultMessage": "Visual workflows"
   },
   "BUGP6fk/PM": {
     "defaultMessage": "审核中"
@@ -13986,7 +13986,7 @@
     "defaultMessage": "Workspace"
   },
   "jq/3JKwWN0": {
-    "defaultMessage": "No advanced workflows yet. Create one to start building on the canvas."
+    "defaultMessage": "No visual workflows yet. Create one to start building on the canvas."
   },
   "jqb6LSQ7FV": {
     "defaultMessage": "目前无法删除自动化设置"

--- a/apps/hyperlocalise-web/src/api/routes/visual-workflow/visual-workflow.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/visual-workflow/visual-workflow.route.test.ts
@@ -158,11 +158,63 @@ describe("visual workflow routes", () => {
     };
     expect(updated.visualWorkflow.name).toBe("Lead ping v2");
 
+    const deletedResponse = await client.api.orgs[":organizationSlug"]["visual-workflows"][
+      ":visualWorkflowId"
+    ].$delete(
+      {
+        param: {
+          organizationSlug,
+          visualWorkflowId: created.visualWorkflow.id,
+        },
+      },
+      { headers },
+    );
+    expect(deletedResponse.status).toBe(204);
+
+    const listedAfterDelete = await client.api.orgs[":organizationSlug"]["visual-workflows"].$get(
+      {
+        param: { organizationSlug },
+        query: { limit: "50", offset: "0" },
+      },
+      { headers },
+    );
+    expect(listedAfterDelete.status).toBe(200);
+    const listedAfter = (await listedAfterDelete.json()) as {
+      visualWorkflows: Array<{ id: string }>;
+    };
+    expect(listedAfter.visualWorkflows.some((row) => row.id === created.visualWorkflow.id)).toBe(
+      false,
+    );
+
     const rows = await db
       .select()
       .from(schema.visualWorkflows)
       .where(eq(schema.visualWorkflows.organizationId, organizationId));
-    expect(rows.some((row) => row.id === created.visualWorkflow.id)).toBe(true);
+    const deletedRow = rows.find((row) => row.id === created.visualWorkflow.id);
+    expect(deletedRow?.status).toBe("archived");
+  });
+
+  it("returns not found when deleting a missing visual workflow", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const response = await client.api.orgs[":organizationSlug"]["visual-workflows"][
+      ":visualWorkflowId"
+    ].$delete(
+      {
+        param: {
+          organizationSlug,
+          visualWorkflowId: crypto.randomUUID(),
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "visual_workflow_not_found",
+    });
   });
 
   it("returns forbidden when the visual workflows feature flag is disabled", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/visual-workflow/visual-workflow.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/visual-workflow/visual-workflow.route.ts
@@ -20,6 +20,7 @@ import { workspaceVisualWorkflowsFlag } from "@/lib/flags/workspace-flags";
 import { isErr } from "@/lib/primitives/result/results";
 import {
   createVisualWorkflow,
+  deleteVisualWorkflow,
   getVisualWorkflowById,
   listVisualWorkflows,
   updateVisualWorkflow,
@@ -234,6 +235,19 @@ export function createVisualWorkflowRoutes() {
       }
 
       return c.json({ visualWorkflow: result.value }, 200);
+    })
+    .delete("/:visualWorkflowId", validateVisualWorkflowParams, async (c) => {
+      const { visualWorkflowId } = c.req.valid("param");
+      const result = await deleteVisualWorkflow({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        visualWorkflowId,
+      });
+
+      if (isErr(result)) {
+        return notFoundResponse(c, result.error.code);
+      }
+
+      return c.body(null, 204);
     })
     .get(
       "/:visualWorkflowId/runs",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -266,7 +266,7 @@ export function AutomationsPageView({
                 variant="outline"
               >
                 <FormattedMessage
-                  defaultMessage="Advanced workflows"
+                  defaultMessage="Visual workflows"
                   id="5Q7wl9b9ir"
                   description="Link from automations list to visual workflows"
                 />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -267,7 +267,7 @@ export function AutomationsPageView({
               >
                 <FormattedMessage
                   defaultMessage="Visual workflows"
-                  id="5Q7wl9b9ir"
+                  id="zK2bwfb+JP"
                   description="Link from automations list to visual workflows"
                 />
               </Button>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-delete-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-delete-dialog.tsx
@@ -69,11 +69,7 @@ export function VisualWorkflowDeleteDialog({
             <FormattedMessage {...visualWorkflowsPageMessages.deleteCancel} />
           </AlertDialogCancel>
           <Button variant="destructive" disabled={isDeleting} onClick={onConfirm}>
-            {isDeleting ? (
-              <Spinner />
-            ) : (
-              <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-            )}
+            {isDeleting ? <Spinner /> : <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />}
             {isDeleting ? (
               <FormattedMessage {...visualWorkflowsPageMessages.deleting} />
             ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-delete-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-delete-dialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Delete02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+
+import { visualWorkflowsPageMessages } from "./visual-workflows-page.messages";
+
+export function VisualWorkflowDeleteDialog({
+  open,
+  workflowName,
+  isDeleting,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  workflowName: string;
+  isDeleting: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (isDeleting) {
+          return;
+        }
+        onOpenChange(nextOpen);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            <FormattedMessage {...visualWorkflowsPageMessages.deleteTitle} />
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {intl.formatMessage(visualWorkflowsPageMessages.deleteDescription, { workflowName })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>
+            <FormattedMessage {...visualWorkflowsPageMessages.deleteCancel} />
+          </AlertDialogCancel>
+          <Button variant="destructive" disabled={isDeleting} onClick={onConfirm}>
+            {isDeleting ? (
+              <Spinner />
+            ) : (
+              <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+            )}
+            {isDeleting ? (
+              <FormattedMessage {...visualWorkflowsPageMessages.deleting} />
+            ) : (
+              <FormattedMessage {...visualWorkflowsPageMessages.deleteConfirm} />
+            )}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor-page-content.tsx
@@ -14,6 +14,7 @@
  */
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { FormattedMessage } from "react-intl";
 import { toast } from "sonner";
@@ -24,9 +25,11 @@ import { fromVisualWorkflowDefinition } from "@/lib/visual-workflows/schema/seri
 import type { VisualWorkflowDefinition } from "@/lib/visual-workflows/schema/types";
 import type { VisualWorkflowRecord } from "@/lib/visual-workflows/visual-workflow-types";
 
+import { VisualWorkflowDeleteDialog } from "./visual-workflow-delete-dialog";
 import { createVisualWorkflowsApi, type VisualWorkflowsApi } from "./visual-workflows-api";
 import { VisualWorkflowEditor } from "./visual-workflow-editor/visual-workflow-editor";
 import { visualWorkflowEditorMessages } from "./visual-workflow-editor/visual-workflow-editor.messages";
+import { visualWorkflowsPageMessages } from "./visual-workflows-page.messages";
 
 const visualWorkflowsApi = createVisualWorkflowsApi();
 
@@ -40,6 +43,7 @@ export function VisualWorkflowEditorPageContent({
   visualWorkflowsApi?: VisualWorkflowsApi;
 }) {
   const router = useRouter();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   useAppShellSidebar({ forceCollapsed: true });
   const editorState = fromVisualWorkflowDefinition({
     ...workflow.definition,
@@ -76,6 +80,17 @@ export function VisualWorkflowEditorPageContent({
     mutateAsync: persistMutation.mutateAsync,
     isPending: persistMutation.isPending,
   };
+
+  const deleteMutation = useMutation({
+    mutationFn: () => injectedApi.deleteVisualWorkflow(organizationSlug, workflow.id),
+    onSuccess: () => {
+      toast.success(<FormattedMessage {...visualWorkflowsPageMessages.deleteSuccess} />);
+      router.push(`/org/${organizationSlug}/automations/visual-workflows`);
+    },
+    onError: () => {
+      toast.error(<FormattedMessage {...visualWorkflowsPageMessages.deleteFailed} />);
+    },
+  });
 
   const handleStatusChange = async (active: boolean, definition: VisualWorkflowDefinition) => {
     try {
@@ -125,6 +140,25 @@ export function VisualWorkflowEditorPageContent({
         workflowStatus={workflow.status}
         onStatusChange={handleStatusChange}
         statusUpdating={saveMutation.isPending}
+        onDelete={() => {
+          if (saveMutation.isPending || deleteMutation.isPending) {
+            return;
+          }
+          setDeleteDialogOpen(true);
+        }}
+        isDeleting={deleteMutation.isPending}
+      />
+      <VisualWorkflowDeleteDialog
+        open={deleteDialogOpen}
+        workflowName={workflow.name}
+        isDeleting={deleteMutation.isPending}
+        onOpenChange={setDeleteDialogOpen}
+        onConfirm={() => {
+          if (saveMutation.isPending) {
+            return;
+          }
+          deleteMutation.mutate();
+        }}
       />
     </div>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/nodes/visual-workflow-compact-node.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/nodes/visual-workflow-compact-node.tsx
@@ -43,7 +43,7 @@ export function VisualWorkflowCompactNode({ id, data, selected }: NodeProps<Visu
   const isAi = data.catalogType === "ai.agent";
   const showErrorHandle = nodeSupportsErrorBranch(data.config);
   const title = intl.formatMessage(titleMessage(data.catalogType));
-  const subtitle = resolveNodeSubtitle(data.config);
+  const subtitle = data.previewSubtitle ?? resolveNodeSubtitle(data.config);
 
   const switchHandles =
     isSwitch && data.config.kind === "logic.switch"
@@ -168,21 +168,23 @@ export function VisualWorkflowCompactNode({ id, data, selected }: NodeProps<Visu
         </div>
       ) : null}
 
-      <button
-        type="button"
-        data-visual-workflow-add=""
-        className="nodrag nopan absolute top-1/2 -right-3 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm hover:bg-muted"
-        aria-label={intl.formatMessage(messages.addNode)}
-        onClick={(event) => {
-          event.stopPropagation();
-          onAddFromNode({
-            nodeId: id,
-            handleId: isIf ? "true" : isSwitch ? "0" : undefined,
-          });
-        }}
-      >
-        <HugeiconsIcon icon={Add01Icon} className="size-3.5" strokeWidth={2} />
-      </button>
+      {data.hideAddAction ? null : (
+        <button
+          type="button"
+          data-visual-workflow-add=""
+          className="nodrag nopan absolute top-1/2 -right-3 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm hover:bg-muted"
+          aria-label={intl.formatMessage(messages.addNode)}
+          onClick={(event) => {
+            event.stopPropagation();
+            onAddFromNode({
+              nodeId: id,
+              handleId: isIf ? "true" : isSwitch ? "0" : undefined,
+            });
+          }}
+        >
+          <HugeiconsIcon icon={Add01Icon} className="size-3.5" strokeWidth={2} />
+        </button>
+      )}
     </Card>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-canvas.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-canvas.tsx
@@ -37,7 +37,7 @@ import type {
 import { VisualWorkflowCompactNode } from "./nodes/visual-workflow-compact-node";
 import { visualWorkflowEditorMessages as messages } from "./visual-workflow-editor.messages";
 
-const nodeTypes = Object.fromEntries(
+export const VISUAL_WORKFLOW_NODE_TYPES = Object.fromEntries(
   VISUAL_NODE_CATALOG.filter((item) => item.enabled).map((item) => [
     item.type,
     VisualWorkflowCompactNode,
@@ -87,7 +87,7 @@ export function VisualWorkflowCanvas({
         className="h-full"
         nodes={nodes}
         edges={edges}
-        nodeTypes={nodeTypes}
+        nodeTypes={VISUAL_WORKFLOW_NODE_TYPES}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-chrome.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-chrome.tsx
@@ -40,6 +40,8 @@ export function VisualWorkflowChrome({
   workflowStatus = "draft",
   onStatusChange,
   statusDisabled = false,
+  onDelete,
+  isDeleting = false,
 }: {
   name: string;
   onNameChange: (name: string) => void;
@@ -56,6 +58,8 @@ export function VisualWorkflowChrome({
   workflowStatus?: VisualWorkflowStatus;
   onStatusChange?: (active: boolean) => void;
   statusDisabled?: boolean;
+  onDelete?: () => void;
+  isDeleting?: boolean;
 }) {
   const intl = useIntl();
   const previewOnly = intl.formatMessage(messages.previewOnly);
@@ -162,6 +166,17 @@ export function VisualWorkflowChrome({
         <Button type="button" variant="outline" size="sm" onClick={onExport}>
           <FormattedMessage {...messages.exportJson} />
         </Button>
+        {onDelete ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isDeleting || isSaving}
+            onClick={onDelete}
+          >
+            <FormattedMessage {...messages.deleteWorkflow} />
+          </Button>
+        ) : null}
         {onSave ? (
           <Button type="button" size="sm" disabled={saveDisabled || isSaving} onClick={onSave}>
             {isSaving ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.test.tsx
@@ -17,7 +17,10 @@ import userEvent from "@testing-library/user-event";
 import { IntlProvider } from "react-intl";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { createDefaultConfig, getVisualNodeDimensions } from "@/lib/visual-workflows/catalog/node-catalog";
+import {
+  createDefaultConfig,
+  getVisualNodeDimensions,
+} from "@/lib/visual-workflows/catalog/node-catalog";
 import type { VisualWorkflowRfNode } from "@/lib/visual-workflows/schema/types";
 
 import { VisualWorkflowConfigPanel } from "./visual-workflow-config-panel";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createDefaultConfig, getVisualNodeDimensions } from "@/lib/visual-workflows/catalog/node-catalog";
+import type { VisualWorkflowRfNode } from "@/lib/visual-workflows/schema/types";
+
+import { VisualWorkflowConfigPanel } from "./visual-workflow-config-panel";
+
+function triggerNode(type: VisualWorkflowRfNode["type"] = "trigger.manual"): VisualWorkflowRfNode {
+  return {
+    id: "t",
+    type,
+    position: { x: 0, y: 0 },
+    ...getVisualNodeDimensions(type),
+    data: {
+      catalogType: type,
+      config: createDefaultConfig(type),
+      runStatus: "idle",
+    },
+  };
+}
+
+describe("VisualWorkflowConfigPanel", () => {
+  it("lets operators change the trigger type and delete the step", async () => {
+    const user = userEvent.setup();
+    const onChangeNodeType = vi.fn();
+    const onDeleteNode = vi.fn();
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <VisualWorkflowConfigPanel
+          node={triggerNode()}
+          issues={[]}
+          onBack={vi.fn()}
+          onChangeConfig={vi.fn()}
+          onChangeNodeType={onChangeNodeType}
+          onDeleteNode={onDeleteNode}
+        />
+      </IntlProvider>,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Trigger" }));
+    await user.click(await screen.findByRole("option", { name: "GitHub" }));
+    expect(onChangeNodeType).toHaveBeenCalledWith("trigger.github");
+
+    await user.click(screen.getByRole("button", { name: "Delete step" }));
+    expect(onDeleteNode).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.tsx
@@ -30,9 +30,15 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 import { assertNever } from "@/lib/primitives/assert-never/assert-never";
+import { isTriggerType } from "@/lib/visual-workflows/catalog/node-catalog";
+import {
+  isVisualTriggerCatalogType,
+  VISUAL_TRIGGER_TYPES,
+} from "@/lib/visual-workflows/editor/visual-workflow-editor-graph";
 import type {
   HttpAuthType,
   HttpMethod,
+  VisualCatalogType,
   VisualKeyValuePair,
   VisualNodeConfig,
   VisualNodeErrorBehavior,
@@ -53,14 +59,19 @@ export function VisualWorkflowConfigPanel({
   issues,
   onBack,
   onChangeConfig,
+  onChangeNodeType,
+  onDeleteNode,
 }: {
   node: VisualWorkflowRfNode;
   issues: readonly VisualWorkflowValidationIssue[];
   onBack: () => void;
   onChangeConfig: (config: VisualNodeConfig) => void;
+  onChangeNodeType: (type: VisualCatalogType) => void;
+  onDeleteNode: () => void;
 }) {
   const intl = useIntl();
   const { config } = node.data;
+  const isTrigger = isTriggerType(node.data.catalogType);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -74,6 +85,23 @@ export function VisualWorkflowConfigPanel({
         <h2 className="text-sm font-medium">
           <FormattedMessage {...messages.configTitle} />
         </h2>
+        {isTrigger ? (
+          <SelectField
+            id="vw-trigger-type"
+            label={intl.formatMessage(messages.triggerType)}
+            value={node.data.catalogType}
+            items={VISUAL_TRIGGER_TYPES.map((type) => ({
+              value: type,
+              label: intl.formatMessage(titleForTrigger(type)),
+            }))}
+            onValueChange={(value) => {
+              if (!value || !isVisualTriggerCatalogType(value)) {
+                return;
+              }
+              onChangeNodeType(value);
+            }}
+          />
+        ) : null}
         {config.kind === "action.http" ? (
           <>
             <SelectField
@@ -509,6 +537,12 @@ export function VisualWorkflowConfigPanel({
           </div>
         ) : null}
       </div>
+      <div className="border-t border-border px-4 py-3">
+        <Button type="button" variant="outline" className="w-full" onClick={onDeleteNode}>
+          <HugeiconsIcon icon={Delete02Icon} className="size-4" strokeWidth={2} />
+          <FormattedMessage {...messages.deleteStep} />
+        </Button>
+      </div>
       {issues.length > 0 ? (
         <div className="border-t border-border px-4 py-3 text-sm text-destructive">
           {issues.map((issue) => (
@@ -746,6 +780,21 @@ function errorBehaviorMessage(behavior: VisualNodeErrorBehavior) {
       return messages.onErrorContinue;
     case "branch":
       return messages.onErrorBranch;
+  }
+}
+
+function titleForTrigger(type: VisualCatalogType) {
+  switch (type) {
+    case "trigger.manual":
+      return messages.nodeManualTrigger;
+    case "trigger.scheduled":
+      return messages.nodeScheduledTrigger;
+    case "trigger.github":
+      return messages.nodeGithubTrigger;
+    case "trigger.source_upload":
+      return messages.nodeSourceUploadTrigger;
+    default:
+      return messages.triggerType;
   }
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages.ts
@@ -307,17 +307,17 @@ export const visualWorkflowEditorMessages = defineMessages({
   },
   triggerType: {
     defaultMessage: "Trigger",
-    id: "vwTrigTyp09",
+    id: "cSkIY27SIk",
     description: "Label for changing the selected visual workflow trigger type",
   },
   deleteStep: {
     defaultMessage: "Delete step",
-    id: "vwDelStp10",
+    id: "d/T+F7hGuw",
     description: "Button that removes the selected node from the visual workflow canvas",
   },
   deleteWorkflow: {
     defaultMessage: "Delete",
-    id: "vwDelWf11",
+    id: "nqnh5BEInQ",
     description: "Button that deletes the current visual workflow",
   },
   httpMethod: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages.ts
@@ -305,6 +305,21 @@ export const visualWorkflowEditorMessages = defineMessages({
     id: "t4mVRTnKLW",
     description: "Right panel heading when a node is selected",
   },
+  triggerType: {
+    defaultMessage: "Trigger",
+    id: "vwTrigTyp09",
+    description: "Label for changing the selected visual workflow trigger type",
+  },
+  deleteStep: {
+    defaultMessage: "Delete step",
+    id: "vwDelStp10",
+    description: "Button that removes the selected node from the visual workflow canvas",
+  },
+  deleteWorkflow: {
+    defaultMessage: "Delete",
+    id: "vwDelWf11",
+    description: "Button that deletes the current visual workflow",
+  },
   httpMethod: {
     defaultMessage: "Method",
     id: "42t+jTqT0q",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.tsx
@@ -31,6 +31,10 @@ import {
   getVisualNodeDimensions,
   isTriggerType,
 } from "@/lib/visual-workflows/catalog/node-catalog";
+import {
+  removeVisualWorkflowNode,
+  replaceVisualWorkflowNodeType,
+} from "@/lib/visual-workflows/editor/visual-workflow-editor-graph";
 import { visualWorkflowDemoDraft } from "@/lib/visual-workflows/fixtures/demo-draft";
 import { toVisualWorkflowDefinition } from "@/lib/visual-workflows/schema/serializers";
 import type {
@@ -76,6 +80,8 @@ export function VisualWorkflowEditor({
   workflowStatus = "draft",
   onStatusChange,
   statusUpdating = false,
+  onDelete,
+  isDeleting = false,
 }: {
   initialNodes?: VisualWorkflowRfNode[];
   initialEdges?: VisualWorkflowRfEdge[];
@@ -91,6 +97,8 @@ export function VisualWorkflowEditor({
   workflowStatus?: VisualWorkflowStatus;
   onStatusChange?: (active: boolean, definition: VisualWorkflowDefinition) => void | Promise<void>;
   statusUpdating?: boolean;
+  onDelete?: () => void;
+  isDeleting?: boolean;
 }) {
   const intl = useIntl();
   const [activeTab, setActiveTab] = useState<"editor" | "executions">("editor");
@@ -203,6 +211,32 @@ export function VisualWorkflowEditor({
     },
     [selectedNodeId],
   );
+
+  const onChangeNodeType = useCallback(
+    (type: VisualCatalogType) => {
+      if (!selectedNodeId) {
+        return;
+      }
+      setNodes((current) =>
+        current.map((node) =>
+          node.id === selectedNodeId ? replaceVisualWorkflowNodeType(node, type) : node,
+        ),
+      );
+    },
+    [selectedNodeId],
+  );
+
+  const onDeleteNode = useCallback(() => {
+    if (!selectedNodeId) {
+      return;
+    }
+    const next = removeVisualWorkflowNode(nodes, edges, selectedNodeId);
+    setNodes(next.nodes);
+    setEdges(next.edges);
+    setSelectedNodeId(null);
+    setPanelMode("picker");
+    setAddFrom(null);
+  }, [edges, nodes, selectedNodeId]);
 
   const setNodeOutputSnapshot = useCallback(
     (
@@ -416,6 +450,8 @@ export function VisualWorkflowEditor({
         workflowStatus={workflowStatus}
         onStatusChange={onStatusChange ? handleStatusChange : undefined}
         statusDisabled={statusUpdating || (!isActive && saveDisabled)}
+        onDelete={onDelete}
+        isDeleting={isDeleting}
       />
       {activeTab === "executions" && organizationSlug && visualWorkflowId && visualWorkflowsApi ? (
         <VisualWorkflowExecutionsPanel
@@ -458,6 +494,8 @@ export function VisualWorkflowEditor({
                   setSelectedNodeId(null);
                 }}
                 onChangeConfig={onChangeConfig}
+                onChangeNodeType={onChangeNodeType}
+                onDeleteNode={onDeleteNode}
               />
             ) : (
               <>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-api.ts
@@ -34,6 +34,7 @@ export type VisualWorkflowsApi = {
       status?: VisualWorkflowRecord["status"];
     },
   ): Promise<VisualWorkflowRecord>;
+  deleteVisualWorkflow(organizationSlug: string, visualWorkflowId: string): Promise<void>;
   createVisualWorkflowRun(
     organizationSlug: string,
     visualWorkflowId: string,
@@ -107,6 +108,18 @@ export function createVisualWorkflowsApi(): VisualWorkflowsApi {
       }
       const body = (await response.json()) as { visualWorkflow: VisualWorkflowRecord };
       return body.visualWorkflow;
+    },
+    async deleteVisualWorkflow(organizationSlug, visualWorkflowId) {
+      const response = await fetch(
+        `${visualWorkflowsBasePath(organizationSlug)}/${encodeURIComponent(visualWorkflowId)}`,
+        {
+          method: "DELETE",
+          credentials: "include",
+        },
+      );
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to delete visual workflow");
+      }
     },
     async createVisualWorkflowRun(organizationSlug, visualWorkflowId, input) {
       const response = await fetch(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.test.tsx
@@ -89,7 +89,7 @@ describe("VisualWorkflowsPageContent", () => {
     renderPage(api);
 
     expect(await screen.findByRole("heading", { name: "Visual workflows" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Lead ping/ })).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: /Lead ping/ })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Delete" }));
     const dialog = await screen.findByRole("alertdialog", { name: "Delete workflow?" });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { createEmptyVisualWorkflowDefinition } from "@/lib/visual-workflows/schema/serializers";
+import type { VisualWorkflowRecord } from "@/lib/visual-workflows/visual-workflow-types";
+
+import { VisualWorkflowsPageContent } from "./visual-workflows-page-content";
+import type { VisualWorkflowsApi } from "./visual-workflows-api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+function createWorkflow(name: string): VisualWorkflowRecord {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    organizationId: "org_1",
+    authorUserId: null,
+    projectId: null,
+    status: "draft",
+    name,
+    definition: createEmptyVisualWorkflowDefinition(name),
+    definitionVersion: 1,
+    triggerFingerprint: null,
+    nextRunAt: null,
+    createdAt: "2026-09-05T00:00:00.000Z",
+    updatedAt: "2026-09-05T00:00:00.000Z",
+  };
+}
+
+function renderPage(api: VisualWorkflowsApi) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      <QueryClientProvider client={queryClient}>
+        <VisualWorkflowsPageContent organizationSlug="acme" visualWorkflowsApi={api} />
+      </QueryClientProvider>
+    </IntlProvider>,
+  );
+}
+
+describe("VisualWorkflowsPageContent", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renames the page to visual workflows and deletes a listed workflow", async () => {
+    const user = userEvent.setup();
+    const workflow = createWorkflow("Lead ping");
+    const deleteVisualWorkflow = vi.fn().mockResolvedValue(undefined);
+    const api: VisualWorkflowsApi = {
+      listVisualWorkflows: vi.fn().mockResolvedValue([workflow]),
+      getVisualWorkflow: vi.fn(),
+      createVisualWorkflow: vi.fn(),
+      updateVisualWorkflow: vi.fn(),
+      deleteVisualWorkflow,
+      createVisualWorkflowRun: vi.fn(),
+      listVisualWorkflowRuns: vi.fn(),
+      getVisualWorkflowRun: vi.fn(),
+    };
+
+    renderPage(api);
+
+    expect(await screen.findByRole("heading", { name: "Visual workflows" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Lead ping/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    const dialog = await screen.findByRole("alertdialog", { name: "Delete workflow?" });
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    expect(deleteVisualWorkflow).toHaveBeenCalledWith("acme", workflow.id);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.tsx
@@ -13,7 +13,9 @@
  * Version 2.0 or later.
  */
 import Link from "next/link";
-import { GitBranchIcon } from "@hugeicons/core-free-icons";
+import { useState } from "react";
+import { Delete02Icon, GitBranchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -26,7 +28,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyP } from "@/components/ui/typography";
+import type { VisualWorkflowRecord } from "@/lib/visual-workflows/visual-workflow-types";
 
+import { VisualWorkflowDeleteDialog } from "./visual-workflow-delete-dialog";
 import { createVisualWorkflowsApi } from "./visual-workflows-api";
 import { visualWorkflowsPageMessages } from "./visual-workflows-page.messages";
 
@@ -46,6 +50,7 @@ export function VisualWorkflowsPageContent({
   const intl = useIntl();
   const router = useRouter();
   const queryClient = useQueryClient();
+  const [workflowToDelete, setWorkflowToDelete] = useState<VisualWorkflowRecord | null>(null);
   const workflowsQuery = useQuery({
     queryKey: visualWorkflowsQueryKey(organizationSlug),
     queryFn: () => injectedApi.listVisualWorkflows(organizationSlug),
@@ -59,6 +64,19 @@ export function VisualWorkflowsPageContent({
     },
     onError: () => {
       toast.error(<FormattedMessage {...visualWorkflowsPageMessages.createFailed} />);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (workflowId: string) =>
+      injectedApi.deleteVisualWorkflow(organizationSlug, workflowId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: visualWorkflowsQueryKey(organizationSlug) });
+      setWorkflowToDelete(null);
+      toast.success(<FormattedMessage {...visualWorkflowsPageMessages.deleteSuccess} />);
+    },
+    onError: () => {
+      toast.error(<FormattedMessage {...visualWorkflowsPageMessages.deleteFailed} />);
     },
   });
 
@@ -89,10 +107,10 @@ export function VisualWorkflowsPageContent({
         ) : workflowsQuery.data && workflowsQuery.data.length > 0 ? (
           <ul className="divide-y divide-border">
             {workflowsQuery.data.map((workflow) => (
-              <li key={workflow.id}>
+              <li key={workflow.id} className="flex items-center gap-2 px-2">
                 <Link
                   href={`/org/${organizationSlug}/automations/visual-workflows/${workflow.id}`}
-                  className="flex items-center justify-between gap-4 px-4 py-3 hover:bg-muted/40"
+                  className="flex min-w-0 flex-1 items-center justify-between gap-4 px-2 py-3 hover:bg-muted/40"
                 >
                   <div className="min-w-0">
                     <p className="truncate font-medium text-foreground">{workflow.name}</p>
@@ -102,6 +120,16 @@ export function VisualWorkflowsPageContent({
                     v{workflow.definitionVersion}
                   </span>
                 </Link>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={intl.formatMessage(visualWorkflowsPageMessages.deleteWorkflow)}
+                  disabled={deleteMutation.isPending}
+                  onClick={() => setWorkflowToDelete(workflow)}
+                >
+                  <HugeiconsIcon icon={Delete02Icon} className="size-4" strokeWidth={2} />
+                </Button>
               </li>
             ))}
           </ul>
@@ -113,6 +141,22 @@ export function VisualWorkflowsPageContent({
           </div>
         )}
       </div>
+      <VisualWorkflowDeleteDialog
+        open={workflowToDelete !== null}
+        workflowName={workflowToDelete?.name ?? ""}
+        isDeleting={deleteMutation.isPending}
+        onOpenChange={(open) => {
+          if (!open) {
+            setWorkflowToDelete(null);
+          }
+        }}
+        onConfirm={() => {
+          if (!workflowToDelete) {
+            return;
+          }
+          deleteMutation.mutate(workflowToDelete.id);
+        }}
+      />
     </WorkspacePageShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page.messages.ts
@@ -17,12 +17,12 @@ import { defineMessages } from "react-intl";
 export const visualWorkflowsPageMessages = defineMessages({
   pageLabel: {
     defaultMessage: "Visual workflows",
-    id: "BU34xLZuIV",
+    id: "cFLoSPa62D",
     description: "Breadcrumb label for the visual workflows list page",
   },
   pageTitle: {
     defaultMessage: "Visual workflows",
-    id: "68KxHHw2pe",
+    id: "XEIB3MxFUn",
     description: "Title for the visual workflows list page",
   },
   pageDescription: {
@@ -37,7 +37,7 @@ export const visualWorkflowsPageMessages = defineMessages({
   },
   emptyState: {
     defaultMessage: "No visual workflows yet. Create one to start building on the canvas.",
-    id: "jq/3JKwWN0",
+    id: "LyO/knpzIv",
     description: "Empty state on the visual workflows list page",
   },
   createFailed: {
@@ -47,42 +47,42 @@ export const visualWorkflowsPageMessages = defineMessages({
   },
   deleteWorkflow: {
     defaultMessage: "Delete",
-    id: "vwDelBtn01",
+    id: "pp9OzwrBNo",
     description: "Button that deletes a visual workflow",
   },
   deleteTitle: {
     defaultMessage: "Delete workflow?",
-    id: "vwDelTtl02",
+    id: "Cuem8lXjuP",
     description: "Title of the delete visual workflow confirmation dialog",
   },
   deleteDescription: {
     defaultMessage: "{workflowName} will be removed from this workspace and will no longer run.",
-    id: "vwDelDsc03",
+    id: "eQ9Hm8R7yH",
     description: "Delete visual workflow confirmation describing the selected workflow",
   },
   deleteCancel: {
     defaultMessage: "Cancel",
-    id: "vwDelCan04",
+    id: "tDv3EqS/ae",
     description: "Cancel button in the delete visual workflow dialog",
   },
   deleting: {
     defaultMessage: "Deleting...",
-    id: "vwDelIng05",
+    id: "A7P5XaZKlw",
     description: "Delete button label while a visual workflow is being deleted",
   },
   deleteConfirm: {
     defaultMessage: "Delete",
-    id: "vwDelCfm06",
+    id: "AXQ2DriknB",
     description: "Confirm button to delete a visual workflow",
   },
   deleteSuccess: {
     defaultMessage: "Workflow deleted",
-    id: "vwDelOk07",
+    id: "YJKHKW9gUY",
     description: "Toast when a visual workflow is deleted successfully",
   },
   deleteFailed: {
     defaultMessage: "Could not delete this workflow.",
-    id: "vwDelErr08",
+    id: "it5kPOtvZj",
     description: "Toast when visual workflow deletion fails",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page.messages.ts
@@ -16,12 +16,12 @@ import { defineMessages } from "react-intl";
 
 export const visualWorkflowsPageMessages = defineMessages({
   pageLabel: {
-    defaultMessage: "Advanced workflows",
+    defaultMessage: "Visual workflows",
     id: "BU34xLZuIV",
     description: "Breadcrumb label for the visual workflows list page",
   },
   pageTitle: {
-    defaultMessage: "Advanced workflows",
+    defaultMessage: "Visual workflows",
     id: "68KxHHw2pe",
     description: "Title for the visual workflows list page",
   },
@@ -36,7 +36,7 @@ export const visualWorkflowsPageMessages = defineMessages({
     description: "Button that creates a new visual workflow draft",
   },
   emptyState: {
-    defaultMessage: "No advanced workflows yet. Create one to start building on the canvas.",
+    defaultMessage: "No visual workflows yet. Create one to start building on the canvas.",
     id: "jq/3JKwWN0",
     description: "Empty state on the visual workflows list page",
   },
@@ -44,5 +44,45 @@ export const visualWorkflowsPageMessages = defineMessages({
     defaultMessage: "Could not create a workflow.",
     id: "Dm+YgrdmFH",
     description: "Toast when visual workflow creation fails",
+  },
+  deleteWorkflow: {
+    defaultMessage: "Delete",
+    id: "vwDelBtn01",
+    description: "Button that deletes a visual workflow",
+  },
+  deleteTitle: {
+    defaultMessage: "Delete workflow?",
+    id: "vwDelTtl02",
+    description: "Title of the delete visual workflow confirmation dialog",
+  },
+  deleteDescription: {
+    defaultMessage: "{workflowName} will be removed from this workspace and will no longer run.",
+    id: "vwDelDsc03",
+    description: "Delete visual workflow confirmation describing the selected workflow",
+  },
+  deleteCancel: {
+    defaultMessage: "Cancel",
+    id: "vwDelCan04",
+    description: "Cancel button in the delete visual workflow dialog",
+  },
+  deleting: {
+    defaultMessage: "Deleting...",
+    id: "vwDelIng05",
+    description: "Delete button label while a visual workflow is being deleted",
+  },
+  deleteConfirm: {
+    defaultMessage: "Delete",
+    id: "vwDelCfm06",
+    description: "Confirm button to delete a visual workflow",
+  },
+  deleteSuccess: {
+    defaultMessage: "Workflow deleted",
+    id: "vwDelOk07",
+    description: "Toast when a visual workflow is deleted successfully",
+  },
+  deleteFailed: {
+    defaultMessage: "Could not delete this workflow.",
+    id: "vwDelErr08",
+    description: "Toast when visual workflow deletion fails",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integration-workflow-preview.test.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integration-workflow-preview.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { IntegrationWorkflowPreview } from "@/components/marketing/integrations/integration-workflow-preview";
+import type { VisualWorkflowRfNode } from "@/lib/visual-workflows/schema/types";
+
+vi.mock("@/components/ai-elements/canvas", () => ({
+  Canvas: ({
+    nodes,
+    children,
+  }: {
+    nodes: VisualWorkflowRfNode[];
+    children?: ReactNode;
+  }) => (
+    <div data-testid="visual-workflow-canvas">
+      {nodes.map((node) => (
+        <div key={node.id}>{node.data.previewSubtitle}</div>
+      ))}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ai-elements/controls", () => ({
+  Controls: () => <div>Canvas controls</div>,
+}));
+
+const copy = {
+  triggerLabel: "Trigger",
+  actionLabel: "Action",
+  previewHint: "Click a step or use play to preview how the automation runs.",
+  playLabel: "Play workflow preview",
+  pauseLabel: "Pause workflow preview",
+};
+
+describe("IntegrationWorkflowPreview", () => {
+  it("shows the selected example on a visual workflow canvas", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <IntegrationWorkflowPreview
+          copy={copy}
+          integrationNamesBySlug={{
+            github: "GitHub",
+            slack: "Slack",
+            hyperlocalise: "Hyperlocalise",
+          }}
+          integrationSlug="github"
+          workflows={[
+            {
+              title: "Catch missing translations before merge",
+              steps: [
+                { label: "PR opened on GitHub" },
+                { label: "Hyperlocalise scans strings" },
+                { label: "Reviewer notified in Slack" },
+              ],
+            },
+            {
+              title: "Ship localization fixes from review findings",
+              steps: [
+                { label: "Agent flags untranslated keys" },
+                { label: "Translations drafted in Hyperlocalise" },
+              ],
+            },
+          ]}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getAllByText("Catch missing translations before merge").length).toBeGreaterThan(0);
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(screen.getByTestId("visual-workflow-canvas")).toBeInTheDocument();
+    expect(screen.getByText("PR opened on GitHub")).toBeInTheDocument();
+    expect(screen.getByText("Hyperlocalise scans strings")).toBeInTheDocument();
+    expect(screen.getByText("Reviewer notified in Slack")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Ship localization fixes from review findings" }));
+
+    expect(
+      screen.getAllByText("Ship localization fixes from review findings").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Agent flags untranslated keys")).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integration-workflow-preview.test.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integration-workflow-preview.test.tsx
@@ -22,13 +22,7 @@ import { IntegrationWorkflowPreview } from "@/components/marketing/integrations/
 import type { VisualWorkflowRfNode } from "@/lib/visual-workflows/schema/types";
 
 vi.mock("@/components/ai-elements/canvas", () => ({
-  Canvas: ({
-    nodes,
-    children,
-  }: {
-    nodes: VisualWorkflowRfNode[];
-    children?: ReactNode;
-  }) => (
+  Canvas: ({ nodes, children }: { nodes: VisualWorkflowRfNode[]; children?: ReactNode }) => (
     <div data-testid="visual-workflow-canvas">
       {nodes.map((node) => (
         <div key={node.id}>{node.data.previewSubtitle}</div>
@@ -85,14 +79,18 @@ describe("IntegrationWorkflowPreview", () => {
       </IntlProvider>,
     );
 
-    expect(screen.getAllByText("Catch missing translations before merge").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Catch missing translations before merge").length).toBeGreaterThan(
+      0,
+    );
     expect(screen.getByText("Preview")).toBeInTheDocument();
     expect(screen.getByTestId("visual-workflow-canvas")).toBeInTheDocument();
     expect(screen.getByText("PR opened on GitHub")).toBeInTheDocument();
     expect(screen.getByText("Hyperlocalise scans strings")).toBeInTheDocument();
     expect(screen.getByText("Reviewer notified in Slack")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Ship localization fixes from review findings" }));
+    await user.click(
+      screen.getByRole("button", { name: "Ship localization fixes from review findings" }),
+    );
 
     expect(
       screen.getAllByText("Ship localization fixes from review findings").length,

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integration-workflow-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integration-workflow-preview.tsx
@@ -14,34 +14,32 @@
  */
 import { useCallback, useEffect, useMemo, useState, type MouseEvent } from "react";
 import {
-  Background,
-  Handle,
-  Position,
+  MarkerType,
   useEdgesState,
   useNodesState,
   type Node,
-  type NodeProps,
   type OnEdgesChange,
   type OnNodesChange,
 } from "@xyflow/react";
 import { PauseIcon, PlayIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage } from "react-intl";
 
 import { Canvas } from "@/components/ai-elements/canvas";
-import { IntegrationLogoMark } from "@/components/marketing/integrations/integration-logo-mark";
-import { getIntegrationCatalogEntry } from "@/lib/integrations/integration-catalog";
-import type {
-  IntegrationIconKey,
-  ResolvedIntegrationWorkflow,
-} from "@/lib/integrations/integration-catalog.types";
+import { Controls } from "@/components/ai-elements/controls";
+import { visualWorkflowEditorMessages as editorMessages } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages";
+import { VisualWorkflowCanvasActionsProvider } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-canvas-actions";
+import { VISUAL_WORKFLOW_NODE_TYPES } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-canvas";
+import type { ResolvedIntegrationWorkflow } from "@/lib/integrations/integration-catalog.types";
 import {
   buildWorkflowEdges,
   buildWorkflowNodes,
   styleWorkflowEdges,
-  type IntegrationWorkflowNodeData,
 } from "@/lib/integrations/integration-workflow-graph";
+import type { VisualWorkflowRfNode } from "@/lib/visual-workflows/schema/types";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { TypographyMuted, TypographyP } from "@/components/ui/typography";
+import { TypographyMuted } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
 type IntegrationWorkflowPreviewCopy = {
@@ -59,83 +57,11 @@ type IntegrationWorkflowPreviewProps = {
   copy: IntegrationWorkflowPreviewCopy;
 };
 
-const KIND_HEADER_CLASS = {
-  trigger: "border-rose-500/25 bg-rose-500/12 text-rose-900 dark:text-rose-100",
-  action: "border-sky-500/25 bg-sky-500/12 text-sky-950 dark:text-sky-100",
-} as const;
-
-function getActorBranding(actorSlug: string) {
-  if (actorSlug === "hyperlocalise") {
-    return {
-      name: "Hyperlocalise",
-      logoSrc: "/images/logo.png",
-      iconKey: undefined as IntegrationIconKey | undefined,
-    };
-  }
-
-  const entry = getIntegrationCatalogEntry(actorSlug);
-  return {
-    name: entry?.slug ?? actorSlug,
-    logoSrc: entry?.logoSrc,
-    iconKey: entry?.iconKey,
-  };
-}
-
-function IntegrationWorkflowNode({ data }: NodeProps<Node<IntegrationWorkflowNodeData>>) {
-  const branding = getActorBranding(data.actorSlug);
-
-  return (
-    <div
-      className={cn(
-        "w-[14rem] overflow-hidden rounded-xl border border-border/80 bg-background text-left shadow-md shadow-black/8 transition-shadow",
-        data.active && "ring-2 ring-primary/35 shadow-lg shadow-primary/10",
-      )}
-    >
-      <Handle
-        className="!size-2 !border-border !bg-background"
-        position={Position.Top}
-        type="target"
-      />
-
-      <div
-        className={cn(
-          "flex items-center justify-between gap-2 border-b px-3 py-1.5 text-[10px] font-semibold tracking-[0.06em] uppercase",
-          KIND_HEADER_CLASS[data.kind],
-        )}
-      >
-        <span>{data.kindLabel}</span>
-        <IntegrationLogoMark
-          iconKey={branding.iconKey}
-          logoSrc={branding.logoSrc}
-          name={branding.name}
-          size="sm"
-        />
-      </div>
-
-      <div className="space-y-1 px-3 py-2.5">
-        <p className="text-[0.8rem] font-medium leading-snug text-foreground">{data.label}</p>
-        {data.description ? (
-          <p className="text-[0.7rem] leading-snug text-muted-foreground">{data.description}</p>
-        ) : null}
-      </div>
-
-      <Handle
-        className="!size-2 !border-border !bg-background"
-        position={Position.Bottom}
-        type="source"
-      />
-    </div>
-  );
-}
-
-const nodeTypes = { integrationWorkflow: IntegrationWorkflowNode };
-
 function buildFlowState(
   workflow: ResolvedIntegrationWorkflow,
   workflowKey: string,
   integrationSlug: string,
   integrationNamesBySlug: Readonly<Record<string, string>>,
-  kindLabels: { trigger: string; action: string },
   activeIndex: number,
 ) {
   const nodes = buildWorkflowNodes(
@@ -143,7 +69,6 @@ function buildFlowState(
     workflowKey,
     integrationSlug,
     integrationNamesBySlug,
-    kindLabels,
     activeIndex,
   );
   const edges = styleWorkflowEdges(
@@ -167,32 +92,18 @@ export function IntegrationWorkflowPreview({
   const selectedWorkflow = workflows[selectedIndex] ?? workflows[0];
   const workflowKey = `workflow-${selectedIndex}`;
 
-  const kindLabels = useMemo(
-    () => ({
-      trigger: copy.triggerLabel,
-      action: copy.actionLabel,
-    }),
-    [copy.actionLabel, copy.triggerLabel],
-  );
-
   const initialFlow = useMemo(
     () =>
-      buildFlowState(
-        selectedWorkflow,
-        workflowKey,
-        integrationSlug,
-        integrationNamesBySlug,
-        kindLabels,
-        activeIndex,
-      ),
-    [
-      activeIndex,
-      integrationNamesBySlug,
-      integrationSlug,
-      kindLabels,
-      selectedWorkflow,
-      workflowKey,
-    ],
+      selectedWorkflow
+        ? buildFlowState(
+            selectedWorkflow,
+            workflowKey,
+            integrationSlug,
+            integrationNamesBySlug,
+            activeIndex,
+          )
+        : { nodes: [], edges: [] },
+    [activeIndex, integrationNamesBySlug, integrationSlug, selectedWorkflow, workflowKey],
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialFlow.nodes);
@@ -209,16 +120,19 @@ export function IntegrationWorkflowPreview({
         nextWorkflowKey,
         integrationSlug,
         integrationNamesBySlug,
-        kindLabels,
         nextActiveIndex,
       );
       setNodes(nextFlow.nodes);
       setEdges(nextFlow.edges);
     },
-    [integrationNamesBySlug, integrationSlug, kindLabels, setEdges, setNodes],
+    [integrationNamesBySlug, integrationSlug, setEdges, setNodes],
   );
 
   useEffect(() => {
+    if (!selectedWorkflow) {
+      return;
+    }
+
     setActiveIndex(0);
     setIsPlaying(true);
     resetFlow(selectedWorkflow, workflowKey, 0);
@@ -230,7 +144,7 @@ export function IntegrationWorkflowPreview({
         ...node,
         data: {
           ...node.data,
-          active: index === activeIndex,
+          runStatus: index < activeIndex ? "succeeded" : index === activeIndex ? "running" : "idle",
         },
       })),
     );
@@ -238,7 +152,7 @@ export function IntegrationWorkflowPreview({
   }, [activeIndex, setEdges, setNodes]);
 
   useEffect(() => {
-    if (!isPlaying || selectedWorkflow.steps.length <= 1) {
+    if (!isPlaying || !selectedWorkflow || selectedWorkflow.steps.length <= 1) {
       return;
     }
 
@@ -247,20 +161,17 @@ export function IntegrationWorkflowPreview({
     }, 1600);
 
     return () => clearInterval(timer);
-  }, [isPlaying, selectedWorkflow.steps.length]);
+  }, [isPlaying, selectedWorkflow]);
 
-  const handleNodeClick = useCallback(
-    (_event: MouseEvent, node: Node<IntegrationWorkflowNodeData>) => {
-      const nodeIndex = Number(node.id.split("-").at(-1));
-      if (Number.isNaN(nodeIndex)) {
-        return;
-      }
+  const handleNodeClick = useCallback((_event: MouseEvent, node: Node) => {
+    const nodeIndex = Number(node.id.split("-").at(-1));
+    if (Number.isNaN(nodeIndex)) {
+      return;
+    }
 
-      setIsPlaying(false);
-      setActiveIndex(nodeIndex);
-    },
-    [],
-  );
+    setIsPlaying(false);
+    setActiveIndex(nodeIndex);
+  }, []);
 
   if (!selectedWorkflow) {
     return null;
@@ -268,13 +179,15 @@ export function IntegrationWorkflowPreview({
 
   return (
     <div className="overflow-hidden rounded-2xl border border-border bg-background shadow-[0_20px_48px_rgba(0,0,0,0.08)]">
-      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border/60 px-5 py-4">
-        <div className="min-w-0 space-y-1">
-          <TypographyP weight="medium">{selectedWorkflow.title}</TypographyP>
-          <TypographyMuted size="small">{copy.previewHint}</TypographyMuted>
+      <header className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border bg-background px-4 py-2.5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <p className="max-w-xs truncate px-2 text-sm font-medium">{selectedWorkflow.title}</p>
+          <Badge variant="outline" className="rounded-full">
+            <FormattedMessage {...editorMessages.previewBadge} />
+          </Badge>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <Button
             aria-label={isPlaying ? copy.pauseLabel : copy.playLabel}
             onClick={() => setIsPlaying((playing) => !playing)}
@@ -303,36 +216,47 @@ export function IntegrationWorkflowPreview({
             ))}
           </div>
         </div>
-      </div>
+      </header>
 
-      <div className="relative min-h-[22rem] w-full">
-        <Canvas
-          defaultEdgeOptions={{
-            type: "smoothstep",
-            style: { strokeWidth: 1.5, stroke: "var(--border)" },
-          }}
-          edges={edges}
-          elementsSelectable
-          fitView
-          fitViewOptions={{ padding: 0.45, minZoom: 0.85, maxZoom: 1.1 }}
-          maxZoom={1.25}
-          minZoom={0.75}
-          nodeTypes={nodeTypes}
-          nodes={nodes}
-          nodesConnectable={false}
-          nodesDraggable
-          onEdgesChange={onEdgesChange as OnEdgesChange}
-          onNodeClick={handleNodeClick}
-          onNodesChange={onNodesChange as OnNodesChange}
-          panOnDrag
-          panOnScroll={false}
-          preventScrolling={false}
-          proOptions={{ hideAttribution: true }}
-          selectionOnDrag={false}
-          zoomOnScroll={false}
-        >
-          <Background color="var(--border)" gap={18} size={1} />
-        </Canvas>
+      <TypographyMuted className="border-b border-border/60 px-5 py-2" size="small">
+        {copy.previewHint}
+      </TypographyMuted>
+
+      <div className="relative h-[28rem] w-full">
+        <VisualWorkflowCanvasActionsProvider onAddFromNode={() => undefined}>
+          <Canvas
+            className="h-full w-full"
+            defaultEdgeOptions={{
+              type: "smoothstep",
+              markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
+              style: { strokeWidth: 1.5, stroke: "var(--border)" },
+            }}
+            edges={edges}
+            elementsSelectable
+            fitView
+            fitViewOptions={{ padding: 0.2, minZoom: 0.7, maxZoom: 1.1 }}
+            maxZoom={1.25}
+            minZoom={0.6}
+            nodeTypes={VISUAL_WORKFLOW_NODE_TYPES}
+            nodes={nodes as VisualWorkflowRfNode[]}
+            nodesConnectable={false}
+            nodesDraggable
+            onEdgesChange={onEdgesChange as OnEdgesChange}
+            onInit={(reactFlow) => {
+              void reactFlow.fitView({ padding: 0.2 });
+            }}
+            onNodeClick={handleNodeClick}
+            onNodesChange={onNodesChange as OnNodesChange}
+            panOnDrag
+            panOnScroll={false}
+            preventScrolling={false}
+            proOptions={{ hideAttribution: true }}
+            selectionOnDrag={false}
+            zoomOnScroll={false}
+          >
+            <Controls showInteractive={false} position="bottom-left" />
+          </Canvas>
+        </VisualWorkflowCanvasActionsProvider>
       </div>
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-page-content.ts
@@ -152,8 +152,8 @@ export function getIntegrationDetailCopy(locale: string) {
     }),
     workflowsHeading: intl.formatMessage({
       defaultMessage: "Visual workflow examples",
-      id: "BNs8waALWE",
-      description: "Heading for the integration visual workflow examples section",
+      id: "p/CGM67hkK",
+      description: "Heading for the integration workflow examples section",
     }),
     workflowsDescription: intl.formatMessage({
       defaultMessage:

--- a/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/integrations/integrations-page-content.ts
@@ -151,9 +151,9 @@ export function getIntegrationDetailCopy(locale: string) {
       description: "Heading for the integration capabilities section",
     }),
     workflowsHeading: intl.formatMessage({
-      defaultMessage: "Example workflows",
+      defaultMessage: "Visual workflow examples",
       id: "BNs8waALWE",
-      description: "Heading for the integration workflow examples section",
+      description: "Heading for the integration visual workflow examples section",
     }),
     workflowsDescription: intl.formatMessage({
       defaultMessage:

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.test.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.test.ts
@@ -16,6 +16,7 @@ import {
   buildWorkflowEdges,
   buildWorkflowNodes,
   inferWorkflowStepActor,
+  inferWorkflowStepCatalogType,
 } from "@/lib/integrations/integration-workflow-graph";
 
 const integrationNames = {
@@ -38,6 +39,18 @@ describe("integration-workflow-graph", () => {
     ).toBe("slack");
   });
 
+  it("maps example steps onto visual workflow catalog types", () => {
+    expect(inferWorkflowStepCatalogType("PR opened on GitHub", 0, "github")).toBe("trigger.github");
+    expect(inferWorkflowStepCatalogType("Hyperlocalise scans strings", 1, "hyperlocalise")).toBe(
+      "ai.agent",
+    );
+    expect(inferWorkflowStepCatalogType("Reviewer notified in Slack", 2, "slack")).toBe(
+      "action.notify_slack",
+    );
+    expect(inferWorkflowStepCatalogType("Fix PR opened on GitHub", 2, "github")).toBe("action.http");
+    expect(inferWorkflowStepCatalogType("New strings submitted", 0, "slack")).toBe("trigger.manual");
+  });
+
   it("builds linear workflow edges", () => {
     expect(buildWorkflowEdges("github-wf-0", 3)).toEqual([
       { id: "github-wf-0-edge-0", source: "github-wf-0-node-0", target: "github-wf-0-node-1" },
@@ -45,7 +58,7 @@ describe("integration-workflow-graph", () => {
     ]);
   });
 
-  it("builds workflow nodes with trigger and action kinds", () => {
+  it("builds compact visual workflow nodes left to right", () => {
     const nodes = buildWorkflowNodes(
       {
         title: "Catch missing translations before merge",
@@ -58,15 +71,18 @@ describe("integration-workflow-graph", () => {
       "github-wf-0",
       "github",
       integrationNames,
-      { trigger: "Trigger", action: "Action" },
       1,
     );
 
     expect(nodes).toHaveLength(3);
-    expect(nodes[0]?.data.kind).toBe("trigger");
-    expect(nodes[1]?.data.kind).toBe("action");
-    expect(nodes[1]?.data.active).toBe(true);
-    expect(nodes[1]?.data.actorSlug).toBe("hyperlocalise");
-    expect(nodes[2]?.data.actorSlug).toBe("slack");
+    expect(nodes[0]?.type).toBe("trigger.github");
+    expect(nodes[0]?.position).toEqual({ x: 0, y: 0 });
+    expect(nodes[1]?.type).toBe("ai.agent");
+    expect(nodes[1]?.position).toEqual({ x: 260, y: 0 });
+    expect(nodes[1]?.data.runStatus).toBe("running");
+    expect(nodes[1]?.data.previewSubtitle).toBe("Hyperlocalise scans strings");
+    expect(nodes[1]?.data.hideAddAction).toBe(true);
+    expect(nodes[2]?.type).toBe("action.notify_slack");
+    expect(nodes[2]?.position).toEqual({ x: 520, y: 0 });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.test.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.test.ts
@@ -53,6 +53,12 @@ describe("integration-workflow-graph", () => {
     expect(inferWorkflowStepCatalogType("New strings submitted", 0, "slack")).toBe(
       "trigger.manual",
     );
+    expect(inferWorkflowStepCatalogType("Review posted to #localization", 1, "hyperlocalise")).toBe(
+      "action.notify_slack",
+    );
+    expect(inferWorkflowStepCatalogType("Alert sent to #launch", 1, "hyperlocalise")).toBe(
+      "action.notify_slack",
+    );
   });
 
   it("builds linear workflow edges", () => {

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.test.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.test.ts
@@ -47,8 +47,12 @@ describe("integration-workflow-graph", () => {
     expect(inferWorkflowStepCatalogType("Reviewer notified in Slack", 2, "slack")).toBe(
       "action.notify_slack",
     );
-    expect(inferWorkflowStepCatalogType("Fix PR opened on GitHub", 2, "github")).toBe("action.http");
-    expect(inferWorkflowStepCatalogType("New strings submitted", 0, "slack")).toBe("trigger.manual");
+    expect(inferWorkflowStepCatalogType("Fix PR opened on GitHub", 2, "github")).toBe(
+      "action.http",
+    );
+    expect(inferWorkflowStepCatalogType("New strings submitted", 0, "slack")).toBe(
+      "trigger.manual",
+    );
   });
 
   it("builds linear workflow edges", () => {

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.ts
@@ -10,23 +10,17 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import type { Edge, Node } from "@xyflow/react";
+import type { Edge } from "@xyflow/react";
 
 import type { ResolvedIntegrationWorkflow } from "@/lib/integrations/integration-catalog.types";
+import { createDefaultConfig } from "@/lib/visual-workflows/catalog/node-catalog";
+import type {
+  MockNodeRunStatus,
+  VisualCatalogType,
+  VisualWorkflowRfNode,
+} from "@/lib/visual-workflows/schema/types";
 
-export type WorkflowNodeKind = "trigger" | "action";
-
-export type IntegrationWorkflowNodeData = {
-  label: string;
-  description?: string;
-  kind: WorkflowNodeKind;
-  kindLabel: string;
-  actorSlug: string;
-  actorName: string;
-  active?: boolean;
-};
-
-const NODE_GAP_Y = 108;
+const NODE_GAP_X = 260;
 const HYPERLOCALISE_SLUG = "hyperlocalise";
 
 export function inferWorkflowStepActor(
@@ -61,6 +55,47 @@ export function inferWorkflowStepActor(
   return HYPERLOCALISE_SLUG;
 }
 
+export function inferWorkflowStepCatalogType(
+  label: string,
+  stepIndex: number,
+  actorSlug: string,
+): VisualCatalogType {
+  const text = label.toLowerCase();
+
+  if (stepIndex === 0) {
+    if (/\bupload\b/.test(text)) {
+      return "trigger.source_upload";
+    }
+
+    if (/\b(hourly|daily|weekly|scheduled|cron)\b/.test(text)) {
+      return "trigger.scheduled";
+    }
+
+    if (
+      actorSlug === "github" ||
+      actorSlug === "gitlab" ||
+      /\b(github|gitlab|pull request|merge request|\bpr\b|\bmr\b|branch|push)\b/.test(text)
+    ) {
+      return "trigger.github";
+    }
+
+    return "trigger.manual";
+  }
+
+  if (actorSlug === "slack" || /\b(slack|notified|alert posted|#\w+)\b/.test(text)) {
+    return "action.notify_slack";
+  }
+
+  if (
+    actorSlug === HYPERLOCALISE_SLUG ||
+    /\b(agent|scan|draft|flag|qa|review|translat)\b/.test(text)
+  ) {
+    return "ai.agent";
+  }
+
+  return "action.http";
+}
+
 export function buildWorkflowEdges(workflowKey: string, stepCount: number): Edge[] {
   return Array.from({ length: stepCount - 1 }, (_, index) => ({
     id: `${workflowKey}-edge-${index}`,
@@ -69,14 +104,25 @@ export function buildWorkflowEdges(workflowKey: string, stepCount: number): Edge
   }));
 }
 
+function runStatusForIndex(index: number, activeIndex: number): MockNodeRunStatus {
+  if (index < activeIndex) {
+    return "succeeded";
+  }
+
+  if (index === activeIndex) {
+    return "running";
+  }
+
+  return "idle";
+}
+
 export function buildWorkflowNodes(
   workflow: ResolvedIntegrationWorkflow,
   workflowKey: string,
   primaryIntegrationSlug: string,
   integrationNamesBySlug: Readonly<Record<string, string>>,
-  kindLabels: { trigger: string; action: string },
   activeIndex: number,
-): Node<IntegrationWorkflowNodeData>[] {
+): VisualWorkflowRfNode[] {
   return workflow.steps.map((step, index) => {
     const actorSlug = inferWorkflowStepActor(
       step.label,
@@ -84,19 +130,18 @@ export function buildWorkflowNodes(
       primaryIntegrationSlug,
       integrationNamesBySlug,
     );
+    const catalogType = inferWorkflowStepCatalogType(step.label, index, actorSlug);
 
     return {
       id: `${workflowKey}-node-${index}`,
-      type: "integrationWorkflow",
-      position: { x: 0, y: index * NODE_GAP_Y },
+      type: catalogType,
+      position: { x: index * NODE_GAP_X, y: 0 },
       data: {
-        label: step.label,
-        description: step.description,
-        kind: index === 0 ? "trigger" : "action",
-        kindLabel: index === 0 ? kindLabels.trigger : kindLabels.action,
-        actorSlug,
-        actorName: integrationNamesBySlug[actorSlug] ?? "Hyperlocalise",
-        active: index === activeIndex,
+        catalogType,
+        config: createDefaultConfig(catalogType),
+        runStatus: runStatusForIndex(index, activeIndex),
+        previewSubtitle: step.description ?? step.label,
+        hideAddAction: true,
       },
       draggable: true,
     };

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-workflow-graph.ts
@@ -82,7 +82,7 @@ export function inferWorkflowStepCatalogType(
     return "trigger.manual";
   }
 
-  if (actorSlug === "slack" || /\b(slack|notified|alert posted|#\w+)\b/.test(text)) {
+  if (actorSlug === "slack" || /slack|notified|alert posted|#\w+/i.test(text)) {
     return "action.notify_slack";
   }
 

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/README.md
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/README.md
@@ -77,7 +77,7 @@ Runs capture the definition at enqueue time under `inputSnapshot.definitionSnaps
 
 ## Testing
 
-- Unit tests: `visual-workflow.test.ts`, `runtime/runtime.test.ts`
+- Unit tests: `visual-workflow.test.ts`, `runtime/runtime.test.ts`, `editor/visual-workflow-editor-graph.ts`
 - Route tests: `visual-workflow.route.test.ts` (uses real Hono app + WorkOS test auth)
 
 Run from `apps/hyperlocalise-web`:

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/editor/visual-workflow-editor-graph.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/editor/visual-workflow-editor-graph.ts
@@ -13,7 +13,6 @@
 import {
   createDefaultConfig,
   getVisualNodeDimensions,
-  isTriggerType,
   VISUAL_NODE_CATALOG,
 } from "../catalog/node-catalog";
 import type {
@@ -60,5 +59,5 @@ export function removeVisualWorkflowNode(
 }
 
 export function isVisualTriggerCatalogType(type: string): type is VisualCatalogType {
-  return VISUAL_TRIGGER_TYPES.includes(type as VisualCatalogType) && isTriggerType(type);
+  return (VISUAL_TRIGGER_TYPES as readonly string[]).includes(type);
 }

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/editor/visual-workflow-editor-graph.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/editor/visual-workflow-editor-graph.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  createDefaultConfig,
+  getVisualNodeDimensions,
+  isTriggerType,
+  VISUAL_NODE_CATALOG,
+} from "../catalog/node-catalog";
+import type {
+  VisualCatalogType,
+  VisualWorkflowRfEdge,
+  VisualWorkflowRfNode,
+} from "../schema/types";
+
+export const VISUAL_TRIGGER_TYPES = VISUAL_NODE_CATALOG.filter(
+  (item) => item.enabled && item.category === "trigger",
+).map((item) => item.type);
+
+export function replaceVisualWorkflowNodeType(
+  node: VisualWorkflowRfNode,
+  nextType: VisualCatalogType,
+): VisualWorkflowRfNode {
+  if (node.data.catalogType === nextType) {
+    return node;
+  }
+
+  return {
+    ...node,
+    type: nextType,
+    ...getVisualNodeDimensions(nextType),
+    data: {
+      catalogType: nextType,
+      config: createDefaultConfig(nextType),
+      runStatus: "idle",
+      lastOutput: null,
+      lastError: null,
+    },
+  };
+}
+
+export function removeVisualWorkflowNode(
+  nodes: readonly VisualWorkflowRfNode[],
+  edges: readonly VisualWorkflowRfEdge[],
+  nodeId: string,
+): { nodes: VisualWorkflowRfNode[]; edges: VisualWorkflowRfEdge[] } {
+  return {
+    nodes: nodes.filter((node) => node.id !== nodeId),
+    edges: edges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId),
+  };
+}
+
+export function isVisualTriggerCatalogType(type: string): type is VisualCatalogType {
+  return VISUAL_TRIGGER_TYPES.includes(type as VisualCatalogType) && isTriggerType(type);
+}

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/types.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/types.ts
@@ -107,6 +107,8 @@ export type VisualWorkflowNodeData = {
   runStatus: MockNodeRunStatus;
   lastOutput?: Record<string, unknown> | null;
   lastError?: Record<string, unknown> | null;
+  previewSubtitle?: string;
+  hideAddAction?: boolean;
 };
 
 export type VisualWorkflowRfNode = Node<VisualWorkflowNodeData, VisualCatalogType>;

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow.test.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow.test.ts
@@ -14,6 +14,10 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { visualWorkflowDemoDraft } from "./fixtures/demo-draft";
 import { createDefaultConfig } from "./catalog/node-catalog";
+import {
+  removeVisualWorkflowNode,
+  replaceVisualWorkflowNodeType,
+} from "./editor/visual-workflow-editor-graph";
 import { visualWorkflowDefinitionSchema } from "./schema/definition-schema";
 import { fromVisualWorkflowDefinition, toVisualWorkflowDefinition } from "./schema/serializers";
 import {
@@ -205,6 +209,33 @@ describe("validateVisualWorkflowDefinition config", () => {
     expect(
       issues.some((issue) => issue.code === "invalid_node_config" && issue.nodeId === "slack"),
     ).toBe(true);
+  });
+});
+
+describe("visual workflow editor graph helpers", () => {
+  it("replaces a trigger type in place and keeps outgoing edges", () => {
+    const trigger = node("t", "trigger.manual", 12, 24);
+    const replaced = replaceVisualWorkflowNodeType(trigger, "trigger.scheduled");
+
+    expect(replaced.id).toBe("t");
+    expect(replaced.position).toEqual({ x: 12, y: 24 });
+    expect(replaced.type).toBe("trigger.scheduled");
+    expect(replaced.data.catalogType).toBe("trigger.scheduled");
+    expect(replaced.data.config).toEqual(createDefaultConfig("trigger.scheduled"));
+  });
+
+  it("removes a node and its connected edges", () => {
+    const result = removeVisualWorkflowNode(
+      [node("t", "trigger.manual"), node("h", "action.http"), node("a", "ai.agent")],
+      [
+        { id: "e1", source: "t", target: "h" },
+        { id: "e2", source: "h", target: "a" },
+      ],
+      "h",
+    );
+
+    expect(result.nodes.map((entry) => entry.id)).toEqual(["t", "a"]);
+    expect(result.edges).toEqual([]);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflows.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflows.ts
@@ -12,7 +12,7 @@
  */
 import "server-only";
 
-import { and, desc, eq, isNull, isNotNull, lte, asc } from "drizzle-orm";
+import { and, desc, eq, isNull, isNotNull, lte, asc, ne } from "drizzle-orm";
 
 import { db, schema, type DatabaseClient } from "@/lib/database/client";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
@@ -164,6 +164,8 @@ export async function listVisualWorkflows(input: {
   const conditions = [eq(schema.visualWorkflows.organizationId, input.organizationId)];
   if (input.status) {
     conditions.push(eq(schema.visualWorkflows.status, input.status));
+  } else {
+    conditions.push(ne(schema.visualWorkflows.status, "archived"));
   }
   if (projectId) {
     conditions.push(eq(schema.visualWorkflows.projectId, projectId));
@@ -407,6 +409,49 @@ export async function updateVisualWorkflow(input: {
       code: "invalid_definition",
       message: "Updated workflow definition could not be read back.",
     });
+  }
+
+  return ok(mapped);
+}
+
+export async function deleteVisualWorkflow(input: {
+  organizationId: string;
+  visualWorkflowId: string;
+  dbClient?: DatabaseClient;
+}): Promise<Result<VisualWorkflowRecord, { code: "visual_workflow_not_found" }>> {
+  const dbClient = input.dbClient ?? db;
+  const existing = await getVisualWorkflowById({
+    organizationId: input.organizationId,
+    visualWorkflowId: input.visualWorkflowId,
+    dbClient,
+  });
+
+  if (!existing) {
+    return err({ code: "visual_workflow_not_found" });
+  }
+
+  if (existing.status === "archived") {
+    return ok(existing);
+  }
+
+  const [row] = await dbClient
+    .update(schema.visualWorkflows)
+    .set({
+      status: "archived",
+      triggerFingerprint: null,
+      nextRunAt: null,
+    })
+    .where(
+      and(
+        eq(schema.visualWorkflows.organizationId, input.organizationId),
+        eq(schema.visualWorkflows.id, input.visualWorkflowId),
+      ),
+    )
+    .returning();
+
+  const mapped = mapVisualWorkflowRow(row);
+  if (!mapped) {
+    return err({ code: "visual_workflow_not_found" });
   }
 
   return ok(mapped);

--- a/docs/platform/automations.mdx
+++ b/docs/platform/automations.mdx
@@ -39,13 +39,13 @@ GitHub triggers need the GitHub App connected first. The UI shows **Connect firs
 
 **Source upload** is the Cloud-side counterpart to [CLI sync push](/platform/cli): the CLI uploads files; this trigger starts translation.
 
-## Advanced workflows
+## Visual workflows
 
-When the `workspace-visual-workflows` flag is enabled, organization **Automations** also shows **Advanced workflows**. These are deterministic graphs (manual trigger, HTTP requests, if/else branching, and AI steps) rather than LLM-orchestrated playbooks.
+When the `workspace-visual-workflows` flag is enabled, organization **Automations** also shows **Visual workflows**. These are deterministic graphs (manual trigger, HTTP requests, if/else branching, and AI steps) rather than LLM-orchestrated playbooks.
 
 Use them for fixed step order and explicit branches. Keep using agent automations for schedule/GitHub/upload triggers and multi-tool orchestration.
 
-See [Advanced workflows](/platform/visual-workflows).
+See [Visual workflows](/platform/visual-workflows).
 
 ## One-off work
 
@@ -55,7 +55,7 @@ Workspace **AI Engine** chooses the model provider agents use.
 
 ## Next
 
-- [Advanced workflows](/platform/visual-workflows)
+- [Visual workflows](/platform/visual-workflows)
 - [Knowledge](/platform/knowledge)
 - [Connect the CLI](/platform/cli)
 - [Getting started](/platform/getting-started)

--- a/docs/platform/visual-workflows.mdx
+++ b/docs/platform/visual-workflows.mdx
@@ -1,34 +1,34 @@
 ---
-title: "Advanced workflows"
+title: "Visual workflows"
 description: "Build and run deterministic automation graphs with triggers, HTTP actions, branching, and AI steps."
 ---
 
-**Advanced workflows** (visual workflows) let operators compose deterministic automation graphs on a canvas. They complement [agent automations](/platform/automations), which use an LLM orchestrator and tool plan.
+**Visual workflows** let operators compose deterministic automation graphs on a canvas. They complement [agent automations](/platform/automations), which use an LLM orchestrator and tool plan.
 
 The feature is in Beta. It is gated by the `workspace-visual-workflows` flag for your organization.
 
 ## Where to find them
 
-Open organization **Automations**. When advanced workflows are enabled, click **Advanced workflows** to open the list at `/org/{slug}/automations/visual-workflows`.
+Open organization **Automations**. When visual workflows are enabled, click **Visual workflows** to open the list at `/org/{slug}/automations/visual-workflows`.
 
-From there you can create a workflow, open the canvas editor, and inspect run history per workflow.
+From there you can create a workflow, open the canvas editor, change the trigger, delete a workflow, and inspect run history per workflow.
 
-Advanced workflows are organization-scoped today. They do not appear on project-scoped automation pages.
+Visual workflows are organization-scoped today. They do not appear on project-scoped automation pages.
 
-## Agent automations vs advanced workflows
+## Agent automations vs visual workflows
 
-| | Agent automations | Advanced workflows |
+| | Agent automations | Visual workflows |
 | --- | --- | --- |
 | **Execution model** | LLM orchestrator picks tools from `toolConfig` | Deterministic graph interpreter walks nodes in order |
 | **Triggers** | Manual, schedule, GitHub, upload, Contentful | Manual only (Phase 1) |
 | **Best for** | Open-ended playbooks with GitHub, Slack, translation tools | Fixed HTTP calls, branching, and short AI prompts in a known graph |
 | **Run history** | Automation run history | Per-workflow runs with per-node snapshots |
 
-Use agent automations when the agent should decide which tools to call. Use advanced workflows when the steps, order, and branches are fixed.
+Use agent automations when the agent should decide which tools to call. Use visual workflows when the steps, order, and branches are fixed.
 
 ## Build a workflow
 
-1. Click **New workflow** on the advanced workflows list.
+1. Click **New workflow** on the visual workflows list.
 2. Add nodes from the picker: **Manual trigger**, **HTTP request**, **If / else**, or **AI agent**.
 3. Connect nodes on the canvas. The graph must have exactly one trigger and every non-trigger node must be reachable from it.
 4. Configure each node in the side panel.
@@ -86,7 +86,7 @@ Do not put secrets in URLs. Prefer short-lived tokens in trigger input when you 
 
 ## Permissions and API
 
-Advanced workflow routes require an organization **operator** role (admin or localization manager). The feature flag must also be enabled.
+Visual workflow routes require an organization **operator** role (admin or localization manager). The feature flag must also be enabled.
 
 Authenticated JSON API (session cookie or equivalent app auth):
 
@@ -96,6 +96,7 @@ Authenticated JSON API (session cookie or equivalent app auth):
 | `POST` | `/api/orgs/{slug}/visual-workflows` | Create a workflow |
 | `GET` | `/api/orgs/{slug}/visual-workflows/{id}` | Read one workflow |
 | `PATCH` | `/api/orgs/{slug}/visual-workflows/{id}` | Update name, status, project, or definition |
+| `DELETE` | `/api/orgs/{slug}/visual-workflows/{id}` | Archive (delete) a workflow |
 | `GET` | `/api/orgs/{slug}/visual-workflows/{id}/runs` | List runs |
 | `POST` | `/api/orgs/{slug}/visual-workflows/{id}/runs` | Queue a manual run (`idempotencyKey` required) |
 | `GET` | `/api/orgs/{slug}/visual-workflows/{id}/runs/{runId}` | Run detail with node snapshots |
@@ -108,7 +109,7 @@ When the flag is off, routes return `forbidden` with `visual_workflows_feature_d
 
 | Symptom | Likely cause |
 | --- | --- |
-| **Advanced workflows** link missing | `workspace-visual-workflows` flag is off for the org |
+| **Visual workflows** link missing | `workspace-visual-workflows` flag is off for the org |
 | Save fails with graph errors | Multiple triggers, orphan node, or broken edge — check validation messages |
 | HTTP node fails with `http_error` | Target returned a non-2xx status |
 | HTTP node fails with `http_request_failed` | Blocked URL, network error, or SSRF validation failure |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Renames Advanced workflows to Visual workflows, adds delete, and lets operators change or remove a trigger. Also fixes the marketing integration detail preview so Visual workflow examples actually render and use the same compact-node canvas as the editor.

- List and editor can archive (delete) a visual workflow
- Trigger nodes can change type; any step can be deleted from the canvas
- Integration detail examples reuse the real compact nodes, lay them out left to right, and give React Flow a fixed height so the canvas is visible

## How to test

- Open a marketing integration detail page (for example `/en/integrations/github`)
- Confirm **Visual workflow examples** shows compact editor-style nodes, not an empty box
- Play/pause and switch examples
- In the signed-in editor: delete a workflow, change a trigger type, delete a step

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

[GitHub visual workflow examples](https://cursor.com/agents/bc-01a06f1e-2541-7f1d-a9cb-2b01f628912b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgithub-visual-workflow-examples.webp)
[Slack visual workflow examples](https://cursor.com/agents/bc-01a06f1e-2541-7f1d-a9cb-2b01f628912b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslack-visual-workflow-examples.webp)
[github-visual-workflow-examples.mp4](https://cursor.com/agents/bc-01a06f1e-2541-7f1d-a9cb-2b01f628912b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgithub-visual-workflow-examples.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06f1e-2541-7f1d-a9cb-2b01f628912b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06f1e-2541-7f1d-a9cb-2b01f628912b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

