### PR TITLE
feat(cli): add Lokalise upload translations (HL-663)

### DIFF
--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -81,6 +81,24 @@ type lokaliseUploadSourcesOptions struct {
 	dryRun              bool
 }
 
+type lokaliseUploadTranslationsOptions struct {
+	configPath          string
+	projectID           string
+	targetLocale        string
+	files               []string
+	format              string
+	branch              string
+	tags                []string
+	tokenEnv            string
+	apiBaseURL          string
+	timeoutSeconds      int
+	convertPlaceholders bool
+	replaceModified     bool
+	distinguishByFile   bool
+	applyTM             bool
+	dryRun              bool
+}
+
 type lokaliseGlossaryCSVWriter interface {
 	WriteGlossaryCSV(context.Context, lokalise.GlossaryDownloadInput, io.Writer) (lokalise.GlossaryDownloadResult, error)
 }
@@ -97,6 +115,10 @@ type lokaliseSourceUploader interface {
 	UploadSourceFile(context.Context, lokalise.SourceUploadInput) (lokalise.SourceUploadResult, error)
 }
 
+type lokaliseTranslationUploader interface {
+	UploadTranslationFile(context.Context, lokalise.TranslationUploadInput) (lokalise.TranslationUploadResult, error)
+}
+
 var newLokaliseGlossaryCSVWriter = func(cfg lokalise.Config) (lokaliseGlossaryCSVWriter, error) {
 	return lokalise.NewHTTPClient(cfg)
 }
@@ -110,6 +132,10 @@ var newLokaliseSourceDownloader = func(cfg lokalise.Config) (lokaliseSourceDownl
 }
 
 var newLokaliseSourceUploader = func(cfg lokalise.Config) (lokaliseSourceUploader, error) {
+	return lokalise.NewHTTPClient(cfg)
+}
+
+var newLokaliseTranslationUploader = func(cfg lokalise.Config) (lokaliseTranslationUploader, error) {
 	return lokalise.NewHTTPClient(cfg)
 }
 
@@ -599,6 +625,7 @@ func newLokaliseUploadCmd() *cobra.Command {
 		Short: "upload files to Lokalise",
 	}
 	cmd.AddCommand(newLokaliseUploadSourcesCmd())
+	cmd.AddCommand(newLokaliseUploadTranslationsCmd())
 	return cmd
 }
 
@@ -630,6 +657,37 @@ func newLokaliseUploadSourcesCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.distinguishByFile, "distinguish-by-file", false, "allow same key names in different filenames")
 	cmd.Flags().BoolVar(&o.applyTM, "apply-tm", false, "apply 100% translation memory matches during import")
 	cmd.Flags().BoolVar(&o.skipDetectLangISO, "skip-detect-lang-iso", false, "skip automatic language detection by filename")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without uploading files")
+	return cmd
+}
+
+func newLokaliseUploadTranslationsCmd() *cobra.Command {
+	o := lokaliseUploadTranslationsOptions{
+		tokenEnv:       defaultLokaliseAPITokenEnv,
+		timeoutSeconds: 30,
+	}
+	cmd := &cobra.Command{
+		Use:          "translations",
+		Short:        "upload translation files to Lokalise",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeLokaliseUploadTranslations(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to i18n config with storage.adapter=lokalise")
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Lokalise project identifier")
+	cmd.Flags().StringVar(&o.targetLocale, "target-locale", "", "target locale ISO in the uploaded file")
+	cmd.Flags().StringArrayVarP(&o.files, "file", "f", nil, "translation file path(s) to upload")
+	cmd.Flags().StringVar(&o.format, "format", "", "Lokalise file format; defaults to each file extension")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Lokalise branch name")
+	cmd.Flags().StringSliceVar(&o.tags, "tag", nil, "tag(s) to assign to uploaded keys")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", o.tokenEnv, "environment variable containing the Lokalise API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
+	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", o.timeoutSeconds, "Lokalise API timeout in seconds")
+	cmd.Flags().BoolVar(&o.convertPlaceholders, "convert-placeholders", false, "convert placeholders to Lokalise universal placeholders")
+	cmd.Flags().BoolVar(&o.replaceModified, "replace-modified", false, "overwrite existing translations that also appear in the uploaded file")
+	cmd.Flags().BoolVar(&o.distinguishByFile, "distinguish-by-file", false, "allow same key names in different filenames")
+	cmd.Flags().BoolVar(&o.applyTM, "apply-tm", false, "apply 100% translation memory matches during import")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without uploading files")
 	return cmd
 }
@@ -754,6 +812,62 @@ func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOpt
 	return err
 }
 
+func executeLokaliseUploadTranslations(cmd *cobra.Command, o lokaliseUploadTranslationsOptions) error {
+	files, err := validateLokaliseUploadFiles(o.files, o.format, "lokalise upload translations")
+	if err != nil {
+		return err
+	}
+	cfg, targetLocale, err := resolveLokaliseUploadTranslationsConfig(cmd, o, !o.dryRun)
+	if err != nil {
+		return err
+	}
+	existing := lokaliseExistingTranslationsLabel(o.replaceModified)
+	if o.dryRun {
+		format := strings.TrimSpace(o.format)
+		if format == "" {
+			format = "auto"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=lokalise-upload-translations project_id=%s target_locale=%s format=%s files=%d existing_translations=%s\n", cfg.ProjectID, targetLocale, format, len(files), existing)
+		return err
+	}
+
+	client, err := newLokaliseTranslationUploader(cfg)
+	if err != nil {
+		return err
+	}
+	processed := 0
+	for _, file := range files {
+		result, err := client.UploadTranslationFile(backgroundContext(), lokalise.TranslationUploadInput{
+			ProjectID:           cfg.ProjectID,
+			TargetLocale:        targetLocale,
+			FilePath:            file,
+			FileFormat:          strings.TrimSpace(o.format),
+			Branch:              strings.TrimSpace(o.branch),
+			Tags:                o.tags,
+			ConvertPlaceholders: o.convertPlaceholders,
+			ReplaceModified:     o.replaceModified,
+			DistinguishByFile:   o.distinguishByFile,
+			ApplyTM:             o.applyTM,
+		})
+		if err != nil {
+			return fmt.Errorf("lokalise upload translations: %w", err)
+		}
+		processed++
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "uploaded file=%s process_id=%s status=%s type=%s existing_translations=%s\n", file, result.ProcessID, result.Status, result.Type, existing); err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-translations processed=%d existing_translations=%s\n", processed, existing)
+	return err
+}
+
+func lokaliseExistingTranslationsLabel(replaceModified bool) string {
+	if replaceModified {
+		return "overwritten"
+	}
+	return "kept"
+}
+
 func resolveLokaliseUploadSourcesConfig(cmd *cobra.Command, o lokaliseUploadSourcesOptions, requireAuth bool) (lokalise.Config, string, error) {
 	cfg := lokalise.Config{}
 	if strings.TrimSpace(o.configPath) != "" {
@@ -809,7 +923,64 @@ func resolveLokaliseUploadSourcesConfig(cmd *cobra.Command, o lokaliseUploadSour
 	return cfg, strings.TrimSpace(cfg.SourceLanguage), nil
 }
 
+func resolveLokaliseUploadTranslationsConfig(cmd *cobra.Command, o lokaliseUploadTranslationsOptions, requireAuth bool) (lokalise.Config, string, error) {
+	cfg := lokalise.Config{}
+	if strings.TrimSpace(o.configPath) != "" {
+		loaded, err := i18nconfig.LoadForCLI(o.configPath)
+		if err != nil {
+			return lokalise.Config{}, "", err
+		}
+		if loaded.Storage == nil {
+			return lokalise.Config{}, "", fmt.Errorf("lokalise upload translations: --config must include storage.adapter=lokalise")
+		}
+		if !strings.EqualFold(strings.TrimSpace(loaded.Storage.Adapter), lokalise.AdapterName) {
+			return lokalise.Config{}, "", fmt.Errorf("lokalise upload translations: --config storage.adapter must be %q", lokalise.AdapterName)
+		}
+		decoded, err := lokalise.DecodeConfig(loaded.Storage.Config)
+		if err != nil {
+			return lokalise.Config{}, "", fmt.Errorf("lokalise upload translations: %w", err)
+		}
+		cfg = decoded
+	}
+
+	if lokaliseFlagChanged(cmd, "project-id") || strings.TrimSpace(cfg.ProjectID) == "" {
+		cfg.ProjectID = strings.TrimSpace(o.projectID)
+	}
+	if lokaliseFlagChanged(cmd, "token-env") || strings.TrimSpace(cfg.APITokenEnv) == "" {
+		cfg.APITokenEnv = strings.TrimSpace(o.tokenEnv)
+	}
+	if lokaliseFlagChanged(cmd, "api-base-url") || strings.TrimSpace(cfg.APIBaseURL) == "" {
+		cfg.APIBaseURL = strings.TrimSpace(o.apiBaseURL)
+	}
+	if lokaliseFlagChanged(cmd, "timeout-seconds") || cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = o.timeoutSeconds
+	}
+
+	targetLocale := strings.TrimSpace(o.targetLocale)
+	if strings.TrimSpace(cfg.ProjectID) == "" {
+		return lokalise.Config{}, "", fmt.Errorf("lokalise upload translations: --project-id is required (or projectID in --config)")
+	}
+	if targetLocale == "" {
+		return lokalise.Config{}, "", fmt.Errorf("lokalise upload translations: --target-locale is required")
+	}
+	if requireAuth {
+		resolved, err := lokalise.ResolveConfig(cfg)
+		if err != nil {
+			return lokalise.Config{}, "", fmt.Errorf("lokalise upload translations: %w", err)
+		}
+		return resolved, targetLocale, nil
+	}
+	if strings.TrimSpace(cfg.APITokenEnv) == "" {
+		cfg.APITokenEnv = defaultLokaliseAPITokenEnv
+	}
+	return cfg, targetLocale, nil
+}
+
 func validateLokaliseSourceFiles(paths []string, format string) ([]string, error) {
+	return validateLokaliseUploadFiles(paths, format, "lokalise upload sources")
+}
+
+func validateLokaliseUploadFiles(paths []string, format, op string) ([]string, error) {
 	files := make([]string, 0, len(paths))
 	for _, path := range paths {
 		trimmed := strings.TrimSpace(path)
@@ -818,18 +989,18 @@ func validateLokaliseSourceFiles(paths []string, format string) ([]string, error
 		}
 		info, err := os.Stat(trimmed)
 		if err != nil {
-			return nil, fmt.Errorf("lokalise upload sources: stat source file %q: %w", trimmed, err)
+			return nil, fmt.Errorf("%s: stat file %q: %w", op, trimmed, err)
 		}
 		if info.IsDir() {
-			return nil, fmt.Errorf("lokalise upload sources: source file %q is a directory", trimmed)
+			return nil, fmt.Errorf("%s: file %q is a directory", op, trimmed)
 		}
 		if strings.TrimSpace(format) == "" && strings.TrimPrefix(filepath.Ext(trimmed), ".") == "" {
-			return nil, fmt.Errorf("lokalise upload sources: could not determine file format for %q; use --format", trimmed)
+			return nil, fmt.Errorf("%s: could not determine file format for %q; use --format", op, trimmed)
 		}
 		files = append(files, trimmed)
 	}
 	if len(files) == 0 {
-		return nil, fmt.Errorf("lokalise upload sources: at least one --file is required")
+		return nil, fmt.Errorf("%s: at least one --file is required", op)
 	}
 	return files, nil
 }

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -837,7 +837,7 @@ func executeLokaliseUploadTranslations(cmd *cobra.Command, o lokaliseUploadTrans
 	}
 	processed := 0
 	for _, file := range files {
-		result, err := client.UploadTranslationFile(backgroundContext(), lokalise.TranslationUploadInput{
+		result, err := client.UploadTranslationFile(cmd.Context(), lokalise.TranslationUploadInput{
 			ProjectID:           cfg.ProjectID,
 			TargetLocale:        targetLocale,
 			FilePath:            file,

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -685,7 +685,7 @@ func newLokaliseUploadTranslationsCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
 	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", o.timeoutSeconds, "Lokalise API timeout in seconds")
 	cmd.Flags().BoolVar(&o.convertPlaceholders, "convert-placeholders", false, "convert placeholders to Lokalise universal placeholders")
-	cmd.Flags().BoolVar(&o.replaceModified, "replace-modified", false, "overwrite existing translations that also appear in the uploaded file")
+	cmd.Flags().BoolVar(&o.replaceModified, "replace-modified", false, "replace translations modified in the uploaded file")
 	cmd.Flags().BoolVar(&o.distinguishByFile, "distinguish-by-file", false, "allow same key names in different filenames")
 	cmd.Flags().BoolVar(&o.applyTM, "apply-tm", false, "apply 100% translation memory matches during import")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without uploading files")
@@ -821,13 +821,13 @@ func executeLokaliseUploadTranslations(cmd *cobra.Command, o lokaliseUploadTrans
 	if err != nil {
 		return err
 	}
-	existing := lokaliseExistingTranslationsLabel(o.replaceModified)
+	modified := lokaliseModifiedTranslationsLabel(o.replaceModified)
 	if o.dryRun {
 		format := strings.TrimSpace(o.format)
 		if format == "" {
 			format = "auto"
 		}
-		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=lokalise-upload-translations project_id=%s target_locale=%s format=%s files=%d existing_translations=%s\n", cfg.ProjectID, targetLocale, format, len(files), existing)
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=lokalise-upload-translations project_id=%s target_locale=%s format=%s files=%d modified_translations=%s\n", cfg.ProjectID, targetLocale, format, len(files), modified)
 		return err
 	}
 
@@ -853,19 +853,19 @@ func executeLokaliseUploadTranslations(cmd *cobra.Command, o lokaliseUploadTrans
 			return fmt.Errorf("lokalise upload translations: %w", err)
 		}
 		processed++
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "uploaded file=%s process_id=%s status=%s type=%s existing_translations=%s\n", file, result.ProcessID, result.Status, result.Type, existing); err != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "uploaded file=%s process_id=%s status=%s type=%s modified_translations=%s\n", file, result.ProcessID, result.Status, result.Type, modified); err != nil {
 			return err
 		}
 	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-translations processed=%d existing_translations=%s\n", processed, existing)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-translations processed=%d modified_translations=%s\n", processed, modified)
 	return err
 }
 
-func lokaliseExistingTranslationsLabel(replaceModified bool) string {
+func lokaliseModifiedTranslationsLabel(replaceModified bool) string {
 	if replaceModified {
-		return "overwritten"
+		return "replaced"
 	}
-	return "kept"
+	return "preserved"
 }
 
 func resolveLokaliseUploadSourcesConfig(cmd *cobra.Command, o lokaliseUploadSourcesOptions, requireAuth bool) (lokalise.Config, string, error) {

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -947,6 +947,193 @@ storage:
 	}
 }
 
+func TestLokaliseUploadTranslationsDryRunDoesNotRequireToken(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(filePath, []byte(`{"hello":"Bonjour"}`), 0o644); err != nil {
+		t.Fatalf("write translation file: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "")
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "translations", "--project-id", "project-1", "--target-locale", "fr", "--file", filePath, "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise upload translations dry-run: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "dry-run action=lokalise-upload-translations") || !strings.Contains(got, "target_locale=fr") || !strings.Contains(got, "existing_translations=kept") {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLokaliseUploadTranslationsRequiresTargetLocaleEvenWithConfig(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(filePath, []byte(`{"hello":"Bonjour"}`), 0o644); err != nil {
+		t.Fatalf("write translation file: %v", err)
+	}
+	configPath := filepath.Join(dir, "i18n.yml")
+	if err := os.WriteFile(configPath, []byte(`
+locales:
+  source: en
+  targets:
+    - fr
+buckets:
+  ui:
+    files:
+      - from: content/en.json
+        to: dist/{{target}}.json
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: test
+storage:
+  adapter: lokalise
+  config:
+    projectID: project-from-config
+    apiTokenEnv: LOKALISE_TEST_TOKEN
+    sourceLanguage: en
+    targetLanguages: [fr, de]
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "upload", "translations", "--config", configPath, "--file", filePath, "--dry-run"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "lokalise upload translations: --target-locale is required") {
+		t.Fatalf("error = %v, want required --target-locale", err)
+	}
+}
+
+func TestLokaliseUploadTranslationsTokenErrorListsEnv(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(filePath, []byte(`{"hello":"Bonjour"}`), 0o644); err != nil {
+		t.Fatalf("write translation file: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "")
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "upload", "translations", "--project-id", "project-1", "--target-locale", "fr", "--file", filePath})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "LOKALISE_API_TOKEN") {
+		t.Fatalf("error = %v, want token env hint", err)
+	}
+}
+
+func TestLokaliseUploadTranslationsRequiresFile(t *testing.T) {
+	t.Setenv("LOKALISE_API_TOKEN", "")
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "upload", "translations", "--project-id", "project-1", "--target-locale", "fr"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "lokalise upload translations: at least one --file is required") {
+		t.Fatalf("error = %v, want missing file", err)
+	}
+}
+
+func TestLokaliseUploadTranslationsUploadsWithTargetLocaleNotConfigSource(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(filePath, []byte(`{"hello":"Bonjour"}`), 0o644); err != nil {
+		t.Fatalf("write translation file: %v", err)
+	}
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+
+	configPath := filepath.Join(dir, "i18n.yml")
+	if err := os.WriteFile(configPath, []byte(`
+locales:
+  source: en
+  targets:
+    - de
+buckets:
+  ui:
+    files:
+      - from: content/en.json
+        to: dist/{{target}}.json
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: test
+storage:
+  adapter: lokalise
+  config:
+    projectID: project-from-config
+    apiTokenEnv: LOKALISE_TEST_TOKEN
+    sourceLanguage: en
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldFactory := newLokaliseTranslationUploader
+	defer func() {
+		newLokaliseTranslationUploader = oldFactory
+	}()
+	fake := &fakeLokaliseTranslationUploader{}
+	newLokaliseTranslationUploader = func(cfg lokalise.Config) (lokaliseTranslationUploader, error) {
+		if cfg.ProjectID != "project-from-config" || cfg.APIToken != "secret" {
+			t.Fatalf("config = %#v, want project/token from storage config", cfg)
+		}
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "translations", "--config", configPath, "--target-locale", "fr", "--file", filePath, "--replace-modified"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise upload translations: %v", err)
+	}
+	if !strings.Contains(out.String(), "existing_translations=overwritten") {
+		t.Fatalf("missing overwrite note: %q", out.String())
+	}
+	if len(fake.inputs) != 1 {
+		t.Fatalf("inputs = %#v, want one upload", fake.inputs)
+	}
+	input := fake.inputs[0]
+	if input.TargetLocale != "fr" || input.ProjectID != "project-from-config" || input.FilePath != filePath {
+		t.Fatalf("input = %#v, want target locale fr from the flag", input)
+	}
+	if !input.ReplaceModified {
+		t.Fatalf("replace modified not passed through: %#v", input)
+	}
+}
+
+func TestLokaliseUploadTranslationsPreservesPartialProgressOnError(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(filePath, []byte(`{"hello":"Bonjour"}`), 0o644); err != nil {
+		t.Fatalf("write translation file: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseTranslationUploader
+	defer func() {
+		newLokaliseTranslationUploader = oldFactory
+	}()
+	newLokaliseTranslationUploader = func(lokalise.Config) (lokaliseTranslationUploader, error) {
+		return &fakeLokaliseTranslationUploader{err: errors.New("api failed")}, nil
+	}
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "upload", "translations", "--project-id", "project-1", "--target-locale", "fr", "--file", filePath})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "lokalise upload translations") || !strings.Contains(err.Error(), "api failed") {
+		t.Fatalf("error = %v, want api failed", err)
+	}
+}
+
 func TestLokaliseUploadSourcesPreservesPartialProgressOnError(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "en.json")
@@ -1092,4 +1279,17 @@ func (f *fakeLokaliseSourceUploader) UploadSourceFile(_ context.Context, input l
 		return lokalise.SourceUploadResult{}, f.err
 	}
 	return lokalise.SourceUploadResult{ProcessID: "proc-1", Type: "file-import", Status: "queued"}, nil
+}
+
+type fakeLokaliseTranslationUploader struct {
+	inputs []lokalise.TranslationUploadInput
+	err    error
+}
+
+func (f *fakeLokaliseTranslationUploader) UploadTranslationFile(_ context.Context, input lokalise.TranslationUploadInput) (lokalise.TranslationUploadResult, error) {
+	f.inputs = append(f.inputs, input)
+	if f.err != nil {
+		return lokalise.TranslationUploadResult{}, f.err
+	}
+	return lokalise.TranslationUploadResult{ProcessID: "proc-1", Type: "file-import", Status: "queued"}, nil
 }

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -964,7 +964,7 @@ func TestLokaliseUploadTranslationsDryRunDoesNotRequireToken(t *testing.T) {
 		t.Fatalf("execute lokalise upload translations dry-run: %v", err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "dry-run action=lokalise-upload-translations") || !strings.Contains(got, "target_locale=fr") || !strings.Contains(got, "existing_translations=kept") {
+	if !strings.Contains(got, "dry-run action=lokalise-upload-translations") || !strings.Contains(got, "target_locale=fr") || !strings.Contains(got, "modified_translations=preserved") {
 		t.Fatalf("unexpected output: %q", got)
 	}
 }
@@ -1094,8 +1094,8 @@ storage:
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute lokalise upload translations: %v", err)
 	}
-	if !strings.Contains(out.String(), "existing_translations=overwritten") {
-		t.Fatalf("missing overwrite note: %q", out.String())
+	if !strings.Contains(out.String(), "modified_translations=replaced") {
+		t.Fatalf("missing replace-modified note: %q", out.String())
 	}
 	if len(fake.inputs) != 1 {
 		t.Fatalf("inputs = %#v, want one upload", fake.inputs)

--- a/docs/cli/commands/lokalise.mdx
+++ b/docs/cli/commands/lokalise.mdx
@@ -1,0 +1,100 @@
+---
+title: "lokalise"
+description: "Lokalise file workflow commands using project flags and API credentials."
+---
+
+## Usage
+
+```bash
+hyperlocalise lokalise upload sources --project-id <id> --source-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--skip-detect-lang-iso] [--dry-run]
+hyperlocalise lokalise upload translations [--config <path>] --project-id <id> --target-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--dry-run]
+hyperlocalise lokalise download sources --project-id <id> --source-locale <locale> [--format <format>] [--output <path>] [--all-platforms] [--force] [--dry-run]
+hyperlocalise lokalise download translations --project-id <id> --target-locale <locale> [--format <format>] [--output <path>] [--bundle-structure <pattern>] [--branch <name>] [--force] [--dry-run]
+hyperlocalise lokalise glossary download --project-id <id> [--language <locale>] [--output <path>] [--token-env <name>] [--api-base-url <url>]
+```
+
+These commands are flag-only. Hyperlocalise does not read a Lokalise YAML config in this version. You can pass `--config` to reuse `projectID` and token settings from an `i18n.yml` storage block.
+
+## What this command family does
+
+These commands talk to the Lokalise API v2 file and glossary endpoints.
+
+They are separate from Hyperlocalise native `i18n.yml` and `sync push` / `sync pull` workflows. Use native sync when you want Hyperlocalise-managed entry sync through the [Lokalise adapter](/cli/storage/lokalise). Use this surface when you want flag-driven file upload and download against a Lokalise project.
+
+Use them for:
+
+- source-file upload (`upload sources`)
+- import of a pre-translated locale file (`upload translations`)
+- source download (`download sources`)
+- translation download (`download translations`)
+- glossary **download** (Hyperlocalise-shaped CSV)
+
+Official [lokalise2](https://github.com/lokalise/lokalise-cli-2-go) uses `file upload` / `file download` with `--lang-iso`. Hyperlocalise keeps the same command family shape as Crowdin, Phrase, and Smartling (`upload sources`, `download translations`).
+
+## Credentials
+
+Hyperlocalise reads `--token-env` (default `LOKALISE_API_TOKEN`).
+
+Do not put the API token in `i18n.yml`. Point `apiTokenEnv` at an environment variable instead.
+
+## Command notes
+
+`upload sources` requires `--project-id` (or `projectID` in `--config`), `--source-locale` (or `sourceLanguage` in `--config`), and at least one `--file`. `--dry-run` checks files and flags and does not need a token.
+
+`upload translations` requires `--target-locale` on every run. It does **not** take the locale from `sourceLanguage` or `targetLanguages` in `--config`. Config may still supply the project id and token. The locale comes from the flag, not the filename: uploading `en.json` as French uses `--target-locale fr`.
+
+Without `--replace-modified`, Lokalise **keeps** translations that already exist. The command then looks like a no-op for those keys. Dry-run and the success line print `existing_translations=kept` or `existing_translations=overwritten`. Pass `--replace-modified` when you intend to overwrite.
+
+Success means the import is **queued**, not that strings are already visible in Lokalise. The command prints a process id and stops. It does not wait for the background import to finish.
+
+Lokalise matches files by name. Use the same filename as the source file when you can. Language codes in the name (`en.json` / `fr.json`) are usually treated as one file. A totally different name can create a second file.
+
+`--file` can repeat for several files in that one locale. Use a separate invocation for each target locale.
+
+`download translations` can take more than one `--target-locale`. Use `%locale%` in `--output` when you download more than one locale to files.
+
+`glossary download` writes CSV to stdout unless you pass `--output`.
+
+## Crowdin and lokalise2 gap inventory
+
+| Crowdin / official lokalise2 | Hyperlocalise today |
+| --- | --- |
+| Crowdin `upload sources` / `upload translations` | `upload sources` / `upload translations` |
+| Crowdin `download sources` / `download translations` | `download sources` / `download translations` |
+| Crowdin `glossary download` | `glossary download` (Hyperlocalise CSV) |
+| Crowdin `init` / `crowdin.yml` / lokalise2 config file | Unsupported (flag-only) |
+| Crowdin `status`, branch, file list/delete, string list | Out of scope |
+| Crowdin `glossary upload` / `tm` list, download, upload | Out of scope (package has no TM export) |
+| Crowdin `auto-translate` / Lokalise tasks and jobs | Out of scope |
+| lokalise2 `file upload --lang-iso` | `upload sources` or `upload translations` (queued; no `--wait`) |
+| lokalise2 process wait / file list / key CRUD | Out of scope |
+
+## Examples
+
+Upload a source file, then a French translation that reuses the source filename:
+
+```bash
+export LOKALISE_API_TOKEN="your-lokalise-token"
+
+hyperlocalise lokalise upload sources \
+  --project-id your-project-id \
+  --source-locale en \
+  --file ./locales/en.json \
+  --dry-run
+
+hyperlocalise lokalise upload translations \
+  --project-id your-project-id \
+  --target-locale fr \
+  --file ./locales/en.json \
+  --replace-modified \
+  --dry-run
+```
+
+Download French translations:
+
+```bash
+hyperlocalise lokalise download translations \
+  --project-id your-project-id \
+  --target-locale fr \
+  --output ./locales/fr.json
+```

--- a/docs/cli/commands/lokalise.mdx
+++ b/docs/cli/commands/lokalise.mdx
@@ -7,7 +7,7 @@ description: "Lokalise file workflow commands using project flags and API creden
 
 ```bash
 hyperlocalise lokalise upload sources --project-id <id> --source-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--skip-detect-lang-iso] [--dry-run]
-hyperlocalise lokalise upload translations [--config <path>] --project-id <id> --target-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--dry-run]
+hyperlocalise lokalise upload translations [--config <path>] [--project-id <id>] --target-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--dry-run]
 hyperlocalise lokalise download sources --project-id <id> --source-locale <locale> [--format <format>] [--output <path>] [--all-platforms] [--force] [--dry-run]
 hyperlocalise lokalise download translations --project-id <id> --target-locale <locale> [--format <format>] [--output <path>] [--bundle-structure <pattern>] [--branch <name>] [--force] [--dry-run]
 hyperlocalise lokalise glossary download --project-id <id> [--language <locale>] [--output <path>] [--token-env <name>] [--api-base-url <url>]

--- a/docs/cli/commands/lokalise.mdx
+++ b/docs/cli/commands/lokalise.mdx
@@ -27,7 +27,7 @@ Use them for:
 - import of a pre-translated locale file (`upload translations`)
 - source download (`download sources`)
 - translation download (`download translations`)
-- glossary **download** (Hyperlocalise-shaped CSV)
+- glossary download (Hyperlocalise-shaped CSV)
 
 Official [lokalise2](https://github.com/lokalise/lokalise-cli-2-go) uses `file upload` / `file download` with `--lang-iso`. Hyperlocalise keeps the same command family shape as Crowdin, Phrase, and Smartling (`upload sources`, `download translations`).
 
@@ -41,11 +41,11 @@ Do not put the API token in `i18n.yml`. Point `apiTokenEnv` at an environment va
 
 `upload sources` requires `--project-id` (or `projectID` in `--config`), `--source-locale` (or `sourceLanguage` in `--config`), and at least one `--file`. `--dry-run` checks files and flags and does not need a token.
 
-`upload translations` requires `--target-locale` on every run. It does **not** take the locale from `sourceLanguage` or `targetLanguages` in `--config`. Config may still supply the project id and token. The locale comes from the flag, not the filename: uploading `en.json` as French uses `--target-locale fr`.
+`upload translations` requires `--target-locale` on every run. It does not take the locale from `sourceLanguage` or `targetLanguages` in `--config`. Config may still supply the project id and token. The locale comes from the flag, not the filename: uploading `en.json` as French uses `--target-locale fr`.
 
 `--replace-modified` maps to Lokalise `replace_modified`. Off (the default) preserves translations Lokalise treats as modified. On replaces those modified translations from the uploaded file. It is not a guarantee that every existing key stays unchanged. Dry-run and the success line print `modified_translations=preserved` or `modified_translations=replaced`.
 
-Success means the import is **queued**, not that strings are already visible in Lokalise. The command prints a process id and stops. It does not wait for the background import to finish.
+Success means the import is queued, not that strings are already visible in Lokalise. The command prints a process id and stops. It does not wait for the background import to finish.
 
 Lokalise matches files by name. Use the same filename as the source file when you can. Language codes in the name (`en.json` / `fr.json`) are usually treated as one file. A totally different name can create a second file.
 

--- a/docs/cli/commands/lokalise.mdx
+++ b/docs/cli/commands/lokalise.mdx
@@ -43,7 +43,7 @@ Do not put the API token in `i18n.yml`. Point `apiTokenEnv` at an environment va
 
 `upload translations` requires `--target-locale` on every run. It does **not** take the locale from `sourceLanguage` or `targetLanguages` in `--config`. Config may still supply the project id and token. The locale comes from the flag, not the filename: uploading `en.json` as French uses `--target-locale fr`.
 
-Without `--replace-modified`, Lokalise **keeps** translations that already exist. The command then looks like a no-op for those keys. Dry-run and the success line print `existing_translations=kept` or `existing_translations=overwritten`. Pass `--replace-modified` when you intend to overwrite.
+`--replace-modified` maps to Lokalise `replace_modified`. Off (the default) preserves translations Lokalise treats as modified. On replaces those modified translations from the uploaded file. It is not a guarantee that every existing key stays unchanged. Dry-run and the success line print `modified_translations=preserved` or `modified_translations=replaced`.
 
 Success means the import is **queued**, not that strings are already visible in Lokalise. The command prints a process id and stops. It does not wait for the background import to finish.
 

--- a/docs/cli/commands/overview.mdx
+++ b/docs/cli/commands/overview.mdx
@@ -15,6 +15,7 @@ Main commands:
 - `crowdin`
 - `phrase`
 - `smartling`
+- `lokalise`
 - `run`
 - `extract`
 - `pack`
@@ -33,6 +34,7 @@ Main commands:
 - Crowdin file workflow: [crowdin](/cli/commands/crowdin)
 - Phrase file workflow: [phrase](/cli/commands/phrase)
 - Smartling file workflow: [smartling](/cli/commands/smartling)
+- Lokalise file workflow: [lokalise](/cli/commands/lokalise)
 - Local draft generation: [run](/cli/commands/run)
 - Extract React Intl catalogs: [extract](/cli/commands/extract)
 - Prepare translation JSON: [pack](/cli/commands/pack)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -195,6 +195,7 @@
                   "cli/commands/crowdin",
                   "cli/commands/phrase",
                   "cli/commands/smartling",
+                  "cli/commands/lokalise",
                   "cli/commands/run",
                   "cli/commands/extract",
                   "cli/commands/pack",

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -60,18 +60,18 @@ type SourceUploadResult struct {
 type TranslationUploadResult = SourceUploadResult
 
 type lokaliseFileUploadRequest struct {
-	Data                string   `json:"data"`
-	Filename            string   `json:"filename"`
-	LangISO             string   `json:"lang_iso"`
-	Format              string   `json:"format,omitempty"`
-	Tags                []string `json:"tags,omitempty"`
+	Data     string   `json:"data"`
+	Filename string   `json:"filename"`
+	LangISO  string   `json:"lang_iso"`
+	Format   string   `json:"format,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
 	// Always send convert_placeholders. Lokalise defaults omitted values to true.
-	ConvertPlaceholders bool     `json:"convert_placeholders"`
-	ReplaceModified     bool     `json:"replace_modified,omitempty"`
-	DistinguishByFile   bool     `json:"distinguish_by_file,omitempty"`
-	ApplyTM             bool     `json:"apply_tm,omitempty"`
-	SkipDetectLangISO   bool     `json:"skip_detect_lang_iso,omitempty"`
-	Queue               bool     `json:"queue"`
+	ConvertPlaceholders bool `json:"convert_placeholders"`
+	ReplaceModified     bool `json:"replace_modified,omitempty"`
+	DistinguishByFile   bool `json:"distinguish_by_file,omitempty"`
+	ApplyTM             bool `json:"apply_tm,omitempty"`
+	SkipDetectLangISO   bool `json:"skip_detect_lang_iso,omitempty"`
+	Queue               bool `json:"queue"`
 }
 
 type lokaliseFileUploadResponse struct {

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -65,7 +65,8 @@ type lokaliseFileUploadRequest struct {
 	LangISO             string   `json:"lang_iso"`
 	Format              string   `json:"format,omitempty"`
 	Tags                []string `json:"tags,omitempty"`
-	ConvertPlaceholders bool     `json:"convert_placeholders,omitempty"`
+	// Always send convert_placeholders. Lokalise defaults omitted values to true.
+	ConvertPlaceholders bool     `json:"convert_placeholders"`
 	ReplaceModified     bool     `json:"replace_modified,omitempty"`
 	DistinguishByFile   bool     `json:"distinguish_by_file,omitempty"`
 	ApplyTM             bool     `json:"apply_tm,omitempty"`

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -34,6 +34,20 @@ type SourceUploadInput struct {
 	SkipDetectLangISO   bool
 }
 
+// TranslationUploadInput describes one Lokalise translation file import.
+type TranslationUploadInput struct {
+	ProjectID           string
+	TargetLocale        string
+	FilePath            string
+	FileFormat          string
+	Branch              string
+	Tags                []string
+	ConvertPlaceholders bool
+	ReplaceModified     bool
+	DistinguishByFile   bool
+	ApplyTM             bool
+}
+
 // SourceUploadResult is the normalized subset of Lokalise's queued import response.
 type SourceUploadResult struct {
 	ProcessID string
@@ -41,6 +55,9 @@ type SourceUploadResult struct {
 	Status    string
 	Message   string
 }
+
+// TranslationUploadResult is the queued import process for a translation file.
+type TranslationUploadResult = SourceUploadResult
 
 type lokaliseFileUploadRequest struct {
 	Data                string   `json:"data"`
@@ -65,50 +82,102 @@ type lokaliseFileUploadResponse struct {
 	} `json:"process"`
 }
 
+type lokaliseFileUploadInput struct {
+	ProjectID           string
+	Locale              string
+	FilePath            string
+	FileFormat          string
+	Branch              string
+	Tags                []string
+	ConvertPlaceholders bool
+	ReplaceModified     bool
+	DistinguishByFile   bool
+	ApplyTM             bool
+	SkipDetectLangISO   bool
+}
+
 // UploadSourceFile imports a source file into Lokalise and returns the queued import process.
 func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput) (SourceUploadResult, error) {
+	return c.uploadLocalizationFile(ctx, lokaliseFileUploadInput{
+		ProjectID:           in.ProjectID,
+		Locale:              in.SourceLocale,
+		FilePath:            in.FilePath,
+		FileFormat:          in.FileFormat,
+		Branch:              in.Branch,
+		Tags:                in.Tags,
+		ConvertPlaceholders: in.ConvertPlaceholders,
+		ReplaceModified:     in.ReplaceModified,
+		DistinguishByFile:   in.DistinguishByFile,
+		ApplyTM:             in.ApplyTM,
+		SkipDetectLangISO:   in.SkipDetectLangISO,
+	}, "source")
+}
+
+// UploadTranslationFile imports a translation file into Lokalise and returns the queued import process.
+// It always skips filename language detection so --target-locale wins over names like en.json.
+func (c *HTTPClient) UploadTranslationFile(ctx context.Context, in TranslationUploadInput) (TranslationUploadResult, error) {
+	return c.uploadLocalizationFile(ctx, lokaliseFileUploadInput{
+		ProjectID:           in.ProjectID,
+		Locale:              in.TargetLocale,
+		FilePath:            in.FilePath,
+		FileFormat:          in.FileFormat,
+		Branch:              in.Branch,
+		Tags:                in.Tags,
+		ConvertPlaceholders: in.ConvertPlaceholders,
+		ReplaceModified:     in.ReplaceModified,
+		DistinguishByFile:   in.DistinguishByFile,
+		ApplyTM:             in.ApplyTM,
+		SkipDetectLangISO:   true,
+	}, "translation")
+}
+
+func (c *HTTPClient) uploadLocalizationFile(ctx context.Context, in lokaliseFileUploadInput, kind string) (SourceUploadResult, error) {
+	op := "lokalise " + kind + " upload"
 	if c == nil || c.httpClient == nil {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: client is nil")
+		return SourceUploadResult{}, fmt.Errorf("%s: client is nil", op)
 	}
 	if strings.TrimSpace(in.ProjectID) == "" {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: project id is required")
+		return SourceUploadResult{}, fmt.Errorf("%s: project id is required", op)
 	}
-	if strings.TrimSpace(in.SourceLocale) == "" {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: source locale is required")
+	if strings.TrimSpace(in.Locale) == "" {
+		if kind == "translation" {
+			return SourceUploadResult{}, fmt.Errorf("%s: target locale is required", op)
+		}
+		return SourceUploadResult{}, fmt.Errorf("%s: source locale is required", op)
 	}
 	if strings.TrimSpace(in.FilePath) == "" {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: file path is required")
+		return SourceUploadResult{}, fmt.Errorf("%s: file path is required", op)
 	}
-	format, err := resolveLokaliseUploadFormat(in.FilePath, in.FileFormat)
+	format, err := resolveLokaliseUploadFormat(in.FilePath, in.FileFormat, op)
 	if err != nil {
 		return SourceUploadResult{}, err
 	}
 
 	file, statErr := os.Open(in.FilePath)
 	if statErr != nil {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: open source file %q: %w", in.FilePath, statErr)
+		return SourceUploadResult{}, fmt.Errorf("%s: open file %q: %w", op, in.FilePath, statErr)
 	}
 	defer func() {
 		_ = file.Close()
 	}()
 	info, statErr := file.Stat()
 	if statErr != nil {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: stat source file %q: %w", in.FilePath, statErr)
+		return SourceUploadResult{}, fmt.Errorf("%s: stat file %q: %w", op, in.FilePath, statErr)
 	}
 	if info.Size() > maxLokaliseUploadFileBytes {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: source file %q exceeds maximum upload size (%d bytes)", in.FilePath, maxLokaliseUploadFileBytes)
+		return SourceUploadResult{}, fmt.Errorf("%s: file %q exceeds maximum upload size (%d bytes)", op, in.FilePath, maxLokaliseUploadFileBytes)
 	}
 	content, err := io.ReadAll(io.LimitReader(file, maxLokaliseUploadFileBytes+1))
 	if err != nil {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: read source file %q: %w", in.FilePath, err)
+		return SourceUploadResult{}, fmt.Errorf("%s: read file %q: %w", op, in.FilePath, err)
 	}
 	if len(content) > maxLokaliseUploadFileBytes {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: source file %q exceeds maximum upload size (%d bytes)", in.FilePath, maxLokaliseUploadFileBytes)
+		return SourceUploadResult{}, fmt.Errorf("%s: file %q exceeds maximum upload size (%d bytes)", op, in.FilePath, maxLokaliseUploadFileBytes)
 	}
 	req := lokaliseFileUploadRequest{
 		Data:                base64.StdEncoding.EncodeToString(content),
 		Filename:            filepath.Base(in.FilePath),
-		LangISO:             strings.TrimSpace(in.SourceLocale),
+		LangISO:             strings.TrimSpace(in.Locale),
 		Format:              format,
 		Tags:                normalizeLokaliseUploadTags(in.Tags),
 		ConvertPlaceholders: in.ConvertPlaceholders,
@@ -123,13 +192,13 @@ func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput)
 	path := fmt.Sprintf("/projects/%s/files/upload", lokaliseProjectPathSegment(in.ProjectID, in.Branch))
 	meta, err := c.doLokaliseUploadJSON(ctx, http.MethodPost, path, req, &out)
 	if err != nil {
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload %q: %w", in.FilePath, err)
+		return SourceUploadResult{}, fmt.Errorf("%s %q: %w", op, in.FilePath, err)
 	}
 	if strings.TrimSpace(out.Process.ID) == "" {
 		if meta.StatusCode == http.StatusFound {
-			return SourceUploadResult{}, fmt.Errorf("lokalise source upload %q: 302 queued response missing process id%s", in.FilePath, lokaliseUploadLocationSuffix(meta.Location))
+			return SourceUploadResult{}, fmt.Errorf("%s %q: 302 queued response missing process id%s", op, in.FilePath, lokaliseUploadLocationSuffix(meta.Location))
 		}
-		return SourceUploadResult{}, fmt.Errorf("lokalise source upload %q: response missing process id", in.FilePath)
+		return SourceUploadResult{}, fmt.Errorf("%s %q: response missing process id", op, in.FilePath)
 	}
 	return SourceUploadResult{
 		ProcessID: strings.TrimSpace(out.Process.ID),
@@ -214,13 +283,13 @@ func lokaliseUploadHTTPClient(client *http.Client) *http.Client {
 	return &cloned
 }
 
-func resolveLokaliseUploadFormat(path, override string) (string, error) {
+func resolveLokaliseUploadFormat(path, override, op string) (string, error) {
 	if trimmed := strings.TrimSpace(override); trimmed != "" {
 		return strings.TrimPrefix(strings.ToLower(trimmed), "."), nil
 	}
 	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
 	if ext == "" {
-		return "", fmt.Errorf("lokalise source upload: could not determine file format for %q: no file extension and no format override provided", path)
+		return "", fmt.Errorf("%s: could not determine file format for %q: no file extension and no format override provided", op, path)
 	}
 	return ext, nil
 }

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -65,13 +65,14 @@ type lokaliseFileUploadRequest struct {
 	LangISO  string   `json:"lang_iso"`
 	Format   string   `json:"format,omitempty"`
 	Tags     []string `json:"tags,omitempty"`
-	// Always send convert_placeholders. Lokalise defaults omitted values to true.
-	ConvertPlaceholders bool `json:"convert_placeholders"`
-	ReplaceModified     bool `json:"replace_modified,omitempty"`
-	DistinguishByFile   bool `json:"distinguish_by_file,omitempty"`
-	ApplyTM             bool `json:"apply_tm,omitempty"`
-	SkipDetectLangISO   bool `json:"skip_detect_lang_iso,omitempty"`
-	Queue               bool `json:"queue"`
+	// Translation uploads always send this so Lokalise cannot default it to true.
+	// Source uploads omit false so existing --convert-placeholders-off behavior stays Lokalise's default.
+	ConvertPlaceholders *bool `json:"convert_placeholders,omitempty"`
+	ReplaceModified     bool  `json:"replace_modified,omitempty"`
+	DistinguishByFile   bool  `json:"distinguish_by_file,omitempty"`
+	ApplyTM             bool  `json:"apply_tm,omitempty"`
+	SkipDetectLangISO   bool  `json:"skip_detect_lang_iso,omitempty"`
+	Queue               bool  `json:"queue"`
 }
 
 type lokaliseFileUploadResponse struct {
@@ -181,7 +182,7 @@ func (c *HTTPClient) uploadLocalizationFile(ctx context.Context, in lokaliseFile
 		LangISO:             strings.TrimSpace(in.Locale),
 		Format:              format,
 		Tags:                normalizeLokaliseUploadTags(in.Tags),
-		ConvertPlaceholders: in.ConvertPlaceholders,
+		ConvertPlaceholders: lokaliseConvertPlaceholdersValue(kind, in.ConvertPlaceholders),
 		ReplaceModified:     in.ReplaceModified,
 		DistinguishByFile:   in.DistinguishByFile,
 		ApplyTM:             in.ApplyTM,
@@ -293,6 +294,14 @@ func resolveLokaliseUploadFormat(path, override, op string) (string, error) {
 		return "", fmt.Errorf("%s: could not determine file format for %q: no file extension and no format override provided", op, path)
 	}
 	return ext, nil
+}
+
+func lokaliseConvertPlaceholdersValue(kind string, convert bool) *bool {
+	if kind != "translation" && !convert {
+		return nil
+	}
+	value := convert
+	return &value
 }
 
 func lokaliseProjectPathSegment(projectID, branch string) string {

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -277,6 +277,9 @@ func TestUploadTranslationFilePostsTargetLocaleAndSkipsFilenameDetection(t *test
 		if body["skip_detect_lang_iso"] != true {
 			t.Fatalf("skip_detect_lang_iso = %#v, want true so filename en.json cannot override fr", body["skip_detect_lang_iso"])
 		}
+		if body["convert_placeholders"] != false {
+			t.Fatalf("convert_placeholders = %#v, want false so Lokalise does not default to converting placeholders", body["convert_placeholders"])
+		}
 		if body["replace_modified"] != true {
 			t.Fatalf("replace_modified = %#v, want true", body["replace_modified"])
 		}

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -254,6 +254,78 @@ func TestUploadSourceFileRejectsLargeFile(t *testing.T) {
 	}
 }
 
+func TestUploadTranslationFilePostsTargetLocaleAndSkipsFilenameDetection(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	filePath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(filePath, []byte(`{"hello":"Bonjour"}`), 0o644); err != nil {
+		t.Fatalf("write translation file: %v", err)
+	}
+
+	mux.HandleFunc("/api2/projects/project-1/files/upload", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["filename"] != "en.json" || body["lang_iso"] != "fr" || body["format"] != "json" {
+			t.Fatalf("unexpected body identity fields: %#v", body)
+		}
+		if body["skip_detect_lang_iso"] != true {
+			t.Fatalf("skip_detect_lang_iso = %#v, want true so filename en.json cannot override fr", body["skip_detect_lang_iso"])
+		}
+		if body["replace_modified"] != true {
+			t.Fatalf("replace_modified = %#v, want true", body["replace_modified"])
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"process": map[string]any{
+				"process_id": "proc-tr",
+				"type":       "file-import",
+				"status":     "queued",
+			},
+		})
+	})
+
+	result, err := client.UploadTranslationFile(context.Background(), TranslationUploadInput{
+		ProjectID:       "project-1",
+		TargetLocale:    "fr",
+		FilePath:        filePath,
+		ReplaceModified: true,
+	})
+	if err != nil {
+		t.Fatalf("upload translation file: %v", err)
+	}
+	if result.ProcessID != "proc-tr" || result.Status != "queued" {
+		t.Fatalf("result = %#v, want queued proc-tr", result)
+	}
+}
+
+func TestUploadTranslationFileRequiresTargetLocale(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api2/projects/", func(http.ResponseWriter, *http.Request) {
+		t.Fatal("upload endpoint should not be called without a target locale")
+	})
+
+	filePath := filepath.Join(t.TempDir(), "fr.json")
+	if err := os.WriteFile(filePath, []byte(`{"hello":"Bonjour"}`), 0o644); err != nil {
+		t.Fatalf("write translation file: %v", err)
+	}
+
+	_, err := client.UploadTranslationFile(context.Background(), TranslationUploadInput{
+		ProjectID: "project-1",
+		FilePath:  filePath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "target locale is required") {
+		t.Fatalf("error = %v, want target locale required", err)
+	}
+}
+
 func TestUploadSourceFileRequiresFormatWhenExtensionMissing(t *testing.T) {
 	client, _, teardown := newLokaliseUploadClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -134,6 +134,9 @@ func TestUploadSourceFileOmitsEmptyTags(t *testing.T) {
 		if _, exists := body["tags"]; exists {
 			t.Fatalf("tags should be omitted when empty, got body: %#v", body)
 		}
+		if _, exists := body["convert_placeholders"]; exists {
+			t.Fatalf("convert_placeholders should be omitted for source uploads when unset, got body: %#v", body)
+		}
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(map[string]any{"process": map[string]any{"process_id": "proc-no-tags", "status": "queued"}})
 	})


### PR DESCRIPTION
## Summary
- Add `hyperlocalise lokalise upload translations` with a required `--target-locale`. Locale is never taken from `sourceLanguage` / `targetLanguages` in `--config`, and filename language detection is always skipped.
- Reuse the existing Lokalise file import helper. Default keep-existing translations (`--replace-modified` off); print queued `process_id` (no `--wait`).
- Add English command docs (`docs/cli/commands/lokalise.mdx`), overview listing, and a Crowdin / lokalise2 gap table.

Closes [HL-663](https://linear.app/hyperlocalise/issue/HL-663/close-lokalise-cli-gaps-vs-crowdin).

## Test plan
- [x] `go test ./internal/i18n/storage/lokalise/...`
- [x] `go test ./apps/cli/cmd -run Lokalise`
- [x] `golangci-lint run` on touched packages
- [x] Mocked tests: `--target-locale` required even with config; config source language is not the upload locale; `--file` required; dry-run without token; `--replace-modified` overwrite path
- [x] Live Lokalise trial: enqueue source + Vietnamese translation upload, then download `vi` (queued import, then strings visible)
- [ ] GitHub CI: Go Lint, Bazel `//:cli` + `//apps/cli/cmd:cmd_test`, Go Quality