### PR TITLE
feat(web): add developer resources section to workspace overview

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resource-urls.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resource-urls.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const HYPERLOCALISE_DOCS_ORIGIN = "https://hyperlocalise.dev";
+
+export const developerResourcesDocUrls = {
+  gettingStarted: `${HYPERLOCALISE_DOCS_ORIGIN}/platform/getting-started`,
+  mcp: `${HYPERLOCALISE_DOCS_ORIGIN}/platform/mcp`,
+  api: `${HYPERLOCALISE_DOCS_ORIGIN}/platform/api`,
+  integrations: `${HYPERLOCALISE_DOCS_ORIGIN}/platform/integrations`,
+} as const;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resources.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resources.messages.ts
@@ -1,0 +1,65 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const overviewDeveloperResourcesMessages = defineMessages({
+  title: {
+    defaultMessage: "Developer resources",
+    id: "KGbU+pSYaa",
+    description: "Overview section title for developer documentation links",
+  },
+  documentationTitle: {
+    defaultMessage: "Documentation",
+    id: "cSLAN3amsY",
+    description: "Developer resources link title for platform getting started docs",
+  },
+  documentationDescription: {
+    defaultMessage:
+      "Set up projects, upload sources, and run your first translation workflow in Cloud.",
+    id: "QJDVG0G3MR",
+    description: "Developer resources link description for platform getting started docs",
+  },
+  mcpTitle: {
+    defaultMessage: "MCP server",
+    id: "cnS8vYmi1I",
+    description: "Developer resources link title for the hosted MCP server docs",
+  },
+  mcpDescription: {
+    defaultMessage: "Tools, auth, and permissions for Claude, Codex, and Cursor agents.",
+    id: "8H9U3m6U34",
+    description: "Developer resources link description for the hosted MCP server docs",
+  },
+  apiTitle: {
+    defaultMessage: "Public API",
+    id: "pi6YCralA1",
+    description: "Developer resources link title for the public HTTP API docs",
+  },
+  apiDescription: {
+    defaultMessage: "Upload sources, create jobs, and pull translations over HTTP.",
+    id: "0l7PHiSZRI",
+    description: "Developer resources link description for the public HTTP API docs",
+  },
+  integrationsTitle: {
+    defaultMessage: "Integrations",
+    id: "b0Ch7Q4CAZ",
+    description: "Developer resources link title for third-party integration docs",
+  },
+  integrationsDescription: {
+    defaultMessage:
+      "Connect GitHub, TMS providers, Slack, and design tools your team already uses.",
+    id: "/2VDnVeMa5",
+    description: "Developer resources link description for third-party integration docs",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resources.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resources.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { OverviewDeveloperResources } from "./overview-developer-resources";
+
+const meta = {
+  title: "App/Overview/DeveloperResources",
+  component: OverviewDeveloperResources,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof OverviewDeveloperResources>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Developer resources" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: /Documentation/ })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: /MCP server/ })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: /Public API/ })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: /Integrations/ })).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resources.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resources.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it } from "vite-plus/test";
+
+import { developerResourcesDocUrls } from "./overview-developer-resource-urls";
+import { OverviewDeveloperResources } from "./overview-developer-resources";
+
+function renderSection() {
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      <OverviewDeveloperResources />
+    </IntlProvider>,
+  );
+}
+
+describe("OverviewDeveloperResources", () => {
+  it("renders the section title and documentation links", () => {
+    renderSection();
+
+    expect(screen.getByRole("heading", { name: "Developer resources" })).toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: /Documentation/ })).toHaveAttribute(
+      "href",
+      developerResourcesDocUrls.gettingStarted,
+    );
+    expect(screen.getByRole("link", { name: /MCP server/ })).toHaveAttribute(
+      "href",
+      developerResourcesDocUrls.mcp,
+    );
+    expect(screen.getByRole("link", { name: /Public API/ })).toHaveAttribute(
+      "href",
+      developerResourcesDocUrls.api,
+    );
+    expect(screen.getByRole("link", { name: /Integrations/ })).toHaveAttribute(
+      "href",
+      developerResourcesDocUrls.integrations,
+    );
+  });
+
+  it("opens documentation links in a new tab", () => {
+    renderSection();
+
+    for (const link of screen.getAllByRole("link")) {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resources.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-developer-resources.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { ApiIcon, BookOpen01Icon, ConnectIcon, Robot01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { ComponentProps } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { cn } from "@/lib/primitives/cn";
+
+import { developerResourcesDocUrls } from "./overview-developer-resource-urls";
+import { overviewDeveloperResourcesMessages as messages } from "./overview-developer-resources.messages";
+
+type DeveloperResourceItem = {
+  href: string;
+  title: typeof messages.documentationTitle;
+  description: typeof messages.documentationDescription;
+  icon: ComponentProps<typeof HugeiconsIcon>["icon"];
+};
+
+const DEVELOPER_RESOURCE_ITEMS: readonly DeveloperResourceItem[] = [
+  {
+    href: developerResourcesDocUrls.gettingStarted,
+    title: messages.documentationTitle,
+    description: messages.documentationDescription,
+    icon: BookOpen01Icon,
+  },
+  {
+    href: developerResourcesDocUrls.mcp,
+    title: messages.mcpTitle,
+    description: messages.mcpDescription,
+    icon: Robot01Icon,
+  },
+  {
+    href: developerResourcesDocUrls.api,
+    title: messages.apiTitle,
+    description: messages.apiDescription,
+    icon: ApiIcon,
+  },
+  {
+    href: developerResourcesDocUrls.integrations,
+    title: messages.integrationsTitle,
+    description: messages.integrationsDescription,
+    icon: ConnectIcon,
+  },
+];
+
+export function OverviewDeveloperResources({ className }: { className?: string }) {
+  const intl = useIntl();
+
+  return (
+    <section
+      aria-labelledby="overview-developer-resources-title"
+      className={cn("flex flex-col gap-4", className)}
+    >
+      <h2
+        className="font-heading text-base font-medium text-foreground"
+        id="overview-developer-resources-title"
+      >
+        <FormattedMessage {...messages.title} />
+      </h2>
+
+      <div aria-hidden className="border-b border-border" />
+
+      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {DEVELOPER_RESOURCE_ITEMS.map((item) => (
+          <li key={item.href}>
+            <a
+              className="group flex flex-col gap-2"
+              href={item.href}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <span className="inline-flex items-center gap-2">
+                <HugeiconsIcon
+                  className="size-4 shrink-0 text-muted-foreground"
+                  icon={item.icon}
+                  strokeWidth={1.8}
+                />
+                <span className="text-sm font-medium text-foreground underline-offset-4 group-hover:underline">
+                  {intl.formatMessage(item.title)}
+                </span>
+              </span>
+              <span className="text-sm leading-5 text-muted-foreground">
+                {intl.formatMessage(item.description)}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
@@ -98,6 +98,8 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Overview" })).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "Connect your agent" })).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "Developer resources" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: /MCP server/ })).toBeInTheDocument();
     await expect(canvas.getByText("2 P1 on Queries")).toBeInTheDocument();
     await expect(canvas.getByText("Activity")).toBeInTheDocument();
     await expect(canvas.getByText("Projects")).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/workspace/overview-snapshot-model";
 
 import { OverviewConnectAgentCard } from "../../_components/overview/overview-connect-agent-card";
+import { OverviewDeveloperResources } from "../../_components/overview/overview-developer-resources";
 import { IssuePriorityIcon } from "../../_components/issue-detail/issue-priority-icon";
 import {
   formatCompactRelativeTimestamp,
@@ -583,6 +584,8 @@ export function DashboardPageView({
         <OverviewConnectAgentCard compact className="min-w-0 flex-1" />
         {slackConnectCard}
       </section>
+
+      <OverviewDeveloperResources />
     </WorkspacePageShell>
   );
 }


### PR DESCRIPTION
## What changed

Add a **Developer resources** section to the workspace Overview page, placed below the Connect your agent card. It links to four docs on `hyperlocalise.dev`:

- Documentation (getting started)
- MCP server
- Public API
- Integrations

Includes a reusable `OverviewDeveloperResources` component, Storybook story, and unit tests.

## How to test

- Open **Overview** in a workspace and confirm the Developer resources section appears below Connect your agent.
- Verify each link opens the correct `hyperlocalise.dev` page in a new tab.
- Run `vp test src/app/[lang]/\(authenticated\)/org/[organizationSlug]/_components/overview/overview-developer-resources.test.tsx`
- Run `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)