### PR TITLE
feat(cli): add Smartling file ops, project info, and download --all

### DIFF
--- a/apps/cli/cmd/smartling.go
+++ b/apps/cli/cmd/smartling.go
@@ -42,11 +42,13 @@ type smartlingDownloadTranslationsOptions struct {
 	projectID      string
 	targetLocales  []string
 	fileURI        string
+	uriMask        string
 	output         string
 	retrievalType  string
 	userIdentifier string
 	userSecret     string
 	userSecretEnv  string
+	all            bool
 	force          bool
 	dryRun         bool
 }
@@ -55,10 +57,12 @@ type smartlingDownloadSourcesOptions struct {
 	projectID      string
 	sourceLocale   string
 	fileURI        string
+	uriMask        string
 	output         string
 	userIdentifier string
 	userSecret     string
 	userSecretEnv  string
+	all            bool
 	force          bool
 	dryRun         bool
 }
@@ -87,10 +91,12 @@ var newSmartlingTranslationImporter = func(cfg smartling.Config) (smartlingTrans
 
 type smartlingSourceDownloader interface {
 	DownloadSourceFile(context.Context, smartling.SourceDownloadInput) (smartling.SourceDownloadResult, error)
+	ListFiles(context.Context, smartling.FileListInput) ([]smartling.FileListItem, error)
 }
 
 type smartlingTranslationDownloader interface {
 	DownloadTranslationFile(context.Context, smartling.TranslationDownloadInput) (smartling.TranslationDownloadResult, error)
+	ListFiles(context.Context, smartling.FileListInput) ([]smartling.FileListItem, error)
 }
 
 type smartlingTranslationImporter interface {
@@ -109,15 +115,16 @@ func newSmartlingDownloadSourcesCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
 	cmd.Flags().StringVar(&o.sourceLocale, "source-locale", "", "deprecated; Smartling source downloads use the project source locale")
-	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "Smartling file URI")
-	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path; omit or use - for stdout")
+	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "Smartling file URI (exactly one of --file-uri or --all)")
+	cmd.Flags().StringVar(&o.uriMask, "uri-mask", "", "substring filter on file URI; only valid with --all")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path for one URI (omit or - for stdout); directory for --all (default .)")
 	cmd.Flags().StringVar(&o.userIdentifier, "user-id", "", "Smartling user identifier")
 	cmd.Flags().StringVar(&o.userSecret, "user-secret", "", "Smartling user secret")
 	cmd.Flags().StringVar(&o.userSecretEnv, "user-secret-env", "", "Environment variable for Smartling user secret")
+	cmd.Flags().BoolVar(&o.all, "all", false, "download every listed file URI")
 	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
 	_ = cmd.MarkFlagRequired("project-id")
-	_ = cmd.MarkFlagRequired("file-uri")
 	_ = cmd.Flags().MarkDeprecated("source-locale", "Smartling source downloads use the project source locale; omit this flag")
 	return cmd
 }
@@ -134,26 +141,32 @@ func newSmartlingDownloadTranslationsCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
 	cmd.Flags().StringSliceVarP(&o.targetLocales, "target-locale", "l", nil, "target locale ID(s) to download")
-	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "Smartling file URI")
-	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path; omit or use - for stdout when downloading one locale; use %locale% for multiple locales")
+	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "Smartling file URI (exactly one of --file-uri or --all)")
+	cmd.Flags().StringVar(&o.uriMask, "uri-mask", "", "substring filter on file URI; only valid with --all")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path for one URI (omit or - for stdout when downloading one locale; use %locale% for multiple locales); directory for --all (default .)")
 	cmd.Flags().StringVar(&o.retrievalType, "retrieval-type", "", "which translations to download: pending, published, or pseudo")
 	cmd.Flags().StringVar(&o.userIdentifier, "user-id", "", "Smartling user identifier")
 	cmd.Flags().StringVar(&o.userSecret, "user-secret", "", "Smartling user secret")
 	cmd.Flags().StringVar(&o.userSecretEnv, "user-secret-env", "", "Environment variable for Smartling user secret")
+	cmd.Flags().BoolVar(&o.all, "all", false, "download every listed file URI")
 	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
 	_ = cmd.MarkFlagRequired("project-id")
 	_ = cmd.MarkFlagRequired("target-locale")
-	_ = cmd.MarkFlagRequired("file-uri")
 	return cmd
 }
 
 func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSourcesOptions) error {
+	const action = "smartling download sources"
 	if strings.TrimSpace(o.projectID) == "" {
-		return fmt.Errorf("smartling download sources: --project-id is required")
+		return fmt.Errorf("%s: --project-id is required", action)
 	}
-	if strings.TrimSpace(o.fileURI) == "" {
-		return fmt.Errorf("smartling download sources: --file-uri is required")
+	if err := validateSmartlingDownloadSelection(o.all, o.fileURI, o.uriMask, action); err != nil {
+		return err
+	}
+
+	if o.all {
+		return executeSmartlingDownloadSourcesAll(cmd, o)
 	}
 
 	outputPath := strings.TrimSpace(o.output)
@@ -169,7 +182,7 @@ func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSour
 		return err
 	}
 
-	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, "smartling download sources")
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
 	if err != nil {
 		return err
 	}
@@ -184,7 +197,7 @@ func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSour
 		FileURI:   strings.TrimSpace(o.fileURI),
 	})
 	if err != nil {
-		return fmt.Errorf("smartling download sources: %w", err)
+		return wrapSmartlingCommandError(action, err)
 	}
 
 	if outputPath == "" || outputPath == "-" {
@@ -198,20 +211,93 @@ func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSour
 	return err
 }
 
+func executeSmartlingDownloadSourcesAll(cmd *cobra.Command, o smartlingDownloadSourcesOptions) error {
+	const action = "smartling download sources"
+	dir, err := resolveSmartlingDownloadAllDirectory(o.output, action)
+	if err != nil {
+		return err
+	}
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
+	if err != nil {
+		return err
+	}
+	cfg.ProjectID = strings.TrimSpace(o.projectID)
+	client, err := newSmartlingSourceDownloader(cfg)
+	if err != nil {
+		return err
+	}
+	files, err := client.ListFiles(backgroundContext(), smartling.FileListInput{
+		ProjectID: strings.TrimSpace(o.projectID),
+		URIMask:   strings.TrimSpace(o.uriMask),
+	})
+	if err != nil {
+		return wrapSmartlingCommandError(action, err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("%s: no files found", action)
+	}
+	if o.dryRun {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-sources-all project_id=%s output_dir=%s\n", strings.TrimSpace(o.projectID), dir); err != nil {
+			return err
+		}
+		for _, file := range files {
+			dest, destErr := smartlingDownloadAllOutputPath(dir, file.FileURI, "")
+			if destErr != nil {
+				return destErr
+			}
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "file_uri=%s output=%s\n", file.FileURI, dest); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("%s: mkdir output directory: %w", action, err)
+	}
+	for _, file := range files {
+		dest, destErr := smartlingDownloadAllOutputPath(dir, file.FileURI, "")
+		if destErr != nil {
+			return destErr
+		}
+		if err := validateSmartlingDownloadSourcesOutputPath(dest, o.force); err != nil {
+			return err
+		}
+		result, err := client.DownloadSourceFile(backgroundContext(), smartling.SourceDownloadInput{
+			ProjectID: strings.TrimSpace(o.projectID),
+			FileURI:   file.FileURI,
+		})
+		if err != nil {
+			return wrapSmartlingCommandError(action, err)
+		}
+		if err := writeSmartlingDownloadedSource(dest, result.Content, o.force); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d file_uri=%s\n", dest, len(result.Content), result.FileURI); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloadTranslationsOptions) error {
+	const action = "smartling download translations"
 	if strings.TrimSpace(o.projectID) == "" {
-		return fmt.Errorf("smartling download translations: --project-id is required")
+		return fmt.Errorf("%s: --project-id is required", action)
 	}
 	locales := normalizeSmartlingLocales(o.targetLocales)
 	if len(locales) == 0 {
-		return fmt.Errorf("smartling download translations: at least one --target-locale is required")
+		return fmt.Errorf("%s: at least one --target-locale is required", action)
 	}
-	if strings.TrimSpace(o.fileURI) == "" {
-		return fmt.Errorf("smartling download translations: --file-uri is required")
+	if err := validateSmartlingDownloadSelection(o.all, o.fileURI, o.uriMask, action); err != nil {
+		return err
 	}
 	retrievalType, err := smartling.NormalizeRetrievalType(o.retrievalType)
 	if err != nil {
-		return fmt.Errorf("smartling download translations: --retrieval-type must be pending, published, or pseudo")
+		return fmt.Errorf("%s: --retrieval-type must be pending, published, or pseudo", action)
+	}
+
+	if o.all {
+		return executeSmartlingDownloadTranslationsAll(cmd, o, locales, retrievalType)
 	}
 
 	outputPath := strings.TrimSpace(o.output)
@@ -279,6 +365,159 @@ func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloa
 		}
 	}
 	return nil
+}
+
+func executeSmartlingDownloadTranslationsAll(cmd *cobra.Command, o smartlingDownloadTranslationsOptions, locales []string, retrievalType string) error {
+	const action = "smartling download translations"
+	dir, err := resolveSmartlingDownloadAllDirectory(o.output, action)
+	if err != nil {
+		return err
+	}
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
+	if err != nil {
+		return err
+	}
+	cfg.ProjectID = strings.TrimSpace(o.projectID)
+	client, err := newSmartlingTranslationDownloader(cfg)
+	if err != nil {
+		return err
+	}
+	files, err := client.ListFiles(backgroundContext(), smartling.FileListInput{
+		ProjectID: strings.TrimSpace(o.projectID),
+		URIMask:   strings.TrimSpace(o.uriMask),
+	})
+	if err != nil {
+		return wrapSmartlingCommandError(action, err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("%s: no files found", action)
+	}
+	if o.dryRun {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-translations-all project_id=%s target_locales=%s retrieval_type=%s output_dir=%s\n", strings.TrimSpace(o.projectID), strings.Join(locales, ","), retrievalType, dir); err != nil {
+			return err
+		}
+		for _, file := range files {
+			for _, locale := range locales {
+				dest, destErr := smartlingDownloadAllOutputPath(dir, file.FileURI, locale)
+				if destErr != nil {
+					return destErr
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "file_uri=%s locale=%s output=%s\n", file.FileURI, locale, dest); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("%s: mkdir output directory: %w", action, err)
+	}
+	for _, file := range files {
+		for _, locale := range locales {
+			dest, destErr := smartlingDownloadAllOutputPath(dir, file.FileURI, locale)
+			if destErr != nil {
+				return destErr
+			}
+			if err := validateSmartlingDownloadTranslationsOutputPath(dest, o.force); err != nil {
+				return err
+			}
+			result, err := client.DownloadTranslationFile(backgroundContext(), smartling.TranslationDownloadInput{
+				ProjectID:     strings.TrimSpace(o.projectID),
+				FileURI:       file.FileURI,
+				LocaleID:      locale,
+				RetrievalType: retrievalType,
+			})
+			if err != nil {
+				return wrapSmartlingCommandError(action, err)
+			}
+			if err := writeSmartlingDownloadedTranslation(dest, result.Content, o.force); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s file_uri=%s\n", dest, len(result.Content), result.LocaleID, file.FileURI); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateSmartlingDownloadSelection(all bool, fileURI, uriMask, action string) error {
+	hasURI := strings.TrimSpace(fileURI) != ""
+	hasMask := strings.TrimSpace(uriMask) != ""
+	switch {
+	case all && hasURI:
+		return fmt.Errorf("%s: exactly one of --file-uri or --all is required", action)
+	case !all && !hasURI:
+		return fmt.Errorf("%s: --file-uri is required", action)
+	case hasMask && !all:
+		return fmt.Errorf("%s: --uri-mask is only valid with --all", action)
+	default:
+		return nil
+	}
+}
+
+func resolveSmartlingDownloadAllDirectory(output, action string) (string, error) {
+	dir := strings.TrimSpace(output)
+	if dir == "-" || strings.Contains(dir, "%locale%") {
+		return "", fmt.Errorf("%s: --output for --all must be a directory (omit for cwd); do not use - or %%locale%%", action)
+	}
+	if dir == "" {
+		dir = "."
+	}
+	info, err := os.Stat(dir)
+	if err == nil && !info.IsDir() {
+		return "", fmt.Errorf("%s: --output %q exists and is not a directory", action, dir)
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("%s: stat output directory %q: %w", action, dir, err)
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("%s: resolve output directory: %w", action, err)
+	}
+	return abs, nil
+}
+
+func smartlingOfficialPullRelativePath(fileURI, locale string) string {
+	uri := strings.ReplaceAll(strings.TrimSpace(fileURI), "\\", "/")
+	uri = strings.TrimLeft(uri, "/")
+	ext := filepath.Ext(uri)
+	name := strings.TrimSuffix(uri, ext)
+	if strings.TrimSpace(locale) == "" {
+		return name + ext
+	}
+	return name + "_" + strings.TrimSpace(locale) + ext
+}
+
+func smartlingPathUnderDirectory(dir, relative string) (string, error) {
+	rel := strings.ReplaceAll(strings.TrimSpace(relative), "\\", "/")
+	rel = strings.TrimLeft(rel, "/")
+	if rel == "" {
+		return "", fmt.Errorf("smartling download: empty file path")
+	}
+	if strings.Contains(rel, "..") {
+		return "", fmt.Errorf("smartling download: file uri %q is not a safe relative path", relative)
+	}
+	if strings.TrimSpace(dir) == "" {
+		dir = "."
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("smartling download: resolve output directory: %w", err)
+	}
+	joined := filepath.Join(absDir, filepath.FromSlash(rel))
+	relOut, err := filepath.Rel(absDir, joined)
+	if err != nil {
+		return "", fmt.Errorf("smartling download: file uri %q is not a safe relative path", relative)
+	}
+	if relOut == ".." || strings.HasPrefix(relOut, ".."+string(os.PathSeparator)) || filepath.IsAbs(relOut) {
+		return "", fmt.Errorf("smartling download: file uri %q is not a safe relative path", relative)
+	}
+	return joined, nil
+}
+
+func smartlingDownloadAllOutputPath(dir, fileURI, locale string) (string, error) {
+	return smartlingPathUnderDirectory(dir, smartlingOfficialPullRelativePath(fileURI, locale))
 }
 
 func resolveSmartlingCLICredentials(userIdentifier, userSecret, userSecretEnv, action string) (smartling.Config, error) {

--- a/apps/cli/cmd/smartling.go
+++ b/apps/cli/cmd/smartling.go
@@ -491,12 +491,14 @@ func smartlingOfficialPullRelativePath(fileURI, locale string) string {
 
 func smartlingPathUnderDirectory(dir, relative string) (string, error) {
 	rel := strings.ReplaceAll(strings.TrimSpace(relative), "\\", "/")
-	rel = strings.TrimLeft(rel, "/")
+	rel = strings.Trim(rel, "/")
 	if rel == "" {
 		return "", fmt.Errorf("smartling download: empty file path")
 	}
-	if strings.Contains(rel, "..") {
-		return "", fmt.Errorf("smartling download: file uri %q is not a safe relative path", relative)
+	for _, part := range strings.Split(rel, "/") {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("smartling download: file uri %q is not a safe relative path", relative)
+		}
 	}
 	if strings.TrimSpace(dir) == "" {
 		dir = "."
@@ -513,7 +515,35 @@ func smartlingPathUnderDirectory(dir, relative string) (string, error) {
 	if relOut == ".." || strings.HasPrefix(relOut, ".."+string(os.PathSeparator)) || filepath.IsAbs(relOut) {
 		return "", fmt.Errorf("smartling download: file uri %q is not a safe relative path", relative)
 	}
+	if err := rejectSmartlingSymlinkInPath(absDir, joined); err != nil {
+		return "", err
+	}
 	return joined, nil
+}
+
+func rejectSmartlingSymlinkInPath(root, dest string) error {
+	rel, err := filepath.Rel(root, dest)
+	if err != nil {
+		return fmt.Errorf("smartling download: file uri is not a safe relative path")
+	}
+	current := root
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("smartling download: stat %q: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("smartling download: refusing to write through symlink %q", current)
+		}
+	}
+	return nil
 }
 
 func smartlingDownloadAllOutputPath(dir, fileURI, locale string) (string, error) {

--- a/apps/cli/cmd/smartling_discovery.go
+++ b/apps/cli/cmd/smartling_discovery.go
@@ -43,11 +43,41 @@ type smartlingProjectsListOptions struct {
 	userSecretEnv  string
 }
 
+type smartlingProjectsInfoOptions struct {
+	projectID      string
+	output         string
+	userIdentifier string
+	userSecret     string
+	userSecretEnv  string
+}
+
+type smartlingFilesDeleteOptions struct {
+	projectID      string
+	fileURI        string
+	userIdentifier string
+	userSecret     string
+	userSecretEnv  string
+	dryRun         bool
+}
+
+type smartlingFilesRenameOptions struct {
+	projectID      string
+	fileURI        string
+	newFileURI     string
+	userIdentifier string
+	userSecret     string
+	userSecretEnv  string
+	dryRun         bool
+}
+
 type smartlingDiscoveryClient interface {
 	ListFiles(context.Context, smartling.FileListInput) ([]smartling.FileListItem, error)
 	GetFileStatus(context.Context, smartling.FileStatusInput) (smartling.FileStatus, error)
 	ListLocales(context.Context, smartling.LocaleListInput) ([]smartling.LocaleListItem, error)
 	ListProjects(context.Context, smartling.ProjectListInput) ([]smartling.ProjectListItem, error)
+	GetProject(context.Context, smartling.ProjectInfoInput) (smartling.ProjectInfo, error)
+	DeleteFile(context.Context, smartling.FileDeleteInput) error
+	RenameFile(context.Context, smartling.FileRenameInput) error
 }
 
 var newSmartlingDiscoveryClient = func(cfg smartling.Config) (smartlingDiscoveryClient, error) {
@@ -57,10 +87,12 @@ var newSmartlingDiscoveryClient = func(cfg smartling.Config) (smartlingDiscovery
 func newSmartlingFilesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "files",
-		Short: "list files and show file status",
+		Short: "list, show status, rename, and delete files",
 	}
 	cmd.AddCommand(newSmartlingFilesListCmd())
 	cmd.AddCommand(newSmartlingFilesStatusCmd())
+	cmd.AddCommand(newSmartlingFilesRenameCmd())
+	cmd.AddCommand(newSmartlingFilesDeleteCmd())
 	return cmd
 }
 
@@ -100,6 +132,43 @@ func newSmartlingFilesStatusCmd() *cobra.Command {
 	return cmd
 }
 
+func newSmartlingFilesRenameCmd() *cobra.Command {
+	o := smartlingFilesRenameOptions{}
+	cmd := &cobra.Command{
+		Use:          "rename",
+		Short:        "rename one Smartling file URI",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeSmartlingFilesRename(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
+	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "current Smartling file URI")
+	cmd.Flags().StringVar(&o.newFileURI, "new-file-uri", "", "new Smartling file URI")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without calling Smartling")
+	addSmartlingCredentialFlags(cmd, &o.userIdentifier, &o.userSecret, &o.userSecretEnv)
+	_ = cmd.MarkFlagRequired("project-id")
+	return cmd
+}
+
+func newSmartlingFilesDeleteCmd() *cobra.Command {
+	o := smartlingFilesDeleteOptions{}
+	cmd := &cobra.Command{
+		Use:          "delete",
+		Short:        "delete one Smartling file URI",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeSmartlingFilesDelete(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
+	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "exact Smartling file URI")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without calling Smartling")
+	addSmartlingCredentialFlags(cmd, &o.userIdentifier, &o.userSecret, &o.userSecretEnv)
+	_ = cmd.MarkFlagRequired("project-id")
+	return cmd
+}
+
 func newSmartlingLocalesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "locales",
@@ -129,9 +198,10 @@ func newSmartlingLocalesListCmd() *cobra.Command {
 func newSmartlingProjectsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "projects",
-		Short: "list Smartling projects for an account",
+		Short: "list and inspect Smartling projects",
 	}
 	cmd.AddCommand(newSmartlingProjectsListCmd())
+	cmd.AddCommand(newSmartlingProjectsInfoCmd())
 	return cmd
 }
 
@@ -148,6 +218,23 @@ func newSmartlingProjectsListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.accountUID, "account-uid", "", "Smartling account UID (same id as glossary download --account-uid)")
 	cmd.Flags().StringVar(&o.output, "output", "text", "output format: text or json")
 	addSmartlingCredentialFlags(cmd, &o.userIdentifier, &o.userSecret, &o.userSecretEnv)
+	return cmd
+}
+
+func newSmartlingProjectsInfoCmd() *cobra.Command {
+	o := smartlingProjectsInfoOptions{output: "text"}
+	cmd := &cobra.Command{
+		Use:          "info",
+		Short:        "show one Smartling project",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeSmartlingProjectsInfo(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
+	cmd.Flags().StringVar(&o.output, "output", "text", "output format: text or json")
+	addSmartlingCredentialFlags(cmd, &o.userIdentifier, &o.userSecret, &o.userSecretEnv)
+	_ = cmd.MarkFlagRequired("project-id")
 	return cmd
 }
 
@@ -293,6 +380,99 @@ func executeSmartlingProjectsList(cmd *cobra.Command, o smartlingProjectsListOpt
 		}
 		return nil
 	}, projects)
+}
+
+func executeSmartlingProjectsInfo(cmd *cobra.Command, o smartlingProjectsInfoOptions) error {
+	if strings.TrimSpace(o.projectID) == "" {
+		return fmt.Errorf("smartling projects info: --project-id is required")
+	}
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, "smartling projects info")
+	if err != nil {
+		return err
+	}
+	cfg.ProjectID = strings.TrimSpace(o.projectID)
+	client, err := newSmartlingDiscoveryClient(cfg)
+	if err != nil {
+		return err
+	}
+	info, err := client.GetProject(backgroundContext(), smartling.ProjectInfoInput{
+		ProjectID: strings.TrimSpace(o.projectID),
+	})
+	if err != nil {
+		return wrapSmartlingCommandError("smartling projects info", err)
+	}
+	return writeEncodedOutput(cmd.OutOrStdout(), o.output, func() error {
+		archived := "false"
+		if info.Archived {
+			archived = "true"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "project_id=%s name=%s account_uid=%s source_locale=%s archived=%s\n", info.ProjectID, info.ProjectName, info.AccountUID, info.SourceLocaleID, archived)
+		return err
+	}, info)
+}
+
+func executeSmartlingFilesRename(cmd *cobra.Command, o smartlingFilesRenameOptions) error {
+	if strings.TrimSpace(o.projectID) == "" {
+		return fmt.Errorf("smartling files rename: --project-id is required")
+	}
+	if strings.TrimSpace(o.fileURI) == "" {
+		return fmt.Errorf("smartling files rename: --file-uri is required")
+	}
+	if strings.TrimSpace(o.newFileURI) == "" {
+		return fmt.Errorf("smartling files rename: --new-file-uri is required")
+	}
+	if o.dryRun {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-files-rename project_id=%s file_uri=%s new_file_uri=%s\n", strings.TrimSpace(o.projectID), strings.TrimSpace(o.fileURI), strings.TrimSpace(o.newFileURI))
+		return err
+	}
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, "smartling files rename")
+	if err != nil {
+		return err
+	}
+	cfg.ProjectID = strings.TrimSpace(o.projectID)
+	client, err := newSmartlingDiscoveryClient(cfg)
+	if err != nil {
+		return err
+	}
+	if err := client.RenameFile(backgroundContext(), smartling.FileRenameInput{
+		ProjectID:  strings.TrimSpace(o.projectID),
+		FileURI:    strings.TrimSpace(o.fileURI),
+		NewFileURI: strings.TrimSpace(o.newFileURI),
+	}); err != nil {
+		return wrapSmartlingCommandError("smartling files rename", err)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "renamed uri=%s new_uri=%s\n", strings.TrimSpace(o.fileURI), strings.TrimSpace(o.newFileURI))
+	return err
+}
+
+func executeSmartlingFilesDelete(cmd *cobra.Command, o smartlingFilesDeleteOptions) error {
+	if strings.TrimSpace(o.projectID) == "" {
+		return fmt.Errorf("smartling files delete: --project-id is required")
+	}
+	if strings.TrimSpace(o.fileURI) == "" {
+		return fmt.Errorf("smartling files delete: --file-uri is required")
+	}
+	if o.dryRun {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-files-delete project_id=%s file_uri=%s\n", strings.TrimSpace(o.projectID), strings.TrimSpace(o.fileURI))
+		return err
+	}
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, "smartling files delete")
+	if err != nil {
+		return err
+	}
+	cfg.ProjectID = strings.TrimSpace(o.projectID)
+	client, err := newSmartlingDiscoveryClient(cfg)
+	if err != nil {
+		return err
+	}
+	if err := client.DeleteFile(backgroundContext(), smartling.FileDeleteInput{
+		ProjectID: strings.TrimSpace(o.projectID),
+		FileURI:   strings.TrimSpace(o.fileURI),
+	}); err != nil {
+		return wrapSmartlingCommandError("smartling files delete", err)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "deleted uri=%s\n", strings.TrimSpace(o.fileURI))
+	return err
 }
 
 func wrapSmartlingCommandError(action string, err error) error {

--- a/apps/cli/cmd/smartling_discovery_test.go
+++ b/apps/cli/cmd/smartling_discovery_test.go
@@ -16,6 +16,7 @@ type fakeSmartlingDiscoveryClient struct {
 	status   smartling.FileStatus
 	locales  []smartling.LocaleListItem
 	projects []smartling.ProjectListItem
+	project  smartling.ProjectInfo
 	err      error
 	assert   func(kind string, in any)
 }
@@ -58,6 +59,30 @@ func (f *fakeSmartlingDiscoveryClient) ListProjects(_ context.Context, in smartl
 		return nil, f.err
 	}
 	return f.projects, nil
+}
+
+func (f *fakeSmartlingDiscoveryClient) GetProject(_ context.Context, in smartling.ProjectInfoInput) (smartling.ProjectInfo, error) {
+	if f.assert != nil {
+		f.assert("info", in)
+	}
+	if f.err != nil {
+		return smartling.ProjectInfo{}, f.err
+	}
+	return f.project, nil
+}
+
+func (f *fakeSmartlingDiscoveryClient) DeleteFile(_ context.Context, in smartling.FileDeleteInput) error {
+	if f.assert != nil {
+		f.assert("delete", in)
+	}
+	return f.err
+}
+
+func (f *fakeSmartlingDiscoveryClient) RenameFile(_ context.Context, in smartling.FileRenameInput) error {
+	if f.assert != nil {
+		f.assert("rename", in)
+	}
+	return f.err
 }
 
 func TestSmartlingHelpListsDiscoveryCommands(t *testing.T) {
@@ -460,5 +485,120 @@ func TestParseSmartlingUploadDirectives(t *testing.T) {
 	summary := formatSmartlingDirectiveSummary(map[string]string{"smartling.foo": "bar"})
 	if summary != "smartling.foo=bar" {
 		t.Fatalf("summary=%q", summary)
+	}
+}
+
+func TestSmartlingProjectsInfoTextAndJSON(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	orig := newSmartlingDiscoveryClient
+	t.Cleanup(func() { newSmartlingDiscoveryClient = orig })
+	newSmartlingDiscoveryClient = func(_ smartling.Config) (smartlingDiscoveryClient, error) {
+		return &fakeSmartlingDiscoveryClient{
+			project: smartling.ProjectInfo{
+				ProjectID:      "proj-1",
+				ProjectName:    "Demo",
+				AccountUID:     "acct-1",
+				SourceLocaleID: "en-US",
+				Archived:       false,
+			},
+		}, nil
+	}
+
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"smartling", "projects", "info", "--project-id", "proj-1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	if got := out.String(); got != "project_id=proj-1 name=Demo account_uid=acct-1 source_locale=en-US archived=false\n" {
+		t.Fatalf("text output=%q", got)
+	}
+
+	out.Reset()
+	root.SetArgs([]string{"smartling", "projects", "info", "--project-id", "proj-1", "--output", "json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("json info: %v", err)
+	}
+	if !strings.Contains(out.String(), `"projectId": "proj-1"`) || !strings.Contains(out.String(), `"archived": false`) {
+		t.Fatalf("json output=%s", out.String())
+	}
+}
+
+func TestSmartlingFilesRenameAndDeleteDryRunVsPOST(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	orig := newSmartlingDiscoveryClient
+	t.Cleanup(func() { newSmartlingDiscoveryClient = orig })
+
+	posted := false
+	newSmartlingDiscoveryClient = func(_ smartling.Config) (smartlingDiscoveryClient, error) {
+		posted = true
+		return &fakeSmartlingDiscoveryClient{}, nil
+	}
+
+	run := func(args ...string) (*bytes.Buffer, error) {
+		root := newRootCmd("test")
+		out := &bytes.Buffer{}
+		root.SetOut(out)
+		root.SetErr(out)
+		root.SetArgs(args)
+		return out, root.Execute()
+	}
+
+	out, err := run("smartling", "files", "rename", "--project-id", "123", "--file-uri", "old.json", "--new-file-uri", "new.json", "--dry-run")
+	if err != nil {
+		t.Fatalf("rename dry-run: %v", err)
+	}
+	if posted {
+		t.Fatal("dry-run should not construct a client")
+	}
+	if !strings.Contains(out.String(), "dry-run action=smartling-files-rename") {
+		t.Fatalf("rename dry-run output=%s", out.String())
+	}
+
+	posted = false
+	out, err = run("smartling", "files", "delete", "--project-id", "123", "--file-uri", "old.json", "--dry-run")
+	if err != nil {
+		t.Fatalf("delete dry-run: %v", err)
+	}
+	if posted {
+		t.Fatal("delete dry-run should not construct a client")
+	}
+	if !strings.Contains(out.String(), "dry-run action=smartling-files-delete") {
+		t.Fatalf("delete dry-run output=%s", out.String())
+	}
+
+	out, err = run("smartling", "files", "rename", "--project-id", "123", "--file-uri", "old.json", "--new-file-uri", "new.json")
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if !posted {
+		t.Fatal("rename should POST")
+	}
+	if out.String() != "renamed uri=old.json new_uri=new.json\n" {
+		t.Fatalf("rename output=%q", out.String())
+	}
+
+	out, err = run("smartling", "files", "delete", "--project-id", "123", "--file-uri", "old.json")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if out.String() != "deleted uri=old.json\n" {
+		t.Fatalf("delete output=%q", out.String())
+	}
+}
+
+func TestSmartlingFilesDeleteRequiresFileURI(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"smartling", "files", "delete", "--project-id", "123"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--file-uri is required") {
+		t.Fatalf("expected --file-uri error, got %v / %s", err, out.String())
 	}
 }

--- a/apps/cli/cmd/smartling_test.go
+++ b/apps/cli/cmd/smartling_test.go
@@ -237,8 +237,11 @@ func TestSmartlingDownloadSourcesSourceLocaleFlagDeprecated(t *testing.T) {
 }
 
 type fakeSmartlingSourceDownloader struct {
-	result smartling.SourceDownloadResult
-	err    error
+	result  smartling.SourceDownloadResult
+	files   []smartling.FileListItem
+	listIn  smartling.FileListInput
+	err     error
+	listErr error
 }
 
 func (f *fakeSmartlingSourceDownloader) DownloadSourceFile(_ context.Context, in smartling.SourceDownloadInput) (smartling.SourceDownloadResult, error) {
@@ -252,6 +255,14 @@ func (f *fakeSmartlingSourceDownloader) DownloadSourceFile(_ context.Context, in
 		FileURI: in.FileURI,
 		Content: []byte(`{"hello":"Hello"}`),
 	}, nil
+}
+
+func (f *fakeSmartlingSourceDownloader) ListFiles(_ context.Context, in smartling.FileListInput) ([]smartling.FileListItem, error) {
+	f.listIn = in
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.files, nil
 }
 
 func TestSmartlingDownloadSourcesWritesStdout(t *testing.T) {
@@ -391,7 +402,10 @@ func TestSmartlingDownloadSourcesForceOverwritesOutputFile(t *testing.T) {
 
 type fakeSmartlingTranslationDownloader struct {
 	results map[string]smartling.TranslationDownloadResult
+	files   []smartling.FileListItem
+	listIn  smartling.FileListInput
 	err     error
+	listErr error
 }
 
 func (f *fakeSmartlingTranslationDownloader) DownloadTranslationFile(_ context.Context, in smartling.TranslationDownloadInput) (smartling.TranslationDownloadResult, error) {
@@ -403,6 +417,14 @@ func (f *fakeSmartlingTranslationDownloader) DownloadTranslationFile(_ context.C
 		return smartling.TranslationDownloadResult{LocaleID: in.LocaleID, Content: []byte(`{}`)}, nil
 	}
 	return result, nil
+}
+
+func (f *fakeSmartlingTranslationDownloader) ListFiles(_ context.Context, in smartling.FileListInput) ([]smartling.FileListItem, error) {
+	f.listIn = in
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.files, nil
 }
 
 func TestSmartlingDownloadTranslationsWritesStdout(t *testing.T) {
@@ -612,6 +634,10 @@ func (f *fakeSmartlingTranslationDownloaderWithError) DownloadTranslationFile(_ 
 		return smartling.TranslationDownloadResult{LocaleID: in.LocaleID, Content: []byte(`{}`)}, nil
 	}
 	return result, nil
+}
+
+func (f *fakeSmartlingTranslationDownloaderWithError) ListFiles(_ context.Context, _ smartling.FileListInput) ([]smartling.FileListItem, error) {
+	return nil, nil
 }
 
 func TestSmartlingDownloadTranslationsRefusesOverwriteWithoutForce(t *testing.T) {
@@ -937,4 +963,159 @@ func (s stubSmartlingTranslationImporter) ImportTranslationFile(_ context.Contex
 		s.assert(in)
 	}
 	return s.result, s.err
+}
+
+func TestSmartlingOfficialPullRelativePath(t *testing.T) {
+	if got := smartlingOfficialPullRelativePath("locales/en.json", ""); got != "locales/en.json" {
+		t.Fatalf("source path=%q", got)
+	}
+	if got := smartlingOfficialPullRelativePath("locales/en.json", "fr-FR"); got != "locales/en_fr-FR.json" {
+		t.Fatalf("translation path=%q", got)
+	}
+	if got := smartlingOfficialPullRelativePath("/locales/en.json", "fr-FR"); got != "locales/en_fr-FR.json" {
+		t.Fatalf("leading slash path=%q", got)
+	}
+}
+
+func TestSmartlingDownloadAllWritesOfficialPaths(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	orig := newSmartlingSourceDownloader
+	t.Cleanup(func() { newSmartlingSourceDownloader = orig })
+	newSmartlingSourceDownloader = func(_ smartling.Config) (smartlingSourceDownloader, error) {
+		return &fakeSmartlingSourceDownloader{
+			files: []smartling.FileListItem{
+				{FileURI: "locales/en.json"},
+				{FileURI: "app/strings.xml"},
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"smartling", "download", "sources", "--project-id", "123", "--all", "--output", dir})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sources --all: %v", err)
+	}
+	for _, rel := range []string{filepath.Join("locales", "en.json"), filepath.Join("app", "strings.xml")} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Fatalf("missing %s: %v\n%s", rel, err, out.String())
+		}
+	}
+	if strings.Contains(out.String(), filepath.Join("fr-FR", "locales")) {
+		t.Fatalf("wrote locale-prefixed tree: %s", out.String())
+	}
+
+	origT := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = origT })
+	fakeT := &fakeSmartlingTranslationDownloader{
+		files: []smartling.FileListItem{
+			{FileURI: "locales/en.json"},
+			{FileURI: "app/strings.xml"},
+		},
+		results: map[string]smartling.TranslationDownloadResult{
+			"fr-FR": {LocaleID: "fr-FR", Content: []byte(`{"hello":"Bonjour"}`)},
+			"de-DE": {LocaleID: "de-DE", Content: []byte(`{"hello":"Hallo"}`)},
+		},
+	}
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return fakeT, nil
+	}
+
+	dir = t.TempDir()
+	out.Reset()
+	root.SetArgs([]string{
+		"smartling", "download", "translations",
+		"--project-id", "123",
+		"--all",
+		"--target-locale", "fr-FR",
+		"--target-locale", "de-DE",
+		"--output", dir,
+		"--uri-mask", "en.json",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("translations --all: %v", err)
+	}
+	if fakeT.listIn.URIMask != "en.json" {
+		t.Fatalf("uri mask=%q", fakeT.listIn.URIMask)
+	}
+	want := []string{
+		filepath.Join("locales", "en_fr-FR.json"),
+		filepath.Join("locales", "en_de-DE.json"),
+		filepath.Join("app", "strings_fr-FR.xml"),
+		filepath.Join("app", "strings_de-DE.xml"),
+	}
+	for _, rel := range want {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Fatalf("missing %s: %v\n%s", rel, err, out.String())
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fr-FR", "locales", "en.json")); err == nil {
+		t.Fatal("wrote locale/fileUri layout")
+	}
+}
+
+func TestSmartlingDownloadAllFlagExclusivityAndSafety(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	orig := newSmartlingSourceDownloader
+	t.Cleanup(func() { newSmartlingSourceDownloader = orig })
+	newSmartlingSourceDownloader = func(_ smartling.Config) (smartlingSourceDownloader, error) {
+		return &fakeSmartlingSourceDownloader{
+			files: []smartling.FileListItem{{FileURI: "/locales/en.json"}},
+		}, nil
+	}
+
+	run := func(args ...string) error {
+		root := newRootCmd("test")
+		out := &bytes.Buffer{}
+		root.SetOut(out)
+		root.SetErr(out)
+		root.SetArgs(args)
+		return root.Execute()
+	}
+
+	err := run("smartling", "download", "sources", "--project-id", "123", "--all", "--file-uri", "locales/en.json")
+	if err == nil || !strings.Contains(err.Error(), "exactly one of --file-uri or --all") {
+		t.Fatalf("expected exclusivity error, got %v", err)
+	}
+
+	err = run("smartling", "download", "sources", "--project-id", "123", "--file-uri", "locales/en.json", "--uri-mask", "en.json", "--dry-run")
+	if err == nil || !strings.Contains(err.Error(), "--uri-mask is only valid with --all") {
+		t.Fatalf("expected uri-mask error, got %v", err)
+	}
+
+	err = run("smartling", "download", "translations", "--project-id", "123", "--all", "--target-locale", "fr-FR", "--output", "out-%locale%.json")
+	if err == nil || !strings.Contains(err.Error(), "do not use") {
+		t.Fatalf("expected %%locale%% error, got %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := run("smartling", "download", "sources", "--project-id", "123", "--all", "--output", dir); err != nil {
+		t.Fatalf("leading slash: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "locales", "en.json")); err != nil {
+		t.Fatalf("leading slash escaped directory: %v", err)
+	}
+
+	newSmartlingSourceDownloader = func(_ smartling.Config) (smartlingSourceDownloader, error) {
+		return &fakeSmartlingSourceDownloader{
+			files: []smartling.FileListItem{{FileURI: "../secret.json"}},
+		}, nil
+	}
+	err = run("smartling", "download", "sources", "--project-id", "123", "--all", "--output", dir)
+	if err == nil || !strings.Contains(err.Error(), "not a safe relative path") {
+		t.Fatalf("expected path safety error, got %v", err)
+	}
+
+	newSmartlingSourceDownloader = func(_ smartling.Config) (smartlingSourceDownloader, error) {
+		return &fakeSmartlingSourceDownloader{files: nil}, nil
+	}
+	err = run("smartling", "download", "sources", "--project-id", "123", "--all", "--output", dir)
+	if err == nil || !strings.Contains(err.Error(), "no files found") {
+		t.Fatalf("expected empty list error, got %v", err)
+	}
 }

--- a/apps/cli/cmd/smartling_test.go
+++ b/apps/cli/cmd/smartling_test.go
@@ -977,6 +977,34 @@ func TestSmartlingOfficialPullRelativePath(t *testing.T) {
 	}
 }
 
+func TestSmartlingPathUnderDirectoryAllowsDotsInFilename(t *testing.T) {
+	dir := t.TempDir()
+	got, err := smartlingPathUnderDirectory(dir, "messages.v1..2.json")
+	if err != nil {
+		t.Fatalf("filename with ..: %v", err)
+	}
+	if filepath.Base(got) != "messages.v1..2.json" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSmartlingPathUnderDirectoryRejectsSymlinkParents(t *testing.T) {
+	root := t.TempDir()
+	victim := t.TempDir()
+	out := filepath.Join(root, "out")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(out, "locales")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Skipf("symlinks not available: %v", err)
+	}
+	_, err := smartlingPathUnderDirectory(out, "locales/en.json")
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+}
+
 func TestSmartlingDownloadAllWritesOfficialPaths(t *testing.T) {
 	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
 	t.Setenv("SMARTLING_USER_SECRET", "secret")

--- a/docs/cli/commands/smartling.mdx
+++ b/docs/cli/commands/smartling.mdx
@@ -9,11 +9,14 @@ description: "Smartling file workflow commands using project flags and API crede
 hyperlocalise smartling locales list --project-id <id> [--output text|json] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 hyperlocalise smartling files list --project-id <id> [--uri-mask <substring>] [--output text|json] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 hyperlocalise smartling files status --project-id <id> --file-uri <uri> [--output text|json] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling files rename --project-id <id> --file-uri <uri> --new-file-uri <uri> [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling files delete --project-id <id> --file-uri <uri> [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 hyperlocalise smartling projects list --account-uid <id> [--output text|json] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling projects info --project-id <id> [--output text|json] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 hyperlocalise smartling upload sources --project-id <id> --file <path> [--file-uri <uri>] [--file-type <type>] [--authorize] [--directive key=value] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>] [--dry-run]
 hyperlocalise smartling upload translations --project-id <id> --file-uri <uri> --target-locale <locale> --file <path> (--published | --post-translation) [--file-type <type>] [--overwrite] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>] [--dry-run]
-hyperlocalise smartling download sources --project-id <id> --file-uri <uri> [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
-hyperlocalise smartling download translations --project-id <id> --file-uri <uri> --target-locale <locale> [--retrieval-type pending|published|pseudo] [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling download sources --project-id <id> (--file-uri <uri> | --all) [--uri-mask <substring>] [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling download translations --project-id <id> (--file-uri <uri> | --all) --target-locale <locale> [--uri-mask <substring>] [--retrieval-type pending|published|pseudo] [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 hyperlocalise smartling glossary download --account-uid <id> --glossary-uid <id> [--language <locale>] [--output <path>] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 hyperlocalise smartling tm download --account-uid <id> --tm-uid <id> --source-language <code> [--target-language <code>] [--format csv|tmx] [--output <path>] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 ```
@@ -30,8 +33,9 @@ They are separate from Hyperlocalise native `i18n.yml` and `sync push` / `sync p
 
 Use them for:
 
-- discovering locale IDs (`locales list`), file URIs (`files list`), and project IDs (`projects list`)
+- discovering locale IDs (`locales list`), file URIs (`files list`), and project IDs (`projects list` / `projects info`)
 - checking one file's translation progress (`files status`)
+- renaming or deleting one exact file URI (`files rename`, `files delete`)
 - source-file upload (`upload sources`)
 - import of a pre-translated locale file (`upload translations`, equivalent to official `smartling-cli files import`)
 - source download (`download sources`)
@@ -74,11 +78,15 @@ Unknown extensions require `--file-type`. Values such as `android` or `gettext` 
 
 `locales list` prints source and target locales as `locale=... source=true/false` lines (`enabled=true/false` when Smartling sends it). Disabled locales stay in the list so you can see why a download failed.
 
-`files list` prints every file URI in the project. `--uri-mask` is Smartling's substring filter, not a glob: `en.json` matches `locales/en.json`. Do not pass `--file-uri` here; that flag means an exact URI on upload, download, and status. Empty projects print nothing in text mode (no output means no files) and `[]` with `--output json`. Both exit 0. `--output` is `text` or `json`.
+`files list` prints every file URI in the project. `--uri-mask` is Smartling's substring filter, not a glob: `en.json` matches `locales/en.json`. Do not pass `--file-uri` here; that flag means an exact URI on upload, download, status, rename, and delete. Empty projects print nothing in text mode (no output means no files) and `[]` with `--output json`. Both exit 0. `--output` is `text` or `json`.
 
 `files status` requires `--file-uri` for one file. It does not check whether a matching file exists on disk. Text progress uses each locale's `authorizedStringCount` / `authorizedWordCount` as `total_strings` / `total_words`. File-level `totalStringCount` from Smartling is often 0, so the file header omits those totals. `percent` is completed strings over authorized strings (0 when nothing is authorized).
 
+`files rename` and `files delete` take one exact `--file-uri`. There is no mask or glob. `--dry-run` prints the planned request and does not call the network. Delete is asynchronous: success means Smartling accepted the request. Re-uploading the same URI may fail until that delete finishes. Hyperlocalise does not poll.
+
 `projects list` requires `--account-uid`. Use the same account id as `glossary download --account-uid`.
+
+`projects info` requires `--project-id`. Text output is `project_id`, `name`, `account_uid`, `source_locale`, and `archived=true|false`. Target locales stay on `locales list`.
 
 `upload sources` requires `--project-id` and at least one `--file`. `--file-uri` is optional for a single file (defaults to the path with `/` separators) and cannot be used with multiple `--file` values. `--authorize` defaults to **true** (official `files push` leaves jobs unauthorized unless `--authorize` is set, and often wraps uploads in a translation job). Repeat `--directive key=value` to send parser hints; Hyperlocalise prefixes the form field with `smartling.` unless the key already has that prefix. The same directive with and without the prefix is a duplicate and is rejected. `foo` with no `=` is an error before any network call. `--dry-run` prints the planned upload (including directives) and does not call the network.
 
@@ -86,7 +94,9 @@ Unknown extensions require `--file-type`. Values such as `android` or `gettext` 
 
 `download sources` writes to stdout when `--output` is omitted or `-`. `--source-locale` is deprecated and ignored. `--force` overwrites an existing output file. `--dry-run` does not download.
 
-`download translations` requires `--target-locale`. Use `%locale%` in `--output` when you pass more than one locale. `--retrieval-type` is `pending`, `published`, or `pseudo`. If you omit it, Hyperlocalise does not send `retrievalType` and Smartling uses its default. Prefer `--retrieval-type published` when you only want published text.
+Pass exactly one of `--file-uri` or `--all`. `--all` lists files (same paging as `files list`, optional `--uri-mask`) then downloads each URI. `--uri-mask` is only valid with `--all`. `--output` is then a directory (default `.`). Local names match official smartling-cli default pull format: URI `locales/en.json` writes `locales/en.json` for sources and `locales/en_fr-FR.json` for `--target-locale fr-FR`. Do not pass `-` or `%locale%` with `--all`. An empty list is a non-zero error. `--all --dry-run` lists files (credentials required) and prints planned paths without downloading bytes. Downloads run sequentially and stop on the first error.
+
+`download translations` requires `--target-locale` even with `--all`. Official smartling-cli can omit locale and pull every locale from file status; Hyperlocalise does not. Use `%locale%` in `--output` when you pass more than one locale with a single `--file-uri`. `--retrieval-type` is `pending`, `published`, or `pseudo`. If you omit it, Hyperlocalise does not send `retrievalType` and Smartling uses its default. Prefer `--retrieval-type published` when you only want published text.
 
 `glossary download` and `tm download` have no `--force` or `--dry-run`. They write CSV (or TMX for `tm --format tmx`) to stdout unless you pass `--output`.
 
@@ -96,12 +106,12 @@ Unknown extensions require `--file-type`. Values such as `android` or `gettext` 
 | --- | --- |
 | `smartling-cli init` / `smartling.yml` | Unsupported (flag-only) |
 | `files push` / `files upload` | `upload sources` (no jobs, no YAML globs, no `--branch`; `--authorize` defaults true; `--directive` supported) |
-| `files pull` / `files download` | `download translations` (one `--file-uri` per call; `--retrieval-type pending\|published\|pseudo`; no `--all`, `--format` templates, or job pull) |
-| `files pull --source` | `download sources` |
+| `files pull` / `files download` | `download translations` (`--file-uri` or `--all`; `--retrieval-type pending\|published\|pseudo`; `--target-locale` always required; no `--format` templates, zip bulk, `--threads`, or job pull) |
+| `files pull --source` | `download sources` (`--file-uri` or `--all`; official `name_locale.ext` paths for `--all`) |
 | `files import` | `upload translations` (`--published` or `--post-translation`; optional `--overwrite`) |
 | `files list` / `files status` | `files list` (`--uri-mask`) / `files status` (one `--file-uri`; no local-disk column) |
-| `files delete` / `files rename` | Out of scope |
-| `projects list` / `info` / `locales` | `projects list` / `locales list` |
+| `files delete` / `files rename` | `files delete` / `files rename` (exact `--file-uri`; delete is async) |
+| `projects list` / `info` / `locales` | `projects list` / `projects info` / `locales list` |
 | Jobs, `mt detect` / `mt translate` | Out of scope |
 | `glossaries export` | `glossary download` (Hyperlocalise CSV; not official CSV/XLSX/TBX parity) |
 | `glossaries import` / create / list | Out of scope |
@@ -144,6 +154,27 @@ hyperlocalise smartling upload translations \
   --dry-run
 ```
 
+Rename or delete one exact URI:
+
+```bash
+hyperlocalise smartling files rename \
+  --project-id your-project-id \
+  --file-uri locales/en.json \
+  --new-file-uri locales/app.json \
+  --dry-run
+
+hyperlocalise smartling files delete \
+  --project-id your-project-id \
+  --file-uri locales/en.json \
+  --dry-run
+```
+
+Inspect one project:
+
+```bash
+hyperlocalise smartling projects info --project-id your-project-id
+```
+
 Download one locale. Use `%locale%` when you pass more than one `--target-locale`:
 
 ```bash
@@ -163,6 +194,18 @@ hyperlocalise smartling download sources \
   --project-id your-project-id \
   --file-uri locales/en.json \
   --output ./locales/en.json \
+  --force
+```
+
+Download every listed file into a directory. Translations still need `--target-locale`:
+
+```bash
+hyperlocalise smartling download translations \
+  --project-id your-project-id \
+  --all \
+  --target-locale fr-FR \
+  --retrieval-type published \
+  --output ./pulled \
   --force
 ```
 

--- a/internal/i18n/storage/smartling/discovery.go
+++ b/internal/i18n/storage/smartling/discovery.go
@@ -96,6 +96,33 @@ type ProjectListItem struct {
 	Archived       bool   `json:"archived,omitempty"`
 }
 
+// ProjectInfoInput fetches one project by ID.
+type ProjectInfoInput struct {
+	ProjectID string
+}
+
+// ProjectInfo is GET /projects-api/v2/projects/{id} without target locales.
+type ProjectInfo struct {
+	ProjectID      string `json:"projectId"`
+	ProjectName    string `json:"projectName"`
+	AccountUID     string `json:"accountUid,omitempty"`
+	SourceLocaleID string `json:"sourceLocaleId,omitempty"`
+	Archived       bool   `json:"archived"`
+}
+
+// FileDeleteInput deletes one source file URI.
+type FileDeleteInput struct {
+	ProjectID string
+	FileURI   string
+}
+
+// FileRenameInput changes a source file URI.
+type FileRenameInput struct {
+	ProjectID  string
+	FileURI    string
+	NewFileURI string
+}
+
 type filesListPayload struct {
 	TotalCount int            `json:"totalCount"`
 	Items      []FileListItem `json:"items"`
@@ -104,6 +131,8 @@ type filesListPayload struct {
 type projectDetailsPayload struct {
 	ProjectID               string `json:"projectId"`
 	ProjectName             string `json:"projectName"`
+	AccountUID              string `json:"accountUid"`
+	Archived                bool   `json:"archived"`
 	SourceLocaleID          string `json:"sourceLocaleId"`
 	SourceLocaleDescription string `json:"sourceLocaleDescription"`
 	TargetLocales           []struct {
@@ -243,24 +272,90 @@ func (c *HTTPClient) GetFileStatus(ctx context.Context, in FileStatusInput) (Fil
 	return payload, nil
 }
 
-// ListLocales returns the project source locale plus target locales.
-func (c *HTTPClient) ListLocales(ctx context.Context, in LocaleListInput) ([]LocaleListItem, error) {
-	if strings.TrimSpace(in.ProjectID) == "" {
-		return nil, fmt.Errorf("smartling locales list: project id is required")
+// GetProject fetches GET /projects-api/v2/projects/{id}.
+func (c *HTTPClient) GetProject(ctx context.Context, in ProjectInfoInput) (ProjectInfo, error) {
+	payload, err := c.fetchProjectDetails(ctx, in.ProjectID, "smartling projects info")
+	if err != nil {
+		return ProjectInfo{}, err
 	}
+	return ProjectInfo{
+		ProjectID:      strings.TrimSpace(payload.ProjectID),
+		ProjectName:    strings.TrimSpace(payload.ProjectName),
+		AccountUID:     strings.TrimSpace(payload.AccountUID),
+		SourceLocaleID: strings.TrimSpace(payload.SourceLocaleID),
+		Archived:       payload.Archived,
+	}, nil
+}
 
+func (c *HTTPClient) fetchProjectDetails(ctx context.Context, projectID, action string) (projectDetailsPayload, error) {
+	if strings.TrimSpace(projectID) == "" {
+		return projectDetailsPayload{}, fmt.Errorf("%s: project id is required", action)
+	}
 	token, err := c.accessToken(ctx)
 	if err != nil {
-		return nil, err
+		return projectDetailsPayload{}, err
 	}
-
-	endpoint := fmt.Sprintf("%s/projects/%s", c.projectsBaseURL, url.PathEscape(strings.TrimSpace(in.ProjectID)))
+	endpoint := fmt.Sprintf("%s/projects/%s", c.projectsBaseURL, url.PathEscape(strings.TrimSpace(projectID)))
 	var envelope smartlingDataEnvelope
 	if err := c.getJSON(ctx, endpoint, token, &envelope); err != nil {
-		return nil, fmt.Errorf("smartling locales list: %w", err)
+		return projectDetailsPayload{}, fmt.Errorf("%s: %w", action, err)
 	}
 	var payload projectDetailsPayload
-	if err := decodeSmartlingData(envelope, "smartling locales list", &payload); err != nil {
+	if err := decodeSmartlingData(envelope, action, &payload); err != nil {
+		return projectDetailsPayload{}, err
+	}
+	return payload, nil
+}
+
+// DeleteFile posts POST /files-api/v2/projects/{id}/file/delete. Smartling finishes asynchronously.
+func (c *HTTPClient) DeleteFile(ctx context.Context, in FileDeleteInput) error {
+	if strings.TrimSpace(in.ProjectID) == "" {
+		return fmt.Errorf("smartling files delete: project id is required")
+	}
+	if strings.TrimSpace(in.FileURI) == "" {
+		return fmt.Errorf("smartling files delete: file uri is required")
+	}
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return err
+	}
+	endpoint := fmt.Sprintf("%s/projects/%s/file/delete", c.filesBaseURL, url.PathEscape(strings.TrimSpace(in.ProjectID)))
+	if err := c.postMultipartFields(ctx, endpoint, token, map[string]string{"fileUri": strings.TrimSpace(in.FileURI)}, nil); err != nil {
+		return fmt.Errorf("smartling files delete: %w", err)
+	}
+	return nil
+}
+
+// RenameFile posts POST /files-api/v2/projects/{id}/file/rename.
+func (c *HTTPClient) RenameFile(ctx context.Context, in FileRenameInput) error {
+	if strings.TrimSpace(in.ProjectID) == "" {
+		return fmt.Errorf("smartling files rename: project id is required")
+	}
+	if strings.TrimSpace(in.FileURI) == "" {
+		return fmt.Errorf("smartling files rename: file uri is required")
+	}
+	if strings.TrimSpace(in.NewFileURI) == "" {
+		return fmt.Errorf("smartling files rename: new file uri is required")
+	}
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return err
+	}
+	endpoint := fmt.Sprintf("%s/projects/%s/file/rename", c.filesBaseURL, url.PathEscape(strings.TrimSpace(in.ProjectID)))
+	params := map[string]string{
+		"fileUri":    strings.TrimSpace(in.FileURI),
+		"newFileUri": strings.TrimSpace(in.NewFileURI),
+	}
+	if err := c.postMultipartFields(ctx, endpoint, token, params, nil); err != nil {
+		return fmt.Errorf("smartling files rename: %w", err)
+	}
+	return nil
+}
+
+// ListLocales returns the project source locale plus target locales.
+func (c *HTTPClient) ListLocales(ctx context.Context, in LocaleListInput) ([]LocaleListItem, error) {
+	payload, err := c.fetchProjectDetails(ctx, in.ProjectID, "smartling locales list")
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/i18n/storage/smartling/discovery_test.go
+++ b/internal/i18n/storage/smartling/discovery_test.go
@@ -238,6 +238,123 @@ func TestHTTPClientListLocalesIncludesDisabledTargets(t *testing.T) {
 	}
 }
 
+func TestHTTPClientGetProjectMapsAccountAndArchived(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/proj-1":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS","data":{"projectId":"proj-1","projectName":"Demo","accountUid":"acct-1","archived":true,"sourceLocaleId":"en-US","targetLocales":[{"localeId":"fr-FR"}]}}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := discoveryTestClient(srv)
+	info, err := client.GetProject(context.Background(), ProjectInfoInput{ProjectID: "proj-1"})
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	if info.ProjectID != "proj-1" || info.ProjectName != "Demo" || info.AccountUID != "acct-1" || info.SourceLocaleID != "en-US" || !info.Archived {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+	locales, err := client.ListLocales(context.Background(), LocaleListInput{ProjectID: "proj-1"})
+	if err != nil {
+		t.Fatalf("ListLocales: %v", err)
+	}
+	if len(locales) != 2 || locales[0].LocaleID != "en-US" || !locales[0].Source || locales[1].LocaleID != "fr-FR" {
+		t.Fatalf("unexpected locales from shared payload: %+v", locales)
+	}
+}
+
+func TestHTTPClientDeleteFileSendsFileURI(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/file/delete":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method=%s", r.Method)
+			}
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if got := r.FormValue("fileUri"); got != "locales/en.json" {
+				t.Fatalf("fileUri=%q", got)
+			}
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := discoveryTestClient(srv)
+	if err := client.DeleteFile(context.Background(), FileDeleteInput{ProjectID: "123", FileURI: "locales/en.json"}); err != nil {
+		t.Fatalf("DeleteFile: %v", err)
+	}
+}
+
+func TestHTTPClientDeleteFileRequiresURI(t *testing.T) {
+	err := (&HTTPClient{}).DeleteFile(context.Background(), FileDeleteInput{ProjectID: "123"})
+	if err == nil || !strings.Contains(err.Error(), "file uri is required") {
+		t.Fatalf("expected uri error, got %v", err)
+	}
+}
+
+func TestHTTPClientDeleteFileHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/file/delete":
+			http.Error(w, `{"response":{"code":"VALIDATION_ERROR"}}`, http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := discoveryTestClient(srv)
+	err := client.DeleteFile(context.Background(), FileDeleteInput{ProjectID: "123", FileURI: "missing.json"})
+	if err == nil || !strings.Contains(err.Error(), "status 404") {
+		t.Fatalf("expected HTTP error, got %v", err)
+	}
+}
+
+func TestHTTPClientRenameFileSendsBothURIs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/file/rename":
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if r.FormValue("fileUri") != "old.json" || r.FormValue("newFileUri") != "new.json" {
+				t.Fatalf("form fileUri=%q newFileUri=%q", r.FormValue("fileUri"), r.FormValue("newFileUri"))
+			}
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := discoveryTestClient(srv)
+	if err := client.RenameFile(context.Background(), FileRenameInput{ProjectID: "123", FileURI: "old.json", NewFileURI: "new.json"}); err != nil {
+		t.Fatalf("RenameFile: %v", err)
+	}
+}
+
+func TestHTTPClientRenameFileRequiresURI(t *testing.T) {
+	err := (&HTTPClient{}).RenameFile(context.Background(), FileRenameInput{ProjectID: "123", FileURI: "old.json"})
+	if err == nil || !strings.Contains(err.Error(), "new file uri is required") {
+		t.Fatalf("expected new uri error, got %v", err)
+	}
+}
+
 func TestHTTPClientListProjectsPages(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -174,13 +174,25 @@ func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadIn
 }
 
 func (c *HTTPClient) uploadMultipart(ctx context.Context, endpoint string, token string, params map[string]string, fileFieldName, filePath string, out any) error {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return fmt.Errorf("open file: %w", err)
+	return c.postMultipart(ctx, endpoint, token, params, fileFieldName, filePath, out)
+}
+
+func (c *HTTPClient) postMultipartFields(ctx context.Context, endpoint string, token string, params map[string]string, out any) error {
+	return c.postMultipart(ctx, endpoint, token, params, "", "", out)
+}
+
+func (c *HTTPClient) postMultipart(ctx context.Context, endpoint string, token string, params map[string]string, fileFieldName, filePath string, out any) error {
+	var file *os.File
+	if filePath != "" {
+		opened, err := os.Open(filePath)
+		if err != nil {
+			return fmt.Errorf("open file: %w", err)
+		}
+		file = opened
+		defer func() {
+			_ = file.Close()
+		}()
 	}
-	defer func() {
-		_ = file.Close()
-	}()
 
 	pr, pw := io.Pipe()
 	writer := multipart.NewWriter(pw)
@@ -198,15 +210,17 @@ func (c *HTTPClient) uploadMultipart(ctx context.Context, endpoint string, token
 				return
 			}
 		}
-		var part io.Writer
-		part, werr = writer.CreateFormFile(fileFieldName, filepath.Base(filePath))
-		if werr != nil {
-			werr = fmt.Errorf("create form file: %w", werr)
-			return
-		}
-		if _, werr = io.Copy(part, file); werr != nil {
-			werr = fmt.Errorf("copy file to form: %w", werr)
-			return
+		if file != nil {
+			var part io.Writer
+			part, werr = writer.CreateFormFile(fileFieldName, filepath.Base(filePath))
+			if werr != nil {
+				werr = fmt.Errorf("create form file: %w", werr)
+				return
+			}
+			if _, werr = io.Copy(part, file); werr != nil {
+				werr = fmt.Errorf("copy file to form: %w", werr)
+				return
+			}
 		}
 		if werr = writer.Close(); werr != nil {
 			werr = fmt.Errorf("close multipart writer: %w", werr)


### PR DESCRIPTION
## Summary
- Add `smartling projects info`, `files rename`, and `files delete` (exact URI, `--dry-run`; delete is async).
- Add `download sources|translations --all` with official `name_locale.ext` paths, `--uri-mask` only with `--all`, and path safety for leading `/` and `..`.
- Update English Smartling CLI docs and the smartling-cli gap table.

Closes [HL-740](https://linear.app/hyperlocalise/issue/HL-740/smartling-cli-file-ops-project-info-and-download-all)

## Test plan
- [ ] `go test ./internal/i18n/storage/smartling ./apps/cli/cmd -run Smartling|HTTPClient -count=1`
- [ ] `projects info` text/json; `files rename`/`delete` dry-run vs live POST; delete without `--file-uri`
- [ ] `--all` writes `locales/en_fr-FR.json` (not `fr-FR/locales/en.json`); `--all` XOR `--file-uri`; `--all` + `%locale%` errors; empty list errors