### PR TITLE
Rename Board to Queries

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -776,7 +776,7 @@
     "description": "Button to close the translation memory import preview without writing"
   },
   "08+4Nn7rgH": {
-    "defaultMessage": "Acme · Board",
+    "defaultMessage": "Acme · Queries",
     "description": "Header breadcrumb in marketing app shell mock"
   },
   "087Hwu4wFp": {
@@ -1708,7 +1708,7 @@
     "description": "Capability 1 description for the marketing-localisation use case"
   },
   "2Q9B8y1llx": {
-    "defaultMessage": "Board",
+    "defaultMessage": "Queries",
     "description": "Sidebar nav label in marketing app shell mock"
   },
   "2QU4QHjp8c": {
@@ -1936,8 +1936,8 @@
     "description": "Empty state when agent repository context lookup returns nothing"
   },
   "32+8NTo5Pl": {
-    "defaultMessage": "Board",
-    "description": "Submenu label grouping Board automation tools"
+    "defaultMessage": "Queries",
+    "description": "Submenu label grouping Queries automation tools"
   },
   "32TT/pgWLo": {
     "defaultMessage": "Developer",
@@ -2081,7 +2081,7 @@
   },
   "3W0VCaMyWO": {
     "defaultMessage": "Create issue",
-    "description": "Menu item and tool title for creating Board issues"
+    "description": "Menu item and tool title for creating Queries issues"
   },
   "3Z+3pA/kaR": {
     "defaultMessage": "Save",
@@ -2377,7 +2377,7 @@
   },
   "46zk0LJShA": {
     "defaultMessage": "Triage open work across this workspace.",
-    "description": "Short description under the workspace Board page title"
+    "description": "Short description under the workspace Queries page title"
   },
   "477uPaXfz1": {
     "defaultMessage": "Block on failure",
@@ -2416,8 +2416,8 @@
     "description": "Loading state while project file details are fetched"
   },
   "4Bnw8oUCip": {
-    "defaultMessage": "The board could not be loaded.",
-    "description": "Error state when the workspace board fails to load"
+    "defaultMessage": "Queries could not be loaded.",
+    "description": "Error state when the workspace Queries page fails to load"
   },
   "4C48CjJZ/y": {
     "defaultMessage": "Role permissions",
@@ -2728,8 +2728,8 @@
     "description": "Inbox notification preview for issue assignment"
   },
   "51tdxkVdu+": {
-    "defaultMessage": "{count} P1 on Board",
-    "description": "Open issues metric subtitle showing P1 issue count on the board"
+    "defaultMessage": "{count} P1 on Queries",
+    "description": "Open issues metric subtitle showing P1 issue count on Queries"
   },
   "520zX1ohk1": {
     "defaultMessage": "Cancel",
@@ -3228,8 +3228,8 @@
     "description": "Collapsed explore rollup with a subject and search count"
   },
   "6XlImduZ6L": {
-    "defaultMessage": "Board is unavailable for this string.",
-    "description": "Shown when the CAT segment cannot link to the Board (missing translation key)"
+    "defaultMessage": "Queries is unavailable for this string.",
+    "description": "Shown when the CAT segment cannot link to Queries (missing translation key)"
   },
   "6YRqpDlcKq": {
     "defaultMessage": "GitHub push",
@@ -3304,8 +3304,8 @@
     "description": "Badge shown on inactive project cards"
   },
   "6haGvAy+HC": {
-    "defaultMessage": "Added to Board",
-    "description": "Toast confirmation after adding a CAT segment to the issue sheet"
+    "defaultMessage": "Added to Queries",
+    "description": "Toast confirmation after adding a CAT segment to Queries"
   },
   "6ieanONu91": {
     "defaultMessage": "Import CSV",
@@ -5448,8 +5448,8 @@
     "description": "Label for the target locale filter"
   },
   "C5SPm8Zbbu": {
-    "defaultMessage": "Board",
-    "description": "Workspace board page title"
+    "defaultMessage": "Queries",
+    "description": "Workspace Queries page title"
   },
   "C5fqvIk+YX": {
     "defaultMessage": "Old",
@@ -5500,7 +5500,7 @@
     "description": "Button label while retrying a localisation audit"
   },
   "CBibCD/p8E": {
-    "defaultMessage": "Read board issues for the selected project during this automation.",
+    "defaultMessage": "Read Queries issues for the selected project during this automation.",
     "description": "Description for the List issues automation tool"
   },
   "CCHRUS19n3": {
@@ -5784,7 +5784,7 @@
     "description": "Error when a Canva claim id is missing"
   },
   "D1Wfd509ws": {
-    "defaultMessage": "Choose which project should receive the imported board rows.",
+    "defaultMessage": "Choose which project should receive the imported Queries rows.",
     "description": "Description of the workspace issues CSV import project picker dialog"
   },
   "D2ZrcxejKr": {
@@ -6244,8 +6244,8 @@
     "description": "Toast and error fallback when starting an agent run fails"
   },
   "E8k6bvQHrX": {
-    "defaultMessage": "Close board",
-    "description": "Accessible label for closing the CAT Board panel"
+    "defaultMessage": "Close Queries",
+    "description": "Accessible label for closing the CAT Queries panel"
   },
   "E8rEmEqTpX": {
     "defaultMessage": "Resolving…",
@@ -7561,7 +7561,7 @@
   },
   "Hjj+QG5LDK": {
     "defaultMessage": "Request failed",
-    "description": "Generic fallback when a CAT Board API request fails"
+    "description": "Generic fallback when a CAT Queries API request fails"
   },
   "Hl4y/YDhod": {
     "defaultMessage": "Knowledge files must be 25 MB or smaller.",
@@ -7604,8 +7604,8 @@
     "description": "Projects page description when no TMS provider is connected"
   },
   "HrspdhKQl+": {
-    "defaultMessage": "Open board",
-    "description": "Accessible label for the Board button in the app shell footer"
+    "defaultMessage": "Open Queries",
+    "description": "Accessible label for the Queries button in the app shell footer"
   },
   "Hs6SYEddPH": {
     "defaultMessage": "Target locale",
@@ -8044,8 +8044,8 @@
     "description": "Trigger label for a web chat automation in the list"
   },
   "J2Tvcwc2sx": {
-    "defaultMessage": "Open board, {count} open",
-    "description": "Accessible label for the Board button when open issues are available"
+    "defaultMessage": "Open Queries, {count} open",
+    "description": "Accessible label for the Queries button when open issues are available"
   },
   "J4PtC/cy7o": {
     "defaultMessage": "Type",
@@ -8072,7 +8072,7 @@
     "description": "Feature teaser benefit for domains"
   },
   "J8uRouTxFR": {
-    "defaultMessage": "Choose whether Inbox updates for board issues are also delivered to your email.",
+    "defaultMessage": "Choose whether Inbox updates for Queries issues are also delivered to your email.",
     "description": "Helper text under notification preferences on account settings"
   },
   "J9N0QX7lou": {
@@ -8177,7 +8177,7 @@
   },
   "JRZrMUrfeM": {
     "defaultMessage": "Triage localization issues for this project.",
-    "description": "Short section description for the project Board page"
+    "description": "Short section description for the project Queries page"
   },
   "JRvO1zUFRY": {
     "defaultMessage": "Reading {detail}",
@@ -8424,8 +8424,8 @@
     "description": "Badge when a native project file has no latest job"
   },
   "KCIvL0TJB4": {
-    "defaultMessage": "Board",
-    "description": "Button to open the Board for the current CAT segment"
+    "defaultMessage": "Queries",
+    "description": "Button to open Queries for the current CAT segment"
   },
   "KCMz//p+DR": {
     "defaultMessage": "Web chat",
@@ -9016,8 +9016,8 @@
     "description": "Metric and property value while locale readiness is loading"
   },
   "M+PhLBJ7kK": {
-    "defaultMessage": "View Board",
-    "description": "Link from overview board to the issues page"
+    "defaultMessage": "View Queries",
+    "description": "Link from overview Queries to the issues page"
   },
   "M/3YJiyMT3": {
     "defaultMessage": "Enter a URL to see how your site feels in other languages. A clear score, then the full report by email.",
@@ -9188,8 +9188,8 @@
     "description": "Mapping option to create a new Issue Sheet column from a CSV header"
   },
   "MQYav5C7q6": {
-    "defaultMessage": "Board",
-    "description": "Overview section label for open issues"
+    "defaultMessage": "Queries",
+    "description": "Overview section label for open Queries issues"
   },
   "MR3nUfsG07": {
     "defaultMessage": "manage",
@@ -10640,8 +10640,8 @@
     "description": "Email subject for Reports feature teaser contact link"
   },
   "QSTiMWaXF/": {
-    "defaultMessage": "The board could not be loaded.",
-    "description": "Error state when Board rows fail to load"
+    "defaultMessage": "Queries could not be loaded.",
+    "description": "Error state when Queries rows fail to load"
   },
   "QT9sZSgQql": {
     "defaultMessage": "Experiment",
@@ -10864,8 +10864,8 @@
     "description": "Label for Canva display name field"
   },
   "R/mQHxnDLt": {
-    "defaultMessage": "Board",
-    "description": "Section title for the project Board page"
+    "defaultMessage": "Queries",
+    "description": "Section title for the project Queries page"
   },
   "R/pK1EOhod": {
     "defaultMessage": "Team name must be 120 characters or fewer.",
@@ -13161,7 +13161,7 @@
   },
   "XNK40wY8Cc": {
     "defaultMessage": "No open issues.",
-    "description": "Empty state for overview board issues"
+    "description": "Empty state for overview Queries issues"
   },
   "XOLvGAW68Q": {
     "defaultMessage": "Integrations",
@@ -13332,8 +13332,8 @@
     "description": "Heading for available provider agent action buttons"
   },
   "XswXu+UFpy": {
-    "defaultMessage": "Board",
-    "description": "Sidebar navigation item for the workspace board"
+    "defaultMessage": "Queries",
+    "description": "Sidebar navigation item for workspace Queries"
   },
   "XtzSAMs4em": {
     "defaultMessage": "Chat, Slack, and general workspace questions with project and glossary context.",
@@ -14596,7 +14596,7 @@
     "description": "Workspace general settings page description"
   },
   "bC8xP17A1P": {
-    "defaultMessage": "Upload a spreadsheet export, map columns to board fields, preview the result, then import.",
+    "defaultMessage": "Upload a spreadsheet export, map columns to Queries fields, preview the result, then import.",
     "description": "Description of the Issue Sheet CSV import dialog"
   },
   "bCXvSTPFsb": {
@@ -14893,7 +14893,7 @@
   },
   "cAQmoTwBPJ": {
     "defaultMessage": "List issues",
-    "description": "Menu item and tool title for listing Board issues"
+    "description": "Menu item and tool title for listing Queries issues"
   },
   "cAVXvKrNnE": {
     "defaultMessage": "Save",
@@ -15244,8 +15244,8 @@
     "description": "Starter plan name on the pricing page"
   },
   "dBZKwTIoEH": {
-    "defaultMessage": "Failed to add to Board",
-    "description": "Fallback error when creating an issue sheet row from CAT fails"
+    "defaultMessage": "Failed to add to Queries",
+    "description": "Fallback error when creating a Queries row from CAT fails"
   },
   "dC80UX3i75": {
     "defaultMessage": "{hours} hr",
@@ -15320,8 +15320,8 @@
     "description": "Fallback error when locking or unlocking CAT segments fails"
   },
   "dKznjRBgya": {
-    "defaultMessage": "Board",
-    "description": "Label for the Board button in the app shell footer"
+    "defaultMessage": "Queries",
+    "description": "Label for the Queries button in the app shell footer"
   },
   "dLOnbBe+SR": {
     "defaultMessage": "Workspace glossaries",
@@ -16825,7 +16825,7 @@
   },
   "h5+KJI2d7A": {
     "defaultMessage": "Could not load issues.",
-    "description": "Error message when CAT segment board issues fail to load"
+    "description": "Error message when CAT segment Queries issues fail to load"
   },
   "h5YfBD98F1": {
     "defaultMessage": "Import issues from CSV",
@@ -16996,8 +16996,8 @@
     "description": "Tool status badge when tool input is still streaming"
   },
   "hYi0NizHJf": {
-    "defaultMessage": "Board · this string",
-    "description": "Title on the editor mock board overlay"
+    "defaultMessage": "Queries · this string",
+    "description": "Title on the editor mock Queries overlay"
   },
   "hYx7Vbi5IN": {
     "defaultMessage": "Connect a provider",
@@ -17400,8 +17400,8 @@
     "description": "Workflow step 4 label for the localisation-quality-monitoring use case"
   },
   "igJunofoju": {
-    "defaultMessage": "Board",
-    "description": "Heading for the CAT segment Board section"
+    "defaultMessage": "Queries",
+    "description": "Heading for the CAT segment Queries section"
   },
   "igisWP9I+4": {
     "defaultMessage": "{confidence}% confidence",
@@ -18368,7 +18368,7 @@
     "description": "Placeholder when a glossary timestamp is unavailable"
   },
   "l+RVkhyT2N": {
-    "defaultMessage": "Create a project first, then import issues into its board.",
+    "defaultMessage": "Create a project first, then import issues into Queries.",
     "description": "Empty state when there are no projects to import issues into"
   },
   "l+wMmn4Krw": {
@@ -20620,8 +20620,8 @@
     "description": "Badge label for a required schema property"
   },
   "r7gtZsn8Qh": {
-    "defaultMessage": "Board",
-    "description": "Project sidebar navigation item for the project board"
+    "defaultMessage": "Queries",
+    "description": "Project sidebar navigation item for project Queries"
   },
   "r7qqla56RV": {
     "defaultMessage": "Shortened written form",
@@ -21044,8 +21044,8 @@
     "description": "Placeholder for the microphone search input"
   },
   "sJoNIftCZI": {
-    "defaultMessage": "Board",
-    "description": "App shell breadcrumb title for the workspace board page"
+    "defaultMessage": "Queries",
+    "description": "App shell breadcrumb title for the workspace Queries page"
   },
   "sKJqM/aeDo": {
     "defaultMessage": "Campaign brief",
@@ -21260,8 +21260,8 @@
     "description": "Capability 6 title for the github-release-localisation use case"
   },
   "sslu9yZyVp": {
-    "defaultMessage": "Board",
-    "description": "App shell breadcrumb title for the project board page"
+    "defaultMessage": "Queries",
+    "description": "App shell breadcrumb title for the project Queries page"
   },
   "svD7SMchJb": {
     "defaultMessage": "{providerName} is ready for member tokens",
@@ -21532,8 +21532,8 @@
     "description": "Badge next to the Hyperlocalise agent name in the Slack mock"
   },
   "tX5h+jHyR2": {
-    "defaultMessage": "Board · acme workspace",
-    "description": "Board panel title in content ops mock"
+    "defaultMessage": "Queries · acme workspace",
+    "description": "Queries panel title in content ops mock"
   },
   "tX7cZ1uzA9": {
     "defaultMessage": "Choose file",
@@ -22712,7 +22712,7 @@
     "description": "CTA for a failed or active job on project overview"
   },
   "weTyi2vT5M": {
-    "defaultMessage": "File board issues for the selected project from automation findings.",
+    "defaultMessage": "File Queries issues for the selected project from automation findings.",
     "description": "Description for the Create issue automation tool"
   },
   "weWSzrQ1Qp": {
@@ -23416,8 +23416,8 @@
     "description": "Startups FAQ question about needing an existing TMS"
   },
   "yGs5M+8byg": {
-    "defaultMessage": "Add a project-specific workflow column to the board.",
-    "description": "Description of the dialog to add a custom Board column"
+    "defaultMessage": "Add a project-specific workflow column to Queries.",
+    "description": "Description of the dialog to add a custom Queries column"
   },
   "yGxOn6oNGU": {
     "defaultMessage": "{count, plural, one {# glossary} other {# glossaries}}",

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -775,7 +775,7 @@
     "defaultMessage": "Cancel",
     "description": "Button to close the translation memory import preview without writing"
   },
-  "08+4Nn7rgH": {
+  "pmPB2F7F47": {
     "defaultMessage": "Acme · Queries",
     "description": "Header breadcrumb in marketing app shell mock"
   },
@@ -1707,7 +1707,7 @@
     "defaultMessage": "Pull messaging intent, audience notes, and creative direction from the tools marketing teams already use.",
     "description": "Capability 1 description for the marketing-localisation use case"
   },
-  "2Q9B8y1llx": {
+  "UznHMJ+o+o": {
     "defaultMessage": "Queries",
     "description": "Sidebar nav label in marketing app shell mock"
   },
@@ -1935,7 +1935,7 @@
     "defaultMessage": "No repository context was found for this string.",
     "description": "Empty state when agent repository context lookup returns nothing"
   },
-  "32+8NTo5Pl": {
+  "5yzXr6bGIC": {
     "defaultMessage": "Queries",
     "description": "Submenu label grouping Queries automation tools"
   },
@@ -2079,7 +2079,7 @@
     "defaultMessage": "Entry updated",
     "description": "Toast after a translation memory entry is updated from the detail sheet"
   },
-  "3W0VCaMyWO": {
+  "ykmACsU9kM": {
     "defaultMessage": "Create issue",
     "description": "Menu item and tool title for creating Queries issues"
   },
@@ -2375,7 +2375,7 @@
     "defaultMessage": "Contextual Audit",
     "description": "Label for the contextual dimension on a localisation audit result"
   },
-  "46zk0LJShA": {
+  "S5zYTuw8xI": {
     "defaultMessage": "Triage open work across this workspace.",
     "description": "Short description under the workspace Queries page title"
   },
@@ -2415,7 +2415,7 @@
     "defaultMessage": "Loading file…",
     "description": "Loading state while project file details are fetched"
   },
-  "4Bnw8oUCip": {
+  "PF5J5zLlad": {
     "defaultMessage": "Queries could not be loaded.",
     "description": "Error state when the workspace Queries page fails to load"
   },
@@ -2727,7 +2727,7 @@
     "defaultMessage": "{actor} assigned you to {issueTitle}",
     "description": "Inbox notification preview for issue assignment"
   },
-  "51tdxkVdu+": {
+  "MnuXzcJn6d": {
     "defaultMessage": "{count} P1 on Queries",
     "description": "Open issues metric subtitle showing P1 issue count on Queries"
   },
@@ -3227,7 +3227,7 @@
     "defaultMessage": "{count, plural, one {Explored {subject}, # search} other {Explored {subject}, # searches}}",
     "description": "Collapsed explore rollup with a subject and search count"
   },
-  "6XlImduZ6L": {
+  "MbppXfDsbM": {
     "defaultMessage": "Queries is unavailable for this string.",
     "description": "Shown when the CAT segment cannot link to Queries (missing translation key)"
   },
@@ -3303,7 +3303,7 @@
     "defaultMessage": "Inactive",
     "description": "Badge shown on inactive project cards"
   },
-  "6haGvAy+HC": {
+  "Z44SZamohK": {
     "defaultMessage": "Added to Queries",
     "description": "Toast confirmation after adding a CAT segment to Queries"
   },
@@ -5447,7 +5447,7 @@
     "defaultMessage": "Target locale",
     "description": "Label for the target locale filter"
   },
-  "C5SPm8Zbbu": {
+  "0PhWie0NMV": {
     "defaultMessage": "Queries",
     "description": "Workspace Queries page title"
   },
@@ -5499,7 +5499,7 @@
     "defaultMessage": "Retrying…",
     "description": "Button label while retrying a localisation audit"
   },
-  "CBibCD/p8E": {
+  "8YTMjuiNpw": {
     "defaultMessage": "Read Queries issues for the selected project during this automation.",
     "description": "Description for the List issues automation tool"
   },
@@ -5783,7 +5783,7 @@
     "defaultMessage": "This Canva connect request is missing or expired.",
     "description": "Error when a Canva claim id is missing"
   },
-  "D1Wfd509ws": {
+  "1LT7IofQ2x": {
     "defaultMessage": "Choose which project should receive the imported Queries rows.",
     "description": "Description of the workspace issues CSV import project picker dialog"
   },
@@ -6243,7 +6243,7 @@
     "defaultMessage": "Failed to start agent run",
     "description": "Toast and error fallback when starting an agent run fails"
   },
-  "E8k6bvQHrX": {
+  "sqEo4EAhoy": {
     "defaultMessage": "Close Queries",
     "description": "Accessible label for closing the CAT Queries panel"
   },
@@ -7559,7 +7559,7 @@
     "defaultMessage": "From",
     "description": "Translation reporting label"
   },
-  "Hjj+QG5LDK": {
+  "+gp2sOH/Py": {
     "defaultMessage": "Request failed",
     "description": "Generic fallback when a CAT Queries API request fails"
   },
@@ -7603,7 +7603,7 @@
     "defaultMessage": "Browse Hyperlocalise projects. Connect a TMS provider to view live provider projects alongside them.",
     "description": "Projects page description when no TMS provider is connected"
   },
-  "HrspdhKQl+": {
+  "LThxvPehnJ": {
     "defaultMessage": "Open Queries",
     "description": "Accessible label for the Queries button in the app shell footer"
   },
@@ -8043,7 +8043,7 @@
     "defaultMessage": "Web chat",
     "description": "Trigger label for a web chat automation in the list"
   },
-  "J2Tvcwc2sx": {
+  "21DxEHM2/g": {
     "defaultMessage": "Open Queries, {count} open",
     "description": "Accessible label for the Queries button when open issues are available"
   },
@@ -8071,7 +8071,7 @@
     "defaultMessage": "Improve SEO and AEO discoverability across markets",
     "description": "Feature teaser benefit for domains"
   },
-  "J8uRouTxFR": {
+  "MsQL5pndXv": {
     "defaultMessage": "Choose whether Inbox updates for Queries issues are also delivered to your email.",
     "description": "Helper text under notification preferences on account settings"
   },
@@ -8175,7 +8175,7 @@
     "defaultMessage": "Intercom",
     "description": "Name shown for the Intercom integrations row"
   },
-  "JRZrMUrfeM": {
+  "W+Q3zuZLIK": {
     "defaultMessage": "Triage localization issues for this project.",
     "description": "Short section description for the project Queries page"
   },
@@ -8423,7 +8423,7 @@
     "defaultMessage": "Uploaded",
     "description": "Badge when a native project file has no latest job"
   },
-  "KCIvL0TJB4": {
+  "C5PXkfW5jk": {
     "defaultMessage": "Queries",
     "description": "Button to open Queries for the current CAT segment"
   },
@@ -9015,7 +9015,7 @@
     "defaultMessage": "Loading progress…",
     "description": "Metric and property value while locale readiness is loading"
   },
-  "M+PhLBJ7kK": {
+  "9wRo7aY8DU": {
     "defaultMessage": "View Queries",
     "description": "Link from overview Queries to the issues page"
   },
@@ -9187,7 +9187,7 @@
     "defaultMessage": "Create: {label}",
     "description": "Mapping option to create a new Issue Sheet column from a CSV header"
   },
-  "MQYav5C7q6": {
+  "xpTr69QuG7": {
     "defaultMessage": "Queries",
     "description": "Overview section label for open Queries issues"
   },
@@ -10639,7 +10639,7 @@
     "defaultMessage": "Demo request: Reports",
     "description": "Email subject for Reports feature teaser contact link"
   },
-  "QSTiMWaXF/": {
+  "PfMYbXS/4p": {
     "defaultMessage": "Queries could not be loaded.",
     "description": "Error state when Queries rows fail to load"
   },
@@ -10863,7 +10863,7 @@
     "defaultMessage": "Display name",
     "description": "Label for Canva display name field"
   },
-  "R/mQHxnDLt": {
+  "xotII997CO": {
     "defaultMessage": "Queries",
     "description": "Section title for the project Queries page"
   },
@@ -13159,7 +13159,7 @@
     "defaultMessage": "Audit criteria",
     "description": "Heading for the criteria list on a localisation audit result"
   },
-  "XNK40wY8Cc": {
+  "Njk9QnNzuI": {
     "defaultMessage": "No open issues.",
     "description": "Empty state for overview Queries issues"
   },
@@ -13331,7 +13331,7 @@
     "defaultMessage": "Agent Actions",
     "description": "Heading for available provider agent action buttons"
   },
-  "XswXu+UFpy": {
+  "lo142sTjcF": {
     "defaultMessage": "Queries",
     "description": "Sidebar navigation item for workspace Queries"
   },
@@ -14595,7 +14595,7 @@
     "defaultMessage": "The name and slug used in navigation, invite links, and the workspace URL.",
     "description": "Workspace general settings page description"
   },
-  "bC8xP17A1P": {
+  "r7n1+etxph": {
     "defaultMessage": "Upload a spreadsheet export, map columns to Queries fields, preview the result, then import.",
     "description": "Description of the Issue Sheet CSV import dialog"
   },
@@ -14891,7 +14891,7 @@
     "defaultMessage": "Edit team",
     "description": "Button to open the edit team dialog on the detail page"
   },
-  "cAQmoTwBPJ": {
+  "GqjLAPYWZT": {
     "defaultMessage": "List issues",
     "description": "Menu item and tool title for listing Queries issues"
   },
@@ -15243,7 +15243,7 @@
     "defaultMessage": "Starter",
     "description": "Starter plan name on the pricing page"
   },
-  "dBZKwTIoEH": {
+  "AJII/bEV+O": {
     "defaultMessage": "Failed to add to Queries",
     "description": "Fallback error when creating a Queries row from CAT fails"
   },
@@ -15319,7 +15319,7 @@
     "defaultMessage": "Failed to update locked strings",
     "description": "Fallback error when locking or unlocking CAT segments fails"
   },
-  "dKznjRBgya": {
+  "Y1cFr7sG1J": {
     "defaultMessage": "Queries",
     "description": "Label for the Queries button in the app shell footer"
   },
@@ -16823,7 +16823,7 @@
     "defaultMessage": "Open {projectName} in provider",
     "description": "Screen-reader label for opening a project in its external TMS provider"
   },
-  "h5+KJI2d7A": {
+  "mBox3Bi4Wv": {
     "defaultMessage": "Could not load issues.",
     "description": "Error message when CAT segment Queries issues fail to load"
   },
@@ -16995,7 +16995,7 @@
     "defaultMessage": "Pending",
     "description": "Tool status badge when tool input is still streaming"
   },
-  "hYi0NizHJf": {
+  "g1U3NC/CnC": {
     "defaultMessage": "Queries · this string",
     "description": "Title on the editor mock Queries overlay"
   },
@@ -17399,7 +17399,7 @@
     "defaultMessage": "Review routing",
     "description": "Workflow step 4 label for the localisation-quality-monitoring use case"
   },
-  "igJunofoju": {
+  "zI9Ceuo8wd": {
     "defaultMessage": "Queries",
     "description": "Heading for the CAT segment Queries section"
   },
@@ -18367,7 +18367,7 @@
     "defaultMessage": "—",
     "description": "Placeholder when a glossary timestamp is unavailable"
   },
-  "l+RVkhyT2N": {
+  "fxgs/d7//D": {
     "defaultMessage": "Create a project first, then import issues into Queries.",
     "description": "Empty state when there are no projects to import issues into"
   },
@@ -20619,7 +20619,7 @@
     "defaultMessage": "required",
     "description": "Badge label for a required schema property"
   },
-  "r7gtZsn8Qh": {
+  "j3S46APZAg": {
     "defaultMessage": "Queries",
     "description": "Project sidebar navigation item for project Queries"
   },
@@ -21043,7 +21043,7 @@
     "defaultMessage": "Search microphones...",
     "description": "Placeholder for the microphone search input"
   },
-  "sJoNIftCZI": {
+  "3CjBlEDVPl": {
     "defaultMessage": "Queries",
     "description": "App shell breadcrumb title for the workspace Queries page"
   },
@@ -21259,7 +21259,7 @@
     "defaultMessage": "Block releases when quality gates fail",
     "description": "Capability 6 title for the github-release-localisation use case"
   },
-  "sslu9yZyVp": {
+  "RueTypLijF": {
     "defaultMessage": "Queries",
     "description": "App shell breadcrumb title for the project Queries page"
   },
@@ -21531,7 +21531,7 @@
     "defaultMessage": "APP",
     "description": "Badge next to the Hyperlocalise agent name in the Slack mock"
   },
-  "tX5h+jHyR2": {
+  "svxgBhLpnH": {
     "defaultMessage": "Queries · acme workspace",
     "description": "Queries panel title in content ops mock"
   },
@@ -22711,7 +22711,7 @@
     "defaultMessage": "Open job",
     "description": "CTA for a failed or active job on project overview"
   },
-  "weTyi2vT5M": {
+  "srC39pzddm": {
     "defaultMessage": "File Queries issues for the selected project from automation findings.",
     "description": "Description for the Create issue automation tool"
   },
@@ -23415,7 +23415,7 @@
     "defaultMessage": "Do I need Crowdin, Lokalise, or another TMS first?",
     "description": "Startups FAQ question about needing an existing TMS"
   },
-  "yGs5M+8byg": {
+  "KAvyqkZVul": {
     "defaultMessage": "Add a project-specific workflow column to Queries.",
     "description": "Description of the dialog to add a custom Queries column"
   },

--- a/apps/hyperlocalise-web/src/agents/README.md
+++ b/apps/hyperlocalise-web/src/agents/README.md
@@ -30,7 +30,7 @@ Each package uses Eve-inspired slots under `agent/`:
 
 - **Plan**: deterministic tool order from `toolConfig` and `executorAgent` skill metadata
 - **Execution**: `ToolLoopAgent` with `prepareStep` forcing each planned tool
-- **Tools**: GitHub workflows, Contentful translation, Board list/create,
+- **Tools**: GitHub workflows, Contentful translation, Queries list/create,
   Slack, and email notifications
 
 Child executors remain specialized packages (`contentful`, `github-repository`) but are invoked as orchestrator tools rather than separate dispatch branches.

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
@@ -43,7 +43,7 @@ const createIssueInputSchema = z.object({
     .array(createIssueItemSchema)
     .max(20)
     .describe(
-      "Issues to create on the project board. Pass an empty array when nothing should be filed this run.",
+      "Issues to create in Queries. Pass an empty array when nothing should be filed this run.",
     ),
 });
 
@@ -79,7 +79,7 @@ async function persistCreateIssueOutput(
 export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
   return defineAgentTool({
     description:
-      "Create Hyperlocalise Board issues for the automation project. Pass an empty issues array when there is nothing actionable to file.",
+      "Create Hyperlocalise Queries issues for the automation project. Pass an empty issues array when there is nothing actionable to file.",
     inputSchema: createIssueInputSchema,
     execute: async ({ issues }) => {
       const createConfig = session.automation.toolConfig.createIssue;

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
@@ -65,7 +65,7 @@ function compactIssue(issue: {
 export function createListIssuesTool(session: WorkspaceOrchestratorSession) {
   return defineAgentTool({
     description:
-      "List Hyperlocalise Board issues for the automation project. Use filters to triage open work before creating or notifying.",
+      "List Hyperlocalise Queries issues for the automation project. Use filters to triage open work before creating or notifying.",
     inputSchema: listIssuesInputSchema,
     execute: async (input) => {
       const listConfig = session.automation.toolConfig.listIssues;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -311,9 +311,9 @@ export const workspaceAutomationFormMessages = defineMessages({
     description: "Submenu label grouping native TMS job automation tools",
   },
   issuesToolsMenu: {
-    defaultMessage: "Board",
+    defaultMessage: "Queries",
     id: "32+8NTo5Pl",
-    description: "Submenu label grouping Board automation tools",
+    description: "Submenu label grouping Queries automation tools",
   },
   memories: {
     defaultMessage: "Use workspace guideline",
@@ -410,20 +410,20 @@ export const workspaceAutomationFormMessages = defineMessages({
   listIssues: {
     defaultMessage: "List issues",
     id: "cAQmoTwBPJ",
-    description: "Menu item and tool title for listing Board issues",
+    description: "Menu item and tool title for listing Queries issues",
   },
   listIssuesDescription: {
-    defaultMessage: "Read board issues for the selected project during this automation.",
+    defaultMessage: "Read Queries issues for the selected project during this automation.",
     id: "CBibCD/p8E",
     description: "Description for the List issues automation tool",
   },
   createIssue: {
     defaultMessage: "Create issue",
     id: "3W0VCaMyWO",
-    description: "Menu item and tool title for creating Board issues",
+    description: "Menu item and tool title for creating Queries issues",
   },
   createIssueDescription: {
-    defaultMessage: "File board issues for the selected project from automation findings.",
+    defaultMessage: "File Queries issues for the selected project from automation findings.",
     id: "weTyi2vT5M",
     description: "Description for the Create issue automation tool",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -312,7 +312,7 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   issuesToolsMenu: {
     defaultMessage: "Queries",
-    id: "32+8NTo5Pl",
+    id: "5yzXr6bGIC",
     description: "Submenu label grouping Queries automation tools",
   },
   memories: {
@@ -409,22 +409,22 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   listIssues: {
     defaultMessage: "List issues",
-    id: "cAQmoTwBPJ",
+    id: "GqjLAPYWZT",
     description: "Menu item and tool title for listing Queries issues",
   },
   listIssuesDescription: {
     defaultMessage: "Read Queries issues for the selected project during this automation.",
-    id: "CBibCD/p8E",
+    id: "8YTMjuiNpw",
     description: "Description for the List issues automation tool",
   },
   createIssue: {
     defaultMessage: "Create issue",
-    id: "3W0VCaMyWO",
+    id: "ykmACsU9kM",
     description: "Menu item and tool title for creating Queries issues",
   },
   createIssueDescription: {
     defaultMessage: "File Queries issues for the selected project from automation findings.",
-    id: "weTyi2vT5M",
+    id: "srC39pzddm",
     description: "Description for the Create issue automation tool",
   },
   removeListIssues: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.messages.ts
@@ -86,9 +86,9 @@ export const dashboardPageViewMessages = defineMessages({
     description: "Automations metric subtitle showing how many automations are paused",
   },
   p1Count: {
-    defaultMessage: "{count} P1 on Board",
+    defaultMessage: "{count} P1 on Queries",
     id: "51tdxkVdu+",
-    description: "Open issues metric subtitle showing P1 issue count on the board",
+    description: "Open issues metric subtitle showing P1 issue count on Queries",
   },
   automationActivityKind: {
     defaultMessage: "Automation",
@@ -111,9 +111,9 @@ export const dashboardPageViewMessages = defineMessages({
     description: "Overview section label for workspace projects",
   },
   boardLabel: {
-    defaultMessage: "Board",
+    defaultMessage: "Queries",
     id: "MQYav5C7q6",
-    description: "Overview section label for open issues",
+    description: "Overview section label for open Queries issues",
   },
   automationsLabel: {
     defaultMessage: "Automations",
@@ -131,9 +131,9 @@ export const dashboardPageViewMessages = defineMessages({
     description: "Link from overview projects to the projects page",
   },
   viewBoard: {
-    defaultMessage: "View Board",
+    defaultMessage: "View Queries",
     id: "M+PhLBJ7kK",
-    description: "Link from overview board to the issues page",
+    description: "Link from overview Queries to the issues page",
   },
   viewAutomations: {
     defaultMessage: "View automations",
@@ -153,7 +153,7 @@ export const dashboardPageViewMessages = defineMessages({
   boardEmpty: {
     defaultMessage: "No open issues.",
     id: "XNK40wY8Cc",
-    description: "Empty state for overview board issues",
+    description: "Empty state for overview Queries issues",
   },
   automationsEmpty: {
     defaultMessage: "No automation runs yet.",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.messages.ts
@@ -87,7 +87,7 @@ export const dashboardPageViewMessages = defineMessages({
   },
   p1Count: {
     defaultMessage: "{count} P1 on Queries",
-    id: "51tdxkVdu+",
+    id: "MnuXzcJn6d",
     description: "Open issues metric subtitle showing P1 issue count on Queries",
   },
   automationActivityKind: {
@@ -112,7 +112,7 @@ export const dashboardPageViewMessages = defineMessages({
   },
   boardLabel: {
     defaultMessage: "Queries",
-    id: "MQYav5C7q6",
+    id: "xpTr69QuG7",
     description: "Overview section label for open Queries issues",
   },
   automationsLabel: {
@@ -132,7 +132,7 @@ export const dashboardPageViewMessages = defineMessages({
   },
   viewBoard: {
     defaultMessage: "View Queries",
-    id: "M+PhLBJ7kK",
+    id: "9wRo7aY8DU",
     description: "Link from overview Queries to the issues page",
   },
   viewAutomations: {
@@ -152,7 +152,7 @@ export const dashboardPageViewMessages = defineMessages({
   },
   boardEmpty: {
     defaultMessage: "No open issues.",
-    id: "XNK40wY8Cc",
+    id: "Njk9QnNzuI",
     description: "Empty state for overview Queries issues",
   },
   automationsEmpty: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
@@ -98,10 +98,10 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Overview" })).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "Connect your agent" })).toBeInTheDocument();
-    await expect(canvas.getByText("2 P1 on Board")).toBeInTheDocument();
+    await expect(canvas.getByText("2 P1 on Queries")).toBeInTheDocument();
     await expect(canvas.getByText("Activity")).toBeInTheDocument();
     await expect(canvas.getByText("Projects")).toBeInTheDocument();
-    await expect(canvas.getByText("Board")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries")).toBeInTheDocument();
     await expect(canvas.getByText("View automations")).toBeInTheDocument();
     await expect(canvas.getByText("WEB-1")).toBeInTheDocument();
     await expect(canvas.getByText("Missing CTA on checkout")).toBeInTheDocument();
@@ -115,7 +115,7 @@ export const AutomationsDisabled: Story = {
     automationsEnabled: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Board")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries")).toBeInTheDocument();
     await expect(canvas.queryByText("View automations")).not.toBeInTheDocument();
     await expect(canvas.queryByText("1 paused")).not.toBeInTheDocument();
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.messages.ts
@@ -16,19 +16,19 @@ import { defineMessages } from "react-intl";
 
 export const issuesPageViewMessages = defineMessages({
   pageTitle: {
-    defaultMessage: "Board",
+    defaultMessage: "Queries",
     id: "C5SPm8Zbbu",
-    description: "Workspace board page title",
+    description: "Workspace Queries page title",
   },
   pageDescription: {
     defaultMessage: "Triage open work across this workspace.",
     id: "46zk0LJShA",
-    description: "Short description under the workspace Board page title",
+    description: "Short description under the workspace Queries page title",
   },
   loadError: {
-    defaultMessage: "The board could not be loaded.",
+    defaultMessage: "Queries could not be loaded.",
     id: "4Bnw8oUCip",
-    description: "Error state when the workspace board fails to load",
+    description: "Error state when the workspace Queries page fails to load",
   },
   empty: {
     defaultMessage: "No issues match this view.",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.messages.ts
@@ -17,17 +17,17 @@ import { defineMessages } from "react-intl";
 export const issuesPageViewMessages = defineMessages({
   pageTitle: {
     defaultMessage: "Queries",
-    id: "C5SPm8Zbbu",
+    id: "0PhWie0NMV",
     description: "Workspace Queries page title",
   },
   pageDescription: {
     defaultMessage: "Triage open work across this workspace.",
-    id: "46zk0LJShA",
+    id: "S5zYTuw8xI",
     description: "Short description under the workspace Queries page title",
   },
   loadError: {
     defaultMessage: "Queries could not be loaded.",
-    id: "4Bnw8oUCip",
+    id: "PF5J5zLlad",
     description: "Error state when the workspace Queries page fails to load",
   },
   empty: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
@@ -22,7 +22,7 @@ import {
 import { IssuesPageView } from "./issues-page-view";
 
 const meta = {
-  title: "App/Board/Page",
+  title: "App/Queries/Page",
   component: IssuesPageView,
   parameters: {
     layout: "fullscreen",
@@ -46,7 +46,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getByRole("heading", { name: "Board" })).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "Queries" })).toBeInTheDocument();
     await expect(canvas.getByText("Source string needs context")).toBeInTheDocument();
     await expect(canvas.getByText("Website localization")).toBeInTheDocument();
     await expect(canvas.getByText("Open")).toBeInTheDocument();
@@ -63,7 +63,7 @@ export const Loading: Story = {
     isLoading: true,
   },
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getByRole("heading", { name: "Board" })).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "Queries" })).toBeInTheDocument();
     await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(
       0,
     );
@@ -93,7 +93,7 @@ export const Error: Story = {
     isError: true,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("The board could not be loaded.")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries could not be loaded.")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.messages.ts
@@ -21,12 +21,12 @@ export const issuesProjectImportDialogMessages = defineMessages({
     description: "Title of the workspace issues CSV import project picker dialog",
   },
   description: {
-    defaultMessage: "Choose which project should receive the imported board rows.",
+    defaultMessage: "Choose which project should receive the imported Queries rows.",
     id: "D1Wfd509ws",
     description: "Description of the workspace issues CSV import project picker dialog",
   },
   emptyProjects: {
-    defaultMessage: "Create a project first, then import issues into its board.",
+    defaultMessage: "Create a project first, then import issues into Queries.",
     id: "l+RVkhyT2N",
     description: "Empty state when there are no projects to import issues into",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.messages.ts
@@ -22,12 +22,12 @@ export const issuesProjectImportDialogMessages = defineMessages({
   },
   description: {
     defaultMessage: "Choose which project should receive the imported Queries rows.",
-    id: "D1Wfd509ws",
+    id: "1LT7IofQ2x",
     description: "Description of the workspace issues CSV import project picker dialog",
   },
   emptyProjects: {
     defaultMessage: "Create a project first, then import issues into Queries.",
-    id: "l+RVkhyT2N",
+    id: "fxgs/d7//D",
     description: "Empty state when there are no projects to import issues into",
   },
   cancel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.messages.ts
@@ -22,7 +22,7 @@ export const issueSheetImportDialogMessages = defineMessages({
   },
   description: {
     defaultMessage:
-      "Upload a spreadsheet export, map columns to board fields, preview the result, then import.",
+      "Upload a spreadsheet export, map columns to Queries fields, preview the result, then import.",
     id: "bC8xP17A1P",
     description: "Description of the Issue Sheet CSV import dialog",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.messages.ts
@@ -23,7 +23,7 @@ export const issueSheetImportDialogMessages = defineMessages({
   description: {
     defaultMessage:
       "Upload a spreadsheet export, map columns to Queries fields, preview the result, then import.",
-    id: "bC8xP17A1P",
+    id: "r7n1+etxph",
     description: "Description of the Issue Sheet CSV import dialog",
   },
   chooseCsvFile: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
@@ -16,14 +16,14 @@ import { defineMessages } from "react-intl";
 
 export const issueSheetPageContentMessages = defineMessages({
   sectionTitle: {
-    defaultMessage: "Board",
+    defaultMessage: "Queries",
     id: "R/mQHxnDLt",
-    description: "Section title for the project Board page",
+    description: "Section title for the project Queries page",
   },
   sectionDescription: {
     defaultMessage: "Triage localization issues for this project.",
     id: "JRZrMUrfeM",
-    description: "Short section description for the project Board page",
+    description: "Short section description for the project Queries page",
   },
   importCsv: {
     defaultMessage: "Import CSV",
@@ -101,9 +101,9 @@ export const issueSheetPageContentMessages = defineMessages({
     description: "Loading state shown while Issue Sheet rows are fetching",
   },
   loadIssuesError: {
-    defaultMessage: "The board could not be loaded.",
+    defaultMessage: "Queries could not be loaded.",
     id: "QSTiMWaXF/",
-    description: "Error state when Board rows fail to load",
+    description: "Error state when Queries rows fail to load",
   },
   emptyTitle: {
     defaultMessage: "No issues in this view.",
@@ -157,9 +157,9 @@ export const issueSheetPageContentMessages = defineMessages({
     description: "Title of the dialog to add a custom Issue Sheet column",
   },
   addColumnDescription: {
-    defaultMessage: "Add a project-specific workflow column to the board.",
+    defaultMessage: "Add a project-specific workflow column to Queries.",
     id: "yGs5M+8byg",
-    description: "Description of the dialog to add a custom Board column",
+    description: "Description of the dialog to add a custom Queries column",
   },
   columnIconLabel: {
     defaultMessage: "Icon",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
@@ -17,12 +17,12 @@ import { defineMessages } from "react-intl";
 export const issueSheetPageContentMessages = defineMessages({
   sectionTitle: {
     defaultMessage: "Queries",
-    id: "R/mQHxnDLt",
+    id: "xotII997CO",
     description: "Section title for the project Queries page",
   },
   sectionDescription: {
     defaultMessage: "Triage localization issues for this project.",
-    id: "JRZrMUrfeM",
+    id: "W+Q3zuZLIK",
     description: "Short section description for the project Queries page",
   },
   importCsv: {
@@ -102,7 +102,7 @@ export const issueSheetPageContentMessages = defineMessages({
   },
   loadIssuesError: {
     defaultMessage: "Queries could not be loaded.",
-    id: "QSTiMWaXF/",
+    id: "PfMYbXS/4p",
     description: "Error state when Queries rows fail to load",
   },
   emptyTitle: {
@@ -158,7 +158,7 @@ export const issueSheetPageContentMessages = defineMessages({
   },
   addColumnDescription: {
     defaultMessage: "Add a project-specific workflow column to Queries.",
-    id: "yGs5M+8byg",
+    id: "KAvyqkZVul",
     description: "Description of the dialog to add a custom Queries column",
   },
   columnIconLabel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
@@ -23,7 +23,7 @@ import { issueSheetOrganizationSlug, issueSheetProjectId } from "./issue-sheet.f
 import { IssueSheetPageContent } from "./issue-sheet-page-content";
 
 const meta = {
-  title: "App/Board/Project",
+  title: "App/Queries/Project",
   component: IssueSheetPageContent,
   parameters: {
     layout: "fullscreen",
@@ -49,7 +49,7 @@ export const Default: Story = {
     },
   },
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getByText("Board")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries")).toBeInTheDocument();
     await expect(canvas.getByText("Source string needs context")).toBeInTheDocument();
     await expect(canvas.getByText("Open")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Issue" })).toBeInTheDocument();
@@ -69,7 +69,7 @@ export const Loading: Story = {
     },
   },
   play: async ({ canvas, canvasElement }) => {
-    await expect(canvas.getByText("Board")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries")).toBeInTheDocument();
     await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(
       0,
     );
@@ -97,8 +97,8 @@ export const Error: Story = {
     },
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Board")).toBeInTheDocument();
-    await expect(canvas.getByText("The board could not be loaded.")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries could not be loaded.")).toBeInTheDocument();
     await expect(canvas.queryByText("No issues in this view.")).not.toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.messages.ts
@@ -22,7 +22,7 @@ export const notificationPreferencesFormMessages = defineMessages({
   },
   sectionDescription: {
     defaultMessage:
-      "Choose whether Inbox updates for board issues are also delivered to your email.",
+      "Choose whether Inbox updates for Queries issues are also delivered to your email.",
     id: "J8uRouTxFR",
     description: "Helper text under notification preferences on account settings",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/notification-preferences-form.messages.ts
@@ -23,7 +23,7 @@ export const notificationPreferencesFormMessages = defineMessages({
   sectionDescription: {
     defaultMessage:
       "Choose whether Inbox updates for Queries issues are also delivered to your email.",
-    id: "J8uRouTxFR",
+    id: "MsQL5pndXv",
     description: "Helper text under notification preferences on account settings",
   },
   emailEnabledLabel: {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -38,17 +38,17 @@ export const appShellFooterMessages = defineMessages({
   },
   issueGuidanceAriaLabel: {
     defaultMessage: "Open Queries",
-    id: "HrspdhKQl+",
+    id: "LThxvPehnJ",
     description: "Accessible label for the Queries button in the app shell footer",
   },
   issueGuidanceAvailableAriaLabel: {
     defaultMessage: "Open Queries, {count} open",
-    id: "J2Tvcwc2sx",
+    id: "21DxEHM2/g",
     description: "Accessible label for the Queries button when open issues are available",
   },
   issueGuidanceLabel: {
     defaultMessage: "Queries",
-    id: "dKznjRBgya",
+    id: "Y1cFr7sG1J",
     description: "Label for the Queries button in the app shell footer",
   },
   styleGuideAriaLabel: {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -37,19 +37,19 @@ export const appShellFooterMessages = defineMessages({
     description: "Label for the glossary guidance button in the app shell footer",
   },
   issueGuidanceAriaLabel: {
-    defaultMessage: "Open board",
+    defaultMessage: "Open Queries",
     id: "HrspdhKQl+",
-    description: "Accessible label for the Board button in the app shell footer",
+    description: "Accessible label for the Queries button in the app shell footer",
   },
   issueGuidanceAvailableAriaLabel: {
-    defaultMessage: "Open board, {count} open",
+    defaultMessage: "Open Queries, {count} open",
     id: "J2Tvcwc2sx",
-    description: "Accessible label for the Board button when open issues are available",
+    description: "Accessible label for the Queries button when open issues are available",
   },
   issueGuidanceLabel: {
-    defaultMessage: "Board",
+    defaultMessage: "Queries",
     id: "dKznjRBgya",
-    description: "Label for the Board button in the app shell footer",
+    description: "Label for the Queries button in the app shell footer",
   },
   styleGuideAriaLabel: {
     defaultMessage: "Open style guide",

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.stories.tsx
@@ -124,7 +124,7 @@ export const SupportOnly: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("link", { name: "Email support" })).toBeInTheDocument();
     await expect(canvas.queryByRole("button", { name: "New request" })).not.toBeInTheDocument();
-    await expect(canvas.queryByText("Board")).not.toBeInTheDocument();
+    await expect(canvas.queryByText("Queries")).not.toBeInTheDocument();
   },
 };
 
@@ -149,7 +149,7 @@ export const GuidanceAvailable: Story = {
     const glossaryButton = canvas.getByRole("button", {
       name: "Glossary guidance, concept matches available",
     });
-    const issuesButton = canvas.getByRole("button", { name: "Open board, 2 open" });
+    const issuesButton = canvas.getByRole("button", { name: "Open Queries, 2 open" });
 
     await expect(glossaryButton).toBeInTheDocument();
     await expect(issuesButton).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -186,8 +186,8 @@ describe("AppShellFooter", () => {
 
     renderFooter({ showPlan: false, showIssueGuidance: true });
 
-    const issues = screen.getByRole("button", { name: "Open board, 2 open" });
-    expect(issues).toHaveTextContent("Board");
+    const issues = screen.getByRole("button", { name: "Open Queries, 2 open" });
+    expect(issues).toHaveTextContent("Queries");
     expect(issues).toHaveTextContent("2");
 
     try {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -23,6 +23,7 @@ describe("getAppShellTitle", () => {
   it.each([
     ["/org/acme/dashboard", "Overview"],
     ["/org/acme/inbox", "Inbox"],
+    ["/org/acme/issues", "Queries"],
     ["/org/acme/inbox/new", "New Request"],
     ["/org/acme/projects", "Projects"],
     ["/org/acme/projects/proj_1", "proj_1"],
@@ -30,7 +31,7 @@ describe("getAppShellTitle", () => {
     ["/org/acme/projects/proj_1/jobs", "Jobs"],
     ["/org/acme/projects/proj_1/automations", "Automations"],
     ["/org/acme/projects/proj_1/knowledge", "Guideline"],
-    ["/org/acme/projects/proj_1/issue-sheet", "Board"],
+    ["/org/acme/projects/proj_1/issue-sheet", "Queries"],
     ["/org/acme/projects/proj_1/strings", "Content Editor"],
     ["/org/acme/projects/proj_1/agent-runs", "Agent Runs"],
     ["/org/acme/projects/proj_1/activity", "Activity"],
@@ -196,11 +197,11 @@ describe("getAppShellBreadcrumbs", () => {
     ).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
-      { label: "Board" },
+      { label: "Queries" },
     ]);
   });
 
-  it("links Board when viewing a permanent issue detail URL", () => {
+  it("links Queries when viewing a permanent issue detail URL", () => {
     expect(
       getAppShellBreadcrumbs(
         "/org/acme/projects/proj_1/issue-sheet/11111111-1111-4111-8111-111111111111",
@@ -210,7 +211,7 @@ describe("getAppShellBreadcrumbs", () => {
     ).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
-      { label: "Board", href: "/org/acme/projects/proj_1/issue-sheet" },
+      { label: "Queries", href: "/org/acme/projects/proj_1/issue-sheet" },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -233,15 +233,15 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
       });
     case "issues":
       return intl.formatMessage({
-        defaultMessage: "Board",
+        defaultMessage: "Queries",
         id: "sJoNIftCZI",
-        description: "App shell breadcrumb title for the workspace board page",
+        description: "App shell breadcrumb title for the workspace Queries page",
       });
     case "issue-sheet":
       return intl.formatMessage({
-        defaultMessage: "Board",
+        defaultMessage: "Queries",
         id: "sslu9yZyVp",
-        description: "App shell breadcrumb title for the project board page",
+        description: "App shell breadcrumb title for the project Queries page",
       });
     case "jobs":
       return intl.formatMessage({

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -234,13 +234,13 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
     case "issues":
       return intl.formatMessage({
         defaultMessage: "Queries",
-        id: "sJoNIftCZI",
+        id: "3CjBlEDVPl",
         description: "App shell breadcrumb title for the workspace Queries page",
       });
     case "issue-sheet":
       return intl.formatMessage({
         defaultMessage: "Queries",
-        id: "sslu9yZyVp",
+        id: "RueTypLijF",
         description: "App shell breadcrumb title for the project Queries page",
       });
     case "jobs":

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.tsx
@@ -104,7 +104,7 @@ export const ContentEditorFooter: Story = {
     await expect(
       canvas.getByRole("button", { name: "Open glossary guidance" }),
     ).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Open board" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Open Queries" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: /Open plan usage:/i })).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -205,7 +205,7 @@ describe("path builders", () => {
     expect(byLabel.get("AI Engine")?.href).toBe("/org/acme/ai-engine");
     expect(byLabel.get("Automations")?.featureFlagKey).toBe(WORKSPACE_AUTOMATIONS_FLAG);
     expect(byLabel.get("Guideline")?.featureFlagKey).toBe(WORKSPACE_KNOWLEDGE_FLAG);
-    expect(byLabel.get("Board")?.featureFlagKey).toBeUndefined();
+    expect(byLabel.get("Queries")?.featureFlagKey).toBeUndefined();
     expect(byLabel.get("Domains")?.featureFlagKey).toBe(WORKSPACE_DOMAINS_FLAG);
     expect(byLabel.get("Hyperlab")?.href).toBe("/org/acme/hyperlab");
     expect(byLabel.get("Hyperlab")?.featureFlagKey).toBe(WORKSPACE_HYPERLAB_FLAG);
@@ -221,7 +221,7 @@ describe("path builders", () => {
     expect(groups[0]?.items.map((item) => item.label)).toEqual([
       "Inbox",
       "My Jobs",
-      "Board",
+      "Queries",
       "Overview",
       "Reports",
     ]);
@@ -236,12 +236,12 @@ describe("path builders", () => {
       ["Files", "/org/acme/projects/proj_1/files"],
       ["Content Editor", "/org/acme/projects/proj_1/strings"],
       ["Jobs", "/org/acme/projects/proj_1/jobs"],
-      ["Board", "/org/acme/projects/proj_1/issue-sheet"],
+      ["Queries", "/org/acme/projects/proj_1/issue-sheet"],
       ["Automations", "/org/acme/projects/proj_1/automations"],
       ["Guideline", "/org/acme/projects/proj_1/knowledge"],
       ["Settings", "/org/acme/projects/proj_1/settings"],
     ]);
-    expect(items.find((item) => item.label === "Board")?.featureFlagKey).toBeUndefined();
+    expect(items.find((item) => item.label === "Queries")?.featureFlagKey).toBeUndefined();
     expect(items.find((item) => item.label === "Automations")?.featureFlagKey).toBe(
       WORKSPACE_AUTOMATIONS_FLAG,
     );

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -139,9 +139,9 @@ export function buildGlobalNavigationGroups(
         },
         {
           label: intl.formatMessage({
-            defaultMessage: "Board",
+            defaultMessage: "Queries",
             id: "XswXu+UFpy",
-            description: "Sidebar navigation item for the workspace board",
+            description: "Sidebar navigation item for workspace Queries",
           }),
           href: org("issues"),
           icon: Copy01Icon,
@@ -406,9 +406,9 @@ export function buildProjectNavigationItems(
     },
     {
       label: intl.formatMessage({
-        defaultMessage: "Board",
+        defaultMessage: "Queries",
         id: "r7gtZsn8Qh",
-        description: "Project sidebar navigation item for the project board",
+        description: "Project sidebar navigation item for project Queries",
       }),
       href: project("issue-sheet"),
       icon: Copy01Icon,

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -140,7 +140,7 @@ export function buildGlobalNavigationGroups(
         {
           label: intl.formatMessage({
             defaultMessage: "Queries",
-            id: "XswXu+UFpy",
+            id: "lo142sTjcF",
             description: "Sidebar navigation item for workspace Queries",
           }),
           href: org("issues"),
@@ -407,7 +407,7 @@ export function buildProjectNavigationItems(
     {
       label: intl.formatMessage({
         defaultMessage: "Queries",
-        id: "r7gtZsn8Qh",
+        id: "j3S46APZAg",
         description: "Project sidebar navigation item for project Queries",
       }),
       href: project("issue-sheet"),

--- a/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.stories.tsx
@@ -175,7 +175,7 @@ export const WithCommentsAndIssues: Story = {
     await expect(canvas.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
     await expect(canvas.getAllByText("Issue")).toHaveLength(3);
 
-    const issueSheetButton = canvas.getByRole("button", { name: "Board" });
+    const issueSheetButton = canvas.getByRole("button", { name: "Queries" });
     await expect(issueSheetButton).toBeInTheDocument();
     await userEvent.click(issueSheetButton);
     await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
@@ -220,7 +220,7 @@ export const CommentOnly: Story = {
     const canvas = within(canvasElement);
     await expect(canvas.queryByRole("tab", { name: "Issue" })).not.toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Add comment" })).toBeInTheDocument();
-    await expect(canvas.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Queries" })).not.toBeInTheDocument();
   },
 };
 
@@ -233,7 +233,7 @@ export const IssueSheetCtaWithExistingIssues: Story = {
   },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
-    const issueSheetButton = canvas.getByRole("button", { name: "Board" });
+    const issueSheetButton = canvas.getByRole("button", { name: "Queries" });
 
     await expect(issueSheetButton).toBeInTheDocument();
     await expect(issueSheetButton).toBeEnabled();
@@ -251,12 +251,12 @@ export const IssueSheetCtaOnIssueTab: Story = {
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Queries" })).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole("tab", { name: "Issue" }));
-    await waitFor(() => expect(canvas.getByRole("button", { name: "Board" })).toBeInTheDocument());
+    await waitFor(() => expect(canvas.getByRole("button", { name: "Queries" })).toBeInTheDocument());
 
-    await userEvent.click(canvas.getByRole("button", { name: "Board" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Queries" }));
     await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
   },
 };
@@ -275,7 +275,7 @@ export const IssueSheetCtaHiddenOnCommentTab: Story = {
       "data-state",
       "active",
     );
-    await expect(canvas.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Queries" })).not.toBeInTheDocument();
   },
 };
 
@@ -290,7 +290,7 @@ export const IssueSheetCtaDisabledWhilePosting: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.getByRole("button", { name: "Board" })).toBeDisabled();
+    await expect(canvas.getByRole("button", { name: "Queries" })).toBeDisabled();
   },
 };
 
@@ -305,7 +305,7 @@ export const RaiseIssueInteraction: Story = {
     await userEvent.click(canvas.getByRole("tab", { name: "Issue" }));
     await waitFor(() => expect(canvas.getByText("Issue type")).toBeInTheDocument());
     await expect(canvas.getByText("General question")).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Board" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Queries" })).toBeInTheDocument();
 
     const input = canvas.getByPlaceholderText("Add a comment...");
     await userEvent.type(input, "Wrong tone for ja-JP.");
@@ -316,7 +316,7 @@ export const RaiseIssueInteraction: Story = {
     await expect(canvas.getByText("1")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
 
-    await userEvent.click(canvas.getByRole("button", { name: "Board" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Queries" }));
     await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
   },
 };

--- a/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.stories.tsx
@@ -254,7 +254,9 @@ export const IssueSheetCtaOnIssueTab: Story = {
     await expect(canvas.queryByRole("button", { name: "Queries" })).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole("tab", { name: "Issue" }));
-    await waitFor(() => expect(canvas.getByRole("button", { name: "Queries" })).toBeInTheDocument());
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: "Queries" })).toBeInTheDocument(),
+    );
 
     await userEvent.click(canvas.getByRole("button", { name: "Queries" }));
     await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);

--- a/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-comments-section.test.tsx
@@ -61,7 +61,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.getByRole("button", { name: "Board" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Queries" })).toBeInTheDocument();
   });
 
   it("shows the Issue Sheet CTA when the Issue tab is selected", async () => {
@@ -71,11 +71,11 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Queries" })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Issue" }));
 
-    expect(screen.getByRole("button", { name: "Board" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Queries" })).toBeInTheDocument();
   });
 
   it("hides the Issue Sheet CTA on the Comment tab when there are no issue comments", () => {
@@ -86,7 +86,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Queries" })).not.toBeInTheDocument();
   });
 
   it("hides the Issue Sheet CTA when no handler is provided", () => {
@@ -96,7 +96,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       }),
     });
 
-    expect(screen.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Queries" })).not.toBeInTheDocument();
   });
 
   it("hides the Issue Sheet CTA when issue comments are unsupported", () => {
@@ -108,7 +108,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.queryByRole("button", { name: "Board" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Queries" })).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Issue" })).not.toBeInTheDocument();
   });
 
@@ -123,7 +123,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet,
     });
 
-    await user.click(screen.getByRole("button", { name: "Board" }));
+    await user.click(screen.getByRole("button", { name: "Queries" }));
 
     expect(onOpenIssueSheet).toHaveBeenCalledTimes(1);
   });
@@ -137,7 +137,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.getByRole("button", { name: "Board" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Queries" })).toBeDisabled();
   });
 
   it("disables the Issue Sheet CTA while resolving an issue", () => {
@@ -150,7 +150,7 @@ describe("ContentEditorEditorCommentsSection", () => {
       onOpenIssueSheet: vi.fn(),
     });
 
-    expect(screen.getByRole("button", { name: "Board" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Queries" })).toBeDisabled();
   });
 
   it("posts a plain comment without issue metadata on the Comment tab", async () => {

--- a/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-panel.test.tsx
@@ -132,7 +132,7 @@ describe("ContentEditorEditorPanel UI", () => {
     const commentsSection = screen.getByText("Comments").closest("section");
     expect(commentsSection).not.toBeNull();
 
-    await user.click(within(commentsSection!).getByRole("button", { name: "Board" }));
+    await user.click(within(commentsSection!).getByRole("button", { name: "Queries" }));
 
     expect(onAddToIssueSheet).toHaveBeenCalledTimes(1);
   });

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.messages.ts
@@ -17,7 +17,7 @@ import { defineMessages } from "react-intl";
 export const contentEditorEditorIssuesSectionMessages = defineMessages({
   title: {
     defaultMessage: "Queries",
-    id: "igJunofoju",
+    id: "zI9Ceuo8wd",
     description: "Heading for the CAT segment Queries section",
   },
   createIssue: {
@@ -37,22 +37,22 @@ export const contentEditorEditorIssuesSectionMessages = defineMessages({
   },
   loadError: {
     defaultMessage: "Could not load issues.",
-    id: "h5+KJI2d7A",
+    id: "mBox3Bi4Wv",
     description: "Error message when CAT segment Queries issues fail to load",
   },
   unavailable: {
     defaultMessage: "Queries is unavailable for this string.",
-    id: "6XlImduZ6L",
+    id: "MbppXfDsbM",
     description: "Shown when the CAT segment cannot link to Queries (missing translation key)",
   },
   requestFailed: {
     defaultMessage: "Request failed",
-    id: "Hjj+QG5LDK",
+    id: "+gp2sOH/Py",
     description: "Generic fallback when a CAT Queries API request fails",
   },
   close: {
     defaultMessage: "Close Queries",
-    id: "E8k6bvQHrX",
+    id: "sqEo4EAhoy",
     description: "Accessible label for closing the CAT Queries panel",
   },
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.messages.ts
@@ -16,9 +16,9 @@ import { defineMessages } from "react-intl";
 
 export const contentEditorEditorIssuesSectionMessages = defineMessages({
   title: {
-    defaultMessage: "Board",
+    defaultMessage: "Queries",
     id: "igJunofoju",
-    description: "Heading for the CAT segment Board section",
+    description: "Heading for the CAT segment Queries section",
   },
   createIssue: {
     defaultMessage: "New issue",
@@ -38,21 +38,21 @@ export const contentEditorEditorIssuesSectionMessages = defineMessages({
   loadError: {
     defaultMessage: "Could not load issues.",
     id: "h5+KJI2d7A",
-    description: "Error message when CAT segment board issues fail to load",
+    description: "Error message when CAT segment Queries issues fail to load",
   },
   unavailable: {
-    defaultMessage: "Board is unavailable for this string.",
+    defaultMessage: "Queries is unavailable for this string.",
     id: "6XlImduZ6L",
-    description: "Shown when the CAT segment cannot link to the Board (missing translation key)",
+    description: "Shown when the CAT segment cannot link to Queries (missing translation key)",
   },
   requestFailed: {
     defaultMessage: "Request failed",
     id: "Hjj+QG5LDK",
-    description: "Generic fallback when a CAT Board API request fails",
+    description: "Generic fallback when a CAT Queries API request fails",
   },
   close: {
-    defaultMessage: "Close board",
+    defaultMessage: "Close Queries",
     id: "E8k6bvQHrX",
-    description: "Accessible label for closing the CAT Board panel",
+    description: "Accessible label for closing the CAT Queries panel",
   },
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.stories.tsx
@@ -74,7 +74,7 @@ type Story = StoryObj<typeof meta>;
 export const WithLinkedIssues: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText("Board")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: /New issue/i })).toBeInTheDocument();
   },
 };
@@ -102,6 +102,6 @@ export const UnavailableWithoutKey: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText("Board is unavailable for this string.")).toBeInTheDocument();
+    await expect(canvas.getByText("Queries is unavailable for this string.")).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/issues/content-editor-editor-issues-section.test.tsx
@@ -168,7 +168,7 @@ describe("ContentEditorEditorIssuesSection", () => {
     await waitFor(() =>
       expect(getCatIssueGuidanceStatus()).toEqual({ available: true, openIssueCount: 1 }),
     );
-    expect(screen.queryByRole("heading", { name: "Board" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Queries" })).toBeNull();
   });
 
   it("clears footer guidance on unmount", async () => {

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.messages.ts
@@ -62,12 +62,12 @@ export const projectFileCatWorkspaceMessages = defineMessages({
   },
   failedToAddToIssueSheet: {
     defaultMessage: "Failed to add to Queries",
-    id: "dBZKwTIoEH",
+    id: "AJII/bEV+O",
     description: "Fallback error when creating a Queries row from CAT fails",
   },
   addedToIssueSheet: {
     defaultMessage: "Added to Queries",
-    id: "6haGvAy+HC",
+    id: "Z44SZamohK",
     description: "Toast confirmation after adding a CAT segment to Queries",
   },
   viewIssueSheetRow: {

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.messages.ts
@@ -61,14 +61,14 @@ export const projectFileCatWorkspaceMessages = defineMessages({
     description: "Link label on an issue sheet row pointing back to the Content Editor",
   },
   failedToAddToIssueSheet: {
-    defaultMessage: "Failed to add to Board",
+    defaultMessage: "Failed to add to Queries",
     id: "dBZKwTIoEH",
-    description: "Fallback error when creating an issue sheet row from CAT fails",
+    description: "Fallback error when creating a Queries row from CAT fails",
   },
   addedToIssueSheet: {
-    defaultMessage: "Added to Board",
+    defaultMessage: "Added to Queries",
     id: "6haGvAy+HC",
-    description: "Toast confirmation after adding a CAT segment to the issue sheet",
+    description: "Toast confirmation after adding a CAT segment to Queries",
   },
   viewIssueSheetRow: {
     defaultMessage: "View row",

--- a/apps/hyperlocalise-web/src/components/content-editor/shared/content-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/shared/content-editor.messages.ts
@@ -1005,9 +1005,9 @@ export const contentEditorEditorPanelMessages = defineMessages({
     description: "Button to look up repository context for the current string",
   },
   addToIssueSheet: {
-    defaultMessage: "Board",
+    defaultMessage: "Queries",
     id: "KCIvL0TJB4",
-    description: "Button to open the Board for the current CAT segment",
+    description: "Button to open Queries for the current CAT segment",
   },
   refreshContextTitle: {
     defaultMessage: "Re-run repository context lookup for this string",

--- a/apps/hyperlocalise-web/src/components/content-editor/shared/content-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/shared/content-editor.messages.ts
@@ -1006,7 +1006,7 @@ export const contentEditorEditorPanelMessages = defineMessages({
   },
   addToIssueSheet: {
     defaultMessage: "Queries",
-    id: "KCIvL0TJB4",
+    id: "C5PXkfW5jk",
     description: "Button to open Queries for the current CAT segment",
   },
   refreshContextTitle: {

--- a/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side-row.test.tsx
@@ -479,7 +479,7 @@ describe("ContentEditorSideBySideRow", () => {
     renderRow({ isDirty: false, onAddToIssueSheet });
 
     expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /^Board$/i }));
+    await user.click(screen.getByRole("button", { name: /^Queries$/i }));
     expect(onAddToIssueSheet).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side.stories.tsx
@@ -149,7 +149,7 @@ export const Default: Story = {
       { timeout: 3000 },
     );
     await expect(canvas.queryByText(/Format & QA checks/i)).not.toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: /^Board$/i })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /^Queries$/i })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: /Find context/i })).toBeInTheDocument();
     await expect(canvas.queryByRole("button", { name: /^Approve/i })).not.toBeInTheDocument();
     await expect(canvas.queryByText(/ICU structure/i)).not.toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -37,7 +37,7 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Sidebar nav label in marketing app shell mock",
   },
   mockNavIssues: {
-    defaultMessage: "Board",
+    defaultMessage: "Queries",
     id: "2Q9B8y1llx",
     description: "Sidebar nav label in marketing app shell mock",
   },
@@ -67,7 +67,7 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Header breadcrumb in marketing app shell mock for inbox triage",
   },
   mockBreadcrumbIssues: {
-    defaultMessage: "Acme · Board",
+    defaultMessage: "Acme · Queries",
     id: "08+4Nn7rgH",
     description: "Header breadcrumb in marketing app shell mock",
   },
@@ -154,9 +154,9 @@ export const contentOpsMockStageMessages = defineMessages({
     description: "Editor mock use case pill for TM, context, and AI suggestions",
   },
   editorIssuesPanelTitle: {
-    defaultMessage: "Board · this string",
+    defaultMessage: "Queries · this string",
     id: "hYi0NizHJf",
-    description: "Title on the editor mock board overlay",
+    description: "Title on the editor mock Queries overlay",
   },
   editorHighlightEditor: {
     defaultMessage: "File editor",
@@ -324,9 +324,9 @@ export const contentOpsMockStageMessages = defineMessages({
   },
 
   issuesTitle: {
-    defaultMessage: "Board · acme workspace",
+    defaultMessage: "Queries · acme workspace",
     id: "tX5h+jHyR2",
-    description: "Board panel title in content ops mock",
+    description: "Queries panel title in content ops mock",
   },
   inboxTitle: {
     defaultMessage: "Inbox",

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -38,7 +38,7 @@ export const contentOpsMockStageMessages = defineMessages({
   },
   mockNavIssues: {
     defaultMessage: "Queries",
-    id: "2Q9B8y1llx",
+    id: "UznHMJ+o+o",
     description: "Sidebar nav label in marketing app shell mock",
   },
   mockNavDashboard: {
@@ -68,7 +68,7 @@ export const contentOpsMockStageMessages = defineMessages({
   },
   mockBreadcrumbIssues: {
     defaultMessage: "Acme · Queries",
-    id: "08+4Nn7rgH",
+    id: "pmPB2F7F47",
     description: "Header breadcrumb in marketing app shell mock",
   },
   mockBreadcrumbCampaign: {
@@ -155,7 +155,7 @@ export const contentOpsMockStageMessages = defineMessages({
   },
   editorIssuesPanelTitle: {
     defaultMessage: "Queries · this string",
-    id: "hYi0NizHJf",
+    id: "g1U3NC/CnC",
     description: "Title on the editor mock Queries overlay",
   },
   editorHighlightEditor: {
@@ -325,7 +325,7 @@ export const contentOpsMockStageMessages = defineMessages({
 
   issuesTitle: {
     defaultMessage: "Queries · acme workspace",
-    id: "tX5h+jHyR2",
+    id: "svxgBhLpnH",
     description: "Queries panel title in content ops mock",
   },
   inboxTitle: {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-types.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-types.ts
@@ -395,7 +395,7 @@ export type WorkspaceAutomationConfigValidationError =
     }
   | {
       code: "scheduled_workflow_required";
-      message: "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.";
+      message: "Scheduled automations require at least one GitHub, Contentful, Queries, Web Search, or Crowdin workflow tool.";
     }
   | {
       code: "invalid_automation_timezone";

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -151,7 +151,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   github_push_branches_required: "Add at least one branch pattern for GitHub triggers.",
   github_events_required: "Choose at least one GitHub event.",
   scheduled_workflow_required:
-    "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.",
+    "Scheduled automations require at least one GitHub, Contentful, Queries, Web Search, or Crowdin workflow tool.",
   invalid_automation_timezone: "Choose a valid timezone for the schedule.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
   slack_channel_required: "Choose a Slack channel for notifications.",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -535,7 +535,7 @@ describe("workspace automations", () => {
     expect(notificationOnlySchedule.error).toMatchObject({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Queries, Web Search, or Crowdin workflow tool.",
     });
 
     const scheduledWebSearch = expectOk(
@@ -585,7 +585,7 @@ describe("workspace automations", () => {
     expect(scheduledUpdate.error).toMatchObject({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Queries, Web Search, or Crowdin workflow tool.",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -160,7 +160,7 @@ function validateWorkspaceAutomationConfig(input: {
     return err({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Board, Web Search, or Crowdin workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Queries, Web Search, or Crowdin workflow tool.",
     });
   }
 

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -226,7 +226,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
 
     expect(itemLabels).not.toContain("Automations");
     expect(itemLabels).not.toContain("Guideline");
-    expect(itemLabels).toContain("Board");
+    expect(itemLabels).toContain("Queries");
     expect(itemLabels).toContain("New Request");
     expect(itemLabels).toContain("AI Engine");
     expect(itemLabels).not.toContain("Domains");
@@ -251,7 +251,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
 
     expect(itemLabels).toContain("Automations");
     expect(itemLabels).toContain("Guideline");
-    expect(itemLabels).toContain("Board");
+    expect(itemLabels).toContain("Queries");
     expect(itemLabels).toContain("Domains");
     expect(itemLabels).toContain("Reports");
     expect(itemLabels).toContain("AI Engine");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Renames the product surface previously labeled **Board** to **Queries**.

This updates user-facing copy in:

- Workspace and project sidebar navigation
- App shell breadcrumbs and footer
- Workspace and project Queries pages
- Overview section and metric copy
- Content editor Queries panel and toasts
- Automation tool grouping and validation
- Marketing content-ops mocks that show this product surface

The jobs kanban **Board** view mode is unchanged. Routes (`/issues`, `/issue-sheet`) and internal identifiers stay the same.

## How to test

- Open a workspace and confirm the sidebar item now reads Queries and still goes to `/issues`
- Open a project and confirm the sidebar item now reads Queries and still goes to `/issue-sheet`
- Confirm breadcrumbs, the app-shell footer button, and Overview “View Queries” use the new name
- In the content editor, confirm the Queries button and panel copy
- Confirm Jobs still has a Board/Row view toggle

Automated:

```
cd apps/hyperlocalise-web
vp test
vp check --fix
```

`vp test`: 899 files, 6553 tests passed.
`vp check --fix`: 0 errors (existing unused-var warnings only).

[Renamed Queries labels](https://cursor.com/agents/bc-01a07dff-bd4a-79d5-bfd7-daf69ab84600/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueries_rename_labels.log)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07dff-bd4a-79d5-bfd7-daf69ab84600?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07dff-bd4a-79d5-bfd7-daf69ab84600&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

