### PR TITLE
feat(web): org view transitions for instant navigation

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-page-suspense.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-page-suspense.tsx
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import { Suspense, type ReactNode } from "react";
+import { ViewTransition } from "react";
 
 import { OrganizationRouteLoading } from "./organization-route-loading";
 
@@ -19,5 +20,17 @@ type OrgPageSuspenseProps = {
 };
 
 export function OrgPageSuspense({ children }: OrgPageSuspenseProps) {
-  return <Suspense fallback={<OrganizationRouteLoading />}>{children}</Suspense>;
+  return (
+    <Suspense
+      fallback={
+        <ViewTransition exit="fade-out" default="none">
+          <OrganizationRouteLoading />
+        </ViewTransition>
+      }
+    >
+      <ViewTransition enter="fade-in" default="none">
+        {children}
+      </ViewTransition>
+    </Suspense>
+  );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.test.tsx
@@ -37,6 +37,7 @@ const apiMocks = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/org/acme/automations/automation-1",
 }));
 
 vi.mock("next/link", () => ({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -13,10 +13,10 @@
  * Version 2.0 or later.
  */
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { Delete02Icon, PlayIcon, SaveIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -44,6 +44,7 @@ import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { buildAutomationsPath } from "@/components/app-shell/navigation-config";
 import { apiClient } from "@/lib/api-client-instance";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 import { readApiResponseError } from "@/lib/api-error";
 import { buildWorkspaceAutomationWebChatHref } from "@/lib/agents/workspace-automation-web-chat-url";
 import {
@@ -91,7 +92,7 @@ export function AutomationDetailPageContent({
   canUpdateKnowledgeMemory?: boolean;
 }) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const queryClient = useQueryClient();
   const automationsBasePath = buildAutomationsPath(organizationSlug, { projectId });
 
@@ -641,7 +642,7 @@ export function AutomationDetailPageContent({
         <Button
           variant="outline"
           nativeButton={false}
-          render={<Link href={`/org/${organizationSlug}/automations`} />}
+          render={<OrgNavLink href={`/org/${organizationSlug}/automations`} />}
         >
           <FormattedMessage {...automationDetailPageContentMessages.backToAutomations} />
         </Button>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
@@ -12,8 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -47,7 +47,7 @@ export function AutomationsNewPageContent({
   canUpdateKnowledgeMemory?: boolean;
 }) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const [form, setForm] = useState(initialForm);
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
   const automationsBasePath = buildAutomationsPath(organizationSlug, { projectId });
@@ -108,7 +108,7 @@ export function AutomationsNewPageContent({
             <Button
               variant="outline"
               nativeButton={false}
-              render={<Link href={automationsBasePath} />}
+              render={<OrgNavLink href={automationsBasePath} />}
             >
               <FormattedMessage {...automationsNewPageContentMessages.cancel} />
             </Button>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { Fragment, useMemo, useState, type ReactNode } from "react";
 import { Add01Icon, FlashIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -108,9 +108,9 @@ function defaultRenderAutomationLink({
   className,
 }: Parameters<AutomationsLinkRenderer>[0]) {
   return (
-    <Link href={href} className={className}>
+    <OrgNavLink href={href} className={className}>
       {children}
-    </Link>
+    </OrgNavLink>
   );
 }
 
@@ -122,7 +122,7 @@ function defaultRenderActionLink({
   return (
     <Button
       nativeButton={false}
-      render={<Link href={href} />}
+      render={<OrgNavLink href={href} />}
       {...(kind === "template" ? { size: "sm" as const, className: "rounded-full" } : {})}
     >
       {children}
@@ -262,7 +262,9 @@ export function AutomationsPageView({
             {visualWorkflowsEnabled && !projectId ? (
               <Button
                 nativeButton={false}
-                render={<Link href={`/org/${organizationSlug}/automations/visual-workflows`} />}
+                render={
+                  <OrgNavLink href={`/org/${organizationSlug}/automations/visual-workflows`} />
+                }
                 variant="outline"
               >
                 <FormattedMessage

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor-page-content.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 import { fromVisualWorkflowDefinition } from "@/lib/visual-workflows/schema/serializers";
 import type { VisualWorkflowDefinition } from "@/lib/visual-workflows/schema/types";
 import type { VisualWorkflowRecord } from "@/lib/visual-workflows/visual-workflow-types";
@@ -43,6 +44,7 @@ export function VisualWorkflowEditorPageContent({
   visualWorkflowsApi?: VisualWorkflowsApi;
 }) {
   const router = useRouter();
+  const orgRouter = useOrgRouter();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   useAppShellSidebar({ forceCollapsed: true });
   const editorState = fromVisualWorkflowDefinition({
@@ -85,7 +87,7 @@ export function VisualWorkflowEditorPageContent({
     mutationFn: () => injectedApi.deleteVisualWorkflow(organizationSlug, workflow.id),
     onSuccess: () => {
       toast.success(<FormattedMessage {...visualWorkflowsPageMessages.deleteSuccess} />);
-      router.push(`/org/${organizationSlug}/automations/visual-workflows`);
+      orgRouter.push(`/org/${organizationSlug}/automations/visual-workflows`);
     },
     onError: () => {
       toast.error(<FormattedMessage {...visualWorkflowsPageMessages.deleteFailed} />);
@@ -116,7 +118,7 @@ export function VisualWorkflowEditorPageContent({
       <div className="flex items-center gap-2 border-b border-border px-4 py-2">
         <Button
           nativeButton={false}
-          render={<Link href={`/org/${organizationSlug}/automations/visual-workflows`} />}
+          render={<OrgNavLink href={`/org/${organizationSlug}/automations/visual-workflows`} />}
           variant="ghost"
           size="sm"
         >

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.test.tsx
@@ -27,6 +27,7 @@ import type { VisualWorkflowsApi } from "./visual-workflows-api";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/org/acme/automations/visual-workflows",
 }));
 
 vi.mock("next/link", () => ({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflows-page-content.tsx
@@ -12,12 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { useState } from "react";
 import { Delete02Icon, GitBranchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
@@ -48,7 +48,7 @@ export function VisualWorkflowsPageContent({
   visualWorkflowsApi?: typeof visualWorkflowsApi;
 }) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const queryClient = useQueryClient();
   const [workflowToDelete, setWorkflowToDelete] = useState<VisualWorkflowRecord | null>(null);
   const workflowsQuery = useQuery({
@@ -108,7 +108,7 @@ export function VisualWorkflowsPageContent({
           <ul className="divide-y divide-border">
             {workflowsQuery.data.map((workflow) => (
               <li key={workflow.id} className="flex items-center gap-2 px-2">
-                <Link
+                <OrgNavLink
                   href={`/org/${organizationSlug}/automations/visual-workflows/${workflow.id}`}
                   className="flex min-w-0 flex-1 items-center justify-between gap-4 px-2 py-3 hover:bg-muted/40"
                 >
@@ -119,7 +119,7 @@ export function VisualWorkflowsPageContent({
                   <span className="text-sm text-muted-foreground">
                     v{workflow.definitionVersion}
                   </span>
-                </Link>
+                </OrgNavLink>
                 <Button
                   type="button"
                   variant="ghost"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/_components/domain-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/_components/domain-detail-page-content.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { usePathname } from "next/navigation";
 import { ArrowLeft01Icon, Globe02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -95,7 +95,7 @@ export function DomainDetailPageContent({
           size="sm"
           className="-ml-2 mb-2"
           nativeButton={false}
-          render={<Link href={`/org/${organizationSlug}/domains`} />}
+          render={<OrgNavLink href={`/org/${organizationSlug}/domains`} />}
         >
           <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={1.7} className="size-4" />
           <FormattedMessage {...messages.backToDomains} />
@@ -130,7 +130,7 @@ export function DomainDetailPageContent({
                     size="sm"
                     nativeButton={false}
                     render={
-                      <Link
+                      <OrgNavLink
                         href={`/org/${organizationSlug}/link-domain/${linkedDomain.domainSlug}`}
                       />
                     }
@@ -144,7 +144,9 @@ export function DomainDetailPageContent({
                     variant="outline"
                     nativeButton={false}
                     render={
-                      <Link href={`/org/${organizationSlug}/projects/${linkedDomain.projectId}`} />
+                      <OrgNavLink
+                        href={`/org/${organizationSlug}/projects/${linkedDomain.projectId}`}
+                      />
                     }
                   >
                     <FormattedMessage {...messages.openProject} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { Globe02Icon } from "@hugeicons/core-free-icons";
 import { useQuery } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -103,12 +103,12 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
               className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
             >
               <div className="min-w-0 space-y-1">
-                <Link
+                <OrgNavLink
                   href={`/org/${organizationSlug}/domains/${domain.id}`}
                   className="font-medium text-foreground underline-offset-4 hover:underline"
                 >
                   {domain.domainKey}
-                </Link>
+                </OrgNavLink>
                 <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                   <Badge variant="outline">{statusLabel(domain.status, intl)}</Badge>
                   <span>
@@ -124,7 +124,7 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
                   size="sm"
                   variant="outline"
                   nativeButton={false}
-                  render={<Link href={`/org/${organizationSlug}/domains/${domain.id}`} />}
+                  render={<OrgNavLink href={`/org/${organizationSlug}/domains/${domain.id}`} />}
                 >
                   <FormattedMessage {...messages.viewReport} />
                 </Button>
@@ -133,7 +133,9 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
                     size="sm"
                     nativeButton={false}
                     render={
-                      <Link href={`/org/${organizationSlug}/link-domain/${domain.domainSlug}`} />
+                      <OrgNavLink
+                        href={`/org/${organizationSlug}/link-domain/${domain.domainSlug}`}
+                      />
                     }
                   >
                     <FormattedMessage {...messages.continueVerification} />
@@ -144,7 +146,9 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
                     size="sm"
                     variant="outline"
                     nativeButton={false}
-                    render={<Link href={`/org/${organizationSlug}/projects/${domain.projectId}`} />}
+                    render={
+                      <OrgNavLink href={`/org/${organizationSlug}/projects/${domain.projectId}`} />
+                    }
                   >
                     <FormattedMessage {...messages.openProject} />
                   </Button>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -170,7 +170,7 @@ export function GlossariesPageContent({
   canManageGlossaries: boolean;
 }) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
   const [crowdinPage, setCrowdinPage] = useState(1);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import type { ReactNode } from "react";
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import {
   ArrowUpRight01Icon,
   BookOpenTextIcon,
@@ -178,7 +178,7 @@ function GlossaryRowActions({
           ) : (
             <Button
               nativeButton={false}
-              render={<Link href={projectHref!} />}
+              render={<OrgNavLink href={projectHref!} />}
               variant="outline"
               size="sm"
               className="gap-1.5 text-xs"
@@ -204,12 +204,12 @@ function GlossaryRowActions({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-48">
                 {primaryAction === "provider" ? (
-                  <DropdownMenuItem render={<Link href={projectHref!} />}>
+                  <DropdownMenuItem render={<OrgNavLink href={projectHref!} />}>
                     <HugeiconsIcon icon={FolderKanbanIcon} strokeWidth={1.8} />
                     <FormattedMessage {...glossariesTableMessages.viewLinkedProject} />
                   </DropdownMenuItem>
                 ) : null}
-                <DropdownMenuItem render={<Link href={jobsHref} />}>
+                <DropdownMenuItem render={<OrgNavLink href={jobsHref} />}>
                   <HugeiconsIcon icon={WorkHistoryIcon} strokeWidth={1.8} />
                   <FormattedMessage {...glossariesTableMessages.viewJobs} />
                 </DropdownMenuItem>
@@ -295,13 +295,13 @@ function GlossaryRow({
         <div className="flex min-w-0 flex-wrap items-center gap-2.5">
           <GlossarySourceMark glossary={glossary} />
           {detailId ? (
-            <Link
+            <OrgNavLink
               href={`/org/${organizationSlug}/glossaries/${detailId}`}
               prefetch
               className="min-w-0 truncate text-[15px] font-semibold tracking-[-0.01em] text-foreground underline-offset-2 hover:underline"
             >
               {glossary.name}
-            </Link>
+            </OrgNavLink>
           ) : (
             <span className="min-w-0 truncate text-[15px] font-semibold tracking-[-0.01em] text-foreground">
               {glossary.name}
@@ -519,7 +519,7 @@ export function GlossariesEmptyAction({
   return (
     <Button
       nativeButton={false}
-      render={<Link href={`/org/${organizationSlug}/integrations`} />}
+      render={<OrgNavLink href={`/org/${organizationSlug}/integrations`} />}
       variant="outline"
       size="sm"
     >

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/loading.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/loading.tsx
@@ -16,7 +16,7 @@ import { OrganizationRouteLoading } from "./_components/organization-route-loadi
 
 export default function OrganizationLoading() {
   return (
-    <ViewTransition exit="slide-down">
+    <ViewTransition exit="fade-out" default="none">
       <OrganizationRouteLoading />
     </ViewTransition>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Add01Icon, CubeIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -117,7 +117,7 @@ function RecentProjectsStrip({
             key={project.id}
             nativeButton={false}
             render={
-              <Link
+              <OrgNavLink
                 href={`/org/${organizationSlug}/projects/${project.id}`}
                 onClick={() => onOpenProject(project.id)}
               />
@@ -451,7 +451,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         <div className="max-w-xl py-4">
           <Button
             nativeButton={false}
-            render={<Link href={`/org/${organizationSlug}/integrations`} />}
+            render={<OrgNavLink href={`/org/${organizationSlug}/integrations`} />}
             variant="outline"
             size="sm"
           >

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
@@ -12,16 +12,23 @@
  */
 // @vitest-environment happy-dom
 
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { ReactElement } from "react";
 import { IntlProvider } from "react-intl";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { DeleteProjectDialog } from "./delete-project-dialog";
 import type { ProjectListRow } from "./project-list";
 import { ProjectsTable } from "./projects-table";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/en/org/acme/projects",
+}));
+
+afterEach(() => {
+  cleanup();
+});
 
 function renderWithIntl(ui: ReactElement) {
   return render(
@@ -134,28 +141,5 @@ describe("ProjectsTable", () => {
     await user.click(await screen.findByText("Delete project..."));
 
     expect(onDeleteProject).toHaveBeenCalledWith(project);
-  });
-});
-
-describe("DeleteProjectDialog", () => {
-  it("requires confirming before deleting the selected native project", async () => {
-    const user = userEvent.setup();
-    const onDelete = vi.fn();
-    const project = createProject();
-
-    renderWithIntl(
-      <DeleteProjectDialog
-        project={project}
-        isDeleting={false}
-        onOpenChange={vi.fn()}
-        onDelete={onDelete}
-      />,
-    );
-
-    expect(screen.getByRole("alertdialog", { name: "Delete project?" })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Delete" }));
-
-    expect(onDelete).toHaveBeenCalledWith(project.id);
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -12,7 +12,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
 import {
   ArrowRight01Icon,
   ArrowUpRight01Icon,
@@ -25,6 +24,7 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -144,7 +144,7 @@ function ProjectCard({
   return (
     <article className="group min-w-0 rounded-lg border border-border bg-muted p-4 transition-colors hover:border-beam-500/30 hover:bg-beam-500/5">
       <div className="flex items-start justify-between gap-4">
-        <Link
+        <OrgNavLink
           href={projectHref}
           prefetch
           onClick={() => onOpenProject?.(project.id)}
@@ -170,7 +170,7 @@ function ProjectCard({
                 intl.formatMessage(projectsTableMessages.noDescriptionYet)}
             </TypographyP>
           </div>
-        </Link>
+        </OrgNavLink>
 
         <div className="flex shrink-0 items-center gap-1">
           {project.externalProjectUrl ? (
@@ -226,7 +226,7 @@ function ProjectCard({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-48">
                 <DropdownMenuGroup>
-                  <DropdownMenuItem render={<Link href={projectHref} prefetch />}>
+                  <DropdownMenuItem render={<OrgNavLink href={projectHref} prefetch />}>
                     <FormattedMessage {...projectsTableMessages.openProject} />
                   </DropdownMenuItem>
                   <DropdownMenuItem
@@ -272,7 +272,7 @@ function ProjectCard({
           </dt>
           <dd className="mt-1 truncate text-sm text-muted-foreground">
             {project.openJobCount > 0 ? (
-              <Link
+              <OrgNavLink
                 href={`/org/${organizationSlug}/projects/${project.id}/jobs`}
                 prefetch
                 className="text-subtle-foreground hover:text-foreground hover:underline"
@@ -280,7 +280,7 @@ function ProjectCard({
                 {intl.formatMessage(projectsTableMessages.openJobsCount, {
                   count: project.openJobCount,
                 })}
-              </Link>
+              </OrgNavLink>
             ) : (
               <span>
                 <FormattedMessage {...projectsTableMessages.noOpenJobs} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { type FormEvent, useEffect, useState } from "react";
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import {
   Add01Icon,
   ArrowLeft01Icon,
@@ -341,7 +341,7 @@ export function TeamDetailPageView({
       <div className="flex flex-col gap-4">
         <Button
           nativeButton={false}
-          render={<Link href={`/org/${organizationSlug}/teams`} />}
+          render={<OrgNavLink href={`/org/${organizationSlug}/teams`} />}
           variant="ghost"
           size="sm"
           className="w-fit px-2 text-muted-foreground hover:text-foreground"
@@ -391,12 +391,12 @@ export function TeamDetailPageView({
                 {...teamDetailPageViewMessages.membersDescription}
                 values={{
                   invite: (chunks) => (
-                    <Link
+                    <OrgNavLink
                       href={`/org/${organizationSlug}/members`}
                       className="font-medium text-subtle-foreground underline-offset-4 hover:text-foreground hover:underline"
                     >
                       {chunks}
-                    </Link>
+                    </OrgNavLink>
                   ),
                 }}
               />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-content.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -41,7 +41,7 @@ export function TeamsPageContent({
   teamsApi?: typeof teamsApi;
 }) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const queryClient = useQueryClient();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingTeam, setEditingTeam] = useState<TeamSummaryRow | null>(null);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import type { ReactNode } from "react";
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import {
   Add01Icon,
   Delete01Icon,
@@ -63,9 +63,9 @@ const teamsTableColumns = "md:grid-cols-[minmax(0,1.5fr)_10rem_8rem_7rem_2.5rem]
 
 function defaultRenderTeamLink({ href, children, className }: Parameters<TeamsLinkRenderer>[0]) {
   return (
-    <Link href={href} className={className}>
+    <OrgNavLink href={href} className={className}>
       {children}
-    </Link>
+    </OrgNavLink>
   );
 }
 
@@ -155,7 +155,7 @@ function TeamRowActions({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-48">
         <DropdownMenuGroup>
-          <DropdownMenuItem render={<Link href={teamHref} />}>
+          <DropdownMenuItem render={<OrgNavLink href={teamHref} />}>
             <FormattedMessage {...teamsPageViewMessages.openTeam} />
           </DropdownMenuItem>
           {canManageTeams ? (
@@ -163,7 +163,7 @@ function TeamRowActions({
               <FormattedMessage {...teamsPageViewMessages.editTeam} />
             </DropdownMenuItem>
           ) : null}
-          <DropdownMenuItem render={<Link href={teamHref} />}>
+          <DropdownMenuItem render={<OrgNavLink href={teamHref} />}>
             <FormattedMessage {...teamsPageViewMessages.manageMembers} />
           </DropdownMenuItem>
         </DropdownMenuGroup>
@@ -281,12 +281,12 @@ export function TeamsPageView({
                 {...teamsPageViewMessages.emptyDescription}
                 values={{
                   members: (chunks) => (
-                    <Link
+                    <OrgNavLink
                       href={`/org/${organizationSlug}/members`}
                       className="font-medium text-subtle-foreground underline-offset-4 hover:text-foreground hover:underline"
                     >
                       {chunks}
-                    </Link>
+                    </OrgNavLink>
                   ),
                 }}
               />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/template.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/template.tsx
@@ -18,11 +18,20 @@ type OrganizationTemplateProps = {
 };
 
 export default function OrganizationTemplate({ children }: OrganizationTemplateProps) {
-  // Cross-fade on lateral sidebar navigation. With partial prefetch, content is
-  // usually ready immediately — this is polish, not a loading mask. Per-page
-  // Suspense reveals live in OrgPageSuspense for uncached segments.
   return (
-    <ViewTransition enter="fade-in" exit="fade-out" default="none">
+    <ViewTransition
+      enter={{
+        "nav-forward": "nav-forward",
+        "nav-back": "nav-back",
+        default: "fade-in",
+      }}
+      exit={{
+        "nav-forward": "nav-forward",
+        "nav-back": "nav-back",
+        default: "fade-out",
+      }}
+      default="none"
+    >
       {children}
     </ViewTransition>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/template.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/template.tsx
@@ -18,11 +18,11 @@ type OrganizationTemplateProps = {
 };
 
 export default function OrganizationTemplate({ children }: OrganizationTemplateProps) {
-  // Outermost VT owns the snapshot for this segment. Nested page-level
-  // <ViewTransition enter/exit> under here will not fire while this one animates —
-  // remove or relocate this wrapper before adding page VTs.
+  // Cross-fade on lateral sidebar navigation. With partial prefetch, content is
+  // usually ready immediately — this is polish, not a loading mask. Per-page
+  // Suspense reveals live in OrgPageSuspense for uncached segments.
   return (
-    <ViewTransition enter="slide-up" default="none">
+    <ViewTransition enter="fade-in" exit="fade-out" default="none">
       {children}
     </ViewTransition>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { useMemo, useState } from "react";
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -244,13 +244,13 @@ export function TranslationMemoryDetailPageContent({
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-      <Link
+      <OrgNavLink
         href={`/org/${organizationSlug}/translation-memories`}
         className="inline-flex w-fit items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
       >
         <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" strokeWidth={1.8} />
         <FormattedMessage {...messages.backToList} />
-      </Link>
+      </OrgNavLink>
 
       <section className="flex flex-col gap-2">
         <div className="flex flex-wrap items-center gap-2">
@@ -443,12 +443,12 @@ export function TranslationMemoryDetailPageContent({
                 key={project.projectId}
                 className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-3 py-2"
               >
-                <Link
+                <OrgNavLink
                   href={`/org/${organizationSlug}/projects/${project.projectId}`}
                   className="text-sm font-medium text-foreground hover:underline"
                 >
                   {project.projectName}
-                </Link>
+                </OrgNavLink>
                 {canEdit ? (
                   <Button
                     type="button"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -13,7 +13,8 @@
  * Version 2.0 or later.
  */
 import { useEffect, useMemo, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -130,7 +131,7 @@ export function TranslationMemoriesPageContent({
   canCreateMemories: boolean;
 }) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import type { ReactNode } from "react";
-import Link from "next/link";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { ArrowUpRight01Icon, LanguageSquareIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { UseQueryResult } from "@tanstack/react-query";
@@ -104,13 +104,13 @@ function MemoryRow({
           {isLiveProviderMemoryId(memory.id) ? (
             <span className="truncate text-sm font-medium text-foreground">{memory.name}</span>
           ) : (
-            <Link
+            <OrgNavLink
               href={`/org/${organizationSlug}/translation-memories/${memory.id}`}
               prefetch
               className="truncate text-sm font-medium text-foreground underline-offset-2 hover:underline"
             >
               {memory.name}
-            </Link>
+            </OrgNavLink>
           )}
           <SourceLabel memory={memory} />
         </div>
@@ -119,13 +119,13 @@ function MemoryRow({
         </TypographyP>
         <div className="mt-2 flex flex-wrap items-center gap-2">
           {memory.projectLinkId ? (
-            <Link
+            <OrgNavLink
               href={`/org/${organizationSlug}/projects/${memory.projectLinkId}`}
               prefetch
               className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
             >
               <FormattedMessage {...translationMemoriesTableMessages.viewLinkedProject} />
-            </Link>
+            </OrgNavLink>
           ) : memory.externalProjectId ? (
             <span className="text-xs text-muted-foreground">
               <FormattedMessage
@@ -243,7 +243,7 @@ export function TranslationMemoriesEmptyAction({
   return (
     <Button
       nativeButton={false}
-      render={<Link href={`/org/${organizationSlug}/integrations`} />}
+      render={<OrgNavLink href={`/org/${organizationSlug}/integrations`} />}
       variant="outline"
       size="sm"
     >

--- a/apps/hyperlocalise-web/src/app/globals.css
+++ b/apps/hyperlocalise-web/src/app/globals.css
@@ -556,16 +556,16 @@ html {
   }
 }
 
-/* View Transition recipes — Suspense reveal (org route loading) */
+/* View Transition recipes — org workspace (instant nav + Suspense reveal) */
 :root {
-  --duration-exit: 150ms;
-  --duration-enter: 210ms;
+  --duration-exit: 120ms;
+  --duration-enter: 160ms;
   --duration-move: 400ms;
 }
 
 @keyframes fade {
   from {
-    filter: blur(3px);
+    filter: blur(2px);
     opacity: 0;
   }
   to {
@@ -574,25 +574,27 @@ html {
   }
 }
 
-@keyframes slide-y {
-  from {
-    transform: translateY(var(--slide-y-offset, 10px));
-  }
-  to {
-    transform: translateY(0);
-  }
+::view-transition-old(.fade-out) {
+  animation: var(--duration-exit) ease-in fade reverse;
 }
 
-::view-transition-old(.slide-down) {
-  animation:
-    var(--duration-exit) ease-out both fade reverse,
-    var(--duration-exit) ease-out both slide-y reverse;
+::view-transition-new(.fade-in) {
+  animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
 }
 
-::view-transition-new(.slide-up) {
-  animation:
-    var(--duration-enter) ease-in var(--duration-exit) both fade,
-    var(--duration-move) ease-in both slide-y;
+::view-transition-group(app-shell-sidebar),
+::view-transition-group(app-shell-header),
+::view-transition-group(app-shell-footer) {
+  animation: none;
+  z-index: 100;
+}
+
+::view-transition-old(app-shell-header) {
+  display: none;
+}
+
+::view-transition-new(app-shell-header) {
+  animation: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/hyperlocalise-web/src/app/globals.css
+++ b/apps/hyperlocalise-web/src/app/globals.css
@@ -574,12 +574,49 @@ html {
   }
 }
 
+@keyframes slide {
+  from {
+    translate: var(--slide-offset);
+  }
+  to {
+    translate: 0;
+  }
+}
+
 ::view-transition-old(.fade-out) {
   animation: var(--duration-exit) ease-in fade reverse;
 }
 
 ::view-transition-new(.fade-in) {
   animation: var(--duration-enter) ease-out var(--duration-exit) both fade;
+}
+
+::view-transition-old(.nav-forward) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+
+::view-transition-new(.nav-forward) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
+}
+
+::view-transition-old(.nav-back) {
+  --slide-offset: 60px;
+  animation:
+    var(--duration-exit) ease-in both fade reverse,
+    var(--duration-move) ease-in-out both slide reverse;
+}
+
+::view-transition-new(.nav-back) {
+  --slide-offset: -60px;
+  animation:
+    var(--duration-enter) ease-out var(--duration-exit) both fade,
+    var(--duration-move) ease-in-out both slide;
 }
 
 ::view-transition-group(app-shell-sidebar),

--- a/apps/hyperlocalise-web/src/app/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/layout.tsx
@@ -12,12 +12,8 @@
  */
 import { Analytics } from "@vercel/analytics/next";
 import type { Metadata } from "next";
-import { GoogleAnalytics } from "@next/third-parties/google";
 
-import { RootLayoutProviders } from "@/components/root-layout/root-layout-providers";
-import { rootHtmlClassName } from "@/components/root-layout/root-layout-fonts";
-import { GA_MEASUREMENT_ID } from "@/lib/analytics/google-analytics";
-import { DEFAULT_APP_LOCALE } from "@/lib/app-i18n/locales";
+import { RootHtml } from "@/components/root-layout/root-html";
 import { PRIVATE_ROBOTS } from "@/lib/seo/robots-metadata";
 import { SITE_URL } from "@/lib/seo/site-url";
 
@@ -36,14 +32,5 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <html lang={DEFAULT_APP_LOCALE} className={rootHtmlClassName()} suppressHydrationWarning>
-      <body>
-        <Analytics />
-        <RootLayoutProviders>{children}</RootLayoutProviders>
-      </body>
-
-      <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
-    </html>
-  );
+  return <RootHtml>{children}</RootHtml>;
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
@@ -13,7 +13,6 @@
  * Version 2.0 or later.
  */
 import { Fragment } from "react";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
@@ -37,6 +36,7 @@ import {
   type AppShellBreadcrumb as AppShellBreadcrumbItem,
 } from "./app-shell-title";
 import { DomainBreadcrumbSelector } from "./domain-breadcrumb-selector";
+import { OrgNavLink } from "./org-nav-link";
 import {
   buildOrganizationPath,
   buildProjectPath,
@@ -158,7 +158,7 @@ function BreadcrumbCrumbContent({
 
   return (
     <BreadcrumbLink
-      render={<Link href={crumb.href} />}
+      render={<OrgNavLink href={crumb.href} />}
       className="block truncate font-medium text-muted-foreground hover:text-foreground"
       title={crumb.label}
     >

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -115,7 +115,11 @@ export function AppShellClient({
         className="min-h-svh bg-background text-foreground"
       >
         <SidebarStoreBridge />
-        <Sidebar variant="sidebar" collapsible="icon">
+        <Sidebar
+          variant="sidebar"
+          collapsible="icon"
+          style={{ viewTransitionName: "app-shell-sidebar" }}
+        >
           <SidebarHeader className="gap-3 border-b border-sidebar-border px-3 py-3 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-0">
             <div className="flex items-center gap-2.5 rounded-xl px-1 py-1 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
               <Image
@@ -147,7 +151,10 @@ export function AppShellClient({
         </Sidebar>
 
         <SidebarInset className="h-svh max-h-svh min-h-0 overflow-hidden bg-background pb-[var(--app-shell-footer-height)]">
-          <div className="sticky top-0 z-20 shrink-0 border-b border-border bg-background/96 backdrop-blur">
+          <div
+            className="sticky top-0 z-20 shrink-0 border-b border-border bg-background/96 backdrop-blur"
+            style={{ viewTransitionName: "app-shell-header" }}
+          >
             <div className="flex h-(--app-shell-header-height) items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
               <div className="flex min-w-0 items-center gap-3">
                 <SidebarTrigger className="-ms-1" />

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -79,7 +79,10 @@ export function AppShellFooter({
   );
 
   return (
-    <footer className="fixed inset-x-0 bottom-0 z-40 flex flex-col border-t border-border bg-background">
+    <footer
+      className="fixed inset-x-0 bottom-0 z-40 flex flex-col border-t border-border bg-background"
+      style={{ viewTransitionName: "app-shell-footer" }}
+    >
       {showChatDock ? <ChatDockBridge organizationSlug={organizationSlug} /> : null}
       {showChatDock && currentUser ? (
         <ChatDockErrorBoundary organizationSlug={organizationSlug}>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -12,7 +12,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ArrowDown01Icon, ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -39,6 +38,7 @@ import {
 } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-notifications-api";
 
 import { appShellNavigationMessages } from "./app-shell-navigation.messages";
+import { OrgNavLink } from "./org-nav-link";
 import { annotateNavigationItemsWithWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
 import { formatInboxUnreadBadgeLabel, inboxUnreadBadgeClassName } from "./inbox-unread-badge";
 
@@ -204,7 +204,7 @@ function ProjectNavigation({
           <SidebarMenu className="gap-1">
             <SidebarMenuItem>
               <SidebarMenuButton
-                render={<Link href={projectsHref} />}
+                render={<OrgNavLink href={projectsHref} />}
                 tooltip={allProjectsLabel}
                 className="h-8 rounded-md px-2.5 text-sm font-medium text-muted-foreground hover:text-sidebar-foreground group-data-[collapsible=icon]:size-8!"
               >
@@ -289,7 +289,7 @@ function NavigationGroupItems({
           return (
             <SidebarMenuItem key={item.href}>
               <SidebarMenuButton
-                render={<Link href={item.href} />}
+                render={<OrgNavLink href={item.href} />}
                 isActive={isActive}
                 tooltip={tooltip}
                 className={navigationButtonClass(isActive)}

--- a/apps/hyperlocalise-web/src/components/app-shell/domain-breadcrumb-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/domain-breadcrumb-selector.tsx
@@ -12,11 +12,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 
 import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 
 import { BreadcrumbCrumbSelector } from "./breadcrumb-crumb-selector";
 import { breadcrumbCrumbSelectorMessages as messages } from "./breadcrumb-crumb-selector.messages";
@@ -39,7 +39,7 @@ export function DomainBreadcrumbSelector({
   isLast = false,
 }: DomainBreadcrumbSelectorProps) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const domainsQuery = useQuery({
     queryKey: organizationDomainsQueryKey(organizationSlug),
     queryFn: async () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/org-nav-link.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/org-nav-link.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ComponentProps } from "react";
+
+import { getOrgNavigationTransitionTypes } from "@/lib/navigation/org-nav-transition";
+
+type OrgNavLinkProps = Omit<ComponentProps<typeof Link>, "href"> & {
+  href: string;
+};
+
+export function OrgNavLink({ href, ...props }: OrgNavLinkProps) {
+  const pathname = usePathname();
+  const transitionTypes = getOrgNavigationTransitionTypes(pathname, href);
+
+  return <Link href={href} transitionTypes={transitionTypes} {...props} />;
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/project-breadcrumb-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/project-breadcrumb-selector.tsx
@@ -12,12 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 
 import { BreadcrumbCrumbSelector } from "./breadcrumb-crumb-selector";
 import { breadcrumbCrumbSelectorMessages as messages } from "./breadcrumb-crumb-selector.messages";
@@ -42,7 +42,7 @@ export function ProjectBreadcrumbSelector({
   isLast = false,
 }: ProjectBreadcrumbSelectorProps) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const projectsQuery = useQuery({
     queryKey: organizationProjectsQueryKey(organizationSlug),
     queryFn: async () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/team-breadcrumb-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/team-breadcrumb-selector.tsx
@@ -12,12 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 
 import { BreadcrumbCrumbSelector } from "./breadcrumb-crumb-selector";
 import { breadcrumbCrumbSelectorMessages as messages } from "./breadcrumb-crumb-selector.messages";
@@ -40,7 +40,7 @@ export function TeamBreadcrumbSelector({
   isLast = false,
 }: TeamBreadcrumbSelectorProps) {
   const intl = useIntl();
-  const router = useRouter();
+  const router = useOrgRouter();
   const teamsQuery = useQuery({
     queryKey: organizationTeamsQueryKey(organizationSlug),
     queryFn: async () => {

--- a/apps/hyperlocalise-web/src/components/root-layout/root-document-locale.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-document-locale.tsx
@@ -12,18 +12,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { usePathname } from "next/navigation";
 import { useLayoutEffect } from "react";
 
-import type { AppLocale } from "@/lib/app-i18n/locales";
+import { normalizeAppLocale, type AppLocale } from "@/lib/app-i18n/locales";
 
 type RootDocumentLocaleProps = {
   locale: AppLocale;
 };
 
 export function RootDocumentLocale({ locale }: RootDocumentLocaleProps) {
+  const pathname = usePathname();
+  const pathLocale = normalizeAppLocale(pathname.split("/").filter(Boolean)[0] ?? "");
+  const documentLocale = pathLocale ?? locale;
+
   useLayoutEffect(() => {
-    document.documentElement.lang = locale;
-  }, [locale]);
+    document.documentElement.lang = documentLocale;
+  }, [documentLocale]);
 
   return null;
 }

--- a/apps/hyperlocalise-web/src/components/root-layout/root-document-locale.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-document-locale.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { usePathname } from "next/navigation";
-import { useLayoutEffect } from "react";
+import { Suspense, useLayoutEffect } from "react";
 
 import { normalizeAppLocale, type AppLocale } from "@/lib/app-i18n/locales";
 
@@ -22,6 +22,14 @@ type RootDocumentLocaleProps = {
 };
 
 export function RootDocumentLocale({ locale }: RootDocumentLocaleProps) {
+  return (
+    <Suspense fallback={null}>
+      <RootDocumentLocaleInner locale={locale} />
+    </Suspense>
+  );
+}
+
+function RootDocumentLocaleInner({ locale }: RootDocumentLocaleProps) {
   const pathname = usePathname();
   const pathLocale = normalizeAppLocale(pathname.split("/").filter(Boolean)[0] ?? "");
   const documentLocale = pathLocale ?? locale;

--- a/apps/hyperlocalise-web/src/components/root-layout/root-html.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-html.tsx
@@ -15,7 +15,7 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import type { ReactNode } from "react";
 
 import { GA_MEASUREMENT_ID } from "@/lib/analytics/google-analytics";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
+import { DEFAULT_APP_LOCALE } from "@/lib/app-i18n/locales";
 
 import { rootHtmlClassName } from "./root-layout-fonts";
 import { RootLayoutProviders } from "./root-layout-providers";
@@ -24,14 +24,12 @@ type RootHtmlProps = {
   children: ReactNode;
 };
 
-export async function RootHtml({ children }: RootHtmlProps) {
-  const locale = await getAppLocale();
-
+export function RootHtml({ children }: RootHtmlProps) {
   return (
-    <html lang={locale} className={rootHtmlClassName()} suppressHydrationWarning>
+    <html lang={DEFAULT_APP_LOCALE} className={rootHtmlClassName()} suppressHydrationWarning>
       <body>
         <Analytics />
-        <RootLayoutProviders locale={locale}>{children}</RootLayoutProviders>
+        <RootLayoutProviders>{children}</RootLayoutProviders>
       </body>
 
       <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />

--- a/apps/hyperlocalise-web/src/components/root-layout/root-html.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-html.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Analytics } from "@vercel/analytics/next";
+import { GoogleAnalytics } from "@next/third-parties/google";
+import type { ReactNode } from "react";
+
+import { GA_MEASUREMENT_ID } from "@/lib/analytics/google-analytics";
+import { getAppLocale } from "@/lib/app-i18n/server-locale";
+
+import { rootHtmlClassName } from "./root-layout-fonts";
+import { RootLayoutProviders } from "./root-layout-providers";
+
+type RootHtmlProps = {
+  children: ReactNode;
+};
+
+export async function RootHtml({ children }: RootHtmlProps) {
+  const locale = await getAppLocale();
+
+  return (
+    <html lang={locale} className={rootHtmlClassName()} suppressHydrationWarning>
+      <body>
+        <Analytics />
+        <RootLayoutProviders locale={locale}>{children}</RootLayoutProviders>
+      </body>
+
+      <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
+    </html>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
@@ -36,9 +36,7 @@ describe("root layout cacheComponents boundary", () => {
       path.join(import.meta.dirname, "root-layout-providers.tsx"),
       "utf8",
     );
-    const fallbackFn = source.match(
-      /function RootLayoutProvidersFallback\([\s\S]*?\n\}/,
-    )?.[0];
+    const fallbackFn = source.match(/function RootLayoutProvidersFallback\([\s\S]*?\n\}/)?.[0];
 
     expect(source).toContain(
       "<Suspense fallback={<RootLayoutProvidersFallback locale={locale} />}>",

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
@@ -24,14 +24,25 @@ describe("root layout cacheComponents boundary", () => {
     expect(source).not.toMatch(/\bheaders\s*\(|\bcookies\s*\(/);
   });
 
+  it("resolves document lang outside the root layout module", () => {
+    const source = readFileSync(path.join(import.meta.dirname, "root-html.tsx"), "utf8");
+
+    expect(source).toMatch(/\bgetAppLocale\b/);
+    expect(source).toMatch(/<html lang=\{locale\}/);
+  });
+
   it("keeps the root Suspense fallback free of route children", () => {
     const source = readFileSync(
       path.join(import.meta.dirname, "root-layout-providers.tsx"),
       "utf8",
     );
-    const fallbackFn = source.match(/function RootLayoutProvidersFallback\(\) \{[\s\S]*?\n\}/)?.[0];
+    const fallbackFn = source.match(
+      /function RootLayoutProvidersFallback\([\s\S]*?\n\}/,
+    )?.[0];
 
-    expect(source).toContain("<Suspense fallback={<RootLayoutProvidersFallback />}>");
+    expect(source).toContain(
+      "<Suspense fallback={<RootLayoutProvidersFallback locale={locale} />}>",
+    );
     expect(fallbackFn).toBeDefined();
     expect(fallbackFn).not.toContain("{children}");
   });

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.test.ts
@@ -24,11 +24,22 @@ describe("root layout cacheComponents boundary", () => {
     expect(source).not.toMatch(/\bheaders\s*\(|\bcookies\s*\(/);
   });
 
-  it("resolves document lang outside the root layout module", () => {
+  it("uses a static document lang in the root html shell", () => {
     const source = readFileSync(path.join(import.meta.dirname, "root-html.tsx"), "utf8");
 
+    expect(source).toMatch(/\bDEFAULT_APP_LOCALE\b/);
+    expect(source).toMatch(/<html lang=\{DEFAULT_APP_LOCALE\}/);
+    expect(source).not.toMatch(/\bgetAppLocale\b/);
+  });
+
+  it("resolves request locale inside the root Suspense boundary", () => {
+    const source = readFileSync(
+      path.join(import.meta.dirname, "root-layout-providers.tsx"),
+      "utf8",
+    );
+
     expect(source).toMatch(/\bgetAppLocale\b/);
-    expect(source).toMatch(/<html lang=\{locale\}/);
+    expect(source).toMatch(/<Suspense fallback={<RootLayoutProvidersFallback/);
   });
 
   it("keeps the root Suspense fallback free of route children", () => {
@@ -38,9 +49,7 @@ describe("root layout cacheComponents boundary", () => {
     );
     const fallbackFn = source.match(/function RootLayoutProvidersFallback\([\s\S]*?\n\}/)?.[0];
 
-    expect(source).toContain(
-      "<Suspense fallback={<RootLayoutProvidersFallback locale={locale} />}>",
-    );
+    expect(source).toContain("<Suspense fallback={<RootLayoutProvidersFallback />}>");
     expect(fallbackFn).toBeDefined();
     expect(fallbackFn).not.toContain("{children}");
   });

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.tsx
@@ -18,7 +18,8 @@ import { QueryProvider } from "@/components/query-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { type AppLocale } from "@/lib/app-i18n/locales";
+import { type AppLocale, DEFAULT_APP_LOCALE } from "@/lib/app-i18n/locales";
+import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import { withAuth } from "@/lib/workos/server-auth";
 
 import { headingFontForLocale } from "./root-layout-fonts";
@@ -26,7 +27,6 @@ import { RootDocumentLocale } from "./root-document-locale";
 
 type RootLayoutProvidersProps = {
   children: ReactNode;
-  locale: AppLocale;
 };
 
 type RootLayoutProvidersInnerProps = {
@@ -35,22 +35,22 @@ type RootLayoutProvidersInnerProps = {
   locale: AppLocale;
 };
 
-export function RootLayoutProviders({ children, locale }: RootLayoutProvidersProps) {
+export function RootLayoutProviders({ children }: RootLayoutProvidersProps) {
   return (
-    <Suspense fallback={<RootLayoutProvidersFallback locale={locale} />}>
-      <RootLayoutProvidersContent locale={locale}>{children}</RootLayoutProvidersContent>
+    <Suspense fallback={<RootLayoutProvidersFallback />}>
+      <RootLayoutProvidersContent>{children}</RootLayoutProvidersContent>
     </Suspense>
   );
 }
 
-function RootLayoutProvidersFallback({ locale }: { locale: AppLocale }) {
+function RootLayoutProvidersFallback() {
   // Keep route children out of the fallback. Including them would prerender
   // uncached page data (cookies, headers, auth) into the static shell.
-  return <RootLayoutProvidersInner initialAuth={undefined} locale={locale} />;
+  return <RootLayoutProvidersInner initialAuth={undefined} locale={DEFAULT_APP_LOCALE} />;
 }
 
-async function RootLayoutProvidersContent({ children, locale }: RootLayoutProvidersProps) {
-  const initialAuth = await getInitialAuth();
+async function RootLayoutProvidersContent({ children }: RootLayoutProvidersProps) {
+  const [locale, initialAuth] = await Promise.all([getAppLocale(), getInitialAuth()]);
 
   return (
     <RootLayoutProvidersInner initialAuth={initialAuth} locale={locale}>

--- a/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.tsx
+++ b/apps/hyperlocalise-web/src/components/root-layout/root-layout-providers.tsx
@@ -18,8 +18,7 @@ import { QueryProvider } from "@/components/query-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { DEFAULT_APP_LOCALE, type AppLocale } from "@/lib/app-i18n/locales";
-import { getAppLocale } from "@/lib/app-i18n/server-locale";
+import { type AppLocale } from "@/lib/app-i18n/locales";
 import { withAuth } from "@/lib/workos/server-auth";
 
 import { headingFontForLocale } from "./root-layout-fonts";
@@ -27,6 +26,7 @@ import { RootDocumentLocale } from "./root-document-locale";
 
 type RootLayoutProvidersProps = {
   children: ReactNode;
+  locale: AppLocale;
 };
 
 type RootLayoutProvidersInnerProps = {
@@ -35,22 +35,22 @@ type RootLayoutProvidersInnerProps = {
   locale: AppLocale;
 };
 
-export function RootLayoutProviders({ children }: RootLayoutProvidersProps) {
+export function RootLayoutProviders({ children, locale }: RootLayoutProvidersProps) {
   return (
-    <Suspense fallback={<RootLayoutProvidersFallback />}>
-      <RootLayoutProvidersContent>{children}</RootLayoutProvidersContent>
+    <Suspense fallback={<RootLayoutProvidersFallback locale={locale} />}>
+      <RootLayoutProvidersContent locale={locale}>{children}</RootLayoutProvidersContent>
     </Suspense>
   );
 }
 
-function RootLayoutProvidersFallback() {
+function RootLayoutProvidersFallback({ locale }: { locale: AppLocale }) {
   // Keep route children out of the fallback. Including them would prerender
   // uncached page data (cookies, headers, auth) into the static shell.
-  return <RootLayoutProvidersInner initialAuth={undefined} locale={DEFAULT_APP_LOCALE} />;
+  return <RootLayoutProvidersInner initialAuth={undefined} locale={locale} />;
 }
 
-async function RootLayoutProvidersContent({ children }: RootLayoutProvidersProps) {
-  const [locale, initialAuth] = await Promise.all([getAppLocale(), getInitialAuth()]);
+async function RootLayoutProvidersContent({ children, locale }: RootLayoutProvidersProps) {
+  const initialAuth = await getInitialAuth();
 
   return (
     <RootLayoutProvidersInner initialAuth={initialAuth} locale={locale}>

--- a/apps/hyperlocalise-web/src/lib/navigation/org-nav-transition.test.ts
+++ b/apps/hyperlocalise-web/src/lib/navigation/org-nav-transition.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { getOrgNavigationTransitionTypes, getOrgRouteDepth } from "./org-nav-transition";
+
+describe("org-nav-transition", () => {
+  it("measures depth after the organization slug", () => {
+    expect(getOrgRouteDepth("/fr-FR/org/acme/dashboard")).toBe(1);
+    expect(getOrgRouteDepth("/org/acme/projects")).toBe(1);
+    expect(getOrgRouteDepth("/en/org/acme/projects/proj_1")).toBe(2);
+    expect(getOrgRouteDepth("/en/org/acme/projects/proj_1/jobs/job_1")).toBe(4);
+  });
+
+  it("returns forward for drill-down navigation", () => {
+    expect(
+      getOrgNavigationTransitionTypes("/fr-FR/org/acme/projects", "/org/acme/projects/proj_1"),
+    ).toEqual(["nav-forward"]);
+  });
+
+  it("returns back for upward navigation", () => {
+    expect(
+      getOrgNavigationTransitionTypes("/fr-FR/org/acme/projects/proj_1", "/org/acme/projects"),
+    ).toEqual(["nav-back"]);
+  });
+
+  it("returns undefined for lateral navigation at the same depth", () => {
+    expect(
+      getOrgNavigationTransitionTypes("/fr-FR/org/acme/dashboard", "/org/acme/projects"),
+    ).toBeUndefined();
+    expect(
+      getOrgNavigationTransitionTypes(
+        "/fr-FR/org/acme/projects/proj_1/files",
+        "/org/acme/projects/proj_1/jobs",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/navigation/org-nav-transition.ts
+++ b/apps/hyperlocalise-web/src/lib/navigation/org-nav-transition.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { stripAppLocalePrefix } from "@/components/app-shell/navigation-config";
+
+export type OrgNavTransitionType = "nav-forward" | "nav-back";
+
+export function getOrgRouteDepth(pathname: string): number {
+  const segments = stripAppLocalePrefix(pathname).split("/").filter(Boolean);
+
+  if (segments[0] !== "org" || !segments[1]) {
+    return 0;
+  }
+
+  return segments.length - 2;
+}
+
+export function getOrgNavigationTransitionTypes(
+  fromPathname: string,
+  toHref: string,
+): OrgNavTransitionType[] | undefined {
+  const fromDepth = getOrgRouteDepth(fromPathname);
+  const toDepth = getOrgRouteDepth(toHref);
+
+  if (toDepth > fromDepth) {
+    return ["nav-forward"];
+  }
+
+  if (toDepth < fromDepth) {
+    return ["nav-back"];
+  }
+
+  return undefined;
+}

--- a/apps/hyperlocalise-web/src/lib/navigation/use-org-router.ts
+++ b/apps/hyperlocalise-web/src/lib/navigation/use-org-router.ts
@@ -1,0 +1,52 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { usePathname, useRouter } from "next/navigation";
+import { addTransitionType, startTransition } from "react";
+
+import { getOrgNavigationTransitionTypes } from "@/lib/navigation/org-nav-transition";
+
+type OrgRouterNavigateOptions = {
+  replace?: boolean;
+  scroll?: boolean;
+};
+
+export function useOrgRouter() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  function navigate(href: string, options?: OrgRouterNavigateOptions) {
+    const transitionTypes = getOrgNavigationTransitionTypes(pathname, href);
+
+    startTransition(() => {
+      for (const transitionType of transitionTypes ?? []) {
+        addTransitionType(transitionType);
+      }
+
+      if (options?.replace) {
+        router.replace(href, { scroll: options.scroll });
+        return;
+      }
+
+      router.push(href, { scroll: options?.scroll });
+    });
+  }
+
+  return {
+    push: (href: string, options?: Omit<OrgRouterNavigateOptions, "replace">) =>
+      navigate(href, options),
+    replace: (href: string, options?: Omit<OrgRouterNavigateOptions, "replace">) =>
+      navigate(href, { ...options, replace: true }),
+  };
+}

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -14,6 +14,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import { buildCrowdinAppFrameAncestorsCsp } from "@/lib/crowdin-app/frame-ancestors";
+import { APP_LOCALE_HEADER_NAME } from "@/lib/app-i18n/locales";
 import { REQUEST_URL_HEADER } from "@/lib/workos/request-url-header";
 import proxy, { ensureRequestUrlHeader, isUnsupportedLocalePath } from "./proxy";
 
@@ -135,6 +136,10 @@ describe("proxy", () => {
     expect(authkitProxyMock).toHaveBeenCalledOnce();
     expect(response?.status).toBe(200);
     expect(response?.headers.get(`x-middleware-request-${REQUEST_URL_HEADER}`)).toBe(request.url);
+    expect(response?.headers.get(`x-middleware-request-${APP_LOCALE_HEADER_NAME}`)).toBe("en");
+    expect(response?.headers.get("x-middleware-override-headers")?.split(",")).toContain(
+      APP_LOCALE_HEADER_NAME,
+    );
   });
 
   it("redirects localized marketing paths without a locale prefix", async () => {

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -212,8 +212,6 @@ function applyLocaleToResponse(response: WorkosProxyResult, locale: string): Wor
     return response;
   }
 
-  response.headers.set(APP_LOCALE_HEADER_NAME, locale);
-
   if (response instanceof NextResponse) {
     response.cookies.set({
       name: APP_LOCALE_COOKIE_NAME,
@@ -222,6 +220,29 @@ function applyLocaleToResponse(response: WorkosProxyResult, locale: string): Wor
       maxAge: 60 * 60 * 24 * 365,
       sameSite: "lax",
     });
+
+    return ensureRequestLocaleHeader(response, locale);
+  }
+
+  return response;
+}
+
+function ensureRequestLocaleHeader(response: NextResponse, locale: string): NextResponse {
+  const requestHeaderName = `x-middleware-request-${APP_LOCALE_HEADER_NAME}`;
+  response.headers.set(requestHeaderName, locale);
+
+  const override = response.headers.get("x-middleware-override-headers");
+  const names =
+    override
+      ?.split(",")
+      .map((name) => name.trim())
+      .filter(Boolean) ?? [];
+
+  if (!names.includes(APP_LOCALE_HEADER_NAME)) {
+    response.headers.set(
+      "x-middleware-override-headers",
+      [...names, APP_LOCALE_HEADER_NAME].join(","),
+    );
   }
 
   return response;


### PR DESCRIPTION
## What changed

Adapts org workspace view transitions for instant navigation (`partialPrefetching` + `cacheComponents`) and adds directional animations for hierarchical routes.

- Replace slide-up/down skeleton reveals with fast cross-fades for prefetched routes
- Resolve `<html lang>` from the request locale instead of hardcoding `en`
- Add depth-based `nav-forward` / `nav-back` transitions via `OrgNavLink`, `useOrgRouter`, and type-keyed `ViewTransition` in the org template
- Lateral navigation (same route depth) continues to cross-fade

## How to test
- `cd apps/hyperlocalise-web && vp check --fix`
- `cd apps/hyperlocalise-web && vp test src/lib/navigation/org-nav-transition.test.ts`
- In the dev app, navigate org workspace routes:
  - List → detail (e.g. Projects → project, Glossaries → glossary) should slide forward
  - Back links should slide back
  - Sidebar tab switches (e.g. Projects ↔ Teams) should cross-fade
  - Verify `<html lang>` matches the locale prefix (e.g. `/de/...` → `lang="de"`)

## Checklist
- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review