### PR TITLE
fix(glossary): map Crowdin language IDs on TBX import

### DIFF
--- a/apps/hyperlocalise-web/docs/adr/2026-09-07-tbx-id-round-trip-design.md
+++ b/apps/hyperlocalise-web/docs/adr/2026-09-07-tbx-id-round-trip-design.md
@@ -1,0 +1,21 @@
+# Preserve TBX IDs Across Round Trips
+
+## Problem
+
+TBX requires XML-compatible `id` attributes. Two distinct application IDs can normalize to the
+same XML ID, so the exporter disambiguates collisions. The XML IDs do not encode the original IDs,
+which causes a later import to match or create the wrong glossary records.
+
+## Design
+
+Keep the XML-compatible IDs for TBX validation and external tool compatibility. Store each original
+concept and term ID in the existing Hyperlocalise labeled-note channel. During parsing, restore the
+original ID from that metadata and use the XML attribute as a fallback for third-party TBX files.
+
+This approach preserves current XML IDs, supports arbitrary application IDs, and reuses metadata
+escaping already implemented for user notes. Tests must assert exact concept and term IDs after an
+export and import, including IDs that collide after XML normalization.
+
+## Validation
+
+Run the TBX unit tests, the full test suite, and `vp check --fix`.

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -16371,6 +16371,10 @@
     "defaultMessage": "View all posts",
     "description": "Link to the marketing blog index from the homepage recent posts section"
   },
+  "gL7qR2tV9mK": {
+    "defaultMessage": "No terms were imported — {count, plural, one {# issue needs} other {# issues need}} attention",
+    "description": "Toast when a glossary import applies zero terms because of validation errors"
+  },
   "gLK1qAKU2c": {
     "defaultMessage": "{position} / {total}",
     "description": "Current segment position in side-by-side CAT view footer"
@@ -16810,6 +16814,10 @@
   "hMoO98tftt": {
     "defaultMessage": "Coordinate localization reviews from Microsoft Teams workspaces.",
     "description": "Microsoft Teams integration description on the integrations page"
+  },
+  "hN4wX8pD3sQ": {
+    "defaultMessage": "Nothing was imported. Resolve these issues and try again:",
+    "description": "Title above the list of glossary import validation errors"
   },
   "hN8qhW4nL5": {
     "defaultMessage": "Search by path, name, or provider ID",

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -9087,6 +9087,10 @@
     "defaultMessage": "Flag unresolved locales before ship",
     "description": "Workflow step 6 description for the product-localisation use case"
   },
+  "MJH9GKk4sA": {
+    "defaultMessage": "Nothing was imported. Resolve these issues and try again:",
+    "description": "Title above the list of glossary import validation errors"
+  },
   "MKqk5CAbrB": {
     "defaultMessage": "Back to integrations",
     "description": "Link back to the integrations page from repository automation"
@@ -13559,6 +13563,10 @@
     "defaultMessage": "Your account is signed in, but this workspace does not have an active organization context you can use.",
     "description": "Default access denied page summary"
   },
+  "YkAJNssSF4": {
+    "defaultMessage": "No terms were imported — {count, plural, one {# issue needs} other {# issues need}} attention",
+    "description": "Toast when a glossary import applies zero terms because of validation errors"
+  },
   "YkALJEyJhF": {
     "defaultMessage": "Change analysis",
     "description": "Workflow step 2 label for the github-release-localisation use case"
@@ -16371,10 +16379,6 @@
     "defaultMessage": "View all posts",
     "description": "Link to the marketing blog index from the homepage recent posts section"
   },
-  "gL7qR2tV9mK": {
-    "defaultMessage": "No terms were imported — {count, plural, one {# issue needs} other {# issues need}} attention",
-    "description": "Toast when a glossary import applies zero terms because of validation errors"
-  },
   "gLK1qAKU2c": {
     "defaultMessage": "{position} / {total}",
     "description": "Current segment position in side-by-side CAT view footer"
@@ -16814,10 +16818,6 @@
   "hMoO98tftt": {
     "defaultMessage": "Coordinate localization reviews from Microsoft Teams workspaces.",
     "description": "Microsoft Teams integration description on the integrations page"
-  },
-  "hN4wX8pD3sQ": {
-    "defaultMessage": "Nothing was imported. Resolve these issues and try again:",
-    "description": "Title above the list of glossary import validation errors"
   },
   "hN8qhW4nL5": {
     "defaultMessage": "Search by path, name, or provider ID",

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -361,12 +361,57 @@ function parseConceptImport(
   // `unknown_locale` and the import silently completes with zero terms.
   const glossaryLocales = options.glossaryLocales ?? [];
   const knownLocaleKeys = new Set(glossaryLocales.map((locale) => locale.toLowerCase()));
+  // Resolves a raw import locale to the glossary locale, recording a warning
+  // when the Crowdin catalog translation changes it. Returns null when the
+  // locale is not a valid BCP 47 tag.
+  const resolveImportLocale = (
+    rawLocale: string,
+    diagnostic: { conceptId: string; termId?: string; field: string; subject: string },
+  ): { locale: string; mapped: boolean } | null => {
+    const mapped = options.localeMapping[rawLocale] ?? rawLocale;
+    const canonical = canonicalizeLocale(mapped);
+    if (!canonical) return null;
+    if (options.localeMapping[rawLocale] !== undefined || knownLocaleKeys.size === 0) {
+      return { locale: canonical, mapped: false };
+    }
+    if (knownLocaleKeys.has(canonical.toLowerCase())) {
+      return { locale: canonical, mapped: false };
+    }
+    const crowdinMapped = toNativeGlossaryLocale(rawLocale, glossaryLocales);
+    const crowdinCanonical = canonicalizeLocale(crowdinMapped) ?? crowdinMapped;
+    if (
+      crowdinCanonical.toLowerCase() !== canonical.toLowerCase() &&
+      knownLocaleKeys.has(crowdinCanonical.toLowerCase())
+    ) {
+      parsed.diagnostics.push({
+        severity: "warning",
+        code: "locale_mapped",
+        message: `${diagnostic.subject} locale "${rawLocale}" was mapped to the glossary locale "${crowdinCanonical}".`,
+        conceptId: diagnostic.conceptId,
+        ...(diagnostic.termId ? { termId: diagnostic.termId } : {}),
+        field: diagnostic.field,
+      });
+      return { locale: crowdinCanonical, mapped: true };
+    }
+    return { locale: canonical, mapped: false };
+  };
   for (const concept of parsed.concepts) {
+    for (const detail of concept.languageDetails ?? []) {
+      const resolved = resolveImportLocale(detail.locale, {
+        conceptId: concept.id,
+        field: "locale",
+        subject: "Language detail",
+      });
+      if (resolved) detail.locale = resolved.locale;
+    }
     for (const term of concept.terms) {
-      const rawLocale = term.locale;
-      const mapped = options.localeMapping[rawLocale] ?? rawLocale;
-      const canonical = canonicalizeLocale(mapped);
-      if (!canonical) {
+      const resolved = resolveImportLocale(term.locale, {
+        conceptId: concept.id,
+        termId: term.id,
+        field: "locale",
+        subject: "Term",
+      });
+      if (!resolved) {
         parsed.diagnostics.push({
           severity: "error",
           code: "invalid_locale",
@@ -377,32 +422,7 @@ function parseConceptImport(
         });
         continue;
       }
-      if (options.localeMapping[rawLocale] !== undefined || knownLocaleKeys.size === 0) {
-        term.locale = canonical;
-        continue;
-      }
-      if (knownLocaleKeys.has(canonical.toLowerCase())) {
-        term.locale = canonical;
-        continue;
-      }
-      const crowdinMapped = toNativeGlossaryLocale(rawLocale, glossaryLocales);
-      const crowdinCanonical = canonicalizeLocale(crowdinMapped) ?? crowdinMapped;
-      if (
-        crowdinCanonical.toLowerCase() !== canonical.toLowerCase() &&
-        knownLocaleKeys.has(crowdinCanonical.toLowerCase())
-      ) {
-        term.locale = crowdinCanonical;
-        parsed.diagnostics.push({
-          severity: "warning",
-          code: "locale_mapped",
-          message: `Term locale "${rawLocale}" was mapped to the glossary locale "${crowdinCanonical}".`,
-          conceptId: concept.id,
-          termId: term.id,
-          field: "locale",
-        });
-      } else {
-        term.locale = canonical;
-      }
+      term.locale = resolved.locale;
     }
   }
   const entries = entriesFromImportDocument(parsed);

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -39,6 +39,7 @@ import type { FileStorageAdapter } from "@/lib/file-storage/types";
 import { enqueueActivityLogEvent } from "@/lib/activity-log/activity-log-writer";
 import { getGlossaryProduct } from "@/lib/glossary/glossary-provider";
 import { canonicalizeLocale } from "@/lib/i18n/locales";
+import { toNativeGlossaryLocale } from "@/lib/providers/adapters/crowdin/crowdin-glossary-language";
 import {
   GlossaryValidationError,
   selectGlossaryPrimaryTerm,
@@ -340,7 +341,11 @@ function parseConceptImport(
   content: string,
   format: "csv" | "tbx" | "xlsx",
   contentEncoding?: "utf8" | "base64",
-  options: { strictLocale: boolean; localeMapping: Record<string, string> } = {
+  options: {
+    strictLocale: boolean;
+    localeMapping: Record<string, string>;
+    glossaryLocales?: readonly string[];
+  } = {
     strictLocale: true,
     localeMapping: {},
   },
@@ -350,15 +355,47 @@ function parseConceptImport(
       ? Uint8Array.from(Buffer.from(content, "base64"))
       : content,
   );
+  // Crowdin exports (notably TBX) carry Crowdin language IDs such as `de` or
+  // `vi` while native glossaries use region-qualified BCP-47 locales such as
+  // `de-DE` or `vi-VN`. Without a translation step every term is rejected as
+  // `unknown_locale` and the import silently completes with zero terms.
+  const glossaryLocales = options.glossaryLocales ?? [];
+  const knownLocaleKeys = new Set(glossaryLocales.map((locale) => locale.toLowerCase()));
   for (const concept of parsed.concepts) {
     for (const term of concept.terms) {
-      const mapped = options.localeMapping[term.locale] ?? term.locale;
+      const rawLocale = term.locale;
+      const mapped = options.localeMapping[rawLocale] ?? rawLocale;
       const canonical = canonicalizeLocale(mapped);
       if (!canonical) {
         parsed.diagnostics.push({
           severity: "error",
           code: "invalid_locale",
           message: "Term locale is not a valid BCP 47 language tag.",
+          conceptId: concept.id,
+          termId: term.id,
+          field: "locale",
+        });
+        continue;
+      }
+      if (options.localeMapping[rawLocale] !== undefined || knownLocaleKeys.size === 0) {
+        term.locale = canonical;
+        continue;
+      }
+      if (knownLocaleKeys.has(canonical.toLowerCase())) {
+        term.locale = canonical;
+        continue;
+      }
+      const crowdinMapped = toNativeGlossaryLocale(rawLocale, glossaryLocales);
+      const crowdinCanonical = canonicalizeLocale(crowdinMapped) ?? crowdinMapped;
+      if (
+        crowdinCanonical.toLowerCase() !== canonical.toLowerCase() &&
+        knownLocaleKeys.has(crowdinCanonical.toLowerCase())
+      ) {
+        term.locale = crowdinCanonical;
+        parsed.diagnostics.push({
+          severity: "warning",
+          code: "locale_mapped",
+          message: `Term locale "${rawLocale}" was mapped to the glossary locale "${crowdinCanonical}".`,
           conceptId: concept.id,
           termId: term.id,
           field: "locale",
@@ -445,6 +482,7 @@ export function createGlossaryConceptRoutes(
           {
             strictLocale: payload.strictLocale,
             localeMapping: payload.localeMapping,
+            glossaryLocales: [glossary.sourceLocale, ...glossary.localeCoverage],
           },
         );
         const sourceTotals = {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
@@ -350,7 +350,7 @@ describe("glossaryRoutes", () => {
       "<note>[Hyperlocalise::translatable]::true</note>",
       '<langSec xml:lang="en"><termSec id="95"><term>destination</term>',
       '<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>',
-      '<langSec xml:lang="de"><termSec id="101"><term>Reiseziel</term>',
+      '<langSec xml:lang="de"><descrip type="definition">Deutscher Suchbegriff.</descrip><termSec id="101"><term>Reiseziel</term>',
       '<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>',
       '<langSec xml:lang="ja"><termSec id="99"><term>目的地</term>',
       '<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>',
@@ -401,11 +401,17 @@ describe("glossaryRoutes", () => {
     const concepts = (await conceptsResponse.json()) as {
       concepts: Array<{
         definition: string;
+        languageDetails: Array<{ locale: string; definition: string }>;
         terms: Array<{ locale: string; term: string }>;
       }>;
     };
     expect(concepts.concepts).toHaveLength(1);
     expect(concepts.concepts[0]?.definition).toBe("The place a traveler plans to visit.");
+    expect(concepts.concepts[0]?.languageDetails).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ locale: "de-DE", definition: "Deutscher Suchbegriff." }),
+      ]),
+    );
     expect(concepts.concepts[0]?.terms).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ locale: "en-US", term: "destination" }),

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
@@ -324,6 +324,99 @@ describe("glossaryRoutes", () => {
     ]);
   });
 
+  it("maps Crowdin TBX language IDs to region-qualified glossary locales", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const glossaryResponse = await fixture.createGlossaryViaApi(
+      identity,
+      { sourceLocale: "en-US" },
+      headers,
+    );
+    const glossaryId = ((await glossaryResponse.json()) as { glossary: { id: string } }).glossary
+      .id;
+    await db
+      .update(schema.glossaries)
+      .set({ localeCoverage: ["de-DE", "ja-JP", "ko-KR", "vi-VN"] })
+      .where(eq(schema.glossaries.id, glossaryId));
+
+    const tbx = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<tbx xmlns="urn:iso:std:iso:30042:ed-2" type="TBX-Basic" style="dca" xml:lang="en">',
+      "<text><body>",
+      '<conceptEntry id="c-ota-001">',
+      '<descrip type="subjectField">search</descrip>',
+      '<descrip type="definition">The place a traveler plans to visit.</descrip>',
+      "<note>[Hyperlocalise::translatable]::true</note>",
+      '<langSec xml:lang="en"><termSec id="95"><term>destination</term>',
+      '<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>',
+      '<langSec xml:lang="de"><termSec id="101"><term>Reiseziel</term>',
+      '<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>',
+      '<langSec xml:lang="ja"><termSec id="99"><term>目的地</term>',
+      '<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>',
+      '<langSec xml:lang="ko"><termSec id="103"><term>목적지</term>',
+      '<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>',
+      '<langSec xml:lang="vi"><termSec id="97"><term>điểm đến</term>',
+      '<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>',
+      "</conceptEntry>",
+      "</body></text></tbx>",
+    ].join("");
+
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].concepts[
+      "import"
+    ].$post(
+      {
+        param: { organizationSlug, glossaryId },
+        json: {
+          format: "tbx",
+          content: tbx,
+          mode: "merge",
+          previewForMode: "merge",
+          strictLocale: true,
+          localeMapping: {},
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      imported: number;
+      diagnostics: Array<{ code: string; severity: string; termId?: string }>;
+    };
+    expect(body.imported).toBeGreaterThan(0);
+    expect(body.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "locale_mapped", severity: "warning" }),
+      ]),
+    );
+    expect(
+      body.diagnostics.some(
+        (entry) => entry.severity === "error" && entry.code === "unknown_locale",
+      ),
+    ).toBe(false);
+    const conceptsResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].concepts.$get({ param: { organizationSlug, glossaryId } }, { headers });
+    const concepts = (await conceptsResponse.json()) as {
+      concepts: Array<{
+        definition: string;
+        terms: Array<{ locale: string; term: string }>;
+      }>;
+    };
+    expect(concepts.concepts).toHaveLength(1);
+    expect(concepts.concepts[0]?.definition).toBe("The place a traveler plans to visit.");
+    expect(concepts.concepts[0]?.terms).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ locale: "en-US", term: "destination" }),
+        expect.objectContaining({ locale: "de-DE", term: "Reiseziel" }),
+        expect.objectContaining({ locale: "ja-JP", term: "目的地" }),
+        expect.objectContaining({ locale: "ko-KR", term: "목적지" }),
+        expect.objectContaining({ locale: "vi-VN", term: "điểm đến" }),
+      ]),
+    );
+  });
+
   it("rejects a malformed import before applying non-replace modes", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
@@ -180,6 +180,17 @@ export const glossaryDetailPageContentMessages = defineMessages({
     id: "w69BfzSUw0",
     description: "Toast after glossary terms are imported from a file",
   },
+  termsImportBlocked: {
+    defaultMessage:
+      "No terms were imported — {count, plural, one {# issue needs} other {# issues need}} attention",
+    id: "YkAJNssSF4",
+    description: "Toast when a glossary import applies zero terms because of validation errors",
+  },
+  termsImportBlockedTitle: {
+    defaultMessage: "Nothing was imported. Resolve these issues and try again:",
+    id: "MJH9GKk4sA",
+    description: "Title above the list of glossary import validation errors",
+  },
   projectAssigned: {
     defaultMessage: "Project assigned",
     id: "lgRbICxGNz",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -791,6 +791,9 @@ export function GlossaryDetailPageContent({
       const applied = (result.imported ?? 0) + (result.updated ?? 0) + (result.merged ?? 0);
       if (applied === 0 && errorDiagnostics.length > 0) {
         setImportDiagnostics(errorDiagnostics.slice(0, 10));
+        // Reset the native input so selecting the same (corrected) file still
+        // fires a change event and retries the import.
+        if (glossaryFileInputRef.current) glossaryFileInputRef.current.value = "";
         toast.error(
           intl.formatMessage(messages.termsImportBlocked, {
             count: errorDiagnostics.length,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -405,6 +405,9 @@ export function GlossaryDetailPageContent({
   const glossaryFileInputRef = useRef<HTMLInputElement>(null);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [importFile, setImportFile] = useState<File | null>(null);
+  const [importDiagnostics, setImportDiagnostics] = useState<
+    Array<{ severity: string; code: string; message: string }>
+  >([]);
 
   const glossaryQuery = useQuery({
     queryKey: ["glossary", organizationSlug, glossaryId],
@@ -768,6 +771,26 @@ export function GlossaryDetailPageContent({
     },
     onSuccess: async (body) => {
       await invalidateConcepts();
+      const errorDiagnostics = (
+        (body.diagnostics ?? []) as Array<{
+          severity: string;
+          code: string;
+          message: string;
+        }>
+      ).filter((entry) => entry.severity === "error");
+      // A strict-locale import can legitimately apply zero terms (for example
+      // when every row targets an unconfigured locale). Keep the dialog open
+      // and show why instead of a misleading "Imported 0 terms" success.
+      if ((body.imported ?? 0) === 0 && errorDiagnostics.length > 0) {
+        setImportDiagnostics(errorDiagnostics.slice(0, 10));
+        toast.error(
+          intl.formatMessage(messages.termsImportBlocked, {
+            count: errorDiagnostics.length,
+          }),
+        );
+        return;
+      }
+      setImportDiagnostics([]);
       setImportDialogOpen(false);
       setImportFile(null);
       toast.success(intl.formatMessage(messages.termsImported, { count: body.imported ?? 0 }));
@@ -2644,6 +2667,7 @@ export function GlossaryDetailPageContent({
           setImportDialogOpen(open);
           if (!open) {
             setImportFile(null);
+            setImportDiagnostics([]);
             if (glossaryFileInputRef.current) glossaryFileInputRef.current.value = "";
           }
         }}
@@ -2669,6 +2693,7 @@ export function GlossaryDetailPageContent({
                 const file = event.target.files?.[0];
                 if (!file) return;
                 setImportFile(file);
+                setImportDiagnostics([]);
                 importConcepts.mutate(file);
               }}
             />
@@ -2700,6 +2725,21 @@ export function GlossaryDetailPageContent({
                   ? importConcepts.error.message
                   : intl.formatMessage(messages.importTermsFailed)}
               </p>
+            ) : null}
+            {importDiagnostics.length > 0 ? (
+              <div className="grid gap-1.5" role="alert" aria-live="polite">
+                <p className="text-sm font-medium text-destructive">
+                  <FormattedMessage {...messages.termsImportBlockedTitle} />
+                </p>
+                <ul className="grid list-disc gap-1 pl-5 text-xs text-muted-foreground">
+                  {importDiagnostics.map((entry, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <li key={`${entry.code}-${index}`}>
+                      {entry.message} <span className="font-mono">({entry.code})</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ) : null}
           </div>
           <DialogFooter>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -771,17 +771,25 @@ export function GlossaryDetailPageContent({
     },
     onSuccess: async (body) => {
       await invalidateConcepts();
-      const errorDiagnostics = (
-        (body.diagnostics ?? []) as Array<{
-          severity: string;
-          code: string;
-          message: string;
-        }>
-      ).filter((entry) => entry.severity === "error");
-      // A strict-locale import can legitimately apply zero terms (for example
+      // The import endpoint returns a union of preview and applied shapes;
+      // this mutation always uses mode:"merge", so read the applied counters
+      // defensively.
+      const result = body as {
+        imported?: number;
+        updated?: number;
+        merged?: number;
+        diagnostics?: Array<{ severity: string; code: string; message: string }>;
+      };
+      const errorDiagnostics = (result.diagnostics ?? []).filter(
+        (entry) => entry.severity === "error",
+      );
+      // A strict-locale import can legitimately apply zero new terms (for example
       // when every row targets an unconfigured locale). Keep the dialog open
-      // and show why instead of a misleading "Imported 0 terms" success.
-      if ((body.imported ?? 0) === 0 && errorDiagnostics.length > 0) {
+      // and show why instead of a misleading "Imported 0 terms" success — but
+      // only when nothing was applied at all, since merge/update imports
+      // report applied work via `updated`/`merged` rather than `imported`.
+      const applied = (result.imported ?? 0) + (result.updated ?? 0) + (result.merged ?? 0);
+      if (applied === 0 && errorDiagnostics.length > 0) {
         setImportDiagnostics(errorDiagnostics.slice(0, 10));
         toast.error(
           intl.formatMessage(messages.termsImportBlocked, {
@@ -793,7 +801,7 @@ export function GlossaryDetailPageContent({
       setImportDiagnostics([]);
       setImportDialogOpen(false);
       setImportFile(null);
-      toast.success(intl.formatMessage(messages.termsImported, { count: body.imported ?? 0 }));
+      toast.success(intl.formatMessage(messages.termsImported, { count: result.imported ?? 0 }));
     },
     onError: (error) => toast.error(error.message),
   });

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
@@ -397,8 +397,7 @@ describe("TBX-Basic DCA interchange", () => {
     expect(reparsed.diagnostics.filter((entry) => entry.severity === "error")).toEqual([]);
     expect(reparsed.concepts[0]?.id).toBe("c-ota-004");
     expect(reparsed.concepts[0]?.translatable).toBe(true);
-    const reTermId = reparsed.concepts[0]?.terms[0]?.id ?? "";
-    expect(reTermId.startsWith("t-125-")).toBe(true);
+    expect(reparsed.concepts[0]?.terms[0]?.id).toBe("125");
     const reserialized = serializeTbx({
       glossary,
       concepts: reparsed.concepts.map((concept) => ({
@@ -494,6 +493,12 @@ describe("TBX-Basic DCA interchange", () => {
     const reparsed = parseTbx(xml);
     expect(reparsed.diagnostics.filter((entry) => entry.severity === "error")).toEqual([]);
     expect(reparsed.concepts).toHaveLength(2);
+    expect(reparsed.concepts.map((item) => item.id)).toEqual(["foo", "c-foo"]);
+    expect(reparsed.concepts.flatMap((item) => item.terms.map((item) => item.id))).toEqual([
+      "bar",
+      "t-bar",
+      "other",
+    ]);
   });
 
   it("rejects malformed XML without truncating valid preceding concepts", () => {

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
@@ -440,6 +440,62 @@ describe("TBX-Basic DCA interchange", () => {
     expect(new TextDecoder().decode(reserialized.content)).toBe(xml);
   });
 
+  it("disambiguates distinct IDs that normalize to the same XML ID", () => {
+    const term = (id: string, locale: string, text: string) => ({
+      id,
+      conceptId: "placeholder",
+      locale,
+      term: text,
+      description: "",
+      note: "",
+      partOfSpeech: "noun",
+      gender: null,
+      termType: null,
+      url: null,
+      lemma: null,
+      status: "preferred",
+      caseSensitive: false,
+      forbidden: false,
+      provenance: "manual",
+      reviewStatus: "approved",
+      metadata: {},
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    const concept = (id: string, terms: ReturnType<typeof term>[]) => ({
+      id,
+      primaryTerm: terms[0]?.term ?? "",
+      subject: "",
+      definition: "",
+      translatable: true,
+      note: "",
+      url: null,
+      figure: null,
+      languageDetails: [],
+      metadata: {},
+      terms: terms.map((item) => ({ ...item, conceptId: id })),
+    });
+    const serialized = serializeTbx({
+      glossary,
+      concepts: [
+        concept("foo", [term("bar", "en-US", "Foo"), term("t-bar", "en-US", "Foo alias")]),
+        concept("c-foo", [term("other", "en-US", "Other")]),
+      ],
+    });
+    expect(serialized.errors).toEqual([]);
+    const xml = new TextDecoder().decode(serialized.content);
+    const conceptIds = [...xml.matchAll(/<conceptEntry id="([^"]+)"/g)].map((match) => match[1]);
+    expect(conceptIds).toHaveLength(2);
+    expect(new Set(conceptIds).size).toBe(2);
+    expect(conceptIds).toContain("c-foo");
+    const termIds = [...xml.matchAll(/<termSec id="([^"]+)"/g)].map((match) => match[1]);
+    expect(new Set(termIds).size).toBe(termIds.length);
+
+    const reparsed = parseTbx(xml);
+    expect(reparsed.diagnostics.filter((entry) => entry.severity === "error")).toEqual([]);
+    expect(reparsed.concepts).toHaveLength(2);
+  });
+
   it("rejects malformed XML without truncating valid preceding concepts", () => {
     const parsed = parseTbx(
       '<?xml version="1.0"?><tbx><text><body><conceptEntry id="c1"><langSec xml:lang="en"><termSec id="t1"><term>ok</term></termSec></langSec></conceptEntry><conceptEntry',

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
@@ -330,6 +330,116 @@ describe("TBX-Basic DCA interchange", () => {
     expect(parsed.concepts[1]?.languageDetails ?? []).toEqual([]);
   });
 
+  it("keeps Crowdin-style IDs stable across an export round-trip", () => {
+    const parsed = parseTbx(
+      `<?xml version="1.0"?><tbx xmlns="${TBX_NAMESPACE}" type="TBX-Basic" style="dca" xml:lang="en"><text><body>` +
+        `<conceptEntry id="c-ota-004"><descrip type="translatable">yes</descrip>` +
+        `<descrip type="subjectField">search</descrip>` +
+        `<descrip type="definition">The calendar date on which a return journey begins.</descrip>` +
+        `<note>[Hyperlocalise::translatable]::true</note>` +
+        `<langSec xml:lang="en"><termSec id="125"><term>return date</term>` +
+        `<termNote type="administrativeStatus">preferredTerm-admn-sts</termNote></termSec></langSec>` +
+        `</conceptEntry></body></text></tbx>`,
+    );
+    expect(parsed.diagnostics.filter((entry) => entry.severity === "error")).toEqual([]);
+    expect(parsed.concepts[0]?.id).toBe("c-ota-004");
+    expect(parsed.concepts[0]?.translatable).toBe(true);
+
+    const serialized = serializeTbx({
+      glossary,
+      concepts: parsed.concepts.map((concept) => ({
+        id: concept.id,
+        primaryTerm: concept.primaryTerm ?? "",
+        subject: concept.subject ?? "",
+        definition: concept.definition ?? "",
+        translatable: concept.translatable ?? true,
+        note: concept.note ?? "",
+        url: null,
+        figure: null,
+        languageDetails: [],
+        metadata: {},
+        terms: concept.terms.map((term) => ({
+          id: term.id,
+          conceptId: concept.id,
+          locale: term.locale,
+          term: term.term,
+          description: "",
+          note: "",
+          partOfSpeech: term.partOfSpeech ?? "",
+          gender: null,
+          termType: null,
+          url: null,
+          lemma: null,
+          status: term.status ?? "draft",
+          caseSensitive: false,
+          forbidden: false,
+          provenance: "manual",
+          reviewStatus: "approved",
+          metadata: {},
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+        })),
+      })),
+    });
+    expect(serialized.errors).toEqual([]);
+    const xml = new TextDecoder().decode(serialized.content);
+    // No doubled prefixes: c-c-ota-004 growth would break merge matching.
+    expect(xml).toContain('conceptEntry id="c-ota-004"');
+    expect(xml).not.toContain("c-c-ota-004");
+    // Numeric Crowdin IDs are not valid XML IDs, so they gain a deterministic
+    // prefixed form instead of being emitted verbatim.
+    expect(xml).toContain('termSec id="t-125-');
+    expect(xml).not.toContain('termSec id="125"');
+    // Empty metadata objects stay out of user-visible notes.
+    expect(xml).not.toContain("[Hyperlocalise::metadata]");
+
+    const reparsed = parseTbx(xml);
+    expect(reparsed.diagnostics.filter((entry) => entry.severity === "error")).toEqual([]);
+    expect(reparsed.concepts[0]?.id).toBe("c-ota-004");
+    expect(reparsed.concepts[0]?.translatable).toBe(true);
+    const reTermId = reparsed.concepts[0]?.terms[0]?.id ?? "";
+    expect(reTermId.startsWith("t-125-")).toBe(true);
+    const reserialized = serializeTbx({
+      glossary,
+      concepts: reparsed.concepts.map((concept) => ({
+        id: concept.id,
+        primaryTerm: concept.primaryTerm ?? "",
+        subject: concept.subject ?? "",
+        definition: concept.definition ?? "",
+        translatable: concept.translatable ?? true,
+        note: concept.note ?? "",
+        url: null,
+        figure: null,
+        languageDetails: [],
+        metadata: {},
+        terms: concept.terms.map((term) => ({
+          id: term.id,
+          conceptId: concept.id,
+          locale: term.locale,
+          term: term.term,
+          description: term.description ?? "",
+          note: term.note ?? "",
+          partOfSpeech: term.partOfSpeech ?? "",
+          gender: null,
+          termType: null,
+          url: null,
+          lemma: null,
+          status: term.status ?? "draft",
+          caseSensitive: false,
+          forbidden: false,
+          provenance: "manual",
+          reviewStatus: "approved",
+          metadata: {},
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+        })),
+      })),
+    });
+    expect(reserialized.errors).toEqual([]);
+    // Second-generation IDs are already XML-safe, so output is now fixed-point.
+    expect(new TextDecoder().decode(reserialized.content)).toBe(xml);
+  });
+
   it("rejects malformed XML without truncating valid preceding concepts", () => {
     const parsed = parseTbx(
       '<?xml version="1.0"?><tbx><text><body><conceptEntry id="c1"><langSec xml:lang="en"><termSec id="t1"><term>ok</term></termSec></langSec></conceptEntry><conceptEntry',

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
@@ -308,6 +308,28 @@ describe("TBX-Basic DCA interchange", () => {
     expect(parsed.concepts[0]?.terms[0]?.note).toContain("\\literal note");
   });
 
+  it("does not leak language-section state into the next concept entry", () => {
+    const parsed = parseTbx(
+      `<?xml version="1.0"?><tbx xmlns="${TBX_NAMESPACE}" type="TBX-Basic" style="dca"><text><body>` +
+        `<conceptEntry id="c-first"><descrip type="definition">First definition.</descrip>` +
+        `<note>[Hyperlocalise::translatable]::true</note>` +
+        `<langSec xml:lang="en"><termSec id="t-1"><term>first</term></termSec></langSec>` +
+        `<langSec xml:lang="vi"><termSec id="t-2"><term>đầu tiên</term></termSec></langSec></conceptEntry>` +
+        `<conceptEntry id="c-second"><descrip type="definition">Second definition.</descrip>` +
+        `<note>[Hyperlocalise::translatable]::false</note>` +
+        `<langSec xml:lang="en"><termSec id="t-3"><term>second</term></termSec></langSec></conceptEntry>` +
+        `</body></text></tbx>`,
+    );
+
+    expect(parsed.diagnostics.filter((entry) => entry.severity === "error")).toEqual([]);
+    expect(parsed.concepts).toHaveLength(2);
+    expect(parsed.concepts[0]?.definition).toBe("First definition.");
+    expect(parsed.concepts[0]?.translatable).toBe(true);
+    expect(parsed.concepts[1]?.definition).toBe("Second definition.");
+    expect(parsed.concepts[1]?.translatable).toBe(false);
+    expect(parsed.concepts[1]?.languageDetails ?? []).toEqual([]);
+  });
+
   it("rejects malformed XML without truncating valid preceding concepts", () => {
     const parsed = parseTbx(
       '<?xml version="1.0"?><tbx><text><body><conceptEntry id="c1"><langSec xml:lang="en"><termSec id="t1"><term>ok</term></termSec></langSec></conceptEntry><conceptEntry',

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.ts
@@ -171,7 +171,7 @@ function addTerm(
 ) {
   const termSec = langSec.ele("termSec", { id: termXmlId });
   termSec.ele("term").txt(term.term);
-  const notes: string[] = [];
+  const notes: string[] = [`[Hyperlocalise::termId]::${JSON.stringify(term.id)}`];
   const addTermNote = (label: string, value: unknown) => {
     if (value === undefined || value === null || value === "") return;
     const serialized = typeof value === "string" ? value : JSON.stringify(value);
@@ -265,6 +265,7 @@ function addConcept(
     conceptEntry.ele("descrip", { type: "definition" }).txt(concept.definition);
   const conceptNotes = [
     encodeTbxUserNote(concept.note.trim()),
+    `[Hyperlocalise::conceptId]::${JSON.stringify(concept.id)}`,
     `[Hyperlocalise::translatable]::${JSON.stringify(concept.translatable)}`,
     concept.createdAt ? `[Hyperlocalise::createdAt]::${concept.createdAt}` : "",
     concept.updatedAt ? `[Hyperlocalise::updatedAt]::${concept.updatedAt}` : "",
@@ -387,7 +388,8 @@ function mergeLanguageDetailNote(
 }
 
 function applyTermLabeledNote(term: MutableTerm, labeled: { key: string; value: unknown }) {
-  if (labeled.key === "partOfSpeech" && typeof labeled.value === "string")
+  if (labeled.key === "termId" && typeof labeled.value === "string") term.id = labeled.value;
+  else if (labeled.key === "partOfSpeech" && typeof labeled.value === "string")
     term.partOfSpeech = labeled.value;
   else if (labeled.key === "gender" && typeof labeled.value === "string")
     term.gender = labeled.value;
@@ -696,6 +698,10 @@ export function parseTbx(content: string): GlossaryImportDocument {
             if (decoded.escaped) return true;
             const labeled = parseLabeledNote(decoded.value);
             if (!labeled) return true;
+            if (labeled.key === "conceptId" && typeof labeled.value === "string") {
+              concept.id = labeled.value;
+              return false;
+            }
             if (labeled.key === "translatable" && typeof labeled.value === "boolean") {
               concept.translatable = labeled.value;
               return false;

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.ts
@@ -41,6 +41,12 @@ function attr(tag: SaxesTagNS, name: string) {
 }
 
 function stableId(prefix: string, value: string) {
+  // Round-trip stability: an ID that already carries this prefix in XML-safe
+  // form (for example a re-exported import) must not gain another prefix
+  // layer, otherwise export -> import can no longer match the original record.
+  if (value.startsWith(`${prefix}-`) && /^[A-Za-z_][A-Za-z0-9_.-]*$/.test(value)) {
+    return value;
+  }
   const base = value.replace(/[^A-Za-z0-9_.-]/g, "-");
   if (base === value && /^[A-Za-z_]/.test(base)) return `${prefix}-${base}`;
   if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(value)) {
@@ -182,7 +188,8 @@ function addTerm(
   addTermNote("Hyperlocalise::provenance", term.provenance);
   addTermNote("Hyperlocalise::createdAt", term.createdAt);
   addTermNote("Hyperlocalise::updatedAt", term.updatedAt);
-  addTermNote("Hyperlocalise::metadata", term.metadata);
+  if (term.metadata && Object.keys(term.metadata).length > 0)
+    addTermNote("Hyperlocalise::metadata", term.metadata);
   if (term.description.trim() || notes.length > 0) {
     if (term.description.trim()) {
       const descriptionGroup = termSec.ele("descripGrp");

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.ts
@@ -566,6 +566,10 @@ export function parseTbx(content: string): GlossaryImportDocument {
       conceptCount++;
       if (conceptCount > MAX_CONCEPTS) throw new Error("TBX concept limit exceeded");
       const id = normalizeImportedId(attr(tag, "id") ?? `import-${conceptCount}`, "c");
+      // Concept-level siblings (descrip/note) must not inherit the previous
+      // concept's language section; reset locale state on every new entry.
+      currentLocale = "";
+      currentTerm = undefined;
       if (!attr(tag, "id"))
         diagnostics.push(
           diagnostic({
@@ -760,6 +764,10 @@ export function parseTbx(content: string): GlossaryImportDocument {
         if (!currentConcept.primaryTerm) currentConcept.primaryTerm = term.term;
       }
       currentTerm = undefined;
+    } else if (frame.local === "langSec" || frame.local === "langSet") {
+      // Concept-level siblings placed after a language section must not
+      // inherit that section's locale.
+      currentLocale = "";
     } else if (frame.local === "conceptEntry" || frame.local === "termEntry") {
       if (currentConcept) {
         if (!currentConcept.terms.length)

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.ts
@@ -66,6 +66,29 @@ function normalizeImportedId(value: string, prefix: "c" | "t") {
   return match?.[1] ?? value;
 }
 
+/**
+ * Assigns the XML ID for a raw interchange ID, reusing `stableId` but
+ * disambiguating when distinct raw IDs normalize to the same value (for
+ * example `foo` and `c-foo`). Disambiguation is deterministic in document
+ * order, so re-serializing a parsed export is fixed-point.
+ */
+function uniqueStableId(used: Map<string, string>, prefix: "c" | "t", rawId: string) {
+  const base = stableId(prefix, rawId);
+  const owner = used.get(base);
+  if (owner === undefined || owner === rawId) {
+    used.set(base, rawId);
+    return base;
+  }
+  const digest = createHash("sha256").update(`${prefix}:${rawId}`).digest("hex").slice(0, 8);
+  let candidate = `${base}-${digest}`;
+  let counter = 2;
+  while (used.has(candidate) && used.get(candidate) !== rawId) {
+    candidate = `${base}-${digest}-${counter++}`;
+  }
+  used.set(candidate, rawId);
+  return candidate;
+}
+
 function containsInvalidXmlCharacters(value: string) {
   for (const character of value) {
     const codePoint = character.codePointAt(0) ?? 0;
@@ -144,8 +167,9 @@ function addTerm(
   langSec: ReturnType<ReturnType<typeof create>["ele"]>,
   term: GlossaryInterchangeTerm,
   warnings: InterchangeDiagnostic[],
+  termXmlId: string,
 ) {
-  const termSec = langSec.ele("termSec", { id: stableId("t", term.id) });
+  const termSec = langSec.ele("termSec", { id: termXmlId });
   termSec.ele("term").txt(term.term);
   const notes: string[] = [];
   const addTermNote = (label: string, value: unknown) => {
@@ -223,6 +247,7 @@ function addConcept(
   sourceLocale: string,
   warnings: InterchangeDiagnostic[],
   errors: InterchangeDiagnostic[],
+  ids: { conceptXmlId: string; termXmlIds: Map<string, string> },
 ) {
   if (concept.terms.length === 0) {
     errors.push(
@@ -234,7 +259,7 @@ function addConcept(
     );
     return;
   }
-  const conceptEntry = body.ele("conceptEntry", { id: stableId("c", concept.id) });
+  const conceptEntry = body.ele("conceptEntry", { id: ids.conceptXmlId });
   if (concept.subject) conceptEntry.ele("descrip", { type: "subjectField" }).txt(concept.subject);
   if (concept.definition)
     conceptEntry.ele("descrip", { type: "definition" }).txt(concept.definition);
@@ -276,7 +301,8 @@ function addConcept(
       const noteLines = languageDetailNoteLines(languageDetail);
       if (noteLines.length > 0) addNote(langSec, noteLines.join("\n"));
     }
-    for (const term of terms) addTerm(langSec, term, warnings);
+    for (const term of terms)
+      addTerm(langSec, term, warnings, ids.termXmlIds.get(term.id) ?? term.id);
   }
   if (!termsByLocale.has(sourceLocale)) {
     warnings.push(
@@ -406,11 +432,16 @@ export function serializeTbx(document: GlossaryInterchangeDocument): Serializati
       }),
     );
   }
-  const conceptIds = new Set<string>();
-  const termIds = new Set<string>();
+  const conceptXmlIds = new Map<string, string>();
+  const termXmlIds = new Map<string, string>();
+  const seenConceptRawIds = new Set<string>();
+  const seenTermRawIds = new Set<string>();
+  // Resolved XML IDs per raw interchange ID, threaded into addConcept/addTerm
+  // so emitted IDs match the validated ones exactly.
+  const conceptXmlIdByRawId = new Map<string, string>();
+  const termXmlIdByRawId = new Map<string, string>();
   for (const concept of document.concepts) {
-    const conceptXmlId = stableId("c", concept.id);
-    if (conceptIds.has(conceptXmlId)) {
+    if (seenConceptRawIds.has(concept.id)) {
       errors.push(
         diagnostic({
           code: "duplicate_concept_id",
@@ -419,10 +450,11 @@ export function serializeTbx(document: GlossaryInterchangeDocument): Serializati
         }),
       );
     }
-    conceptIds.add(conceptXmlId);
+    seenConceptRawIds.add(concept.id);
+    const conceptXmlId = uniqueStableId(conceptXmlIds, "c", concept.id);
+    conceptXmlIdByRawId.set(concept.id, conceptXmlId);
     for (const term of concept.terms) {
-      const termXmlId = stableId("t", term.id);
-      if (termIds.has(termXmlId)) {
+      if (seenTermRawIds.has(term.id)) {
         errors.push(
           diagnostic({
             code: "duplicate_term_id",
@@ -432,7 +464,9 @@ export function serializeTbx(document: GlossaryInterchangeDocument): Serializati
           }),
         );
       }
-      termIds.add(termXmlId);
+      seenTermRawIds.add(term.id);
+      const termXmlId = uniqueStableId(termXmlIds, "t", term.id);
+      termXmlIdByRawId.set(term.id, termXmlId);
       const textFields = [
         term.term,
         term.description,
@@ -504,7 +538,10 @@ export function serializeTbx(document: GlossaryInterchangeDocument): Serializati
   header.ele("sourceDesc").ele("p").txt("Exported from Hyperlocalise");
   const body = root.ele("text").ele("body");
   for (const concept of document.concepts)
-    addConcept(body, concept, document.glossary.sourceLocale, warnings, errors);
+    addConcept(body, concept, document.glossary.sourceLocale, warnings, errors, {
+      conceptXmlId: conceptXmlIdByRawId.get(concept.id) ?? concept.id,
+      termXmlIds: termXmlIdByRawId,
+    });
   if (errors.length > 0) return { content: new Uint8Array(), warnings, errors };
   const content = Buffer.from(root.end({ prettyPrint: true }), "utf8");
   if (content.byteLength > MAX_TBX_BYTES) {


### PR DESCRIPTION
Crowdin-exported TBX files carry bare language IDs (en/de/ja/ko/vi) while native glossaries use region-qualified locales (en-US/de-DE/…). Strict-locale validation rejected every term as unknown_locale, so the Import glossary modal silently completed with 0 terms.

- Auto-map unmatched import locales via the existing toNativeGlossaryLocale() Crowdin catalog against the target glossary's locales; explicit localeMapping still wins and exact matches are untouched. Each mapping emits a locale_mapped warning in the import report.
- Fix TBX parser leaking langSec locale state into subsequent concept entries (definition/translatable misrouted for concepts 2..N).
- Surface zero-import validation errors in the import dialog (error toast + diagnostics list) instead of a misleading success toast.

Tests: new route test (bare-locale TBX into region-qualified glossary), new tbx parser regression test; full glossary suite 533 passed, vp check clean.