### PR TITLE
feat(mt): add Google translation client

### DIFF
--- a/internal/mt/BUILD.bazel
+++ b/internal/mt/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "doc.go",
         "engine.go",
         "errors.go",
+        "google.go",
         "types.go",
         "validate.go",
     ],

--- a/internal/mt/BUILD.bazel
+++ b/internal/mt/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     srcs = [
         "config_test.go",
         "errors_test.go",
+        "google_test.go",
         "testhelpers_test.go",
         "validate_test.go",
     ],

--- a/internal/mt/google.go
+++ b/internal/mt/google.go
@@ -1,0 +1,231 @@
+package mt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/text/language"
+)
+
+const (
+	defaultGoogleTranslateBaseURL = "https://translation.googleapis.com"
+	googleTranslateV2Path         = "/language/translate/v2"
+)
+
+// GoogleClient translates text using Cloud Translation v2 with API-key auth.
+type GoogleClient struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+var _ Engine = (*GoogleClient)(nil)
+
+// NewGoogleClient builds a GoogleClient from cfg. cfg.APIKey is required;
+// cfg.BaseURL and cfg.HTTPClient are optional overrides used by tests.
+func NewGoogleClient(cfg Config) (*GoogleClient, error) {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, &Error{Code: ErrorCodeValidation, Message: "API key is required"}
+	}
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultGoogleTranslateBaseURL
+	}
+	return &GoogleClient{
+		apiKey:     cfg.APIKey,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: cfg.httpClient(),
+	}, nil
+}
+
+type googleTranslateRequest struct {
+	Q      []string `json:"q"`
+	Source string   `json:"source"`
+	Target string   `json:"target"`
+	Format string   `json:"format"`
+}
+
+type googleTranslateResponse struct {
+	Data struct {
+		Translations []struct {
+			TranslatedText string `json:"translatedText"`
+		} `json:"translations"`
+	} `json:"data"`
+}
+
+type googleErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Errors  []struct {
+			Domain string `json:"domain"`
+			Reason string `json:"reason"`
+		} `json:"errors"`
+	} `json:"error"`
+}
+
+// Translate implements Engine using Cloud Translation v2.
+func (c *GoogleClient) Translate(ctx context.Context, req Request) (Response, error) {
+	if err := validateRequest(req); err != nil {
+		return Response{}, err
+	}
+
+	body := googleTranslateRequest{
+		Q:      req.Sources,
+		Source: googleLanguageCode(req.SourceLocale),
+		Target: googleLanguageCode(req.TargetLocale),
+		Format: "text",
+	}
+
+	var out googleTranslateResponse
+	if err := c.request(ctx, http.MethodPost, c.translateURL(), body, &out); err != nil {
+		return Response{}, err
+	}
+
+	// Cloud Translation v2 preserves q-array order 1:1 in the response.
+	translations := make([]string, len(out.Data.Translations))
+	for i, t := range out.Data.Translations {
+		translations[i] = t.TranslatedText
+	}
+	return Response{Translations: translations}, nil
+}
+
+func (c *GoogleClient) translateURL() string {
+	values := url.Values{}
+	values.Set("key", c.apiKey)
+	return c.baseURL + googleTranslateV2Path + "?" + values.Encode()
+}
+
+func (c *GoogleClient) request(ctx context.Context, method, requestURL string, body, out any) error {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("mt: marshal google translate request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, requestURL, bytes.NewReader(encoded))
+	if err != nil {
+		return fmt.Errorf("mt: build google translate request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return &Error{
+			Code:    ErrorCodeUpstreamUnavailable,
+			Message: "could not reach Google Cloud Translation: " + err.Error(),
+			Path:    googleTranslateV2Path,
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return &Error{
+			Code:    ErrorCodeUpstreamUnavailable,
+			Message: "could not read Google Cloud Translation response",
+			Path:    googleTranslateV2Path,
+		}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return googleHTTPError(resp.StatusCode, googleTranslateV2Path, respBody)
+	}
+
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return &Error{
+			Code:       ErrorCodeUpstream,
+			Message:    "Google Cloud Translation returned invalid JSON",
+			StatusCode: resp.StatusCode,
+			Path:       googleTranslateV2Path,
+		}
+	}
+	return nil
+}
+
+// googleHTTPError maps a non-2xx response to a typed Error. Cloud Translation v2
+// does not distinguish an unsupported language from other invalid-request causes:
+// both return a generic 400 with reason "invalid", so non-keyInvalid 400s map to
+// ErrorCodeUpstream rather than ErrorCodeUnsupportedLanguagePair.
+func googleHTTPError(statusCode int, path string, body []byte) *Error {
+	var parsed googleErrorResponse
+	_ = json.Unmarshal(body, &parsed)
+	reason, domain := firstGoogleError(parsed)
+	message := googleErrorMessage(statusCode, parsed, body)
+
+	switch {
+	case statusCode == http.StatusBadRequest && reason == "keyInvalid":
+		return &Error{Code: ErrorCodeAuthFailed, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode == http.StatusBadRequest:
+		return &Error{Code: ErrorCodeUpstream, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode == http.StatusUnauthorized:
+		return &Error{Code: ErrorCodeAuthFailed, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode == http.StatusForbidden && domain == "usageLimits" && (reason == "dailyLimitExceeded" || reason == "userRateLimitExceeded"):
+		return &Error{Code: ErrorCodeRateLimited, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode == http.StatusForbidden:
+		return &Error{Code: ErrorCodeAuthFailed, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode == http.StatusTooManyRequests:
+		return &Error{Code: ErrorCodeRateLimited, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode >= 500:
+		return &Error{Code: ErrorCodeUpstreamUnavailable, Message: message, StatusCode: statusCode, Path: path}
+	default:
+		return &Error{Code: ErrorCodeUpstream, Message: message, StatusCode: statusCode, Path: path}
+	}
+}
+
+func firstGoogleError(parsed googleErrorResponse) (reason, domain string) {
+	if len(parsed.Error.Errors) == 0 {
+		return "", ""
+	}
+	return parsed.Error.Errors[0].Reason, parsed.Error.Errors[0].Domain
+}
+
+func googleErrorMessage(statusCode int, parsed googleErrorResponse, body []byte) string {
+	if parsed.Error.Message != "" {
+		return fmt.Sprintf("Google Cloud Translation error (%d): %s", statusCode, parsed.Error.Message)
+	}
+	snippet := truncateGoogleErrorBody(body, 300)
+	if snippet == "" {
+		return fmt.Sprintf("Google Cloud Translation error (%d)", statusCode)
+	}
+	return fmt.Sprintf("Google Cloud Translation error (%d): %s", statusCode, snippet)
+}
+
+func truncateGoogleErrorBody(body []byte, max int) string {
+	trimmed := strings.TrimSpace(string(body))
+	if len(trimmed) <= max {
+		return trimmed
+	}
+	return trimmed[:max] + "..."
+}
+
+// googleLanguageCode maps a validated BCP 47 locale to a Cloud Translation v2
+// language code. Chinese is keyed off the resolved script rather than the raw
+// tag string: language.Parse infers script "Hans"/"Hant" even for tags that
+// don't spell it out (zh, zh-CN, zh-HK, zh-TW, zh-Hans-CN, ...), so matching on
+// tag.String() would miss regional variants like "zh-Hant-HK".
+func googleLanguageCode(locale string) string {
+	tag, err := language.Parse(locale)
+	if err != nil {
+		return locale
+	}
+	base, _ := tag.Base()
+	if base.String() == "zh" {
+		script, _ := tag.Script()
+		if script.String() == "Hant" {
+			return "zh-TW"
+		}
+		return "zh-CN"
+	}
+	return base.String()
+}

--- a/internal/mt/google.go
+++ b/internal/mt/google.go
@@ -18,7 +18,7 @@ const (
 	googleTranslateV2Path         = "/language/translate/v2"
 )
 
-// GoogleClient translates text using Cloud Translation v2 with API-key auth.
+// GoogleClient translates text using Cloud Translation v2.
 type GoogleClient struct {
 	apiKey     string
 	baseURL    string
@@ -27,8 +27,7 @@ type GoogleClient struct {
 
 var _ Engine = (*GoogleClient)(nil)
 
-// NewGoogleClient builds a GoogleClient from cfg. cfg.APIKey is required;
-// cfg.BaseURL and cfg.HTTPClient are optional overrides used by tests.
+// NewGoogleClient creates a Cloud Translation v2 client.
 func NewGoogleClient(cfg Config) (*GoogleClient, error) {
 	if strings.TrimSpace(cfg.APIKey) == "" {
 		return nil, &Error{Code: ErrorCodeValidation, Message: "API key is required"}
@@ -87,7 +86,6 @@ func (c *GoogleClient) Translate(ctx context.Context, req Request) (Response, er
 		return Response{}, err
 	}
 
-	// Cloud Translation v2 preserves q-array order 1:1 in the response.
 	translations := make([]string, len(out.Data.Translations))
 	for i, t := range out.Data.Translations {
 		translations[i] = t.TranslatedText
@@ -153,10 +151,8 @@ func (c *GoogleClient) request(ctx context.Context, method, requestURL string, b
 	return nil
 }
 
-// googleHTTPError maps a non-2xx response to a typed Error. Cloud Translation v2
-// does not distinguish an unsupported language from other invalid-request causes:
-// both return a generic 400 with reason "invalid", so non-keyInvalid 400s map to
-// ErrorCodeUpstream rather than ErrorCodeUnsupportedLanguagePair.
+// Google v2 does not distinguish unsupported languages from other invalid
+// requests, so generic 400 responses map to ErrorCodeUpstream.
 func googleHTTPError(statusCode int, path string, body []byte) *Error {
 	var parsed googleErrorResponse
 	_ = json.Unmarshal(body, &parsed)
@@ -209,11 +205,8 @@ func truncateGoogleErrorBody(body []byte, max int) string {
 	return trimmed[:max] + "..."
 }
 
-// googleLanguageCode maps a validated BCP 47 locale to a Cloud Translation v2
-// language code. Chinese is keyed off the resolved script rather than the raw
-// tag string: language.Parse infers script "Hans"/"Hant" even for tags that
-// don't spell it out (zh, zh-CN, zh-HK, zh-TW, zh-Hans-CN, ...), so matching on
-// tag.String() would miss regional variants like "zh-Hant-HK".
+// googleLanguageCode maps BCP 47 locales to Google v2 language codes.
+// Chinese uses the resolved script so regional variants map correctly.
 func googleLanguageCode(locale string) string {
 	tag, err := language.Parse(locale)
 	if err != nil {

--- a/internal/mt/google.go
+++ b/internal/mt/google.go
@@ -118,7 +118,7 @@ func (c *GoogleClient) request(ctx context.Context, method, requestURL string, b
 		}
 		return &Error{
 			Code:    ErrorCodeUpstreamUnavailable,
-			Message: "could not reach Google Cloud Translation: " + err.Error(),
+			Message: "could not reach Google Cloud Translation",
 			Path:    googleTranslateV2Path,
 		}
 	}

--- a/internal/mt/google.go
+++ b/internal/mt/google.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
@@ -88,7 +89,7 @@ func (c *GoogleClient) Translate(ctx context.Context, req Request) (Response, er
 
 	translations := make([]string, len(out.Data.Translations))
 	for i, t := range out.Data.Translations {
-		translations[i] = t.TranslatedText
+		translations[i] = html.UnescapeString(t.TranslatedText)
 	}
 	return Response{Translations: translations}, nil
 }

--- a/internal/mt/google_test.go
+++ b/internal/mt/google_test.go
@@ -1,0 +1,246 @@
+package mt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newGoogleTestClient(t *testing.T, handler http.HandlerFunc) *GoogleClient {
+	t.Helper()
+	cfg := newTestServer(t, handler)
+	cfg.APIKey = "test-key"
+	client, err := NewGoogleClient(cfg)
+	require.NoError(t, err)
+	return client
+}
+
+func TestGoogleClientTranslateSuccess(t *testing.T) {
+	var gotBody googleTranslateRequest
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, googleTranslateV2Path, r.URL.Path)
+		require.Equal(t, "test-key", r.URL.Query().Get("key"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"translations":[{"translatedText":"Bonjour"},{"translatedText":"Salut"}]}}`))
+	})
+
+	resp, err := client.Translate(t.Context(), Request{
+		SourceLocale: "en",
+		TargetLocale: "fr",
+		Sources:      []string{"Hello", "Hi"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"Bonjour", "Salut"}, resp.Translations)
+
+	require.Equal(t, []string{"Hello", "Hi"}, gotBody.Q)
+	require.Equal(t, "en", gotBody.Source)
+	require.Equal(t, "fr", gotBody.Target)
+	require.Equal(t, "text", gotBody.Format)
+}
+
+func TestGoogleClientTranslateMapsChineseScriptVariants(t *testing.T) {
+	var gotBody googleTranslateRequest
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"translations":[{"translatedText":"x"}]}}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{
+		SourceLocale: "zh-Hans",
+		TargetLocale: "zh-Hant-HK",
+		Sources:      []string{"你好"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "zh-CN", gotBody.Source)
+	require.Equal(t, "zh-TW", gotBody.Target)
+}
+
+func TestGoogleClientTranslateAuthFailed401(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":401,"message":"Request had invalid authentication credentials."}}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeAuthFailed, typed.Code)
+	require.Equal(t, http.StatusUnauthorized, typed.StatusCode)
+}
+
+func TestGoogleClientTranslateAuthFailed403(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"errors":[{"domain":"global","reason":"forbidden","message":"The caller does not have permission"}],"message":"The caller does not have permission"}}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeAuthFailed, typed.Code)
+}
+
+func TestGoogleClientTranslateAuthFailedInvalidAPIKey(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"errors":[{"domain":"global","reason":"keyInvalid","message":"API key not valid. Please pass a valid API key."}],"message":"API key not valid. Please pass a valid API key."}}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeAuthFailed, typed.Code)
+}
+
+func TestGoogleClientTranslateRateLimited429(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Quota exceeded"}}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeRateLimited, typed.Code)
+}
+
+func TestGoogleClientTranslateRateLimited403Quota(t *testing.T) {
+	for _, reason := range []string{"dailyLimitExceeded", "userRateLimitExceeded"} {
+		t.Run(reason, func(t *testing.T) {
+			client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				body, err := json.Marshal(map[string]any{
+					"error": map[string]any{
+						"code": 403,
+						"errors": []map[string]any{
+							{"domain": "usageLimits", "reason": reason, "message": "Rate Limit Exceeded"},
+						},
+						"message": "Rate Limit Exceeded",
+					},
+				})
+				require.NoError(t, err)
+				_, _ = w.Write(body)
+			})
+
+			_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeRateLimited, typed.Code)
+		})
+	}
+}
+
+// TestGoogleClientTranslateUnsupportedLanguageMapsToUpstreamError documents a
+// deliberate limitation rather than satisfying a literal unsupported-pair
+// mapping: Cloud Translation v2 returns the same generic domain "global",
+// reason "invalid" 400 for an unsupported language code as it does for other
+// malformed requests, so this client cannot reliably tell them apart and maps
+// both to ErrorCodeUpstream instead of guessing ErrorCodeUnsupportedLanguagePair.
+func TestGoogleClientTranslateUnsupportedLanguageMapsToUpstreamError(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"errors":[{"domain":"global","reason":"invalid","message":"Invalid Value"}],"message":"Invalid Value"}}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "de", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestGoogleClientTranslateUpstreamUnavailable(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"code":503,"message":"Service Unavailable"}}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+}
+
+func TestGoogleClientTranslateInvalidJSONResponse(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestGoogleClientTranslateEmptyInputMakesNoRequest(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected HTTP call for empty input")
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: nil})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestGoogleClientTranslateContextDeadlineExceeded(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"translations":[]}}`))
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+
+	_, err := client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded))
+	_, ok := AsError(err)
+	require.False(t, ok)
+}
+
+func TestNewGoogleClientRequiresAPIKey(t *testing.T) {
+	client, err := NewGoogleClient(Config{})
+	require.Nil(t, client)
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestGoogleLanguageCode(t *testing.T) {
+	cases := []struct {
+		locale string
+		want   string
+	}{
+		{"en", "en"},
+		{"pt-BR", "pt"},
+		{"en-GB", "en"},
+		{"zh", "zh-CN"},
+		{"zh-CN", "zh-CN"},
+		{"zh-Hans", "zh-CN"},
+		{"zh-Hans-CN", "zh-CN"},
+		{"zh-TW", "zh-TW"},
+		{"zh-HK", "zh-TW"},
+		{"zh-Hant", "zh-TW"},
+		{"zh-Hant-HK", "zh-TW"},
+		{"zh-Hant-TW", "zh-TW"},
+		{"he", "he"},
+		{"iw", "he"},
+		{"id", "id"},
+		{"in", "id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.locale, func(t *testing.T) {
+			require.Equal(t, tc.want, googleLanguageCode(tc.locale))
+		})
+	}
+}

--- a/internal/mt/google_test.go
+++ b/internal/mt/google_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -138,12 +139,8 @@ func TestGoogleClientTranslateRateLimited403Quota(t *testing.T) {
 	}
 }
 
-// TestGoogleClientTranslateUnsupportedLanguageMapsToUpstreamError documents a
-// deliberate limitation rather than satisfying a literal unsupported-pair
-// mapping: Cloud Translation v2 returns the same generic domain "global",
-// reason "invalid" 400 for an unsupported language code as it does for other
-// malformed requests, so this client cannot reliably tell them apart and maps
-// both to ErrorCodeUpstream instead of guessing ErrorCodeUnsupportedLanguagePair.
+// Google v2 does not distinguish unsupported languages from other invalid
+// requests, so generic 400s map to ErrorCodeUpstream.
 func TestGoogleClientTranslateUnsupportedLanguageMapsToUpstreamError(t *testing.T) {
 	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -154,6 +151,41 @@ func TestGoogleClientTranslateUnsupportedLanguageMapsToUpstreamError(t *testing.
 	typed, ok := AsError(err)
 	require.True(t, ok)
 	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestGoogleClientTranslateTransportErrorDoesNotLeakAPIKey(t *testing.T) {
+	const apiKey = "super-secret-api-key-12345"
+
+	client, err := NewGoogleClient(Config{
+		BaseURL: defaultGoogleTranslateBaseURL,
+		APIKey:  apiKey,
+		HTTPClient: &http.Client{
+			Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("Post %q: connection refused", req.URL.String())
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.Translate(t.Context(), Request{
+		SourceLocale: "en",
+		TargetLocale: "fr",
+		Sources:      []string{"hi"},
+	})
+	require.Error(t, err)
+
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+	require.Equal(t, googleTranslateV2Path, typed.Path)
+	require.NotContains(t, typed.Message, apiKey)
+	require.NotContains(t, err.Error(), apiKey)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestGoogleClientTranslateUpstreamUnavailable(t *testing.T) {

--- a/internal/mt/google_test.go
+++ b/internal/mt/google_test.go
@@ -46,6 +46,21 @@ func TestGoogleClientTranslateSuccess(t *testing.T) {
 	require.Equal(t, "text", gotBody.Format)
 }
 
+func TestGoogleClientTranslateDecodesHTMLEscapedText(t *testing.T) {
+	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"translations":[{"translatedText":"C&#39;est l&#39;amour &amp; la vie"}]}}`))
+	})
+
+	resp, err := client.Translate(t.Context(), Request{
+		SourceLocale: "en",
+		TargetLocale: "fr",
+		Sources:      []string{"It's love & life"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"C'est l'amour & la vie"}, resp.Translations)
+}
+
 func TestGoogleClientTranslateMapsChineseScriptVariants(t *testing.T) {
 	var gotBody googleTranslateRequest
 	client := newGoogleTestClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What changed

- Added the Google Cloud Translation v2 client behind the `internal/mt` `Engine` interface.
- Added API-key auth, BCP 47 locale mapping, batch translation, typed error mapping, and context cancellation.
- Added `httptest` coverage for success, validation, auth, rate limits, upstream failures, locale mapping, and cancellation.
- Google v2 does not reliably distinguish unsupported languages from other invalid requests, so generic 400s map to `ErrorCodeUpstream`.

## How to test

- `go test ./internal/mt`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
