### PR TITLE
feat(mt): add Amazon Translate client

### DIFF
--- a/internal/mt/BUILD.bazel
+++ b/internal/mt/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "mt",
     srcs = [
+        "amazon.go",
         "config.go",
         "deepl.go",
         "doc.go",
@@ -20,6 +21,7 @@ go_library(
 go_test(
     name = "mt_test",
     srcs = [
+        "amazon_test.go",
         "config_test.go",
         "deepl_test.go",
         "errors_test.go",

--- a/internal/mt/amazon.go
+++ b/internal/mt/amazon.go
@@ -1,0 +1,364 @@
+package mt
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+const (
+	amazonServiceName = "translate"
+
+	amazonTargetHeader = "AWSShineFrontendService_20170701.TranslateText"
+
+	amazonTranslateAction = "TranslateText"
+
+	// TranslateText limits Text to 10,000 UTF-8 bytes.
+	amazonMaxTextBytes = 10000
+)
+
+// AmazonClient translates text using Amazon Translate's TranslateText API,
+// authenticating requests with AWS Signature Version 4.
+type AmazonClient struct {
+	accessKeyID     string
+	secretAccessKey string
+	sessionToken    string
+	region          string
+	baseURL         string
+	httpClient      *http.Client
+}
+
+var _ Engine = (*AmazonClient)(nil)
+
+// NewAmazonClient creates an Amazon Translate client.
+func NewAmazonClient(cfg Config) (*AmazonClient, error) {
+	if strings.TrimSpace(cfg.AccessKeyID) == "" {
+		return nil, &Error{Code: ErrorCodeValidation, Message: "access key ID is required"}
+	}
+	if strings.TrimSpace(cfg.SecretAccessKey) == "" {
+		return nil, &Error{Code: ErrorCodeValidation, Message: "secret access key is required"}
+	}
+	region := strings.TrimSpace(cfg.Region)
+	if region == "" {
+		return nil, &Error{Code: ErrorCodeValidation, Message: "region is required"}
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("https://translate.%s.amazonaws.com", region)
+	}
+
+	return &AmazonClient{
+		accessKeyID:     cfg.AccessKeyID,
+		secretAccessKey: cfg.SecretAccessKey,
+		sessionToken:    cfg.SessionToken,
+		region:          region,
+		baseURL:         strings.TrimRight(baseURL, "/"),
+		httpClient:      cfg.httpClient(),
+	}, nil
+}
+
+type amazonTranslateRequest struct {
+	Text               string `json:"Text"`
+	SourceLanguageCode string `json:"SourceLanguageCode"`
+	TargetLanguageCode string `json:"TargetLanguageCode"`
+}
+
+type amazonTranslateResponse struct {
+	TranslatedText string `json:"TranslatedText"`
+}
+
+type amazonErrorResponse struct {
+	Type       string `json:"__type"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	MessageCap string `json:"Message"`
+}
+
+// Translate implements Engine using Amazon Translate.
+func (c *AmazonClient) Translate(ctx context.Context, req Request) (Response, error) {
+	if err := validateRequest(req); err != nil {
+		return Response{}, err
+	}
+
+	for i, s := range req.Sources {
+		if n := len(s); n == 0 || n > amazonMaxTextBytes {
+			return Response{}, &Error{
+				Code: ErrorCodeValidation,
+				Message: fmt.Sprintf(
+					"source %d must be between 1 and %d bytes, got %d", i, amazonMaxTextBytes, n),
+			}
+		}
+	}
+
+	sourceCode := amazonLanguageCode(req.SourceLocale)
+	targetCode := amazonLanguageCode(req.TargetLocale)
+
+	translations := make([]string, len(req.Sources))
+	for i, s := range req.Sources {
+		translated, err := c.translateOne(ctx, sourceCode, targetCode, s)
+		if err != nil {
+			return Response{}, err
+		}
+		translations[i] = translated
+	}
+	return Response{Translations: translations}, nil
+}
+
+func (c *AmazonClient) translateOne(ctx context.Context, sourceCode, targetCode, text string) (string, error) {
+	body := amazonTranslateRequest{
+		Text:               text,
+		SourceLanguageCode: sourceCode,
+		TargetLanguageCode: targetCode,
+	}
+
+	var out amazonTranslateResponse
+	if err := c.request(ctx, body, &out); err != nil {
+		return "", err
+	}
+	return out.TranslatedText, nil
+}
+
+func (c *AmazonClient) request(ctx context.Context, body, out any) error {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("mt: marshal amazon translate request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/", bytes.NewReader(encoded))
+	if err != nil {
+		return fmt.Errorf("mt: build amazon translate request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	httpReq.Header.Set("X-Amz-Target", amazonTargetHeader)
+	c.sign(httpReq, encoded, time.Now().UTC())
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return &Error{
+			Code:    ErrorCodeUpstreamUnavailable,
+			Message: "could not reach Amazon Translate",
+			Path:    amazonTranslateAction,
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return &Error{
+			Code:    ErrorCodeUpstreamUnavailable,
+			Message: "could not read Amazon Translate response",
+			Path:    amazonTranslateAction,
+		}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return amazonHTTPError(resp.StatusCode, resp.Header.Get("X-Amzn-Errortype"), respBody)
+	}
+
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return &Error{
+			Code:       ErrorCodeUpstream,
+			Message:    "Amazon Translate returned invalid JSON",
+			StatusCode: resp.StatusCode,
+			Path:       amazonTranslateAction,
+		}
+	}
+	return nil
+}
+
+// SigV4/credential errors Amazon returns as HTTP 400.
+var amazonAuthErrorTypes = map[string]bool{
+	"UnrecognizedClientException":         true,
+	"InvalidSignatureException":           true,
+	"IncompleteSignatureException":        true,
+	"MissingAuthenticationTokenException": true,
+	"AccessDeniedException":               true,
+	"ExpiredTokenException":               true,
+}
+
+func amazonHTTPError(statusCode int, headerType string, body []byte) *Error {
+	var parsed amazonErrorResponse
+	_ = json.Unmarshal(body, &parsed)
+	errType := amazonErrorType(headerType, parsed)
+	message := amazonErrorMessage(statusCode, parsed)
+
+	switch {
+	case statusCode == http.StatusBadRequest && errType == "UnsupportedLanguagePairException":
+		return &Error{Code: ErrorCodeUnsupportedLanguagePair, Message: message, StatusCode: statusCode, Path: amazonTranslateAction}
+	case statusCode == http.StatusBadRequest && errType == "TooManyRequestsException":
+		return &Error{Code: ErrorCodeRateLimited, Message: message, StatusCode: statusCode, Path: amazonTranslateAction}
+	case statusCode == http.StatusUnauthorized, statusCode == http.StatusForbidden:
+		return &Error{Code: ErrorCodeAuthFailed, Message: message, StatusCode: statusCode, Path: amazonTranslateAction}
+	case statusCode == http.StatusBadRequest && amazonAuthErrorTypes[errType]:
+		return &Error{Code: ErrorCodeAuthFailed, Message: message, StatusCode: statusCode, Path: amazonTranslateAction}
+	case statusCode >= 500:
+		return &Error{Code: ErrorCodeUpstreamUnavailable, Message: message, StatusCode: statusCode, Path: amazonTranslateAction}
+	default:
+		return &Error{Code: ErrorCodeUpstream, Message: message, StatusCode: statusCode, Path: amazonTranslateAction}
+	}
+}
+
+// Resolve the error type from the header, then "__type", then "code".
+func amazonErrorType(headerType string, parsed amazonErrorResponse) string {
+	if headerType != "" {
+		return sanitizeAmazonErrorType(headerType)
+	}
+	if parsed.Type != "" {
+		return sanitizeAmazonErrorType(parsed.Type)
+	}
+	return sanitizeAmazonErrorType(parsed.Code)
+}
+
+// Strip AWS error namespace and HTTP-status decorations.
+func sanitizeAmazonErrorType(errType string) string {
+	if idx := strings.IndexByte(errType, '#'); idx != -1 {
+		errType = errType[idx+1:]
+	}
+	if idx := strings.IndexByte(errType, ':'); idx != -1 {
+		errType = errType[:idx]
+	}
+	return errType
+}
+
+func amazonErrorMessage(statusCode int, parsed amazonErrorResponse) string {
+	msg := parsed.Message
+	if msg == "" {
+		msg = parsed.MessageCap
+	}
+	if msg != "" {
+		return fmt.Sprintf("Amazon Translate error (%d): %s", statusCode, msg)
+	}
+	return fmt.Sprintf("Amazon Translate error (%d)", statusCode)
+}
+
+// Region-qualified Amazon codes; pt-BR normalizes to bare "pt".
+var amazonRegionOverrides = map[string]map[string]string{
+	"fr": {"CA": "fr-CA"},
+	"es": {"MX": "es-MX"},
+	"pt": {"PT": "pt-PT"},
+	"fa": {"AF": "fa-AF"},
+}
+
+func amazonLanguageCode(locale string) string {
+	tag, err := language.Parse(locale)
+	if err != nil {
+		return locale
+	}
+	base, _ := tag.Base()
+	baseCode := base.String()
+
+	if baseCode == "zh" {
+		if script, conf := tag.Script(); conf == language.Exact && script.String() == "Hant" {
+			return "zh-TW"
+		}
+		if region, conf := tag.Region(); conf == language.Exact {
+			switch region.String() {
+			case "TW", "HK", "MO":
+				return "zh-TW"
+			}
+		}
+		return "zh"
+	}
+
+	if overrides, ok := amazonRegionOverrides[baseCode]; ok {
+		if region, conf := tag.Region(); conf == language.Exact {
+			if code, ok := overrides[region.String()]; ok {
+				return code
+			}
+		}
+	}
+	return baseCode
+}
+
+func (c *AmazonClient) sign(req *http.Request, payload []byte, now time.Time) {
+	const amzDateLayout = "20060102T150405Z"
+	const dateLayout = "20060102"
+
+	amzDate := now.Format(amzDateLayout)
+	dateStamp := now.Format(dateLayout)
+	payloadHash := sha256Hex(payload)
+
+	req.Header.Set("Host", req.URL.Host)
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	if c.sessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", c.sessionToken)
+	}
+
+	signedHeaderNames := []string{"content-type", "host", "x-amz-content-sha256", "x-amz-date", "x-amz-target"}
+	if c.sessionToken != "" {
+		signedHeaderNames = append(signedHeaderNames, "x-amz-security-token")
+	}
+	sort.Strings(signedHeaderNames)
+
+	var canonicalHeaders strings.Builder
+	for _, name := range signedHeaderNames {
+		canonicalHeaders.WriteString(name)
+		canonicalHeaders.WriteString(":")
+		canonicalHeaders.WriteString(strings.TrimSpace(req.Header.Get(name)))
+		canonicalHeaders.WriteString("\n")
+	}
+	signedHeaders := strings.Join(signedHeaderNames, ";")
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		req.URL.EscapedPath(),
+		"",
+		canonicalHeaders.String(),
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	credentialScope := strings.Join([]string{dateStamp, c.region, amazonServiceName, "aws4_request"}, "/")
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := amazonSigningKey(c.secretAccessKey, dateStamp, c.region)
+	signature := hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
+
+	req.Header.Set("Authorization", strings.Join([]string{
+		"AWS4-HMAC-SHA256 Credential=" + c.accessKeyID + "/" + credentialScope,
+		"SignedHeaders=" + signedHeaders,
+		"Signature=" + signature,
+	}, ", "))
+}
+
+func amazonSigningKey(secretAccessKey, dateStamp, region string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secretAccessKey), dateStamp)
+	kRegion := hmacSHA256(kDate, region)
+	kService := hmacSHA256(kRegion, amazonServiceName)
+	return hmacSHA256(kService, "aws4_request")
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	h := hmac.New(sha256.New, key)
+	_, _ = h.Write([]byte(data))
+	return h.Sum(nil)
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/mt/amazon_test.go
+++ b/internal/mt/amazon_test.go
@@ -1,0 +1,462 @@
+package mt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type amazonRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f amazonRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newAmazonTestClient(t *testing.T, handler http.HandlerFunc) *AmazonClient {
+	t.Helper()
+	cfg := newTestServer(t, handler)
+	cfg.AccessKeyID = "AKIATEST"
+	cfg.SecretAccessKey = "test-secret"
+	cfg.Region = "us-east-1"
+	client, err := NewAmazonClient(cfg)
+	require.NoError(t, err)
+	return client
+}
+
+func decodeAmazonRequest(t *testing.T, r *http.Request) amazonTranslateRequest {
+	t.Helper()
+	var body amazonTranslateRequest
+	require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+	return body
+}
+
+func TestNewAmazonClientRequiresAccessKeyID(t *testing.T) {
+	client, err := NewAmazonClient(Config{SecretAccessKey: "secret", Region: "us-east-1"})
+	require.Nil(t, client)
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestNewAmazonClientRequiresSecretAccessKey(t *testing.T) {
+	client, err := NewAmazonClient(Config{AccessKeyID: "AKIATEST", Region: "us-east-1"})
+	require.Nil(t, client)
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestNewAmazonClientRequiresRegion(t *testing.T) {
+	client, err := NewAmazonClient(Config{AccessKeyID: "AKIATEST", SecretAccessKey: "secret"})
+	require.Nil(t, client)
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestNewAmazonClientDoesNotDefaultRegion(t *testing.T) {
+	// Region must never be silently defaulted, unlike BaseURL.
+	client, err := NewAmazonClient(Config{AccessKeyID: "AKIATEST", SecretAccessKey: "secret", Region: "  "})
+	require.Nil(t, client)
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+var amazonAuthHeaderPattern = regexp.MustCompile(
+	`^AWS4-HMAC-SHA256 Credential=AKIATEST/\d{8}/us-east-1/translate/aws4_request, ` +
+		`SignedHeaders=([a-z0-9;-]+), Signature=[0-9a-f]{64}$`)
+
+func TestAmazonClientTranslateSuccess(t *testing.T) {
+	var gotMethod, gotPath, gotContentType, gotTarget, gotAuth, gotDate string
+	var gotBody amazonTranslateRequest
+
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		gotTarget = r.Header.Get("X-Amz-Target")
+		gotAuth = r.Header.Get("Authorization")
+		gotDate = r.Header.Get("X-Amz-Date")
+		gotBody = decodeAmazonRequest(t, r)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"TranslatedText":"Bonjour"}`))
+	})
+
+	resp, err := client.Translate(t.Context(), Request{
+		SourceLocale: "en",
+		TargetLocale: "fr",
+		Sources:      []string{"Hello"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"Bonjour"}, resp.Translations)
+
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, "/", gotPath)
+	require.Equal(t, "application/x-amz-json-1.1", gotContentType)
+	require.Equal(t, amazonTargetHeader, gotTarget)
+	require.Regexp(t, `^\d{8}T\d{6}Z$`, gotDate)
+	require.Regexp(t, amazonAuthHeaderPattern, gotAuth)
+	require.Equal(t, "content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target",
+		amazonAuthHeaderPattern.FindStringSubmatch(gotAuth)[1])
+
+	require.Equal(t, amazonTranslateRequest{Text: "Hello", SourceLanguageCode: "en", TargetLanguageCode: "fr"}, gotBody)
+}
+
+func TestAmazonClientTranslateSessionTokenSentAndSigned(t *testing.T) {
+	const token = "test-session-token"
+
+	var gotToken, gotAuth string
+	cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Amz-Security-Token")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"TranslatedText":"Bonjour"}`))
+	})
+	cfg.AccessKeyID = "AKIATEST"
+	cfg.SecretAccessKey = "test-secret"
+	cfg.Region = "us-east-1"
+	cfg.SessionToken = token
+	client, err := NewAmazonClient(cfg)
+	require.NoError(t, err)
+
+	_, err = client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"Hello"}})
+	require.NoError(t, err)
+
+	require.Equal(t, token, gotToken)
+	signedHeaders := amazonAuthHeaderPattern.FindStringSubmatch(gotAuth)
+	require.NotNil(t, signedHeaders)
+	require.Equal(t, "content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-target", signedHeaders[1])
+}
+
+func TestAmazonClientTranslateOrderPreservedAcrossMultipleCalls(t *testing.T) {
+	sources := []string{"one", "two", "three"}
+
+	var calls int
+	var seen []string
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		body := decodeAmazonRequest(t, r)
+		seen = append(seen, body.Text)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"TranslatedText":%q}`, body.Text+"-out")
+	})
+
+	resp, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: sources})
+	require.NoError(t, err)
+
+	require.Equal(t, 3, calls)
+	require.Equal(t, sources, seen)
+	require.Equal(t, []string{"one-out", "two-out", "three-out"}, resp.Translations)
+}
+
+func TestAmazonClientTranslateSourceExceedsByteLimitMakesNoRequest(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected HTTP call for an over-limit source")
+	})
+
+	oversized := strings.Repeat("a", amazonMaxTextBytes+1)
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{oversized}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestAmazonClientTranslateEmptySourceMakesNoRequest(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected HTTP call for an empty source")
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi", ""}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestAmazonClientTranslateEmptyInputMakesNoRequest(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected HTTP call for empty input")
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: nil})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeValidation, typed.Code)
+}
+
+func TestAmazonClientTranslateAuthFailed(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"__type":"UnrecognizedClientException","message":"The security token included in the request is invalid."}`))
+			})
+
+			_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeAuthFailed, typed.Code)
+			require.Equal(t, status, typed.StatusCode)
+		})
+	}
+}
+
+func TestAmazonClientTranslateAuthFailedAt400(t *testing.T) {
+	// Some SigV4 failures are documented at HTTP 400 rather than 401/403.
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"__type":"IncompleteSignatureException","message":"bad signature"}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeAuthFailed, typed.Code)
+}
+
+func TestAmazonClientTranslateUnsupportedLanguagePair(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"__type":"UnsupportedLanguagePairException","Message":"Amazon Translate cannot translate from en to xx."}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUnsupportedLanguagePair, typed.Code)
+	require.Equal(t, http.StatusBadRequest, typed.StatusCode)
+}
+
+func TestAmazonClientTranslateUnsupportedLanguagePairViaHeader(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Amzn-Errortype", "com.amazonaws.translate#UnsupportedLanguagePairException:400")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUnsupportedLanguagePair, typed.Code)
+}
+
+func TestAmazonClientTranslateBadRequestNotUnsupportedLanguage(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"__type":"InvalidRequestException","message":"bad request"}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestAmazonClientTranslateRateLimited(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"__type":"TooManyRequestsException","message":"too many requests"}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeRateLimited, typed.Code)
+	require.Equal(t, http.StatusBadRequest, typed.StatusCode)
+}
+
+func TestAmazonClientTranslateTextSizeLimitExceededMapsToUpstreamError(t *testing.T) {
+	// Size is validated locally, so an upstream size rejection indicates API drift.
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"__type":"TextSizeLimitExceededException","message":"text too long"}`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestAmazonClientTranslateUpstreamUnavailable(t *testing.T) {
+	for _, status := range []int{http.StatusInternalServerError, http.StatusServiceUnavailable} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"__type":"InternalServerException","message":"internal error"}`))
+			})
+
+			_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+			typed, ok := AsError(err)
+			require.True(t, ok)
+			require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+		})
+	}
+}
+
+func TestAmazonClientTranslateRawErrorBodyNotEchoed(t *testing.T) {
+	const rawBody = "Internal Server Error: stack trace and sensitive upstream details"
+
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(rawBody))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+	require.Equal(t, "Amazon Translate error (500)", typed.Message)
+	require.NotContains(t, typed.Message, rawBody)
+	require.NotContains(t, err.Error(), rawBody)
+}
+
+func TestAmazonClientTranslateInvalidJSONResponse(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	})
+
+	_, err := client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstream, typed.Code)
+}
+
+func TestAmazonClientTranslateContextCanceled(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"TranslatedText":"Bonjour"}`))
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled))
+	_, ok := AsError(err)
+	require.False(t, ok)
+}
+
+func TestAmazonClientTranslateContextDeadlineExceeded(t *testing.T) {
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"TranslatedText":"Bonjour"}`))
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+
+	_, err := client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded))
+	_, ok := AsError(err)
+	require.False(t, ok)
+}
+
+func TestAmazonClientTranslateContextCanceledBetweenCalls(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var calls int
+	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		require.Equal(t, 1, calls, "no request should be sent for a source after cancellation")
+
+		body := decodeAmazonRequest(t, r)
+		respBody := fmt.Sprintf(`{"TranslatedText":%q}`, body.Text+"-out")
+		w.Header().Set("Content-Length", strconv.Itoa(len(respBody)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		cancel()
+	})
+
+	_, err := client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"one", "two"}})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled))
+	_, ok := AsError(err)
+	require.False(t, ok)
+	require.Equal(t, 1, calls)
+}
+
+func TestAmazonClientTranslateTransportErrorDoesNotLeakCredentials(t *testing.T) {
+	const secret = "super-secret-access-key-12345"
+	const token = "super-secret-session-token-67890"
+
+	client, err := NewAmazonClient(Config{
+		AccessKeyID:     "AKIATEST",
+		SecretAccessKey: secret,
+		SessionToken:    token,
+		Region:          "us-east-1",
+		HTTPClient: &http.Client{
+			Transport: amazonRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("dial tcp: connection refused, auth: " + req.Header.Get("Authorization") + " token: " + req.Header.Get("X-Amz-Security-Token"))
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.Translate(t.Context(), Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"hi"}})
+	require.Error(t, err)
+
+	typed, ok := AsError(err)
+	require.True(t, ok)
+	require.Equal(t, ErrorCodeUpstreamUnavailable, typed.Code)
+	require.Equal(t, amazonTranslateAction, typed.Path)
+	require.NotContains(t, typed.Message, secret)
+	require.NotContains(t, typed.Message, token)
+	require.NotContains(t, err.Error(), secret)
+	require.NotContains(t, err.Error(), token)
+}
+
+func TestAmazonLanguageCode(t *testing.T) {
+	cases := []struct {
+		locale string
+		want   string
+	}{
+		{"en", "en"},
+		{"de", "de"},
+		{"ja", "ja"},
+		{"zh", "zh"},
+		{"zh-Hans", "zh"},
+		{"zh-CN", "zh"},
+		{"zh-Hant", "zh-TW"},
+		{"zh-TW", "zh-TW"},
+		{"zh-HK", "zh-TW"},
+		{"fr", "fr"},
+		{"fr-CA", "fr-CA"},
+		{"fr-FR", "fr"},
+		{"es", "es"},
+		{"es-MX", "es-MX"},
+		{"es-ES", "es"},
+		{"pt", "pt"},
+		{"pt-BR", "pt"},
+		{"pt-PT", "pt-PT"},
+		{"fa", "fa"},
+		{"fa-AF", "fa-AF"},
+		{"fa-IR", "fa"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.locale, func(t *testing.T) {
+			require.Equal(t, tc.want, amazonLanguageCode(tc.locale))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Added the Amazon Translate client behind the `internal/mt` `Engine`.
- Added SigV4 authentication, Amazon locale mapping, request validation, typed error mapping, and context cancellation.
- Preserved source order across sequential `TranslateText` calls and added coverage for vendor limits, errors, and credential safety.

## How to test

- `go test ./internal/mt`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
