### PR TITLE
chore(cli): pin hyperlocalise CLI to 1.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.10.0
+          version: 1.11.0
 
       - name: Dry-run sync push
         run: hl sync push --dry-run

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.10.0
+          version: 1.11.0
 
       - name: Extract source catalog
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.10.0
+          version: 1.11.0
 
       - name: Extract source catalog
         run: |

--- a/apps/cli/cmd/templates/i18n.yml
+++ b/apps/cli/cmd/templates/i18n.yml
@@ -3,7 +3,7 @@
 # This starter intentionally skips advanced sections like groups, rules, and remote cache config.
 # When groups are omitted, Hyperlocalise runs all buckets for all target locales.
 # Pin the Hyperlocalise CLI version (like packageManager in package.json).
-# version: hyperlocalise@1.10.0
+# version: hyperlocalise@1.11.0
 locales:
   # Source locale: the language your original content is written in.
   source: en-US

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -19,7 +19,7 @@ import { isReleaseSandboxVcrImageEnabled } from "@/lib/flags/release-flags";
 export const sandboxRipgrepReleaseVersion = "14.1.1";
 
 /** Pinned hyperlocalise CLI release installed into every sandbox. */
-export const sandboxHyperlocaliseReleaseVersion = "1.10.0";
+export const sandboxHyperlocaliseReleaseVersion = "1.11.0";
 
 /**
  * Pinned Playwright release used for Debian/Ubuntu `install-deps` fallback.

--- a/apps/sandbox-image/Dockerfile
+++ b/apps/sandbox-image/Dockerfile
@@ -59,7 +59,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Keep in sync with apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
 ARG NODE_MAJOR=24
-ARG HYPERLOCALISE_VERSION=1.10.0
+ARG HYPERLOCALISE_VERSION=1.11.0
 ARG PLAYWRIGHT_VERSION=1.61.1
 # Optional pin; omit / leave empty to install the latest Volta release.
 ARG VOLTA_VERSION=

--- a/docs/cli/configuration/i18n-config.mdx
+++ b/docs/cli/configuration/i18n-config.mdx
@@ -12,10 +12,10 @@ description: "Field-by-field guide for the i18n config file used by run, status,
 Pin the Hyperlocalise CLI version at the top of `i18n.yml`, similar to `packageManager` in `package.json`:
 
 ```yaml
-version: hyperlocalise@1.10.0
+version: hyperlocalise@1.11.0
 ```
 
-When set, commands that load the config (`run`, `check`, `status`, `pack`, `sync`, and others) fail if the running CLI version does not match the pinned value. The `hl` alias is also accepted (`hl@1.10.0`).
+When set, commands that load the config (`run`, `check`, `status`, `pack`, `sync`, and others) fail if the running CLI version does not match the pinned value. The `hl` alias is also accepted (`hl@1.11.0`).
 
 In GitHub Actions, set `hyperlocalise-version: config` to install the version declared in your i18n config file.
 


### PR DESCRIPTION
## What changed

Pin the Hyperlocalise CLI from 1.10.0 to 1.11.0 in CI, sandbox install paths, the starter config example, and docs so they match the latest release.

## How to test

- [ ] Confirm GitHub Actions install steps in `ci.yml` and `hyperlocalise-web-localize.yml` request `1.11.0`
- [ ] Confirm sandbox image `HYPERLOCALISE_VERSION` and `sandboxHyperlocaliseReleaseVersion` are `1.11.0`
- [x] `vp test src/lib/vercel-sandbox-config.test.ts` and `vp check --fix src/lib/vercel-sandbox-config.ts` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)