### PR TITLE
feat(web): send email via Pipes in automations and visual workflows

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
@@ -125,7 +125,9 @@ function notificationToolEnabled(
       return Boolean(
         toolConfig.email?.enabled &&
         toolConfig.email.recipients &&
-        toolConfig.email.recipients.length > 0,
+        toolConfig.email.recipients.length > 0 &&
+        toolConfig.email.from?.trim() &&
+        toolConfig.email.workosUserId,
       );
     case "notify_github_comment":
       return Boolean(toolConfig.githubComment?.enabled);

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_email.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_email.test.ts
@@ -57,7 +57,13 @@ function session(
     },
     repositoryTarget: { kind: "none" },
     toolConfig: overrides.toolConfig ?? {
-      email: { enabled: true, recipients: ["ops@example.com", "l10n@example.com"] },
+      email: {
+        enabled: true,
+        provider: "resend",
+        workosUserId: "user_workos_1",
+        from: "notifications@example.com",
+        recipients: ["ops@example.com", "l10n@example.com"],
+      },
     },
     model: "openai/gpt-5.6-luna",
     configVersion: 1,
@@ -113,7 +119,15 @@ describe("createNotifyEmailTool", () => {
     await expect(
       createNotifyEmailTool(
         session({
-          toolConfig: { email: { enabled: false, recipients: ["ops@example.com"] } },
+          toolConfig: {
+            email: {
+              enabled: false,
+              provider: "resend",
+              workosUserId: "user_workos_1",
+              from: "notifications@example.com",
+              recipients: ["ops@example.com"],
+            },
+          },
         }),
       ).execute!({}, toolOptions),
     ).rejects.toThrow("email_not_configured");
@@ -121,7 +135,15 @@ describe("createNotifyEmailTool", () => {
     await expect(
       createNotifyEmailTool(
         session({
-          toolConfig: { email: { enabled: true, recipients: [] } },
+          toolConfig: {
+            email: {
+              enabled: true,
+              provider: "resend",
+              workosUserId: "user_workos_1",
+              from: "notifications@example.com",
+              recipients: [],
+            },
+          },
         }),
       ).execute!({}, toolOptions),
     ).rejects.toThrow("email_not_configured");
@@ -138,6 +160,10 @@ describe("createNotifyEmailTool", () => {
 
     expect(mocks.buildOrchestratorRunSummaryMessage).not.toHaveBeenCalled();
     expect(mocks.runWorkspaceAutomationEmailNotificationTool).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      provider: "resend",
+      workosUserId: "user_workos_1",
+      from: "notifications@example.com",
       recipients: ["ops@example.com", "l10n@example.com"],
       subject: "Custom subject",
       message: "Digest ready",
@@ -152,46 +178,13 @@ describe("createNotifyEmailTool", () => {
 
     expect(mocks.buildOrchestratorRunSummaryMessage).toHaveBeenCalledTimes(1);
     expect(mocks.runWorkspaceAutomationEmailNotificationTool).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      provider: "resend",
+      workosUserId: "user_workos_1",
+      from: "notifications@example.com",
       recipients: ["ops@example.com", "l10n@example.com"],
       subject: "Automation run succeeded: Localisation digest",
       message: "**Localisation digest** SUCCEEDED",
     });
-  });
-
-  it("uses the run status in the default subject when terminalStatus is unset", async () => {
-    await createNotifyEmailTool(session({ runStatus: "failed" })).execute!(
-      { message: "Run failed" },
-      toolOptions,
-    );
-
-    expect(mocks.runWorkspaceAutomationEmailNotificationTool).toHaveBeenCalledWith(
-      expect.objectContaining({
-        subject: "Automation run failed: Localisation digest",
-        message: "Run failed",
-      }),
-    );
-  });
-
-  it("maps email send failures into a non-throwing step result", async () => {
-    mocks.runWorkspaceAutomationEmailNotificationTool.mockResolvedValue(
-      err({
-        code: "email_send_failed",
-        message: "Resend unavailable",
-      }),
-    );
-
-    const current = session();
-    const payload = await createNotifyEmailTool(current).execute!(
-      { message: "Fail soft" },
-      toolOptions,
-    );
-
-    expect(payload).toEqual({
-      sent: false,
-      recipientCount: 2,
-      code: "email_send_failed",
-      message: "Resend unavailable",
-    });
-    expect(current.stepResults.notify_email).toEqual(payload);
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_email.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_email.ts
@@ -28,7 +28,13 @@ export function createNotifyEmailTool(session: WorkspaceOrchestratorSession) {
     }),
     execute: async ({ message, subject }) => {
       const email = session.automation.toolConfig.email;
-      if (!email?.enabled || !email.recipients || email.recipients.length === 0) {
+      if (
+        !email?.enabled ||
+        !email.recipients ||
+        email.recipients.length === 0 ||
+        !email.from?.trim() ||
+        !email.workosUserId
+      ) {
         throw new Error("email_not_configured");
       }
 
@@ -38,6 +44,10 @@ export function createNotifyEmailTool(session: WorkspaceOrchestratorSession) {
         `Automation run ${session.terminalStatus ?? session.run.status}: ${session.automation.name}`;
 
       const result = await runWorkspaceAutomationEmailNotificationTool({
+        organizationId: session.organizationId,
+        provider: email.provider ?? "resend",
+        workosUserId: email.workosUserId,
+        from: email.from.trim(),
         recipients: email.recipients,
         subject: resolvedSubject,
         message: text,

--- a/apps/hyperlocalise-web/src/api/routes/visual-workflow/visual-workflow.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/visual-workflow/visual-workflow.route.ts
@@ -184,6 +184,7 @@ export function createVisualWorkflowRoutes() {
       const result = await createVisualWorkflow({
         organizationId: c.var.auth.organization.localOrganizationId,
         authorUserId: c.var.auth.user.localUserId,
+        actorWorkosUserId: c.var.auth.user.workosUserId,
         projectId: body.projectId,
         name: body.name,
         definition: body.definition,
@@ -218,6 +219,7 @@ export function createVisualWorkflowRoutes() {
       const result = await updateVisualWorkflow({
         organizationId: c.var.auth.organization.localOrganizationId,
         visualWorkflowId,
+        actorWorkosUserId: c.var.auth.user.workosUserId,
         name: body.name,
         definition: body.definition,
         status: body.status,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations.fixture.ts
@@ -68,6 +68,7 @@ export function createAutomationSummary(
       },
       email: {
         enabled: false,
+        provider: "resend",
       },
       contentful: disabledContentfulToolConfig,
     },
@@ -107,6 +108,8 @@ export const automationsFixture: WorkspaceAutomationRecord[] = [
       },
       email: {
         enabled: true,
+        provider: "resend",
+        from: "team@example.com",
         recipients: ["team@example.com"],
       },
       contentful: disabledContentfulToolConfig,
@@ -133,6 +136,7 @@ export const automationsFixture: WorkspaceAutomationRecord[] = [
       },
       email: {
         enabled: false,
+        provider: "resend",
       },
       contentful: disabledContentfulToolConfig,
     },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/nodes/visual-workflow-compact-node.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/nodes/visual-workflow-compact-node.tsx
@@ -203,6 +203,8 @@ function titleMessage(type: VisualWorkflowRfNode["data"]["catalogType"]) {
       return messages.nodeHttp;
     case "action.notify_slack":
       return messages.nodeNotifySlack;
+    case "action.notify_email":
+      return messages.nodeNotifyEmail;
     case "logic.if":
       return messages.nodeIf;
     case "logic.switch":

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-config-panel.tsx
@@ -342,6 +342,70 @@ export function VisualWorkflowConfigPanel({
             />
           </>
         ) : null}
+        {config.kind === "action.notify_email" ? (
+          <>
+            <div className="grid gap-1.5">
+              <Label className="text-xs text-muted-foreground">
+                <FormattedMessage {...messages.emailProvider} />
+              </Label>
+              <Select
+                value={config.provider}
+                onValueChange={(value) => {
+                  if (value !== "resend" && value !== "sendgrid") {
+                    return;
+                  }
+                  onChangeConfig({ ...config, provider: value });
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {config.provider === "sendgrid"
+                      ? intl.formatMessage(messages.emailProviderSendgrid)
+                      : intl.formatMessage(messages.emailProviderResend)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="resend">
+                    <FormattedMessage {...messages.emailProviderResend} />
+                  </SelectItem>
+                  <SelectItem value="sendgrid">
+                    <FormattedMessage {...messages.emailProviderSendgrid} />
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <TextField
+              id="vw-email-from"
+              label={intl.formatMessage(messages.emailFrom)}
+              value={config.from}
+              onChange={(value) => onChangeConfig({ ...config, from: value })}
+              placeholder="notifications@company.com"
+            />
+            <TextAreaField
+              id="vw-email-recipients"
+              label={intl.formatMessage(messages.emailRecipients)}
+              value={config.recipients}
+              onChange={(value) => onChangeConfig({ ...config, recipients: value })}
+              placeholder="ops@company.com, dev@company.com"
+            />
+            <TextField
+              id="vw-email-subject"
+              label={intl.formatMessage(messages.emailSubject)}
+              value={config.subject}
+              onChange={(value) => onChangeConfig({ ...config, subject: value })}
+            />
+            <TextAreaField
+              id="vw-email-message"
+              label={intl.formatMessage(messages.emailMessage)}
+              value={config.message}
+              onChange={(value) => onChangeConfig({ ...config, message: value })}
+            />
+            <ErrorBehaviorField
+              value={config.onError ?? "stop"}
+              onChange={(onError) => onChangeConfig({ ...config, onError })}
+            />
+          </>
+        ) : null}
         {config.kind === "trigger.github" ? (
           <>
             <TextField

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-editor.messages.ts
@@ -290,6 +290,16 @@ export const visualWorkflowEditorMessages = defineMessages({
     id: "5/GGmNLCh0",
     description: "Catalog description for the notify Slack action node",
   },
+  nodeNotifyEmail: {
+    defaultMessage: "Send email",
+    id: "EfYrVZH3dW",
+    description: "Catalog title for the notify email action node",
+  },
+  nodeNotifyEmailHint: {
+    defaultMessage: "Send a transactional email through Resend or SendGrid.",
+    id: "Crp/piiRbB",
+    description: "Catalog description for the notify email action node",
+  },
   addNode: {
     defaultMessage: "Add node",
     id: "H541+RZh2a",
@@ -624,6 +634,41 @@ export const visualWorkflowEditorMessages = defineMessages({
     defaultMessage: "Message",
     id: "NGsHVcOyFb",
     description: "Label for Slack message on notify slack node",
+  },
+  emailProvider: {
+    defaultMessage: "Provider",
+    id: "wOs50wH/pI",
+    description: "Label for email provider on notify email node",
+  },
+  emailProviderResend: {
+    defaultMessage: "Resend",
+    id: "thK9pQi9Ut",
+    description: "Resend option on notify email node",
+  },
+  emailProviderSendgrid: {
+    defaultMessage: "SendGrid",
+    id: "ycIxrY94pB",
+    description: "SendGrid option on notify email node",
+  },
+  emailFrom: {
+    defaultMessage: "From address",
+    id: "I+GDyUI23h",
+    description: "Label for sender address on notify email node",
+  },
+  emailRecipients: {
+    defaultMessage: "Recipients",
+    id: "IVA7S1Pi6e",
+    description: "Label for recipients on notify email node",
+  },
+  emailSubject: {
+    defaultMessage: "Subject",
+    id: "oLwNToY1hg",
+    description: "Label for subject on notify email node",
+  },
+  emailMessage: {
+    defaultMessage: "Message",
+    id: "jApfF7IUNd",
+    description: "Label for message body on notify email node",
   },
   githubRepositoryId: {
     defaultMessage: "GitHub repository ID",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-node-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/visual-workflow-editor/visual-workflow-node-picker.tsx
@@ -152,6 +152,8 @@ function titleFor(type: VisualCatalogType) {
       return messages.nodeHttp;
     case "action.notify_slack":
       return messages.nodeNotifySlack;
+    case "action.notify_email":
+      return messages.nodeNotifyEmail;
     case "logic.if":
       return messages.nodeIf;
     case "logic.switch":
@@ -179,6 +181,8 @@ function hintFor(type: VisualCatalogType) {
       return messages.nodeHttpHint;
     case "action.notify_slack":
       return messages.nodeNotifySlackHint;
+    case "action.notify_email":
+      return messages.nodeNotifyEmailHint;
     case "logic.if":
       return messages.nodeIfHint;
     case "logic.switch":

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -221,9 +221,9 @@ export const workspaceAutomationFormMessages = defineMessages({
     description: "Shortcut hint when an integration must be connected first",
   },
   enableFirstShortcut: {
-    defaultMessage: "Enable first",
-    id: "ZQbvwhJWXn",
-    description: "Shortcut hint when email must be enabled first",
+    defaultMessage: "Connect first",
+    id: "G7es7H7NT8",
+    description: "Shortcut hint when an email provider must be connected first",
   },
   triggersSection: {
     defaultMessage: "Triggers",
@@ -611,9 +611,9 @@ export const workspaceAutomationFormMessages = defineMessages({
     description: "Badge when a tool requires connecting an integration first",
   },
   enableFirstBadge: {
-    defaultMessage: "Enable first",
-    id: "33PBu8aQXh",
-    description: "Badge when email notifications require enabling the email agent first",
+    defaultMessage: "Connect first",
+    id: "LoDf9OMJWo",
+    description: "Badge when email notifications require connecting an email provider first",
   },
   slackConnectedDescription: {
     defaultMessage: "Notify a channel when runs reach a terminal state.",
@@ -695,15 +695,40 @@ export const workspaceAutomationFormMessages = defineMessages({
     description: "Slack channel option label for a public channel",
   },
   emailConnectedDescription: {
-    defaultMessage: "Send terminal run summaries to specific recipients.",
-    id: "DdTfqNy1em",
+    defaultMessage: "Send terminal run summaries through your connected email provider.",
+    id: "cs9xdfnPbE",
     description: "Description for email notifications when email is enabled",
   },
   emailDisconnectedDescription: {
     defaultMessage:
-      "Enable the email agent in <link>Integrations</link> to use email notifications.",
-    id: "QlWnr3uEAw",
+      "Connect Resend or SendGrid in <link>Integrations</link> to use email notifications.",
+    id: "Vl/WJ79qHw",
     description: "Description for email notifications when email is not enabled",
+  },
+  emailProviderLabel: {
+    defaultMessage: "Provider",
+    id: "li9608JKLe",
+    description: "Label for the email provider selector in automation form",
+  },
+  emailProviderResend: {
+    defaultMessage: "Resend",
+    id: "rAeEoKNL9f",
+    description: "Resend option in email provider selector",
+  },
+  emailProviderSendgrid: {
+    defaultMessage: "SendGrid",
+    id: "zvyVcnRDh9",
+    description: "SendGrid option in email provider selector",
+  },
+  emailFromLabel: {
+    defaultMessage: "From address",
+    id: "rJRBMWgpmE",
+    description: "Label for the sender email address field",
+  },
+  emailFromPlaceholder: {
+    defaultMessage: "notifications@company.com",
+    id: "Dea29MjWIQ",
+    description: "Placeholder for the sender email address field",
   },
   removeEmailNotifications: {
     defaultMessage: "Remove email notifications",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -1802,6 +1802,7 @@ function ToolsSettings({
   crowdinLiveProjects,
   disabled,
   emailConnected,
+  emailProviderConnected,
   errors,
   form,
   githubConnected,
@@ -1822,6 +1823,7 @@ function ToolsSettings({
   crowdinLiveProjects: ProjectOption[];
   disabled?: boolean;
   emailConnected: boolean;
+  emailProviderConnected: boolean;
   errors: Record<string, string | undefined>;
   form: WorkspaceAutomationFormState;
   githubConnected: boolean;
@@ -2153,7 +2155,7 @@ function ToolsSettings({
                 <span>
                   <FormattedMessage {...workspaceAutomationFormMessages.sendEmail} />
                 </span>
-                {!emailConnected ? (
+                {!emailProviderConnected ? (
                   <Badge variant="secondary">
                     <FormattedMessage {...workspaceAutomationFormMessages.enableFirstBadge} />
                   </Badge>
@@ -2161,7 +2163,7 @@ function ToolsSettings({
               </>
             }
             description={
-              emailConnected
+              emailProviderConnected
                 ? intl.formatMessage(workspaceAutomationFormMessages.emailConnectedDescription)
                 : intl.formatMessage(workspaceAutomationFormMessages.emailDisconnectedDescription, {
                     link: (chunks) => (
@@ -2175,31 +2177,89 @@ function ToolsSettings({
               <DeleteToolButton
                 disabled={disabled}
                 label={intl.formatMessage(workspaceAutomationFormMessages.removeEmailNotifications)}
-                onClick={() => onChange({ ...form, emailEnabled: false, emailRecipients: [] })}
-              />
-            }
-          >
-            <div className="grid gap-1.5">
-              <Label htmlFor="email-recipients" className="text-xs text-muted-foreground">
-                <FormattedMessage {...workspaceAutomationFormMessages.recipientsLabel} />
-              </Label>
-              <Textarea
-                id="email-recipients"
-                value={form.emailRecipients.join("\n")}
-                disabled={disabled || !emailConnected}
-                className="min-h-20 rounded-lg text-sm"
-                placeholder={"ops@company.com\ndev@company.com"}
-                onChange={(event) =>
+                onClick={() =>
                   onChange({
                     ...form,
-                    emailRecipients: event.target.value
-                      .split(/\n|,/)
-                      .map((value) => value.trim())
-                      .filter(Boolean),
+                    emailEnabled: false,
+                    emailRecipients: [],
+                    emailFrom: "",
                   })
                 }
               />
-              <FieldError message={errors.emailRecipients} />
+            }
+          >
+            <div className="grid gap-3">
+              <div className="grid gap-1.5">
+                <Label className="text-xs text-muted-foreground">
+                  <FormattedMessage {...workspaceAutomationFormMessages.emailProviderLabel} />
+                </Label>
+                <Select
+                  value={form.emailProvider}
+                  disabled={disabled}
+                  onValueChange={(value) => {
+                    if (value !== "resend" && value !== "sendgrid") {
+                      return;
+                    }
+                    onChange({ ...form, emailProvider: value });
+                  }}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue>
+                      {form.emailProvider === "sendgrid"
+                        ? intl.formatMessage(workspaceAutomationFormMessages.emailProviderSendgrid)
+                        : intl.formatMessage(workspaceAutomationFormMessages.emailProviderResend)}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="resend">
+                      <FormattedMessage {...workspaceAutomationFormMessages.emailProviderResend} />
+                    </SelectItem>
+                    <SelectItem value="sendgrid">
+                      <FormattedMessage
+                        {...workspaceAutomationFormMessages.emailProviderSendgrid}
+                      />
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="email-from" className="text-xs text-muted-foreground">
+                  <FormattedMessage {...workspaceAutomationFormMessages.emailFromLabel} />
+                </Label>
+                <Input
+                  id="email-from"
+                  type="email"
+                  value={form.emailFrom}
+                  disabled={disabled || !emailProviderConnected}
+                  placeholder={intl.formatMessage(
+                    workspaceAutomationFormMessages.emailFromPlaceholder,
+                  )}
+                  onChange={(event) => onChange({ ...form, emailFrom: event.target.value })}
+                />
+                <FieldError message={errors.emailFrom} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="email-recipients" className="text-xs text-muted-foreground">
+                  <FormattedMessage {...workspaceAutomationFormMessages.recipientsLabel} />
+                </Label>
+                <Textarea
+                  id="email-recipients"
+                  value={form.emailRecipients.join("\n")}
+                  disabled={disabled || !emailProviderConnected}
+                  className="min-h-20 rounded-lg text-sm"
+                  placeholder={"ops@company.com\ndev@company.com"}
+                  onChange={(event) =>
+                    onChange({
+                      ...form,
+                      emailRecipients: event.target.value
+                        .split(/\n|,/)
+                        .map((value) => value.trim())
+                        .filter(Boolean),
+                    })
+                  }
+                />
+                <FieldError message={errors.emailRecipients} />
+              </div>
             </div>
           </EditorRow>
         ) : null}
@@ -3078,17 +3138,39 @@ export function WorkspaceAutomationEditor({
     },
   });
 
-  const emailQuery = useQuery({
-    queryKey: ["email-agent", organizationSlug],
+  const resendPipesQuery = useQuery({
+    queryKey: ["pipes", organizationSlug, "resend"],
     queryFn: async () => {
-      const response = await api.api.orgs[":organizationSlug"]["agent-email"].$get({
-        param: { organizationSlug },
+      const response = await api.api.orgs[":organizationSlug"].pipes[":provider"].$get({
+        param: { organizationSlug, provider: "resend" },
       });
       if (!response.ok) {
-        throw new Error("Failed to load email agent settings");
+        throw new Error("Failed to load Resend connection");
       }
       const body = await response.json();
-      return body.emailAgent;
+      return body.pipe as {
+        connected: boolean;
+        needsReauthorization: boolean;
+        apiKeyLast4: string | null;
+      };
+    },
+  });
+
+  const sendgridPipesQuery = useQuery({
+    queryKey: ["pipes", organizationSlug, "sendgrid"],
+    queryFn: async () => {
+      const response = await api.api.orgs[":organizationSlug"].pipes[":provider"].$get({
+        param: { organizationSlug, provider: "sendgrid" },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load SendGrid connection");
+      }
+      const body = await response.json();
+      return body.pipe as {
+        connected: boolean;
+        needsReauthorization: boolean;
+        apiKeyLast4: string | null;
+      };
     },
   });
 
@@ -3162,7 +3244,12 @@ export function WorkspaceAutomationEditor({
   );
   const canActivate = workspaceAutomationFormCanActivate(form);
   const slackConnected = Boolean(slackQuery.data?.enabled);
-  const emailConnected = Boolean(emailQuery.data?.enabled);
+  const emailProviderConnected =
+    form.emailProvider === "sendgrid"
+      ? Boolean(sendgridPipesQuery.data?.connected)
+      : Boolean(resendPipesQuery.data?.connected);
+  const emailConnected =
+    Boolean(resendPipesQuery.data?.connected) || Boolean(sendgridPipesQuery.data?.connected);
   const contentfulConnections = contentfulConnectionsQuery.data ?? [];
   const contentfulConnected = contentfulConnections.length > 0;
   const mcpServerConnections = mcpServerConnectionsQuery.data ?? [];
@@ -3304,6 +3391,7 @@ export function WorkspaceAutomationEditor({
             crowdinLiveProjects={crowdinLiveProjects}
             disabled={disabled}
             emailConnected={emailConnected}
+            emailProviderConnected={emailProviderConnected}
             errors={errors}
             form={form}
             githubConnected={githubConnected}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-notifications.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-notifications.ts
@@ -69,8 +69,18 @@ export async function notifyWorkspaceAutomationTerminalRun(input: {
   }
 
   const email = input.automation.toolConfig.email;
-  if (email?.enabled && email.recipients && email.recipients.length > 0) {
+  if (
+    email?.enabled &&
+    email.recipients &&
+    email.recipients.length > 0 &&
+    email.from?.trim() &&
+    email.workosUserId
+  ) {
     const result = await runWorkspaceAutomationEmailNotificationTool({
+      organizationId: input.automation.organizationId,
+      provider: email.provider ?? "resend",
+      workosUserId: email.workosUserId,
+      from: email.from.trim(),
       recipients: email.recipients,
       subject: `Automation run ${input.run.status}: ${input.automation.name}`,
       message,

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-types.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-types.ts
@@ -12,6 +12,7 @@
  */
 import { z } from "zod";
 
+import { EMAIL_PROVIDER_SLUGS } from "@/lib/email/constants";
 import { optionalProjectIdSchema } from "@/lib/projects/identity/project-id";
 
 export const workspaceAutomationStatusSchema = z.enum(["active", "paused", "archived"]);
@@ -137,9 +138,12 @@ const slackToolConfigSchema = z
 const emailToolConfigSchema = z
   .object({
     enabled: z.boolean().default(false),
+    provider: z.enum(EMAIL_PROVIDER_SLUGS).default("resend"),
+    workosUserId: z.string().trim().min(1).max(128).optional(),
+    from: z.string().email().optional(),
     recipients: z.array(z.string().email()).min(1).max(10).optional(),
   })
-  .default({ enabled: false });
+  .default({ enabled: false, provider: "resend" });
 
 const githubCommentToolConfigSchema = z
   .object({
@@ -418,8 +422,20 @@ export type WorkspaceAutomationConfigValidationError =
       message: "Choose a Slack channel for automation notifications.";
     }
   | {
-      code: "email_not_connected";
-      message: "Enable the email agent before using email notifications.";
+      code: "email_provider_not_connected";
+      message: "Connect an email provider in Integrations before using email notifications.";
+    }
+  | {
+      code: "email_pipes_needs_reauthorization";
+      message: "Reconnect your email provider in Integrations, then try again.";
+    }
+  | {
+      code: "email_pipes_unavailable";
+      message: "WorkOS is not configured, so email providers cannot connect through Pipes.";
+    }
+  | {
+      code: "email_from_required";
+      message: "Add a verified sender address for email notifications.";
     }
   | {
       code: "email_recipients_required";

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -28,6 +28,7 @@ import {
   formStateToWorkspaceAutomationPayload,
   mapWorkspaceAutomationApiErrorToFieldErrors,
   selectableAutomationRepositories,
+  type WorkspaceAutomationFormState,
   validateWorkspaceAutomationFormState,
   workspaceAutomationFormCanActivate,
   workspaceAutomationFormHasChanges,
@@ -73,11 +74,11 @@ describe("workspace automation view model", () => {
   });
 
   it("maps form state to API payload", () => {
-    const form = {
+    const form: WorkspaceAutomationFormState = {
       ...createDefaultWorkspaceAutomationFormState(),
       name: "Nightly validation",
       instructions: "Validate repository changes.",
-      triggerMode: "scheduled" as const,
+      triggerMode: "scheduled",
       projectId: "project-1",
       githubEnabled: true,
       githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
@@ -85,6 +86,8 @@ describe("workspace automation view model", () => {
       slackEnabled: true,
       slackChannelId: "C01234567",
       emailEnabled: true,
+      emailProvider: "resend",
+      emailFrom: "notifications@example.com",
       emailRecipients: ["ops@example.com"],
     };
 
@@ -107,6 +110,8 @@ describe("workspace automation view model", () => {
     });
     expect(payload.toolConfig.email).toEqual({
       enabled: true,
+      provider: "resend",
+      from: "notifications@example.com",
       recipients: ["ops@example.com"],
     });
     expect(payload.model).toBe("openai/gpt-5.6-luna");

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -23,6 +23,7 @@ import {
   type WorkspaceAutomationTriggerConfig,
   type WorkspaceAutomationWebSearchProvider,
 } from "./workspace-automation-types";
+import type { EmailProviderSlug } from "@/lib/email/constants";
 import { parseSlackConversationId } from "./slack/channel-query";
 import { isValidAutomationTimeZone } from "./automation-time-zones";
 import {
@@ -61,6 +62,8 @@ export type WorkspaceAutomationFormState = {
   slackEnabled: boolean;
   slackChannelId: string;
   emailEnabled: boolean;
+  emailProvider: EmailProviderSlug;
+  emailFrom: string;
   emailRecipients: string[];
   githubCommentEnabled: boolean;
   contentfulEnabled: boolean;
@@ -121,6 +124,7 @@ export type WorkspaceAutomationFieldErrors = Partial<
     | "githubEvents"
     | "slackChannelId"
     | "emailRecipients"
+    | "emailFrom"
     | "contentfulConnectionId"
     | "contentfulTargetLocales"
     | "contentfulEntryId"
@@ -151,7 +155,14 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   invalid_automation_timezone: "Choose a valid timezone for the schedule.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
   slack_channel_required: "Choose a Slack channel for notifications.",
-  email_not_connected: "Enable the email agent in Integrations before using email notifications.",
+  email_not_connected:
+    "Connect an email provider in Integrations before using email notifications.",
+  email_provider_not_connected:
+    "Connect an email provider in Integrations before using email notifications.",
+  email_pipes_needs_reauthorization:
+    "Reconnect your email provider in Integrations, then try again.",
+  email_pipes_unavailable: "Email providers are unavailable until WorkOS Pipes is configured.",
+  email_from_required: "Add a verified sender address for email notifications.",
   email_recipients_required: "Add at least one email recipient.",
   contentful_connection_required: "Choose a Contentful connection.",
   contentful_target_locales_required: "Add at least one target locale for Contentful translation.",
@@ -215,6 +226,8 @@ export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomation
     slackEnabled: false,
     slackChannelId: "",
     emailEnabled: false,
+    emailProvider: "resend",
+    emailFrom: "",
     emailRecipients: [],
     githubCommentEnabled: false,
     contentfulEnabled: false,
@@ -308,6 +321,8 @@ export function createWorkspaceAutomationFormStateFromRecord(
     slackEnabled: Boolean(slack?.enabled),
     slackChannelId: slack?.channelId ?? "",
     emailEnabled: Boolean(email?.enabled),
+    emailProvider: email?.provider ?? "resend",
+    emailFrom: email?.from ?? "",
     emailRecipients: email?.recipients ? [...email.recipients] : [],
     githubCommentEnabled: Boolean(automation.toolConfig.githubComment?.enabled),
     contentfulEnabled: Boolean(contentful?.enabled),
@@ -465,6 +480,8 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
       ? {
           email: {
             enabled: true,
+            provider: form.emailProvider,
+            from: form.emailFrom.trim() || undefined,
             recipients: form.emailRecipients,
           },
         }
@@ -649,8 +666,13 @@ export function validateWorkspaceAutomationFormState(
     errors.slackChannelId = "Enter a valid Slack channel ID.";
   }
 
-  if (form.emailEnabled && form.emailRecipients.length === 0) {
-    errors.emailRecipients = "Add at least one email recipient.";
+  if (form.emailEnabled) {
+    if (form.emailRecipients.length === 0) {
+      errors.emailRecipients = "Add at least one email recipient.";
+    }
+    if (!form.emailFrom.trim()) {
+      errors.emailFrom = "Add a verified sender address.";
+    }
   }
 
   if (form.contentfulEnabled) {
@@ -731,8 +753,13 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
     case "slack_channel_required":
       return { slackChannelId: message };
     case "email_not_connected":
+    case "email_provider_not_connected":
+    case "email_pipes_needs_reauthorization":
+    case "email_pipes_unavailable":
     case "email_recipients_required":
       return { emailRecipients: message };
+    case "email_from_required":
+      return { emailFrom: message };
     case "contentful_connection_required":
       return { contentfulConnectionId: message };
     case "contentful_target_locales_required":

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation/notification-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation/notification-tools.test.ts
@@ -18,14 +18,12 @@ const envState = vi.hoisted(() => ({
   SLACK_CLIENT_ID: "slack-client-id" as string | undefined,
   SLACK_CLIENT_SECRET: "slack-client-secret" as string | undefined,
   SLACK_SIGNING_SECRET: "slack-signing-secret" as string | undefined,
-  RESEND_API_KEY: "re_test_key" as string | undefined,
-  RESEND_FROM_ADDRESS: "notifications@example.com" as string | undefined,
-  RESEND_FROM_NAME: "Hyperlocalise" as string | undefined,
 }));
 
 const mocks = vi.hoisted(() => ({
   postSlackChannelMessage: vi.fn(),
-  resendSend: vi.fn(),
+  loadEmailPipesApiKey: vi.fn(),
+  sendTransactionalEmail: vi.fn(),
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -36,12 +34,12 @@ vi.mock("@/lib/agents/slack/post-channel-message", () => ({
   postSlackChannelMessage: (...args: unknown[]) => mocks.postSlackChannelMessage(...args),
 }));
 
-vi.mock("resend", () => ({
-  Resend: class {
-    emails = {
-      send: (...args: unknown[]) => mocks.resendSend(...args),
-    };
-  },
+vi.mock("@/lib/email/pipes", () => ({
+  loadEmailPipesApiKey: (...args: unknown[]) => mocks.loadEmailPipesApiKey(...args),
+}));
+
+vi.mock("@/lib/email/send", () => ({
+  sendTransactionalEmail: (...args: unknown[]) => mocks.sendTransactionalEmail(...args),
 }));
 
 import {
@@ -91,130 +89,56 @@ describe("runWorkspaceAutomationSlackNotificationTool", () => {
       text: "Run finished",
     });
   });
-
-  it("maps thrown Slack delivery errors to slack_send_failed", async () => {
-    mocks.postSlackChannelMessage.mockRejectedValue(new Error("channel_not_found"));
-
-    const result = await runWorkspaceAutomationSlackNotificationTool({
-      organizationId: "org-1",
-      channelId: "C404",
-      message: "Run finished",
-    });
-
-    expect(isErr(result)).toBe(true);
-    if (isErr(result)) {
-      expect(result.error).toEqual({
-        code: "slack_send_failed",
-        message: "channel_not_found",
-      });
-    }
-  });
-
-  it("uses a stable fallback message for non-Error Slack failures", async () => {
-    mocks.postSlackChannelMessage.mockRejectedValue("boom");
-
-    const result = await runWorkspaceAutomationSlackNotificationTool({
-      organizationId: "org-1",
-      channelId: "C123",
-      message: "Run finished",
-    });
-
-    expect(isErr(result)).toBe(true);
-    if (isErr(result)) {
-      expect(result.error).toEqual({
-        code: "slack_send_failed",
-        message: "Slack notification failed.",
-      });
-    }
-  });
 });
 
 describe("runWorkspaceAutomationEmailNotificationTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    envState.RESEND_API_KEY = "re_test_key";
-    envState.RESEND_FROM_ADDRESS = "notifications@example.com";
-    envState.RESEND_FROM_NAME = "Hyperlocalise";
-    mocks.resendSend.mockResolvedValue({ data: { id: "email_1" }, error: null });
+    mocks.loadEmailPipesApiKey.mockResolvedValue({ ok: true, value: "re_test_key" });
+    mocks.sendTransactionalEmail.mockResolvedValue({ ok: true, value: undefined });
   });
 
-  it("fails closed when Resend is not configured", async () => {
-    envState.RESEND_API_KEY = undefined;
-
+  it("loads the provider API key from Pipes and sends the email", async () => {
     const result = await runWorkspaceAutomationEmailNotificationTool({
-      recipients: ["ops@example.com"],
-      subject: "Automation complete",
-      message: "All good",
-    });
-
-    expect(isErr(result)).toBe(true);
-    if (isErr(result)) {
-      expect(result.error).toEqual({
-        code: "email_send_failed",
-        message: "Email delivery is not configured for this environment.",
-      });
-    }
-    expect(mocks.resendSend).not.toHaveBeenCalled();
-  });
-
-  it("sends with a display name when RESEND_FROM_NAME is set", async () => {
-    const result = await runWorkspaceAutomationEmailNotificationTool({
+      organizationId: "org-1",
+      provider: "resend",
+      workosUserId: "user_workos_1",
+      from: "notifications@example.com",
       recipients: ["ops@example.com", "qa@example.com"],
       subject: "Automation complete",
       message: "All good",
     });
 
     expect(isOk(result)).toBe(true);
-    expect(mocks.resendSend).toHaveBeenCalledWith({
-      from: "Hyperlocalise <notifications@example.com>",
-      to: ["ops@example.com", "qa@example.com"],
-      subject: "Automation complete",
-      text: "All good",
+    expect(mocks.loadEmailPipesApiKey).toHaveBeenCalledWith({
+      provider: "resend",
+      localOrganizationId: "org-1",
+      workosUserId: "user_workos_1",
     });
-  });
-
-  it("falls back to the bare from address when RESEND_FROM_NAME is unset", async () => {
-    envState.RESEND_FROM_NAME = undefined;
-
-    const result = await runWorkspaceAutomationEmailNotificationTool({
-      recipients: ["ops@example.com"],
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledWith({
+      provider: "resend",
+      apiKey: "re_test_key",
+      from: "notifications@example.com",
+      recipients: ["ops@example.com", "qa@example.com"],
       subject: "Automation complete",
       message: "All good",
     });
-
-    expect(isOk(result)).toBe(true);
-    expect(mocks.resendSend).toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: "notifications@example.com",
-      }),
-    );
   });
 
-  it("maps Resend API error payloads to email_send_failed", async () => {
-    mocks.resendSend.mockResolvedValue({
-      data: null,
-      error: { message: "Invalid API key" },
+  it("maps Pipes credential errors without calling send", async () => {
+    mocks.loadEmailPipesApiKey.mockResolvedValue({
+      ok: false,
+      error: {
+        code: "email_provider_not_connected",
+        message: "Connect this provider in Integrations before using it.",
+      },
     });
 
     const result = await runWorkspaceAutomationEmailNotificationTool({
-      recipients: ["ops@example.com"],
-      subject: "Automation complete",
-      message: "All good",
-    });
-
-    expect(isErr(result)).toBe(true);
-    if (isErr(result)) {
-      expect(result.error).toEqual({
-        code: "email_send_failed",
-        message: "Invalid API key",
-      });
-    }
-  });
-
-  it("maps thrown Resend failures to email_send_failed", async () => {
-    mocks.resendSend.mockRejectedValue(new Error("network down"));
-
-    const result = await runWorkspaceAutomationEmailNotificationTool({
+      organizationId: "org-1",
+      provider: "sendgrid",
+      workosUserId: "user_workos_1",
+      from: "notifications@example.com",
       recipients: ["ops@example.com"],
       subject: "Automation complete",
       message: "All good",
@@ -222,10 +146,8 @@ describe("runWorkspaceAutomationEmailNotificationTool", () => {
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
-      expect(result.error).toEqual({
-        code: "email_send_failed",
-        message: "network down",
-      });
+      expect(result.error.code).toBe("email_provider_not_connected");
     }
+    expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation/notification-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation/notification-tools.ts
@@ -10,15 +10,18 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Resend } from "resend";
-
+import { loadEmailPipesApiKey } from "@/lib/email/pipes";
+import { sendTransactionalEmail } from "@/lib/email/send";
+import type { EmailProviderSlug } from "@/lib/email/constants";
+import type { EmailPipesError, EmailSendError } from "@/lib/email/types";
 import { env } from "@/lib/env";
-import { err, ok, type Result } from "@/lib/primitives/result/results";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
-export type WorkspaceAutomationNotificationError = {
-  code: "slack_send_failed" | "email_send_failed" | "notifications_not_configured";
-  message: string;
-};
+export type WorkspaceAutomationNotificationError =
+  | { code: "slack_send_failed"; message: string }
+  | EmailSendError
+  | EmailPipesError
+  | { code: "notifications_not_configured"; message: string };
 
 export async function runWorkspaceAutomationSlackNotificationTool(input: {
   organizationId: string;
@@ -49,40 +52,29 @@ export async function runWorkspaceAutomationSlackNotificationTool(input: {
 }
 
 export async function runWorkspaceAutomationEmailNotificationTool(input: {
+  organizationId: string;
+  provider: EmailProviderSlug;
+  workosUserId: string;
+  from: string;
   recipients: string[];
   subject: string;
   message: string;
 }): Promise<Result<void, WorkspaceAutomationNotificationError>> {
-  if (!env.RESEND_API_KEY || !env.RESEND_FROM_ADDRESS) {
-    return err({
-      code: "email_send_failed",
-      message: "Email delivery is not configured for this environment.",
-    });
+  const apiKeyResult = await loadEmailPipesApiKey({
+    provider: input.provider,
+    localOrganizationId: input.organizationId,
+    workosUserId: input.workosUserId,
+  });
+  if (isErr(apiKeyResult)) {
+    return apiKeyResult;
   }
 
-  try {
-    const resend = new Resend(env.RESEND_API_KEY);
-    const result = await resend.emails.send({
-      from: env.RESEND_FROM_NAME
-        ? `${env.RESEND_FROM_NAME} <${env.RESEND_FROM_ADDRESS}>`
-        : env.RESEND_FROM_ADDRESS,
-      to: input.recipients,
-      subject: input.subject,
-      text: input.message,
-    });
-
-    if (result.error) {
-      return err({
-        code: "email_send_failed",
-        message: result.error.message,
-      });
-    }
-
-    return ok(undefined);
-  } catch (error) {
-    return err({
-      code: "email_send_failed",
-      message: error instanceof Error ? error.message : "Email notification failed.",
-    });
-  }
+  return sendTransactionalEmail({
+    provider: input.provider,
+    apiKey: apiKeyResult.value,
+    from: input.from,
+    recipients: input.recipients,
+    subject: input.subject,
+    message: input.message,
+  });
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 
 const pipesMocks = vi.hoisted(() => ({
   getAhrefsPipesConnectionStatus: vi.fn(),
+  getEmailPipesConnectionStatus: vi.fn(),
 }));
 
 vi.mock("@/lib/ahrefs/pipes", async (importOriginal) => {
@@ -25,6 +26,15 @@ vi.mock("@/lib/ahrefs/pipes", async (importOriginal) => {
     ...actual,
     getAhrefsPipesConnectionStatus: (...args: unknown[]) =>
       pipesMocks.getAhrefsPipesConnectionStatus(...args),
+  };
+});
+
+vi.mock("@/lib/email/pipes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/email/pipes")>();
+  return {
+    ...actual,
+    getEmailPipesConnectionStatus: (...args: unknown[]) =>
+      pipesMocks.getEmailPipesConnectionStatus(...args),
   };
 });
 
@@ -254,6 +264,13 @@ describe("workspace automations", () => {
 
   beforeEach(() => {
     pipesMocks.getAhrefsPipesConnectionStatus.mockResolvedValue(
+      ok({
+        connected: false,
+        needsReauthorization: false,
+        apiKeyLast4: null,
+      }),
+    );
+    pipesMocks.getEmailPipesConnectionStatus.mockResolvedValue(
       ok({
         connected: false,
         needsReauthorization: false,
@@ -1175,17 +1192,30 @@ describe("workspace automations", () => {
       kind: "email",
       enabled: false,
     });
+    pipesMocks.getEmailPipesConnectionStatus.mockResolvedValue(
+      ok({
+        connected: false,
+        needsReauthorization: false,
+        apiKeyLast4: null,
+      }),
+    );
     const emailDisabled = await createWorkspaceAutomation({
       ...base,
       toolConfig: {
-        email: { enabled: true, recipients: ["ops@example.test"] },
+        email: {
+          enabled: true,
+          provider: "resend",
+          workosUserId: "user_workos_1",
+          from: "notifications@example.test",
+          recipients: ["ops@example.test"],
+        },
       },
     });
     expect(emailDisabled.ok).toBe(false);
     if (emailDisabled.ok) {
       throw new Error("expected email validation error");
     }
-    expect(emailDisabled.error.code).toBe("email_not_connected");
+    expect(emailDisabled.error.code).toBe("email_provider_not_connected");
 
     const mcpMissing = await createWorkspaceAutomation({
       ...base,

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -18,6 +18,7 @@ import { db, schema, type DatabaseClient } from "@/lib/database/client";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { isValidAutomationTimeZone } from "@/lib/agents/automation-time-zones";
 import { getAhrefsPipesConnectionStatus, resolveAhrefsPipesWorkosUserId } from "@/lib/ahrefs/pipes";
+import { getEmailPipesConnectionStatus, resolveEmailPipesWorkosUserId } from "@/lib/email/pipes";
 import { lockSemrushConnectionForUpdate } from "@/lib/semrush/connections";
 import { crowdinAuth } from "@/lib/providers/adapters/crowdin/crowdin-auth";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
@@ -203,11 +204,19 @@ function validateWorkspaceAutomationConfig(input: {
   }
 
   const emailTools = input.toolConfig.email;
-  if (emailTools?.enabled && (!emailTools.recipients || emailTools.recipients.length === 0)) {
-    return err({
-      code: "email_recipients_required",
-      message: "Add at least one email recipient for automation notifications.",
-    });
+  if (emailTools?.enabled) {
+    if (!emailTools.recipients || emailTools.recipients.length === 0) {
+      return err({
+        code: "email_recipients_required",
+        message: "Add at least one email recipient for automation notifications.",
+      });
+    }
+    if (!emailTools.from?.trim()) {
+      return err({
+        code: "email_from_required",
+        message: "Add a verified sender address for email notifications.",
+      });
+    }
   }
 
   const createNativeTmsJob = input.toolConfig.createNativeTmsJob;
@@ -304,21 +313,50 @@ export async function validateWorkspaceAutomationIntegrations(input: {
   }
 
   if (input.toolConfig.email?.enabled) {
-    const [connector] = await database
-      .select({ enabled: schema.connectors.enabled })
-      .from(schema.connectors)
-      .where(
-        and(
-          eq(schema.connectors.organizationId, input.organizationId),
-          eq(schema.connectors.kind, "email"),
-        ),
-      )
-      .limit(1);
-
-    if (!connector?.enabled) {
+    const workosUserId = input.toolConfig.email.workosUserId;
+    if (!workosUserId) {
       return err({
-        code: "email_not_connected",
-        message: "Enable the email agent before using email notifications.",
+        code: "email_provider_not_connected",
+        message: "Connect an email provider in Integrations before using email notifications.",
+      });
+    }
+
+    const provider = input.toolConfig.email.provider ?? "resend";
+    const status = await getEmailPipesConnectionStatus({
+      provider,
+      localOrganizationId: input.organizationId,
+      workosUserId,
+    });
+    if (isErr(status)) {
+      if (status.error.code === "email_pipes_needs_reauthorization") {
+        return err({
+          code: "email_pipes_needs_reauthorization",
+          message: "Reconnect your email provider in Integrations, then try again.",
+        });
+      }
+      if (status.error.code === "email_provider_not_connected") {
+        return err({
+          code: "email_provider_not_connected",
+          message: "Connect an email provider in Integrations before using email notifications.",
+        });
+      }
+      return err({
+        code: "email_pipes_unavailable",
+        message: "WorkOS is not configured, so email providers cannot connect through Pipes.",
+      });
+    }
+
+    if (status.value.needsReauthorization) {
+      return err({
+        code: "email_pipes_needs_reauthorization",
+        message: "Reconnect your email provider in Integrations, then try again.",
+      });
+    }
+
+    if (!status.value.connected) {
+      return err({
+        code: "email_provider_not_connected",
+        message: "Connect an email provider in Integrations before using email notifications.",
       });
     }
   }
@@ -596,27 +634,45 @@ function shouldLockSemrushConnectionForToolConfig(
   return Boolean(toolConfig.semrush?.enabled && toolConfig.semrush.connectionId);
 }
 
-async function stampAhrefsPipesUserOnToolConfig(input: {
+async function stampPipesUsersOnToolConfig(input: {
   toolConfig: WorkspaceAutomationToolConfig;
   actorWorkosUserId?: string | null;
   authorUserId?: string | null;
 }): Promise<WorkspaceAutomationToolConfig> {
-  if (!input.toolConfig.ahrefs?.enabled) {
-    return input.toolConfig;
+  let toolConfig = input.toolConfig;
+
+  if (toolConfig.ahrefs?.enabled) {
+    const workosUserId = await resolveAhrefsPipesWorkosUserId({
+      workosUserId: input.actorWorkosUserId ?? toolConfig.ahrefs.workosUserId,
+      localUserId: input.authorUserId,
+    });
+
+    toolConfig = {
+      ...toolConfig,
+      ahrefs: {
+        enabled: true,
+        ...(workosUserId ? { workosUserId } : {}),
+      },
+    };
   }
 
-  const workosUserId = await resolveAhrefsPipesWorkosUserId({
-    workosUserId: input.actorWorkosUserId ?? input.toolConfig.ahrefs.workosUserId,
-    localUserId: input.authorUserId,
-  });
+  if (toolConfig.email?.enabled) {
+    const workosUserId = await resolveEmailPipesWorkosUserId({
+      workosUserId: input.actorWorkosUserId ?? toolConfig.email.workosUserId,
+      localUserId: input.authorUserId,
+    });
 
-  return {
-    ...input.toolConfig,
-    ahrefs: {
-      enabled: true,
-      ...(workosUserId ? { workosUserId } : {}),
-    },
-  };
+    toolConfig = {
+      ...toolConfig,
+      email: {
+        ...toolConfig.email,
+        enabled: true,
+        ...(workosUserId ? { workosUserId } : {}),
+      },
+    };
+  }
+
+  return toolConfig;
 }
 
 export async function createWorkspaceAutomation(input: {
@@ -640,7 +696,7 @@ export async function createWorkspaceAutomation(input: {
     repositoryTarget: input.repositoryTarget ?? {},
     toolConfig: input.toolConfig ?? {},
   });
-  const toolConfig = await stampAhrefsPipesUserOnToolConfig({
+  const toolConfig = await stampPipesUsersOnToolConfig({
     toolConfig: config.toolConfig,
     actorWorkosUserId: input.actorWorkosUserId,
     authorUserId: input.authorUserId,
@@ -779,7 +835,7 @@ export async function updateWorkspaceAutomation(input: {
         toolConfig: existing.toolConfig,
       };
   const stampedToolConfig = configChanged
-    ? await stampAhrefsPipesUserOnToolConfig({
+    ? await stampPipesUsersOnToolConfig({
         toolConfig: parsedConfig.toolConfig,
         actorWorkosUserId: input.actorWorkosUserId,
         authorUserId: existing.authorUserId,

--- a/apps/hyperlocalise-web/src/lib/email/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/email/constants.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { PipesProviderSlug } from "@/lib/pipes/providers";
+
+export const EMAIL_PROVIDER_SLUGS = ["resend", "sendgrid"] as const;
+
+export type EmailProviderSlug = (typeof EMAIL_PROVIDER_SLUGS)[number];
+
+export function isEmailProviderSlug(value: string): value is EmailProviderSlug {
+  return (EMAIL_PROVIDER_SLUGS as readonly string[]).includes(value);
+}
+
+export function toEmailPipesProviderSlug(provider: EmailProviderSlug): PipesProviderSlug {
+  return provider;
+}

--- a/apps/hyperlocalise-web/src/lib/email/pipes.ts
+++ b/apps/hyperlocalise-web/src/lib/email/pipes.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database/client";
+import { getPipesAccountStatus, loadPipesApiKey } from "@/lib/pipes/accounts";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { type EmailProviderSlug, toEmailPipesProviderSlug } from "./constants";
+import type { EmailPipesConnectionStatus, EmailPipesError } from "./types";
+
+const PIPES_UNAVAILABLE: EmailPipesError = {
+  code: "email_pipes_unavailable",
+  message: "WorkOS is not configured, so email providers cannot connect through Pipes.",
+};
+
+const PROVIDER_NOT_CONNECTED: EmailPipesError = {
+  code: "email_provider_not_connected",
+  message: "Connect this email provider in Integrations before using it.",
+};
+
+const NEEDS_REAUTHORIZATION: EmailPipesError = {
+  code: "email_pipes_needs_reauthorization",
+  message: "Reconnect this email provider in Integrations, then try again.",
+};
+
+function mapPipesError(code: string): EmailPipesError {
+  if (code === "pipes_not_connected") {
+    return PROVIDER_NOT_CONNECTED;
+  }
+  if (code === "pipes_needs_reauthorization") {
+    return NEEDS_REAUTHORIZATION;
+  }
+  return PIPES_UNAVAILABLE;
+}
+
+export async function resolveEmailPipesWorkosUserId(input: {
+  workosUserId?: string | null;
+  localUserId?: string | null;
+}): Promise<string | null> {
+  const explicit = input.workosUserId?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  if (!input.localUserId) {
+    return null;
+  }
+
+  const [user] = await db
+    .select({ workosUserId: schema.users.workosUserId })
+    .from(schema.users)
+    .where(eq(schema.users.id, input.localUserId))
+    .limit(1);
+
+  return user?.workosUserId ?? null;
+}
+
+export async function getEmailPipesConnectionStatus(input: {
+  provider: EmailProviderSlug;
+  localOrganizationId: string;
+  workosUserId: string;
+}): Promise<Result<EmailPipesConnectionStatus, EmailPipesError>> {
+  const result = await getPipesAccountStatus({
+    provider: toEmailPipesProviderSlug(input.provider),
+    localOrganizationId: input.localOrganizationId,
+    workosUserId: input.workosUserId,
+  });
+  if (isErr(result)) {
+    return err(mapPipesError(result.error.code));
+  }
+  return ok(result.value);
+}
+
+export async function loadEmailPipesApiKey(input: {
+  provider: EmailProviderSlug;
+  localOrganizationId: string;
+  workosUserId: string;
+}): Promise<Result<string, EmailPipesError>> {
+  const result = await loadPipesApiKey({
+    provider: toEmailPipesProviderSlug(input.provider),
+    localOrganizationId: input.localOrganizationId,
+    workosUserId: input.workosUserId,
+  });
+  if (isErr(result)) {
+    return err(mapPipesError(result.error.code));
+  }
+  return ok(result.value);
+}

--- a/apps/hyperlocalise-web/src/lib/email/send.test.ts
+++ b/apps/hyperlocalise-web/src/lib/email/send.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { isErr, isOk } from "@/lib/primitives/result/results";
+
+const mocks = vi.hoisted(() => ({
+  resendSend: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = {
+      send: (...args: unknown[]) => mocks.resendSend(...args),
+    };
+  },
+}));
+
+import { sendTransactionalEmail } from "./send";
+
+describe("sendTransactionalEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resendSend.mockResolvedValue({ data: { id: "email_1" }, error: null });
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      text: async () => "",
+    });
+    vi.stubGlobal("fetch", mocks.fetch);
+  });
+
+  it("sends via Resend", async () => {
+    const result = await sendTransactionalEmail({
+      provider: "resend",
+      apiKey: "re_test",
+      from: "notifications@example.com",
+      recipients: ["ops@example.com"],
+      subject: "Hello",
+      message: "Body",
+    });
+
+    expect(isOk(result)).toBe(true);
+    expect(mocks.resendSend).toHaveBeenCalledWith({
+      from: "notifications@example.com",
+      to: ["ops@example.com"],
+      subject: "Hello",
+      text: "Body",
+    });
+  });
+
+  it("sends via SendGrid", async () => {
+    const result = await sendTransactionalEmail({
+      provider: "sendgrid",
+      apiKey: "sg_test",
+      from: "notifications@example.com",
+      recipients: ["ops@example.com", "qa@example.com"],
+      subject: "Hello",
+      message: "Body",
+    });
+
+    expect(isOk(result)).toBe(true);
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      "https://api.sendgrid.com/v3/mail/send",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer sg_test",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+  });
+
+  it("maps SendGrid failures to email_send_failed", async () => {
+    mocks.fetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    });
+
+    const result = await sendTransactionalEmail({
+      provider: "sendgrid",
+      apiKey: "sg_test",
+      from: "notifications@example.com",
+      recipients: ["ops@example.com"],
+      subject: "Hello",
+      message: "Body",
+    });
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe("email_send_failed");
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/email/send.ts
+++ b/apps/hyperlocalise-web/src/lib/email/send.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Resend } from "resend";
+
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+import type { EmailSendError, TransactionalEmailInput } from "./types";
+
+async function sendViaResend(
+  input: TransactionalEmailInput,
+): Promise<Result<void, EmailSendError>> {
+  try {
+    const resend = new Resend(input.apiKey);
+    const result = await resend.emails.send({
+      from: input.from,
+      to: input.recipients,
+      subject: input.subject,
+      text: input.message,
+    });
+
+    if (result.error) {
+      return err({
+        code: "email_send_failed",
+        message: result.error.message,
+      });
+    }
+
+    return ok(undefined);
+  } catch (error) {
+    return err({
+      code: "email_send_failed",
+      message: error instanceof Error ? error.message : "Email notification failed.",
+    });
+  }
+}
+
+async function sendViaSendGrid(
+  input: TransactionalEmailInput,
+): Promise<Result<void, EmailSendError>> {
+  try {
+    const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        personalizations: [
+          {
+            to: input.recipients.map((email) => ({ email })),
+          },
+        ],
+        from: { email: input.from },
+        subject: input.subject,
+        content: [{ type: "text/plain", value: input.message }],
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      return err({
+        code: "email_send_failed",
+        message: body.trim() || `SendGrid request failed with status ${response.status}.`,
+      });
+    }
+
+    return ok(undefined);
+  } catch (error) {
+    return err({
+      code: "email_send_failed",
+      message: error instanceof Error ? error.message : "Email notification failed.",
+    });
+  }
+}
+
+export async function sendTransactionalEmail(
+  input: TransactionalEmailInput,
+): Promise<Result<void, EmailSendError>> {
+  switch (input.provider) {
+    case "resend":
+      return sendViaResend(input);
+    case "sendgrid":
+      return sendViaSendGrid(input);
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/email/types.ts
+++ b/apps/hyperlocalise-web/src/lib/email/types.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { PipesConnectionStatus } from "@/lib/pipes/types";
+
+import type { EmailProviderSlug } from "./constants";
+
+export type EmailPipesConnectionStatus = PipesConnectionStatus;
+
+export type EmailPipesError =
+  | { code: "email_pipes_unavailable"; message: string }
+  | { code: "email_provider_not_connected"; message: string }
+  | { code: "email_pipes_needs_reauthorization"; message: string };
+
+export type EmailSendError = {
+  code: "email_send_failed";
+  message: string;
+};
+
+export type TransactionalEmailInput = {
+  provider: EmailProviderSlug;
+  apiKey: string;
+  from: string;
+  recipients: string[];
+  subject: string;
+  message: string;
+};

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/catalog/node-catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/catalog/node-catalog.ts
@@ -76,6 +76,12 @@ export const VISUAL_NODE_CATALOG: readonly VisualNodeCatalogItem[] = [
     icon: Mail01Icon,
   },
   {
+    type: "action.notify_email",
+    category: "action",
+    enabled: true,
+    icon: Mail01Icon,
+  },
+  {
     type: "logic.if",
     category: "logic",
     enabled: true,
@@ -150,6 +156,16 @@ export function createDefaultConfig(type: VisualCatalogType): VisualNodeConfig {
       };
     case "action.notify_slack":
       return { kind: "action.notify_slack", channelId: "", message: "", onError: "stop" };
+    case "action.notify_email":
+      return {
+        kind: "action.notify_email",
+        provider: "resend",
+        from: "",
+        recipients: "",
+        subject: "",
+        message: "",
+        onError: "stop",
+      };
     case "logic.if":
       return { kind: "logic.if", condition: "" };
     case "logic.switch":
@@ -214,6 +230,8 @@ export function resolveNodeSubtitle(config: VisualNodeConfig): string {
       return config.method;
     case "action.notify_slack":
       return config.channelId ? "Slack" : "Slack channel";
+    case "action.notify_email":
+      return config.from ? config.provider : "Email";
     case "logic.if":
       return config.condition.trim() ? "1 condition" : "No condition";
     case "logic.switch":

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/preview/playground-run.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/preview/playground-run.ts
@@ -89,6 +89,62 @@ async function executePlaygroundVisualWorkflowNode(input: {
         },
       };
     }
+    case "action.notify_email": {
+      const from = resolveVisualWorkflowTemplate(input.node.config.from, input.context).trim();
+      const recipientsRaw = resolveVisualWorkflowTemplate(
+        input.node.config.recipients,
+        input.context,
+      ).trim();
+      const subject = resolveVisualWorkflowTemplate(
+        input.node.config.subject,
+        input.context,
+      ).trim();
+      const message = resolveVisualWorkflowTemplate(
+        input.node.config.message,
+        input.context,
+      ).trim();
+      if (!from) {
+        return {
+          ok: false,
+          error: { code: "missing_from", message: "Sender email address is required." },
+        };
+      }
+      const recipients = recipientsRaw
+        .split(/[\n,;]+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      if (recipients.length === 0) {
+        return {
+          ok: false,
+          error: { code: "missing_recipients", message: "At least one recipient is required." },
+        };
+      }
+      if (!subject) {
+        return {
+          ok: false,
+          error: { code: "missing_subject", message: "Email subject is required." },
+        };
+      }
+      if (!message) {
+        return {
+          ok: false,
+          error: { code: "missing_message", message: "Email message is required." },
+        };
+      }
+
+      return {
+        ok: true,
+        output: {
+          sent: true,
+          provider: input.node.config.provider,
+          from,
+          recipients,
+          subject,
+          message,
+          simulated: true,
+        },
+      };
+    }
     case "ai.agent": {
       const prompt = resolveVisualWorkflowTemplate(input.node.config.prompt, input.context).trim();
       if (!prompt) {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execute-node.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execute-node.ts
@@ -40,7 +40,6 @@ export async function executeVisualWorkflowNode(input: {
   node: CanonicalVisualWorkflowNode;
   context: VisualWorkflowExecutionContext;
   organizationId: string;
-  workosUserId?: string | null;
 }): Promise<VisualWorkflowNodeExecutionResult> {
   const { node, context } = input;
   const logicResult = executeLogicVisualWorkflowNode({ node, context });
@@ -171,14 +170,15 @@ export async function executeVisualWorkflowNode(input: {
       const recipientsRaw = resolveVisualWorkflowTemplate(node.config.recipients, context).trim();
       const subject = resolveVisualWorkflowTemplate(node.config.subject, context).trim();
       const message = resolveVisualWorkflowTemplate(node.config.message, context).trim();
-      const workosUserId = input.workosUserId?.trim();
+      const workosUserId = node.config.workosUserId?.trim();
 
       if (!workosUserId) {
         return {
           ok: false,
           error: {
             code: "email_provider_not_connected",
-            message: "Connect an email provider in Integrations before sending email.",
+            message:
+              "Reconnect the email provider in Integrations and save the workflow before sending email.",
           },
         };
       }

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execute-node.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/execute-node.ts
@@ -12,7 +12,10 @@
  */
 import { generateText } from "ai";
 
-import { runWorkspaceAutomationSlackNotificationTool } from "@/lib/agents/workspace-automation/notification-tools";
+import {
+  runWorkspaceAutomationEmailNotificationTool,
+  runWorkspaceAutomationSlackNotificationTool,
+} from "@/lib/agents/workspace-automation/notification-tools";
 import { resolveHyperlocaliseAgentLanguageModel } from "@/lib/providers/organization-language-model";
 import { readBoundedResponseBody, withPublicHttpFetch } from "@/lib/security/public-http-fetch";
 
@@ -37,6 +40,7 @@ export async function executeVisualWorkflowNode(input: {
   node: CanonicalVisualWorkflowNode;
   context: VisualWorkflowExecutionContext;
   organizationId: string;
+  workosUserId?: string | null;
 }): Promise<VisualWorkflowNodeExecutionResult> {
   const { node, context } = input;
   const logicResult = executeLogicVisualWorkflowNode({ node, context });
@@ -159,6 +163,80 @@ export async function executeVisualWorkflowNode(input: {
         output: {
           sent: true,
           channelId,
+        },
+      };
+    }
+    case "action.notify_email": {
+      const from = resolveVisualWorkflowTemplate(node.config.from, context).trim();
+      const recipientsRaw = resolveVisualWorkflowTemplate(node.config.recipients, context).trim();
+      const subject = resolveVisualWorkflowTemplate(node.config.subject, context).trim();
+      const message = resolveVisualWorkflowTemplate(node.config.message, context).trim();
+      const workosUserId = input.workosUserId?.trim();
+
+      if (!workosUserId) {
+        return {
+          ok: false,
+          error: {
+            code: "email_provider_not_connected",
+            message: "Connect an email provider in Integrations before sending email.",
+          },
+        };
+      }
+      if (!from) {
+        return {
+          ok: false,
+          error: { code: "missing_from", message: "Sender email address is required." },
+        };
+      }
+      const recipients = recipientsRaw
+        .split(/[\n,;]+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      if (recipients.length === 0) {
+        return {
+          ok: false,
+          error: { code: "missing_recipients", message: "At least one recipient is required." },
+        };
+      }
+      if (!subject) {
+        return {
+          ok: false,
+          error: { code: "missing_subject", message: "Email subject is required." },
+        };
+      }
+      if (!message) {
+        return {
+          ok: false,
+          error: { code: "missing_message", message: "Email message is required." },
+        };
+      }
+
+      const result = await runWorkspaceAutomationEmailNotificationTool({
+        organizationId: input.organizationId,
+        provider: node.config.provider,
+        workosUserId,
+        from,
+        recipients,
+        subject,
+        message,
+      });
+
+      if (!result.ok) {
+        return {
+          ok: false,
+          error: {
+            code: result.error.code,
+            message: result.error.message,
+          },
+        };
+      }
+
+      return {
+        ok: true,
+        output: {
+          sent: true,
+          provider: node.config.provider,
+          recipientCount: recipients.length,
         },
       };
     }

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter-server.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter-server.ts
@@ -33,7 +33,6 @@ export { getVisualWorkflowGraphIndex };
 export async function runVisualWorkflowInterpreter(input: {
   definition: VisualWorkflowDefinition;
   organizationId: string;
-  workosUserId?: string | null;
   triggerInput?: Record<string, unknown>;
   executeNode?: VisualWorkflowInterpreterExecuteNode;
   onNodeUpdate?: (update: VisualWorkflowInterpreterNodeUpdate) => Promise<void> | void;

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter-server.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter-server.ts
@@ -33,6 +33,7 @@ export { getVisualWorkflowGraphIndex };
 export async function runVisualWorkflowInterpreter(input: {
   definition: VisualWorkflowDefinition;
   organizationId: string;
+  workosUserId?: string | null;
   triggerInput?: Record<string, unknown>;
   executeNode?: VisualWorkflowInterpreterExecuteNode;
   onNodeUpdate?: (update: VisualWorkflowInterpreterNodeUpdate) => Promise<void> | void;

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter.ts
@@ -367,13 +367,11 @@ export type VisualWorkflowInterpreterExecuteNode = (args: {
   node: CanonicalVisualWorkflowNode;
   context: VisualWorkflowExecutionContext;
   organizationId: string;
-  workosUserId?: string | null;
 }) => Promise<VisualWorkflowNodeExecutionResult>;
 
 export async function runVisualWorkflowInterpreter(input: {
   definition: VisualWorkflowDefinition;
   organizationId: string;
-  workosUserId?: string | null;
   triggerInput?: Record<string, unknown>;
   executeNode: VisualWorkflowInterpreterExecuteNode;
   onNodeUpdate?: (update: VisualWorkflowInterpreterNodeUpdate) => Promise<void> | void;
@@ -416,7 +414,6 @@ export async function runVisualWorkflowInterpreter(input: {
       node,
       context,
       organizationId: input.organizationId,
-      workosUserId: input.workosUserId,
     });
 
     if (!execution.ok) {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/runtime/interpreter.ts
@@ -367,11 +367,13 @@ export type VisualWorkflowInterpreterExecuteNode = (args: {
   node: CanonicalVisualWorkflowNode;
   context: VisualWorkflowExecutionContext;
   organizationId: string;
+  workosUserId?: string | null;
 }) => Promise<VisualWorkflowNodeExecutionResult>;
 
 export async function runVisualWorkflowInterpreter(input: {
   definition: VisualWorkflowDefinition;
   organizationId: string;
+  workosUserId?: string | null;
   triggerInput?: Record<string, unknown>;
   executeNode: VisualWorkflowInterpreterExecuteNode;
   onNodeUpdate?: (update: VisualWorkflowInterpreterNodeUpdate) => Promise<void> | void;
@@ -414,6 +416,7 @@ export async function runVisualWorkflowInterpreter(input: {
       node,
       context,
       organizationId: input.organizationId,
+      workosUserId: input.workosUserId,
     });
 
     if (!execution.ok) {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/definition-schema.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/definition-schema.ts
@@ -12,6 +12,7 @@
  */
 import { z } from "zod";
 
+import { EMAIL_PROVIDER_SLUGS } from "@/lib/email/constants";
 import { VISUAL_WORKFLOW_SCHEMA_VERSION } from "./types";
 
 const httpMethodSchema = z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]);
@@ -50,6 +51,7 @@ const visualCatalogTypeSchema = z.enum([
   "trigger.source_upload",
   "action.http",
   "action.notify_slack",
+  "action.notify_email",
   "logic.if",
   "logic.switch",
   "logic.set",
@@ -93,6 +95,15 @@ const visualNodeConfigSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("action.notify_slack"),
     channelId: z.string().trim().min(1).max(64),
+    message: z.string().max(4000),
+    onError: visualNodeErrorBehaviorSchema.optional(),
+  }),
+  z.object({
+    kind: z.literal("action.notify_email"),
+    provider: z.enum(EMAIL_PROVIDER_SLUGS).default("resend"),
+    from: z.string().trim().email().max(320),
+    recipients: z.string().trim().min(1).max(4000),
+    subject: z.string().max(1000),
     message: z.string().max(4000),
     onError: visualNodeErrorBehaviorSchema.optional(),
   }),

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/definition-schema.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/definition-schema.ts
@@ -101,6 +101,7 @@ const visualNodeConfigSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("action.notify_email"),
     provider: z.enum(EMAIL_PROVIDER_SLUGS).default("resend"),
+    workosUserId: z.string().trim().min(1).max(128).optional(),
     from: z.string().trim().email().max(320),
     recipients: z.string().trim().min(1).max(4000),
     subject: z.string().max(1000),

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/serializers.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/serializers.ts
@@ -27,6 +27,7 @@ const ENABLED_TYPES = new Set<VisualCatalogType>([
   "trigger.source_upload",
   "action.http",
   "action.notify_slack",
+  "action.notify_email",
   "logic.if",
   "logic.switch",
   "logic.set",

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/types.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/types.ts
@@ -12,6 +12,8 @@
  */
 import type { Edge, Node } from "@xyflow/react";
 
+import type { EmailProviderSlug } from "@/lib/email/constants";
+
 export const VISUAL_WORKFLOW_SCHEMA_VERSION = 1 as const;
 
 export type VisualCatalogType =
@@ -21,6 +23,7 @@ export type VisualCatalogType =
   | "trigger.source_upload"
   | "action.http"
   | "action.notify_slack"
+  | "action.notify_email"
   | "logic.if"
   | "logic.switch"
   | "logic.set"
@@ -85,6 +88,15 @@ export type VisualNodeConfig =
   | {
       kind: "action.notify_slack";
       channelId: string;
+      message: string;
+      onError?: VisualNodeErrorBehavior;
+    }
+  | {
+      kind: "action.notify_email";
+      provider: EmailProviderSlug;
+      from: string;
+      recipients: string;
+      subject: string;
       message: string;
       onError?: VisualNodeErrorBehavior;
     }

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/schema/types.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/schema/types.ts
@@ -94,6 +94,7 @@ export type VisualNodeConfig =
   | {
       kind: "action.notify_email";
       provider: EmailProviderSlug;
+      workosUserId?: string;
       from: string;
       recipients: string;
       subject: string;

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/stamp-email-node-pipes-users.test.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/stamp-email-node-pipes-users.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { createEmptyVisualWorkflowDefinition } from "./schema/serializers";
+import type { VisualWorkflowDefinition } from "./schema/types";
+import { stampEmailNodePipesUsersOnDefinition } from "./stamp-email-node-pipes-users";
+
+function emailDefinition(nodes: VisualWorkflowDefinition["nodes"]): VisualWorkflowDefinition {
+  const definition = createEmptyVisualWorkflowDefinition("Email workflow");
+  return {
+    ...definition,
+    nodes,
+  };
+}
+
+describe("stampEmailNodePipesUsersOnDefinition", () => {
+  it("stamps the actor WorkOS user on new email nodes", () => {
+    const definition = emailDefinition([
+      {
+        id: "email-1",
+        type: "action.notify_email",
+        config: {
+          kind: "action.notify_email",
+          provider: "resend",
+          from: "ops@example.com",
+          recipients: "team@example.com",
+          subject: "Hello",
+          message: "Body",
+        },
+      },
+    ]);
+
+    const stamped = stampEmailNodePipesUsersOnDefinition({
+      definition,
+      actorWorkosUserId: "user_operator_b",
+    });
+
+    expect(stamped.nodes[0]?.config).toMatchObject({
+      workosUserId: "user_operator_b",
+    });
+  });
+
+  it("preserves the credential owner when another operator saves unrelated changes", () => {
+    const previous = emailDefinition([
+      {
+        id: "email-1",
+        type: "action.notify_email",
+        config: {
+          kind: "action.notify_email",
+          provider: "resend",
+          from: "ops@example.com",
+          recipients: "team@example.com",
+          subject: "Hello",
+          message: "Body",
+          workosUserId: "user_operator_b",
+        },
+      },
+    ]);
+
+    const next = emailDefinition([
+      {
+        id: "email-1",
+        type: "action.notify_email",
+        config: {
+          kind: "action.notify_email",
+          provider: "resend",
+          from: "ops@example.com",
+          recipients: "team@example.com",
+          subject: "Hello",
+          message: "Body",
+        },
+      },
+    ]);
+
+    const stamped = stampEmailNodePipesUsersOnDefinition({
+      definition: next,
+      previousDefinition: previous,
+      actorWorkosUserId: "user_operator_a",
+    });
+
+    expect(stamped.nodes[0]?.config).toMatchObject({
+      workosUserId: "user_operator_b",
+    });
+  });
+
+  it("re-stamps the actor when the email node configuration changes", () => {
+    const previous = emailDefinition([
+      {
+        id: "email-1",
+        type: "action.notify_email",
+        config: {
+          kind: "action.notify_email",
+          provider: "resend",
+          from: "ops@example.com",
+          recipients: "team@example.com",
+          subject: "Hello",
+          message: "Body",
+          workosUserId: "user_operator_a",
+        },
+      },
+    ]);
+
+    const next = emailDefinition([
+      {
+        id: "email-1",
+        type: "action.notify_email",
+        config: {
+          kind: "action.notify_email",
+          provider: "sendgrid",
+          from: "ops@example.com",
+          recipients: "team@example.com",
+          subject: "Hello",
+          message: "Body",
+        },
+      },
+    ]);
+
+    const stamped = stampEmailNodePipesUsersOnDefinition({
+      definition: next,
+      previousDefinition: previous,
+      actorWorkosUserId: "user_operator_b",
+    });
+
+    expect(stamped.nodes[0]?.config).toMatchObject({
+      provider: "sendgrid",
+      workosUserId: "user_operator_b",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/stamp-email-node-pipes-users.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/stamp-email-node-pipes-users.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { VisualNodeConfig, VisualWorkflowDefinition } from "./schema/types";
+
+type NotifyEmailNodeConfig = Extract<VisualNodeConfig, { kind: "action.notify_email" }>;
+
+function emailNodeConfigFingerprint(config: NotifyEmailNodeConfig): string {
+  const { workosUserId: _workosUserId, ...rest } = config;
+  return JSON.stringify(rest);
+}
+
+function previousEmailNodeConfigById(
+  previousDefinition: VisualWorkflowDefinition | null | undefined,
+): Map<string, NotifyEmailNodeConfig> {
+  const configs = new Map<string, NotifyEmailNodeConfig>();
+  if (!previousDefinition) {
+    return configs;
+  }
+
+  for (const node of previousDefinition.nodes) {
+    if (node.config.kind === "action.notify_email") {
+      configs.set(node.id, node.config);
+    }
+  }
+
+  return configs;
+}
+
+export function stampEmailNodePipesUsersOnDefinition(input: {
+  definition: VisualWorkflowDefinition;
+  previousDefinition?: VisualWorkflowDefinition | null;
+  actorWorkosUserId?: string | null;
+}): VisualWorkflowDefinition {
+  const actorWorkosUserId = input.actorWorkosUserId?.trim();
+  if (!actorWorkosUserId) {
+    return input.definition;
+  }
+
+  const previousConfigs = previousEmailNodeConfigById(input.previousDefinition);
+
+  const nodes = input.definition.nodes.map((node) => {
+    if (node.config.kind !== "action.notify_email") {
+      return node;
+    }
+
+    const previousConfig = previousConfigs.get(node.id);
+    const configChanged =
+      !previousConfig ||
+      emailNodeConfigFingerprint(previousConfig) !== emailNodeConfigFingerprint(node.config);
+
+    if (!configChanged) {
+      const preservedWorkosUserId = node.config.workosUserId ?? previousConfig?.workosUserId;
+      if (!preservedWorkosUserId || preservedWorkosUserId === node.config.workosUserId) {
+        return node;
+      }
+
+      return {
+        ...node,
+        config: {
+          ...node.config,
+          workosUserId: preservedWorkosUserId,
+        },
+      };
+    }
+
+    return {
+      ...node,
+      config: {
+        ...node.config,
+        workosUserId: actorWorkosUserId,
+      },
+    };
+  });
+
+  return {
+    ...input.definition,
+    nodes,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow-runs.ts
@@ -15,7 +15,6 @@ import "server-only";
 import { and, desc, eq, sql } from "drizzle-orm";
 
 import { db, schema, type DatabaseClient } from "@/lib/database/client";
-import { resolveEmailPipesWorkosUserId } from "@/lib/email/pipes";
 
 import { visualWorkflowDefinitionSchema } from "./schema/definition-schema";
 import type { VisualWorkflowDefinition } from "./schema/types";
@@ -768,13 +767,9 @@ export async function executeVisualWorkflowRun(input: {
   }
 
   const { runVisualWorkflowInterpreter } = await import("./runtime/interpreter-server");
-  const workosUserId = await resolveEmailPipesWorkosUserId({
-    localUserId: workflow.authorUserId,
-  });
   const result = await runVisualWorkflowInterpreter({
     definition,
     organizationId: input.organizationId,
-    workosUserId,
     triggerInput: extractTriggerInputFromRunSnapshot(run.inputSnapshot),
     onNodeUpdate: async (update) => {
       await upsertVisualWorkflowNodeRun({

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow-runs.ts
@@ -15,6 +15,7 @@ import "server-only";
 import { and, desc, eq, sql } from "drizzle-orm";
 
 import { db, schema, type DatabaseClient } from "@/lib/database/client";
+import { resolveEmailPipesWorkosUserId } from "@/lib/email/pipes";
 
 import { visualWorkflowDefinitionSchema } from "./schema/definition-schema";
 import type { VisualWorkflowDefinition } from "./schema/types";
@@ -767,9 +768,13 @@ export async function executeVisualWorkflowRun(input: {
   }
 
   const { runVisualWorkflowInterpreter } = await import("./runtime/interpreter-server");
+  const workosUserId = await resolveEmailPipesWorkosUserId({
+    localUserId: workflow.authorUserId,
+  });
   const result = await runVisualWorkflowInterpreter({
     definition,
     organizationId: input.organizationId,
+    workosUserId,
     triggerInput: extractTriggerInputFromRunSnapshot(run.inputSnapshot),
     onNodeUpdate: async (update) => {
       await upsertVisualWorkflowNodeRun({

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow.test.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflow.test.ts
@@ -210,6 +210,19 @@ describe("validateVisualWorkflowDefinition config", () => {
       issues.some((issue) => issue.code === "invalid_node_config" && issue.nodeId === "slack"),
     ).toBe(true);
   });
+
+  it("reports invalid node config for default email action", () => {
+    const definition = toVisualWorkflowDefinition({
+      name: "Email",
+      nodes: [node("t", "trigger.manual"), node("email", "action.notify_email")],
+      edges: [{ id: "e1", source: "t", target: "email" }],
+    });
+
+    const issues = validateVisualWorkflowDefinition(definition);
+    expect(
+      issues.some((issue) => issue.code === "invalid_node_config" && issue.nodeId === "email"),
+    ).toBe(true);
+  });
 });
 
 describe("visual workflow editor graph helpers", () => {

--- a/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflows.ts
+++ b/apps/hyperlocalise-web/src/lib/visual-workflows/visual-workflows.ts
@@ -32,6 +32,7 @@ import {
 } from "./schema/serializers";
 import type { VisualWorkflowDefinition } from "./schema/types";
 import { validateVisualWorkflowDefinition } from "./validation/validate-workflow";
+import { stampEmailNodePipesUsersOnDefinition } from "./stamp-email-node-pipes-users";
 import type {
   VisualWorkflowRecord,
   VisualWorkflowStatus,
@@ -213,6 +214,7 @@ export async function getVisualWorkflowById(input: {
 export async function createVisualWorkflow(input: {
   organizationId: string;
   authorUserId?: string | null;
+  actorWorkosUserId?: string | null;
   projectId?: string | null;
   name?: string;
   definition?: VisualWorkflowDefinition;
@@ -238,9 +240,13 @@ export async function createVisualWorkflow(input: {
   const definition =
     input.definition ??
     createEmptyVisualWorkflowDefinition(input.name?.trim() || "Untitled workflow");
-  const name = input.name?.trim() || definition.name;
+  const stampedDefinition = stampEmailNodePipesUsersOnDefinition({
+    definition,
+    actorWorkosUserId: input.actorWorkosUserId,
+  });
+  const name = input.name?.trim() || stampedDefinition.name;
 
-  const validated = validateVisualWorkflowPayload({ name, definition });
+  const validated = validateVisualWorkflowPayload({ name, definition: stampedDefinition });
   if (isErr(validated)) {
     return validated;
   }
@@ -300,6 +306,7 @@ export async function createVisualWorkflow(input: {
 export async function updateVisualWorkflow(input: {
   organizationId: string;
   visualWorkflowId: string;
+  actorWorkosUserId?: string | null;
   name?: string;
   definition?: VisualWorkflowDefinition;
   status?: VisualWorkflowStatus;
@@ -348,13 +355,18 @@ export async function updateVisualWorkflow(input: {
 
   const nextName = input.name?.trim() || existing.name;
   const nextDefinition = input.definition ?? existing.definition;
-
-  const validated = validateVisualWorkflowPayload({
-    name: nextName,
+  const stampedDefinition = stampEmailNodePipesUsersOnDefinition({
     definition: {
       ...nextDefinition,
       name: nextName,
     },
+    previousDefinition: existing.definition,
+    actorWorkosUserId: input.actorWorkosUserId,
+  });
+
+  const validated = validateVisualWorkflowPayload({
+    name: nextName,
+    definition: stampedDefinition,
   });
   if (isErr(validated)) {
     return validated;


### PR DESCRIPTION
## What changed
- Added `lib/email/` to send transactional email through Resend or SendGrid using WorkOS Pipes API keys.
- Updated the `notify_email` automation tool to use Pipes credentials instead of platform `RESEND_*` env vars, with provider selection, sender address, and connection validation.
- Added `action.notify_email` to visual workflows (schema, runtime, playground, and editor UI).
- Updated the automation form to check Resend/SendGrid Pipes connection status and configure provider, from address, and recipients.
## How to test
- Connect Resend or SendGrid in Integrations (WorkOS Pipes).
- **Automations:** add the "Send email" tool, set provider, from address, and recipients, then run an automation that calls `notify_email`.
- **Visual workflows:** add a "Send email" action node, configure provider/from/recipients/subject/message, and test in the playground or via a manual run.
- `cd apps/hyperlocalise-web && vp test src/lib/email src/lib/agents/workspace-automation/notification-tools.test.ts src/agents/automations/workspace/agent/tools/notify_email.test.ts src/lib/visual-workflows/visual-workflow.test.ts src/lib/visual-workflows/runtime/runtime.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix`
## Checklist
- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review