### PR TITLE
feat(mt): add DeepL translation client

### DIFF
--- a/internal/mt/BUILD.bazel
+++ b/internal/mt/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "mt",
     srcs = [
         "config.go",
+        "deepl.go",
         "doc.go",
         "engine.go",
         "errors.go",
@@ -19,6 +20,7 @@ go_test(
     name = "mt_test",
     srcs = [
         "config_test.go",
+        "deepl_test.go",
         "errors_test.go",
         "testhelpers_test.go",
         "validate_test.go",

--- a/internal/mt/deepl.go
+++ b/internal/mt/deepl.go
@@ -175,8 +175,18 @@ func deeplSourceLanguageCode(locale string) string {
 	return strings.ToUpper(base.String())
 }
 
-// deeplTargetLanguageCode preserves only explicitly specified target subtags.
-// x/text may infer region/script values unless confidence is Exact.
+// deeplTargetVariantCodes contains DeepL's documented region/script-qualified
+// target language codes.
+var deeplTargetVariantCodes = map[string]bool{
+	"EN-US": true, "EN-GB": true,
+	"PT-BR": true, "PT-PT": true,
+	"DE-DE": true, "DE-CH": true,
+	"FR-FR": true, "FR-CA": true,
+	"ES-419":  true,
+	"ZH-HANS": true, "ZH-HANT": true,
+}
+
+// x/text may infer region/script subtags unless confidence is Exact.
 func deeplTargetLanguageCode(locale string) string {
 	tag, err := language.Parse(locale)
 	if err != nil {
@@ -184,11 +194,16 @@ func deeplTargetLanguageCode(locale string) string {
 	}
 	base, _ := tag.Base()
 	code := strings.ToUpper(base.String())
+
 	if script, conf := tag.Script(); conf == language.Exact {
-		return code + "-" + strings.ToUpper(script.String())
+		if candidate := code + "-" + strings.ToUpper(script.String()); deeplTargetVariantCodes[candidate] {
+			return candidate
+		}
 	}
 	if region, conf := tag.Region(); conf == language.Exact {
-		return code + "-" + region.String()
+		if candidate := code + "-" + region.String(); deeplTargetVariantCodes[candidate] {
+			return candidate
+		}
 	}
 	return code
 }

--- a/internal/mt/deepl.go
+++ b/internal/mt/deepl.go
@@ -1,0 +1,194 @@
+package mt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/text/language"
+)
+
+// DeepLProBaseURL and DeepLFreeBaseURL are DeepL's API hosts.
+const (
+	DeepLProBaseURL  = "https://api.deepl.com"
+	DeepLFreeBaseURL = "https://api-free.deepl.com"
+)
+
+const deeplTranslatePath = "/v2/translate"
+
+const deeplStatusQuotaExceeded = 456
+
+type DeepLClient struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+var _ Engine = (*DeepLClient)(nil)
+
+// NewDeepLClient creates a DeepL API client.
+// Config.BaseURL must select the Pro or Free API host.
+func NewDeepLClient(cfg Config) (*DeepLClient, error) {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, &Error{Code: ErrorCodeValidation, Message: "API key is required"}
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		return nil, &Error{Code: ErrorCodeValidation, Message: "base URL is required"}
+	}
+	return &DeepLClient{
+		apiKey:     cfg.APIKey,
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		httpClient: cfg.httpClient(),
+	}, nil
+}
+
+type deeplTranslateResponse struct {
+	Translations []struct {
+		Text string `json:"text"`
+	} `json:"translations"`
+}
+
+type deeplErrorResponse struct {
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+func (c *DeepLClient) Translate(ctx context.Context, req Request) (Response, error) {
+	if err := validateRequest(req); err != nil {
+		return Response{}, err
+	}
+
+	form := url.Values{}
+	for _, s := range req.Sources {
+		form.Add("text", s)
+	}
+	form.Set("source_lang", deeplSourceLanguageCode(req.SourceLocale))
+	form.Set("target_lang", deeplTargetLanguageCode(req.TargetLocale))
+
+	var out deeplTranslateResponse
+	if err := c.request(ctx, http.MethodPost, c.baseURL+deeplTranslatePath, form, &out); err != nil {
+		return Response{}, err
+	}
+
+	if len(out.Translations) != len(req.Sources) {
+		return Response{}, &Error{
+			Code:    ErrorCodeUpstream,
+			Message: fmt.Sprintf("DeepL returned %d translations for %d inputs", len(out.Translations), len(req.Sources)),
+			Path:    deeplTranslatePath,
+		}
+	}
+
+	translations := make([]string, len(out.Translations))
+	for i, t := range out.Translations {
+		translations[i] = t.Text
+	}
+	return Response{Translations: translations}, nil
+}
+
+func (c *DeepLClient) request(ctx context.Context, method, requestURL string, form url.Values, out any) error {
+	httpReq, err := http.NewRequestWithContext(ctx, method, requestURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("mt: build deepl translate request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	httpReq.Header.Set("Authorization", "DeepL-Auth-Key "+c.apiKey)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return &Error{
+			Code:    ErrorCodeUpstreamUnavailable,
+			Message: "could not reach DeepL",
+			Path:    deeplTranslatePath,
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return &Error{
+			Code:    ErrorCodeUpstreamUnavailable,
+			Message: "could not read DeepL response",
+			Path:    deeplTranslatePath,
+		}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return deeplHTTPError(resp.StatusCode, deeplTranslatePath, respBody)
+	}
+
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return &Error{
+			Code:       ErrorCodeUpstream,
+			Message:    "DeepL returned invalid JSON",
+			StatusCode: resp.StatusCode,
+			Path:       deeplTranslatePath,
+		}
+	}
+	return nil
+}
+
+// DeepL has no stable machine-readable unsupported-language signal,
+// so generic 400 responses map to ErrorCodeUpstream.
+func deeplHTTPError(statusCode int, path string, body []byte) *Error {
+	var parsed deeplErrorResponse
+	_ = json.Unmarshal(body, &parsed)
+	message := deeplErrorMessage(statusCode, parsed)
+
+	switch {
+	case statusCode == http.StatusBadRequest:
+		return &Error{Code: ErrorCodeUpstream, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode == http.StatusUnauthorized, statusCode == http.StatusForbidden:
+		return &Error{Code: ErrorCodeAuthFailed, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode == http.StatusTooManyRequests, statusCode == deeplStatusQuotaExceeded:
+		return &Error{Code: ErrorCodeRateLimited, Message: message, StatusCode: statusCode, Path: path}
+	case statusCode >= 500:
+		return &Error{Code: ErrorCodeUpstreamUnavailable, Message: message, StatusCode: statusCode, Path: path}
+	default:
+		return &Error{Code: ErrorCodeUpstream, Message: message, StatusCode: statusCode, Path: path}
+	}
+}
+
+func deeplErrorMessage(statusCode int, parsed deeplErrorResponse) string {
+	if parsed.Message != "" {
+		return fmt.Sprintf("DeepL error (%d): %s", statusCode, parsed.Message)
+	}
+	return fmt.Sprintf("DeepL error (%d)", statusCode)
+}
+
+// deeplSourceLanguageCode drops region and script subtags for DeepL source_lang.
+func deeplSourceLanguageCode(locale string) string {
+	tag, err := language.Parse(locale)
+	if err != nil {
+		return locale
+	}
+	base, _ := tag.Base()
+	return strings.ToUpper(base.String())
+}
+
+// deeplTargetLanguageCode preserves only explicitly specified target subtags.
+// x/text may infer region/script values unless confidence is Exact.
+func deeplTargetLanguageCode(locale string) string {
+	tag, err := language.Parse(locale)
+	if err != nil {
+		return locale
+	}
+	base, _ := tag.Base()
+	code := strings.ToUpper(base.String())
+	if script, conf := tag.Script(); conf == language.Exact {
+		return code + "-" + strings.ToUpper(script.String())
+	}
+	if region, conf := tag.Region(); conf == language.Exact {
+		return code + "-" + region.String()
+	}
+	return code
+}

--- a/internal/mt/deepl.go
+++ b/internal/mt/deepl.go
@@ -22,6 +22,8 @@ const deeplTranslatePath = "/v2/translate"
 
 const deeplStatusQuotaExceeded = 456
 
+const deeplMaxTextsPerRequest = 50 // DeepL API limit
+
 type DeepLClient struct {
 	apiKey     string
 	baseURL    string
@@ -62,22 +64,43 @@ func (c *DeepLClient) Translate(ctx context.Context, req Request) (Response, err
 		return Response{}, err
 	}
 
+	sourceLang := deeplSourceLanguageCode(req.SourceLocale)
+	targetLang := deeplTargetLanguageCode(req.TargetLocale)
+
+	translations := make([]string, 0, len(req.Sources))
+	for start := 0; start < len(req.Sources); start += deeplMaxTextsPerRequest {
+		end := start + deeplMaxTextsPerRequest
+		if end > len(req.Sources) {
+			end = len(req.Sources)
+		}
+
+		chunkTranslations, err := c.translateChunk(ctx, sourceLang, targetLang, req.Sources[start:end])
+		if err != nil {
+			return Response{}, err
+		}
+		translations = append(translations, chunkTranslations...)
+	}
+
+	return Response{Translations: translations}, nil
+}
+
+func (c *DeepLClient) translateChunk(ctx context.Context, sourceLang, targetLang string, sources []string) ([]string, error) {
 	form := url.Values{}
-	for _, s := range req.Sources {
+	for _, s := range sources {
 		form.Add("text", s)
 	}
-	form.Set("source_lang", deeplSourceLanguageCode(req.SourceLocale))
-	form.Set("target_lang", deeplTargetLanguageCode(req.TargetLocale))
+	form.Set("source_lang", sourceLang)
+	form.Set("target_lang", targetLang)
 
 	var out deeplTranslateResponse
 	if err := c.request(ctx, http.MethodPost, c.baseURL+deeplTranslatePath, form, &out); err != nil {
-		return Response{}, err
+		return nil, err
 	}
 
-	if len(out.Translations) != len(req.Sources) {
-		return Response{}, &Error{
+	if len(out.Translations) != len(sources) {
+		return nil, &Error{
 			Code:    ErrorCodeUpstream,
-			Message: fmt.Sprintf("DeepL returned %d translations for %d inputs", len(out.Translations), len(req.Sources)),
+			Message: fmt.Sprintf("DeepL returned %d translations for %d inputs", len(out.Translations), len(sources)),
 			Path:    deeplTranslatePath,
 		}
 	}
@@ -86,7 +109,7 @@ func (c *DeepLClient) Translate(ctx context.Context, req Request) (Response, err
 	for i, t := range out.Translations {
 		translations[i] = t.Text
 	}
-	return Response{Translations: translations}, nil
+	return translations, nil
 }
 
 func (c *DeepLClient) request(ctx context.Context, method, requestURL string, form url.Values, out any) error {

--- a/internal/mt/deepl_test.go
+++ b/internal/mt/deepl_test.go
@@ -314,13 +314,22 @@ func TestDeepLTargetLanguageCode(t *testing.T) {
 		{"zh", "ZH"},
 		{"en-US", "EN-US"},
 		{"en-GB", "EN-GB"},
+		{"en-AU", "EN"},
 		{"pt-BR", "PT-BR"},
 		{"pt-PT", "PT-PT"},
 		{"zh-Hans", "ZH-HANS"},
 		{"zh-Hant", "ZH-HANT"},
 		{"zh-Hant-HK", "ZH-HANT"},
+		{"fr-FR", "FR-FR"},
 		{"fr-CA", "FR-CA"},
+		{"fr-BE", "FR"},
+		{"de-DE", "DE-DE"},
+		{"de-CH", "DE-CH"},
+		{"de-AT", "DE"},
 		{"es-419", "ES-419"},
+		{"es-MX", "ES"},
+		{"ja-JP", "JA"},
+		{"vi-VN", "VI"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.locale, func(t *testing.T) {

--- a/internal/mt/deepl_test.go
+++ b/internal/mt/deepl_test.go
@@ -1,0 +1,330 @@
+package mt
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type deeplRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f deeplRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newDeepLTestClient(t *testing.T, handler http.HandlerFunc) *DeepLClient {
+	t.Helper()
+	cfg := newTestServer(t, handler)
+	cfg.APIKey = "test-key"
+	client, err := NewDeepLClient(cfg)
+	require.NoError(t, err)
+	return client
+}
+
+func TestNewDeepLClientRequiresAPIKey(t *testing.T) {
+	client, err := NewDeepLClient(Config{BaseURL: DeepLProBaseURL})
+	require.Nil(t, client)
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestNewDeepLClientRequiresBaseURL(t *testing.T) {
+	client, err := NewDeepLClient(Config{APIKey: "test-key"})
+	require.Nil(t, client)
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestNewDeepLClientUsesConfiguredBaseURL(t *testing.T) {
+	for _, base := range []string{DeepLProBaseURL, DeepLFreeBaseURL} {
+		t.Run(base, func(t *testing.T) {
+			var gotURL string
+			client, err := NewDeepLClient(Config{
+				APIKey:  "test-key",
+				BaseURL: base,
+				HTTPClient: &http.Client{
+					Transport: deeplRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+						gotURL = req.URL.String()
+						return nil, errors.New("no network in this test")
+					}),
+				},
+			})
+			require.NoError(t, err)
+
+			_, _ = client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+			require.True(t, len(gotURL) >= len(base) && gotURL[:len(base)] == base, "expected URL %q to start with %q", gotURL, base)
+		})
+	}
+}
+
+func TestDeepLClientTranslateSuccess(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotForm url.Values
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		require.NoError(t, r.ParseForm())
+		gotForm = r.PostForm
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"translations":[{"text":"Bonjour"},{"text":"Salut"}]}`))
+	})
+
+	resp, err := client.Translate(t.Context(), Request{
+		SourceLocale: "en",
+		TargetLocale: "fr",
+		Sources:      []string{"Hello", "Hi"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"Bonjour", "Salut"}, resp.Translations)
+
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, deeplTranslatePath, gotPath)
+	require.Equal(t, "DeepL-Auth-Key test-key", gotAuth)
+	require.Equal(t, []string{"Hello", "Hi"}, gotForm["text"])
+	require.Equal(t, "EN", gotForm.Get("source_lang"))
+	require.Equal(t, "FR", gotForm.Get("target_lang"))
+}
+
+func TestDeepLClientTranslateRawErrorBodyNotEchoed(t *testing.T) {
+	const rawBody = "Internal Server Error: stack trace and sensitive upstream details"
+
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(rawBody))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+	require.Equal(t, http.StatusInternalServerError, typed.StatusCode)
+	require.Equal(t, "DeepL error (500)", typed.Message)
+	require.NotContains(t, typed.Message, rawBody)
+	require.NotContains(t, err.Error(), rawBody)
+}
+
+func TestDeepLClientTranslateAuthFailed(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"message":"Authorization failed"}`))
+			})
+
+			_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeAuthFailed, typed.Code)
+			require.Equal(t, status, typed.StatusCode)
+		})
+	}
+}
+
+func TestDeepLClientTranslateRateLimited(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, deeplStatusQuotaExceeded} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"message":"Too many requests"}`))
+			})
+
+			_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeRateLimited, typed.Code)
+			require.Equal(t, status, typed.StatusCode)
+		})
+	}
+}
+
+func TestDeepLClientTranslateBadRequestMapsToUpstreamError(t *testing.T) {
+	messages := []string{
+		`{"message":"Value for 'target_lang' not supported."}`,
+		`{"message":"invalid_content_type"}`,
+	}
+	for _, body := range messages {
+		t.Run(body, func(t *testing.T) {
+			client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(body))
+			})
+
+			_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeUpstream, typed.Code)
+			require.Equal(t, http.StatusBadRequest, typed.StatusCode)
+		})
+	}
+}
+
+func TestDeepLClientTranslateUpstreamUnavailable(t *testing.T) {
+	for _, status := range []int{http.StatusInternalServerError, http.StatusGatewayTimeout} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"message":"Internal error"}`))
+			})
+
+			_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+		})
+	}
+}
+
+func TestDeepLClientTranslateTranslationCountMismatchMapsToUpstreamError(t *testing.T) {
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"translations":[{"text":"Bonjour"}]}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{
+		SourceLocale: "en",
+		TargetLocale: "fr",
+		Sources:      []string{"Hello", "Hi"},
+	})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestDeepLClientTranslateContextCanceled(t *testing.T) {
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"translations":[]}`))
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled))
+	_, ok := AsError(err)
+	require.False(t, ok)
+}
+
+func TestDeepLClientTranslateContextDeadlineExceeded(t *testing.T) {
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"translations":[]}`))
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+
+	_, err := client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded))
+	_, ok := AsError(err)
+	require.False(t, ok)
+}
+
+func TestDeepLClientTranslateTransportErrorDoesNotLeakAPIKey(t *testing.T) {
+	const apiKey = "super-secret-deepl-key-12345"
+
+	client, err := NewDeepLClient(Config{
+		BaseURL: DeepLProBaseURL,
+		APIKey:  apiKey,
+		HTTPClient: &http.Client{
+			Transport: deeplRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("dial tcp: connection refused, headers: " + req.Header.Get("Authorization"))
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.Translate(t.Context(), Request{
+		SourceLocale: "en",
+		TargetLocale: "fr",
+		Sources:      []string{"hi"},
+	})
+	require.Error(t, err)
+
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+	require.Equal(t, deeplTranslatePath, typed.Path)
+	require.NotContains(t, typed.Message, apiKey)
+	require.NotContains(t, err.Error(), apiKey)
+}
+
+func TestDeepLClientTranslateEmptyInputMakesNoRequest(t *testing.T) {
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected HTTP call for empty input")
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: nil})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestDeepLClientTranslateInvalidJSONResponse(t *testing.T) {
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestDeepLSourceLanguageCode(t *testing.T) {
+	cases := []struct {
+		locale string
+		want   string
+	}{
+		{"en", "EN"},
+		{"en-US", "EN"},
+		{"en-GB", "EN"},
+		{"pt-BR", "PT"},
+		{"zh-Hant", "ZH"},
+		{"zh-Hans", "ZH"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.locale, func(t *testing.T) {
+			require.Equal(t, tc.want, deeplSourceLanguageCode(tc.locale))
+		})
+	}
+}
+
+func TestDeepLTargetLanguageCode(t *testing.T) {
+	cases := []struct {
+		locale string
+		want   string
+	}{
+		{"en", "EN"},
+		{"pt", "PT"},
+		{"zh", "ZH"},
+		{"en-US", "EN-US"},
+		{"en-GB", "EN-GB"},
+		{"pt-BR", "PT-BR"},
+		{"pt-PT", "PT-PT"},
+		{"zh-Hans", "ZH-HANS"},
+		{"zh-Hant", "ZH-HANT"},
+		{"zh-Hant-HK", "ZH-HANT"},
+		{"fr-CA", "FR-CA"},
+		{"es-419", "ES-419"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.locale, func(t *testing.T) {
+			require.Equal(t, tc.want, deeplTargetLanguageCode(tc.locale))
+		})
+	}
+}

--- a/internal/mt/deepl_test.go
+++ b/internal/mt/deepl_test.go
@@ -2,7 +2,9 @@ package mt
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,6 +18,27 @@ type deeplRoundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f deeplRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+// translationOut and translateResp build synthetic DeepL success bodies for
+// the chunking tests below.
+type translationOut struct {
+	Text string `json:"text"`
+}
+
+type translateResp struct {
+	Translations []translationOut `json:"translations"`
+}
+
+func deeplSuccessBody(t *testing.T, texts []string, suffix string) []byte {
+	t.Helper()
+	resp := translateResp{Translations: make([]translationOut, len(texts))}
+	for i, text := range texts {
+		resp.Translations[i] = translationOut{Text: text + suffix}
+	}
+	body, err := json.Marshal(resp)
+	require.NoError(t, err)
+	return body
 }
 
 func newDeepLTestClient(t *testing.T, handler http.HandlerFunc) *DeepLClient {
@@ -197,6 +220,129 @@ func TestDeepLClientTranslateTranslationCountMismatchMapsToUpstreamError(t *test
 	typed, ok := AsError(err)
 	require.True(t, ok)
 	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestDeepLClientTranslate51SourcesSplitsIntoTwoRequests(t *testing.T) {
+	sources := make([]string, 51)
+	for i := range sources {
+		sources[i] = fmt.Sprintf("s%d", i)
+	}
+
+	var calls int
+	var formsSeen [][]string
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		require.NoError(t, r.ParseForm())
+		texts := append([]string(nil), r.PostForm["text"]...)
+		formsSeen = append(formsSeen, texts)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(deeplSuccessBody(t, texts, "-out"))
+	})
+
+	resp, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: sources})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, calls)
+	require.Equal(t, sources[:50], formsSeen[0])
+	require.Equal(t, sources[50:], formsSeen[1])
+
+	want := make([]string, 51)
+	for i, s := range sources {
+		want[i] = s + "-out"
+	}
+	require.Equal(t, want, resp.Translations)
+}
+
+func TestDeepLClientTranslate50SourcesSingleRequest(t *testing.T) {
+	sources := make([]string, 50)
+	for i := range sources {
+		sources[i] = fmt.Sprintf("s%d", i)
+	}
+
+	var calls int
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		require.NoError(t, r.ParseForm())
+		require.Len(t, r.PostForm["text"], 50)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(deeplSuccessBody(t, r.PostForm["text"], "-out"))
+	})
+
+	resp, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: sources})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	require.Len(t, resp.Translations, 50)
+}
+
+func TestDeepLClientTranslateLaterChunkFailureReturnsNoPartialResponse(t *testing.T) {
+	sources := make([]string, 51)
+	for i := range sources {
+		sources[i] = fmt.Sprintf("s%d", i)
+	}
+
+	var calls int
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		require.NoError(t, r.ParseForm())
+		texts := r.PostForm["text"]
+
+		if calls == 1 {
+			require.Len(t, texts, 50)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(deeplSuccessBody(t, texts, "-out"))
+			return
+		}
+
+		require.Len(t, texts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"Internal error"}`))
+	})
+
+	resp, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: sources})
+	require.Equal(t, 2, calls)
+	require.Empty(t, resp.Translations)
+
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+}
+
+func TestDeepLClientTranslateContextCanceledBetweenChunks(t *testing.T) {
+	sources := make([]string, 51)
+	for i := range sources {
+		sources[i] = fmt.Sprintf("s%d", i)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var calls int
+	client := newDeepLTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		require.Equal(t, 1, calls, "no request should be sent for a chunk after cancellation")
+		require.NoError(t, r.ParseForm())
+		texts := r.PostForm["text"]
+		require.Len(t, texts, 50)
+
+		body := deeplSuccessBody(t, texts, "-out")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		cancel()
+	})
+
+	_, err := client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: sources})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled))
+	_, ok := AsError(err)
+	require.False(t, ok)
+	require.Equal(t, 1, calls)
 }
 
 func TestDeepLClientTranslateContextCanceled(t *testing.T) {


### PR DESCRIPTION
## What changed

- Added the DeepL client behind the `internal/mt` `Engine`.
- Added explicit Pro/Free host selection, API-key auth, BCP 47 locale mapping, batch translation, typed error mapping, and context cancellation.
- Added coverage for host selection, request/response ordering, auth/rate-limit/upstream failures, locale mapping, cancellation, malformed responses, and translation-count mismatches.
- DeepL does not expose a stable machine-readable unsupported-language signal, so ambiguous 400 responses map to `ErrorCodeUpstream`

## How to test

- `go test ./internal/mt`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
