### PR TITLE
feat(cli): add Smartling translation file import

### DIFF
--- a/apps/cli/cmd/smartling.go
+++ b/apps/cli/cmd/smartling.go
@@ -76,12 +76,20 @@ var newSmartlingTranslationDownloader = func(cfg smartling.Config) (smartlingTra
 	return smartling.NewHTTPClient(cfg)
 }
 
+var newSmartlingTranslationImporter = func(cfg smartling.Config) (smartlingTranslationImporter, error) {
+	return smartling.NewHTTPClient(cfg)
+}
+
 type smartlingSourceDownloader interface {
 	DownloadSourceFile(context.Context, smartling.SourceDownloadInput) (smartling.SourceDownloadResult, error)
 }
 
 type smartlingTranslationDownloader interface {
 	DownloadTranslationFile(context.Context, smartling.TranslationDownloadInput) (smartling.TranslationDownloadResult, error)
+}
+
+type smartlingTranslationImporter interface {
+	ImportTranslationFile(context.Context, smartling.TranslationImportInput) (smartling.TranslationImportResult, error)
 }
 
 func newSmartlingDownloadSourcesCmd() *cobra.Command {
@@ -711,7 +719,132 @@ func newSmartlingUploadCmd() *cobra.Command {
 		Short: "upload sources or translations to Smartling",
 	}
 	cmd.AddCommand(newSmartlingUploadSourcesCmd())
+	cmd.AddCommand(newSmartlingUploadTranslationsCmd())
 	return cmd
+}
+
+type smartlingUploadTranslationsOptions struct {
+	projectID       string
+	fileURI         string
+	targetLocale    string
+	filePath        string
+	fileType        string
+	published       bool
+	postTranslation bool
+	overwrite       bool
+	userIdentifier  string
+	userSecret      string
+	userSecretEnv   string
+	dryRun          bool
+}
+
+func newSmartlingUploadTranslationsCmd() *cobra.Command {
+	o := smartlingUploadTranslationsOptions{}
+	cmd := &cobra.Command{
+		Use:          "translations",
+		Short:        "import a pre-translated file into Smartling (files import)",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeSmartlingUploadTranslations(cmd, o)
+		},
+	}
+
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
+	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "existing Smartling source file URI")
+	cmd.Flags().StringVarP(&o.targetLocale, "target-locale", "l", "", "target locale ID to import")
+	cmd.Flags().StringVarP(&o.filePath, "file", "f", "", "translated file path to import")
+	cmd.Flags().StringVar(&o.fileType, "file-type", "", "Smartling file type (e.g. json, yaml, ios, android, gettext, html, markdown)")
+	cmd.Flags().BoolVar(&o.published, "published", false, "import translations as PUBLISHED")
+	cmd.Flags().BoolVar(&o.postTranslation, "post-translation", false, "import translations as POST_TRANSLATION")
+	cmd.Flags().BoolVar(&o.overwrite, "overwrite", false, "overwrite existing translations for the file URI")
+	cmd.Flags().StringVar(&o.userIdentifier, "user-id", "", "Smartling user identifier")
+	cmd.Flags().StringVar(&o.userSecret, "user-secret", "", "Smartling user secret")
+	cmd.Flags().StringVar(&o.userSecretEnv, "user-secret-env", "", "Environment variable for Smartling user secret")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview import without sending the file")
+
+	_ = cmd.MarkFlagRequired("project-id")
+	_ = cmd.MarkFlagRequired("file-uri")
+	_ = cmd.MarkFlagRequired("target-locale")
+	_ = cmd.MarkFlagRequired("file")
+	cmd.MarkFlagsMutuallyExclusive("published", "post-translation")
+	cmd.MarkFlagsOneRequired("published", "post-translation")
+
+	return cmd
+}
+
+func executeSmartlingUploadTranslations(cmd *cobra.Command, o smartlingUploadTranslationsOptions) error {
+	if strings.TrimSpace(o.projectID) == "" {
+		return fmt.Errorf("smartling upload translations: --project-id is required")
+	}
+	if strings.TrimSpace(o.fileURI) == "" {
+		return fmt.Errorf("smartling upload translations: --file-uri is required")
+	}
+	if strings.TrimSpace(o.targetLocale) == "" {
+		return fmt.Errorf("smartling upload translations: --target-locale is required")
+	}
+	if strings.TrimSpace(o.filePath) == "" {
+		return fmt.Errorf("smartling upload translations: --file is required")
+	}
+	if o.published == o.postTranslation {
+		return fmt.Errorf("smartling upload translations: exactly one of --published or --post-translation is required")
+	}
+
+	fileType := strings.TrimSpace(o.fileType)
+	if fileType == "" {
+		fileType = smartling.FileTypeForExtension(filepath.Ext(o.filePath))
+	}
+	if fileType == "" {
+		return fmt.Errorf("smartling upload translations: could not determine file type for %q; use --file-type", o.filePath)
+	}
+
+	state := smartling.TranslationStatePublished
+	if o.postTranslation {
+		state = smartling.TranslationStatePostTranslation
+	}
+
+	if o.dryRun {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-upload-translations file=%s uri=%s locale=%s type=%s translation_state=%s overwrite=%t\n", o.filePath, strings.TrimSpace(o.fileURI), strings.TrimSpace(o.targetLocale), fileType, state, o.overwrite)
+		return err
+	}
+
+	cfg := smartling.Config{
+		ProjectID:      strings.TrimSpace(o.projectID),
+		UserIdentifier: strings.TrimSpace(o.userIdentifier),
+		UserSecret:     strings.TrimSpace(o.userSecret),
+		UserSecretEnv:  strings.TrimSpace(o.userSecretEnv),
+	}
+	if cfg.UserSecret == "" {
+		envVar := cfg.UserSecretEnv
+		if envVar == "" {
+			envVar = "SMARTLING_USER_SECRET"
+		}
+		cfg.UserSecret = os.Getenv(envVar)
+	}
+	if cfg.UserIdentifier == "" {
+		cfg.UserIdentifier = os.Getenv("SMARTLING_USER_IDENTIFIER")
+	}
+	if cfg.UserIdentifier == "" || cfg.UserSecret == "" {
+		return fmt.Errorf("smartling upload translations: credentials are required (via flags or SMARTLING_USER_IDENTIFIER/SMARTLING_USER_SECRET)")
+	}
+
+	client, err := newSmartlingTranslationImporter(cfg)
+	if err != nil {
+		return err
+	}
+	result, err := client.ImportTranslationFile(backgroundContext(), smartling.TranslationImportInput{
+		ProjectID:        strings.TrimSpace(o.projectID),
+		FileURI:          strings.TrimSpace(o.fileURI),
+		FilePath:         o.filePath,
+		FileType:         fileType,
+		LocaleID:         strings.TrimSpace(o.targetLocale),
+		TranslationState: state,
+		Overwrite:        o.overwrite,
+	})
+	if err != nil {
+		return fmt.Errorf("smartling upload translations: %w", err)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "imported file=%s uri=%s locale=%s strings=%d words=%d\n", o.filePath, strings.TrimSpace(o.fileURI), strings.TrimSpace(o.targetLocale), result.StringCount, result.WordCount)
+	return err
 }
 
 func newSmartlingUploadSourcesCmd() *cobra.Command {

--- a/apps/cli/cmd/smartling_test.go
+++ b/apps/cli/cmd/smartling_test.go
@@ -742,3 +742,198 @@ func TestSmartlingUploadSourcesRejectsSharedFileURIForMultipleFiles(t *testing.T
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestSmartlingUploadTranslationsFlags(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{"smartling", "upload", "translations"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+	if !strings.Contains(err.Error(), "required flag(s)") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	out.Reset()
+	root.SetArgs([]string{"smartling", "upload", "translations", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("help failed: %v", err)
+	}
+	help := out.String()
+	if !strings.Contains(help, "--project-id") ||
+		!strings.Contains(help, "--file-uri") ||
+		!strings.Contains(help, "--target-locale") ||
+		!strings.Contains(help, "--file") ||
+		!strings.Contains(help, "--published") ||
+		!strings.Contains(help, "--post-translation") ||
+		!strings.Contains(help, "--overwrite") {
+		t.Errorf("help output missing required flags: %s", help)
+	}
+}
+
+func TestSmartlingUploadTranslationsRequiresTranslationState(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{
+		"smartling", "upload", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+		"--target-locale", "fr-FR",
+		"--file", "fr.json",
+		"--dry-run",
+	})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected translation state flag error")
+	}
+	if !strings.Contains(err.Error(), "published") && !strings.Contains(err.Error(), "post-translation") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSmartlingUploadTranslationsRejectsBothTranslationStates(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{
+		"smartling", "upload", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+		"--target-locale", "fr-FR",
+		"--file", "fr.json",
+		"--published",
+		"--post-translation",
+		"--dry-run",
+	})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected mutually exclusive flag error")
+	}
+	if !strings.Contains(err.Error(), "published") || !strings.Contains(err.Error(), "post-translation") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSmartlingUploadTranslationsDryRun(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{
+		"smartling", "upload", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+		"--target-locale", "fr-FR",
+		"--file", "fr.json",
+		"--published",
+		"--dry-run",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "dry-run action=smartling-upload-translations file=fr.json") {
+		t.Errorf("unexpected output: %s", got)
+	}
+	if !strings.Contains(got, "translation_state=PUBLISHED") {
+		t.Errorf("expected PUBLISHED state in output: %s", got)
+	}
+}
+
+func TestSmartlingUploadTranslationsImportsFile(t *testing.T) {
+	orig := newSmartlingTranslationImporter
+	newSmartlingTranslationImporter = func(cfg smartling.Config) (smartlingTranslationImporter, error) {
+		if cfg.ProjectID != "proj" || cfg.UserIdentifier != "uid" || cfg.UserSecret != "secret" {
+			t.Fatalf("unexpected config: %+v", cfg)
+		}
+		return stubSmartlingTranslationImporter{
+			result: smartling.TranslationImportResult{StringCount: 3, WordCount: 7},
+			assert: func(in smartling.TranslationImportInput) {
+				if in.ProjectID != "proj" || in.FileURI != "locales/en.json" || in.LocaleID != "fr-FR" {
+					t.Fatalf("unexpected input ids: %+v", in)
+				}
+				if in.FilePath != "fr.json" || in.FileType != "json" {
+					t.Fatalf("unexpected file fields: %+v", in)
+				}
+				if in.TranslationState != smartling.TranslationStatePostTranslation {
+					t.Fatalf("unexpected translation state: %q", in.TranslationState)
+				}
+				if !in.Overwrite {
+					t.Fatal("expected overwrite")
+				}
+			},
+		}, nil
+	}
+	defer func() { newSmartlingTranslationImporter = orig }()
+
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{
+		"smartling", "upload", "translations",
+		"--project-id", "proj",
+		"--file-uri", "locales/en.json",
+		"--target-locale", "fr-FR",
+		"--file", "fr.json",
+		"--post-translation",
+		"--overwrite",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "imported file=fr.json uri=locales/en.json locale=fr-FR strings=3 words=7") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestSmartlingUploadTranslationsRequiresCredentials(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "")
+	t.Setenv("SMARTLING_USER_SECRET", "")
+
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{
+		"smartling", "upload", "translations",
+		"--project-id", "proj",
+		"--file-uri", "locales/en.json",
+		"--target-locale", "fr-FR",
+		"--file", "fr.json",
+		"--published",
+	})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected credentials error")
+	}
+	if !strings.Contains(err.Error(), "credentials are required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type stubSmartlingTranslationImporter struct {
+	result smartling.TranslationImportResult
+	err    error
+	assert func(smartling.TranslationImportInput)
+}
+
+func (s stubSmartlingTranslationImporter) ImportTranslationFile(_ context.Context, in smartling.TranslationImportInput) (smartling.TranslationImportResult, error) {
+	if s.assert != nil {
+		s.assert(in)
+	}
+	return s.result, s.err
+}

--- a/docs/cli/commands/overview.mdx
+++ b/docs/cli/commands/overview.mdx
@@ -14,6 +14,7 @@ Main commands:
 - `init`
 - `crowdin`
 - `phrase`
+- `smartling`
 - `run`
 - `extract`
 - `pack`
@@ -31,6 +32,7 @@ Main commands:
 - First setup: [init](/cli/commands/init)
 - Crowdin file workflow: [crowdin](/cli/commands/crowdin)
 - Phrase file workflow: [phrase](/cli/commands/phrase)
+- Smartling file workflow: [smartling](/cli/commands/smartling)
 - Local draft generation: [run](/cli/commands/run)
 - Extract React Intl catalogs: [extract](/cli/commands/extract)
 - Prepare translation JSON: [pack](/cli/commands/pack)

--- a/docs/cli/commands/smartling.mdx
+++ b/docs/cli/commands/smartling.mdx
@@ -1,0 +1,143 @@
+---
+title: "smartling"
+description: "Smartling file workflow commands using project flags and API credentials."
+---
+
+## Usage
+
+```bash
+hyperlocalise smartling upload sources --project-id <id> --file <path> [--file-uri <uri>] [--file-type <type>] [--authorize] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>] [--dry-run]
+hyperlocalise smartling upload translations --project-id <id> --file-uri <uri> --target-locale <locale> --file <path> (--published | --post-translation) [--file-type <type>] [--overwrite] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>] [--dry-run]
+hyperlocalise smartling download sources --project-id <id> --file-uri <uri> [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling download translations --project-id <id> --file-uri <uri> --target-locale <locale> [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling glossary download --account-uid <id> --glossary-uid <id> [--language <locale>] [--output <path>] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling tm download --account-uid <id> --tm-uid <id> --source-language <code> [--target-language <code>] [--format csv|tmx] [--output <path>] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+```
+
+`tm` also accepts the alias `translation-memory`.
+
+These commands are flag-only. Hyperlocalise does not read `smartling.yml` in this version.
+
+## What this command family does
+
+These commands talk to the Smartling Files, Glossary, and Translation Memory APIs.
+
+They are separate from Hyperlocalise native `i18n.yml` and `sync push` / `sync pull` workflows. Use native sync when you want Hyperlocalise-managed entry sync through the [Smartling adapter](/cli/storage/smartling). Use this surface when you want flag-driven file upload and download against a Smartling project.
+
+Use them for:
+
+- source-file upload (`upload sources`)
+- import of a pre-translated locale file (`upload translations`, equivalent to official `smartling-cli files import`)
+- source download (`download sources`)
+- translation download (`download translations`)
+- glossary and translation-memory **download** (Hyperlocalise-shaped CSV/TMX)
+
+Official [smartling-cli](https://github.com/Smartling/smartling-cli) uses `files push` / `files pull` (aliases `upload` / `download`) and `files import`. Hyperlocalise keeps the same command family shape as Crowdin and Phrase (`upload sources`, `download translations`) instead of renaming to `files push`.
+
+## Credentials
+
+Hyperlocalise reads:
+
+- `--user-id`, or `SMARTLING_USER_IDENTIFIER`
+- `--user-secret`, or `--user-secret-env` (default `SMARTLING_USER_SECRET`)
+
+Official `smartling-cli` commonly uses `SMARTLING_USER_ID` and `SMARTLING_SECRET`. Those names are **not** read here. Export Hyperlocalise names, or pass `--user-id` and `--user-secret` / `--user-secret-env`.
+
+Do not put the user secret in `i18n.yml`. Do not commit `smartling.yml` that contains a secret.
+
+## File types
+
+When `--file-type` is omitted, Hyperlocalise infers Smartling `fileType` from the path extension:
+
+| Extension | Smartling `fileType` |
+| --- | --- |
+| `.json` | `json` |
+| `.yaml`, `.yml` | `yaml` |
+| `.xml` | `xml` |
+| `.html`, `.htm` | `html` |
+| `.csv` | `csv` |
+| `.strings` | `ios` |
+| `.stringsdict` | `ios_stringsdict` |
+| `.properties` | `javaProperties` |
+| `.xliff`, `.xlf` | `xliff` |
+| `.md`, `.markdown` | `markdown` |
+
+Unknown extensions require `--file-type`. Values such as `android` or `gettext` are valid when you pass them explicitly; they are not inferred from `.xml` or `.po`.
+
+## Command notes
+
+`upload sources` requires `--project-id` and at least one `--file`. `--file-uri` is optional for a single file (defaults to the path with `/` separators) and cannot be used with multiple `--file` values. `--authorize` defaults to **true** (official `files push` leaves jobs unauthorized unless `--authorize` is set, and often wraps uploads in a translation job). `--dry-run` prints the planned upload and does not call the network.
+
+`upload translations` imports translations for an **existing** source file URI. Pass exactly one of `--published` or `--post-translation`. The source file must already exist in the project. JSON/XML imports may require Smartling `source_key_paths` on the original source upload; Hyperlocalise does not add those directives. One `--target-locale` per invocation.
+
+`download sources` writes to stdout when `--output` is omitted or `-`. `--source-locale` is deprecated and ignored. `--force` overwrites an existing output file. `--dry-run` does not download.
+
+`download translations` requires `--target-locale`. Use `%locale%` in `--output` when you pass more than one locale. It does not send Smartling `retrievalType` (`pending`, `published`, `pseudo`).
+
+`glossary download` and `tm download` have no `--force` or `--dry-run`. They write CSV (or TMX for `tm --format tmx`) to stdout unless you pass `--output`.
+
+## smartling-cli gap inventory
+
+| Official smartling-cli | Hyperlocalise today |
+| --- | --- |
+| `smartling-cli init` / `smartling.yml` | Unsupported (flag-only) |
+| `files push` / `files upload` | `upload sources` (no jobs, no YAML globs, no `--branch`; `--authorize` defaults true) |
+| `files pull` / `files download` | `download translations` (one `--file-uri` per call; no `--retrieve`, `--all`, `--format` templates, or job pull) |
+| `files pull --source` | `download sources` |
+| `files import` | `upload translations` (`--published` or `--post-translation`; optional `--overwrite`) |
+| `files list` / `files status` | Unsupported |
+| `files delete` / `files rename` | Out of scope |
+| `projects list` / `info` / `locales` | Unsupported |
+| Jobs, `mt detect` / `mt translate` | Out of scope |
+| `glossaries export` | `glossary download` (Hyperlocalise CSV; not official CSV/XLSX/TBX parity) |
+| `glossaries import` / create / list | Out of scope |
+| TM export | `tm download` (CSV/TMX) |
+| TM / glossary upload | Out of scope |
+
+## Examples
+
+Upload a source file:
+
+```bash
+export SMARTLING_USER_IDENTIFIER="your-user-identifier"
+export SMARTLING_USER_SECRET="your-user-secret"
+
+hyperlocalise smartling upload sources \
+  --project-id your-project-id \
+  --file ./locales/en.json \
+  --file-uri locales/en.json \
+  --dry-run
+```
+
+Import a pre-translated locale file (source URI must already exist):
+
+```bash
+hyperlocalise smartling upload translations \
+  --project-id your-project-id \
+  --file-uri locales/en.json \
+  --target-locale fr-FR \
+  --file ./locales/fr.json \
+  --published \
+  --dry-run
+```
+
+Download one locale. Use `%locale%` when you pass more than one `--target-locale`:
+
+```bash
+hyperlocalise smartling download translations \
+  --project-id your-project-id \
+  --file-uri locales/en.json \
+  --target-locale fr-FR \
+  --output ./locales/%locale%.json \
+  --force
+```
+
+Download the source file:
+
+```bash
+hyperlocalise smartling download sources \
+  --project-id your-project-id \
+  --file-uri locales/en.json \
+  --output ./locales/en.json \
+  --force
+```

--- a/docs/cli/storage/smartling.mdx
+++ b/docs/cli/storage/smartling.mdx
@@ -1,9 +1,22 @@
 ---
 title: "Smartling adapter"
-description: "Configure Smartling for remote translation pull/push synchronization."
+description: "Configure Smartling for native sync mode or flag-driven file commands."
 ---
 
-## Required config
+## Two Smartling workflows
+
+Hyperlocalise supports two Smartling integrations:
+
+1. Native sync mode with `i18n.yml` plus `sync push` / `sync pull`
+2. Flag-driven file commands with `hyperlocalise smartling ...`
+
+Use native sync mode when you want Hyperlocalise-managed entry sync.
+
+Use the file commands when you want to upload and download Smartling files by `--project-id` and `--file-uri`. See [smartling](/cli/commands/smartling) for commands, flags, credential env vars, and the gap list versus official `smartling-cli`. Hyperlocalise does not read `smartling.yml` yet.
+
+## Native sync mode
+
+### Required config
 
 ```jsonc
 {
@@ -59,7 +72,7 @@ export SMARTLING_USER_SECRET="your-smartling-user-secret"
 
 ## Common issues
 
-- missing secret: export `SMARTLING_USER_SECRET` in the same shell session
-- missing user identifier: set `storage.config.userIdentifier`
+- missing secret: export `SMARTLING_USER_SECRET` in the same shell session (native sync and file commands). Official `smartling-cli` uses `SMARTLING_SECRET`; Hyperlocalise does not read that name.
+- missing user identifier: set `storage.config.userIdentifier`, or for file commands `SMARTLING_USER_IDENTIFIER` / `--user-id` (not official `SMARTLING_USER_ID`)
 - locale mismatch: align `targetLanguages` with your project locales
 - file mode import failure: verify `fileFormat` matches your project settings

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -194,6 +194,7 @@
                   "cli/commands/init",
                   "cli/commands/crowdin",
                   "cli/commands/phrase",
+                  "cli/commands/smartling",
                   "cli/commands/run",
                   "cli/commands/extract",
                   "cli/commands/pack",

--- a/internal/i18n/storage/phrase/source_upload_wait.go
+++ b/internal/i18n/storage/phrase/source_upload_wait.go
@@ -109,7 +109,7 @@ func (c *HTTPClient) WaitForUpload(ctx context.Context, in UploadWaitInput) (Sou
 
 	result, err := c.GetUpload(ctx, getInput)
 	if err != nil {
-		return SourceUploadResult{ID: strings.TrimSpace(in.UploadID)}, err
+		return uploadWaitResultOnError(in.UploadID, result, err, ctx)
 	}
 	if IsUploadSuccessState(result.State) {
 		return result, nil
@@ -123,11 +123,11 @@ func (c *HTTPClient) WaitForUpload(ctx context.Context, in UploadWaitInput) (Sou
 
 	for {
 		if err := sleepWithContext(ctx, interval); err != nil {
-			return result, fmt.Errorf("phrase upload %s wait timed out: state=%s: %w", result.ID, result.State, err)
+			return result, uploadWaitTimeoutError(result, err)
 		}
 		next, err := c.GetUpload(ctx, getInput)
 		if err != nil {
-			return result, err
+			return uploadWaitResultOnError(in.UploadID, result, err, ctx)
 		}
 		result = next
 		if IsUploadSuccessState(result.State) {
@@ -140,6 +140,23 @@ func (c *HTTPClient) WaitForUpload(ctx context.Context, in UploadWaitInput) (Sou
 			return result, fmt.Errorf("phrase upload %s is in unknown state %q", result.ID, result.State)
 		}
 	}
+}
+
+func uploadWaitResultOnError(uploadID string, last SourceUploadResult, err error, ctx context.Context) (SourceUploadResult, error) {
+	if last.ID == "" {
+		last.ID = strings.TrimSpace(uploadID)
+	}
+	if ctx.Err() != nil {
+		if last.State != "" {
+			return last, uploadWaitTimeoutError(last, ctx.Err())
+		}
+		return last, fmt.Errorf("phrase upload %s wait timed out: %w", last.ID, ctx.Err())
+	}
+	return last, err
+}
+
+func uploadWaitTimeoutError(result SourceUploadResult, err error) error {
+	return fmt.Errorf("phrase upload %s wait timed out: state=%s: %w", result.ID, result.State, err)
 }
 
 func (c *HTTPClient) uploadShow(ctx context.Context, projectID, uploadID string, opts *phraseapi.UploadShowOpts) (phraseapi.Upload, error) {

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -647,6 +647,135 @@ type TranslationDownloadResult struct {
 	Content  []byte
 }
 
+const (
+	TranslationStatePublished       = "PUBLISHED"
+	TranslationStatePostTranslation = "POST_TRANSLATION"
+)
+
+// TranslationImportInput contains the parameters for importing a translated file into Smartling.
+type TranslationImportInput struct {
+	ProjectID        string
+	FileURI          string
+	FilePath         string
+	FileType         string
+	LocaleID         string
+	TranslationState string
+	Overwrite        bool
+}
+
+// TranslationImportResult contains the results of a translation file import.
+type TranslationImportResult struct {
+	WordCount   int `json:"wordCount"`
+	StringCount int `json:"stringCount"`
+}
+
+type translationImportErrorItem struct {
+	FileURI        string   `json:"fileUri"`
+	ImportKey      string   `json:"importKey"`
+	StringHashcode string   `json:"stringHashcode"`
+	Messages       []string `json:"messages"`
+}
+
+type translationImportPayload struct {
+	WordCount               int                          `json:"wordCount"`
+	StringCount             int                          `json:"stringCount"`
+	TranslationImportErrors []translationImportErrorItem `json:"translationImportErrors"`
+}
+
+// translationImportEnvelope accepts the Files API shape (data nested under response)
+// and the sibling-data shape used elsewhere in this client.
+type translationImportEnvelope struct {
+	Response struct {
+		Code string                    `json:"code"`
+		Data *translationImportPayload `json:"data"`
+	} `json:"response"`
+	Data *translationImportPayload `json:"data"`
+}
+
+func normalizeTranslationImportState(state string) (string, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(state))
+	switch normalized {
+	case TranslationStatePublished, TranslationStatePostTranslation:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("smartling import: translationState must be PUBLISHED or POST_TRANSLATION")
+	}
+}
+
+func translationImportResultFromEnvelope(envelope translationImportEnvelope) (TranslationImportResult, error) {
+	code := strings.TrimSpace(envelope.Response.Code)
+	if code != "" && !strings.EqualFold(code, "SUCCESS") {
+		return TranslationImportResult{}, fmt.Errorf("smartling import: unexpected response code %s", code)
+	}
+	payload := envelope.Response.Data
+	if payload == nil {
+		payload = envelope.Data
+	}
+	if payload == nil {
+		return TranslationImportResult{}, fmt.Errorf("smartling import: empty response data")
+	}
+	if len(payload.TranslationImportErrors) > 0 {
+		first := payload.TranslationImportErrors[0]
+		msg := strings.Join(first.Messages, "; ")
+		if strings.TrimSpace(msg) == "" {
+			msg = "import failed"
+		}
+		if key := strings.TrimSpace(first.ImportKey); key != "" {
+			return TranslationImportResult{}, fmt.Errorf("smartling import: %d string error(s); first key=%s: %s", len(payload.TranslationImportErrors), key, msg)
+		}
+		return TranslationImportResult{}, fmt.Errorf("smartling import: %d string error(s); %s", len(payload.TranslationImportErrors), msg)
+	}
+	return TranslationImportResult{WordCount: payload.WordCount, StringCount: payload.StringCount}, nil
+}
+
+// ImportTranslationFile imports a pre-translated locale file for an existing source file URI.
+func (c *HTTPClient) ImportTranslationFile(ctx context.Context, in TranslationImportInput) (TranslationImportResult, error) {
+	if strings.TrimSpace(in.ProjectID) == "" {
+		return TranslationImportResult{}, fmt.Errorf("smartling import: project id is required")
+	}
+	if strings.TrimSpace(in.FileURI) == "" {
+		return TranslationImportResult{}, fmt.Errorf("smartling import: file uri is required")
+	}
+	if strings.TrimSpace(in.FilePath) == "" {
+		return TranslationImportResult{}, fmt.Errorf("smartling import: file path is required")
+	}
+	if strings.TrimSpace(in.FileType) == "" {
+		return TranslationImportResult{}, fmt.Errorf("smartling import: file type is required")
+	}
+	if strings.TrimSpace(in.LocaleID) == "" {
+		return TranslationImportResult{}, fmt.Errorf("smartling import: locale id is required")
+	}
+	state, err := normalizeTranslationImportState(in.TranslationState)
+	if err != nil {
+		return TranslationImportResult{}, err
+	}
+
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return TranslationImportResult{}, err
+	}
+
+	endpoint := fmt.Sprintf("%s/projects/%s/locales/%s/file/import", c.filesBaseURL, url.PathEscape(strings.TrimSpace(in.ProjectID)), url.PathEscape(strings.TrimSpace(in.LocaleID)))
+	params := map[string]string{
+		"fileUri":          strings.TrimSpace(in.FileURI),
+		"fileType":         strings.TrimSpace(in.FileType),
+		"translationState": state,
+	}
+	if in.Overwrite {
+		params["overwrite"] = "true"
+	}
+
+	var envelope translationImportEnvelope
+	if err := c.uploadMultipart(ctx, endpoint, token, params, "file", in.FilePath, &envelope); err != nil {
+		return TranslationImportResult{}, fmt.Errorf("smartling import file: %w", err)
+	}
+	result, err := translationImportResultFromEnvelope(envelope)
+	if err != nil {
+		return TranslationImportResult{}, err
+	}
+	return result, nil
+}
+
 // DownloadTranslationFile downloads a translated file from Smartling for a specific locale.
 func (c *HTTPClient) DownloadTranslationFile(ctx context.Context, in TranslationDownloadInput) (TranslationDownloadResult, error) {
 	if strings.TrimSpace(in.ProjectID) == "" {

--- a/internal/i18n/storage/smartling/http_client_test.go
+++ b/internal/i18n/storage/smartling/http_client_test.go
@@ -447,6 +447,243 @@ func TestHTTPClientUploadSourceFile(t *testing.T) {
 	}
 }
 
+func TestHTTPClientImportTranslationFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/locales/fr-FR/file/import":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method: %s", r.Method)
+			}
+			if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+				t.Fatalf("unexpected content type: %s", r.Header.Get("Content-Type"))
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer token" {
+				t.Fatalf("unexpected auth header: %q", got)
+			}
+
+			err := r.ParseMultipartForm(10 << 20)
+			if err != nil {
+				t.Fatalf("parse multipart form: %v", err)
+			}
+
+			if got := r.FormValue("fileUri"); got != "locales/en.json" {
+				t.Fatalf("unexpected fileUri: %q", got)
+			}
+			if got := r.FormValue("fileType"); got != "json" {
+				t.Fatalf("unexpected fileType: %q", got)
+			}
+			if got := r.FormValue("translationState"); got != TranslationStatePublished {
+				t.Fatalf("unexpected translationState: %q", got)
+			}
+			if got := r.FormValue("overwrite"); got != "" {
+				t.Fatalf("overwrite should be omitted when false, got %q", got)
+			}
+
+			file, _, err := r.FormFile("file")
+			if err != nil {
+				t.Fatalf("get file part: %v", err)
+			}
+			defer func() { _ = file.Close() }()
+			content, _ := io.ReadAll(file)
+			if string(content) != `{"k":"bonjour"}` {
+				t.Fatalf("unexpected content: %q", string(content))
+			}
+
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS","data":{"stringCount":4,"wordCount":12,"translationImportErrors":[]}}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL:    srv.URL,
+		filesBaseURL:   srv.URL,
+		http:           srv.Client(),
+		userIdentifier: "id",
+		userSecret:     "secret",
+	}
+
+	tempFile, err := os.CreateTemp("", "import-*.json")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tempFile.Name()) }()
+	_, _ = tempFile.WriteString(`{"k":"bonjour"}`)
+	_ = tempFile.Close()
+
+	result, err := client.ImportTranslationFile(context.Background(), TranslationImportInput{
+		ProjectID:        "123",
+		FileURI:          "locales/en.json",
+		FilePath:         tempFile.Name(),
+		FileType:         "json",
+		LocaleID:         "fr-FR",
+		TranslationState: "published",
+	})
+	if err != nil {
+		t.Fatalf("import translation file: %v", err)
+	}
+	if result.StringCount != 4 || result.WordCount != 12 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestHTTPClientImportTranslationFileOverwrite(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/locales/de-DE/file/import":
+			err := r.ParseMultipartForm(10 << 20)
+			if err != nil {
+				t.Fatalf("parse multipart form: %v", err)
+			}
+			if got := r.FormValue("translationState"); got != TranslationStatePostTranslation {
+				t.Fatalf("unexpected translationState: %q", got)
+			}
+			if got := r.FormValue("overwrite"); got != "true" {
+				t.Fatalf("unexpected overwrite: %q", got)
+			}
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS","data":{"stringCount":1,"wordCount":2,"translationImportErrors":[]}}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL:    srv.URL,
+		filesBaseURL:   srv.URL,
+		http:           srv.Client(),
+		userIdentifier: "id",
+		userSecret:     "secret",
+	}
+
+	tempFile, err := os.CreateTemp("", "import-overwrite-*.json")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tempFile.Name()) }()
+	_, _ = tempFile.WriteString(`{"k":"hallo"}`)
+	_ = tempFile.Close()
+
+	_, err = client.ImportTranslationFile(context.Background(), TranslationImportInput{
+		ProjectID:        "123",
+		FileURI:          "locales/en.json",
+		FilePath:         tempFile.Name(),
+		FileType:         "json",
+		LocaleID:         "de-DE",
+		TranslationState: TranslationStatePostTranslation,
+		Overwrite:        true,
+	})
+	if err != nil {
+		t.Fatalf("import translation file: %v", err)
+	}
+}
+
+func TestHTTPClientImportTranslationFileReportsStringErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/locales/fr-FR/file/import":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS","data":{"stringCount":0,"wordCount":0,"translationImportErrors":[{"fileUri":"locales/en.json","importKey":"welcome.title","stringHashcode":"abc","messages":["source string not found"]}]}}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL:    srv.URL,
+		filesBaseURL:   srv.URL,
+		http:           srv.Client(),
+		userIdentifier: "id",
+		userSecret:     "secret",
+	}
+
+	tempFile, err := os.CreateTemp("", "import-errors-*.json")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tempFile.Name()) }()
+	_, _ = tempFile.WriteString(`{"welcome.title":"Bonjour"}`)
+	_ = tempFile.Close()
+
+	_, err = client.ImportTranslationFile(context.Background(), TranslationImportInput{
+		ProjectID:        "123",
+		FileURI:          "locales/en.json",
+		FilePath:         tempFile.Name(),
+		FileType:         "json",
+		LocaleID:         "fr-FR",
+		TranslationState: TranslationStatePublished,
+	})
+	if err == nil {
+		t.Fatal("expected import string errors")
+	}
+	if !strings.Contains(err.Error(), "1 string error(s)") || !strings.Contains(err.Error(), "welcome.title") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTranslationImportResultFromEnvelope(t *testing.T) {
+	nested := translationImportEnvelope{}
+	nested.Response.Code = "SUCCESS"
+	nested.Response.Data = &translationImportPayload{StringCount: 2, WordCount: 5}
+	got, err := translationImportResultFromEnvelope(nested)
+	if err != nil {
+		t.Fatalf("nested envelope: %v", err)
+	}
+	if got.StringCount != 2 || got.WordCount != 5 {
+		t.Fatalf("unexpected nested result: %+v", got)
+	}
+
+	sibling := translationImportEnvelope{}
+	sibling.Response.Code = "SUCCESS"
+	sibling.Data = &translationImportPayload{StringCount: 8, WordCount: 9}
+	got, err = translationImportResultFromEnvelope(sibling)
+	if err != nil {
+		t.Fatalf("sibling envelope: %v", err)
+	}
+	if got.StringCount != 8 || got.WordCount != 9 {
+		t.Fatalf("unexpected sibling result: %+v", got)
+	}
+
+	bad := translationImportEnvelope{}
+	bad.Response.Code = "VALIDATION_ERROR"
+	if _, err := translationImportResultFromEnvelope(bad); err == nil || !strings.Contains(err.Error(), "VALIDATION_ERROR") {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestHTTPClientImportTranslationFileValidation(t *testing.T) {
+	client := &HTTPClient{}
+	_, err := client.ImportTranslationFile(context.Background(), TranslationImportInput{
+		ProjectID:        "123",
+		FileURI:          "file.json",
+		FilePath:         "file.json",
+		FileType:         "json",
+		LocaleID:         "fr-FR",
+		TranslationState: "pending",
+	})
+	if err == nil {
+		t.Fatal("expected translationState error")
+	}
+	if !strings.Contains(err.Error(), "PUBLISHED or POST_TRANSLATION") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = client.ImportTranslationFile(context.Background(), TranslationImportInput{})
+	if err == nil {
+		t.Fatal("expected project id error")
+	}
+	if !strings.Contains(err.Error(), "project id is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestHTTPClientDownloadSourceFile(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
## Summary
- Add `hyperlocalise smartling upload translations` for official Files API import (`translationState` required via `--published` or `--post-translation`).
- Add HTTP `ImportTranslationFile` with nested `response.data` decoding and fail closed on `translationImportErrors`.
- Document the Smartling command family and official `smartling-cli` gap table (HL-659 / HL-660 / HL-661).

## Test plan
- [x] `go test ./internal/i18n/storage/smartling -run HTTPClientImport|TranslationImport`
- [x] `go test ./apps/cli/cmd -run Smartling`
- [ ] Live-test: upload a source URI, then import a translation with `--published` against a real Smartling project (JSON/XML may need `source_key_paths` on the original source)
