### PR TITLE
feat(web): implement mixed Projects page design

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.messages.ts
@@ -82,7 +82,7 @@ export const projectsPageContentMessages = defineMessages({
   },
   pageDescriptionWithTms: {
     defaultMessage: "Manage Hyperlocalise projects and browse live TMS-synced projects.",
-    id: 'PKp1AQm4Ed',
+    id: "PKp1AQm4Ed",
     description: "Projects page description when a TMS provider is connected",
   },
   pageDescriptionWithoutTms: {
@@ -154,7 +154,7 @@ export const projectsPageContentMessages = defineMessages({
   },
   searchPlaceholder: {
     defaultMessage: "Search projects…",
-    id: 'OUDcVk0AHJ',
+    id: "OUDcVk0AHJ",
     description: "Placeholder for the projects search field",
   },
   filterAll: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.messages.ts
@@ -81,9 +81,8 @@ export const projectsPageContentMessages = defineMessages({
     description: "Fallback label when no TMS provider name is available",
   },
   pageDescriptionWithTms: {
-    defaultMessage:
-      "Browse live {providerName} projects and manage Hyperlocalise workspace projects.",
-    id: "MOJri1ONT9",
+    defaultMessage: "Manage Hyperlocalise projects and browse live TMS-synced projects.",
+    id: 'PKp1AQm4Ed',
     description: "Projects page description when a TMS provider is connected",
   },
   pageDescriptionWithoutTms: {
@@ -154,8 +153,8 @@ export const projectsPageContentMessages = defineMessages({
     description: "Label for the projects search field",
   },
   searchPlaceholder: {
-    defaultMessage: "Search by name...",
-    id: "nSqpG2XwMB",
+    defaultMessage: "Search projects…",
+    id: 'OUDcVk0AHJ',
     description: "Placeholder for the projects search field",
   },
   filterAll: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.stories.tsx
@@ -19,41 +19,107 @@ import { recordRecentProjectVisit } from "./recent-projects";
 const ORGANIZATION_SLUG = "projects-design-preview";
 const HOURS = 3_600_000;
 const projects = [
-  { id: "marketing", name: "Marketing Site", description: "Web copy & landing pages", source: "native", sourceLocale: "en", targetLocales: ["fr", "de", "vi", "zh", "ja", "es"], openJobCount: 2, updatedAt: new Date(Date.now() - 4 * HOURS).toISOString() },
-  { id: "docs", name: "Product Docs", description: "Developer documentation", source: "native", sourceLocale: "en", targetLocales: ["fr", "de", "vi", "zh"], openJobCount: 1, updatedAt: new Date(Date.now() - 72 * HOURS).toISOString() },
-  { id: "mobile", name: "Mobile App", description: "iOS & Android strings", source: "external_tms", externalProviderKind: "crowdin", sourceLocale: "en", targetLocales: ["fr", "de", "vi", "zh", "ja", "es", "ko", "pt", "it", "nl", "ar", "th"], openJobCount: 3, updatedAt: new Date(Date.now() - 2 * HOURS).toISOString() },
-  { id: "help", name: "Help Center", description: "Knowledge base articles", source: "external_tms", externalProviderKind: "crowdin", sourceLocale: "en", targetLocales: ["fr", "de", "vi", "zh", "ja", "es", "ko", "pt"], openJobCount: 0, updatedAt: new Date(Date.now() - 24 * HOURS).toISOString() },
+  {
+    id: "marketing",
+    name: "Marketing Site",
+    description: "Web copy & landing pages",
+    source: "native",
+    sourceLocale: "en",
+    targetLocales: ["fr", "de", "vi", "zh", "ja", "es"],
+    openJobCount: 2,
+    updatedAt: new Date(Date.now() - 4 * HOURS).toISOString(),
+  },
+  {
+    id: "docs",
+    name: "Product Docs",
+    description: "Developer documentation",
+    source: "native",
+    sourceLocale: "en",
+    targetLocales: ["fr", "de", "vi", "zh"],
+    openJobCount: 1,
+    updatedAt: new Date(Date.now() - 72 * HOURS).toISOString(),
+  },
+  {
+    id: "mobile",
+    name: "Mobile App",
+    description: "iOS & Android strings",
+    source: "external_tms",
+    externalProviderKind: "crowdin",
+    sourceLocale: "en",
+    targetLocales: ["fr", "de", "vi", "zh", "ja", "es", "ko", "pt", "it", "nl", "ar", "th"],
+    openJobCount: 3,
+    updatedAt: new Date(Date.now() - 2 * HOURS).toISOString(),
+  },
+  {
+    id: "help",
+    name: "Help Center",
+    description: "Knowledge base articles",
+    source: "external_tms",
+    externalProviderKind: "crowdin",
+    sourceLocale: "en",
+    targetLocales: ["fr", "de", "vi", "zh", "ja", "es", "ko", "pt"],
+    openJobCount: 0,
+    updatedAt: new Date(Date.now() - 24 * HOURS).toISOString(),
+  },
 ];
 const meta = {
   title: "App/Projects/Page",
   component: ProjectsPageContent,
-  parameters: { layout: "fullscreen", nextjs: { appDirectory: true, navigation: { pathname: `/en/org/${ORGANIZATION_SLUG}/projects` } }, msw: { handlers: [
-    http.get("*/api/orgs/:organizationSlug/projects", () => HttpResponse.json({projects: projects.filter(project => project.source === "native")})),
-    http.get("*/api/orgs/:organizationSlug/tms-provider/connection", () => HttpResponse.json({connection: {providerKind: "crowdin", displayName: "Crowdin", validationStatus: "valid", validationMessage: null}})),
-    http.get("*/api/orgs/:organizationSlug/tms-provider/projects", () => HttpResponse.json({projects: projects.filter(project => project.source === "external_tms")})),
-  ] } },
-  args: {organizationSlug: ORGANIZATION_SLUG},
-  loaders: [() => {
-    recordRecentProjectVisit(ORGANIZATION_SLUG, "help", {visitedAt: 1});
-    recordRecentProjectVisit(ORGANIZATION_SLUG, "marketing", {visitedAt: 2});
-    recordRecentProjectVisit(ORGANIZATION_SLUG, "mobile", {visitedAt: 3});
-    return {};
-  }],
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: `/en/org/${ORGANIZATION_SLUG}/projects` },
+    },
+    msw: {
+      handlers: [
+        http.get("*/api/orgs/:organizationSlug/projects", () =>
+          HttpResponse.json({
+            projects: projects.filter((project) => project.source === "native"),
+          }),
+        ),
+        http.get("*/api/orgs/:organizationSlug/tms-provider/connection", () =>
+          HttpResponse.json({
+            connection: {
+              providerKind: "crowdin",
+              displayName: "Crowdin",
+              validationStatus: "valid",
+              validationMessage: null,
+            },
+          }),
+        ),
+        http.get("*/api/orgs/:organizationSlug/tms-provider/projects", () =>
+          HttpResponse.json({
+            projects: projects.filter((project) => project.source === "external_tms"),
+          }),
+        ),
+      ],
+    },
+  },
+  args: { organizationSlug: ORGANIZATION_SLUG },
+  loaders: [
+    () => {
+      recordRecentProjectVisit(ORGANIZATION_SLUG, "help", { visitedAt: 1 });
+      recordRecentProjectVisit(ORGANIZATION_SLUG, "marketing", { visitedAt: 2 });
+      recordRecentProjectVisit(ORGANIZATION_SLUG, "mobile", { visitedAt: 3 });
+      return {};
+    },
+  ],
 } satisfies Meta<typeof ProjectsPageContent>;
 export default meta;
 type Story = StoryObj<typeof meta>;
 export const Mixed: Story = {};
 export const SearchAndFilter: Story = {
-  play: async ({canvas, userEvent}) => {
-    const table = within(await canvas.findByRole("table", {name: "Projects"}));
-    await expect(await table.findByRole("link", {name: "Mobile App"})).toBeInTheDocument();
-    await userEvent.click(canvas.getByRole("tab", {name: "Hyperlocalise"}));
-    await expect(table.queryByRole("link", {name: "Mobile App"})).not.toBeInTheDocument();
-    await expect(table.getByRole("link", {name: "Marketing Site"})).toBeInTheDocument();
-    await userEvent.type(canvas.getByRole("textbox", {name: "Search"}), "Product");
-    await expect(table.getByRole("link", {name: "Product Docs"})).toBeInTheDocument();
-    await expect(table.queryByRole("link", {name: "Marketing Site"})).not.toBeInTheDocument();
-    await userEvent.clear(canvas.getByRole("textbox", {name: "Search"}));
-    await userEvent.click(canvas.getByRole("tab", {name: "All"}));
+  play: async ({ canvas, userEvent }) => {
+    const table = within(await canvas.findByRole("table", { name: "Projects" }));
+    await expect(await table.findByRole("link", { name: "Mobile App" })).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("tab", { name: "Hyperlocalise" }));
+    await expect(table.queryByRole("link", { name: "Mobile App" })).not.toBeInTheDocument();
+    await expect(table.getByRole("link", { name: "Marketing Site" })).toBeInTheDocument();
+    await userEvent.type(canvas.getByRole("textbox", { name: "Search" }), "Product");
+    await expect(table.getByRole("link", { name: "Product Docs" })).toBeInTheDocument();
+    await expect(table.queryByRole("link", { name: "Marketing Site" })).not.toBeInTheDocument();
+    await userEvent.clear(canvas.getByRole("textbox", { name: "Search" }));
+    await userEvent.click(canvas.getByRole("tab", { name: "All" }));
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { http, HttpResponse } from "msw";
+import { expect, within } from "storybook/test";
+import { ProjectsPageContent } from "./projects-page-content";
+import { recordRecentProjectVisit } from "./recent-projects";
+
+const ORGANIZATION_SLUG = "projects-design-preview";
+const HOURS = 3_600_000;
+const projects = [
+  { id: "marketing", name: "Marketing Site", description: "Web copy & landing pages", source: "native", sourceLocale: "en", targetLocales: ["fr", "de", "vi", "zh", "ja", "es"], openJobCount: 2, updatedAt: new Date(Date.now() - 4 * HOURS).toISOString() },
+  { id: "docs", name: "Product Docs", description: "Developer documentation", source: "native", sourceLocale: "en", targetLocales: ["fr", "de", "vi", "zh"], openJobCount: 1, updatedAt: new Date(Date.now() - 72 * HOURS).toISOString() },
+  { id: "mobile", name: "Mobile App", description: "iOS & Android strings", source: "external_tms", externalProviderKind: "crowdin", sourceLocale: "en", targetLocales: ["fr", "de", "vi", "zh", "ja", "es", "ko", "pt", "it", "nl", "ar", "th"], openJobCount: 3, updatedAt: new Date(Date.now() - 2 * HOURS).toISOString() },
+  { id: "help", name: "Help Center", description: "Knowledge base articles", source: "external_tms", externalProviderKind: "crowdin", sourceLocale: "en", targetLocales: ["fr", "de", "vi", "zh", "ja", "es", "ko", "pt"], openJobCount: 0, updatedAt: new Date(Date.now() - 24 * HOURS).toISOString() },
+];
+const meta = {
+  title: "App/Projects/Page",
+  component: ProjectsPageContent,
+  parameters: { layout: "fullscreen", nextjs: { appDirectory: true, navigation: { pathname: `/en/org/${ORGANIZATION_SLUG}/projects` } }, msw: { handlers: [
+    http.get("*/api/orgs/:organizationSlug/projects", () => HttpResponse.json({projects: projects.filter(project => project.source === "native")})),
+    http.get("*/api/orgs/:organizationSlug/tms-provider/connection", () => HttpResponse.json({connection: {providerKind: "crowdin", displayName: "Crowdin", validationStatus: "valid", validationMessage: null}})),
+    http.get("*/api/orgs/:organizationSlug/tms-provider/projects", () => HttpResponse.json({projects: projects.filter(project => project.source === "external_tms")})),
+  ] } },
+  args: {organizationSlug: ORGANIZATION_SLUG},
+  loaders: [() => {
+    recordRecentProjectVisit(ORGANIZATION_SLUG, "help", {visitedAt: 1});
+    recordRecentProjectVisit(ORGANIZATION_SLUG, "marketing", {visitedAt: 2});
+    recordRecentProjectVisit(ORGANIZATION_SLUG, "mobile", {visitedAt: 3});
+    return {};
+  }],
+} satisfies Meta<typeof ProjectsPageContent>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Mixed: Story = {};
+export const SearchAndFilter: Story = {
+  play: async ({canvas, userEvent}) => {
+    const table = within(await canvas.findByRole("table", {name: "Projects"}));
+    await expect(await table.findByRole("link", {name: "Mobile App"})).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("tab", {name: "Hyperlocalise"}));
+    await expect(table.queryByRole("link", {name: "Mobile App"})).not.toBeInTheDocument();
+    await expect(table.getByRole("link", {name: "Marketing Site"})).toBeInTheDocument();
+    await userEvent.type(canvas.getByRole("textbox", {name: "Search"}), "Product");
+    await expect(table.getByRole("link", {name: "Product Docs"})).toBeInTheDocument();
+    await expect(table.queryByRole("link", {name: "Marketing Site"})).not.toBeInTheDocument();
+    await userEvent.clear(canvas.getByRole("textbox", {name: "Search"}));
+    await userEvent.click(canvas.getByRole("tab", {name: "All"}));
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -14,13 +14,15 @@
  */
 import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Add01Icon, CubeIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, GridViewIcon, Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+import { projectsTableMessages } from "./projects-table.messages";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TypographyP } from "@/components/ui/typography";
@@ -28,11 +30,7 @@ import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import { getTmsProviderBranding } from "@/lib/providers/shared/tms-provider-branding";
 
-import {
-  PageHeader,
-  WorkspaceFilterField,
-  WorkspacePageShell,
-} from "../../_components/workspace-resource-shared";
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
 import { fetchTmsLiveProjects, tmsLiveProjectsQueryKey } from "../../_hooks/use-tms-live-projects";
 import { DeleteProjectDialog } from "./delete-project-dialog";
@@ -44,12 +42,19 @@ import {
 } from "./project-form";
 import { ProjectDialog } from "./project-dialog";
 import { mapProjectToListRow, type ProjectListRow } from "./project-list";
-import { PROJECTS_PAGE_SIZE, ProjectsTable } from "./projects-table";
+import {
+  PROJECTS_PAGE_SIZE,
+  ProjectsTable,
+  ProjectsTableHeader,
+  ProjectSourceMark,
+} from "./projects-table";
 import { projectsPageContentMessages } from "./projects-page-content.messages";
 import { recordRecentProjectVisit, resolveRecentProjects } from "./recent-projects";
 
 const nativeProjectsQueryKey = (organizationSlug: string) =>
   ["translation-projects", organizationSlug, "native"] as const;
+
+const EMPTY_PROJECTS: ProjectListRow[] = [];
 
 type ProjectSourceFilter = "all" | "tms" | "native";
 
@@ -91,7 +96,9 @@ function RecentProjectsStrip({
   organizationSlug,
   projects,
   onOpenProject,
+  allProjects,
 }: {
+  allProjects: ProjectListRow[];
   organizationSlug: string;
   projects: Array<{ id: string; name: string }>;
   onOpenProject: (projectId: string) => void;
@@ -101,7 +108,7 @@ function RecentProjectsStrip({
   }
 
   return (
-    <section className="space-y-3">
+    <section className="space-y-2.5">
       <TypographyP
         className="tracking-[0.08em]"
         size="xsmall"
@@ -124,8 +131,17 @@ function RecentProjectsStrip({
             }
             variant="outline"
             size="sm"
-            className="max-w-full"
+            className="max-w-full gap-2 rounded-lg bg-background"
           >
+            <ProjectSourceMark
+              compact
+              project={
+                allProjects.find((row) => row.id === project.id) ?? {
+                  source: "native",
+                  externalProviderKind: null,
+                }
+              }
+            />
             <span className="truncate">{project.name}</span>
           </Button>
         ))}
@@ -251,8 +267,8 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     },
   });
 
-  const nativeProjects = nativeProjectsQuery.data ?? [];
-  const tmsProjects = tmsProjectsQuery.data ?? [];
+  const nativeProjects = nativeProjectsQuery.data ?? EMPTY_PROJECTS;
+  const tmsProjects = tmsProjectsQuery.data ?? EMPTY_PROJECTS;
   const allProjects = useMemo(
     () => [...tmsProjects, ...nativeProjects],
     [nativeProjects, tmsProjects],
@@ -364,9 +380,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   }
 
   const pageDescription = hasTmsConnection
-    ? intl.formatMessage(projectsPageContentMessages.pageDescriptionWithTms, {
-        providerName: tmsProviderName,
-      })
+    ? intl.formatMessage(projectsPageContentMessages.pageDescriptionWithTms)
     : intl.formatMessage(projectsPageContentMessages.pageDescriptionWithoutTms);
 
   const createProjectAction =
@@ -375,7 +389,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         type="button"
         onClick={openCreateProjectDialog}
         variant="outline"
-        className="w-full sm:w-fit"
+        className="w-full rounded-lg sm:w-fit"
         disabled={isSavingProject}
       >
         <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
@@ -385,7 +399,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       <Button
         type="button"
         onClick={openCreateProjectDialog}
-        className="w-full sm:w-fit"
+        className="w-full rounded-lg sm:w-fit"
         disabled={isSavingProject}
       >
         <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
@@ -394,51 +408,43 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     );
 
   const tmsSection = showTmsSection ? (
-    <section className="space-y-4">
-      <ProjectsSectionHeader
-        title={intl.formatMessage(projectsPageContentMessages.tmsProjectsTitle, {
-          providerName: tmsProviderName,
-        })}
-        description={intl.formatMessage(projectsPageContentMessages.tmsProjectsDescription)}
-      />
-      <ProjectsTable
-        projects={visibleTmsProjects}
-        projectsQuery={tmsProjectsQuery}
-        isSavingProject={isSavingProject}
-        isDeletingProject={deleteProjectMutation.isPending}
-        organizationSlug={organizationSlug}
-        variant="tms"
-        hasMore={hasMoreTmsProjects}
-        onLoadMore={loadMoreTmsProjects}
-        onOpenProject={handleOpenProject}
-      />
-    </section>
+    <ProjectsTable
+      grouped
+      groupLabel={tmsProviderName}
+      totalCount={filteredTmsProjects.length}
+      suppressEmpty={Boolean(searchQuery.trim())}
+      projects={visibleTmsProjects}
+      projectsQuery={tmsProjectsQuery}
+      isSavingProject={isSavingProject}
+      isDeletingProject={deleteProjectMutation.isPending}
+      organizationSlug={organizationSlug}
+      variant="tms"
+      hasMore={hasMoreTmsProjects}
+      onLoadMore={loadMoreTmsProjects}
+      onOpenProject={handleOpenProject}
+    />
   ) : null;
 
   const nativeSection = showNativeSection ? (
-    <section className="space-y-4">
-      <ProjectsSectionHeader
-        title={intl.formatMessage(projectsPageContentMessages.hyperlocaliseProjectsTitle)}
-        description={intl.formatMessage(
-          projectsPageContentMessages.hyperlocaliseProjectsDescription,
-        )}
-      />
-      <ProjectsTable
-        projects={visibleNativeProjects}
-        projectsQuery={nativeProjectsQuery}
-        isSavingProject={isSavingProject}
-        isDeletingProject={deleteProjectMutation.isPending}
-        organizationSlug={organizationSlug}
-        variant="native"
-        compactEmptyNative={compactNativeEmpty}
-        hasMore={hasMoreNativeProjects}
-        onLoadMore={loadMoreNativeProjects}
-        onEditProject={openEditProjectDialog}
-        onDeleteProject={setDeleteProject}
-        onCreateProject={openCreateProjectDialog}
-        onOpenProject={handleOpenProject}
-      />
-    </section>
+    <ProjectsTable
+      grouped
+      groupLabel={intl.formatMessage(projectsPageContentMessages.filterHyperlocalise)}
+      totalCount={filteredNativeProjects.length}
+      suppressEmpty={Boolean(searchQuery.trim())}
+      projects={visibleNativeProjects}
+      projectsQuery={nativeProjectsQuery}
+      isSavingProject={isSavingProject}
+      isDeletingProject={deleteProjectMutation.isPending}
+      organizationSlug={organizationSlug}
+      variant="native"
+      compactEmptyNative={compactNativeEmpty}
+      hasMore={hasMoreNativeProjects}
+      onLoadMore={loadMoreNativeProjects}
+      onEditProject={openEditProjectDialog}
+      onDeleteProject={setDeleteProject}
+      onCreateProject={openCreateProjectDialog}
+      onOpenProject={handleOpenProject}
+    />
   ) : null;
 
   const connectTmsSection =
@@ -462,40 +468,95 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     ) : null;
 
   return (
-    <WorkspacePageShell>
+    <WorkspacePageShell className="min-w-0 p-4 md:px-8 md:pt-6 md:pb-8 [&>section:first-child]:md:items-start">
       <PageHeader
-        icon={CubeIcon}
+        icon={GridViewIcon}
         label={intl.formatMessage(projectsPageContentMessages.pageLabel)}
         title={intl.formatMessage(projectsPageContentMessages.pageTitle)}
         description={pageDescription}
         actions={createProjectAction}
       />
 
-      {hasAnyProjects ? (
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <WorkspaceFilterField
-            label={intl.formatMessage(projectsPageContentMessages.searchLabel)}
-            className="w-full sm:max-w-xs"
+      <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {[
+          {
+            label: projectsPageContentMessages.pageTitle,
+            value: allProjects.length,
+            ready:
+              nativeProjectsQuery.isSuccess &&
+              activeTmsProviderQuery.isSuccess &&
+              (!hasTmsConnection || tmsProjectsQuery.isSuccess),
+          },
+          {
+            label: projectsTableMessages.openJobsLabel,
+            value: allProjects.reduce((total, project) => total + project.openJobCount, 0),
+            ready:
+              nativeProjectsQuery.isSuccess &&
+              activeTmsProviderQuery.isSuccess &&
+              (!hasTmsConnection || tmsProjectsQuery.isSuccess),
+            accent: true,
+          },
+          {
+            label: projectsTableMessages.nativeSource,
+            value: nativeProjects.length,
+            ready: nativeProjectsQuery.isSuccess,
+          },
+          {
+            label: projectsPageContentMessages.tmsFallbackName,
+            value: tmsProjects.length,
+            ready:
+              activeTmsProviderQuery.isSuccess && (!hasTmsConnection || tmsProjectsQuery.isSuccess),
+          },
+        ].map((metric) => (
+          <div
+            key={metric.label.id}
+            className="rounded-lg border border-border bg-background px-4 py-3"
           >
+            <dt className="text-[10px] leading-3 font-medium tracking-[0.08em] text-muted-foreground uppercase">
+              <FormattedMessage {...metric.label} />
+            </dt>
+            <dd
+              className={cn(
+                "mt-0.5 text-xl leading-6 font-medium tabular-nums",
+                metric.accent && "text-primary",
+              )}
+            >
+              {metric.ready ? intl.formatNumber(metric.value) : "—"}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      {hasAnyProjects ? (
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="relative w-full sm:max-w-90">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              aria-hidden="true"
+              className="pointer-events-none absolute start-3 top-2.5 size-4 text-muted-foreground"
+            />
             <Input
+              aria-label={intl.formatMessage(projectsPageContentMessages.searchLabel)}
               placeholder={intl.formatMessage(projectsPageContentMessages.searchPlaceholder)}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full"
+              className="h-9 w-full rounded-lg ps-9"
             />
-          </WorkspaceFilterField>
+          </div>
           {hasTmsConnection ? (
             <Tabs
               value={sourceFilter}
               onValueChange={(value) => setSourceFilter(value as ProjectSourceFilter)}
             >
-              <TabsList>
-                <TabsTrigger value="all">
+              <TabsList className="max-w-full gap-1 rounded-lg p-1">
+                <TabsTrigger className="rounded-md px-3 data-active:border-border" value="all">
                   <FormattedMessage {...projectsPageContentMessages.filterAll} />
                 </TabsTrigger>
-                <TabsTrigger value="tms">{tmsProviderName}</TabsTrigger>
-                <TabsTrigger value="native">
+                <TabsTrigger className="rounded-md px-3 data-active:border-border" value="native">
                   <FormattedMessage {...projectsPageContentMessages.filterHyperlocalise} />
+                </TabsTrigger>
+                <TabsTrigger className="rounded-md px-3 data-active:border-border" value="tms">
+                  {tmsProviderName}
                 </TabsTrigger>
               </TabsList>
             </Tabs>
@@ -507,11 +568,12 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         <RecentProjectsStrip
           organizationSlug={organizationSlug}
           projects={recentProjects}
+          allProjects={allProjects}
           onOpenProject={handleOpenProject}
         />
       ) : null}
 
-      {hasAnyProjects && !hasFilteredResults ? (
+      {hasAnyProjects && searchQuery.trim() && !hasFilteredResults && !nativeProjectsQuery.isLoading && !isTmsProjectsLoading ? (
         <div className="border-t border-border px-1 py-8 text-sm text-muted-foreground">
           <FormattedMessage
             {...projectsPageContentMessages.noSearchResults}
@@ -530,19 +592,17 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         </div>
       ) : null}
 
-      <div className="space-y-10">
-        {hasTmsConnection ? (
-          <>
-            {tmsSection}
-            {nativeSection}
-          </>
-        ) : (
-          <>
-            {nativeSection}
-            {connectTmsSection}
-          </>
-        )}
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table
+          className="w-full min-w-180 table-fixed"
+          aria-label={intl.formatMessage(projectsPageContentMessages.pageTitle)}
+        >
+          <ProjectsTableHeader />
+          {nativeSection}
+          {tmsSection}
+        </table>
       </div>
+      {connectTmsSection}
 
       <ProjectDialog
         open={projectDialogMode !== null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -573,7 +573,11 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         />
       ) : null}
 
-      {hasAnyProjects && searchQuery.trim() && !hasFilteredResults && !nativeProjectsQuery.isLoading && !isTmsProjectsLoading ? (
+      {hasAnyProjects &&
+      searchQuery.trim() &&
+      !hasFilteredResults &&
+      !nativeProjectsQuery.isLoading &&
+      !isTmsProjectsLoading ? (
         <div className="border-t border-border px-1 py-8 text-sm text-muted-foreground">
           <FormattedMessage
             {...projectsPageContentMessages.noSearchResults}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.messages.ts
@@ -138,12 +138,29 @@ export const projectsTableMessages = defineMessages({
     id: "C31IoV3z9k",
     description: "Button to load more projects in the list",
   },
-  nativeSource: { defaultMessage: "Native", id: 'mMLVebRDAJ', description: "Projects list nativeSource" },
-  projectLabel: { defaultMessage: "Project", id: 'Qh1hAhKzYj', description: "Projects list projectLabel" },
-  sourceLabel: { defaultMessage: "Source", id: 'PBDgruWZRx', description: "Projects list sourceLabel" },
-  actionsLabel: { defaultMessage: "Actions", id: 'IigPo0Yd+k', description: "Projects list actionsLabel" },
+  nativeSource: {
+    defaultMessage: "Native",
+    id: "mMLVebRDAJ",
+    description: "Projects list nativeSource",
+  },
+  projectLabel: {
+    defaultMessage: "Project",
+    id: "Qh1hAhKzYj",
+    description: "Projects list projectLabel",
+  },
+  sourceLabel: {
+    defaultMessage: "Source",
+    id: "PBDgruWZRx",
+    description: "Projects list sourceLabel",
+  },
+  actionsLabel: {
+    defaultMessage: "Actions",
+    id: "IigPo0Yd+k",
+    description: "Projects list actionsLabel",
+  },
   projectCount: {
-    defaultMessage: "{count, plural, one {# project} other {# projects}}", id: 'pDidtWgxX9',
+    defaultMessage: "{count, plural, one {# project} other {# projects}}",
+    id: "pDidtWgxX9",
     description: "Projects list projectCount",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.messages.ts
@@ -138,4 +138,12 @@ export const projectsTableMessages = defineMessages({
     id: "C31IoV3z9k",
     description: "Button to load more projects in the list",
   },
+  nativeSource: { defaultMessage: "Native", id: 'mMLVebRDAJ', description: "Projects list nativeSource" },
+  projectLabel: { defaultMessage: "Project", id: 'Qh1hAhKzYj', description: "Projects list projectLabel" },
+  sourceLabel: { defaultMessage: "Source", id: 'PBDgruWZRx', description: "Projects list sourceLabel" },
+  actionsLabel: { defaultMessage: "Actions", id: 'IigPo0Yd+k', description: "Projects list actionsLabel" },
+  projectCount: {
+    defaultMessage: "{count, plural, one {# project} other {# projects}}", id: 'pDidtWgxX9',
+    description: "Projects list projectCount",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
@@ -12,7 +12,7 @@
  */
 // @vitest-environment happy-dom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { ReactElement } from "react";
@@ -76,7 +76,7 @@ function successQuery(): UseQueryResult<ProjectListRow[], Error> {
 }
 
 describe("ProjectsTable", () => {
-  it("shows source-to-target locales for native and external project cards", () => {
+  it("shows source badges and accessible locale routes for native and external rows", () => {
     renderWithIntl(
       <>
         <ProjectsTable
@@ -110,7 +110,7 @@ describe("ProjectsTable", () => {
       </>,
     );
 
-    expect(screen.getByText("Hyperlocalise")).toBeInTheDocument();
+    expect(screen.getByText("Native")).toBeInTheDocument();
     expect(screen.getByText("Crowdin")).toBeInTheDocument();
     expect(screen.getAllByText("en → vi")).toHaveLength(2);
   });
@@ -142,4 +142,19 @@ describe("ProjectsTable", () => {
 
     expect(onDeleteProject).toHaveBeenCalledWith(project);
   });
+  it("shows numeric counts with a working jobs link and loads more within its group", async () => {
+    const user = userEvent.setup();
+    const onLoadMore = vi.fn();
+    const onOpenProject = vi.fn();
+    renderWithIntl(<ProjectsTable projects={[createProject({openJobCount: 3, targetLocales: ["vi", "fr"]})]} projectsQuery={successQuery()} organizationSlug="acme" variant="native" isSavingProject={false} isDeletingProject={false} groupLabel="Hyperlocalise" totalCount={15} hasMore onLoadMore={onLoadMore} onOpenProject={onOpenProject} />);
+    expect(screen.getByText("15 projects")).toBeInTheDocument();
+    const row = screen.getByRole("link", {name: "Hyperlocalise Web"}).closest("tr")!;
+    expect(within(row).getByTitle("en → vi, fr")).toHaveTextContent("2");
+    expect(within(row).getByRole("link", {name: "3 jobs"})).toHaveAttribute("href", "/org/acme/projects/project_native/jobs");
+    await user.click(screen.getByRole("button", {name: "Load more"}));
+    expect(onLoadMore).toHaveBeenCalledOnce();
+    await user.click(screen.getByRole("link", {name: "Hyperlocalise Web"}));
+    expect(onOpenProject).toHaveBeenCalledWith("project_native");
+  });
+
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
@@ -146,15 +146,31 @@ describe("ProjectsTable", () => {
     const user = userEvent.setup();
     const onLoadMore = vi.fn();
     const onOpenProject = vi.fn();
-    renderWithIntl(<ProjectsTable projects={[createProject({openJobCount: 3, targetLocales: ["vi", "fr"]})]} projectsQuery={successQuery()} organizationSlug="acme" variant="native" isSavingProject={false} isDeletingProject={false} groupLabel="Hyperlocalise" totalCount={15} hasMore onLoadMore={onLoadMore} onOpenProject={onOpenProject} />);
+    renderWithIntl(
+      <ProjectsTable
+        projects={[createProject({ openJobCount: 3, targetLocales: ["vi", "fr"] })]}
+        projectsQuery={successQuery()}
+        organizationSlug="acme"
+        variant="native"
+        isSavingProject={false}
+        isDeletingProject={false}
+        groupLabel="Hyperlocalise"
+        totalCount={15}
+        hasMore
+        onLoadMore={onLoadMore}
+        onOpenProject={onOpenProject}
+      />,
+    );
     expect(screen.getByText("15 projects")).toBeInTheDocument();
-    const row = screen.getByRole("link", {name: "Hyperlocalise Web"}).closest("tr")!;
+    const row = screen.getByRole("link", { name: "Hyperlocalise Web" }).closest("tr")!;
     expect(within(row).getByTitle("en → vi, fr")).toHaveTextContent("2");
-    expect(within(row).getByRole("link", {name: "3 jobs"})).toHaveAttribute("href", "/org/acme/projects/project_native/jobs");
-    await user.click(screen.getByRole("button", {name: "Load more"}));
+    expect(within(row).getByRole("link", { name: "3 jobs" })).toHaveAttribute(
+      "href",
+      "/org/acme/projects/project_native/jobs",
+    );
+    await user.click(screen.getByRole("button", { name: "Load more" }));
     expect(onLoadMore).toHaveBeenCalledOnce();
-    await user.click(screen.getByRole("link", {name: "Hyperlocalise Web"}));
+    await user.click(screen.getByRole("link", { name: "Hyperlocalise Web" }));
     expect(onOpenProject).toHaveBeenCalledWith("project_native");
   });
-
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -13,7 +13,6 @@
  * Version 2.0 or later.
  */
 import {
-  ArrowRight01Icon,
   ArrowUpRight01Icon,
   Delete02Icon,
   Edit02Icon,
@@ -37,37 +36,16 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { TypographyH3, TypographyP } from "@/components/ui/typography";
+import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 import { getTmsProviderBranding } from "@/lib/providers/shared/tms-provider-branding";
 import { isTmsUserConnectionRequiredError } from "@/lib/providers/credentials/tms-user-connection-shared";
 
 import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
-import { ProjectAvatar } from "./project-avatar";
 import { formatProjectLocaleRoute, type ProjectListRow } from "./project-list";
 import { projectsTableMessages } from "./projects-table.messages";
 
 export const PROJECTS_PAGE_SIZE = 12;
-
-function ProjectCardSkeleton() {
-  return (
-    <article className="rounded-lg border border-border bg-muted p-4">
-      <div className="flex items-start gap-3">
-        <Skeleton className="size-10 shrink-0 rounded-lg" />
-        <div className="min-w-0 flex-1 space-y-2">
-          <Skeleton className="h-4 w-48 max-w-full" />
-          <Skeleton className="h-3 w-full max-w-sm" />
-          <Skeleton className="h-3 w-32" />
-        </div>
-      </div>
-      <dl className="mt-4 grid gap-3 sm:grid-cols-3">
-        <Skeleton className="h-8 w-full" />
-        <Skeleton className="h-8 w-full" />
-        <Skeleton className="h-8 w-full" />
-      </dl>
-    </article>
-  );
-}
 
 function NativeEmptyState({
   compact,
@@ -112,7 +90,7 @@ function NativeEmptyState({
   );
 }
 
-function ProjectCard({
+function ProjectRow({
   project,
   organizationSlug,
   isSavingProject,
@@ -142,44 +120,75 @@ function ProjectCard({
   const projectHref = `/org/${organizationSlug}/projects/${project.id}`;
 
   return (
-    <article className="group min-w-0 rounded-lg border border-border bg-muted p-4 transition-colors hover:border-beam-500/30 hover:bg-beam-500/5">
-      <div className="flex items-start justify-between gap-4">
-        <OrgNavLink
-          href={projectHref}
-          prefetch
-          onClick={() => onOpenProject?.(project.id)}
-          className="min-w-0 flex flex-1 items-start gap-3"
-        >
-          <ProjectAvatar project={project} />
-          <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-center gap-2">
-              <TypographyH3 className="min-w-0" lineClamp={1} weight="medium" tone="content">
-                {project.name}
-              </TypographyH3>
-              {!project.isActive ? (
-                <Badge variant="outline" className="text-[10px]">
-                  <FormattedMessage {...projectsTableMessages.inactiveBadge} />
-                </Badge>
-              ) : null}
-            </div>
-            <TypographyP className="mt-1" lineClamp={1} size="xsmall" tone="subtle">
-              {providerName}
-            </TypographyP>
-            <TypographyP className="mt-1" lineClamp={2} size="xsmall" tone="subtle">
+    <tr className="group border-b border-border last:border-b-0 hover:bg-muted/50">
+      <td className="px-4 py-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <ProjectSourceMark project={project} />
+          <div className="min-w-0">
+            <OrgNavLink
+              href={projectHref}
+              prefetch
+              onClick={() => onOpenProject?.(project.id)}
+              className="block truncate text-sm font-medium text-foreground hover:underline"
+            >
+              {project.name}
+            </OrgNavLink>
+            <p className="mt-0.5 max-w-xl truncate text-xs text-muted-foreground">
               {project.descriptionValue ||
                 intl.formatMessage(projectsTableMessages.noDescriptionYet)}
-            </TypographyP>
+            </p>
           </div>
-        </OrgNavLink>
-
+          {!project.isActive ? (
+            <Badge variant="outline">
+              <FormattedMessage {...projectsTableMessages.inactiveBadge} />
+            </Badge>
+          ) : null}
+        </div>
+      </td>
+      <td className="px-2 py-3">
+        <span
+          className={cn(
+            "inline-flex rounded-full px-2 py-0.5 text-xs",
+            isNativeProject
+              ? "bg-[#F0F4FF] text-[#4F6BED] dark:bg-blue-100 dark:text-blue-900"
+              : "bg-[#E8F4F8] text-muted-foreground dark:bg-muted",
+          )}
+        >
+          {isNativeProject ? intl.formatMessage(projectsTableMessages.nativeSource) : providerName}
+        </span>
+      </td>
+      <td className="px-2 py-3 text-right text-sm tabular-nums" title={localeRoute}>
+        {intl.formatNumber(project.targetLocales.length)}
+        <span className="sr-only">{localeRoute}</span>
+      </td>
+      <td className="px-2 py-3 text-right text-sm tabular-nums">
+        {project.openJobCount > 0 ? (
+          <OrgNavLink
+            href={`${projectHref}/jobs`}
+            prefetch
+            className="font-medium text-primary hover:underline"
+            aria-label={intl.formatMessage(projectsTableMessages.openJobsCount, {
+              count: project.openJobCount,
+            })}
+          >
+            {intl.formatNumber(project.openJobCount)}
+          </OrgNavLink>
+        ) : (
+          intl.formatNumber(0)
+        )}
+      </td>
+      <td className="whitespace-nowrap px-2 py-3 text-right text-sm text-muted-foreground">
+        {activityLabel}
+      </td>
+      <td className="px-2 py-3">
         <div className="flex shrink-0 items-center gap-1">
           {project.externalProjectUrl ? (
             <Tooltip>
               <TooltipTrigger
                 render={
                   <Button
-                    type="button"
-                    size="icon-sm"
+                    nativeButton={false}
+                    size="icon-xs"
                     variant="ghost"
                     render={
                       <a
@@ -212,7 +221,7 @@ function ProjectCard({
                 render={
                   <Button
                     type="button"
-                    size="icon-sm"
+                    size="icon-xs"
                     variant="ghost"
                     aria-label={intl.formatMessage(projectsTableMessages.actionsForProject, {
                       projectName: project.name,
@@ -251,51 +260,65 @@ function ProjectCard({
               </DropdownMenuContent>
             </DropdownMenu>
           ) : null}
-          <HugeiconsIcon
-            icon={ArrowRight01Icon}
-            strokeWidth={1.8}
-            className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
-          />
         </div>
-      </div>
+      </td>
+    </tr>
+  );
+}
 
-      <dl className="mt-5 grid gap-3 border-t border-border pt-4 sm:grid-cols-3">
-        <div className="min-w-0">
-          <dt className="text-xs font-medium text-muted-foreground uppercase">
-            <FormattedMessage {...projectsTableMessages.localesLabel} />
-          </dt>
-          <dd className="mt-1 truncate text-sm text-muted-foreground">{localeRoute}</dd>
-        </div>
-        <div className="min-w-0">
-          <dt className="text-xs font-medium text-muted-foreground uppercase">
-            <FormattedMessage {...projectsTableMessages.openJobsLabel} />
-          </dt>
-          <dd className="mt-1 truncate text-sm text-muted-foreground">
-            {project.openJobCount > 0 ? (
-              <OrgNavLink
-                href={`/org/${organizationSlug}/projects/${project.id}/jobs`}
-                prefetch
-                className="text-subtle-foreground hover:text-foreground hover:underline"
-              >
-                {intl.formatMessage(projectsTableMessages.openJobsCount, {
-                  count: project.openJobCount,
-                })}
-              </OrgNavLink>
-            ) : (
-              <span>
-                <FormattedMessage {...projectsTableMessages.noOpenJobs} />
-              </span>
-            )}
-          </dd>
-        </div>
-        <div className="min-w-0">
-          <dt className="text-xs font-medium text-muted-foreground uppercase">
-            <FormattedMessage {...projectsTableMessages.updatedLabel} />
-          </dt>
-          <dd className="mt-1 truncate text-sm text-muted-foreground">{activityLabel}</dd>
-        </div>
-      </dl>
-    </article>
+export function ProjectSourceMark({
+  project,
+  compact = false,
+}: {
+  project: Pick<ProjectListRow, "source" | "externalProviderKind">;
+  compact?: boolean;
+}) {
+  const isNative = project.source === "native";
+  const label = isNative
+    ? "H"
+    : getTmsProviderBranding(project.externalProviderKind).name.slice(0, 1);
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center font-medium",
+        compact ? "size-5 rounded-sm text-[9px]" : "size-8 rounded-md text-[11px]",
+        isNative
+          ? "bg-[#F0F4FF] text-[#4F6BED] dark:bg-blue-100 dark:text-blue-900"
+          : "bg-[#E8F4F8] text-primary dark:bg-muted",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function ProjectsTableHeader() {
+  return (
+    <thead className="border-b border-border bg-muted text-xs font-medium text-muted-foreground">
+      <tr>
+        <th scope="col" className="px-4 py-2.5 text-left font-medium">
+          <FormattedMessage {...projectsTableMessages.projectLabel} />
+        </th>
+        <th scope="col" className="w-24 px-2 py-2.5 text-left font-medium">
+          <FormattedMessage {...projectsTableMessages.sourceLabel} />
+        </th>
+        <th scope="col" className="w-20 px-2 py-2.5 text-right font-medium">
+          <FormattedMessage {...projectsTableMessages.localesLabel} />
+        </th>
+        <th scope="col" className="w-22 px-2 py-2.5 text-right font-medium">
+          <FormattedMessage {...projectsTableMessages.openJobsLabel} />
+        </th>
+        <th scope="col" className="w-28 px-2 py-2.5 text-right font-medium">
+          <FormattedMessage {...projectsTableMessages.updatedLabel} />
+        </th>
+        <th scope="col" className="w-10">
+          <span className="sr-only">
+            <FormattedMessage {...projectsTableMessages.actionsLabel} />
+          </span>
+        </th>
+      </tr>
+    </thead>
   );
 }
 
@@ -307,6 +330,10 @@ export function ProjectsTable({
   organizationSlug,
   variant,
   compactEmptyNative = false,
+  groupLabel,
+  totalCount = projects.length,
+  grouped = false,
+  suppressEmpty = false,
   hasMore = false,
   onLoadMore,
   onEditProject,
@@ -321,6 +348,10 @@ export function ProjectsTable({
   organizationSlug: string;
   variant: "native" | "tms";
   compactEmptyNative?: boolean;
+  groupLabel?: string;
+  totalCount?: number;
+  grouped?: boolean;
+  suppressEmpty?: boolean;
   hasMore?: boolean;
   onLoadMore?: () => void;
   onEditProject?: (project: ProjectListRow) => void;
@@ -330,78 +361,88 @@ export function ProjectsTable({
 }) {
   const intl = useIntl();
 
-  return (
-    <section>
-      {projectsQuery.isLoading ? (
-        <div
-          className="grid gap-3 py-4 lg:grid-cols-2"
-          aria-busy="true"
-          aria-label={intl.formatMessage(projectsTableMessages.loadingProjects)}
-        >
-          {Array.from({ length: 4 }).map((_, index) => (
-            <ProjectCardSkeleton key={index} />
-          ))}
-        </div>
+  const rows = (
+    <tbody>
+      {groupLabel ? (
+        <tr className="border-b border-border bg-muted">
+          <th
+            colSpan={6}
+            scope="rowgroup"
+            className="px-4 py-2 text-left text-[10px] font-medium text-muted-foreground"
+          >
+            <span className="tracking-[0.08em] uppercase">{groupLabel}</span>
+            {projectsQuery.isSuccess ? (
+              <span className="ml-2 font-normal">
+                <FormattedMessage
+                  {...projectsTableMessages.projectCount}
+                  values={{ count: totalCount }}
+                />
+              </span>
+            ) : null}
+          </th>
+        </tr>
       ) : null}
+      {projectsQuery.isLoading
+        ? Array.from({ length: 3 }, (_, index) => (
+            <tr
+              key={index}
+              aria-busy="true"
+              aria-label={intl.formatMessage(projectsTableMessages.loadingProjects)}
+            >
+              <td colSpan={6} className="px-4 py-3">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="size-8 rounded-md" />
+                  <Skeleton className="h-8 w-1/3" />
+                  <Skeleton className="ml-auto h-4 w-1/4" />
+                </div>
+              </td>
+            </tr>
+          ))
+        : null}
       {projectsQuery.isError ? (
-        <div className={cn(variant === "tms" ? "py-4" : "py-8")}>
-          {variant === "tms" && isTmsUserConnectionRequiredError(projectsQuery.error) ? (
-            <TmsUserConnectionErrorPanel
-              organizationSlug={organizationSlug}
-              resource="projects"
-              error={projectsQuery.error}
-            />
-          ) : (
-            <>
-              <TypographyP className="text-flame-100" size="small" weight="medium">
-                <FormattedMessage {...projectsTableMessages.loadFailedTitle} />
-              </TypographyP>
-              <TypographyP className="mt-1" size="xsmall" tone="subtle">
-                {projectsQuery.error instanceof Error
-                  ? projectsQuery.error.message
-                  : intl.formatMessage(projectsTableMessages.loadFailedFallback)}
-              </TypographyP>
-            </>
-          )}
-        </div>
+        <tr>
+          <td colSpan={6} className="px-4 py-4">
+            {variant === "tms" && isTmsUserConnectionRequiredError(projectsQuery.error) ? (
+              <TmsUserConnectionErrorPanel
+                organizationSlug={organizationSlug}
+                resource="projects"
+                error={projectsQuery.error}
+              />
+            ) : (
+              <div role="alert">
+                <TypographyP className="text-destructive" size="small" weight="medium">
+                  <FormattedMessage {...projectsTableMessages.loadFailedTitle} />
+                </TypographyP>
+                <TypographyP className="mt-1" size="xsmall" tone="subtle">
+                  {projectsQuery.error.message ||
+                    intl.formatMessage(projectsTableMessages.loadFailedFallback)}
+                </TypographyP>
+              </div>
+            )}
+          </td>
+        </tr>
       ) : null}
-      {projectsQuery.isSuccess && projects.length === 0 ? (
-        variant === "native" ? (
-          <NativeEmptyState compact={compactEmptyNative} onCreateProject={onCreateProject} />
-        ) : (
-          <div className="max-w-xl space-y-3 py-4">
-            <TypographyP size="small" weight="medium" tone="content">
-              <FormattedMessage {...projectsTableMessages.emptyTmsTitle} />
-            </TypographyP>
-            <TypographyP className="leading-6" size="small" tone="subtle">
-              <FormattedMessage {...projectsTableMessages.emptyTmsDescription} />
-            </TypographyP>
-          </div>
-        )
+      {projectsQuery.isSuccess && projects.length === 0 && !suppressEmpty ? (
+        <tr>
+          <td colSpan={6} className="px-4 py-4">
+            {variant === "native" ? (
+              <NativeEmptyState compact={compactEmptyNative} onCreateProject={onCreateProject} />
+            ) : (
+              <div className="space-y-2">
+                <TypographyP size="small" weight="medium">
+                  <FormattedMessage {...projectsTableMessages.emptyTmsTitle} />
+                </TypographyP>
+                <TypographyP size="small" tone="subtle">
+                  <FormattedMessage {...projectsTableMessages.emptyTmsDescription} />
+                </TypographyP>
+              </div>
+            )}
+          </td>
+        </tr>
       ) : null}
-      {projectsQuery.isSuccess && projects.length > 0 && variant === "tms" ? (
-        <div className="grid gap-3 lg:grid-cols-2">
-          {projects.map((project) => (
-            <ProjectCard
-              key={project.id}
-              project={project}
-              organizationSlug={organizationSlug}
-              isSavingProject={isSavingProject}
-              isDeletingProject={isDeletingProject}
-              onDeleteProject={onDeleteProject}
-              onOpenProject={onOpenProject}
-            />
-          ))}
-        </div>
-      ) : null}
-      {projectsQuery.isSuccess &&
-      projects.length > 0 &&
-      variant === "native" &&
-      onEditProject &&
-      onDeleteProject ? (
-        <div className="grid gap-3 lg:grid-cols-2">
-          {projects.map((project) => (
-            <ProjectCard
+      {projectsQuery.isSuccess
+        ? projects.map((project) => (
+            <ProjectRow
               key={project.id}
               project={project}
               organizationSlug={organizationSlug}
@@ -411,16 +452,27 @@ export function ProjectsTable({
               onDeleteProject={onDeleteProject}
               onOpenProject={onOpenProject}
             />
-          ))}
-        </div>
+          ))
+        : null}
+      {hasMore && projectsQuery.isSuccess && onLoadMore ? (
+        <tr>
+          <td colSpan={6} className="px-4 py-3 text-center">
+            <Button type="button" variant="outline" size="sm" onClick={onLoadMore}>
+              <FormattedMessage {...projectsTableMessages.loadMore} />
+            </Button>
+          </td>
+        </tr>
       ) : null}
-      {hasMore && projectsQuery.isSuccess && projects.length > 0 && onLoadMore ? (
-        <div className={cn("flex justify-center", variant === "tms" ? "pt-4" : "pt-6")}>
-          <Button type="button" variant="outline" onClick={onLoadMore} className="rounded-full">
-            <FormattedMessage {...projectsTableMessages.loadMore} />
-          </Button>
-        </div>
-      ) : null}
-    </section>
+    </tbody>
+  );
+  return grouped ? (
+    rows
+  ) : (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full min-w-180 table-fixed">
+        <ProjectsTableHeader />
+        {rows}
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
## What changed

Updated the Projects page to match the “02 Projects — Mixed” design:

- Added project summary metrics for total projects, open jobs, native projects, and TMS projects.
- Replaced project cards with a grouped table layout.
- Added source badges, locale counts, open-job links, updated timestamps, and project actions.
- Added search and source filters for native and TMS projects.
- Enhanced recently opened projects with source markers.
- Added a Storybook preview covering mixed projects, filtering, and search behavior.

## How to test

- Review the Projects page at desktop and narrow widths.
- Verify native and TMS projects appear in separate groups.
- Test search, source filters, recent-project links, open-job links, and project action menus.
- Open the Storybook story: `App/Projects/Page`.

Automated checks were not completed because dependency installation and database access were unavailable in the environment.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review