### PR TITLE
fix(phrase): continue filtered CAT pagination scans

### DIFF
--- a/apps/hyperlocalise-web/src/lib/projects/content-editor/content-editor-filtered-export-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/content-editor/content-editor-filtered-export-service.test.ts
@@ -296,6 +296,53 @@ describe("collectCatFilteredExportRows", () => {
     ).resolves.toEqual({ kind: "empty" });
   });
 
+  it("continues through empty pages that provide a scan cursor", async () => {
+    const loadCatQueue = vi
+      .fn<ContentEditorQueueLoader>()
+      .mockResolvedValueOnce({
+        kind: "ok",
+        contentEditorQueue: queuePage({
+          segments: [],
+          hasMore: true,
+          nextPhraseScanPage: 52,
+          nextPhraseScanSkip: 0,
+        }),
+      })
+      .mockResolvedValueOnce({
+        kind: "ok",
+        contentEditorQueue: queuePage({
+          segments: [segment({ externalStringId: "k1", key: "home.title", sourceText: "Title" })],
+          hasMore: false,
+          offset: 0,
+        }),
+      });
+
+    const result = await collectCatFilteredExportRows({
+      auth,
+      projectId: "project_1",
+      query: baseQuery,
+      sourceLocale: "en",
+      loadCatQueue,
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      truncated: false,
+      rows: [
+        {
+          key: "home.title",
+          sourceText: "Title",
+          targetText: "",
+        },
+      ],
+    });
+    expect(loadCatQueue).toHaveBeenCalledTimes(2);
+    expect(loadCatQueue.mock.calls[1]?.[2]).toMatchObject({
+      phraseScanPage: 52,
+      phraseScanSkip: 0,
+    });
+  });
+
   it("propagates loader failures without fetching targets", async () => {
     const loadCatQueue = vi.fn<ContentEditorQueueLoader>().mockResolvedValue({
       kind: "feature_unavailable",

--- a/apps/hyperlocalise-web/src/lib/projects/content-editor/content-editor-filtered-export-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/content-editor/content-editor-filtered-export-service.ts
@@ -137,7 +137,31 @@ export async function collectCatFilteredExportRows(input: {
 
     const { contentEditorQueue } = pageResult;
     if (contentEditorQueue.segments.length === 0) {
-      break;
+      const pagination = contentEditorQueue.pagination;
+      if (!pagination?.hasMore) {
+        break;
+      }
+
+      const nextOffset = pagination.offset + pagination.returnedCount;
+      const progressed =
+        nextOffset > offset ||
+        pagination.nextPhraseScanPage !== phraseScanPage ||
+        pagination.nextPhraseScanSkip !== phraseScanSkip ||
+        pagination.nextSortBucket !== sortBucket ||
+        pagination.nextSortBucketOffset !== sortBucketOffset;
+      if (!progressed) {
+        break;
+      }
+
+      // Provider scans can return an empty intermediate page when the current
+      // window has no matches. Follow its continuation cursor before deciding
+      // that the filtered export is empty.
+      offset = nextOffset;
+      phraseScanPage = pagination.nextPhraseScanPage;
+      phraseScanSkip = pagination.nextPhraseScanSkip;
+      sortBucket = pagination.nextSortBucket;
+      sortBucketOffset = pagination.nextSortBucketOffset;
+      continue;
     }
 
     const targetById = isProvider

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider-live-content-editor-core.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider-live-content-editor-core.test.ts
@@ -444,6 +444,122 @@ describe("phraseTmsProvider.buildLiveCatFile", () => {
     expect(listKeyPageRequests).toEqual([1]);
   });
 
+  it("continues after the filtered scan budget instead of reporting a false end", async () => {
+    const listKeyPageRequests: number[] = [];
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys?")) {
+        const page = Number(new URL(path).searchParams.get("page") ?? "1");
+        listKeyPageRequests.push(page);
+        const keys =
+          page <= 51
+            ? Array.from({ length: 100 }, (_, index) => ({
+                id: `key-${page}-${index}`,
+                name: `other.${page}.${index}`,
+                description: null,
+                plural: false,
+                tags: ["app"],
+              }))
+            : [
+                {
+                  id: "key-after-budget",
+                  name: "home.after-budget",
+                  description: null,
+                  plural: false,
+                  tags: ["app"],
+                },
+              ];
+        return new Response(JSON.stringify(keys), { status: 200 });
+      }
+
+      if (path.includes("/translations")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const file = createPhraseKeyFile({
+      sourcePath: "locales/en/home.json",
+      filename: "home.json",
+      metadata: {
+        id: "upload-1",
+        name: "home.json",
+        branch: null,
+        tags: ["app"],
+      },
+      provider: {
+        kind: "phrase",
+        resourceType: "file",
+        externalProjectId: "project-1",
+        externalResourceId: "upload-1",
+        externalUrl: null,
+        syncState: "synced",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        localeReadiness: {},
+        revision: null,
+        format: "json",
+        lastSyncedAt: null,
+      },
+    });
+
+    const firstPage = await phraseTmsProvider.buildLiveCatFile({
+      secretMaterial: "token",
+      externalProjectId: "project-1",
+      file,
+      targetLocale: "fr",
+      canEditTranslations: true,
+      pagination: {
+        offset: 0,
+        limit: 1,
+        search: "home",
+        queueFilter: "all",
+        paginated: true,
+      },
+    });
+
+    expect(firstPage.segments).toHaveLength(0);
+    expect(firstPage.pagination).toMatchObject({
+      hasMore: true,
+      nextPhraseScanPage: 52,
+      nextPhraseScanSkip: 0,
+    });
+
+    const secondPage = await phraseTmsProvider.buildLiveCatFile({
+      secretMaterial: "token",
+      externalProjectId: "project-1",
+      file,
+      targetLocale: "fr",
+      canEditTranslations: true,
+      pagination: {
+        offset: 0,
+        limit: 1,
+        search: "home",
+        queueFilter: "all",
+        paginated: true,
+        phraseScanPage: firstPage.pagination?.nextPhraseScanPage,
+        phraseScanSkip: firstPage.pagination?.nextPhraseScanSkip,
+      },
+    });
+
+    expect(secondPage.segments).toHaveLength(1);
+    expect(secondPage.segments[0]?.key).toBe("home.after-budget");
+    expect(listKeyPageRequests).toEqual([...Array.from({ length: 51 }, (_, i) => i + 1), 52]);
+  });
+
   it("throws when the requested target locale cannot be matched", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       const path = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
@@ -2867,9 +2867,18 @@ async function loadPhraseQueuePage(input: {
     skipMatches = 0;
   }
 
+  // A filtered scan can exhaust its safety budget before Phrase reports the end of
+  // the key set. Expose the next page as a continuation cursor so callers can keep
+  // scanning instead of treating the partial result as the end of the queue.
+  const scanStoppedByBudget = !scanComplete && collected.length < limit;
+  if (scanStoppedByBudget) {
+    nextPhraseScanPage = scanPageBudget + 1;
+    nextPhraseScanSkip = 0;
+  }
+
   return {
     segments: collected,
-    hasMore: collected.length >= limit && !scanComplete,
+    hasMore: (collected.length >= limit && !scanComplete) || scanStoppedByBudget,
     nextPhraseScanPage,
     nextPhraseScanSkip,
   };

--- a/docs/adr/2026-09-07-phrase-cat-pagination-design.md
+++ b/docs/adr/2026-09-07-phrase-cat-pagination-design.md
@@ -1,0 +1,20 @@
+# Phrase CAT filtered pagination continuation
+
+## Problem
+
+Phrase CAT queues apply search and tag filters client-side. The provider bounds
+the number of API pages scanned per request, but previously reported the queue
+as exhausted when that bound was reached before Phrase's key set was exhausted.
+
+## Design
+
+Keep the scan budget as a safety limit. When the budget ends without filling the
+requested page, return `hasMore: true` with a cursor for the next Phrase page.
+The next request resumes from that page and continues applying the same filters.
+When Phrase returns a short page, mark the scan complete and preserve the
+existing end-of-queue behavior.
+
+## Validation
+
+The Phrase live CAT tests cover a match resumed after the scan budget and verify
+that the continuation page is requested without restarting at page one.


### PR DESCRIPTION
## What changed

Phrase CAT filtered queues could incorrectly report the end of the queue when the client-side scan budget was reached before all matching keys were examined.

This change returns a continuation cursor and `hasMore: true` so subsequent requests resume scanning from the next Phrase page. Added regression coverage for matches found beyond the scan budget and documented the behavior in an ADR.

## How to test

- `vp test src/lib/providers/adapters/phrase/phrase-provider-live-content-editor-core.test.ts` — 11 passed.
- `vp check --fix` — formatting completed; existing unrelated dependency and lint issues remain.
- Full `vp test` was attempted; integration failures were caused by sandbox `EPERM` connections to local Postgres and port 3000.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review