### PR TITLE
feat(cli): Smartling optional download locales and glossary admin

### DIFF
--- a/apps/cli/cmd/crowdin_list.go
+++ b/apps/cli/cmd/crowdin_list.go
@@ -336,6 +336,9 @@ func addCrowdinListFlags(cmd *cobra.Command, o *crowdinListOptions, includeLangu
 }
 
 func writeEncodedOutput(w io.Writer, output string, writeText func() error, value any) error {
+	if err := validateEncodedOutputFormat(output); err != nil {
+		return err
+	}
 	switch strings.ToLower(strings.TrimSpace(output)) {
 	case "", "text":
 		return writeText()
@@ -343,6 +346,15 @@ func writeEncodedOutput(w io.Writer, output string, writeText func() error, valu
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(value)
+	default:
+		return fmt.Errorf("unsupported output format %q", output)
+	}
+}
+
+func validateEncodedOutputFormat(output string) error {
+	switch strings.ToLower(strings.TrimSpace(output)) {
+	case "", "text", "json":
+		return nil
 	default:
 		return fmt.Errorf("unsupported output format %q", output)
 	}

--- a/apps/cli/cmd/smartling.go
+++ b/apps/cli/cmd/smartling.go
@@ -96,6 +96,7 @@ type smartlingSourceDownloader interface {
 
 type smartlingTranslationDownloader interface {
 	DownloadTranslationFile(context.Context, smartling.TranslationDownloadInput) (smartling.TranslationDownloadResult, error)
+	GetFileStatus(context.Context, smartling.FileStatusInput) (smartling.FileStatus, error)
 	ListFiles(context.Context, smartling.FileListInput) ([]smartling.FileListItem, error)
 }
 
@@ -140,7 +141,7 @@ func newSmartlingDownloadTranslationsCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
-	cmd.Flags().StringSliceVarP(&o.targetLocales, "target-locale", "l", nil, "target locale ID(s) to download")
+	cmd.Flags().StringSliceVarP(&o.targetLocales, "target-locale", "l", nil, "target locale ID(s) to download; omit to download every locale from file status")
 	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "Smartling file URI (exactly one of --file-uri or --all)")
 	cmd.Flags().StringVar(&o.uriMask, "uri-mask", "", "substring filter on file URI; only valid with --all")
 	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path for one URI (omit or - for stdout when downloading one locale; use %locale% for multiple locales); directory for --all (default .)")
@@ -152,7 +153,6 @@ func newSmartlingDownloadTranslationsCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
 	_ = cmd.MarkFlagRequired("project-id")
-	_ = cmd.MarkFlagRequired("target-locale")
 	return cmd
 }
 
@@ -284,10 +284,6 @@ func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloa
 	if strings.TrimSpace(o.projectID) == "" {
 		return fmt.Errorf("%s: --project-id is required", action)
 	}
-	locales := normalizeSmartlingLocales(o.targetLocales)
-	if len(locales) == 0 {
-		return fmt.Errorf("%s: at least one --target-locale is required", action)
-	}
 	if err := validateSmartlingDownloadSelection(o.all, o.fileURI, o.uriMask, action); err != nil {
 		return err
 	}
@@ -296,8 +292,41 @@ func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloa
 		return fmt.Errorf("%s: --retrieval-type must be pending, published, or pseudo", action)
 	}
 
+	filterLocales := normalizeSmartlingLocales(o.targetLocales)
+	if !o.all && len(filterLocales) > 1 {
+		if _, err := smartlingTranslationOutputPaths(strings.TrimSpace(o.output), filterLocales); err != nil {
+			return err
+		}
+	}
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
+	if err != nil {
+		return err
+	}
+	cfg.ProjectID = strings.TrimSpace(o.projectID)
+	client, err := newSmartlingTranslationDownloader(cfg)
+	if err != nil {
+		return err
+	}
+
 	if o.all {
-		return executeSmartlingDownloadTranslationsAll(cmd, o, locales, retrievalType)
+		return executeSmartlingDownloadTranslationsAll(cmd, o, filterLocales, retrievalType, client)
+	}
+	return executeSmartlingDownloadTranslationsOne(cmd, o, filterLocales, retrievalType, client)
+}
+
+func executeSmartlingDownloadTranslationsOne(cmd *cobra.Command, o smartlingDownloadTranslationsOptions, filterLocales []string, retrievalType string, client smartlingTranslationDownloader) error {
+	const action = "smartling download translations"
+	fileURI := strings.TrimSpace(o.fileURI)
+	status, err := client.GetFileStatus(backgroundContext(), smartling.FileStatusInput{
+		ProjectID: strings.TrimSpace(o.projectID),
+		FileURI:   fileURI,
+	})
+	if err != nil {
+		return wrapSmartlingCommandError(action, err)
+	}
+	locales, err := resolveSmartlingDownloadLocalesFromStatus(status, filterLocales, action)
+	if err != nil {
+		return err
 	}
 
 	outputPath := strings.TrimSpace(o.output)
@@ -310,7 +339,7 @@ func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloa
 		if destination == "" {
 			destination = "-"
 		}
-		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-translations project_id=%s target_locales=%s file_uri=%s retrieval_type=%s output=%s\n", strings.TrimSpace(o.projectID), strings.Join(locales, ","), strings.TrimSpace(o.fileURI), retrievalType, destination)
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-translations project_id=%s target_locales=%s file_uri=%s retrieval_type=%s output=%s\n", strings.TrimSpace(o.projectID), strings.Join(locales, ","), fileURI, retrievalType, destination)
 		return err
 	}
 	for _, output := range outputs {
@@ -319,28 +348,17 @@ func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloa
 		}
 	}
 
-	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, "smartling download translations")
-	if err != nil {
-		return err
-	}
-	cfg.ProjectID = strings.TrimSpace(o.projectID)
-
-	client, err := newSmartlingTranslationDownloader(cfg)
-	if err != nil {
-		return err
-	}
-
 	writtenOutputs := make([]string, 0, len(outputs))
 	for idx, locale := range locales {
 		result, err := client.DownloadTranslationFile(backgroundContext(), smartling.TranslationDownloadInput{
 			ProjectID:     strings.TrimSpace(o.projectID),
-			FileURI:       strings.TrimSpace(o.fileURI),
+			FileURI:       fileURI,
 			LocaleID:      locale,
 			RetrievalType: retrievalType,
 		})
 		if err != nil {
 			removeSmartlingDownloadedTranslationOutputs(writtenOutputs)
-			return fmt.Errorf("smartling download translations: %w", err)
+			return fmt.Errorf("%s: %w", action, err)
 		}
 
 		output := outputs[idx]
@@ -359,7 +377,7 @@ func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloa
 		if !outputExisted {
 			writtenOutputs = append(writtenOutputs, output)
 		}
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s file_uri=%s\n", output, len(result.Content), result.LocaleID, strings.TrimSpace(o.fileURI)); err != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s file_uri=%s\n", output, len(result.Content), result.LocaleID, fileURI); err != nil {
 			removeSmartlingDownloadedTranslationOutputs(writtenOutputs)
 			return err
 		}
@@ -367,18 +385,9 @@ func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloa
 	return nil
 }
 
-func executeSmartlingDownloadTranslationsAll(cmd *cobra.Command, o smartlingDownloadTranslationsOptions, locales []string, retrievalType string) error {
+func executeSmartlingDownloadTranslationsAll(cmd *cobra.Command, o smartlingDownloadTranslationsOptions, filterLocales []string, retrievalType string, client smartlingTranslationDownloader) error {
 	const action = "smartling download translations"
 	dir, err := resolveSmartlingDownloadAllDirectory(o.output, action)
-	if err != nil {
-		return err
-	}
-	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
-	if err != nil {
-		return err
-	}
-	cfg.ProjectID = strings.TrimSpace(o.projectID)
-	client, err := newSmartlingTranslationDownloader(cfg)
 	if err != nil {
 		return err
 	}
@@ -393,10 +402,21 @@ func executeSmartlingDownloadTranslationsAll(cmd *cobra.Command, o smartlingDown
 		return fmt.Errorf("%s: no files found", action)
 	}
 	if o.dryRun {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-translations-all project_id=%s target_locales=%s retrieval_type=%s output_dir=%s\n", strings.TrimSpace(o.projectID), strings.Join(locales, ","), retrievalType, dir); err != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-translations-all project_id=%s retrieval_type=%s output_dir=%s\n", strings.TrimSpace(o.projectID), retrievalType, dir); err != nil {
 			return err
 		}
 		for _, file := range files {
+			status, err := client.GetFileStatus(backgroundContext(), smartling.FileStatusInput{
+				ProjectID: strings.TrimSpace(o.projectID),
+				FileURI:   file.FileURI,
+			})
+			if err != nil {
+				return wrapSmartlingCommandError(action, err)
+			}
+			locales, err := resolveSmartlingDownloadLocalesFromStatus(status, filterLocales, action)
+			if err != nil {
+				return err
+			}
 			for _, locale := range locales {
 				dest, destErr := smartlingDownloadAllOutputPath(dir, file.FileURI, locale)
 				if destErr != nil {
@@ -413,6 +433,17 @@ func executeSmartlingDownloadTranslationsAll(cmd *cobra.Command, o smartlingDown
 		return fmt.Errorf("%s: mkdir output directory: %w", action, err)
 	}
 	for _, file := range files {
+		status, err := client.GetFileStatus(backgroundContext(), smartling.FileStatusInput{
+			ProjectID: strings.TrimSpace(o.projectID),
+			FileURI:   file.FileURI,
+		})
+		if err != nil {
+			return wrapSmartlingCommandError(action, err)
+		}
+		locales, err := resolveSmartlingDownloadLocalesFromStatus(status, filterLocales, action)
+		if err != nil {
+			return err
+		}
 		for _, locale := range locales {
 			dest, destErr := smartlingDownloadAllOutputPath(dir, file.FileURI, locale)
 			if destErr != nil {
@@ -439,6 +470,58 @@ func executeSmartlingDownloadTranslationsAll(cmd *cobra.Command, o smartlingDown
 		}
 	}
 	return nil
+}
+
+func localeIDsFromFileStatus(status smartling.FileStatus) []string {
+	seen := make(map[string]string)
+	order := make([]string, 0, len(status.Items))
+	for _, item := range status.Items {
+		id := strings.TrimSpace(item.LocaleID)
+		if id == "" {
+			continue
+		}
+		key := strings.ToLower(id)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = id
+		order = append(order, id)
+	}
+	slices.Sort(order)
+	return order
+}
+
+func resolveSmartlingDownloadLocalesFromStatus(status smartling.FileStatus, filterLocales []string, action string) ([]string, error) {
+	fromStatus := localeIDsFromFileStatus(status)
+	if len(fromStatus) == 0 {
+		uri := strings.TrimSpace(status.FileURI)
+		if uri == "" {
+			uri = "file"
+		}
+		return nil, fmt.Errorf("%s: file %q has no target locales in file status", action, uri)
+	}
+	if len(filterLocales) == 0 {
+		return fromStatus, nil
+	}
+
+	statusByLower := make(map[string]string, len(fromStatus))
+	for _, locale := range fromStatus {
+		statusByLower[strings.ToLower(locale)] = locale
+	}
+	intersection := make([]string, 0, len(filterLocales))
+	for _, locale := range filterLocales {
+		if canonical, ok := statusByLower[strings.ToLower(locale)]; ok {
+			intersection = append(intersection, canonical)
+		}
+	}
+	if len(intersection) == 0 {
+		uri := strings.TrimSpace(status.FileURI)
+		if uri == "" {
+			uri = "file"
+		}
+		return nil, fmt.Errorf("%s: none of the requested target locales match file status locales for %q", action, uri)
+	}
+	return intersection, nil
 }
 
 func validateSmartlingDownloadSelection(all bool, fileURI, uriMask, action string) error {
@@ -786,6 +869,9 @@ func newSmartlingGlossaryCmd() *cobra.Command {
 		Short: "Smartling glossary commands",
 	}
 	cmd.AddCommand(newSmartlingGlossaryDownloadCmd())
+	cmd.AddCommand(newSmartlingGlossaryListCmd())
+	cmd.AddCommand(newSmartlingGlossaryCreateCmd())
+	cmd.AddCommand(newSmartlingGlossaryImportCmd())
 	return cmd
 }
 

--- a/apps/cli/cmd/smartling_glossary_cmds.go
+++ b/apps/cli/cmd/smartling_glossary_cmds.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/smartling"
+	"github.com/spf13/cobra"
+)
+
+type smartlingGlossaryListOptions struct {
+	accountUID     string
+	name           string
+	output         string
+	userIdentifier string
+	userSecret     string
+	userSecretEnv  string
+}
+
+type smartlingGlossaryCreateOptions struct {
+	accountUID     string
+	name           string
+	description    string
+	locales        []string
+	output         string
+	userIdentifier string
+	userSecret     string
+	userSecretEnv  string
+}
+
+type smartlingGlossaryImportOptions struct {
+	accountUID     string
+	glossaryUID    string
+	filePath       string
+	userIdentifier string
+	userSecret     string
+	userSecretEnv  string
+}
+
+func newSmartlingGlossaryListCmd() *cobra.Command {
+	o := smartlingGlossaryListOptions{output: "text"}
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "list Smartling glossaries on an account",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeSmartlingGlossaryList(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.accountUID, "account-uid", "", "Smartling account UID")
+	cmd.Flags().StringVar(&o.name, "name", "", "optional glossary name search query")
+	cmd.Flags().StringVar(&o.output, "output", "text", "output format: text or json")
+	addSmartlingCredentialFlags(cmd, &o.userIdentifier, &o.userSecret, &o.userSecretEnv)
+	_ = cmd.MarkFlagRequired("account-uid")
+	return cmd
+}
+
+func newSmartlingGlossaryCreateCmd() *cobra.Command {
+	o := smartlingGlossaryCreateOptions{output: "text"}
+	cmd := &cobra.Command{
+		Use:          "create",
+		Short:        "create a Smartling glossary",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeSmartlingGlossaryCreate(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.accountUID, "account-uid", "", "Smartling account UID")
+	cmd.Flags().StringVar(&o.name, "name", "", "glossary name")
+	cmd.Flags().StringVar(&o.description, "description", "", "optional glossary description")
+	cmd.Flags().StringSliceVarP(&o.locales, "locale", "l", nil, "locale ID(s) for the glossary (repeatable)")
+	cmd.Flags().StringVar(&o.output, "output", "text", "output format: text or json")
+	addSmartlingCredentialFlags(cmd, &o.userIdentifier, &o.userSecret, &o.userSecretEnv)
+	_ = cmd.MarkFlagRequired("account-uid")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("locale")
+	return cmd
+}
+
+func newSmartlingGlossaryImportCmd() *cobra.Command {
+	o := smartlingGlossaryImportOptions{}
+	cmd := &cobra.Command{
+		Use:          "import",
+		Short:        "import Smartling's official glossary CSV",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeSmartlingGlossaryImport(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.accountUID, "account-uid", "", "Smartling account UID")
+	cmd.Flags().StringVar(&o.glossaryUID, "glossary-uid", "", "Smartling glossary UID")
+	cmd.Flags().StringVar(&o.filePath, "file", "", "official Smartling glossary import CSV path")
+	addSmartlingCredentialFlags(cmd, &o.userIdentifier, &o.userSecret, &o.userSecretEnv)
+	_ = cmd.MarkFlagRequired("account-uid")
+	_ = cmd.MarkFlagRequired("glossary-uid")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+func executeSmartlingGlossaryList(cmd *cobra.Command, o smartlingGlossaryListOptions) error {
+	const action = "smartling glossary list"
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
+	if err != nil {
+		return err
+	}
+	client, err := smartling.NewHTTPClient(cfg)
+	if err != nil {
+		return err
+	}
+	glossaries, err := client.SearchGlossaries(backgroundContext(), smartling.GlossarySearchInput{
+		AccountUID: strings.TrimSpace(o.accountUID),
+		Query:      strings.TrimSpace(o.name),
+	})
+	if err != nil {
+		return wrapSmartlingCommandError(action, err)
+	}
+	if glossaries == nil {
+		glossaries = []smartling.GlossarySummary{}
+	}
+	return writeEncodedOutput(cmd.OutOrStdout(), o.output, func() error {
+		for _, glossary := range glossaries {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "glossary_uid=%s name=%s locales=%s\n", glossary.GlossaryUID, glossary.Name, strings.Join(glossary.LocaleIDs, ",")); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, glossaries)
+}
+
+func executeSmartlingGlossaryCreate(cmd *cobra.Command, o smartlingGlossaryCreateOptions) error {
+	const action = "smartling glossary create"
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
+	if err != nil {
+		return err
+	}
+	client, err := smartling.NewHTTPClient(cfg)
+	if err != nil {
+		return err
+	}
+	result, err := client.CreateGlossary(backgroundContext(), smartling.GlossaryCreateInput{
+		AccountUID:  strings.TrimSpace(o.accountUID),
+		Name:        strings.TrimSpace(o.name),
+		Description: strings.TrimSpace(o.description),
+		LocaleIDs:   o.locales,
+	})
+	if err != nil {
+		return wrapSmartlingCommandError(action, err)
+	}
+	return writeEncodedOutput(cmd.OutOrStdout(), o.output, func() error {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "glossary_uid=%s name=%s account_uid=%s\n", result.GlossaryUID, result.Name, result.AccountUID)
+		return err
+	}, result)
+}
+
+func executeSmartlingGlossaryImport(cmd *cobra.Command, o smartlingGlossaryImportOptions) error {
+	const action = "smartling glossary import"
+	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
+	if err != nil {
+		return err
+	}
+	client, err := smartling.NewHTTPClient(cfg)
+	if err != nil {
+		return err
+	}
+	result, err := client.ImportGlossary(backgroundContext(), smartling.GlossaryImportInput{
+		AccountUID:  strings.TrimSpace(o.accountUID),
+		GlossaryUID: strings.TrimSpace(o.glossaryUID),
+		FilePath:    strings.TrimSpace(o.filePath),
+	})
+	if err != nil {
+		return wrapSmartlingCommandError(action, err)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "import_uid=%s status=%s\n", result.ImportUID, result.ImportStatus)
+	return err
+}

--- a/apps/cli/cmd/smartling_glossary_cmds.go
+++ b/apps/cli/cmd/smartling_glossary_cmds.go
@@ -99,6 +99,9 @@ func newSmartlingGlossaryImportCmd() *cobra.Command {
 
 func executeSmartlingGlossaryList(cmd *cobra.Command, o smartlingGlossaryListOptions) error {
 	const action = "smartling glossary list"
+	if err := validateEncodedOutputFormat(o.output); err != nil {
+		return err
+	}
 	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
 	if err != nil {
 		return err
@@ -129,6 +132,9 @@ func executeSmartlingGlossaryList(cmd *cobra.Command, o smartlingGlossaryListOpt
 
 func executeSmartlingGlossaryCreate(cmd *cobra.Command, o smartlingGlossaryCreateOptions) error {
 	const action = "smartling glossary create"
+	if err := validateEncodedOutputFormat(o.output); err != nil {
+		return err
+	}
 	cfg, err := resolveSmartlingCLICredentials(o.userIdentifier, o.userSecret, o.userSecretEnv, action)
 	if err != nil {
 		return err

--- a/apps/cli/cmd/smartling_test.go
+++ b/apps/cli/cmd/smartling_test.go
@@ -157,6 +157,22 @@ func TestSmartlingDownloadSourcesFlags(t *testing.T) {
 }
 
 func TestSmartlingDownloadTranslationsDryRun(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return &fakeSmartlingTranslationDownloader{
+			statusByURI: map[string]smartling.FileStatus{
+				"test.json": {
+					FileURI: "test.json",
+					Items:   []smartling.FileStatusLocale{{LocaleID: "fr"}},
+				},
+			},
+		}, nil
+	}
+
 	root := newRootCmd("test")
 	out := &bytes.Buffer{}
 	root.SetOut(out)
@@ -401,11 +417,25 @@ func TestSmartlingDownloadSourcesForceOverwritesOutputFile(t *testing.T) {
 }
 
 type fakeSmartlingTranslationDownloader struct {
-	results map[string]smartling.TranslationDownloadResult
-	files   []smartling.FileListItem
-	listIn  smartling.FileListInput
-	err     error
-	listErr error
+	results     map[string]smartling.TranslationDownloadResult
+	statusByURI map[string]smartling.FileStatus
+	files       []smartling.FileListItem
+	listIn      smartling.FileListInput
+	err         error
+	listErr     error
+}
+
+func (f *fakeSmartlingTranslationDownloader) GetFileStatus(_ context.Context, in smartling.FileStatusInput) (smartling.FileStatus, error) {
+	if f.statusByURI != nil {
+		if status, ok := f.statusByURI[in.FileURI]; ok {
+			return status, nil
+		}
+	}
+	items := make([]smartling.FileStatusLocale, 0, len(f.results))
+	for locale := range f.results {
+		items = append(items, smartling.FileStatusLocale{LocaleID: locale})
+	}
+	return smartling.FileStatus{FileURI: in.FileURI, Items: items}, nil
 }
 
 func (f *fakeSmartlingTranslationDownloader) DownloadTranslationFile(_ context.Context, in smartling.TranslationDownloadInput) (smartling.TranslationDownloadResult, error) {
@@ -592,6 +622,15 @@ func TestSmartlingDownloadTranslationsRemovesWrittenFilesOnLaterFailure(t *testi
 	// We need to simulate an error on the second locale. Use a custom downloader.
 	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
 		return &fakeSmartlingTranslationDownloaderWithError{
+			statusByURI: map[string]smartling.FileStatus{
+				"test.json": {
+					FileURI: "test.json",
+					Items: []smartling.FileStatusLocale{
+						{LocaleID: "fr"},
+						{LocaleID: "de"},
+					},
+				},
+			},
 			results: map[string]smartling.TranslationDownloadResult{
 				"fr": {LocaleID: "fr", Content: []byte(`{"hello":"Bonjour"}`)},
 				"de": {LocaleID: "de", Content: []byte(`{"hello":"Hallo"}`)},
@@ -621,8 +660,22 @@ func TestSmartlingDownloadTranslationsRemovesWrittenFilesOnLaterFailure(t *testi
 }
 
 type fakeSmartlingTranslationDownloaderWithError struct {
-	results   map[string]smartling.TranslationDownloadResult
-	errLocale string
+	results     map[string]smartling.TranslationDownloadResult
+	statusByURI map[string]smartling.FileStatus
+	errLocale   string
+}
+
+func (f *fakeSmartlingTranslationDownloaderWithError) GetFileStatus(_ context.Context, in smartling.FileStatusInput) (smartling.FileStatus, error) {
+	if f.statusByURI != nil {
+		if status, ok := f.statusByURI[in.FileURI]; ok {
+			return status, nil
+		}
+	}
+	items := make([]smartling.FileStatusLocale, 0, len(f.results))
+	for locale := range f.results {
+		items = append(items, smartling.FileStatusLocale{LocaleID: locale})
+	}
+	return smartling.FileStatus{FileURI: in.FileURI, Items: items}, nil
 }
 
 func (f *fakeSmartlingTranslationDownloaderWithError) DownloadTranslationFile(_ context.Context, in smartling.TranslationDownloadInput) (smartling.TranslationDownloadResult, error) {
@@ -641,6 +694,22 @@ func (f *fakeSmartlingTranslationDownloaderWithError) ListFiles(_ context.Contex
 }
 
 func TestSmartlingDownloadTranslationsRefusesOverwriteWithoutForce(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return &fakeSmartlingTranslationDownloader{
+			statusByURI: map[string]smartling.FileStatus{
+				"test.json": {
+					FileURI: "test.json",
+					Items:   []smartling.FileStatusLocale{{LocaleID: "fr"}},
+				},
+			},
+		}, nil
+	}
+
 	outputPath := filepath.Join(t.TempDir(), "fr.json")
 	if err := os.WriteFile(outputPath, []byte(`{"old":"Old"}`), 0o644); err != nil {
 		t.Fatalf("write existing output: %v", err)
@@ -671,6 +740,15 @@ func TestSmartlingDownloadTranslationsForceKeepsOverwrittenFileOnLaterFailure(t 
 	orig := newSmartlingTranslationDownloader
 	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
 		return &fakeSmartlingTranslationDownloaderWithError{
+			statusByURI: map[string]smartling.FileStatus{
+				"test.json": {
+					FileURI: "test.json",
+					Items: []smartling.FileStatusLocale{
+						{LocaleID: "fr"},
+						{LocaleID: "de"},
+					},
+				},
+			},
 			results: map[string]smartling.TranslationDownloadResult{
 				"fr": {LocaleID: "fr", Content: []byte(`{"hello":"Bonjour"}`)},
 				"de": {LocaleID: "de", Content: []byte(`{"hello":"Hallo"}`)},
@@ -1145,5 +1223,287 @@ func TestSmartlingDownloadAllFlagExclusivityAndSafety(t *testing.T) {
 	err = run("smartling", "download", "sources", "--project-id", "123", "--all", "--output", dir)
 	if err == nil || !strings.Contains(err.Error(), "no files found") {
 		t.Fatalf("expected empty list error, got %v", err)
+	}
+}
+
+func TestSmartlingDownloadTranslationsUsesFileStatusWhenTargetLocaleOmitted(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return &fakeSmartlingTranslationDownloader{
+			statusByURI: map[string]smartling.FileStatus{
+				"locales/en.json": {
+					FileURI: "locales/en.json",
+					Items: []smartling.FileStatusLocale{
+						{LocaleID: "fr-FR"},
+						{LocaleID: "de-DE"},
+					},
+				},
+			},
+			results: map[string]smartling.TranslationDownloadResult{
+				"fr-FR": {LocaleID: "fr-FR", Content: []byte(`{"fr":"oui"}`)},
+				"de-DE": {LocaleID: "de-DE", Content: []byte(`{"de":"ja"}`)},
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{
+		"smartling", "download", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+		"--output", filepath.Join(dir, "%locale%.json"),
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v\n%s", err, out.String())
+	}
+	for _, locale := range []string{"fr-FR", "de-DE"} {
+		path := filepath.Join(dir, locale+".json")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("missing %s: %v", path, err)
+		}
+	}
+}
+
+func TestSmartlingDownloadTranslationsFiltersTargetLocalesAgainstFileStatus(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return &fakeSmartlingTranslationDownloader{
+			statusByURI: map[string]smartling.FileStatus{
+				"locales/en.json": {
+					FileURI: "locales/en.json",
+					Items: []smartling.FileStatusLocale{
+						{LocaleID: "fr-FR"},
+						{LocaleID: "de-DE"},
+					},
+				},
+			},
+			results: map[string]smartling.TranslationDownloadResult{
+				"fr-FR": {LocaleID: "fr-FR", Content: []byte(`{"fr":"oui"}`)},
+			},
+		}, nil
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "fr.json")
+	root := newRootCmd("test")
+	root.SetArgs([]string{
+		"smartling", "download", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+		"--target-locale", "fr-fr",
+		"--output", outputPath,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("missing output: %v", err)
+	}
+}
+
+func TestSmartlingDownloadTranslationsEmptyStatusLocalesErrors(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return &fakeSmartlingTranslationDownloader{
+			statusByURI: map[string]smartling.FileStatus{
+				"locales/en.json": {FileURI: "locales/en.json", Items: nil},
+			},
+		}, nil
+	}
+
+	root := newRootCmd("test")
+	root.SetArgs([]string{
+		"smartling", "download", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+	})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no target locales in file status") {
+		t.Fatalf("expected empty status error, got %v", err)
+	}
+}
+
+func TestSmartlingDownloadTranslationsDryRunCallsFileStatus(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	fake := &fakeSmartlingTranslationDownloader{
+		statusByURI: map[string]smartling.FileStatus{
+			"locales/en.json": {
+				FileURI: "locales/en.json",
+				Items:   []smartling.FileStatusLocale{{LocaleID: "fr-FR"}},
+			},
+		},
+	}
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return fake, nil
+	}
+
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{
+		"smartling", "download", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+		"--dry-run",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("dry-run failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "target_locales=fr-FR") {
+		t.Fatalf("unexpected dry-run output: %s", out.String())
+	}
+}
+
+func TestSmartlingDownloadTranslationsAllUsesPerFileStatusLocales(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	fake := &fakeSmartlingTranslationDownloader{
+		files: []smartling.FileListItem{
+			{FileURI: "locales/en.json"},
+			{FileURI: "app/strings.xml"},
+		},
+		statusByURI: map[string]smartling.FileStatus{
+			"locales/en.json": {
+				FileURI: "locales/en.json",
+				Items:   []smartling.FileStatusLocale{{LocaleID: "fr-FR"}},
+			},
+			"app/strings.xml": {
+				FileURI: "app/strings.xml",
+				Items:   []smartling.FileStatusLocale{{LocaleID: "de-DE"}},
+			},
+		},
+		results: map[string]smartling.TranslationDownloadResult{
+			"fr-FR": {LocaleID: "fr-FR", Content: []byte(`{"fr":"oui"}`)},
+			"de-DE": {LocaleID: "de-DE", Content: []byte(`{"de":"ja"}`)},
+		},
+	}
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return fake, nil
+	}
+
+	dir := t.TempDir()
+	root := newRootCmd("test")
+	root.SetArgs([]string{
+		"smartling", "download", "translations",
+		"--project-id", "123",
+		"--all",
+		"--output", dir,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "locales", "en_fr-FR.json")); err != nil {
+		t.Fatalf("missing fr file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "app", "strings_de-DE.xml")); err != nil {
+		t.Fatalf("missing de file: %v", err)
+	}
+}
+
+func TestSmartlingDownloadTranslationsEmptyIntersectErrors(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return &fakeSmartlingTranslationDownloader{
+			statusByURI: map[string]smartling.FileStatus{
+				"locales/en.json": {
+					FileURI: "locales/en.json",
+					Items:   []smartling.FileStatusLocale{{LocaleID: "fr-FR"}},
+				},
+			},
+		}, nil
+	}
+
+	root := newRootCmd("test")
+	root.SetArgs([]string{
+		"smartling", "download", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+		"--target-locale", "de-DE",
+	})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "none of the requested target locales match") {
+		t.Fatalf("expected empty intersect error, got %v", err)
+	}
+}
+
+func TestSmartlingDownloadTranslationsStatusLocalesRequireOutputPattern(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingTranslationDownloader
+	t.Cleanup(func() { newSmartlingTranslationDownloader = orig })
+	newSmartlingTranslationDownloader = func(_ smartling.Config) (smartlingTranslationDownloader, error) {
+		return &fakeSmartlingTranslationDownloader{
+			statusByURI: map[string]smartling.FileStatus{
+				"locales/en.json": {
+					FileURI: "locales/en.json",
+					Items: []smartling.FileStatusLocale{
+						{LocaleID: "fr-FR"},
+						{LocaleID: "de-DE"},
+					},
+				},
+			},
+		}, nil
+	}
+
+	root := newRootCmd("test")
+	root.SetArgs([]string{
+		"smartling", "download", "translations",
+		"--project-id", "123",
+		"--file-uri", "locales/en.json",
+		"--output", "translations.json",
+	})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "must include %locale%") {
+		t.Fatalf("expected output pattern error, got %v", err)
+	}
+}
+
+func TestSmartlingGlossaryListCreateImportFlags(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{"smartling", "glossary", "list"})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "required flag(s)") {
+		t.Fatalf("expected list required flags error, got %v", err)
+	}
+
+	root.SetArgs([]string{"smartling", "glossary", "create"})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "required flag(s)") {
+		t.Fatalf("expected create required flags error, got %v", err)
+	}
+
+	root.SetArgs([]string{"smartling", "glossary", "import"})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "required flag(s)") {
+		t.Fatalf("expected import required flags error, got %v", err)
 	}
 }

--- a/apps/cli/cmd/smartling_test.go
+++ b/apps/cli/cmd/smartling_test.go
@@ -1507,3 +1507,22 @@ func TestSmartlingGlossaryListCreateImportFlags(t *testing.T) {
 		t.Fatalf("expected import required flags error, got %v", err)
 	}
 }
+
+func TestSmartlingGlossaryCreateRejectsInvalidOutputBeforeAPI(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{
+		"smartling", "glossary", "create",
+		"--account-uid", "acc-1",
+		"--name", "Brand terms",
+		"--locale", "en-US",
+		"--output", "yaml",
+	})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), `unsupported output format "yaml"`) {
+		t.Fatalf("expected invalid output error before API, got %v", err)
+	}
+}

--- a/docs/cli/commands/smartling.mdx
+++ b/docs/cli/commands/smartling.mdx
@@ -16,8 +16,11 @@ hyperlocalise smartling projects info --project-id <id> [--output text|json] [--
 hyperlocalise smartling upload sources --project-id <id> --file <path> [--file-uri <uri>] [--file-type <type>] [--authorize] [--directive key=value] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>] [--dry-run]
 hyperlocalise smartling upload translations --project-id <id> --file-uri <uri> --target-locale <locale> --file <path> (--published | --post-translation) [--file-type <type>] [--overwrite] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>] [--dry-run]
 hyperlocalise smartling download sources --project-id <id> (--file-uri <uri> | --all) [--uri-mask <substring>] [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
-hyperlocalise smartling download translations --project-id <id> (--file-uri <uri> | --all) --target-locale <locale> [--uri-mask <substring>] [--retrieval-type pending|published|pseudo] [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling download translations --project-id <id> (--file-uri <uri> | --all) [--target-locale <locale>] [--uri-mask <substring>] [--retrieval-type pending|published|pseudo] [--output <path>] [--force] [--dry-run] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 hyperlocalise smartling glossary download --account-uid <id> --glossary-uid <id> [--language <locale>] [--output <path>] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling glossary list --account-uid <id> [--name <query>] [--output text|json] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling glossary create --account-uid <id> --name <name> --locale <locale> [--description <text>] [--output text|json] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
+hyperlocalise smartling glossary import --account-uid <id> --glossary-uid <id> --file <path> [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 hyperlocalise smartling tm download --account-uid <id> --tm-uid <id> --source-language <code> [--target-language <code>] [--format csv|tmx] [--output <path>] [--user-id <id>] [--user-secret <secret>] [--user-secret-env <name>]
 ```
 
@@ -96,7 +99,9 @@ Unknown extensions require `--file-type`. Values such as `android` or `gettext` 
 
 Pass exactly one of `--file-uri` or `--all`. `--all` lists files (same paging as `files list`, optional `--uri-mask`) then downloads each URI. `--uri-mask` is only valid with `--all`. `--output` is then a directory (default `.`). Local names match official smartling-cli default pull format: URI `locales/en.json` writes `locales/en.json` for sources and `locales/en_fr-FR.json` for `--target-locale fr-FR`. Do not pass `-` or `%locale%` with `--all`. An empty list is a non-zero error. `--all --dry-run` lists files (credentials required) and prints planned paths without downloading bytes. Downloads run sequentially and stop on the first error.
 
-`download translations` requires `--target-locale` even with `--all`. Official smartling-cli can omit locale and pull every locale from file status; Hyperlocalise does not. Use `%locale%` in `--output` when you pass more than one locale with a single `--file-uri`. `--retrieval-type` is `pending`, `published`, or `pseudo`. If you omit it, Hyperlocalise does not send `retrievalType` and Smartling uses its default. Prefer `--retrieval-type published` when you only want published text.
+`download translations` omits `--target-locale` to download every locale listed in file status for each URI. When you pass `--target-locale`, Hyperlocalise intersects your values with file status (case-insensitive) and uses Smartling's locale IDs from status. `--all` resolves locales per file URI, not once for the whole project. `--dry-run` still calls file status (credentials required). Use `%locale%` in `--output` when you download more than one locale for a single `--file-uri`. `--retrieval-type` is `pending`, `published`, or `pseudo`. If you omit it, Hyperlocalise does not send `retrievalType` and Smartling uses its default. Prefer `--retrieval-type published` when you only want published text.
+
+`glossary list` searches glossaries on an account (`--name` is an optional search query). `glossary create` needs `--name` and at least one `--locale`. `glossary import` uploads Smartling's official glossary import CSV (not the Hyperlocalise-shaped CSV from `glossary download`), confirms the import, and polls until Smartling finishes.
 
 `glossary download` and `tm download` have no `--force` or `--dry-run`. They write CSV (or TMX for `tm --format tmx`) to stdout unless you pass `--output`.
 
@@ -106,7 +111,7 @@ Pass exactly one of `--file-uri` or `--all`. `--all` lists files (same paging as
 | --- | --- |
 | `smartling-cli init` / `smartling.yml` | Unsupported (flag-only) |
 | `files push` / `files upload` | `upload sources` (no jobs, no YAML globs, no `--branch`; `--authorize` defaults true; `--directive` supported) |
-| `files pull` / `files download` | `download translations` (`--file-uri` or `--all`; `--retrieval-type pending\|published\|pseudo`; `--target-locale` always required; no `--format` templates, zip bulk, `--threads`, or job pull) |
+| `files pull` / `files download` | `download translations` (`--file-uri` or `--all`; optional `--target-locale` from file status; `--retrieval-type pending\|published\|pseudo`; no `--format` templates, zip bulk, `--threads`, or job pull) |
 | `files pull --source` | `download sources` (`--file-uri` or `--all`; official `name_locale.ext` paths for `--all`) |
 | `files import` | `upload translations` (`--published` or `--post-translation`; optional `--overwrite`) |
 | `files list` / `files status` | `files list` (`--uri-mask`) / `files status` (one `--file-uri`; no local-disk column) |
@@ -114,7 +119,8 @@ Pass exactly one of `--file-uri` or `--all`. `--all` lists files (same paging as
 | `projects list` / `info` / `locales` | `projects list` / `projects info` / `locales list` |
 | Jobs, `mt detect` / `mt translate` | Out of scope |
 | `glossaries export` | `glossary download` (Hyperlocalise CSV; not official CSV/XLSX/TBX parity) |
-| `glossaries import` / create / list | Out of scope |
+| `glossaries list` / `glossaries create` | `glossary list` / `glossary create` |
+| `glossaries import` | `glossary import` (official Smartling CSV; confirm + poll) |
 | TM export | `tm download` (CSV/TMX) |
 | TM / glossary upload | Out of scope |
 
@@ -197,13 +203,12 @@ hyperlocalise smartling download sources \
   --force
 ```
 
-Download every listed file into a directory. Translations still need `--target-locale`:
+Download every listed file into a directory. Omit `--target-locale` to pull every locale from each file's status:
 
 ```bash
 hyperlocalise smartling download translations \
   --project-id your-project-id \
   --all \
-  --target-locale fr-FR \
   --retrieval-type published \
   --output ./pulled \
   --force

--- a/internal/i18n/storage/smartling/BUILD.bazel
+++ b/internal/i18n/storage/smartling/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/csvsafe",
+        "//internal/i18n/locales",
         "//internal/i18n/storage",
     ],
 )

--- a/internal/i18n/storage/smartling/glossary_v3.go
+++ b/internal/i18n/storage/smartling/glossary_v3.go
@@ -21,9 +21,9 @@ const (
 
 var (
 	glossaryImportPollInterval = time.Second
-	glossaryImportMaxPolls       = 120
-	glossarySearchPageLimit      = 100
-	glossarySearchMaxPages       = 1000
+	glossaryImportMaxPolls     = 120
+	glossarySearchPageLimit    = 100
+	glossarySearchMaxPages     = 1000
 )
 
 // GlossarySummary is one glossary from the v3 search API.
@@ -74,8 +74,8 @@ type glossarySearchPayload struct {
 }
 
 type glossaryCreatePayload struct {
-	GlossaryUID string `json:"glossaryUid"`
-	AccountUID  string `json:"accountUid"`
+	GlossaryUID  string `json:"glossaryUid"`
+	AccountUID   string `json:"accountUid"`
 	GlossaryName string `json:"glossaryName"`
 }
 

--- a/internal/i18n/storage/smartling/glossary_v3.go
+++ b/internal/i18n/storage/smartling/glossary_v3.go
@@ -29,7 +29,7 @@ var (
 // GlossarySummary is one glossary from the v3 search API.
 type GlossarySummary struct {
 	GlossaryUID string   `json:"glossaryUid"`
-	Name        string   `json:"glossaryName"`
+	Name        string   `json:"name"`
 	Description string   `json:"description,omitempty"`
 	LocaleIDs   []string `json:"localeIds"`
 }
@@ -51,7 +51,7 @@ type GlossaryCreateInput struct {
 // GlossaryCreateResult is the created glossary identity.
 type GlossaryCreateResult struct {
 	GlossaryUID string `json:"glossaryUid"`
-	Name        string `json:"glossaryName"`
+	Name        string `json:"name"`
 	AccountUID  string `json:"accountUid,omitempty"`
 }
 
@@ -74,9 +74,9 @@ type glossarySearchPayload struct {
 }
 
 type glossaryCreatePayload struct {
-	GlossaryUID  string `json:"glossaryUid"`
-	AccountUID   string `json:"accountUid"`
-	GlossaryName string `json:"glossaryName"`
+	GlossaryUID string `json:"glossaryUid"`
+	AccountUID  string `json:"accountUid"`
+	Name        string `json:"name"`
 }
 
 type glossaryImportUploadPayload struct {
@@ -177,8 +177,8 @@ func (c *HTTPClient) CreateGlossary(ctx context.Context, in GlossaryCreateInput)
 	}
 
 	body := map[string]any{
-		"glossaryName": name,
-		"localeIds":    localeIDs,
+		"name":      name,
+		"localeIds": localeIDs,
 	}
 	if description := strings.TrimSpace(in.Description); description != "" {
 		body["description"] = description
@@ -199,7 +199,7 @@ func (c *HTTPClient) CreateGlossary(ctx context.Context, in GlossaryCreateInput)
 	}
 	return GlossaryCreateResult{
 		GlossaryUID: glossaryUID,
-		Name:        strings.TrimSpace(payload.GlossaryName),
+		Name:        strings.TrimSpace(payload.Name),
 		AccountUID:  strings.TrimSpace(payload.AccountUID),
 	}, nil
 }

--- a/internal/i18n/storage/smartling/glossary_v3.go
+++ b/internal/i18n/storage/smartling/glossary_v3.go
@@ -1,0 +1,300 @@
+package smartling
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/locales"
+)
+
+const (
+	glossaryImportStatusPending    = "PENDING"
+	glossaryImportStatusInProgress = "IN_PROGRESS"
+	glossaryImportStatusSuccessful = "SUCCESSFUL"
+	glossaryImportStatusFailed     = "FAILED"
+)
+
+var (
+	glossaryImportPollInterval = time.Second
+	glossaryImportMaxPolls       = 120
+	glossarySearchPageLimit      = 100
+	glossarySearchMaxPages       = 1000
+)
+
+// GlossarySummary is one glossary from the v3 search API.
+type GlossarySummary struct {
+	GlossaryUID string   `json:"glossaryUid"`
+	Name        string   `json:"glossaryName"`
+	Description string   `json:"description,omitempty"`
+	LocaleIDs   []string `json:"localeIds"`
+}
+
+// GlossarySearchInput lists glossaries on an account.
+type GlossarySearchInput struct {
+	AccountUID string
+	Query      string
+}
+
+// GlossaryCreateInput creates a glossary on an account.
+type GlossaryCreateInput struct {
+	AccountUID  string
+	Name        string
+	Description string
+	LocaleIDs   []string
+}
+
+// GlossaryCreateResult is the created glossary identity.
+type GlossaryCreateResult struct {
+	GlossaryUID string `json:"glossaryUid"`
+	Name        string `json:"glossaryName"`
+	AccountUID  string `json:"accountUid,omitempty"`
+}
+
+// GlossaryImportInput uploads Smartling's official glossary import CSV.
+type GlossaryImportInput struct {
+	AccountUID  string
+	GlossaryUID string
+	FilePath    string
+}
+
+// GlossaryImportResult summarizes a completed glossary import.
+type GlossaryImportResult struct {
+	ImportUID    string `json:"importUid"`
+	ImportStatus string `json:"importStatus"`
+}
+
+type glossarySearchPayload struct {
+	TotalCount int               `json:"totalCount"`
+	Items      []GlossarySummary `json:"items"`
+}
+
+type glossaryCreatePayload struct {
+	GlossaryUID string `json:"glossaryUid"`
+	AccountUID  string `json:"accountUid"`
+	GlossaryName string `json:"glossaryName"`
+}
+
+type glossaryImportUploadPayload struct {
+	GlossaryImport struct {
+		GlossaryUID  string `json:"glossaryUid"`
+		ImportUID    string `json:"importUid"`
+		ImportStatus string `json:"importStatus"`
+	} `json:"glossaryImport"`
+}
+
+type glossaryImportStatusPayload struct {
+	GlossaryUID  string `json:"glossaryUid"`
+	ImportUID    string `json:"importUid"`
+	ImportStatus string `json:"importStatus"`
+}
+
+// SearchGlossaries posts POST /glossary-api/v3/accounts/{accountUid}/glossaries/search.
+func (c *HTTPClient) SearchGlossaries(ctx context.Context, in GlossarySearchInput) ([]GlossarySummary, error) {
+	accountUID := strings.TrimSpace(in.AccountUID)
+	if accountUID == "" {
+		return nil, fmt.Errorf("smartling glossary list: account uid is required")
+	}
+
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("%s/accounts/%s/glossaries/search", c.glossaryV3BaseURL, url.PathEscape(accountUID))
+	query := strings.TrimSpace(in.Query)
+	limit := glossarySearchPageLimit
+	if limit <= 0 {
+		limit = 100
+	}
+	maxPages := glossarySearchMaxPages
+	if maxPages <= 0 {
+		maxPages = 1000
+	}
+
+	var all []GlossarySummary
+	offset := 0
+	for page := 1; ; page++ {
+		if page > maxPages {
+			return nil, fmt.Errorf("smartling glossary list: exceeded maximum page count")
+		}
+		body := map[string]any{
+			"query": query,
+			"paging": map[string]int{
+				"offset": offset,
+				"limit":  limit,
+			},
+		}
+		var envelope smartlingDataEnvelope
+		if err := c.postJSON(ctx, endpoint, token, body, &envelope); err != nil {
+			return nil, fmt.Errorf("smartling glossary list: %w", err)
+		}
+		var payload glossarySearchPayload
+		if err := decodeSmartlingData(envelope, "smartling glossary list", &payload); err != nil {
+			return nil, err
+		}
+		if len(payload.Items) == 0 {
+			break
+		}
+		all = append(all, payload.Items...)
+		if len(payload.Items) < limit {
+			break
+		}
+		if payload.TotalCount > 0 && len(all) >= payload.TotalCount {
+			break
+		}
+		next := offset + limit
+		if next <= offset {
+			return nil, fmt.Errorf("smartling glossary list: pagination offset did not advance")
+		}
+		offset = next
+	}
+	return all, nil
+}
+
+// CreateGlossary posts POST /glossary-api/v3/accounts/{accountUid}/glossaries.
+func (c *HTTPClient) CreateGlossary(ctx context.Context, in GlossaryCreateInput) (GlossaryCreateResult, error) {
+	accountUID := strings.TrimSpace(in.AccountUID)
+	if accountUID == "" {
+		return GlossaryCreateResult{}, fmt.Errorf("smartling glossary create: account uid is required")
+	}
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return GlossaryCreateResult{}, fmt.Errorf("smartling glossary create: glossary name is required")
+	}
+	localeIDs := normalizeGlossaryLocaleIDs(in.LocaleIDs)
+	if len(localeIDs) == 0 {
+		return GlossaryCreateResult{}, fmt.Errorf("smartling glossary create: at least one locale is required")
+	}
+
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return GlossaryCreateResult{}, err
+	}
+
+	body := map[string]any{
+		"glossaryName": name,
+		"localeIds":    localeIDs,
+	}
+	if description := strings.TrimSpace(in.Description); description != "" {
+		body["description"] = description
+	}
+
+	endpoint := fmt.Sprintf("%s/accounts/%s/glossaries", c.glossaryV3BaseURL, url.PathEscape(accountUID))
+	var envelope smartlingDataEnvelope
+	if err := c.postJSON(ctx, endpoint, token, body, &envelope); err != nil {
+		return GlossaryCreateResult{}, fmt.Errorf("smartling glossary create: %w", err)
+	}
+	var payload glossaryCreatePayload
+	if err := decodeSmartlingData(envelope, "smartling glossary create", &payload); err != nil {
+		return GlossaryCreateResult{}, err
+	}
+	glossaryUID := strings.TrimSpace(payload.GlossaryUID)
+	if glossaryUID == "" {
+		return GlossaryCreateResult{}, fmt.Errorf("smartling glossary create: missing glossary uid in response")
+	}
+	return GlossaryCreateResult{
+		GlossaryUID: glossaryUID,
+		Name:        strings.TrimSpace(payload.GlossaryName),
+		AccountUID:  strings.TrimSpace(payload.AccountUID),
+	}, nil
+}
+
+// ImportGlossary uploads, confirms, and polls a glossary CSV import.
+func (c *HTTPClient) ImportGlossary(ctx context.Context, in GlossaryImportInput) (GlossaryImportResult, error) {
+	accountUID := strings.TrimSpace(in.AccountUID)
+	if accountUID == "" {
+		return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: account uid is required")
+	}
+	glossaryUID := strings.TrimSpace(in.GlossaryUID)
+	if glossaryUID == "" {
+		return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: glossary uid is required")
+	}
+	filePath := strings.TrimSpace(in.FilePath)
+	if filePath == "" {
+		return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: file path is required")
+	}
+	if _, err := os.Stat(filePath); err != nil {
+		if os.IsNotExist(err) {
+			return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: file %q does not exist", filePath)
+		}
+		return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: stat file %q: %w", filePath, err)
+	}
+
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return GlossaryImportResult{}, err
+	}
+
+	uploadEndpoint := fmt.Sprintf("%s/accounts/%s/glossaries/%s/import", c.glossaryV3BaseURL, url.PathEscape(accountUID), url.PathEscape(glossaryUID))
+	var uploadEnvelope smartlingDataEnvelope
+	if err := c.postMultipart(ctx, uploadEndpoint, token, map[string]string{
+		"importFileName":      filepath.Base(filePath),
+		"importFileMediaType": "text/csv",
+		"archiveMode":         "false",
+	}, "importFile", filePath, &uploadEnvelope); err != nil {
+		return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: %w", err)
+	}
+	var uploadPayload glossaryImportUploadPayload
+	if err := decodeSmartlingData(uploadEnvelope, "smartling glossary import", &uploadPayload); err != nil {
+		return GlossaryImportResult{}, err
+	}
+	importUID := strings.TrimSpace(uploadPayload.GlossaryImport.ImportUID)
+	if importUID == "" {
+		return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: missing import uid in response")
+	}
+
+	confirmEndpoint := fmt.Sprintf("%s/accounts/%s/glossaries/%s/import/%s/confirm", c.glossaryV3BaseURL, url.PathEscape(accountUID), url.PathEscape(glossaryUID), url.PathEscape(importUID))
+	if err := c.postJSON(ctx, confirmEndpoint, token, map[string]any{}, nil); err != nil {
+		return GlossaryImportResult{}, fmt.Errorf("smartling glossary import confirm: %w", err)
+	}
+
+	statusEndpoint := fmt.Sprintf("%s/accounts/%s/glossaries/%s/import/%s", c.glossaryV3BaseURL, url.PathEscape(accountUID), url.PathEscape(glossaryUID), url.PathEscape(importUID))
+	for attempt := 0; attempt < glossaryImportMaxPolls; attempt++ {
+		var statusEnvelope smartlingDataEnvelope
+		if err := c.getJSON(ctx, statusEndpoint, token, &statusEnvelope); err != nil {
+			return GlossaryImportResult{}, fmt.Errorf("smartling glossary import status: %w", err)
+		}
+		var statusPayload glossaryImportStatusPayload
+		if err := decodeSmartlingData(statusEnvelope, "smartling glossary import status", &statusPayload); err != nil {
+			return GlossaryImportResult{}, err
+		}
+		switch strings.ToUpper(strings.TrimSpace(statusPayload.ImportStatus)) {
+		case glossaryImportStatusSuccessful:
+			return GlossaryImportResult{
+				ImportUID:    importUID,
+				ImportStatus: statusPayload.ImportStatus,
+			}, nil
+		case glossaryImportStatusFailed:
+			return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: import %s failed", importUID)
+		case glossaryImportStatusPending, glossaryImportStatusInProgress:
+			if err := waitForGlossaryImportPoll(ctx); err != nil {
+				return GlossaryImportResult{}, err
+			}
+		default:
+			if err := waitForGlossaryImportPoll(ctx); err != nil {
+				return GlossaryImportResult{}, err
+			}
+		}
+	}
+	return GlossaryImportResult{}, fmt.Errorf("smartling glossary import: timed out waiting for import %s", importUID)
+}
+
+func normalizeGlossaryLocaleIDs(values []string) []string {
+	return locales.NormalizeList(values)
+}
+
+func waitForGlossaryImportPoll(ctx context.Context) error {
+	timer := time.NewTimer(glossaryImportPollInterval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/i18n/storage/smartling/glossary_v3_test.go
+++ b/internal/i18n/storage/smartling/glossary_v3_test.go
@@ -28,9 +28,9 @@ func TestHTTPClientSearchGlossaries(t *testing.T) {
 					"totalCount": 1,
 					"items": []map[string]any{
 						{
-							"glossaryUid":  "gloss-1",
-							"glossaryName": "Brand terms",
-							"localeIds":    []string{"en-US", "fr-FR"},
+							"glossaryUid": "gloss-1",
+							"name":        "Brand terms",
+							"localeIds":   []string{"en-US", "fr-FR"},
 						},
 					},
 				},
@@ -72,9 +72,9 @@ func TestHTTPClientSearchGlossariesPaginates(t *testing.T) {
 			var items []map[string]any
 			switch page {
 			case 1:
-				items = []map[string]any{{"glossaryUid": "gloss-1", "glossaryName": "One", "localeIds": []string{"en-US"}}}
+				items = []map[string]any{{"glossaryUid": "gloss-1", "name": "One", "localeIds": []string{"en-US"}}}
 			case 2:
-				items = []map[string]any{{"glossaryUid": "gloss-2", "glossaryName": "Two", "localeIds": []string{"fr-FR"}}}
+				items = []map[string]any{{"glossaryUid": "gloss-2", "name": "Two", "localeIds": []string{"fr-FR"}}}
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"response": map[string]any{"code": "SUCCESS"},
@@ -127,12 +127,21 @@ func TestHTTPClientCreateGlossary(t *testing.T) {
 				"data":     map[string]any{"accessToken": "test-token", "expiresIn": 3600},
 			})
 		case strings.Contains(r.URL.Path, "/glossaries") && r.Method == http.MethodPost && !strings.Contains(r.URL.Path, "/search"):
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if body["name"] != "New glossary" {
+				http.Error(w, "expected name in request body", http.StatusBadRequest)
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"response": map[string]any{"code": "SUCCESS"},
 				"data": map[string]any{
-					"glossaryUid":  "gloss-new",
-					"glossaryName": "New glossary",
-					"accountUid":   "acc-1",
+					"glossaryUid": "gloss-new",
+					"name":        "New glossary",
+					"accountUid":  "acc-1",
 				},
 			})
 		default:

--- a/internal/i18n/storage/smartling/glossary_v3_test.go
+++ b/internal/i18n/storage/smartling/glossary_v3_test.go
@@ -1,0 +1,227 @@
+package smartling
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHTTPClientSearchGlossaries(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/authenticate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "success"},
+				"data":     map[string]any{"accessToken": "test-token", "expiresIn": 3600},
+			})
+		case strings.Contains(r.URL.Path, "/glossaries/search"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "SUCCESS"},
+				"data": map[string]any{
+					"totalCount": 1,
+					"items": []map[string]any{
+						{
+							"glossaryUid":  "gloss-1",
+							"glossaryName": "Brand terms",
+							"localeIds":    []string{"en-US", "fr-FR"},
+						},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, _ := NewHTTPClient(Config{UserIdentifier: "user", UserSecret: "secret"})
+	client.authBaseURL = server.URL
+	client.glossaryV3BaseURL = server.URL
+
+	glossaries, err := client.SearchGlossaries(context.Background(), GlossarySearchInput{
+		AccountUID: "acc-1",
+		Query:      "Brand",
+	})
+	if err != nil {
+		t.Fatalf("SearchGlossaries: %v", err)
+	}
+	if len(glossaries) != 1 || glossaries[0].GlossaryUID != "gloss-1" || glossaries[0].Name != "Brand terms" {
+		t.Fatalf("unexpected glossaries: %#v", glossaries)
+	}
+}
+
+func TestHTTPClientSearchGlossariesPaginates(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/authenticate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "success"},
+				"data":     map[string]any{"accessToken": "test-token", "expiresIn": 3600},
+			})
+		case strings.Contains(r.URL.Path, "/glossaries/search"):
+			page++
+			var items []map[string]any
+			switch page {
+			case 1:
+				items = []map[string]any{{"glossaryUid": "gloss-1", "glossaryName": "One", "localeIds": []string{"en-US"}}}
+			case 2:
+				items = []map[string]any{{"glossaryUid": "gloss-2", "glossaryName": "Two", "localeIds": []string{"fr-FR"}}}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "SUCCESS"},
+				"data": map[string]any{
+					"totalCount": 2,
+					"items":      items,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	glossarySearchPageLimit = 1
+	t.Cleanup(func() { glossarySearchPageLimit = 100 })
+
+	client, _ := NewHTTPClient(Config{UserIdentifier: "user", UserSecret: "secret"})
+	client.authBaseURL = server.URL
+	client.glossaryV3BaseURL = server.URL
+
+	glossaries, err := client.SearchGlossaries(context.Background(), GlossarySearchInput{AccountUID: "acc-1"})
+	if err != nil {
+		t.Fatalf("SearchGlossaries: %v", err)
+	}
+	if len(glossaries) != 2 || glossaries[0].GlossaryUID != "gloss-1" || glossaries[1].GlossaryUID != "gloss-2" {
+		t.Fatalf("unexpected glossaries: %#v", glossaries)
+	}
+}
+
+func TestHTTPClientImportGlossaryMissingFile(t *testing.T) {
+	client, _ := NewHTTPClient(Config{UserIdentifier: "user", UserSecret: "secret"})
+	_, err := client.ImportGlossary(context.Background(), GlossaryImportInput{
+		AccountUID:  "acc-1",
+		GlossaryUID: "gloss-1",
+		FilePath:    filepath.Join(t.TempDir(), "missing.csv"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("expected missing file error, got %v", err)
+	}
+}
+
+func TestHTTPClientCreateGlossary(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/authenticate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "success"},
+				"data":     map[string]any{"accessToken": "test-token", "expiresIn": 3600},
+			})
+		case strings.Contains(r.URL.Path, "/glossaries") && r.Method == http.MethodPost && !strings.Contains(r.URL.Path, "/search"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "SUCCESS"},
+				"data": map[string]any{
+					"glossaryUid":  "gloss-new",
+					"glossaryName": "New glossary",
+					"accountUid":   "acc-1",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, _ := NewHTTPClient(Config{UserIdentifier: "user", UserSecret: "secret"})
+	client.authBaseURL = server.URL
+	client.glossaryV3BaseURL = server.URL
+
+	result, err := client.CreateGlossary(context.Background(), GlossaryCreateInput{
+		AccountUID: "acc-1",
+		Name:       "New glossary",
+		LocaleIDs:  []string{"en-US", "fr-FR"},
+	})
+	if err != nil {
+		t.Fatalf("CreateGlossary: %v", err)
+	}
+	if result.GlossaryUID != "gloss-new" || result.Name != "New glossary" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestHTTPClientImportGlossary(t *testing.T) {
+	status := glossaryImportStatusInProgress
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/authenticate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "success"},
+				"data":     map[string]any{"accessToken": "test-token", "expiresIn": 3600},
+			})
+		case strings.Contains(r.URL.Path, "/import") && r.Method == http.MethodPost && !strings.Contains(r.URL.Path, "/confirm"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "SUCCESS"},
+				"data": map[string]any{
+					"glossaryImport": map[string]any{
+						"glossaryUid":  "gloss-1",
+						"importUid":    "import-1",
+						"importStatus": glossaryImportStatusPending,
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/confirm"):
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/import/import-1"):
+			if status == glossaryImportStatusInProgress {
+				status = glossaryImportStatusSuccessful
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"response": map[string]any{"code": "SUCCESS"},
+				"data": map[string]any{
+					"glossaryUid":  "gloss-1",
+					"importUid":    "import-1",
+					"importStatus": status,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	oldInterval := glossaryImportPollInterval
+	glossaryImportPollInterval = time.Millisecond
+	t.Cleanup(func() { glossaryImportPollInterval = oldInterval })
+
+	client, _ := NewHTTPClient(Config{UserIdentifier: "user", UserSecret: "secret"})
+	client.authBaseURL = server.URL
+	client.glossaryV3BaseURL = server.URL
+
+	dir := t.TempDir()
+	csvPath := filepath.Join(dir, "import.csv")
+	if err := os.WriteFile(csvPath, []byte("term,definition\nhello,world\n"), 0o644); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+
+	result, err := client.ImportGlossary(context.Background(), GlossaryImportInput{
+		AccountUID:  "acc-1",
+		GlossaryUID: "gloss-1",
+		FilePath:    csvPath,
+	})
+	if err != nil {
+		t.Fatalf("ImportGlossary: %v", err)
+	}
+	if result.ImportUID != "import-1" || result.ImportStatus != glossaryImportStatusSuccessful {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -28,6 +28,7 @@ const (
 	stringsAPIBaseURL        = "https://api.smartling.com/strings-api/v2"
 	filesAPIBaseURL          = "https://api.smartling.com/files-api/v2"
 	glossaryAPIBaseURL       = "https://api.smartling.com/glossary-api/v2"
+	glossaryAPIV3BaseURL     = "https://api.smartling.com/glossary-api/v3"
 	tmAPIBaseURL             = "https://api.smartling.com/translation-memory-api/v2"
 	translationsLimit        = 500
 	glossaryLimit            = 500
@@ -41,6 +42,7 @@ type HTTPClient struct {
 	projectsBaseURL string
 	accountsBaseURL string
 	glossaryBaseURL string
+	glossaryV3BaseURL string
 	tmBaseURL       string
 	http            *http.Client
 	userIdentifier  string
@@ -64,6 +66,7 @@ func NewHTTPClient(cfg Config) (*HTTPClient, error) {
 		projectsBaseURL: projectsAPIBaseURL,
 		accountsBaseURL: accountsAPIBaseURL,
 		glossaryBaseURL: glossaryAPIBaseURL,
+		glossaryV3BaseURL: glossaryAPIV3BaseURL,
 		tmBaseURL:       tmAPIBaseURL,
 		http:            &http.Client{Timeout: timeout},
 		userIdentifier:  cfg.UserIdentifier,

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -24,29 +24,29 @@ import (
 )
 
 const (
-	authAPIBaseURL           = "https://api.smartling.com/auth-api/v2"
-	stringsAPIBaseURL        = "https://api.smartling.com/strings-api/v2"
-	filesAPIBaseURL          = "https://api.smartling.com/files-api/v2"
-	glossaryAPIBaseURL       = "https://api.smartling.com/glossary-api/v2"
-	glossaryAPIV3BaseURL     = "https://api.smartling.com/glossary-api/v3"
-	tmAPIBaseURL             = "https://api.smartling.com/translation-memory-api/v2"
-	translationsLimit        = 500
-	glossaryLimit            = 500
-	maxDownloadBytes   int64 = 50 * 1024 * 1024 // 50 MB
+	authAPIBaseURL             = "https://api.smartling.com/auth-api/v2"
+	stringsAPIBaseURL          = "https://api.smartling.com/strings-api/v2"
+	filesAPIBaseURL            = "https://api.smartling.com/files-api/v2"
+	glossaryAPIBaseURL         = "https://api.smartling.com/glossary-api/v2"
+	glossaryAPIV3BaseURL       = "https://api.smartling.com/glossary-api/v3"
+	tmAPIBaseURL               = "https://api.smartling.com/translation-memory-api/v2"
+	translationsLimit          = 500
+	glossaryLimit              = 500
+	maxDownloadBytes     int64 = 50 * 1024 * 1024 // 50 MB
 )
 
 type HTTPClient struct {
-	authBaseURL     string
-	stringsBaseURL  string
-	filesBaseURL    string
-	projectsBaseURL string
-	accountsBaseURL string
-	glossaryBaseURL string
+	authBaseURL       string
+	stringsBaseURL    string
+	filesBaseURL      string
+	projectsBaseURL   string
+	accountsBaseURL   string
+	glossaryBaseURL   string
 	glossaryV3BaseURL string
-	tmBaseURL       string
-	http            *http.Client
-	userIdentifier  string
-	userSecret      string
+	tmBaseURL         string
+	http              *http.Client
+	userIdentifier    string
+	userSecret        string
 
 	tokenMu           sync.Mutex
 	cachedAccessToken string
@@ -60,17 +60,17 @@ func NewHTTPClient(cfg Config) (*HTTPClient, error) {
 	}
 
 	return &HTTPClient{
-		authBaseURL:     authAPIBaseURL,
-		stringsBaseURL:  stringsAPIBaseURL,
-		filesBaseURL:    filesAPIBaseURL,
-		projectsBaseURL: projectsAPIBaseURL,
-		accountsBaseURL: accountsAPIBaseURL,
-		glossaryBaseURL: glossaryAPIBaseURL,
+		authBaseURL:       authAPIBaseURL,
+		stringsBaseURL:    stringsAPIBaseURL,
+		filesBaseURL:      filesAPIBaseURL,
+		projectsBaseURL:   projectsAPIBaseURL,
+		accountsBaseURL:   accountsAPIBaseURL,
+		glossaryBaseURL:   glossaryAPIBaseURL,
 		glossaryV3BaseURL: glossaryAPIV3BaseURL,
-		tmBaseURL:       tmAPIBaseURL,
-		http:            &http.Client{Timeout: timeout},
-		userIdentifier:  cfg.UserIdentifier,
-		userSecret:      cfg.UserSecret,
+		tmBaseURL:         tmAPIBaseURL,
+		http:              &http.Client{Timeout: timeout},
+		userIdentifier:    cfg.UserIdentifier,
+		userSecret:        cfg.UserSecret,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- **HL-741**: `download translations` no longer requires `--target-locale`. When omitted, locales come from per-file `files status`; explicit `--target-locale` values intersect case-insensitively with status. `--all` resolves locales per URI. Dry-run still calls file status (credentials required).
- **HL-742**: Add `glossary list` and `glossary create` against Smartling glossary API v3 (`--account-uid`, text/json output). List paginates search results.
- **HL-743**: Add `glossary import` for Smartling official CSV (upload, confirm, poll until `SUCCESSFUL`).

## Test plan

- [x] `go test ./apps/cli/cmd -run Smartling`
- [x] `go test ./internal/i18n/storage/smartling/...`
- [x] `golangci-lint run ./apps/cli/cmd/... ./internal/i18n/storage/smartling/...`
- [ ] CI green on PR

## Notes

- `glossary download` CSV is Hyperlocalise-shaped; `glossary import` expects Smartling official import CSV (documented in `docs/cli/commands/smartling.mdx`).
- `--all` download remains fail-fast: earlier files stay on disk if a later file errors.