### PR TITLE
Surface project style guide as markdown

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
@@ -76,9 +76,9 @@ export const projectOverviewPageContentMessages = defineMessages({
     description: "CTA for a failed or active job on project overview",
   },
   addGuidanceCta: {
-    defaultMessage: "Add guidance",
+    defaultMessage: "Add style guide",
     id: "U+ZJP/RMin",
-    description: "CTA when translation guidance is missing on project overview",
+    description: "CTA when the project style guide is missing on project overview",
   },
   triageReviewTitle: {
     defaultMessage: "Waiting for review",
@@ -91,14 +91,14 @@ export const projectOverviewPageContentMessages = defineMessages({
     description: "Status label for failed job triage items",
   },
   triageGuidanceTitle: {
-    defaultMessage: "Add translation guidance",
+    defaultMessage: "Add a style guide",
     id: "DGx/LlMkDv",
-    description: "Title when native translation guidance is missing",
+    description: "Title when the native project style guide is missing",
   },
   triageGuidanceDescription: {
     defaultMessage: "Shared tone and terminology so agents stay consistent.",
     id: "+y5oYiRfPw",
-    description: "Description when native translation guidance is missing",
+    description: "Description when the native project style guide is missing",
   },
   triageJobRunning: {
     defaultMessage: "In progress",
@@ -126,14 +126,14 @@ export const projectOverviewPageContentMessages = defineMessages({
     description: "Shown when the project has no target locales configured",
   },
   guidanceTitle: {
-    defaultMessage: "Translation guidance",
+    defaultMessage: "Style guide",
     id: "6KrEdJWOHm",
-    description: "Section heading for translation guidance preview on project overview",
+    description: "Section heading for the style guide preview on project overview",
   },
   guidanceEdit: {
     defaultMessage: "Edit",
     id: "Hvpl2DhEOB",
-    description: "Link to edit translation guidance in project settings",
+    description: "Link to edit the style guide in project settings",
   },
   shipTitle: {
     defaultMessage: "Sync",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
@@ -77,7 +77,7 @@ export const projectOverviewPageContentMessages = defineMessages({
   },
   addGuidanceCta: {
     defaultMessage: "Add style guide",
-    id: "U+ZJP/RMin",
+    id: "Z92vemu70G",
     description: "CTA when the project style guide is missing on project overview",
   },
   triageReviewTitle: {
@@ -92,12 +92,12 @@ export const projectOverviewPageContentMessages = defineMessages({
   },
   triageGuidanceTitle: {
     defaultMessage: "Add a style guide",
-    id: "DGx/LlMkDv",
+    id: "2DwX6LeAoB",
     description: "Title when the native project style guide is missing",
   },
   triageGuidanceDescription: {
     defaultMessage: "Shared tone and terminology so agents stay consistent.",
-    id: "+y5oYiRfPw",
+    id: "X02KnwxTqG",
     description: "Description when the native project style guide is missing",
   },
   triageJobRunning: {
@@ -127,12 +127,12 @@ export const projectOverviewPageContentMessages = defineMessages({
   },
   guidanceTitle: {
     defaultMessage: "Style guide",
-    id: "6KrEdJWOHm",
+    id: "dPOyhsBM1G",
     description: "Section heading for the style guide preview on project overview",
   },
   guidanceEdit: {
     defaultMessage: "Edit",
-    id: "Hvpl2DhEOB",
+    id: "4/O19yxuqg",
     description: "Link to edit the style guide in project settings",
   },
   shipTitle: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
@@ -58,7 +58,7 @@ export const Default: Story = {
           content.includes("de-DE") && content.includes("es-ES") && content.includes("Mina"),
       ),
     ).toBeInTheDocument();
-    await expect(canvas.getByText("Translation guidance")).toBeInTheDocument();
+    await expect(canvas.getByText("Style guide")).toBeInTheDocument();
     await expect(canvas.getByText("Sync")).toBeInTheDocument();
     await expect(canvas.queryByText("Locale health")).toBeNull();
   },
@@ -83,8 +83,8 @@ export const MissingGuidance: Story = {
     jobs: [],
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Add translation guidance")).toBeInTheDocument();
-    await expect(canvas.getByText("Add guidance")).toBeInTheDocument();
+    await expect(canvas.getByText("Add a style guide")).toBeInTheDocument();
+    await expect(canvas.getByText("Add style guide")).toBeInTheDocument();
   },
 };
 
@@ -99,7 +99,7 @@ export const TmsProject: Story = {
       "/org/acme/projects/ext%3Acrowdin%3A42/strings",
     );
     await expect(canvas.queryByText("Sync")).toBeNull();
-    await expect(canvas.queryByText("Translation guidance")).toBeNull();
+    await expect(canvas.queryByText("Style guide")).toBeNull();
     await expect(canvas.getByText("Locales")).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -19,6 +19,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { buildProjectPath } from "@/components/app-shell/navigation-config";
+import { MarkdownPreview } from "@/components/markdown-editor/markdown-editor";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
@@ -427,14 +428,12 @@ export function ProjectOverviewPageContentView({
               <FormattedMessage {...messages.guidanceEdit} />
             </Button>
           </div>
-          <TypographyP
-            className="whitespace-pre-wrap leading-6"
-            lineClamp={3}
-            size="small"
-            tone="subtle"
-          >
-            {project?.translationContextValue}
-          </TypographyP>
+          <MarkdownPreview
+            value={project?.translationContextValue ?? ""}
+            chrome="minimal"
+            className="line-clamp-6"
+            contentClassName="text-sm leading-6 text-subtle-foreground"
+          />
         </section>
       ) : null}
     </ProjectPageShell>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.messages.ts
@@ -99,24 +99,24 @@ export const projectSettingsPageContentMessages = defineMessages({
   },
   styleGuideTitle: {
     defaultMessage: "Style guide",
-    id: "iL9/D33IcM",
+    id: "PBd06JWdET",
     description: "Heading for the project style guide settings section",
   },
   styleGuideDescription: {
     defaultMessage:
       "Tone, terminology, and formatting rules for translators and agents. Write this as markdown.",
-    id: "DR8B4GRFYT",
+    id: "E316KXeVHB",
     description: "Description for the project style guide settings section",
   },
   styleGuideLabel: {
     defaultMessage: "Style guide",
-    id: "/uFRS+73Kw",
+    id: "MsLC2ttSM5",
     description: "Accessible label for the project style guide editor",
   },
   styleGuidePlaceholder: {
     defaultMessage:
       "Keep product names in English. Use concise UI copy. Prefer an informal tone for marketing pages.",
-    id: "k2nQ8sL4pR",
+    id: "V9FwiTxbs+",
     description: "Placeholder shown in the empty project style guide editor",
   },
   localesTitle: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.messages.ts
@@ -97,20 +97,27 @@ export const projectSettingsPageContentMessages = defineMessages({
     id: "gCJJUH5CEa",
     description: "Help text under the project description field",
   },
-  translationGuidanceTitle: {
-    defaultMessage: "Translation guidance",
+  styleGuideTitle: {
+    defaultMessage: "Style guide",
     id: "iL9/D33IcM",
-    description: "Heading for the translation guidance settings section",
+    description: "Heading for the project style guide settings section",
   },
-  translationGuidanceDescription: {
-    defaultMessage: "Shared instructions for tone, terminology, formatting, and product context.",
+  styleGuideDescription: {
+    defaultMessage:
+      "Tone, terminology, and formatting rules for translators and agents. Write this as markdown.",
     id: "DR8B4GRFYT",
-    description: "Description for the translation guidance settings section",
+    description: "Description for the project style guide settings section",
   },
-  guidanceLabel: {
-    defaultMessage: "Guidance",
+  styleGuideLabel: {
+    defaultMessage: "Style guide",
     id: "/uFRS+73Kw",
-    description: "Label for the translation guidance field",
+    description: "Accessible label for the project style guide editor",
+  },
+  styleGuidePlaceholder: {
+    defaultMessage:
+      "Keep product names in English. Use concise UI copy. Prefer an informal tone for marketing pages.",
+    id: "k2nQ8sL4pR",
+    description: "Placeholder shown in the empty project style guide editor",
   },
   localesTitle: {
     defaultMessage: "Locales",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.test.tsx
@@ -84,17 +84,20 @@ vi.mock("./project-issue-columns-settings", () => ({
 
 vi.mock("@/components/markdown-editor/markdown-editor", () => ({
   MarkdownEditor: ({
+    id,
     value,
     onChange,
     ariaLabel,
     disabled,
   }: {
+    id?: string;
     value: string;
     onChange: (next: string) => void;
     ariaLabel?: string;
     disabled?: boolean;
   }) => (
     <textarea
+      id={id}
       aria-label={ariaLabel}
       value={value}
       disabled={disabled}
@@ -278,6 +281,7 @@ describe("ProjectSettingsPageContent", () => {
     renderSettings();
 
     const styleGuide = await screen.findByLabelText("Style guide");
+    expect(styleGuide).toHaveAttribute("id", "translation-context");
     await user.clear(styleGuide);
     await user.type(styleGuide, "Keep product names in English.");
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.test.tsx
@@ -82,6 +82,27 @@ vi.mock("./project-issue-columns-settings", () => ({
   ProjectIssueColumnsSettings: () => null,
 }));
 
+vi.mock("@/components/markdown-editor/markdown-editor", () => ({
+  MarkdownEditor: ({
+    value,
+    onChange,
+    ariaLabel,
+    disabled,
+  }: {
+    value: string;
+    onChange: (next: string) => void;
+    ariaLabel?: string;
+    disabled?: boolean;
+  }) => (
+    <textarea
+      aria-label={ariaLabel}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
+  ),
+}));
+
 import { ProjectSettingsPageContent } from "./project-settings-page-content";
 
 function createProject(overrides: Partial<ProjectListRow> = {}): ProjectListRow {
@@ -250,5 +271,23 @@ describe("ProjectSettingsPageContent", () => {
 
     expect(screen.queryByRole("button", { name: "Save settings" })).not.toBeInTheDocument();
     expect(screen.getByText("Loading project settings...")).toBeInTheDocument();
+  });
+
+  it("saves markdown style guide content as translation context", async () => {
+    const user = userEvent.setup();
+    renderSettings();
+
+    const styleGuide = await screen.findByLabelText("Style guide");
+    await user.clear(styleGuide);
+    await user.type(styleGuide, "Keep product names in English.");
+
+    await user.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() => expect(patchMock).toHaveBeenCalled());
+    expect(patchMock.mock.calls[0]?.[0]).toMatchObject({
+      json: expect.objectContaining({
+        translationContext: "Keep product names in English.",
+      }),
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -457,20 +457,19 @@ export function ProjectSettingsPageContent({
               </TypographyP>
             </div>
             <Field className="gap-1.5" data-invalid={Boolean(errors.translationContext)}>
-              <div id="translation-context">
-                <MarkdownEditor
-                  value={values.translationContext}
-                  disabled={isSaving}
-                  onChange={(translationContext) =>
-                    setValues((current) => (current ? { ...current, translationContext } : current))
-                  }
-                  ariaLabel={intl.formatMessage(projectSettingsPageContentMessages.styleGuideLabel)}
-                  placeholder={intl.formatMessage(
-                    projectSettingsPageContentMessages.styleGuidePlaceholder,
-                  )}
-                  className="[&_.tiptap]:min-h-36"
-                />
-              </div>
+              <MarkdownEditor
+                id="translation-context"
+                value={values.translationContext}
+                disabled={isSaving}
+                onChange={(translationContext) =>
+                  setValues((current) => (current ? { ...current, translationContext } : current))
+                }
+                ariaLabel={intl.formatMessage(projectSettingsPageContentMessages.styleGuideLabel)}
+                placeholder={intl.formatMessage(
+                  projectSettingsPageContentMessages.styleGuidePlaceholder,
+                )}
+                className="[&_.tiptap]:min-h-36"
+              />
               <FieldError
                 errors={
                   errors.translationContext ? [{ message: errors.translationContext }] : undefined

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -19,6 +19,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
+import { MarkdownEditor } from "@/components/markdown-editor/markdown-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Field, FieldDescription, FieldError, FieldLabel } from "@/components/ui/field";
@@ -360,7 +361,7 @@ export function ProjectSettingsPageContent({
         section="Settings"
         description={
           metadataEditable
-            ? "Edit project metadata, translation guidance, locales, and source connection details."
+            ? "Edit project metadata, style guide, locales, and source connection details."
             : "View provider-managed project metadata, locales, and source connection details. You can still edit the issue identifier."
         }
       />
@@ -449,33 +450,29 @@ export function ProjectSettingsPageContent({
           <section className="grid gap-4 rounded-lg border border-border bg-muted p-4">
             <div>
               <ProjectSectionTitle>
-                <FormattedMessage
-                  {...projectSettingsPageContentMessages.translationGuidanceTitle}
-                />
+                <FormattedMessage {...projectSettingsPageContentMessages.styleGuideTitle} />
               </ProjectSectionTitle>
               <TypographyP className="mt-1" size="small" tone="subtle">
-                <FormattedMessage
-                  {...projectSettingsPageContentMessages.translationGuidanceDescription}
-                />
+                <FormattedMessage {...projectSettingsPageContentMessages.styleGuideDescription} />
               </TypographyP>
             </div>
-            <Field className="gap-1.5">
-              <FieldLabel htmlFor="translation-context">
-                <FormattedMessage {...projectSettingsPageContentMessages.guidanceLabel} />
-              </FieldLabel>
-              <Textarea
-                id="translation-context"
-                value={values.translationContext}
-                disabled={isSaving}
-                onChange={(event) =>
-                  setValues((current) =>
-                    current ? { ...current, translationContext: event.target.value } : current,
-                  )
-                }
-                aria-invalid={Boolean(errors.translationContext)}
-                className="min-h-36"
-                placeholder="Example: Keep product names in English. Use concise UI copy. Prefer informal tone for marketing pages."
-              />
+            <Field className="gap-1.5" data-invalid={Boolean(errors.translationContext)}>
+              <div id="translation-context">
+                <MarkdownEditor
+                  value={values.translationContext}
+                  disabled={isSaving}
+                  onChange={(translationContext) =>
+                    setValues((current) =>
+                      current ? { ...current, translationContext } : current,
+                    )
+                  }
+                  ariaLabel={intl.formatMessage(projectSettingsPageContentMessages.styleGuideLabel)}
+                  placeholder={intl.formatMessage(
+                    projectSettingsPageContentMessages.styleGuidePlaceholder,
+                  )}
+                  className="[&_.tiptap]:min-h-36"
+                />
+              </div>
               <FieldError
                 errors={
                   errors.translationContext ? [{ message: errors.translationContext }] : undefined

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -462,9 +462,7 @@ export function ProjectSettingsPageContent({
                   value={values.translationContext}
                   disabled={isSaving}
                   onChange={(translationContext) =>
-                    setValues((current) =>
-                      current ? { ...current, translationContext } : current,
-                    )
+                    setValues((current) => (current ? { ...current, translationContext } : current))
                   }
                   ariaLabel={intl.formatMessage(projectSettingsPageContentMessages.styleGuideLabel)}
                   placeholder={intl.formatMessage(

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -31,7 +31,11 @@ import { AppShellBreadcrumb } from "./app-shell-breadcrumb";
 import { AppShellNavigation } from "./app-shell-navigation";
 import { TmsUserConnectButton } from "./tms-user-connect-button";
 import { TmsUserOAuthErrorToast } from "./tms-user-oauth-error-toast";
-import { isOrganizationSettingsPath, type NavigationGroup } from "./navigation-config";
+import {
+  isOrganizationSettingsPath,
+  parseProjectRoute,
+  type NavigationGroup,
+} from "./navigation-config";
 import { AppShellHeaderActions } from "./store/app-shell-header-actions";
 import { AppShellStoreProvider } from "./store/app-shell-store-context";
 import { SidebarStoreBridge } from "./store/sidebar-store-bridge";
@@ -85,6 +89,7 @@ export function AppShellClient({
   const intl = useIntl();
   const pathname = usePathname();
   const organizationSlug = activeOrganization.slug ?? "";
+  const projectRoute = parseProjectRoute(pathname);
   const isContentEditorWorkspaceRoute =
     pathname.includes("/strings") || pathname.includes("/files/content-editor");
   const isOrgSettingsRoute = isOrganizationSettingsPath(pathname);
@@ -202,9 +207,11 @@ export function AppShellClient({
 
         <AppShellFooter
           organizationSlug={organizationSlug}
+          projectId={projectRoute?.projectId ?? null}
           showPlan={showBillingLink && autumnConfigured}
           showGlossaryGuidance={isContentEditorWorkspaceRoute}
           showIssueGuidance={isContentEditorWorkspaceRoute}
+          showStyleGuide={isContentEditorWorkspaceRoute}
           currentUser={
             organizationSlug
               ? {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -66,6 +66,7 @@ type AppShellClientProps = {
   showApiKeysLink?: boolean;
   showBillingLink?: boolean;
   showMembersLink?: boolean;
+  canWriteProjects?: boolean;
   user: {
     name: string;
     email: string;
@@ -84,6 +85,7 @@ export function AppShellClient({
   showApiKeysLink = false,
   showBillingLink = false,
   showMembersLink = false,
+  canWriteProjects = false,
   user,
 }: AppShellClientProps) {
   const intl = useIntl();
@@ -212,6 +214,7 @@ export function AppShellClient({
           showGlossaryGuidance={isContentEditorWorkspaceRoute}
           showIssueGuidance={isContentEditorWorkspaceRoute}
           showStyleGuide={isContentEditorWorkspaceRoute}
+          canWriteProjects={canWriteProjects}
           currentUser={
             organizationSlug
               ? {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -51,6 +51,16 @@ export const appShellFooterMessages = defineMessages({
     id: "dKznjRBgya",
     description: "Label for the Board button in the app shell footer",
   },
+  styleGuideAriaLabel: {
+    defaultMessage: "Open style guide",
+    id: "sG8nFtrA1b",
+    description: "Accessible label for the style guide button in the app shell footer",
+  },
+  styleGuideLabel: {
+    defaultMessage: "Style guide",
+    id: "sG8nFtrA1c",
+    description: "Label for the style guide button in the app shell footer",
+  },
   supportLabel: {
     defaultMessage: "Support",
     id: "VvLbwcYPHK",

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -53,12 +53,12 @@ export const appShellFooterMessages = defineMessages({
   },
   styleGuideAriaLabel: {
     defaultMessage: "Open style guide",
-    id: "sG8nFtrA1b",
+    id: "3MzWPxEFTr",
     description: "Accessible label for the style guide button in the app shell footer",
   },
   styleGuideLabel: {
     defaultMessage: "Style guide",
-    id: "sG8nFtrA1c",
+    id: "FK5XT+2lld",
     description: "Label for the style guide button in the app shell footer",
   },
   supportLabel: {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
@@ -12,6 +12,7 @@
  */
 import { useEffect, type CSSProperties, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import { AppShellStoreProvider } from "@/components/app-shell/store/app-shell-store-context";
@@ -41,19 +42,21 @@ const currentUser = {
 
 function FooterStoryFrame({ children }: { children: ReactNode }) {
   return (
-    <AppShellStoreProvider defaultNavigationGroups={[]}>
-      <div
-        className="min-h-screen bg-muted/20 text-foreground"
-        style={{ "--app-shell-plan-footer-height": "3rem" } as CSSProperties}
-      >
-        <div className="mx-auto max-w-5xl px-6 py-10">
-          <p className="text-sm text-muted-foreground">
-            App shell content placeholder so the fixed footer is shown in context.
-          </p>
+    <QueryClientProvider client={new QueryClient()}>
+      <AppShellStoreProvider defaultNavigationGroups={[]}>
+        <div
+          className="min-h-screen bg-muted/20 text-foreground"
+          style={{ "--app-shell-plan-footer-height": "3rem" } as CSSProperties}
+        >
+          <div className="mx-auto max-w-5xl px-6 py-10">
+            <p className="text-sm text-muted-foreground">
+              App shell content placeholder so the fixed footer is shown in context.
+            </p>
+          </div>
+          {children}
         </div>
-        {children}
-      </div>
-    </AppShellStoreProvider>
+      </AppShellStoreProvider>
+    </QueryClientProvider>
   );
 }
 
@@ -197,6 +200,16 @@ export const GlossaryDefault: Story = {
     await expect(
       canvas.getByRole("button", { name: "Open glossary guidance" }),
     ).toBeInTheDocument();
+  },
+};
+
+export const StyleGuide: Story = {
+  args: {
+    showStyleGuide: true,
+    projectId: "project_website",
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Open style guide" })).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -39,13 +39,12 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/components/content-editor/style-guide/content-editor-style-guide-sheet", () => ({
-  ContentEditorStyleGuideSheet: ({
-    open,
-    projectId,
-  }: {
-    open: boolean;
-    projectId: string;
-  }) => (open ? <div role="dialog" aria-label="Style guide">{projectId}</div> : null),
+  ContentEditorStyleGuideSheet: ({ open, projectId }: { open: boolean; projectId: string }) =>
+    open ? (
+      <div role="dialog" aria-label="Style guide">
+        {projectId}
+      </div>
+    ) : null,
 }));
 
 afterEach(() => {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -38,6 +38,16 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/org/acme/dashboard",
 }));
 
+vi.mock("@/components/content-editor/style-guide/content-editor-style-guide-sheet", () => ({
+  ContentEditorStyleGuideSheet: ({
+    open,
+    projectId,
+  }: {
+    open: boolean;
+    projectId: string;
+  }) => (open ? <div role="dialog" aria-label="Style guide">{projectId}</div> : null),
+}));
+
 afterEach(() => {
   autumnMocks.useCustomer.mockReset();
   autumnMocks.useListPlans.mockReset();
@@ -47,16 +57,20 @@ afterEach(() => {
 function renderFooter(
   props: {
     organizationSlug?: string;
+    projectId?: string | null;
     showPlan?: boolean;
     withChat?: boolean;
     showIssueGuidance?: boolean;
+    showStyleGuide?: boolean;
   } = {},
 ) {
   const {
     organizationSlug = "acme",
+    projectId = null,
     showPlan = true,
     withChat = false,
     showIssueGuidance = false,
+    showStyleGuide = false,
   } = props;
 
   return render(
@@ -65,8 +79,10 @@ function renderFooter(
         <AppShellStoreProvider defaultNavigationGroups={[]}>
           <AppShellFooter
             organizationSlug={organizationSlug}
+            projectId={projectId}
             showPlan={showPlan}
             showIssueGuidance={showIssueGuidance}
+            showStyleGuide={showStyleGuide}
             currentUser={
               withChat
                 ? {
@@ -181,5 +197,20 @@ describe("AppShellFooter", () => {
     } finally {
       window.removeEventListener(CAT_ISSUE_GUIDANCE_OPEN_EVENT, openListener);
     }
+  });
+
+  it("opens the style guide sheet from the footer on content editor routes", async () => {
+    const user = userEvent.setup();
+    renderFooter({
+      showPlan: false,
+      showStyleGuide: true,
+      projectId: "project_1",
+    });
+
+    expect(screen.queryByRole("dialog", { name: "Style guide" })).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Open style guide" }));
+
+    expect(screen.getByRole("dialog", { name: "Style guide" })).toHaveTextContent("project_1");
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -210,6 +210,8 @@ describe("AppShellFooter", () => {
 
     await user.click(screen.getByRole("button", { name: "Open style guide" }));
 
-    expect(screen.getByRole("dialog", { name: "Style guide" })).toHaveTextContent("project_1");
+    expect(await screen.findByRole("dialog", { name: "Style guide" })).toHaveTextContent(
+      "project_1",
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -13,6 +13,7 @@
  * Version 2.0 or later.
  */
 import { useEffect, useState, useSyncExternalStore } from "react";
+import dynamic from "next/dynamic";
 import {
   BookOpenTextIcon,
   CheckmarkCircle02Icon,
@@ -44,7 +45,6 @@ import {
   requestCatIssueGuidance,
   subscribeCatIssueGuidance,
 } from "@/components/content-editor/issues/content-editor-issue-guidance-event";
-import { ContentEditorStyleGuideSheet } from "@/components/content-editor/style-guide/content-editor-style-guide-sheet";
 import { Button } from "@/components/ui/button";
 import { Box } from "@/components/ui/layout/box";
 import { Column } from "@/components/ui/layout/column";
@@ -54,6 +54,16 @@ import { SUPPORT_EMAIL } from "@/lib/support-contact";
 
 import { appShellFooterMessages } from "./app-shell-footer.messages";
 
+const ContentEditorStyleGuideSheet = dynamic(
+  () =>
+    import("@/components/content-editor/style-guide/content-editor-style-guide-sheet").then(
+      (module) => ({
+        default: module.ContentEditorStyleGuideSheet,
+      }),
+    ),
+  { ssr: false },
+);
+
 export function AppShellFooter({
   organizationSlug,
   projectId = null,
@@ -61,6 +71,7 @@ export function AppShellFooter({
   showGlossaryGuidance = false,
   showIssueGuidance = false,
   showStyleGuide = false,
+  canWriteProjects = false,
   currentUser,
 }: {
   organizationSlug: string;
@@ -69,16 +80,19 @@ export function AppShellFooter({
   showGlossaryGuidance?: boolean;
   showIssueGuidance?: boolean;
   showStyleGuide?: boolean;
+  canWriteProjects?: boolean;
   currentUser?: InboxCurrentUser;
 }) {
   const intl = useIntl();
   const showChatDock = Boolean(organizationSlug && currentUser);
   const [styleGuideOpen, setStyleGuideOpen] = useState(false);
+  const [styleGuideMounted, setStyleGuideMounted] = useState(false);
   const canShowStyleGuide = showStyleGuide && Boolean(projectId);
 
   useEffect(() => {
     if (!canShowStyleGuide) {
       setStyleGuideOpen(false);
+      setStyleGuideMounted(false);
     }
   }, [canShowStyleGuide]);
 
@@ -119,7 +133,10 @@ export function AppShellFooter({
                   <Button
                     type="button"
                     variant="ghost"
-                    onClick={() => setStyleGuideOpen(true)}
+                    onClick={() => {
+                      setStyleGuideMounted(true);
+                      setStyleGuideOpen(true);
+                    }}
                     aria-label={intl.formatMessage(appShellFooterMessages.styleGuideAriaLabel)}
                   >
                     <HugeiconsIcon icon={TextFontIcon} strokeWidth={2} data-icon="inline-start" />
@@ -216,12 +233,13 @@ export function AppShellFooter({
           </Columns>
         </Box>
       </div>
-      {canShowStyleGuide && projectId ? (
+      {canShowStyleGuide && projectId && styleGuideMounted ? (
         <ContentEditorStyleGuideSheet
           organizationSlug={organizationSlug}
           projectId={projectId}
           open={styleGuideOpen}
           onOpenChange={setStyleGuideOpen}
+          canWriteProjects={canWriteProjects}
         />
       ) : null}
     </footer>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -81,6 +81,7 @@ export function AppShellFooter({
       setStyleGuideOpen(false);
     }
   }, [canShowStyleGuide]);
+
   const glossaryGuidanceStatus = useSyncExternalStore(
     subscribeCatGlossaryGuidance,
     getCatGlossaryGuidanceStatus,

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -12,13 +12,14 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import {
   BookOpenTextIcon,
   CheckmarkCircle02Icon,
   Copy01Icon,
   CustomerSupportIcon,
   MinusSignCircleIcon,
+  TextFontIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -43,6 +44,7 @@ import {
   requestCatIssueGuidance,
   subscribeCatIssueGuidance,
 } from "@/components/content-editor/issues/content-editor-issue-guidance-event";
+import { ContentEditorStyleGuideSheet } from "@/components/content-editor/style-guide/content-editor-style-guide-sheet";
 import { Button } from "@/components/ui/button";
 import { Box } from "@/components/ui/layout/box";
 import { Column } from "@/components/ui/layout/column";
@@ -54,19 +56,31 @@ import { appShellFooterMessages } from "./app-shell-footer.messages";
 
 export function AppShellFooter({
   organizationSlug,
+  projectId = null,
   showPlan,
   showGlossaryGuidance = false,
   showIssueGuidance = false,
+  showStyleGuide = false,
   currentUser,
 }: {
   organizationSlug: string;
+  projectId?: string | null;
   showPlan: boolean;
   showGlossaryGuidance?: boolean;
   showIssueGuidance?: boolean;
+  showStyleGuide?: boolean;
   currentUser?: InboxCurrentUser;
 }) {
   const intl = useIntl();
   const showChatDock = Boolean(organizationSlug && currentUser);
+  const [styleGuideOpen, setStyleGuideOpen] = useState(false);
+  const canShowStyleGuide = showStyleGuide && Boolean(projectId);
+
+  useEffect(() => {
+    if (!canShowStyleGuide) {
+      setStyleGuideOpen(false);
+    }
+  }, [canShowStyleGuide]);
   const glossaryGuidanceStatus = useSyncExternalStore(
     subscribeCatGlossaryGuidance,
     getCatGlossaryGuidanceStatus,
@@ -100,6 +114,17 @@ export function AppShellFooter({
             ) : null}
             <Column width="content">
               <Row spacing="1u" alignY="center">
+                {canShowStyleGuide && projectId ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setStyleGuideOpen(true)}
+                    aria-label={intl.formatMessage(appShellFooterMessages.styleGuideAriaLabel)}
+                  >
+                    <HugeiconsIcon icon={TextFontIcon} strokeWidth={2} data-icon="inline-start" />
+                    <FormattedMessage {...appShellFooterMessages.styleGuideLabel} />
+                  </Button>
+                ) : null}
                 {showGlossaryGuidance ? (
                   <Button
                     type="button"
@@ -190,6 +215,14 @@ export function AppShellFooter({
           </Columns>
         </Box>
       </div>
+      {canShowStyleGuide && projectId ? (
+        <ContentEditorStyleGuideSheet
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          open={styleGuideOpen}
+          onOpenChange={setStyleGuideOpen}
+        />
+      ) : null}
     </footer>
   );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.tsx
@@ -94,11 +94,13 @@ export const ContentEditorFooter: Story = {
   render: () => (
     <AppShellStoryFrame autumnConfigured showBillingLink>
       <p className="text-sm text-muted-foreground">
-        Content editor routes enable glossary and issue guidance controls in the footer.
+        Content editor routes enable style guide, glossary, and issue guidance controls in the
+        footer.
       </p>
     </AppShellStoryFrame>
   ),
   play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Open style guide" })).toBeInTheDocument();
     await expect(
       canvas.getByRole("button", { name: "Open glossary guidance" }),
     ).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -99,6 +99,7 @@ async function AppShellWithData({
       showApiKeysLink={hasCapability(auth.membership.role, "api_keys:read")}
       showBillingLink={hasCapability(auth.membership.role, "billing:read")}
       showMembersLink={hasCapability(auth.membership.role, "workspace:read")}
+      canWriteProjects={hasCapability(auth.membership.role, "projects:write")}
       user={{
         name: displayName,
         email: auth.sessionUser.email,

--- a/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.messages.ts
@@ -1,0 +1,48 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const contentEditorStyleGuideSheetMessages = defineMessages({
+  title: {
+    defaultMessage: "Style guide",
+    id: "sG8nQ2wL4k",
+    description: "Title for the content editor style guide sheet",
+  },
+  description: {
+    defaultMessage: "Project tone, terminology, and formatting for translators and agents.",
+    id: "sG8nQ2wL4m",
+    description: "Description for the content editor style guide sheet",
+  },
+  loading: {
+    defaultMessage: "Loading style guide...",
+    id: "sG8nQ2wL4n",
+    description: "Loading state for the content editor style guide sheet",
+  },
+  loadError: {
+    defaultMessage: "Unable to load the style guide.",
+    id: "sG8nQ2wL4o",
+    description: "Error state when the content editor style guide fails to load",
+  },
+  empty: {
+    defaultMessage: "No style guide yet. Add one in project settings.",
+    id: "sG8nQ2wL4p",
+    description: "Empty state when the project has no style guide",
+  },
+  editInSettings: {
+    defaultMessage: "Edit in settings",
+    id: "sG8nQ2wL4q",
+    description: "Link from the style guide sheet to project settings",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.messages.ts
@@ -17,32 +17,32 @@ import { defineMessages } from "react-intl";
 export const contentEditorStyleGuideSheetMessages = defineMessages({
   title: {
     defaultMessage: "Style guide",
-    id: "sG8nQ2wL4k",
+    id: "yKFLGCc18p",
     description: "Title for the content editor style guide sheet",
   },
   description: {
     defaultMessage: "Project tone, terminology, and formatting for translators and agents.",
-    id: "sG8nQ2wL4m",
+    id: "MTwF8eOJic",
     description: "Description for the content editor style guide sheet",
   },
   loading: {
     defaultMessage: "Loading style guide...",
-    id: "sG8nQ2wL4n",
+    id: "pqhSI7L7NV",
     description: "Loading state for the content editor style guide sheet",
   },
   loadError: {
     defaultMessage: "Unable to load the style guide.",
-    id: "sG8nQ2wL4o",
+    id: "AJdf6PzoHW",
     description: "Error state when the content editor style guide fails to load",
   },
   empty: {
     defaultMessage: "No style guide yet. Add one in project settings.",
-    id: "sG8nQ2wL4p",
+    id: "UlnuVlbp4t",
     description: "Empty state when the project has no style guide",
   },
   editInSettings: {
     defaultMessage: "Edit in settings",
-    id: "sG8nQ2wL4q",
+    id: "HCwou8cplr",
     description: "Link from the style guide sheet to project settings",
   },
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { IntlProvider } from "react-intl";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { ProjectListRow } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list";
+
+const { useProjectPageQueryMock } = vi.hoisted(() => ({
+  useProjectPageQueryMock: vi.fn(),
+}));
+
+vi.mock(
+  "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell",
+  () => ({
+    useProjectPageQuery: (...args: unknown[]) => useProjectPageQueryMock(...args),
+  }),
+);
+
+vi.mock("@/components/markdown-editor/markdown-editor", () => ({
+  MarkdownPreview: ({ value, emptyMessage }: { value: string; emptyMessage?: string }) => (
+    <div>{value.trim() ? value : emptyMessage}</div>
+  ),
+}));
+
+import { ContentEditorStyleGuideSheet } from "./content-editor-style-guide-sheet";
+
+function createProject(overrides: Partial<ProjectListRow> = {}): ProjectListRow {
+  return {
+    id: "project_1",
+    name: "Tourmatic",
+    key: "TM",
+    identifier: "TM",
+    description: "No description",
+    descriptionValue: "",
+    translationContext: "Keep product names in English.",
+    translationContextValue: "Keep product names in English.",
+    created: "Apr 29, 2026",
+    updated: "Apr 30, 2026",
+    source: "native",
+    externalProviderKind: null,
+    externalProjectId: null,
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR"],
+    externalProjectUrl: null,
+    isActive: true,
+    logoUrl: null,
+    lastActivityAt: null,
+    lastSyncedAt: null,
+    lastSyncErrorAt: null,
+    lastSyncErrorMessage: null,
+    openJobCount: 0,
+    ...overrides,
+  };
+}
+
+function renderSheet(project: ProjectListRow | undefined, options?: { isLoading?: boolean; isError?: boolean }) {
+  useProjectPageQueryMock.mockReturnValue({
+    isLoading: options?.isLoading ?? false,
+    isFetching: options?.isLoading ?? false,
+    isError: options?.isError ?? false,
+    isSuccess: Boolean(project),
+    data: project,
+    error: null,
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={new QueryClient()}>
+        <IntlProvider locale="en" messages={{}}>
+          {children}
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  return render(
+    <ContentEditorStyleGuideSheet
+      organizationSlug="acme"
+      projectId="project_1"
+      open
+      onOpenChange={vi.fn()}
+    />,
+    { wrapper: Wrapper },
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ContentEditorStyleGuideSheet", () => {
+  it("renders markdown style guide content and a settings link for native projects", () => {
+    renderSheet(createProject());
+
+    expect(screen.getByRole("dialog", { name: "Style guide" })).toBeTruthy();
+    expect(screen.getByText("Keep product names in English.")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Edit in settings" })).toHaveAttribute(
+      "href",
+      "/org/acme/projects/project_1/settings",
+    );
+  });
+
+  it("shows an empty state when the project has no style guide", () => {
+    renderSheet(
+      createProject({
+        translationContext: "No translation context",
+        translationContextValue: "",
+      }),
+    );
+
+    expect(screen.getByText("No style guide yet. Add one in project settings.")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Edit in settings" })).toBeTruthy();
+  });
+
+  it("hides the settings link for provider-managed projects", () => {
+    renderSheet(createProject({ source: "external_tms" }));
+
+    expect(screen.getByText("Keep product names in English.")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Edit in settings" })).toBeNull();
+  });
+
+  it("shows a loading state while the project is fetching", () => {
+    renderSheet(undefined, { isLoading: true });
+
+    expect(screen.getByText("Loading style guide...")).toBeTruthy();
+  });
+
+  it("shows an error when the project fails to load", () => {
+    renderSheet(undefined, { isError: true });
+
+    expect(screen.getByText("Unable to load the style guide.")).toBeTruthy();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.test.tsx
@@ -86,7 +86,7 @@ function createProject(overrides: Partial<ProjectListRow> = {}): ProjectListRow 
 
 function renderSheet(
   project: ProjectListRow | undefined,
-  options?: { isLoading?: boolean; isError?: boolean },
+  options?: { isLoading?: boolean; isError?: boolean; canWriteProjects?: boolean },
 ) {
   useProjectPageQueryMock.mockReturnValue({
     isLoading: options?.isLoading ?? false,
@@ -113,6 +113,7 @@ function renderSheet(
       projectId="project_1"
       open
       onOpenChange={vi.fn()}
+      canWriteProjects={options?.canWriteProjects ?? true}
     />,
     { wrapper: Wrapper },
   );
@@ -148,6 +149,13 @@ describe("ContentEditorStyleGuideSheet", () => {
 
   it("hides the settings link for provider-managed projects", () => {
     renderSheet(createProject({ source: "external_tms" }));
+
+    expect(screen.getByText("Keep product names in English.")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Edit in settings" })).toBeNull();
+  });
+
+  it("hides the settings link when the viewer cannot write projects", () => {
+    renderSheet(createProject(), { canWriteProjects: false });
 
     expect(screen.getByText("Keep product names in English.")).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Edit in settings" })).toBeNull();

--- a/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.test.tsx
@@ -24,6 +24,22 @@ const { useProjectPageQueryMock } = vi.hoisted(() => ({
   useProjectPageQueryMock: vi.fn(),
 }));
 
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    onClick,
+  }: {
+    href: string;
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock(
   "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell",
   () => ({
@@ -68,7 +84,10 @@ function createProject(overrides: Partial<ProjectListRow> = {}): ProjectListRow 
   };
 }
 
-function renderSheet(project: ProjectListRow | undefined, options?: { isLoading?: boolean; isError?: boolean }) {
+function renderSheet(
+  project: ProjectListRow | undefined,
+  options?: { isLoading?: boolean; isError?: boolean },
+) {
   useProjectPageQueryMock.mockReturnValue({
     isLoading: options?.isLoading ?? false,
     isFetching: options?.isLoading ?? false,

--- a/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import Link from "next/link";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { useProjectPageQuery } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell";
+import { buildProjectPath } from "@/components/app-shell/navigation-config";
+import { MarkdownPreview } from "@/components/markdown-editor/markdown-editor";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { TypographyP } from "@/components/ui/typography";
+
+import { contentEditorStyleGuideSheetMessages as messages } from "./content-editor-style-guide-sheet.messages";
+
+export function ContentEditorStyleGuideSheet({
+  organizationSlug,
+  projectId,
+  open,
+  onOpenChange,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const intl = useIntl();
+  const projectQuery = useProjectPageQuery(organizationSlug, projectId, { enabled: open });
+  const project = projectQuery.data;
+  const content = project?.translationContextValue ?? "";
+  const canEdit = project?.source === "native";
+  const settingsHref = buildProjectPath(organizationSlug, projectId, "settings");
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-xl" aria-busy={projectQuery.isFetching}>
+        <SheetHeader>
+          <SheetTitle>
+            <FormattedMessage {...messages.title} />
+          </SheetTitle>
+          <SheetDescription>
+            <FormattedMessage {...messages.description} />
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
+          {projectQuery.isLoading ? (
+            <TypographyP size="small" tone="subtle">
+              <FormattedMessage {...messages.loading} />
+            </TypographyP>
+          ) : null}
+
+          {projectQuery.isError ? (
+            <TypographyP className="text-flame-100" size="small">
+              <FormattedMessage {...messages.loadError} />
+            </TypographyP>
+          ) : null}
+
+          {project && !projectQuery.isLoading ? (
+            <MarkdownPreview
+              value={content}
+              emptyMessage={intl.formatMessage(messages.empty)}
+              className="border-border bg-transparent"
+            />
+          ) : null}
+        </div>
+
+        {canEdit ? (
+          <SheetFooter>
+            <Button
+              nativeButton={false}
+              variant="outline"
+              render={<Link href={settingsHref} />}
+              onClick={() => onOpenChange(false)}
+            >
+              <FormattedMessage {...messages.editInSettings} />
+            </Button>
+          </SheetFooter>
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/style-guide/content-editor-style-guide-sheet.tsx
@@ -36,17 +36,19 @@ export function ContentEditorStyleGuideSheet({
   projectId,
   open,
   onOpenChange,
+  canWriteProjects = false,
 }: {
   organizationSlug: string;
   projectId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  canWriteProjects?: boolean;
 }) {
   const intl = useIntl();
   const projectQuery = useProjectPageQuery(organizationSlug, projectId, { enabled: open });
   const project = projectQuery.data;
   const content = project?.translationContextValue ?? "";
-  const canEdit = project?.source === "native";
+  const canEdit = canWriteProjects && project?.source === "native";
   const settingsHref = buildProjectPath(organizationSlug, projectId, "settings");
 
   return (

--- a/apps/hyperlocalise-web/src/components/markdown-editor/markdown-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/markdown-editor/markdown-editor.tsx
@@ -194,6 +194,7 @@ function useMarkdownEditorExtensions(
 }
 
 export function MarkdownEditor({
+  id,
   value,
   onChange,
   onBlur,
@@ -207,6 +208,7 @@ export function MarkdownEditor({
   onMentionNavigate,
   imageUpload = null,
 }: {
+  id?: string;
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;
@@ -364,6 +366,7 @@ export function MarkdownEditor({
       attributes: {
         class: editorContentClassName,
         "aria-label": resolvedAriaLabel,
+        ...(id ? { id } : {}),
       },
       handleClick: (_view, _pos, event) =>
         tryHandleMentionClick(event, onMentionNavigateRef.current),
@@ -460,6 +463,7 @@ export function MarkdownEditor({
         attributes: {
           class: editorContentClassName,
           "aria-label": resolvedAriaLabel,
+          ...(id ? { id } : {}),
         },
         handleClick: (_view, _pos, event) =>
           tryHandleMentionClick(event, onMentionNavigateRef.current),
@@ -502,7 +506,7 @@ export function MarkdownEditor({
         },
       },
     });
-  }, [editor, editorContentClassName, resolvedAriaLabel, scheduleBlurCommit]);
+  }, [editor, editorContentClassName, id, resolvedAriaLabel, scheduleBlurCommit]);
 
   // Editable TipTap leaves Link clicks to the browser when openOnClick is false.
   // Capture mention: navigation so drafts don't open raw mention URLs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Projects already store a style guide as `translationContext` on the settings page (previously labeled “Translation guidance” and edited as a plain textarea).

This change:

- Surfaces that field as **Style guide** in project settings and edits it with the existing TipTap `MarkdownEditor`
- Adds a **Style guide** button in the app shell footer on content editor routes (`/strings` and `/files/content-editor`)
- Opens a read-only sheet that renders the markdown guide
- Shows **Edit in settings** only for native projects when the viewer has `projects:write`
- Lazy-loads the style guide sheet after the first footer click so TipTap is not in the global footer bundle
- Puts the `translation-context` id on the TipTap contenteditable so validation can focus the editor
- Updates the project overview preview to use the same Style guide language and markdown rendering

## How to test

1. Open a native project’s **Settings** page
2. Confirm the Style guide section uses the markdown editor (headings, lists, formatting)
3. Save a markdown style guide
4. Open the project **Content Editor** (`/strings` or `/files/content-editor`)
5. Click **Style guide** in the app shell footer
6. Confirm the sheet shows the rendered markdown
7. Confirm **Edit in settings** appears for members who can write projects, and is hidden for translators/reviewers
8. Confirm an empty guide shows the empty state
9. Confirm the footer button is hidden outside the content editor
10. On settings, exceed the 20,000 character limit and save — focus should move to the style guide editor

Automated:

```
cd apps/hyperlocalise-web
vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.test.tsx src/components/app-shell/app-shell-footer.test.tsx src/components/content-editor/style-guide/content-editor-style-guide-sheet.test.tsx
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07520-9308-7003-bdd9-2f78cc937590?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07520-9308-7003-bdd9-2f78cc937590&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

