### PR TITLE
fix(workflow): serialize AI features step as a POJO

### DIFF
--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job-ai-features.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job-ai-features.test.ts
@@ -26,10 +26,7 @@ vi.mock("@/lib/billing/ai-features", async (importOriginal) => {
   };
 });
 
-import {
-  AI_FEATURES_REQUIRED_CODE,
-  AI_FEATURES_REQUIRED_MESSAGE,
-} from "@/lib/billing/ai-features";
+import { AI_FEATURES_REQUIRED_CODE, AI_FEATURES_REQUIRED_MESSAGE } from "@/lib/billing/ai-features";
 import { ensureAiFeaturesAllowedStep } from "@/workflows/steps/translation-job";
 
 function expectPlainObject(value: unknown) {

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job-ai-features.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job-ai-features.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { err, ok } from "@/lib/primitives/result/results";
+
+const { ensureAiFeaturesAllowedMock } = vi.hoisted(() => ({
+  ensureAiFeaturesAllowedMock: vi.fn(),
+}));
+
+vi.mock("@/lib/billing/ai-features", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/billing/ai-features")>();
+  return {
+    ...actual,
+    ensureAiFeaturesAllowed: ensureAiFeaturesAllowedMock,
+  };
+});
+
+import {
+  AI_FEATURES_REQUIRED_CODE,
+  AI_FEATURES_REQUIRED_MESSAGE,
+} from "@/lib/billing/ai-features";
+import { ensureAiFeaturesAllowedStep } from "@/workflows/steps/translation-job";
+
+function expectPlainObject(value: unknown) {
+  expect(value).toEqual(expect.any(Object));
+  expect(Object.getPrototypeOf(value)).toBe(Object.prototype);
+}
+
+describe("ensureAiFeaturesAllowedStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a serializable POJO when AI features are allowed", async () => {
+    ensureAiFeaturesAllowedMock.mockResolvedValue(ok(undefined));
+
+    const result = await ensureAiFeaturesAllowedStep({ organizationId: "org_1" });
+
+    expect(result).toEqual({ ok: true });
+    expectPlainObject(result);
+    expect("value" in result).toBe(false);
+    expect(ensureAiFeaturesAllowedMock).toHaveBeenCalledWith({ organizationId: "org_1" });
+  });
+
+  it("returns a serializable POJO when AI features are denied", async () => {
+    ensureAiFeaturesAllowedMock.mockResolvedValue(
+      err({
+        code: AI_FEATURES_REQUIRED_CODE,
+        message: AI_FEATURES_REQUIRED_MESSAGE,
+      }),
+    );
+
+    const result = await ensureAiFeaturesAllowedStep({ organizationId: "org_1" });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: AI_FEATURES_REQUIRED_CODE,
+        message: AI_FEATURES_REQUIRED_MESSAGE,
+      },
+    });
+    expectPlainObject(result);
+    if (!result.ok) {
+      expectPlainObject(result.error);
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -28,9 +28,7 @@ export async function claimTranslationJobStep(input: {
  * Workflow DevKit serializes step returns with devalue. `Result` is a class
  * instance (`ok(undefined)`), so return a plain object instead.
  */
-export type AiFeaturesAllowedStepResult =
-  | { ok: true }
-  | { ok: false; error: AiFeaturesError };
+export type AiFeaturesAllowedStepResult = { ok: true } | { ok: false; error: AiFeaturesError };
 
 export async function ensureAiFeaturesAllowedStep(input: {
   organizationId: string;

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import type { AiFeaturesError } from "@/lib/billing/ai-features";
 import type { StringTranslationJobResult } from "@/lib/translation/domain";
 import type { ClaimedTranslationJob } from "@/lib/translation/jobs";
 import type { TranslationJobEventData } from "@/lib/workflow/types";
@@ -23,10 +24,24 @@ export async function claimTranslationJobStep(input: {
   return claimTranslationJob(input);
 }
 
-export async function ensureAiFeaturesAllowedStep(input: { organizationId: string }) {
+/**
+ * Workflow DevKit serializes step returns with devalue. `Result` is a class
+ * instance (`ok(undefined)`), so return a plain object instead.
+ */
+export type AiFeaturesAllowedStepResult =
+  | { ok: true }
+  | { ok: false; error: AiFeaturesError };
+
+export async function ensureAiFeaturesAllowedStep(input: {
+  organizationId: string;
+}): Promise<AiFeaturesAllowedStepResult> {
   "use step";
   const { ensureAiFeaturesAllowed } = await import("@/lib/billing/ai-features");
-  return ensureAiFeaturesAllowed(input);
+  const result = await ensureAiFeaturesAllowed(input);
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+  return { ok: true };
 }
 
 export async function executeClaimedTranslationJobStep(job: ClaimedTranslationJob) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

File translation workflows failed immediately after `ensureAiFeaturesAllowedStep` with:

```
WorkflowRuntimeError: Failed to serialize step return value
[cause]: DevalueError: Cannot stringify arbitrary non-POJOs
value: r { value: undefined, ok: true }
```

That step returned a `Result` class instance (`ok(undefined)`). Workflow DevKit serializes step returns with devalue, which only accepts plain objects.

The step now maps the billing gate to a plain `{ ok: true }` or `{ ok: false, error }` object. Denied jobs still fail with the same `aiFeatures.error.code` / `message` path.

## How to test

- `vp test src/workflows/steps/translation-job-ai-features.test.ts` (2 passed)
- `vp check --fix` (0 errors; existing unused-var warnings only)
- Re-run a file translation job that previously failed on `ensureAiFeaturesAllowedStep`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec4c34b7-f3d0-4907-859a-a38edf02a124?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec4c34b7-f3d0-4907-859a-a38edf02a124&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

