### PR TITLE
fix(web): dashboard board overlap and settings breadcrumb slugs

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -718,7 +718,10 @@ function OverviewBoardRow({
           size="sm"
           className={issue.priority === "P1" ? "bg-amber-600 text-[11px]" : "text-[11px]"}
         />
-        <span className="w-12 shrink-0 font-mono text-xs leading-4 text-muted-foreground">
+        <span
+          className="w-24 shrink-0 truncate font-mono text-xs leading-4 text-muted-foreground tabular-nums"
+          title={issue.identifier}
+        >
           {issue.identifier}
         </span>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -57,6 +57,8 @@ describe("getAppShellTitle", () => {
     ["/org/acme/settings/account", "Account"],
     ["/org/acme/settings/billing", "Billing"],
     ["/org/acme/settings/api-keys", "API keys"],
+    ["/org/acme/settings/activity-logs", "Activity logs"],
+    ["/org/acme/settings/linked-domains", "Domains"],
   ])("returns the route title for %s", (pathname, title) => {
     expect(getAppShellTitle(pathname, intl)).toBe(title);
   });
@@ -107,6 +109,10 @@ describe("getAppShellBreadcrumbs", () => {
     expect(getAppShellBreadcrumbs("/org/acme/settings/api-keys", intl)).toEqual([
       { label: "Settings", href: "/org/acme/settings" },
       { label: "API keys" },
+    ]);
+    expect(getAppShellBreadcrumbs("/org/acme/settings/activity-logs", intl)).toEqual([
+      { label: "Settings", href: "/org/acme/settings" },
+      { label: "Activity logs" },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -24,6 +24,7 @@ export type AppShellBreadcrumb = {
 type RouteTitleKey =
   | "account"
   | "activity"
+  | "activity-logs"
   | "agent-runs"
   | "ai-engine"
   | "api-keys"
@@ -39,6 +40,7 @@ type RouteTitleKey =
   | "issue-sheet"
   | "jobs"
   | "knowledge"
+  | "linked-domains"
   | "locales"
   | "members"
   | "my-jobs"
@@ -74,6 +76,7 @@ function isRouteTitleKey(value: string): value is RouteTitleKey {
   return (
     value === "account" ||
     value === "activity" ||
+    value === "activity-logs" ||
     value === "agent-runs" ||
     value === "ai-engine" ||
     value === "api-keys" ||
@@ -90,6 +93,7 @@ function isRouteTitleKey(value: string): value is RouteTitleKey {
     value === "jobs" ||
     value === "automations" ||
     value === "knowledge" ||
+    value === "linked-domains" ||
     value === "locales" ||
     value === "members" ||
     value === "my-jobs" ||
@@ -160,6 +164,12 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
         defaultMessage: "Activity",
         id: "rW0O4vxb9w",
         description: "App shell breadcrumb title for the activity page",
+      });
+    case "activity-logs":
+      return intl.formatMessage({
+        defaultMessage: "Activity logs",
+        id: "B6VzK5q3GO",
+        description: "App shell breadcrumb title for the activity logs settings page",
       });
     case "agent-runs":
       return intl.formatMessage({
@@ -250,6 +260,12 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
         defaultMessage: "Guideline",
         id: "1INOkRkMDD",
         description: "App shell breadcrumb title for the guideline page",
+      });
+    case "linked-domains":
+      return intl.formatMessage({
+        defaultMessage: "Domains",
+        id: "il32pCskAo",
+        description: "App shell breadcrumb title for the legacy linked domains settings page",
       });
     case "locales":
       return intl.formatMessage({


### PR DESCRIPTION
## What

Two small UI fixes reported from production:

1. **Dashboard board overlap** (`/dashboard`) — the issue identifier column in `OverviewBoardRow` was fixed at `w-12` (48px) with no overflow handling. Real identifiers like `P8F8E415-12` overflowed visibly into the issue title (and wrapped after the hyphen). Widened to `w-24`, added `truncate`, and exposed the full identifier via `title`.

2. **Settings breadcrumb showed raw slugs** — `Settings > activity-logs` rendered the URL slug because `activity-logs` (and the legacy `linked-domains` redirect) were missing from the `RouteTitleKey` label map in `app-shell-title.ts`, falling back to the verbatim segment. Added both mappings plus test coverage.

## Verification

- `vp test "app-shell-title.test.ts"` — 62 passed
- `vp test "dashboard-page-view.test.tsx"` — 1 passed
- `vp test "activity-log"` — 16 passed
- `vp check --fix` — 0 errors