### PR TITLE
feat(overview): show daily counts on metric bar hover

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -18219,6 +18219,10 @@
     "defaultMessage": "Searching",
     "description": "Live explore status when the agent is searching without a subject"
   },
+  "n4Rk8Qm2vL": {
+    "defaultMessage": "{date}: {count}",
+    "description": "Tooltip for a daily count bar on an overview metric chart"
+  },
   "n4hpRZLl37": {
     "defaultMessage": "Add case",
     "description": "Button to add a switch case"
@@ -18926,6 +18930,10 @@
   "p7RJtpKZ+J": {
     "defaultMessage": "Call tools from a connected remote MCP server during this automation.",
     "description": "Description for the MCP Server automation tool when a connection exists"
+  },
+  "p7Wx3sT9hC": {
+    "defaultMessage": "{metric} by day: {values}",
+    "description": "Accessible summary of the daily count bars on an overview metric card"
   },
   "p8Xes8vaYS": {
     "defaultMessage": "Source & context",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.messages.ts
@@ -70,6 +70,16 @@ export const dashboardPageViewMessages = defineMessages({
     id: "21rpYl9weA",
     description: "Metric card subtitle for a 7-day lookback",
   },
+  sparklineBarTooltip: {
+    defaultMessage: "{date}: {count}",
+    id: "3aG6RMsKle",
+    description: "Tooltip for a daily count bar on an overview metric chart",
+  },
+  sparklineChartAriaLabel: {
+    defaultMessage: "{metric} by day: {values}",
+    id: "kF6mTL+t+j",
+    description: "Accessible summary of the daily count bars on an overview metric card",
+  },
   pausedCount: {
     defaultMessage: "{count} paused",
     id: "iN7gragIFi",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import type { ReactNode } from "react";
+import { render, screen, within } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { dailySeriesDays } from "@/lib/workspace/overview-snapshot-model";
+
+import { dashboardOverviewFixture } from "./dashboard.fixture";
+import { DashboardPageView } from "./dashboard-page-view";
+
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt?: string }) => <img alt={alt ?? ""} />,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+function renderDashboard() {
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      <TooltipProvider>
+        <DashboardPageView
+          organizationSlug="acme"
+          overview={dashboardOverviewFixture}
+          automationsEnabled
+          onNewRequest={() => undefined}
+        />
+      </TooltipProvider>
+    </IntlProvider>,
+  );
+}
+
+function formatBarLabel(day: Date, count: number) {
+  const date = new Intl.DateTimeFormat("en", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(day);
+  return `${date}: ${count}`;
+}
+
+describe("DashboardPageView sparkline", () => {
+  it("labels each bar with its date and count", () => {
+    renderDashboard();
+
+    const jobsChart = screen.getByRole("group", { name: /Jobs by day:/ });
+    expect(jobsChart).toHaveAccessibleName("Jobs by day: 4, 6, 5, 8, 7, 9, 9");
+
+    const jobsCounts = dashboardOverviewFixture.metrics.jobs.series;
+    const bars = within(jobsChart).getAllByRole("button");
+    expect(bars.map((bar) => bar.getAttribute("aria-label"))).toEqual(
+      dailySeriesDays().map((day, index) => formatBarLabel(day, jobsCounts[index] ?? 0)),
+    );
+    expect(bars[0]?.getAttribute("data-slot")).toBe("tooltip-trigger");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -21,16 +21,18 @@ import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
-import type {
-  OverviewActivityItem,
-  OverviewAutomationItem,
-  OverviewBoardItem,
-  OverviewJobKind,
-  OverviewProjectItem,
-  OverviewResolvedTitle,
-  WorkspaceOverviewSnapshot,
+import {
+  dailySeriesDays,
+  type OverviewActivityItem,
+  type OverviewAutomationItem,
+  type OverviewBoardItem,
+  type OverviewJobKind,
+  type OverviewProjectItem,
+  type OverviewResolvedTitle,
+  type WorkspaceOverviewSnapshot,
 } from "@/lib/workspace/overview-snapshot-model";
 
 import { OverviewConnectAgentCard } from "../../_components/overview/overview-connect-agent-card";
@@ -190,23 +192,55 @@ function formatOverviewProjectSubtitle(project: OverviewProjectItem, intl: IntlS
   return [project.domain, sourceLabel].filter((part): part is string => Boolean(part)).join(" · ");
 }
 
-function Sparkline({ series }: { series: readonly number[] }) {
+function Sparkline({ label, series }: { label: string; series: readonly number[] }) {
+  const intl = useIntl();
   const peak = Math.max(...series, 1);
+  const days = dailySeriesDays(undefined, series.length);
+  const chartLabel = intl.formatMessage(dashboardPageViewMessages.sparklineChartAriaLabel, {
+    metric: label,
+    values: series.map((value) => intl.formatNumber(value)).join(", "),
+  });
 
   return (
-    <div className="flex h-10 w-full shrink-0 items-end gap-[5px]" aria-hidden>
-      {series.map((value, index) => (
-        <div
-          key={index}
-          className={cn(
-            "grow rounded-[2px]",
-            SPARKLINE_BAR_CLASSES[index % SPARKLINE_BAR_CLASSES.length],
-          )}
-          style={{
-            height: `${SPARKLINE_MIN_HEIGHT_PX + (value / peak) * (SPARKLINE_MAX_HEIGHT_PX - SPARKLINE_MIN_HEIGHT_PX)}px`,
-          }}
-        />
-      ))}
+    <div
+      className="flex h-10 w-full shrink-0 items-end gap-[5px]"
+      role="group"
+      aria-label={chartLabel}
+    >
+      {series.map((value, index) => {
+        const day = days[index];
+        const tooltip = intl.formatMessage(dashboardPageViewMessages.sparklineBarTooltip, {
+          date: day
+            ? intl.formatDate(day, { day: "numeric", month: "short", timeZone: "UTC" })
+            : "",
+          count: intl.formatNumber(value),
+        });
+
+        return (
+          <Tooltip key={day?.toISOString() ?? index}>
+            <TooltipTrigger
+              delay={0}
+              render={
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={tooltip}
+                  className={cn(
+                    "min-w-0 grow rounded-[2px] border-0 p-0",
+                    SPARKLINE_BAR_CLASSES[index % SPARKLINE_BAR_CLASSES.length],
+                  )}
+                  style={{
+                    height: `${SPARKLINE_MIN_HEIGHT_PX + (value / peak) * (SPARKLINE_MAX_HEIGHT_PX - SPARKLINE_MIN_HEIGHT_PX)}px`,
+                  }}
+                />
+              }
+            />
+            <TooltipContent>
+              <span className="tabular-nums">{tooltip}</span>
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
     </div>
   );
 }
@@ -313,7 +347,7 @@ function OverviewMetricCard({
         </p>
         <p className="text-[13px] leading-5 text-muted-foreground">{detail}</p>
       </div>
-      {series ? <Sparkline series={series} /> : null}
+      {series ? <Sparkline label={label} series={series} /> : null}
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/workspace/overview-snapshot-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workspace/overview-snapshot-model.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   countOverviewAutomationStatuses,
+  dailySeriesDays,
   fillDailySeries,
   formatOverviewLocaleRoute,
   mergeOverviewProjectSources,
@@ -56,6 +57,15 @@ describe("overview snapshot helpers", () => {
         now,
       ),
     ).toEqual([0, 0, 0, 0, 4, 0, 2]);
+    expect(dailySeriesDays(now).map(utcDayKey)).toEqual([
+      "2026-08-29",
+      "2026-08-30",
+      "2026-08-31",
+      "2026-09-01",
+      "2026-09-02",
+      "2026-09-03",
+      "2026-09-04",
+    ]);
   });
 
   it("resolves external title, then metadata, then review or sync fallbacks", () => {

--- a/apps/hyperlocalise-web/src/lib/workspace/overview-snapshot-model.ts
+++ b/apps/hyperlocalise-web/src/lib/workspace/overview-snapshot-model.ts
@@ -115,21 +115,24 @@ export function utcDayKey(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+export function dailySeriesDays(now = new Date(), days = OVERVIEW_LOOKBACK_DAYS): Date[] {
+  const startUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const dates: Date[] = [];
+
+  for (let offset = days - 1; offset >= 0; offset -= 1) {
+    dates.push(new Date(startUtc - offset * 86_400_000));
+  }
+
+  return dates;
+}
+
 export function fillDailySeries(
   rows: readonly { day: string; count: number }[],
   now = new Date(),
   days = OVERVIEW_LOOKBACK_DAYS,
 ): number[] {
   const counts = new Map(rows.map((row) => [row.day, row.count]));
-  const series: number[] = [];
-  const startUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
-
-  for (let offset = days - 1; offset >= 0; offset -= 1) {
-    const day = new Date(startUtc - offset * 86_400_000);
-    series.push(counts.get(utcDayKey(day)) ?? 0);
-  }
-
-  return series;
+  return dailySeriesDays(now, days).map((day) => counts.get(utcDayKey(day)) ?? 0);
 }
 
 export function resolveOverviewJobTitle(job: OverviewJobTitleInput): OverviewResolvedTitle {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Hovering a bar on the Overview jobs or translations sparkline now shows that day's count. The tooltip includes the UTC date so each bar is identifiable in the 7-day series.

## How to test

1. Open the workspace Overview page (or the `App/Dashboard/Page` Storybook story).
2. Hover bars on the **Jobs** and **Translations** cards.
3. Confirm each tooltip shows `{date}: {count}` for that day.

Automated:

- `vp test` for `overview-snapshot-model.test.ts` and `dashboard-page-view.test.tsx`
- `vp check --fix`

Manual verification (Storybook Default story):

[overview-bar-chart-hover-tooltips.mp4](https://cursor.com/agents/bc-01a075bf-5a62-7389-8eb8-9ce244c2f662/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverview-bar-chart-hover-tooltips.mp4)

[Jobs sparkline tooltip showing Sep 6: 9](https://cursor.com/agents/bc-01a075bf-5a62-7389-8eb8-9ce244c2f662/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverview_jobs_bar_tooltip.png)
[Translations sparkline tooltip showing Sep 6: 62](https://cursor.com/agents/bc-01a075bf-5a62-7389-8eb8-9ce244c2f662/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverview_translations_bar_tooltip.png)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, focused `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a075bf-5a62-7389-8eb8-9ce244c2f662?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a075bf-5a62-7389-8eb8-9ce244c2f662&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

