### PR TITLE
feat(web): gate reports behind a workspace flag

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/reports/reports.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/reports/reports.route.test.ts
@@ -12,22 +12,31 @@
  */
 import "dotenv/config";
 
-import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
     (options) =>
       globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
       globalThis.__testApiAuthContext ??
       null,
   ),
+  workspaceReportsFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
   return {
     ...actual,
-    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+    resolveApiAuthContextFromSession: mocks.resolveApiAuthContextFromSessionMock,
+  };
+});
+
+vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
+  return {
+    ...actual,
+    workspaceReportsFlag: { run: mocks.workspaceReportsFlagRunMock },
   };
 });
 
@@ -42,8 +51,12 @@ beforeAll(async () => {
   await db.$client.query("select 1");
 });
 
+beforeEach(() => {
+  mocks.workspaceReportsFlagRunMock.mockResolvedValue(true);
+});
+
 afterEach(async () => {
-  resolveApiAuthContextFromSessionMock.mockClear();
+  vi.clearAllMocks();
   await fixture.cleanup();
 });
 
@@ -102,6 +115,19 @@ describe("reports routes", () => {
     expect(created.status).toBe(201);
     await expect(created.json()).resolves.toMatchObject({
       rate: { name: "Default", step: "translation" },
+    });
+  });
+
+  it("denies report access when the feature flag is disabled", async () => {
+    mocks.workspaceReportsFlagRunMock.mockResolvedValue(false);
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const slug = identity.organization.slug ?? "missing-slug";
+
+    const response = await app.request(reportsUrl(slug), { headers });
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "feature_unavailable",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/reports/reports.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/reports/reports.route.ts
@@ -15,8 +15,10 @@ import { and, eq, inArray, desc, sql } from "drizzle-orm";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { hasCapability } from "@/api/auth/policy";
 import { getAccessibleProjectIds, buildAccessibleJobsWhere } from "@/api/auth/team-access";
+import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import { badRequestResponse, forbiddenResponse, notFoundResponse } from "@/api/response.schema";
 import { db, schema } from "@/lib/database/client";
+import { workspaceReportsFlag } from "@/lib/flags/workspace-flags";
 import { queryReport, reportCsv } from "@/lib/reporting/query";
 import { hourlyCost } from "@/lib/reporting/money";
 import { resolveReportingRate, reportingStart } from "@/lib/reporting/capture";
@@ -34,6 +36,13 @@ import {
 export function createReportsRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
+    .use(
+      "*",
+      createWorkspaceFeatureFlagMiddleware(
+        workspaceReportsFlag,
+        "Reports is not enabled for this workspace",
+      ),
+    )
     .get("/", async (c) => {
       const parsed = reportQuerySchema.safeParse(c.req.query());
       if (!parsed.success) return badRequestResponse(c, "invalid_report_query");

--- a/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
@@ -8,6 +8,7 @@ import {
   workspaceAutomationsFlag,
   workspaceDomainsFlag,
   workspaceKnowledgeFlag,
+  workspaceReportsFlag,
 } from "../../../../lib/flags/workspace-flags";
 
 export const GET = createFlagsDiscoveryEndpoint(async () =>
@@ -15,6 +16,7 @@ export const GET = createFlagsDiscoveryEndpoint(async () =>
     workspaceAutomationsFlag,
     workspaceDomainsFlag,
     workspaceKnowledgeFlag,
+    workspaceReportsFlag,
     releaseContentEditorAllFilesFlag,
     releaseSandboxVcrImageFlag,
   }),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -34,12 +34,14 @@ export function JobDetailPageContent({
   projectId,
   canEditJobFields,
   canEditSharedCredentialProviderJobFields = false,
+  reportsEnabled = false,
 }: {
   jobId: string;
   organizationSlug: string;
   projectId: string;
   canEditJobFields: boolean;
   canEditSharedCredentialProviderJobFields?: boolean;
+  reportsEnabled?: boolean;
 }) {
   const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
   const encodedProviderJobFromRoute = parseProviderJobId(jobId);
@@ -108,6 +110,7 @@ export function JobDetailPageContent({
       organizationSlug={organizationSlug}
       projectId={projectId}
       canEditJobFields={canEditJobFields}
+      reportsEnabled={reportsEnabled}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
@@ -86,11 +86,13 @@ export function NativeJobDetailContent({
   organizationSlug,
   projectId,
   canEditJobFields = false,
+  reportsEnabled = false,
 }: {
   jobId: string;
   organizationSlug: string;
   projectId: string;
   canEditJobFields?: boolean;
+  reportsEnabled?: boolean;
 }) {
   const [markFailedDialogOpen, setMarkFailedDialogOpen] = useState(false);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
@@ -398,13 +400,15 @@ export function NativeJobDetailContent({
                   showAgentActions={false}
                 />
               )
-            : () => (
-                <ReportsWorkspace
-                  organizationSlug={organizationSlug}
-                  projectId={projectId}
-                  jobId={jobId}
-                />
-              )
+            : reportsEnabled
+              ? () => (
+                  <ReportsWorkspace
+                    organizationSlug={organizationSlug}
+                    projectId={projectId}
+                    jobId={jobId}
+                  />
+                )
+              : undefined
         }
       />
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/page.tsx
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import { hasCapability, isWorkspaceOperatorRole } from "@/api/auth/policy";
+import { getWorkspaceFeatureFlagEnabled, workspaceReportsFlag } from "@/lib/flags/workspace-flags";
 import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
@@ -39,6 +40,7 @@ async function ProjectJobDetailPageLoader({
   const auth = await requireAppAuthContext({ organizationSlug });
   const canEditJobFields = hasCapability(auth.membership.role, "jobs:write");
   const canEditSharedCredentialProviderJobFields = isWorkspaceOperatorRole(auth.membership.role);
+  const reportsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceReportsFlag, auth);
 
   return (
     <JobDetailPageContent
@@ -47,6 +49,7 @@ async function ProjectJobDetailPageLoader({
       projectId={projectId}
       canEditJobFields={canEditJobFields}
       canEditSharedCredentialProviderJobFields={canEditSharedCredentialProviderJobFields}
+      reportsEnabled={reportsEnabled}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/reports/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/reports/page.tsx
@@ -10,8 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { OrgPageSuspense } from "../../../_components/org-page-suspense";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
+import { getWorkspaceFeatureFlagEnabled, workspaceReportsFlag } from "@/lib/flags/workspace-flags";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { ReportsWorkspace } from "@/components/reports/reports-workspace";
+
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
+
 export default function ReportsPage({
   params,
 }: {
@@ -23,11 +28,19 @@ export default function ReportsPage({
     </OrgPageSuspense>
   );
 }
+
 async function ReportsLoader({
   params,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+  const reportsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceReportsFlag, auth);
+
+  if (!reportsEnabled) {
+    return <FeatureTeaserPage feature="reports" scope="project" />;
+  }
+
   return <ReportsWorkspace organizationSlug={organizationSlug} projectId={projectId} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/reports/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/reports/page.tsx
@@ -10,8 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { OrgPageSuspense } from "../_components/org-page-suspense";
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
+import { getWorkspaceFeatureFlagEnabled, workspaceReportsFlag } from "@/lib/flags/workspace-flags";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { ReportsWorkspace } from "@/components/reports/reports-workspace";
+
+import { OrgPageSuspense } from "../_components/org-page-suspense";
+
 export default function ReportsPage({ params }: { params: Promise<{ organizationSlug: string }> }) {
   return (
     <OrgPageSuspense>
@@ -19,7 +24,15 @@ export default function ReportsPage({ params }: { params: Promise<{ organization
     </OrgPageSuspense>
   );
 }
+
 async function ReportsLoader({ params }: { params: Promise<{ organizationSlug: string }> }) {
   const { organizationSlug } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+  const reportsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceReportsFlag, auth);
+
+  if (!reportsEnabled) {
+    return <FeatureTeaserPage feature="reports" scope="workspace" />;
+  }
+
   return <ReportsWorkspace organizationSlug={organizationSlug} />;
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.messages.ts
@@ -40,4 +40,9 @@ export const appShellNavigationMessages = defineMessages({
     id: "qiPX0q5vvf",
     description: "Sidebar badge for gated features that link to teaser pages",
   },
+  trySection: {
+    defaultMessage: "Try",
+    id: "cCjEeqCM8J",
+    description: "Sidebar group label for gated features that are not yet enabled",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -12,6 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import type { ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { ArrowDown01Icon, ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -39,7 +40,10 @@ import {
 
 import { appShellNavigationMessages } from "./app-shell-navigation.messages";
 import { OrgNavLink } from "./org-nav-link";
-import { annotateNavigationItemsWithWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
+import {
+  annotateNavigationItemsWithWorkspaceFlags,
+  groupPreviewNavigationGroups,
+} from "@/lib/flags/workspace-flag-navigation";
 import { formatInboxUnreadBadgeLabel, inboxUnreadBadgeClassName } from "./inbox-unread-badge";
 
 import {
@@ -117,9 +121,15 @@ function GlobalNavigation({
   groups: readonly NavigationGroup[];
   pathname: string;
 }) {
+  const intl = useIntl();
+  const grouped = groupPreviewNavigationGroups(
+    groups,
+    intl.formatMessage(appShellNavigationMessages.trySection),
+  );
+
   return (
     <div className="flex flex-col gap-3">
-      {groups.map((group, groupIndex) => {
+      {grouped.map((group, groupIndex) => {
         const content = (
           <NavigationGroupItems
             group={group}
@@ -137,19 +147,9 @@ function GlobalNavigation({
         }
 
         return (
-          <Collapsible key={group.label} defaultOpen className={cn(groupIndex > 0 && "mt-2")}>
-            <SidebarGroup className="p-0">
-              <CollapsibleTrigger className="group/collapsible-trigger flex h-7 w-full items-center gap-2 rounded-md px-3 text-left text-xs font-medium tracking-wide text-muted-foreground uppercase outline-hidden transition-[margin,opacity,color] duration-200 hover:text-sidebar-foreground focus-visible:text-sidebar-foreground group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0">
-                <span className="min-w-0 flex-1 truncate">{group.label}</span>
-                <HugeiconsIcon
-                  icon={ArrowDown01Icon}
-                  strokeWidth={1.8}
-                  className="size-3.5 shrink-0 transition-transform group-data-panel-open/collapsible-trigger:rotate-180"
-                />
-              </CollapsibleTrigger>
-              <CollapsibleContent hiddenUntilFound>{content}</CollapsibleContent>
-            </SidebarGroup>
-          </Collapsible>
+          <LabeledNavigationSection key={group.label} label={group.label} offset={groupIndex > 0}>
+            {content}
+          </LabeledNavigationSection>
         );
       })}
     </div>
@@ -190,6 +190,10 @@ function ProjectNavigation({
     items ?? buildProjectNavigationItems(organizationSlug, projectId, intl),
     store.workspaceFeatureFlags,
   );
+  const tryLabel = intl.formatMessage(appShellNavigationMessages.trySection);
+  const grouped = groupPreviewNavigationGroups([{ items: resolvedItems }], tryLabel);
+  const tryGroup = grouped.find((group) => group.label === tryLabel);
+  const projectItems = grouped.find((group) => group.label !== tryLabel)?.items ?? [];
   const resolvedProjectName =
     projectName ??
     projectQuery.data?.name ??
@@ -232,13 +236,50 @@ function ProjectNavigation({
           )}
         </div>
         <NavigationGroupItems
-          group={{ items: resolvedItems }}
+          group={{ items: projectItems }}
           pathname={pathname}
           organizationSlug={organizationSlug}
           projectId={projectId}
         />
       </SidebarGroup>
+
+      {tryGroup ? (
+        <LabeledNavigationSection label={tryLabel} offset>
+          <NavigationGroupItems
+            group={tryGroup}
+            pathname={pathname}
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+          />
+        </LabeledNavigationSection>
+      ) : null}
     </div>
+  );
+}
+
+function LabeledNavigationSection({
+  label,
+  offset = false,
+  children,
+}: {
+  label: string;
+  offset?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Collapsible defaultOpen className={cn(offset && "mt-2")}>
+      <SidebarGroup className="p-0">
+        <CollapsibleTrigger className="group/collapsible-trigger flex h-7 w-full items-center gap-2 rounded-md px-3 text-left text-xs font-medium tracking-wide text-muted-foreground uppercase outline-hidden transition-[margin,opacity,color] duration-200 hover:text-sidebar-foreground focus-visible:text-sidebar-foreground group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0">
+          <span className="min-w-0 flex-1 truncate">{label}</span>
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            strokeWidth={1.8}
+            className="size-3.5 shrink-0 transition-transform group-data-panel-open/collapsible-trigger:rotate-180"
+          />
+        </CollapsibleTrigger>
+        <CollapsibleContent hiddenUntilFound>{children}</CollapsibleContent>
+      </SidebarGroup>
+    </Collapsible>
   );
 }
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.fixture.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.fixture.tsx
@@ -75,6 +75,7 @@ export const ALL_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
   domains: true,
   glossarySearch: true,
   hyperlab: true,
+  reports: true,
 };
 
 export function buildAppShellStoryNavigationGroups(locale: string = "en") {

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -20,6 +20,7 @@ import {
   WORKSPACE_DOMAINS_FLAG,
   WORKSPACE_HYPERLAB_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
+  WORKSPACE_REPORTS_FLAG,
 } from "@/lib/flags/workos-flag-entities";
 import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
 import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
@@ -208,6 +209,8 @@ describe("path builders", () => {
     expect(byLabel.get("Domains")?.featureFlagKey).toBe(WORKSPACE_DOMAINS_FLAG);
     expect(byLabel.get("Hyperlab")?.href).toBe("/org/acme/hyperlab");
     expect(byLabel.get("Hyperlab")?.featureFlagKey).toBe(WORKSPACE_HYPERLAB_FLAG);
+    expect(byLabel.get("Reports")?.href).toBe("/org/acme/reports");
+    expect(byLabel.get("Reports")?.featureFlagKey).toBe(WORKSPACE_REPORTS_FLAG);
 
     expect(groups.map((group) => group.label)).toEqual([undefined, "Agents", "Workspace"]);
     expect(groups[1]?.items.map((item) => item.label)).toEqual([
@@ -244,6 +247,9 @@ describe("path builders", () => {
     );
     expect(items.find((item) => item.label === "Guideline")?.featureFlagKey).toBe(
       WORKSPACE_KNOWLEDGE_FLAG,
+    );
+    expect(items.find((item) => item.label === "Reports")?.featureFlagKey).toBe(
+      WORKSPACE_REPORTS_FLAG,
     );
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -20,6 +20,7 @@ import {
   WORKSPACE_DOMAINS_FLAG,
   WORKSPACE_HYPERLAB_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
+  WORKSPACE_REPORTS_FLAG,
 } from "@/lib/flags/workos-flag-entities";
 import { supportsContentEditorAllFilesProvider } from "@/lib/projects/content-editor-all-files";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
@@ -27,6 +28,7 @@ import {
   BookOpenTextIcon,
   Bookmark01Icon,
   CenterFocusIcon,
+  ChartHistogramIcon,
   Copy01Icon,
   CubeIcon,
   DashboardSquare01Icon,
@@ -60,6 +62,7 @@ export type NavigationItem = {
     | typeof WORKSPACE_KNOWLEDGE_FLAG
     | typeof WORKSPACE_DOMAINS_FLAG
     | typeof WORKSPACE_HYPERLAB_FLAG
+    | typeof WORKSPACE_REPORTS_FLAG
     | typeof RELEASE_CAT_ALL_FILES_FLAG;
   /** When true, the feature flag is off and the nav item links to a teaser page. */
   preview?: boolean;
@@ -159,7 +162,8 @@ export function buildGlobalNavigationGroups(
             description: "Workspace translation reports",
           }),
           href: org("reports"),
-          icon: DashboardSquare01Icon,
+          icon: ChartHistogramIcon,
+          featureFlagKey: WORKSPACE_REPORTS_FLAG,
         },
       ],
     },
@@ -363,7 +367,8 @@ export function buildProjectNavigationItems(
         description: "Project translation reports",
       }),
       href: project("reports"),
-      icon: DashboardSquare01Icon,
+      icon: ChartHistogramIcon,
+      featureFlagKey: WORKSPACE_REPORTS_FLAG,
     },
     {
       label: intl.formatMessage({

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.stories.tsx
@@ -173,3 +173,29 @@ export const Hyperlab: Story = {
     await expect(canvas.getByRole("link", { name: "Contact us" })).toBeInTheDocument();
   },
 };
+
+export const Reports: Story = {
+  args: {
+    feature: "reports",
+    scope: "workspace",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/reports",
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Reports" })).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Know what translation is costing before the invoice arrives"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Q3 localisation volume")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Track words, time, and cost by project and locale"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Request a demo" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Contact us" })).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.tsx
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-page.tsx
@@ -23,6 +23,7 @@ import { AutomationsMockUI } from "@/components/marketing/product/automations-mo
 import { DomainsMockUI } from "@/components/marketing/product/domains-mock-ui";
 import { GuidelineMockUI } from "@/components/marketing/product/guideline-mock-ui";
 import { HyperlabMockUI } from "@/components/marketing/product/hyperlab-mock-ui";
+import { ReportsMockUI } from "@/components/marketing/product/reports-mock-ui";
 import type { MarketingMockMeshPosition } from "@/components/marketing/product/marketing-mock-shell";
 
 import { FeatureTeaserCtaPanel } from "./feature-teaser-cta-panel";
@@ -51,6 +52,8 @@ function FeatureTeaserShowcase({ feature, aside }: { feature: FeatureTeaserId; a
       return <DomainsMockUI {...teaserMockProps} aside={aside} />;
     case "hyperlab":
       return <HyperlabMockUI {...teaserMockProps} aside={aside} />;
+    case "reports":
+      return <ReportsMockUI {...teaserMockProps} aside={aside} />;
   }
 }
 

--- a/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-registry.ts
+++ b/apps/hyperlocalise-web/src/components/feature-teaser/feature-teaser-registry.ts
@@ -15,6 +15,7 @@
 import { defineMessages, type MessageDescriptor } from "react-intl";
 import {
   Bookmark01Icon,
+  ChartHistogramIcon,
   FlashIcon,
   FlaskConicalIcon,
   Globe02Icon,
@@ -22,7 +23,7 @@ import {
 
 import type { NavigationIcon } from "@/components/app-shell/navigation-config";
 
-export type FeatureTeaserId = "automations" | "guideline" | "domains" | "hyperlab";
+export type FeatureTeaserId = "automations" | "guideline" | "domains" | "hyperlab" | "reports";
 
 export type FeatureTeaserScope = "workspace" | "project";
 
@@ -73,6 +74,11 @@ export const featureTeaserMessages = defineMessages({
     defaultMessage: "Demo request: Hyperlab",
     id: "omHOw+4o9P",
     description: "Email subject for Hyperlab feature teaser contact link",
+  },
+  contactSubjectReports: {
+    defaultMessage: "Demo request: Reports",
+    id: "QRlf1XEwRc",
+    description: "Email subject for Reports feature teaser contact link",
   },
 
   automationsPageLabel: {
@@ -288,6 +294,58 @@ export const featureTeaserMessages = defineMessages({
     id: "cGCurVuGU/",
     description: "Feature teaser benefit for Hyperlab",
   },
+
+  reportsPageLabel: {
+    defaultMessage: "Workspace",
+    id: "tznfLKixWB",
+    description: "Feature teaser page label for workspace reports",
+  },
+  reportsPageLabelProject: {
+    defaultMessage: "Project",
+    id: "aDWMRaDSsk",
+    description: "Feature teaser page label for project reports",
+  },
+  reportsTitle: {
+    defaultMessage: "Reports",
+    id: "b/0QCcEDip",
+    description: "Feature teaser page title for reports",
+  },
+  reportsDescription: {
+    defaultMessage: "See word counts, time, and cost across projects so you can forecast spend.",
+    id: "Y2qBs5EsBK",
+    description: "Feature teaser page description for workspace reports",
+  },
+  reportsDescriptionProject: {
+    defaultMessage: "See word counts, time, and cost for this project before work overruns.",
+    id: "k1Ku5BR4yb",
+    description: "Feature teaser page description for project reports",
+  },
+  reportsEarlyAccessTitle: {
+    defaultMessage: "Know what translation is costing before the invoice arrives",
+    id: "3iwjDXakJS",
+    description: "Feature teaser early access title for reports",
+  },
+  reportsEarlyAccessDescription: {
+    defaultMessage:
+      "Reports rolls word counts, time, and vendor rates into one workspace view. Available in early access. Book a demo to see it on your volume.",
+    id: "0/uc5H+XGR",
+    description: "Feature teaser early access description for reports",
+  },
+  reportsBenefit0: {
+    defaultMessage: "Track words, time, and cost by project and locale",
+    id: "uG/a2iMgAc",
+    description: "Feature teaser benefit for reports",
+  },
+  reportsBenefit1: {
+    defaultMessage: "Set rates and budgets before work overruns",
+    id: "T+CONpD3t0",
+    description: "Feature teaser benefit for reports",
+  },
+  reportsBenefit2: {
+    defaultMessage: "Export the numbers finance and vendors already ask for",
+    id: "B3BorgouDo",
+    description: "Feature teaser benefit for reports",
+  },
 });
 
 export const featureTeaserRegistry: Record<FeatureTeaserId, FeatureTeaserConfig> = {
@@ -351,6 +409,21 @@ export const featureTeaserRegistry: Record<FeatureTeaserId, FeatureTeaserConfig>
       featureTeaserMessages.hyperlabBenefit2,
     ],
   },
+  reports: {
+    icon: ChartHistogramIcon,
+    pageLabel: featureTeaserMessages.reportsPageLabel,
+    pageLabelProject: featureTeaserMessages.reportsPageLabelProject,
+    pageTitle: featureTeaserMessages.reportsTitle,
+    pageDescription: featureTeaserMessages.reportsDescription,
+    pageDescriptionProject: featureTeaserMessages.reportsDescriptionProject,
+    earlyAccessTitle: featureTeaserMessages.reportsEarlyAccessTitle,
+    earlyAccessDescription: featureTeaserMessages.reportsEarlyAccessDescription,
+    benefits: [
+      featureTeaserMessages.reportsBenefit0,
+      featureTeaserMessages.reportsBenefit1,
+      featureTeaserMessages.reportsBenefit2,
+    ],
+  },
 };
 
 export const featureTeaserContactSubjects: Record<FeatureTeaserId, MessageDescriptor> = {
@@ -358,4 +431,5 @@ export const featureTeaserContactSubjects: Record<FeatureTeaserId, MessageDescri
   guideline: featureTeaserMessages.contactSubjectGuideline,
   domains: featureTeaserMessages.contactSubjectDomains,
   hyperlab: featureTeaserMessages.contactSubjectHyperlab,
+  reports: featureTeaserMessages.contactSubjectReports,
 };

--- a/apps/hyperlocalise-web/src/components/marketing/product/reports-mock-ui.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/reports-mock-ui.messages.ts
@@ -1,0 +1,130 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const reportsMockMessages = defineMessages({
+  eyebrow: {
+    defaultMessage: "Reports",
+    id: "4YZHJp3TTf",
+    description: "Reports mock UI eyebrow label",
+  },
+  headline: {
+    defaultMessage: "Word counts, time, and cost in one workspace view",
+    id: "pNiuJWXzZ/",
+    description: "Reports mock UI section heading",
+  },
+  requestDemo: {
+    defaultMessage: "Request a Demo",
+    id: "kwrN4tVZmS",
+    description: "Reports mock UI call-to-action button",
+  },
+
+  useCaseWordsTitle: {
+    defaultMessage: "Word counts",
+    id: "N68DJYdhtT",
+    description: "Reports mock UI word counts use case title",
+  },
+  useCaseWordsDescription: {
+    defaultMessage: "Source and workload words by project and locale",
+    id: "wPaeLzlE/q",
+    description: "Reports mock UI word counts use case description",
+  },
+  useCaseCostsTitle: {
+    defaultMessage: "Spend",
+    id: "VDIjD34xp9",
+    description: "Reports mock UI spend use case title",
+  },
+  useCaseCostsDescription: {
+    defaultMessage: "Vendor rates, accrued cost, and remaining budget",
+    id: "eVvfL6mYVo",
+    description: "Reports mock UI spend use case description",
+  },
+  useCaseTimeTitle: {
+    defaultMessage: "Time",
+    id: "nai+jIIHq8",
+    description: "Reports mock UI time use case title",
+  },
+  useCaseTimeDescription: {
+    defaultMessage: "Hours logged against translation and review",
+    id: "ZKajfLhp2+",
+    description: "Reports mock UI time use case description",
+  },
+
+  panelTitle: {
+    defaultMessage: "Q3 localisation volume",
+    id: "9CrGAdF92d",
+    description: "Reports mock UI dashboard panel title",
+  },
+  panelRange: {
+    defaultMessage: "1 Jul – 30 Sep",
+    id: "kdGPpCpall",
+    description: "Reports mock UI date range label",
+  },
+  sourceWords: {
+    defaultMessage: "Source words",
+    id: "n8Ah06y+R3",
+    description: "Reports mock UI source words metric label",
+  },
+  workloadWords: {
+    defaultMessage: "Workload words",
+    id: "vY4jaTW3UF",
+    description: "Reports mock UI workload words metric label",
+  },
+  accruedSpend: {
+    defaultMessage: "Accrued spend",
+    id: "CcgTbDz1bK",
+    description: "Reports mock UI accrued spend metric label",
+  },
+  budgetLeft: {
+    defaultMessage: "Budget remaining",
+    id: "pGsPfXixZ5",
+    description: "Reports mock UI budget remaining metric label",
+  },
+  hoursLogged: {
+    defaultMessage: "Hours logged",
+    id: "Om0BHjcSlW",
+    description: "Reports mock UI hours logged metric label",
+  },
+  reviewHours: {
+    defaultMessage: "Review hours",
+    id: "CWy7HumdqL",
+    description: "Reports mock UI review hours metric label",
+  },
+  localeJa: {
+    defaultMessage: "Japanese",
+    id: "KzRIFEhp9d",
+    description: "Reports mock UI Japanese locale row",
+  },
+  localeDe: {
+    defaultMessage: "German",
+    id: "61xU5NDlUo",
+    description: "Reports mock UI German locale row",
+  },
+  localeFr: {
+    defaultMessage: "French",
+    id: "wXjiwek9WE",
+    description: "Reports mock UI French locale row",
+  },
+  translationStep: {
+    defaultMessage: "Translation",
+    id: "wmX7YgFAaQ",
+    description: "Reports mock UI translation step label",
+  },
+  reviewStep: {
+    defaultMessage: "Review",
+    id: "pSKdUu/J4G",
+    description: "Reports mock UI review step label",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/reports-mock-ui.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/reports-mock-ui.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { ReportsMockUI } from "./reports-mock-ui";
+
+function ReportsMockShowcase({ variant = "full" }: { variant?: "full" | "embedded" }) {
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <ReportsMockUI variant={variant} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Marketing/Product/ReportsMock",
+  component: ReportsMockShowcase,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof ReportsMockShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Word counts, time, and cost in one workspace view",
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Word counts" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Spend" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Time" })).toBeInTheDocument();
+    await expect(canvas.getByText("Q3 localisation volume")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Request a Demo" })).toBeInTheDocument();
+  },
+};
+
+export const Embedded: Story = {
+  render: () => <ReportsMockShowcase variant="embedded" />,
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Q3 localisation volume")).toBeInTheDocument();
+    await expect(canvas.getByText("Source words")).toBeInTheDocument();
+    await expect(canvas.queryByRole("link", { name: "Request a Demo" })).not.toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/marketing/product/reports-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/reports-mock-ui.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useMemo, useState, type ReactNode } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { SAGE_MESH_GRADIENT_SRC } from "@/components/marketing/hero-frame-mesh-stage";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { reportsMockMessages } from "./reports-mock-ui.messages";
+import {
+  MarketingMockShell,
+  type MarketingMockMeshPosition,
+  type MarketingMockVariant,
+} from "./marketing-mock-shell";
+import { MarketingMockUseCaseSelector } from "./marketing-mock-use-case-selector";
+
+type ReportFocus = "words" | "costs" | "time";
+
+function ReportsDashboard({ focus }: { focus: ReportFocus }) {
+  const intl = useIntl();
+
+  const metrics = useMemo(() => {
+    if (focus === "costs") {
+      return [
+        { label: intl.formatMessage(reportsMockMessages.accruedSpend), value: "$4,820" },
+        { label: intl.formatMessage(reportsMockMessages.budgetLeft), value: "$1,180" },
+      ];
+    }
+
+    if (focus === "time") {
+      return [
+        { label: intl.formatMessage(reportsMockMessages.hoursLogged), value: "86.5" },
+        { label: intl.formatMessage(reportsMockMessages.reviewHours), value: "22.0" },
+      ];
+    }
+
+    return [
+      { label: intl.formatMessage(reportsMockMessages.sourceWords), value: "12,480" },
+      { label: intl.formatMessage(reportsMockMessages.workloadWords), value: "18,210" },
+    ];
+  }, [focus, intl]);
+
+  const rows: { locale: string; step: string; value: string; highlight?: boolean }[] =
+    useMemo(() => {
+      const locales = [
+        intl.formatMessage(reportsMockMessages.localeJa),
+        intl.formatMessage(reportsMockMessages.localeDe),
+        intl.formatMessage(reportsMockMessages.localeFr),
+      ];
+      const translation = intl.formatMessage(reportsMockMessages.translationStep);
+      const review = intl.formatMessage(reportsMockMessages.reviewStep);
+
+      if (focus === "costs") {
+        return [
+          { locale: locales[0], step: translation, value: "$2,140" },
+          { locale: locales[1], step: translation, value: "$1,560" },
+          { locale: locales[2], step: review, value: "$1,120", highlight: true },
+        ];
+      }
+
+      if (focus === "time") {
+        return [
+          { locale: locales[0], step: translation, value: "34.0 h" },
+          { locale: locales[1], step: translation, value: "28.5 h" },
+          { locale: locales[2], step: review, value: "24.0 h" },
+        ];
+      }
+
+      return [
+        { locale: locales[0], step: translation, value: "6,420" },
+        { locale: locales[1], step: translation, value: "5,180" },
+        { locale: locales[2], step: review, value: "6,610" },
+      ];
+    }, [focus, intl]);
+
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <div>
+          <div className="text-sm font-semibold text-foreground">
+            <FormattedMessage {...reportsMockMessages.panelTitle} />
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            <FormattedMessage {...reportsMockMessages.panelRange} />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 border-b border-border/50 px-4 py-4">
+        {metrics.map((metric) => (
+          <div key={metric.label} className="rounded-lg border border-border/60 px-3 py-2.5">
+            <div className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+              {metric.label}
+            </div>
+            <div className="mt-1 font-heading text-2xl font-medium tabular-nums text-foreground">
+              {metric.value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <ul className="divide-y divide-border/50">
+        {rows.map((row) => (
+          <li
+            key={`${row.locale}-${row.step}`}
+            className={cn(
+              "flex items-center justify-between gap-3 px-4 py-2.5 text-xs",
+              row.highlight ? "bg-primary/5" : undefined,
+            )}
+          >
+            <span className="font-medium text-foreground">{row.locale}</span>
+            <span className="text-muted-foreground">{row.step}</span>
+            <span className="tabular-nums text-foreground">{row.value}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function ReportsMockUI({
+  priority = false,
+  pauseAutoplay: _pauseAutoplay = false,
+  renderCta,
+  variant = "full",
+  aside,
+  meshPosition = "left",
+}: {
+  priority?: boolean;
+  pauseAutoplay?: boolean;
+  renderCta?: () => ReactNode;
+  variant?: MarketingMockVariant;
+  aside?: ReactNode;
+  meshPosition?: MarketingMockMeshPosition;
+}) {
+  const intl = useIntl();
+
+  const useCases = useMemo(
+    () => [
+      {
+        id: "words",
+        title: intl.formatMessage(reportsMockMessages.useCaseWordsTitle),
+        description: intl.formatMessage(reportsMockMessages.useCaseWordsDescription),
+      },
+      {
+        id: "costs",
+        title: intl.formatMessage(reportsMockMessages.useCaseCostsTitle),
+        description: intl.formatMessage(reportsMockMessages.useCaseCostsDescription),
+      },
+      {
+        id: "time",
+        title: intl.formatMessage(reportsMockMessages.useCaseTimeTitle),
+        description: intl.formatMessage(reportsMockMessages.useCaseTimeDescription),
+      },
+    ],
+    [intl],
+  );
+
+  const [activeId, setActiveId] = useState(useCases[0]?.id ?? "words");
+  const focus = (activeId as ReportFocus) || "words";
+
+  const sidebar =
+    variant === "full" ? (
+      <MarketingMockUseCaseSelector
+        eyebrow={reportsMockMessages.eyebrow}
+        headline={reportsMockMessages.headline}
+        useCases={useCases}
+        activeId={activeId}
+        onSelect={setActiveId}
+        cta={
+          renderCta === undefined ? (
+            <Button
+              variant="outline"
+              size="lg"
+              nativeButton={false}
+              render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+              className="cursor-pointer rounded-sm"
+            >
+              <FormattedMessage {...reportsMockMessages.requestDemo} />
+            </Button>
+          ) : (
+            renderCta()
+          )
+        }
+      />
+    ) : undefined;
+
+  return (
+    <MarketingMockShell
+      visual={<ReportsDashboard focus={focus} />}
+      sidebar={sidebar}
+      aside={aside}
+      meshSrc={SAGE_MESH_GRADIENT_SRC}
+      priority={priority}
+      variant={variant}
+      meshPosition={meshPosition}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   filterNavigationByWorkspaceFlags,
   annotateNavigationByWorkspaceFlags,
+  groupPreviewNavigationGroups,
 } from "@/lib/flags/workspace-flag-navigation";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 
@@ -164,6 +165,7 @@ describe("annotateNavigationByWorkspaceFlags", () => {
       domains: false,
       glossarySearch: false,
       hyperlab: false,
+      reports: false,
     });
 
     const automationsItem = annotated
@@ -175,10 +177,14 @@ describe("annotateNavigationByWorkspaceFlags", () => {
     const domainsItem = annotated
       .flatMap((group) => group.items)
       .find((item) => item.label === "Domains");
+    const reportsItem = annotated
+      .flatMap((group) => group.items)
+      .find((item) => item.label === "Reports");
 
     expect(automationsItem?.preview).toBe(true);
     expect(guidelineItem?.preview).toBe(true);
     expect(domainsItem?.preview).toBe(true);
+    expect(reportsItem?.preview).toBe(true);
   });
 
   it("clears preview badges when workspace flags are enabled", () => {
@@ -191,6 +197,7 @@ describe("annotateNavigationByWorkspaceFlags", () => {
       domains: true,
       glossarySearch: true,
       hyperlab: true,
+      reports: true,
     });
 
     const flaggedItems = annotated
@@ -212,6 +219,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
       domains: false,
       glossarySearch: false,
       hyperlab: false,
+      reports: false,
     });
 
     const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));
@@ -222,6 +230,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
     expect(itemLabels).toContain("New Request");
     expect(itemLabels).toContain("AI Engine");
     expect(itemLabels).not.toContain("Domains");
+    expect(itemLabels).not.toContain("Reports");
     expect(itemLabels).toContain("Projects");
   });
 
@@ -235,6 +244,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
       domains: true,
       glossarySearch: true,
       hyperlab: true,
+      reports: true,
     });
 
     const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));
@@ -243,6 +253,60 @@ describe("filterNavigationByWorkspaceFlags", () => {
     expect(itemLabels).toContain("Guideline");
     expect(itemLabels).toContain("Board");
     expect(itemLabels).toContain("Domains");
+    expect(itemLabels).toContain("Reports");
     expect(itemLabels).toContain("AI Engine");
+  });
+});
+
+describe("groupPreviewNavigationGroups", () => {
+  it("moves preview items into a Try section and leaves enabled items in place", () => {
+    const groups = annotateNavigationByWorkspaceFlags(buildGlobalNavigationGroups("acme", intl), {
+      automations: false,
+      knowledge: false,
+      visualMock: false,
+      visualWorkflows: false,
+      domains: false,
+      glossarySearch: false,
+      hyperlab: false,
+      reports: false,
+    });
+    const grouped = groupPreviewNavigationGroups(groups, "Try");
+
+    const tryGroup = grouped.find((group) => group.label === "Try");
+    const agentsGroup = grouped.find((group) => group.label === "Agents");
+    const workspaceGroup = grouped.find((group) => group.label === "Workspace");
+    const promotedLabels = grouped[0]?.items.map((item) => item.label) ?? [];
+
+    expect(tryGroup?.items.map((item) => item.label)).toEqual([
+      "Reports",
+      "Automations",
+      "Domains",
+      "Hyperlab",
+      "Guideline",
+    ]);
+    expect(agentsGroup?.items.map((item) => item.label)).toEqual(["New Request", "AI Engine"]);
+    expect(workspaceGroup?.items.map((item) => item.label)).not.toContain("Domains");
+    expect(workspaceGroup?.items.map((item) => item.label)).toContain("Projects");
+    expect(promotedLabels).toContain("Inbox");
+    expect(promotedLabels).not.toContain("Reports");
+  });
+
+  it("omits the Try section when no items are in preview", () => {
+    const groups = annotateNavigationByWorkspaceFlags(buildGlobalNavigationGroups("acme", intl), {
+      automations: true,
+      knowledge: true,
+      visualMock: true,
+      visualWorkflows: true,
+      domains: true,
+      glossarySearch: true,
+      hyperlab: true,
+      reports: true,
+    });
+    const grouped = groupPreviewNavigationGroups(groups, "Try");
+
+    expect(grouped.some((group) => group.label === "Try")).toBe(false);
+    expect(grouped.flatMap((group) => group.items.map((item) => item.label))).toContain(
+      "Automations",
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
@@ -17,6 +17,7 @@ export const WORKSPACE_VISUAL_WORKFLOWS_FLAG = "workspace-visual-workflows";
 export const WORKSPACE_DOMAINS_FLAG = "workspace-domains";
 export const WORKSPACE_GLOSSARY_SEARCH_FLAG = "workspace-glossary-search";
 export const WORKSPACE_HYPERLAB_FLAG = "workspace-hyperlab";
+export const WORKSPACE_REPORTS_FLAG = "workspace-reports";
 export const WORKSPACE_FEATURE_UNAVAILABLE_REASON = "feature-unavailable";
 
 export type WorkosFlagEntities = {
@@ -32,6 +33,7 @@ export type WorkspaceFeatureFlagState = {
   domains: boolean;
   glossarySearch: boolean;
   hyperlab: boolean;
+  reports: boolean;
 };
 
 export const DISABLED_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
@@ -42,4 +44,5 @@ export const DISABLED_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
   domains: false,
   glossarySearch: false,
   hyperlab: false,
+  reports: false,
 };

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
@@ -18,6 +18,7 @@ import {
   WORKSPACE_GLOSSARY_SEARCH_FLAG,
   WORKSPACE_HYPERLAB_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
+  WORKSPACE_REPORTS_FLAG,
   WORKSPACE_VISUAL_MOCK_FLAG,
   WORKSPACE_VISUAL_WORKFLOWS_FLAG,
   type WorkspaceFeatureFlagState,
@@ -32,6 +33,7 @@ function workspaceFlagEnabledByKey(flags: WorkspaceFeatureFlagState): Record<str
     [WORKSPACE_DOMAINS_FLAG]: flags.domains,
     [WORKSPACE_GLOSSARY_SEARCH_FLAG]: flags.glossarySearch,
     [WORKSPACE_HYPERLAB_FLAG]: flags.hyperlab,
+    [WORKSPACE_REPORTS_FLAG]: flags.reports,
   };
 }
 
@@ -69,6 +71,33 @@ export function annotateNavigationByWorkspaceFlags(
     ...group,
     items: group.items.map((item) => annotateNavigationItemWithWorkspaceFlags(item, enabledByKey)),
   }));
+}
+
+export function groupPreviewNavigationGroups(
+  groups: readonly NavigationGroup[],
+  tryLabel: string,
+): readonly NavigationGroup[] {
+  const previewItems: NavigationItem[] = [];
+  const remainingGroups = groups
+    .map((group) => {
+      const items = group.items.filter((item) => {
+        if (item.preview) {
+          previewItems.push(item);
+          return false;
+        }
+
+        return true;
+      });
+
+      return { ...group, items };
+    })
+    .filter((group) => group.items.length > 0);
+
+  if (previewItems.length === 0) {
+    return remainingGroups;
+  }
+
+  return [...remainingGroups, { label: tryLabel, items: previewItems }];
 }
 
 /** @deprecated Use annotateNavigationItemsWithWorkspaceFlags — kept for tests during migration. */

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -26,6 +26,7 @@ import {
   WORKSPACE_GLOSSARY_SEARCH_FLAG,
   WORKSPACE_HYPERLAB_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
+  WORKSPACE_REPORTS_FLAG,
   WORKSPACE_VISUAL_MOCK_FLAG,
   WORKSPACE_VISUAL_WORKFLOWS_FLAG,
   type WorkosFlagEntities,
@@ -37,6 +38,7 @@ export {
   annotateNavigationItemsWithWorkspaceFlags,
   filterNavigationByWorkspaceFlags,
   filterNavigationItemsByWorkspaceFlags,
+  groupPreviewNavigationGroups,
 } from "./workspace-flag-navigation";
 
 export const workspaceAutomationsFlag = flag<boolean, WorkosFlagEntities>({
@@ -89,23 +91,48 @@ export const workspaceHyperlabFlag = flag<boolean, WorkosFlagEntities>({
   adapter: workosAdapter(),
 });
 
+export const workspaceReportsFlag = flag<boolean, WorkosFlagEntities>({
+  key: WORKSPACE_REPORTS_FLAG,
+  defaultValue: false,
+  description: "Workspace translation reports for word counts, time, and cost.",
+  adapter: workosAdapter(),
+});
+
 export async function evaluateWorkspaceFeatureFlags(
   auth: Pick<AppAuthContext, "activeOrganization" | "user">,
 ): Promise<WorkspaceFeatureFlagState> {
   const identify = () => createWorkosIdentify(auth);
 
-  const [automations, knowledge, visualMock, visualWorkflows, domains, glossarySearch, hyperlab] =
-    await Promise.all([
-      workspaceAutomationsFlag.run({ identify }),
-      workspaceKnowledgeFlag.run({ identify }),
-      workspaceVisualMockFlag.run({ identify }),
-      workspaceVisualWorkflowsFlag.run({ identify }),
-      workspaceDomainsFlag.run({ identify }),
-      workspaceGlossarySearchFlag.run({ identify }),
-      workspaceHyperlabFlag.run({ identify }),
-    ]);
+  const [
+    automations,
+    knowledge,
+    visualMock,
+    visualWorkflows,
+    domains,
+    glossarySearch,
+    hyperlab,
+    reports,
+  ] = await Promise.all([
+    workspaceAutomationsFlag.run({ identify }),
+    workspaceKnowledgeFlag.run({ identify }),
+    workspaceVisualMockFlag.run({ identify }),
+    workspaceVisualWorkflowsFlag.run({ identify }),
+    workspaceDomainsFlag.run({ identify }),
+    workspaceGlossarySearchFlag.run({ identify }),
+    workspaceHyperlabFlag.run({ identify }),
+    workspaceReportsFlag.run({ identify }),
+  ]);
 
-  return { automations, knowledge, visualMock, visualWorkflows, domains, glossarySearch, hyperlab };
+  return {
+    automations,
+    knowledge,
+    visualMock,
+    visualWorkflows,
+    domains,
+    glossarySearch,
+    hyperlab,
+    reports,
+  };
 }
 
 export async function resolveWorkspaceVisualMockFlag(input: {


### PR DESCRIPTION
## What changed

Reports is now a preview feature behind the WorkOS flag `workspace-reports` (off by default). The sidebar uses a distinct chart icon, and preview items are grouped in a **Try** section until the flag is enabled.

When the flag is off:
- workspace and project Reports pages show a feature teaser
- `/api/orgs/:org/reports` returns 403 `feature_unavailable`
- native job-detail reporting is hidden

## How to test

- [ ] With `workspace-reports` off, confirm Reports sits under **Try** in workspace and project nav, and opening it shows the teaser
- [ ] Confirm the job detail page does not show the reporting panel
- [ ] Enable `workspace-reports` for an org in WorkOS, then confirm Reports returns to its original nav group with the chart icon and pages/API work
- [ ] `vp check --fix` in `apps/hyperlocalise-web`
- [ ] `vp test` for reports route, navigation-config, and workos-adapter tests

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted `vp test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)