### PR TITLE
feat(activity-log): record file and string-segment events

### DIFF
--- a/apps/hyperlocalise-web/docs/adr/2026-09-08-file-and-segment-activity-events-design.md
+++ b/apps/hyperlocalise-web/docs/adr/2026-09-08-file-and-segment-activity-events-design.md
@@ -1,0 +1,51 @@
+# File and string-segment activity events
+
+## Status
+
+Accepted
+
+## Context
+
+Workspace activity logging already covers members, projects, jobs, and automations.
+Editors still need a file-scoped history of high-signal CAT actions without a
+second event store.
+
+The original workspace contract left CAT edits out of v1 because draft saves
+would be too noisy and would risk storing linguistic content.
+
+## Decision
+
+Reuse `organization_activity_events` and the existing writer/reader.
+
+New target kinds:
+
+- `file` — identity is `${projectId}:${normalizedSourcePath}`
+- `string_segment` — identity is the segment UUID
+
+Recorded events:
+
+- `file_uploaded`
+- `file_translations_imported`
+- `string_segment_approved`
+- `string_segment_status_changed`
+- `string_segment_hidden`
+- `string_segment_unhidden`
+- `string_segment_locked`
+- `string_segment_unlocked`
+- `string_segment_commented`
+
+Do not emit events on every draft save.
+
+Payloads stay privacy-safe: project id, source path, file name, optional stored
+file / version ids, segment id, locale, item counts, and statuses. Never store
+source text, target text, comment bodies, or file contents.
+
+Settings → Activity logs still requires `activity_logs:read`. The file editor
+dialog uses a project-scoped CAT GET that any project member can read, filtered
+to these event types and the current `projectId` + `sourcePath`.
+
+## Consequences
+
+File and string history is queryable from both Settings and the content editor.
+The existing table, cursor, and best-effort Workflow writer stay unchanged.
+Draft typing remains out of the log on purpose.

--- a/apps/hyperlocalise-web/docs/adr/2026-09-08-file-and-segment-activity-events-design.md
+++ b/apps/hyperlocalise-web/docs/adr/2026-09-08-file-and-segment-activity-events-design.md
@@ -34,7 +34,8 @@ Recorded events:
 - `string_segment_unlocked`
 - `string_segment_commented`
 
-Do not emit events on every draft save.
+Do not emit events on every draft save. Emit `file_translations_imported`
+only after `translationFileImportWorkflow` finishes importing entries.
 
 Payloads stay privacy-safe: project id, source path, file name, optional stored
 file / version ids, segment id, locale, item counts, and statuses. Never store

--- a/apps/hyperlocalise-web/src/api/routes/project/project-content-editor.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-content-editor.route.test.ts
@@ -3273,11 +3273,38 @@ describe("project file CAT routes", () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
       activityLogs: Array<{ eventType: string; target: { displayName: string | null } }>;
+      actors?: unknown;
     };
     expect(body.activityLogs).toHaveLength(1);
     expect(body.activityLogs[0]).toMatchObject({
       eventType: "file_uploaded",
       target: { displayName: "en.json" },
     });
+    expect(body.actors).toBeUndefined();
+  });
+
+  it("rejects provider activity logs when the live project is not accessible", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat["activity-logs"].$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:999",
+        },
+        query: { sourcePath: "locales/en.json", limit: "50" },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(404);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project-content-editor.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-content-editor.route.test.ts
@@ -3265,7 +3265,7 @@ describe("project file CAT routes", () => {
           organizationSlug: identity.organization.slug ?? "missing-slug",
           projectId: project.id,
         },
-        query: { sourcePath: "locales/en.json" },
+        query: { sourcePath: "locales/en.json", limit: "50" },
       },
       { headers },
     );

--- a/apps/hyperlocalise-web/src/api/routes/project/project-content-editor.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-content-editor.route.test.ts
@@ -60,6 +60,11 @@ const {
   createStoredFileMock,
   deleteStoredFileMock,
   isReleaseContentEditorAllFilesEnabledMock,
+  enqueueStringSegmentApprovedActivityMock,
+  enqueueStringSegmentCommentedActivityMock,
+  enqueueStringSegmentHiddenActivityMock,
+  enqueueStringSegmentLockedActivityMock,
+  enqueueStringSegmentStatusChangedActivityMock,
 } = vi.hoisted(() => ({
   getTmsProviderConnectionMock: vi.fn(),
   getTmsProviderLiveCatFileMock: vi.fn(),
@@ -75,7 +80,24 @@ const {
   createStoredFileMock: vi.fn(),
   deleteStoredFileMock: vi.fn(),
   isReleaseContentEditorAllFilesEnabledMock: vi.fn(async () => false),
+  enqueueStringSegmentApprovedActivityMock: vi.fn(),
+  enqueueStringSegmentCommentedActivityMock: vi.fn(),
+  enqueueStringSegmentHiddenActivityMock: vi.fn(),
+  enqueueStringSegmentLockedActivityMock: vi.fn(),
+  enqueueStringSegmentStatusChangedActivityMock: vi.fn(),
 }));
+
+vi.mock("@/lib/activity-log/file-segment-events", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/activity-log/file-segment-events")>();
+  return {
+    ...actual,
+    enqueueStringSegmentApprovedActivity: enqueueStringSegmentApprovedActivityMock,
+    enqueueStringSegmentCommentedActivity: enqueueStringSegmentCommentedActivityMock,
+    enqueueStringSegmentHiddenActivity: enqueueStringSegmentHiddenActivityMock,
+    enqueueStringSegmentLockedActivity: enqueueStringSegmentLockedActivityMock,
+    enqueueStringSegmentStatusChangedActivity: enqueueStringSegmentStatusChangedActivityMock,
+  };
+});
 
 vi.mock("@/lib/flags/release-flags", () => ({
   isReleaseContentEditorAllFilesEnabled: isReleaseContentEditorAllFilesEnabledMock,
@@ -792,6 +814,15 @@ describe("project file CAT routes", () => {
         source: "native",
         status: "approved",
       },
+    );
+    expect(enqueueStringSegmentApprovedActivityMock).toHaveBeenCalledTimes(1);
+    expect(enqueueStringSegmentApprovedActivityMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: project.id,
+        segmentId: translationKey!.id,
+        sourcePath,
+        targetLocale: "fr-FR",
+      }),
     );
 
     trackSpy.mockClear();
@@ -3188,5 +3219,65 @@ describe("project file CAT routes", () => {
     ]);
     expect(body.contentEditorQueue.projectTeamId).toBe(team.id);
     expect(body.contentEditorQueue.canContributeTeamGlossary).toBe(true);
+  });
+
+  it("lists file and string activity for the current source path", async () => {
+    const { identity, project, organization, user } =
+      await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+
+    await db.insert(schema.organizationActivityEvents).values([
+      {
+        actorKind: "user",
+        actorUserId: user.id,
+        eventType: "file_uploaded",
+        organizationId: organization.id,
+        payload: {
+          fileName: "en.json",
+          name: "en.json",
+          projectId: project.id,
+          sourcePath: "locales/en.json",
+        },
+        targetId: `${project.id}:locales/en.json`,
+        targetKind: "file",
+      },
+      {
+        actorKind: "user",
+        actorUserId: user.id,
+        eventType: "file_uploaded",
+        organizationId: organization.id,
+        payload: {
+          fileName: "de.json",
+          name: "de.json",
+          projectId: project.id,
+          sourcePath: "locales/de.json",
+        },
+        targetId: `${project.id}:locales/de.json`,
+        targetKind: "file",
+      },
+    ]);
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat["activity-logs"].$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        query: { sourcePath: "locales/en.json" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      activityLogs: Array<{ eventType: string; target: { displayName: string | null } }>;
+    };
+    expect(body.activityLogs).toHaveLength(1);
+    expect(body.activityLogs[0]).toMatchObject({
+      eventType: "file_uploaded",
+      target: { displayName: "en.json" },
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project-file-translation-import.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-file-translation-import.route.test.ts
@@ -27,14 +27,24 @@ import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/tes
 import { createProjectTestFixture } from "./project.fixture";
 import { createMemoryFileStorageAdapter } from "../public-files/public-files.fixture";
 
-const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
-  resolveApiAuthContextFromSessionMock: vi.fn(
-    (options) =>
-      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
-      globalThis.__testApiAuthContext ??
-      null,
-  ),
-}));
+const { enqueueFileTranslationsImportedActivityMock, resolveApiAuthContextFromSessionMock } =
+  vi.hoisted(() => ({
+    enqueueFileTranslationsImportedActivityMock: vi.fn(),
+    resolveApiAuthContextFromSessionMock: vi.fn(
+      (options) =>
+        globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+        globalThis.__testApiAuthContext ??
+        null,
+    ),
+  }));
+
+vi.mock("@/lib/activity-log/file-segment-events", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/activity-log/file-segment-events")>();
+  return {
+    ...actual,
+    enqueueFileTranslationsImportedActivity: enqueueFileTranslationsImportedActivityMock,
+  };
+});
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
@@ -139,6 +149,13 @@ describe("project file translation import route", () => {
       sourcePath: "locales/en.json",
       targetLocale: "fr",
     });
+    expect(enqueueFileTranslationsImportedActivityMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId,
+        sourcePath: "locales/en.json",
+        targetLocale: "fr",
+      }),
+    );
 
     const storedFiles = await db
       .select({ role: schema.storedFiles.role })

--- a/apps/hyperlocalise-web/src/api/routes/project/project-file-translation-import.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-file-translation-import.route.test.ts
@@ -149,13 +149,7 @@ describe("project file translation import route", () => {
       sourcePath: "locales/en.json",
       targetLocale: "fr",
     });
-    expect(enqueueFileTranslationsImportedActivityMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectId,
-        sourcePath: "locales/en.json",
-        targetLocale: "fr",
-      }),
-    );
+    expect(enqueueFileTranslationsImportedActivityMock).not.toHaveBeenCalled();
 
     const storedFiles = await db
       .select({ role: schema.storedFiles.role })

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -41,7 +41,6 @@ import {
 } from "@/lib/billing/workspace-resource-limits";
 import { FILE_SEGMENT_ACTIVITY_EVENT_TYPES } from "@/lib/activity-log/activity-log-contract";
 import {
-  enqueueFileTranslationsImportedActivity,
   enqueueFileUploadedActivity,
   enqueueStringSegmentApprovedActivity,
   enqueueStringSegmentCommentedActivity,
@@ -1236,15 +1235,14 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           return providerProjectUnavailableResponse(c, target);
         }
 
-        if (target.kind !== "provider") {
-          const project = await getOwnedProject(c.var.auth, params.projectId);
-          if (!project) {
-            return projectNotFoundResponse(c);
-          }
+        const project = await getOwnedProject(c.var.auth, params.projectId);
+        if (!project) {
+          return projectNotFoundResponse(c);
         }
 
         try {
-          const result = await listActivityLogEvents({
+          const { activityLogs, nextCursor } = await listActivityLogEvents({
+            includeActors: false,
             organizationId: c.var.auth.organization.localOrganizationId,
             organizationSlug: c.req.param("organizationSlug") ?? "",
             query: {
@@ -1256,7 +1254,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
               cursor: query.cursor,
             },
           });
-          return c.json(result, 200);
+          return c.json({ activityLogs, nextCursor }, 200);
         } catch (error) {
           if (error instanceof InvalidActivityLogCursorError) {
             return badRequestResponse(
@@ -1586,7 +1584,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           );
 
           if (body.approve) {
-            void enqueueStringSegmentApprovedActivity({
+            await enqueueStringSegmentApprovedActivity({
               ...sessionActivityActor(c.var.auth.user.localUserId),
               organizationId: c.var.auth.organization.localOrganizationId,
               projectId: params.projectId,
@@ -1627,7 +1625,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           );
 
           if (translation.isApproved) {
-            void enqueueStringSegmentApprovedActivity({
+            await enqueueStringSegmentApprovedActivity({
               ...sessionActivityActor(c.var.auth.user.localUserId),
               organizationId: c.var.auth.organization.localOrganizationId,
               projectId: params.projectId,
@@ -1697,7 +1695,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             feature: "comment",
           });
 
-          void enqueueStringSegmentCommentedActivity({
+          await enqueueStringSegmentCommentedActivity({
             ...sessionActivityActor(c.var.auth.user.localUserId),
             organizationId: c.var.auth.organization.localOrganizationId,
             projectId: params.projectId,
@@ -1733,7 +1731,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             feature: body.type === "issue" ? "issue" : "comment",
           });
 
-          void enqueueStringSegmentCommentedActivity({
+          await enqueueStringSegmentCommentedActivity({
             ...sessionActivityActor(c.var.auth.user.localUserId),
             organizationId: c.var.auth.organization.localOrganizationId,
             projectId: params.projectId,
@@ -2024,7 +2022,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             source: "native",
             status: "approved",
           });
-          void enqueueStringSegmentApprovedActivity({
+          await enqueueStringSegmentApprovedActivity({
             ...sessionActivityActor(c.var.auth.user.localUserId),
             organizationId: c.var.auth.organization.localOrganizationId,
             projectId: params.projectId,
@@ -2033,7 +2031,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             targetLocale: body.targetLocale,
           });
         } else {
-          void enqueueStringSegmentStatusChangedActivity({
+          await enqueueStringSegmentStatusChangedActivity({
             ...sessionActivityActor(c.var.auth.user.localUserId),
             nextStatus: body.status,
             organizationId: c.var.auth.organization.localOrganizationId,
@@ -2083,7 +2081,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
               { actorUserId: c.var.auth.user.localUserId },
             );
 
-            void enqueueStringSegmentHiddenActivity({
+            await enqueueStringSegmentHiddenActivity({
               ...sessionActivityActor(c.var.auth.user.localUserId),
               isHidden: result.isHidden,
               itemCount: result.updatedCount,
@@ -2118,7 +2116,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           sourcePath: body.sourcePath,
         });
 
-        void enqueueStringSegmentHiddenActivity({
+        await enqueueStringSegmentHiddenActivity({
           ...sessionActivityActor(c.var.auth.user.localUserId),
           isHidden: body.isHidden,
           itemCount: result.updatedCount,
@@ -2169,7 +2167,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           actorUserId: c.var.auth.user.localUserId,
         });
 
-        void enqueueStringSegmentLockedActivity({
+        await enqueueStringSegmentLockedActivity({
           ...sessionActivityActor(c.var.auth.user.localUserId),
           isLocked: body.isLocked,
           itemCount: result.updatedCount,
@@ -3618,7 +3616,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           );
         });
 
-        void enqueueFileUploadedActivity({
+        await enqueueFileUploadedActivity({
           ...sessionActivityActor(c.var.auth.user.localUserId),
           organizationId: c.var.auth.organization.localOrganizationId,
           projectId: params.projectId,
@@ -3744,15 +3742,6 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           await adapter.delete({ keyOrUrl: storedFile.storageKey }).catch(() => undefined);
           throw error;
         }
-
-        void enqueueFileTranslationsImportedActivity({
-          ...sessionActivityActor(c.var.auth.user.localUserId),
-          organizationId: c.var.auth.organization.localOrganizationId,
-          projectId: params.projectId,
-          sourcePath: parsed.data.sourcePath,
-          storedFileId: storedFile.id,
-          targetLocale: parsed.data.locale,
-        });
 
         return c.json(
           {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -39,6 +39,21 @@ import {
   workspaceResourceLimitErrorDetails,
   workspaceResourceLimitMessage,
 } from "@/lib/billing/workspace-resource-limits";
+import { FILE_SEGMENT_ACTIVITY_EVENT_TYPES } from "@/lib/activity-log/activity-log-contract";
+import {
+  enqueueFileTranslationsImportedActivity,
+  enqueueFileUploadedActivity,
+  enqueueStringSegmentApprovedActivity,
+  enqueueStringSegmentCommentedActivity,
+  enqueueStringSegmentHiddenActivity,
+  enqueueStringSegmentLockedActivity,
+  enqueueStringSegmentStatusChangedActivity,
+  sessionActivityActor,
+} from "@/lib/activity-log/file-segment-events";
+import {
+  InvalidActivityLogCursorError,
+  listActivityLogEvents,
+} from "@/lib/activity-log/activity-log-reader";
 import { enqueueActivityLogEvent } from "@/lib/activity-log/activity-log-writer";
 import { db, schema, type DatabaseClient } from "@/lib/database/client";
 import type { Project } from "@/lib/database/types";
@@ -167,6 +182,7 @@ import {
   projectFileCatSegmentParamsSchema,
   projectFileCatSegmentQuerySchema,
   projectFileCatQuerySchema,
+  projectFileCatActivityLogQuerySchema,
   projectFileCatExportQuerySchema,
   projectFileCatConcordanceBodySchema,
   projectFileCatCommentBodySchema,
@@ -647,6 +663,16 @@ const validateProjectFileContentEditorQuery = validator("query", (value, c) => {
 
 const validateProjectFileContentEditorExportQuery = validator("query", (value, c) => {
   const parsed = projectFileCatExportQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFileContentEditorActivityLogQuery = validator("query", (value, c) => {
+  const parsed = projectFileCatActivityLogQuerySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidProjectPayloadResponse(c);
@@ -1199,6 +1225,51 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       },
     )
     .get(
+      "/:projectId/files/detail/cat/activity-logs",
+      validateProjectParams,
+      validateProjectFileContentEditorActivityLogQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query = c.req.valid("query");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind !== "provider") {
+          const project = await getOwnedProject(c.var.auth, params.projectId);
+          if (!project) {
+            return projectNotFoundResponse(c);
+          }
+        }
+
+        try {
+          const result = await listActivityLogEvents({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            organizationSlug: c.req.param("organizationSlug") ?? "",
+            query: {
+              eventTypes: [...FILE_SEGMENT_ACTIVITY_EVENT_TYPES],
+              limit: query.limit,
+              projectId: params.projectId,
+              range: "all",
+              sourcePath: query.sourcePath,
+              cursor: query.cursor,
+            },
+          });
+          return c.json(result, 200);
+        } catch (error) {
+          if (error instanceof InvalidActivityLogCursorError) {
+            return badRequestResponse(
+              c,
+              "invalid_activity_log_cursor",
+              "Activity log cursor is invalid",
+            );
+          }
+          throw error;
+        }
+      },
+    )
+    .get(
       "/:projectId/files/detail/cat/export",
       validateProjectParams,
       validateProjectFileContentEditorExportQuery,
@@ -1514,6 +1585,17 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             },
           );
 
+          if (body.approve) {
+            void enqueueStringSegmentApprovedActivity({
+              ...sessionActivityActor(c.var.auth.user.localUserId),
+              organizationId: c.var.auth.organization.localOrganizationId,
+              projectId: params.projectId,
+              segmentId: body.externalStringId,
+              sourcePath: body.sourcePath,
+              targetLocale: body.targetLocale,
+            });
+          }
+
           return c.json({ translation }, 200);
         }
 
@@ -1543,6 +1625,17 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
               status: translation.isApproved ? "approved" : "draft",
             },
           );
+
+          if (translation.isApproved) {
+            void enqueueStringSegmentApprovedActivity({
+              ...sessionActivityActor(c.var.auth.user.localUserId),
+              organizationId: c.var.auth.organization.localOrganizationId,
+              projectId: params.projectId,
+              segmentId: body.externalStringId,
+              sourcePath: body.sourcePath,
+              targetLocale: body.targetLocale,
+            });
+          }
 
           return c.json({ translation }, 200);
         } catch (error) {
@@ -1604,6 +1697,15 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             feature: "comment",
           });
 
+          void enqueueStringSegmentCommentedActivity({
+            ...sessionActivityActor(c.var.auth.user.localUserId),
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: params.projectId,
+            segmentId: body.externalStringId,
+            sourcePath: body.sourcePath,
+            targetLocale: body.targetLocale,
+          });
+
           return c.json({ comment }, 200);
         }
 
@@ -1629,6 +1731,15 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.contentEditorCommentCreated, {
             source: "external_tms",
             feature: body.type === "issue" ? "issue" : "comment",
+          });
+
+          void enqueueStringSegmentCommentedActivity({
+            ...sessionActivityActor(c.var.auth.user.localUserId),
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: params.projectId,
+            segmentId: body.externalStringId,
+            sourcePath: body.sourcePath,
+            targetLocale: body.targetLocale,
           });
 
           return c.json({ comment }, 200);
@@ -1913,6 +2024,24 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             source: "native",
             status: "approved",
           });
+          void enqueueStringSegmentApprovedActivity({
+            ...sessionActivityActor(c.var.auth.user.localUserId),
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: params.projectId,
+            segmentId: body.externalStringId,
+            sourcePath: body.sourcePath,
+            targetLocale: body.targetLocale,
+          });
+        } else {
+          void enqueueStringSegmentStatusChangedActivity({
+            ...sessionActivityActor(c.var.auth.user.localUserId),
+            nextStatus: body.status,
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: params.projectId,
+            segmentId: body.externalStringId,
+            sourcePath: body.sourcePath,
+            targetLocale: body.targetLocale,
+          });
         }
 
         return c.json({ translation }, 200);
@@ -1954,6 +2083,16 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
               { actorUserId: c.var.auth.user.localUserId },
             );
 
+            void enqueueStringSegmentHiddenActivity({
+              ...sessionActivityActor(c.var.auth.user.localUserId),
+              isHidden: result.isHidden,
+              itemCount: result.updatedCount,
+              organizationId: c.var.auth.organization.localOrganizationId,
+              projectId: params.projectId,
+              segmentId: body.externalStringIds[0]!,
+              sourcePath: body.sourcePath,
+            });
+
             return c.json(
               {
                 updatedCount: result.updatedCount,
@@ -1976,6 +2115,16 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           projectId: params.projectId,
           translationKeyIds: body.externalStringIds,
           isHidden: body.isHidden,
+          sourcePath: body.sourcePath,
+        });
+
+        void enqueueStringSegmentHiddenActivity({
+          ...sessionActivityActor(c.var.auth.user.localUserId),
+          isHidden: body.isHidden,
+          itemCount: result.updatedCount,
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          segmentId: body.externalStringIds[0]!,
           sourcePath: body.sourcePath,
         });
 
@@ -2018,6 +2167,17 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           externalStringIds: body.externalStringIds,
           isLocked: body.isLocked,
           actorUserId: c.var.auth.user.localUserId,
+        });
+
+        void enqueueStringSegmentLockedActivity({
+          ...sessionActivityActor(c.var.auth.user.localUserId),
+          isLocked: body.isLocked,
+          itemCount: result.updatedCount,
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          segmentId: body.externalStringIds[0]!,
+          sourcePath: body.sourcePath,
+          targetLocale: body.targetLocale,
         });
 
         return c.json({ contentEditorSegmentLock: result }, 200);
@@ -3458,6 +3618,15 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           );
         });
 
+        void enqueueFileUploadedActivity({
+          ...sessionActivityActor(c.var.auth.user.localUserId),
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          sourcePath: parsed.data.sourcePath,
+          storedFileId: storedFile.id,
+          versionId: version.id,
+        });
+
         return c.json(
           {
             file: {
@@ -3575,6 +3744,15 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           await adapter.delete({ keyOrUrl: storedFile.storageKey }).catch(() => undefined);
           throw error;
         }
+
+        void enqueueFileTranslationsImportedActivity({
+          ...sessionActivityActor(c.var.auth.user.localUserId),
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          sourcePath: parsed.data.sourcePath,
+          storedFileId: storedFile.id,
+          targetLocale: parsed.data.locale,
+        });
 
         return c.json(
           {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.test.ts
@@ -14,8 +14,22 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   externalTmsTranslationPushBodySchema,
+  projectFileCatActivityLogQuerySchema,
   projectFileCatMaxLengthBodySchema,
 } from "./project.schema";
+
+describe("projectFileCatActivityLogQuerySchema", () => {
+  it("requires a source path and defaults the page size", () => {
+    expect(projectFileCatActivityLogQuerySchema.parse({ sourcePath: "locales/en.json" })).toEqual({
+      limit: 50,
+      sourcePath: "locales/en.json",
+    });
+  });
+
+  it("rejects a missing source path", () => {
+    expect(projectFileCatActivityLogQuerySchema.safeParse({}).success).toBe(false);
+  });
+});
 
 describe("projectFileCatMaxLengthBodySchema", () => {
   it("accepts a positive maxLength", () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -304,6 +304,12 @@ export const projectFileCatQuerySchema = z.object({
   sortBucketOffset: z.coerce.number().int().min(0).optional(),
 });
 
+export const projectFileCatActivityLogQuerySchema = z.object({
+  cursor: z.string().trim().min(1).max(2048).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  sourcePath: z.string().trim().min(1).max(2048),
+});
+
 export const projectFileCatExportFormatSchema = z.enum(["csv", "tmx", "xlf", "xliff"]);
 
 export const projectFileCatExportQuerySchema = projectFileCatQuerySchema

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-content-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-content-editor-page-content.tsx
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { ProjectFileContentEditorWorkspace } from "@/components/content-editor/project-file/project-file-content-editor-workspace";
+import { ContentEditorActivityLogButton } from "@/components/content-editor/activity-log/content-editor-activity-log-dialog";
 import { ContentEditorQueueToolbarHost } from "@/components/content-editor/queue/content-editor-queue-toolbar-host";
 import {
   attemptCatPageNavigation,
@@ -611,6 +612,12 @@ export function ProjectFileContentEditorPageContent({
               onTargetLocaleChange={handleLocaleChange}
             />
           ) : null}
+
+          <ContentEditorActivityLogButton
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            sourcePath={allFiles ? CONTENT_EDITOR_ALL_FILES_SOURCE_PATH : (sourcePath as string)}
+          />
         </div>
 
         <ContentEditorQueueToolbarHost />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-content-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-content-editor-page-content.tsx
@@ -52,6 +52,7 @@ import {
 } from "./select-job-content-editor-repository";
 import { jobCatPageContentMessages } from "./job-content-editor-page-content.messages";
 import { ProjectFileContentEditorWorkspace } from "@/components/content-editor/project-file/project-file-content-editor-workspace";
+import { ContentEditorActivityLogButton } from "@/components/content-editor/activity-log/content-editor-activity-log-dialog";
 import { ContentEditorQueueToolbarHost } from "@/components/content-editor/queue/content-editor-queue-toolbar-host";
 import {
   attemptCatPageNavigation,
@@ -662,6 +663,12 @@ export function JobContentEditorPageContent({
                 onTargetLocaleChange={handleAllFilesLocaleChange}
               />
             ) : null}
+
+            <ContentEditorActivityLogButton
+              organizationSlug={organizationSlug}
+              projectId={projectId}
+              sourcePath={CONTENT_EDITOR_ALL_FILES_SOURCE_PATH}
+            />
           </div>
 
           <ContentEditorQueueToolbarHost />
@@ -840,6 +847,12 @@ export function JobContentEditorPageContent({
                 onTargetLocaleChange={handleLocaleChange}
               />
             ) : null}
+
+            <ContentEditorActivityLogButton
+              organizationSlug={organizationSlug}
+              projectId={projectId}
+              sourcePath={selectedFile.sourcePath}
+            />
           </div>
 
           <ContentEditorQueueToolbarHost />
@@ -980,6 +993,12 @@ export function JobContentEditorPageContent({
               onTargetLocaleChange={handleLocaleChange}
             />
           ) : null}
+
+          <ContentEditorActivityLogButton
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            sourcePath={selectedFile.sourcePath}
+          />
         </div>
 
         <ContentEditorQueueToolbarHost />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-log-event-type-filter.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-log-event-type-filter.tsx
@@ -19,10 +19,12 @@ import {
   Building06Icon,
   Cancel01Icon,
   DatabaseIcon,
+  File01Icon,
   FilterIcon,
   FolderLibraryIcon,
   Key01Icon,
   PuzzleIcon,
+  TextFontIcon,
   UserGroup02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -115,6 +117,24 @@ const eventTypeGroups: readonly EventTypeGroup[] = [
     label: messages.automationEventGroup,
     eventTypes: ["automation_run_started", "automation_enabled", "automation_disabled"],
   },
+  {
+    icon: File01Icon,
+    label: messages.fileEventGroup,
+    eventTypes: ["file_uploaded", "file_translations_imported"],
+  },
+  {
+    icon: TextFontIcon,
+    label: messages.stringSegmentEventGroup,
+    eventTypes: [
+      "string_segment_approved",
+      "string_segment_status_changed",
+      "string_segment_hidden",
+      "string_segment_unhidden",
+      "string_segment_locked",
+      "string_segment_unlocked",
+      "string_segment_commented",
+    ],
+  },
 ];
 
 const eventTypeLabels = {
@@ -148,6 +168,15 @@ const eventTypeLabels = {
   automation_run_started: messages.automationRunStartedEventType,
   automation_enabled: messages.automationEnabledEventType,
   automation_disabled: messages.automationDisabledEventType,
+  file_uploaded: messages.fileUploadedEventType,
+  file_translations_imported: messages.fileTranslationsImportedEventType,
+  string_segment_approved: messages.stringSegmentApprovedEventType,
+  string_segment_status_changed: messages.stringSegmentStatusChangedEventType,
+  string_segment_hidden: messages.stringSegmentHiddenEventType,
+  string_segment_unhidden: messages.stringSegmentUnhiddenEventType,
+  string_segment_locked: messages.stringSegmentLockedEventType,
+  string_segment_unlocked: messages.stringSegmentUnlockedEventType,
+  string_segment_commented: messages.stringSegmentCommentedEventType,
 } satisfies Record<ImplementedActivityEventType, MessageDescriptor>;
 
 export function ActivityLogEventTypeFilter({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-log-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-log-list.tsx
@@ -22,6 +22,8 @@ import {
   PuzzleIcon,
   UserGroup02Icon,
   DatabaseIcon,
+  File01Icon,
+  TextFontIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -73,6 +75,15 @@ const eventActions = {
   automation_run_started: messages.automationRunStartedAction,
   automation_enabled: messages.automationEnabledAction,
   automation_disabled: messages.automationDisabledAction,
+  file_uploaded: messages.fileUploadedAction,
+  file_translations_imported: messages.fileTranslationsImportedAction,
+  string_segment_approved: messages.stringSegmentApprovedAction,
+  string_segment_status_changed: messages.stringSegmentStatusChangedAction,
+  string_segment_hidden: messages.stringSegmentHiddenAction,
+  string_segment_unhidden: messages.stringSegmentUnhiddenAction,
+  string_segment_locked: messages.stringSegmentLockedAction,
+  string_segment_unlocked: messages.stringSegmentUnlockedAction,
+  string_segment_commented: messages.stringSegmentCommentedAction,
 };
 
 type ActivityVisual = {
@@ -101,6 +112,12 @@ function activityVisual(eventType: ImplementedActivityEventType): ActivityVisual
   }
   if (eventType.startsWith("automation_")) {
     return { icon: PuzzleIcon, className: "bg-success/10 text-success" };
+  }
+  if (eventType.startsWith("file_")) {
+    return { icon: File01Icon, className: "bg-primary/10 text-primary" };
+  }
+  if (eventType.startsWith("string_segment_")) {
+    return { icon: TextFontIcon, className: "bg-warning/10 text-warning" };
   }
   return { icon: DatabaseIcon, className: "bg-info/10 text-info" };
 }
@@ -140,65 +157,76 @@ function targetDisplayName(item: ActivityLogItem): string | null {
 export function ActivityLogList({
   activityLogs,
   now = Date.now(),
+  variant = "card",
 }: {
   activityLogs: ActivityLogItem[];
   now?: number;
+  variant?: "card" | "plain";
 }) {
   const intl = useIntl();
 
+  const list = (
+    <ol className="divide-y divide-border">
+      {activityLogs.map((item) => {
+        const displayName = targetDisplayName(item);
+        const target = displayName ? ` · ${displayName}` : "";
+        const relative = relativeTime(item.createdAt, now);
+        const visual = activityVisual(item.eventType);
+        return (
+          <li
+            key={item.id}
+            className={cn("flex gap-3", variant === "plain" ? "px-1 py-3" : "px-4 py-4 md:px-6")}
+          >
+            <div
+              className={cn(
+                "grid size-8 shrink-0 place-content-center rounded-full",
+                visual.className,
+              )}
+              aria-hidden="true"
+            >
+              <HugeiconsIcon icon={visual.icon} strokeWidth={1.8} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <TypographyP size="small" weight="medium" tone="content">
+                  {intl.formatMessage(messages.eventDescription, {
+                    actor: item.actor.displayName,
+                    action: intl.formatMessage(eventActions[item.eventType]),
+                    target,
+                  })}
+                </TypographyP>
+                <Badge variant="outline">{item.actor.kind}</Badge>
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                {item.target.href && displayName ? (
+                  <Link
+                    className="underline underline-offset-2 hover:text-foreground"
+                    href={item.target.href}
+                  >
+                    {displayName}
+                  </Link>
+                ) : null}
+                <span title={new Date(item.createdAt).toLocaleString()}>
+                  {new Intl.RelativeTimeFormat(undefined, { numeric: "auto" }).format(
+                    relative.value,
+                    relative.unit,
+                  )}
+                </span>
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+
+  if (variant === "plain") {
+    return list;
+  }
+
   return (
     <Card>
-      <CardContent className="p-0">
-        <ol className="divide-y divide-border">
-          {activityLogs.map((item) => {
-            const displayName = targetDisplayName(item);
-            const target = displayName ? ` · ${displayName}` : "";
-            const relative = relativeTime(item.createdAt, now);
-            const visual = activityVisual(item.eventType);
-            return (
-              <li key={item.id} className="flex gap-3 px-4 py-4 md:px-6">
-                <div
-                  className={cn(
-                    "grid size-8 shrink-0 place-content-center rounded-full",
-                    visual.className,
-                  )}
-                  aria-hidden="true"
-                >
-                  <HugeiconsIcon icon={visual.icon} strokeWidth={1.8} />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <TypographyP size="small" weight="medium" tone="content">
-                      {intl.formatMessage(messages.eventDescription, {
-                        actor: item.actor.displayName,
-                        action: intl.formatMessage(eventActions[item.eventType]),
-                        target,
-                      })}
-                    </TypographyP>
-                    <Badge variant="outline">{item.actor.kind}</Badge>
-                  </div>
-                  <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                    {item.target.href && displayName ? (
-                      <Link
-                        className="underline underline-offset-2 hover:text-foreground"
-                        href={item.target.href}
-                      >
-                        {displayName}
-                      </Link>
-                    ) : null}
-                    <span title={new Date(item.createdAt).toLocaleString()}>
-                      {new Intl.RelativeTimeFormat(undefined, { numeric: "auto" }).format(
-                        relative.value,
-                        relative.unit,
-                      )}
-                    </span>
-                  </div>
-                </div>
-              </li>
-            );
-          })}
-        </ol>
-      </CardContent>
+      <CardContent className="p-0">{list}</CardContent>
     </Card>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-logs-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-logs-page-content.messages.ts
@@ -230,6 +230,51 @@ export const activityLogsPageContentMessages = defineMessages({
     id: "uIkNdFV4AX",
     description: "Activity log event type label for disabling automations",
   },
+  fileUploadedEventType: {
+    defaultMessage: "File Uploaded",
+    id: "fUp1eVtY2a",
+    description: "Activity log event type label for file uploads",
+  },
+  fileTranslationsImportedEventType: {
+    defaultMessage: "File Translations Imported",
+    id: "kIm2rTwP8c",
+    description: "Activity log event type label for file translation imports",
+  },
+  stringSegmentApprovedEventType: {
+    defaultMessage: "String Approved",
+    id: "sEg3aPrQ1d",
+    description: "Activity log event type label for string approval",
+  },
+  stringSegmentStatusChangedEventType: {
+    defaultMessage: "String Status Changed",
+    id: "sEg4sTcH2e",
+    description: "Activity log event type label for string status changes",
+  },
+  stringSegmentHiddenEventType: {
+    defaultMessage: "String Hidden",
+    id: "sEg5hIdN3f",
+    description: "Activity log event type label for hiding strings",
+  },
+  stringSegmentUnhiddenEventType: {
+    defaultMessage: "String Unhidden",
+    id: "sEg6uNhI4g",
+    description: "Activity log event type label for unhiding strings",
+  },
+  stringSegmentLockedEventType: {
+    defaultMessage: "String Locked",
+    id: "sEg7lOcK5h",
+    description: "Activity log event type label for locking strings",
+  },
+  stringSegmentUnlockedEventType: {
+    defaultMessage: "String Unlocked",
+    id: "sEg8uNlK6i",
+    description: "Activity log event type label for unlocking strings",
+  },
+  stringSegmentCommentedEventType: {
+    defaultMessage: "String Commented",
+    id: "sEg9cOmM7j",
+    description: "Activity log event type label for string comments",
+  },
   membershipEventGroup: {
     defaultMessage: "Membership",
     id: "3Di0YY2oCY",
@@ -274,6 +319,16 @@ export const activityLogsPageContentMessages = defineMessages({
     defaultMessage: "Automations",
     id: "JA+rxr35jC",
     description: "Activity log event type group for automations",
+  },
+  fileEventGroup: {
+    defaultMessage: "Files",
+    id: "fIl0eVtG8k",
+    description: "Activity log event type group for files",
+  },
+  stringSegmentEventGroup: {
+    defaultMessage: "Strings",
+    id: "sTr1sEgG9l",
+    description: "Activity log event type group for string segments",
   },
   actorLabel: {
     defaultMessage: "Actor",
@@ -529,5 +584,50 @@ export const activityLogsPageContentMessages = defineMessages({
     defaultMessage: "disabled an automation",
     id: "MmRAbYJJub",
     description: "Action for disabling an automation",
+  },
+  fileUploadedAction: {
+    defaultMessage: "uploaded a file",
+    id: "fUp2aCtI0m",
+    description: "Action for a file upload activity",
+  },
+  fileTranslationsImportedAction: {
+    defaultMessage: "imported translations",
+    id: "fIm3tRnJ1n",
+    description: "Action for a file translation import activity",
+  },
+  stringSegmentApprovedAction: {
+    defaultMessage: "approved a string",
+    id: "sAp4pRvK2o",
+    description: "Action for a string approval activity",
+  },
+  stringSegmentStatusChangedAction: {
+    defaultMessage: "changed a string status",
+    id: "sSt5cHgL3p",
+    description: "Action for a string status change activity",
+  },
+  stringSegmentHiddenAction: {
+    defaultMessage: "hid a string",
+    id: "sHi6dStM4q",
+    description: "Action for a hidden string activity",
+  },
+  stringSegmentUnhiddenAction: {
+    defaultMessage: "unhid a string",
+    id: "sUn7hIdN5r",
+    description: "Action for an unhidden string activity",
+  },
+  stringSegmentLockedAction: {
+    defaultMessage: "locked a string",
+    id: "sLo8cKeO6s",
+    description: "Action for a locked string activity",
+  },
+  stringSegmentUnlockedAction: {
+    defaultMessage: "unlocked a string",
+    id: "sUl9nCkP7t",
+    description: "Action for an unlocked string activity",
+  },
+  stringSegmentCommentedAction: {
+    defaultMessage: "commented on a string",
+    id: "sCo0mNtQ8u",
+    description: "Action for a string comment activity",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-logs-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-logs-page-content.messages.ts
@@ -232,47 +232,47 @@ export const activityLogsPageContentMessages = defineMessages({
   },
   fileUploadedEventType: {
     defaultMessage: "File Uploaded",
-    id: "fUp1eVtY2a",
+    id: "b0hzgbcjSl",
     description: "Activity log event type label for file uploads",
   },
   fileTranslationsImportedEventType: {
     defaultMessage: "File Translations Imported",
-    id: "kIm2rTwP8c",
+    id: "fKmUmenDYW",
     description: "Activity log event type label for file translation imports",
   },
   stringSegmentApprovedEventType: {
     defaultMessage: "String Approved",
-    id: "sEg3aPrQ1d",
+    id: "4IGqbe4A0j",
     description: "Activity log event type label for string approval",
   },
   stringSegmentStatusChangedEventType: {
     defaultMessage: "String Status Changed",
-    id: "sEg4sTcH2e",
+    id: "NtW3KnFblK",
     description: "Activity log event type label for string status changes",
   },
   stringSegmentHiddenEventType: {
     defaultMessage: "String Hidden",
-    id: "sEg5hIdN3f",
+    id: "Qw3AuwhQJ4",
     description: "Activity log event type label for hiding strings",
   },
   stringSegmentUnhiddenEventType: {
     defaultMessage: "String Unhidden",
-    id: "sEg6uNhI4g",
+    id: "ZJtpLzte1C",
     description: "Activity log event type label for unhiding strings",
   },
   stringSegmentLockedEventType: {
     defaultMessage: "String Locked",
-    id: "sEg7lOcK5h",
+    id: "79CAb1uFN6",
     description: "Activity log event type label for locking strings",
   },
   stringSegmentUnlockedEventType: {
     defaultMessage: "String Unlocked",
-    id: "sEg8uNlK6i",
+    id: "4pUrDejiya",
     description: "Activity log event type label for unlocking strings",
   },
   stringSegmentCommentedEventType: {
     defaultMessage: "String Commented",
-    id: "sEg9cOmM7j",
+    id: "o2Y08elyIM",
     description: "Activity log event type label for string comments",
   },
   membershipEventGroup: {
@@ -322,12 +322,12 @@ export const activityLogsPageContentMessages = defineMessages({
   },
   fileEventGroup: {
     defaultMessage: "Files",
-    id: "fIl0eVtG8k",
+    id: "gWW0AlUbAk",
     description: "Activity log event type group for files",
   },
   stringSegmentEventGroup: {
     defaultMessage: "Strings",
-    id: "sTr1sEgG9l",
+    id: "HAcQZdyjXj",
     description: "Activity log event type group for string segments",
   },
   actorLabel: {
@@ -587,47 +587,47 @@ export const activityLogsPageContentMessages = defineMessages({
   },
   fileUploadedAction: {
     defaultMessage: "uploaded a file",
-    id: "fUp2aCtI0m",
+    id: "qICJFGMBSv",
     description: "Action for a file upload activity",
   },
   fileTranslationsImportedAction: {
     defaultMessage: "imported translations",
-    id: "fIm3tRnJ1n",
+    id: "2evxUsSaO3",
     description: "Action for a file translation import activity",
   },
   stringSegmentApprovedAction: {
     defaultMessage: "approved a string",
-    id: "sAp4pRvK2o",
+    id: "9d14HnH3r+",
     description: "Action for a string approval activity",
   },
   stringSegmentStatusChangedAction: {
     defaultMessage: "changed a string status",
-    id: "sSt5cHgL3p",
+    id: "D4SMVMIcIp",
     description: "Action for a string status change activity",
   },
   stringSegmentHiddenAction: {
     defaultMessage: "hid a string",
-    id: "sHi6dStM4q",
+    id: "e5w8XM92TM",
     description: "Action for a hidden string activity",
   },
   stringSegmentUnhiddenAction: {
     defaultMessage: "unhid a string",
-    id: "sUn7hIdN5r",
+    id: "LCaZaBXgAV",
     description: "Action for an unhidden string activity",
   },
   stringSegmentLockedAction: {
     defaultMessage: "locked a string",
-    id: "sLo8cKeO6s",
+    id: "Lhr+5G4eBn",
     description: "Action for a locked string activity",
   },
   stringSegmentUnlockedAction: {
     defaultMessage: "unlocked a string",
-    id: "sUl9nCkP7t",
+    id: "BfavHio26Z",
     description: "Action for an unlocked string activity",
   },
   stringSegmentCommentedAction: {
     defaultMessage: "commented on a string",
-    id: "sCo0mNtQ8u",
+    id: "UKiNYTCKL8",
     description: "Action for a string comment activity",
   },
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log-dialog.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { renderWithContentEditorProviders } from "@/components/content-editor/shared/content-editor-test-utils";
+
+import { ContentEditorActivityLogButton } from "./content-editor-activity-log-dialog";
+
+const activityLogsGetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-client-instance", () => ({
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          projects: {
+            ":projectId": {
+              files: {
+                detail: {
+                  cat: {
+                    "activity-logs": {
+                      $get: (...args: unknown[]) => activityLogsGetMock(...args),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+describe("ContentEditorActivityLogButton", () => {
+  it("opens a dialog of file and string activity", async () => {
+    const user = userEvent.setup();
+    activityLogsGetMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        activityLogs: [
+          {
+            actor: { displayName: "Ada Lovelace", kind: "user", userId: "user-1" },
+            createdAt: "2026-09-08T10:00:00.000Z",
+            eventType: "string_segment_approved",
+            id: "activity-1",
+            payload: { fileName: "en.json", name: "en.json" },
+            target: { displayName: "en.json", href: null, kind: "string_segment" },
+          },
+        ],
+        nextCursor: null,
+      }),
+    });
+
+    renderWithContentEditorProviders(
+      <ContentEditorActivityLogButton
+        organizationSlug="acme"
+        projectId="project-1"
+        sourcePath="locales/en.json"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show file activity" }));
+
+    expect(await screen.findByRole("heading", { name: "Activity" })).toBeInTheDocument();
+    expect(screen.getByText(/approved a string/)).toBeInTheDocument();
+    expect(activityLogsGetMock).toHaveBeenCalledWith({
+      param: { organizationSlug: "acme", projectId: "project-1" },
+      query: {
+        sourcePath: "locales/en.json",
+        cursor: undefined,
+        limit: "50",
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log-dialog.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log-dialog.tsx
@@ -132,7 +132,12 @@ export function ContentEditorActivityLogButton({
                 <TypographyP size="small" weight="medium" tone="critical">
                   <FormattedMessage {...messages.loadError} />
                 </TypographyP>
-                <Button type="button" variant="outline" size="sm" onClick={() => activityQuery.refetch()}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => activityQuery.refetch()}
+                >
                   <FormattedMessage {...messages.retry} />
                 </Button>
               </div>

--- a/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log-dialog.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log-dialog.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { HistoryIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import {
+  ActivityLogList,
+  type ActivityLogItem,
+} from "@/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/activity-log-list";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import { isContentEditorAllFilesSourcePath } from "@/lib/projects/content-editor-all-files";
+
+import { contentEditorActivityLogMessages as messages } from "./content-editor-activity-log.messages";
+
+type ActivityLogResponse = {
+  activityLogs: ActivityLogItem[];
+  nextCursor: string | null;
+};
+
+function contentEditorActivityLogsQueryKey(
+  organizationSlug: string,
+  projectId: string,
+  sourcePath: string,
+) {
+  return ["content-editor-activity-logs", organizationSlug, projectId, sourcePath] as const;
+}
+
+export function ContentEditorActivityLogButton({
+  organizationSlug,
+  projectId,
+  sourcePath,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+}) {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const [now] = useState(() => Date.now());
+  const allFiles = isContentEditorAllFilesSourcePath(sourcePath);
+
+  const activityQuery = useInfiniteQuery({
+    queryKey: contentEditorActivityLogsQueryKey(organizationSlug, projectId, sourcePath),
+    initialPageParam: undefined as string | undefined,
+    enabled: open,
+    queryFn: async ({ pageParam }) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat["activity-logs"].$get({
+        param: { organizationSlug, projectId },
+        query: {
+          sourcePath,
+          cursor: pageParam,
+          limit: "50",
+        },
+      });
+      if (!response.ok) {
+        throw new Error(intl.formatMessage(messages.loadError));
+      }
+      return (await response.json()) as ActivityLogResponse;
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+
+  const activityLogs = useMemo(
+    () => activityQuery.data?.pages.flatMap((page) => page.activityLogs) ?? [],
+    [activityQuery.data?.pages],
+  );
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        className="size-8 shrink-0"
+        aria-label={intl.formatMessage(messages.openAria)}
+        title={intl.formatMessage(messages.openAria)}
+        onClick={() => setOpen(true)}
+      >
+        <HugeiconsIcon icon={HistoryIcon} className="size-4" />
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...messages.title} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage
+                {...(allFiles ? messages.allFilesDescription : messages.description)}
+              />
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="max-h-[min(28rem,60vh)] overflow-y-auto">
+            {activityQuery.isLoading ? (
+              <div className="flex items-center justify-center gap-2 py-8">
+                <Spinner className="size-4" />
+                <TypographyP size="small" tone="subtle">
+                  <FormattedMessage {...messages.loading} />
+                </TypographyP>
+              </div>
+            ) : activityQuery.isError ? (
+              <div className="flex flex-col items-start gap-3 py-4">
+                <TypographyP size="small" weight="medium" tone="critical">
+                  <FormattedMessage {...messages.loadError} />
+                </TypographyP>
+                <Button type="button" variant="outline" size="sm" onClick={() => activityQuery.refetch()}>
+                  <FormattedMessage {...messages.retry} />
+                </Button>
+              </div>
+            ) : activityLogs.length === 0 ? (
+              <div className="flex flex-col gap-1 py-4">
+                <TypographyP size="small" weight="medium" tone="content">
+                  <FormattedMessage {...messages.emptyTitle} />
+                </TypographyP>
+                <TypographyP size="small" tone="subtle">
+                  <FormattedMessage {...messages.emptyDescription} />
+                </TypographyP>
+              </div>
+            ) : (
+              <ActivityLogList activityLogs={activityLogs} now={now} variant="plain" />
+            )}
+          </div>
+
+          {activityQuery.hasNextPage ? (
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => activityQuery.fetchNextPage()}
+                disabled={activityQuery.isFetchingNextPage}
+              >
+                {activityQuery.isFetchingNextPage ? (
+                  <Spinner className="size-3.5" />
+                ) : (
+                  <FormattedMessage {...messages.loadMore} />
+                )}
+              </Button>
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log.messages.ts
@@ -17,52 +17,52 @@ import { defineMessages } from "react-intl";
 export const contentEditorActivityLogMessages = defineMessages({
   openAria: {
     defaultMessage: "Show file activity",
-    id: "cAt1oPnA9v",
+    id: "7qG8V9eHbJ",
     description: "Accessible label for the file editor activity log button",
   },
   title: {
     defaultMessage: "Activity",
-    id: "cAt2tItL0w",
+    id: "2uw5+lQ54T",
     description: "Title for the file editor activity dialog",
   },
   description: {
     defaultMessage: "Changes to this file and its strings.",
-    id: "cAt3dScP1x",
+    id: "VL1n4lhYVe",
     description: "Description for the file editor activity dialog",
   },
   allFilesDescription: {
     defaultMessage: "Changes to files and strings in this project.",
-    id: "cAt4aLfD2y",
+    id: "1Kqhhea0Ee",
     description: "Description for the All Files activity dialog",
   },
   loading: {
     defaultMessage: "Loading activity…",
-    id: "cAt5lOdA3z",
+    id: "mF2ibzlVS8",
     description: "Loading state for the file editor activity dialog",
   },
   emptyTitle: {
     defaultMessage: "No activity yet",
-    id: "cAt6eMpT4a",
+    id: "CrdjVes1wn",
     description: "Empty state title for the file editor activity dialog",
   },
   emptyDescription: {
     defaultMessage: "Approvals, comments, and file changes will appear here.",
-    id: "cAt7eMpD5b",
+    id: "kKTupKEcTR",
     description: "Empty state description for the file editor activity dialog",
   },
   loadError: {
     defaultMessage: "Activity could not be loaded.",
-    id: "cAt8eRrT6c",
+    id: "m3RSvNywAR",
     description: "Error title when file editor activity fails to load",
   },
   retry: {
     defaultMessage: "Retry",
-    id: "cAt9rTyB7d",
+    id: "rttw694uiK",
     description: "Retry button for the file editor activity dialog",
   },
   loadMore: {
     defaultMessage: "Load more",
-    id: "cAt0lDmR8e",
+    id: "l1mlJzFoj/",
     description: "Load more button for the file editor activity dialog",
   },
 });

--- a/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log.messages.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/activity-log/content-editor-activity-log.messages.ts
@@ -1,0 +1,68 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const contentEditorActivityLogMessages = defineMessages({
+  openAria: {
+    defaultMessage: "Show file activity",
+    id: "cAt1oPnA9v",
+    description: "Accessible label for the file editor activity log button",
+  },
+  title: {
+    defaultMessage: "Activity",
+    id: "cAt2tItL0w",
+    description: "Title for the file editor activity dialog",
+  },
+  description: {
+    defaultMessage: "Changes to this file and its strings.",
+    id: "cAt3dScP1x",
+    description: "Description for the file editor activity dialog",
+  },
+  allFilesDescription: {
+    defaultMessage: "Changes to files and strings in this project.",
+    id: "cAt4aLfD2y",
+    description: "Description for the All Files activity dialog",
+  },
+  loading: {
+    defaultMessage: "Loading activity…",
+    id: "cAt5lOdA3z",
+    description: "Loading state for the file editor activity dialog",
+  },
+  emptyTitle: {
+    defaultMessage: "No activity yet",
+    id: "cAt6eMpT4a",
+    description: "Empty state title for the file editor activity dialog",
+  },
+  emptyDescription: {
+    defaultMessage: "Approvals, comments, and file changes will appear here.",
+    id: "cAt7eMpD5b",
+    description: "Empty state description for the file editor activity dialog",
+  },
+  loadError: {
+    defaultMessage: "Activity could not be loaded.",
+    id: "cAt8eRrT6c",
+    description: "Error title when file editor activity fails to load",
+  },
+  retry: {
+    defaultMessage: "Retry",
+    id: "cAt9rTyB7d",
+    description: "Retry button for the file editor activity dialog",
+  },
+  loadMore: {
+    defaultMessage: "Load more",
+    id: "cAt0lDmR8e",
+    description: "Load more button for the file editor activity dialog",
+  },
+});

--- a/apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.test.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.test.ts
@@ -16,6 +16,7 @@ import {
   ACTIVITY_ACTOR_KINDS,
   ACTIVITY_TARGET_KINDS,
   assertSafeActivityLogPayload,
+  FILE_SEGMENT_ACTIVITY_EVENT_TYPES,
   isV1ActivityEventType,
   LATER_ACTIVITY_EVENT_TYPES,
   RESERVED_ACTIVITY_EVENT_TYPES,
@@ -40,6 +41,8 @@ describe("activity log contract", () => {
       "translation_memory",
       "job",
       "automation",
+      "file",
+      "string_segment",
     ]);
   });
 
@@ -60,6 +63,17 @@ describe("activity log contract", () => {
       "automation_run_started",
       "automation_enabled",
       "automation_disabled",
+    ]);
+    expect(FILE_SEGMENT_ACTIVITY_EVENT_TYPES).toEqual([
+      "file_uploaded",
+      "file_translations_imported",
+      "string_segment_approved",
+      "string_segment_status_changed",
+      "string_segment_hidden",
+      "string_segment_unhidden",
+      "string_segment_locked",
+      "string_segment_unlocked",
+      "string_segment_commented",
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/activity-log-contract.ts
@@ -26,6 +26,8 @@ export const ACTIVITY_TARGET_KINDS = [
   "translation_memory",
   "job",
   "automation",
+  "file",
+  "string_segment",
 ] as const;
 export type ActivityTargetKind = (typeof ACTIVITY_TARGET_KINDS)[number];
 
@@ -74,16 +76,31 @@ export const LATER_ACTIVITY_EVENT_TYPES = [
 ] as const;
 export type LaterActivityEventType = (typeof LATER_ACTIVITY_EVENT_TYPES)[number];
 
+export const FILE_SEGMENT_ACTIVITY_EVENT_TYPES = [
+  "file_uploaded",
+  "file_translations_imported",
+  "string_segment_approved",
+  "string_segment_status_changed",
+  "string_segment_hidden",
+  "string_segment_unhidden",
+  "string_segment_locked",
+  "string_segment_unlocked",
+  "string_segment_commented",
+] as const;
+export type FileSegmentActivityEventType = (typeof FILE_SEGMENT_ACTIVITY_EVENT_TYPES)[number];
+
 export const IMPLEMENTED_ACTIVITY_EVENT_TYPES = [
   ...V1_ACTIVITY_EVENT_TYPES,
   ...LATER_ACTIVITY_EVENT_TYPES,
+  ...FILE_SEGMENT_ACTIVITY_EVENT_TYPES,
 ] as const;
 export type ImplementedActivityEventType = (typeof IMPLEMENTED_ACTIVITY_EVENT_TYPES)[number];
 
 export type ActivityEventType =
   | V1ActivityEventType
   | ReservedActivityEventType
-  | LaterActivityEventType;
+  | LaterActivityEventType
+  | FileSegmentActivityEventType;
 
 export type ActivityMembershipRole =
   | "admin"
@@ -110,6 +127,25 @@ type ImportExportPayload = {
 type AttachmentPayload = {
   projectId: string;
   resourceId: string;
+};
+
+type FileActivityPayload = {
+  fileName: string;
+  name: string;
+  projectId: string;
+  sourcePath: string;
+  storedFileId?: string;
+  versionId?: string;
+};
+
+type StringSegmentActivityPayload = {
+  fileName: string;
+  itemCount?: number;
+  name: string;
+  projectId: string;
+  segmentId: string;
+  sourcePath: string;
+  targetLocale?: string;
 };
 
 export type ActivityPayloadByEventType = {
@@ -211,6 +247,20 @@ export type ActivityPayloadByEventType = {
     name: string;
     status: "archived" | "paused";
   };
+  file_uploaded: FileActivityPayload;
+  file_translations_imported: FileActivityPayload & {
+    targetLocale: string;
+  };
+  string_segment_approved: StringSegmentActivityPayload;
+  string_segment_status_changed: StringSegmentActivityPayload & {
+    nextStatus: string;
+    previousStatus?: string;
+  };
+  string_segment_hidden: StringSegmentActivityPayload;
+  string_segment_unhidden: StringSegmentActivityPayload;
+  string_segment_locked: StringSegmentActivityPayload;
+  string_segment_unlocked: StringSegmentActivityPayload;
+  string_segment_commented: StringSegmentActivityPayload;
 };
 
 export type ActivityTargetKindByEventType = {
@@ -244,6 +294,15 @@ export type ActivityTargetKindByEventType = {
   automation_run_started: "automation";
   automation_enabled: "automation";
   automation_disabled: "automation";
+  file_uploaded: "file";
+  file_translations_imported: "file";
+  string_segment_approved: "string_segment";
+  string_segment_status_changed: "string_segment";
+  string_segment_hidden: "string_segment";
+  string_segment_unhidden: "string_segment";
+  string_segment_locked: "string_segment";
+  string_segment_unlocked: "string_segment";
+  string_segment_commented: "string_segment";
 };
 
 type ActivityLogEventBase = {

--- a/apps/hyperlocalise-web/src/lib/activity-log/activity-log-reader.test.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/activity-log-reader.test.ts
@@ -49,6 +49,7 @@ describe("payloadTargetDisplayName", () => {
   it("uses provider and token identifiers when no name is stored", () => {
     expect(payloadTargetDisplayName({ integrationKind: "phrase" })).toBe("phrase");
     expect(payloadTargetDisplayName({ keyPrefix: "hl_AbCd" })).toBe("hl_AbCd");
+    expect(payloadTargetDisplayName({ fileName: "en.json" })).toBe("en.json");
     expect(payloadTargetDisplayName({ resourceId: "resource_123" })).toBeNull();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/activity-log/activity-log-reader.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/activity-log-reader.ts
@@ -417,6 +417,7 @@ export async function listActivityLogActors(input: {
 
 export async function listActivityLogEvents(input: {
   database?: DatabaseClient;
+  includeActors?: boolean;
   organizationId: string;
   organizationSlug: string;
   query: ActivityLogQuery;
@@ -490,10 +491,12 @@ export async function listActivityLogEvents(input: {
         desc(schema.organizationActivityEvents.id),
       )
       .limit(input.query.limit + 1),
-    listActivityLogActors({
-      database,
-      organizationId: input.organizationId,
-    }),
+    input.includeActors === false
+      ? Promise.resolve([])
+      : listActivityLogActors({
+          database,
+          organizationId: input.organizationId,
+        }),
   ]);
 
   const hasNextPage = rows.length > input.query.limit;

--- a/apps/hyperlocalise-web/src/lib/activity-log/activity-log-reader.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/activity-log-reader.ts
@@ -18,6 +18,9 @@ import { z } from "zod";
 import { and, desc, eq, gt, inArray, lt, or, sql } from "drizzle-orm";
 
 import { db, schema, type DatabaseClient } from "@/lib/database/client";
+import { normalizeSourcePath } from "@/lib/file-storage/records";
+import { isContentEditorAllFilesSourcePath } from "@/lib/projects/content-editor-all-files";
+
 import {
   IMPLEMENTED_ACTIVITY_EVENT_TYPES,
   type ImplementedActivityEventType,
@@ -37,7 +40,9 @@ export type ActivityLogQuery = {
   cursor?: string;
   eventTypes: ImplementedActivityEventType[];
   limit: number;
+  projectId?: string;
   range: ActivityLogRange;
+  sourcePath?: string;
 };
 
 export type ActivityLogActorView = {
@@ -80,6 +85,9 @@ export function payloadTargetDisplayName(payload: Record<string, unknown>): stri
   if (typeof payload.name === "string" && payload.name.trim()) {
     return payload.name;
   }
+  if (typeof payload.fileName === "string" && payload.fileName.trim()) {
+    return payload.fileName;
+  }
   if (typeof payload.integrationKind === "string" && payload.integrationKind.trim()) {
     return payload.integrationKind;
   }
@@ -101,7 +109,9 @@ function filterFingerprint(query: ActivityLogQuery): string {
       JSON.stringify({
         actor: query.actor ?? null,
         eventTypes: [...query.eventTypes].sort((left, right) => left.localeCompare(right)),
+        projectId: query.projectId ?? null,
         range: query.range,
+        sourcePath: query.sourcePath ?? null,
       }),
     )
     .digest("hex");
@@ -352,9 +362,20 @@ async function loadTargetViews(
       continue;
     }
 
+    const displayName = payloadTargetDisplayName(row.payload);
+    const projectId = typeof row.payload.projectId === "string" ? row.payload.projectId : null;
+    const sourcePath = typeof row.payload.sourcePath === "string" ? row.payload.sourcePath : null;
+    const canLinkFile =
+      (row.targetKind === "file" || row.targetKind === "string_segment") &&
+      Boolean(projectId) &&
+      Boolean(sourcePath) &&
+      !isContentEditorAllFilesSourcePath(sourcePath);
+
     views.set(key, {
-      displayName: payloadTargetDisplayName(row.payload),
-      href: null,
+      displayName,
+      href: canLinkFile
+        ? `/org/${organizationSlug}/projects/${encodeURIComponent(projectId!)}/files/content-editor?sourcePath=${encodeURIComponent(sourcePath!)}`
+        : null,
       id: row.targetId,
       kind: row.targetKind,
     });
@@ -423,6 +444,16 @@ export async function listActivityLogEvents(input: {
         )!,
       );
     }
+  }
+  if (input.query.projectId) {
+    conditions.push(
+      sql`${schema.organizationActivityEvents.payload}->>'projectId' = ${input.query.projectId}`,
+    );
+  }
+  if (input.query.sourcePath && !isContentEditorAllFilesSourcePath(input.query.sourcePath)) {
+    conditions.push(
+      sql`${schema.organizationActivityEvents.payload}->>'sourcePath' = ${normalizeSourcePath(input.query.sourcePath)}`,
+    );
   }
   if (cursor) {
     conditions.push(

--- a/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { enqueueActivityLogEvent } from "./activity-log-writer";
+import {
+  enqueueFileTranslationsImportedActivity,
+  enqueueFileUploadedActivity,
+  enqueueStringSegmentApprovedActivity,
+  enqueueStringSegmentHiddenActivity,
+  fileActivityFileName,
+  fileActivityTargetId,
+  uploadActivityActor,
+} from "./file-segment-events";
+
+vi.mock("./activity-log-writer", () => ({
+  enqueueActivityLogEvent: vi.fn(),
+}));
+
+const enqueueMock = vi.mocked(enqueueActivityLogEvent);
+
+const actor = {
+  actorCredentialId: null,
+  actorKind: "user" as const,
+  actorUserId: "user-1",
+};
+
+describe("file and segment activity helpers", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("derives a stable file target from project and path", () => {
+    expect(fileActivityFileName("./locales/en.json")).toBe("en.json");
+    expect(fileActivityTargetId("project-1", "./locales/en.json")).toBe("project-1:locales/en.json");
+  });
+
+  it("records a file upload without linguistic content", async () => {
+    enqueueMock.mockResolvedValue({ ok: true, value: { createdAt: new Date(), id: "event-1" } });
+
+    await enqueueFileUploadedActivity({
+      ...actor,
+      organizationId: "org-1",
+      projectId: "project-1",
+      sourcePath: "locales/en.json",
+      storedFileId: "file-1",
+      versionId: "version-1",
+    });
+
+    expect(enqueueMock).toHaveBeenCalledWith({
+      ...actor,
+      eventType: "file_uploaded",
+      organizationId: "org-1",
+      payload: {
+        fileName: "en.json",
+        name: "en.json",
+        projectId: "project-1",
+        sourcePath: "locales/en.json",
+        storedFileId: "file-1",
+        versionId: "version-1",
+      },
+      targetId: "project-1:locales/en.json",
+      targetKind: "file",
+    });
+    expect(JSON.stringify(enqueueMock.mock.calls)).not.toContain("sourceText");
+    expect(JSON.stringify(enqueueMock.mock.calls)).not.toContain("targetText");
+  });
+
+  it("records a translation import against the file", async () => {
+    enqueueMock.mockResolvedValue({ ok: true, value: { createdAt: new Date(), id: "event-1" } });
+
+    await enqueueFileTranslationsImportedActivity({
+      ...actor,
+      organizationId: "org-1",
+      projectId: "project-1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr-FR",
+    });
+
+    expect(enqueueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "file_translations_imported",
+        payload: expect.objectContaining({
+          fileName: "en.json",
+          targetLocale: "fr-FR",
+        }),
+        targetKind: "file",
+      }),
+    );
+  });
+
+  it("records segment approval and hide batches with opaque identifiers", async () => {
+    enqueueMock.mockResolvedValue({ ok: true, value: { createdAt: new Date(), id: "event-1" } });
+
+    await enqueueStringSegmentApprovedActivity({
+      ...actor,
+      organizationId: "org-1",
+      projectId: "project-1",
+      segmentId: "segment-1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr-FR",
+    });
+    await enqueueStringSegmentHiddenActivity({
+      ...actor,
+      isHidden: true,
+      itemCount: 4,
+      organizationId: "org-1",
+      projectId: "project-1",
+      segmentId: "segment-1",
+      sourcePath: "locales/en.json",
+    });
+
+    expect(enqueueMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        eventType: "string_segment_approved",
+        payload: expect.objectContaining({
+          segmentId: "segment-1",
+          targetLocale: "fr-FR",
+        }),
+        targetId: "segment-1",
+        targetKind: "string_segment",
+      }),
+    );
+    expect(enqueueMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        eventType: "string_segment_hidden",
+        payload: expect.objectContaining({ itemCount: 4 }),
+      }),
+    );
+  });
+
+  it("maps API uploads to api_key actors", () => {
+    expect(
+      uploadActivityActor({
+        actorUserId: "user-1",
+        uploadedByApiKeyId: "key-1",
+      }),
+    ).toEqual({
+      actorCredentialId: "key-1",
+      actorKind: "api_key",
+      actorUserId: "user-1",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.test.ts
@@ -42,12 +42,12 @@ describe("file and segment activity helpers", () => {
 
   it("derives a stable file target from project and path", () => {
     expect(fileActivityFileName("./locales/en.json")).toBe("en.json");
-    expect(fileActivityTargetId("project-1", "./locales/en.json")).toBe("project-1:locales/en.json");
+    expect(fileActivityTargetId("project-1", "./locales/en.json")).toBe(
+      "project-1:locales/en.json",
+    );
   });
 
   it("records a file upload without linguistic content", async () => {
-    enqueueMock.mockResolvedValue({ ok: true, value: { createdAt: new Date(), id: "event-1" } });
-
     await enqueueFileUploadedActivity({
       ...actor,
       organizationId: "org-1",
@@ -77,8 +77,6 @@ describe("file and segment activity helpers", () => {
   });
 
   it("records a translation import against the file", async () => {
-    enqueueMock.mockResolvedValue({ ok: true, value: { createdAt: new Date(), id: "event-1" } });
-
     await enqueueFileTranslationsImportedActivity({
       ...actor,
       organizationId: "org-1",
@@ -100,8 +98,6 @@ describe("file and segment activity helpers", () => {
   });
 
   it("records segment approval and hide batches with opaque identifiers", async () => {
-    enqueueMock.mockResolvedValue({ ok: true, value: { createdAt: new Date(), id: "event-1" } });
-
     await enqueueStringSegmentApprovedActivity({
       ...actor,
       organizationId: "org-1",

--- a/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "server-only";
+
+import { normalizeSourcePath } from "@/lib/file-storage/records";
+
+import type { ActivityActorKind } from "./activity-log-contract";
+import { enqueueActivityLogEvent } from "./activity-log-writer";
+
+export type ActivityActor = {
+  actorCredentialId: string | null;
+  actorKind: ActivityActorKind;
+  actorUserId: string | null;
+};
+
+function activityActor(input: ActivityActor) {
+  return {
+    actorCredentialId: input.actorCredentialId,
+    actorKind: input.actorKind,
+    actorUserId: input.actorUserId,
+  };
+}
+
+export function fileActivityFileName(sourcePath: string): string {
+  const normalized = normalizeSourcePath(sourcePath);
+  return normalized.split("/").filter(Boolean).at(-1) || normalized;
+}
+
+export function fileActivityTargetId(projectId: string, sourcePath: string): string {
+  return `${projectId}:${normalizeSourcePath(sourcePath)}`;
+}
+
+function filePayload(input: {
+  projectId: string;
+  sourcePath: string;
+  storedFileId?: string | null;
+  versionId?: string | null;
+}) {
+  const sourcePath = normalizeSourcePath(input.sourcePath);
+  const fileName = fileActivityFileName(sourcePath);
+  return {
+    fileName,
+    name: fileName,
+    projectId: input.projectId,
+    sourcePath,
+    ...(input.storedFileId ? { storedFileId: input.storedFileId } : {}),
+    ...(input.versionId ? { versionId: input.versionId } : {}),
+  };
+}
+
+function segmentPayload(input: {
+  itemCount?: number;
+  projectId: string;
+  segmentId: string;
+  sourcePath: string;
+  targetLocale?: string | null;
+}) {
+  const sourcePath = normalizeSourcePath(input.sourcePath);
+  const fileName = fileActivityFileName(sourcePath);
+  return {
+    fileName,
+    name: fileName,
+    projectId: input.projectId,
+    segmentId: input.segmentId,
+    sourcePath,
+    ...(input.targetLocale ? { targetLocale: input.targetLocale } : {}),
+    ...(input.itemCount && input.itemCount > 1 ? { itemCount: input.itemCount } : {}),
+  };
+}
+
+type FileActivityInput = ActivityActor & {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  storedFileId?: string | null;
+  versionId?: string | null;
+};
+
+export async function enqueueFileUploadedActivity(input: FileActivityInput) {
+  const payload = filePayload(input);
+  return enqueueActivityLogEvent({
+    ...activityActor(input),
+    eventType: "file_uploaded",
+    organizationId: input.organizationId,
+    payload,
+    targetId: fileActivityTargetId(input.projectId, payload.sourcePath),
+    targetKind: "file",
+  });
+}
+
+export async function enqueueFileTranslationsImportedActivity(
+  input: FileActivityInput & { targetLocale: string },
+) {
+  const payload = filePayload(input);
+  return enqueueActivityLogEvent({
+    ...activityActor(input),
+    eventType: "file_translations_imported",
+    organizationId: input.organizationId,
+    payload: {
+      ...payload,
+      targetLocale: input.targetLocale,
+    },
+    targetId: fileActivityTargetId(input.projectId, payload.sourcePath),
+    targetKind: "file",
+  });
+}
+
+type SegmentActivityInput = ActivityActor & {
+  itemCount?: number;
+  organizationId: string;
+  projectId: string;
+  segmentId: string;
+  sourcePath: string;
+  targetLocale?: string | null;
+};
+
+export async function enqueueStringSegmentApprovedActivity(input: SegmentActivityInput) {
+  return enqueueActivityLogEvent({
+    ...activityActor(input),
+    eventType: "string_segment_approved",
+    organizationId: input.organizationId,
+    payload: segmentPayload(input),
+    targetId: input.segmentId,
+    targetKind: "string_segment",
+  });
+}
+
+export async function enqueueStringSegmentStatusChangedActivity(
+  input: SegmentActivityInput & { nextStatus: string; previousStatus?: string },
+) {
+  return enqueueActivityLogEvent({
+    ...activityActor(input),
+    eventType: "string_segment_status_changed",
+    organizationId: input.organizationId,
+    payload: {
+      ...segmentPayload(input),
+      nextStatus: input.nextStatus,
+      ...(input.previousStatus ? { previousStatus: input.previousStatus } : {}),
+    },
+    targetId: input.segmentId,
+    targetKind: "string_segment",
+  });
+}
+
+export async function enqueueStringSegmentHiddenActivity(
+  input: SegmentActivityInput & { isHidden: boolean },
+) {
+  return enqueueActivityLogEvent({
+    ...activityActor(input),
+    eventType: input.isHidden ? "string_segment_hidden" : "string_segment_unhidden",
+    organizationId: input.organizationId,
+    payload: segmentPayload(input),
+    targetId: input.segmentId,
+    targetKind: "string_segment",
+  });
+}
+
+export async function enqueueStringSegmentLockedActivity(
+  input: SegmentActivityInput & { isLocked: boolean },
+) {
+  return enqueueActivityLogEvent({
+    ...activityActor(input),
+    eventType: input.isLocked ? "string_segment_locked" : "string_segment_unlocked",
+    organizationId: input.organizationId,
+    payload: segmentPayload(input),
+    targetId: input.segmentId,
+    targetKind: "string_segment",
+  });
+}
+
+export async function enqueueStringSegmentCommentedActivity(input: SegmentActivityInput) {
+  return enqueueActivityLogEvent({
+    ...activityActor(input),
+    eventType: "string_segment_commented",
+    organizationId: input.organizationId,
+    payload: segmentPayload(input),
+    targetId: input.segmentId,
+    targetKind: "string_segment",
+  });
+}
+
+export function sessionActivityActor(userId: string | null | undefined): ActivityActor {
+  return {
+    actorCredentialId: null,
+    actorKind: userId ? "user" : "system",
+    actorUserId: userId ?? null,
+  };
+}
+
+export function uploadActivityActor(input: {
+  actorUserId?: string | null;
+  uploadedByApiKeyId?: string | null;
+  uploadedByUserId?: string | null;
+}): ActivityActor {
+  if (input.uploadedByApiKeyId) {
+    return {
+      actorCredentialId: input.uploadedByApiKeyId,
+      actorKind: "api_key",
+      actorUserId: input.actorUserId ?? input.uploadedByUserId ?? null,
+    };
+  }
+
+  const userId = input.uploadedByUserId ?? input.actorUserId ?? null;
+  return {
+    actorCredentialId: null,
+    actorKind: userId ? "user" : "system",
+    actorUserId: userId,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.test.ts
@@ -35,12 +35,26 @@ vi.mock("@/lib/agents/repository-write-gate", () => ({
   canPushToGitHubBranch: canPushToGitHubBranchMock,
 }));
 
-const { createStoredFileMock, createRepositorySourceFileVersionMock, deleteStoredObjectMock } =
-  vi.hoisted(() => ({
-    createStoredFileMock: vi.fn(),
-    createRepositorySourceFileVersionMock: vi.fn(),
-    deleteStoredObjectMock: vi.fn(),
-  }));
+const {
+  createStoredFileMock,
+  createRepositorySourceFileVersionMock,
+  deleteStoredObjectMock,
+  enqueueFileUploadedActivityMock,
+} = vi.hoisted(() => ({
+  createStoredFileMock: vi.fn(),
+  createRepositorySourceFileVersionMock: vi.fn(),
+  deleteStoredObjectMock: vi.fn(),
+  enqueueFileUploadedActivityMock: vi.fn(),
+}));
+
+vi.mock("@/lib/activity-log/file-segment-events", () => ({
+  enqueueFileUploadedActivity: enqueueFileUploadedActivityMock,
+  sessionActivityActor: (userId: string | null | undefined) => ({
+    actorCredentialId: null,
+    actorKind: userId ? "user" : "system",
+    actorUserId: userId ?? null,
+  }),
+}));
 
 vi.mock("@/lib/file-storage/get-file-storage-adapter", () => ({
   getFileStorageAdapter: vi.fn(() => ({
@@ -412,6 +426,7 @@ describe("createUploadSourcesTool", () => {
       storedFileId: input.storedFile.id,
       sourcePath: input.sourcePath,
     }));
+    enqueueFileUploadedActivityMock.mockResolvedValue(undefined);
   });
 
   it("denies upload when the write gate rejects it", async () => {
@@ -493,6 +508,18 @@ describe("createUploadSourcesTool", () => {
         sourcePath: "src/i18n/en.json",
         workflowRunId: "run_1",
         uploadSurface: "repository_agent",
+      }),
+    );
+    expect(enqueueFileUploadedActivityMock).toHaveBeenCalledTimes(2);
+    expect(enqueueFileUploadedActivityMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorKind: "user",
+        actorUserId: "user_1",
+        organizationId: "org_1",
+        projectId: "proj_1",
+        sourcePath: "src/i18n/en.json",
+        storedFileId: "file_en.json",
+        versionId: "version_file_en.json",
       }),
     );
   });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.ts
@@ -13,6 +13,10 @@
 import { tool } from "ai";
 import { z } from "zod";
 
+import {
+  enqueueFileUploadedActivity,
+  sessionActivityActor,
+} from "@/lib/activity-log/file-segment-events";
 import { getVercelSandboxWorkspace } from "@/lib/agent-runtime/workspaces/vercel-sandbox-runtime";
 import { auditRepositoryMutation } from "@/lib/agent-runtime/tools/audit";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
@@ -385,7 +389,8 @@ export function createUploadSourcesTool(ctx: ToolContext) {
         return { success: false, error: gate.reason };
       }
 
-      if (!ctx.projectId) {
+      const projectId = ctx.projectId;
+      if (!projectId) {
         return {
           success: false,
           error: "No project is attached to this workflow. Upload requires a project.",
@@ -430,7 +435,7 @@ export function createUploadSourcesTool(ctx: ToolContext) {
             .transaction(async (tx) => {
               uploadedFile = await createStoredFile({
                 organizationId: ctx.organizationId,
-                projectId: ctx.projectId,
+                projectId,
                 createdByUserId: ctx.actor?.userId ?? null,
                 role: "source",
                 sourceKind: "repository_file",
@@ -471,6 +476,15 @@ export function createUploadSourcesTool(ctx: ToolContext) {
             fileId: storedFile.id,
             sourceFileVersionId: version.id,
           });
+
+          await enqueueFileUploadedActivity({
+            ...sessionActivityActor(ctx.localUserId),
+            organizationId: ctx.organizationId,
+            projectId,
+            sourcePath: normalizedPath,
+            storedFileId: storedFile.id,
+            versionId: version.id,
+          });
         }
 
         await logMutation(ctx, {
@@ -482,7 +496,7 @@ export function createUploadSourcesTool(ctx: ToolContext) {
         return {
           success: true,
           uploaded,
-          message: `Uploaded ${uploaded.length} source file(s) to project ${ctx.projectId}.`,
+          message: `Uploaded ${uploaded.length} source file(s) to project ${projectId}.`,
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.test.ts
@@ -17,6 +17,7 @@ const {
   createStoredFileMock,
   dbTransactionMock,
   deleteStoredObjectMock,
+  enqueueFileUploadedActivityMock,
   enqueueSourceFileIngestAfterUploadMock,
   getLatestRepositorySourceFileVersionMock,
   readTranslatedFileMock,
@@ -25,6 +26,7 @@ const {
   createStoredFileMock: vi.fn(),
   dbTransactionMock: vi.fn(),
   deleteStoredObjectMock: vi.fn(),
+  enqueueFileUploadedActivityMock: vi.fn(),
   enqueueSourceFileIngestAfterUploadMock: vi.fn(),
   getLatestRepositorySourceFileVersionMock: vi.fn(),
   readTranslatedFileMock: vi.fn(),
@@ -54,6 +56,10 @@ vi.mock("@/lib/file-storage/records", async (importOriginal) => {
   };
 });
 
+vi.mock("@/lib/activity-log/file-segment-events", () => ({
+  enqueueFileUploadedActivity: enqueueFileUploadedActivityMock,
+}));
+
 vi.mock("@/lib/projects/files/source-file-ingest", () => ({
   enqueueSourceFileIngestAfterUpload: enqueueSourceFileIngestAfterUploadMock,
 }));
@@ -78,6 +84,7 @@ describe("uploadRepositorySourceFilesFromSandbox", () => {
     dbTransactionMock.mockImplementation(async (callback) => callback("tx"));
     getLatestRepositorySourceFileVersionMock.mockResolvedValue(null);
     enqueueSourceFileIngestAfterUploadMock.mockResolvedValue(undefined);
+    enqueueFileUploadedActivityMock.mockResolvedValue(undefined);
     createStoredFileMock.mockImplementation(async (input) => ({
       id: "file_utf8",
       organizationId: input.organizationId,
@@ -152,6 +159,16 @@ describe("uploadRepositorySourceFilesFromSandbox", () => {
       sourceFileVersionId: "source_file_version_utf8",
       sourcePath: "src/messages/en.json",
       sourceHash: expectedSourceHash,
+    });
+    expect(enqueueFileUploadedActivityMock).toHaveBeenCalledWith({
+      actorCredentialId: null,
+      actorKind: "agent",
+      actorUserId: null,
+      organizationId: "org_1",
+      projectId: "proj_1",
+      sourcePath: "src/messages/en.json",
+      storedFileId: "file_utf8",
+      versionId: "source_file_version_utf8",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.ts
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { enqueueFileUploadedActivity } from "@/lib/activity-log/file-segment-events";
 import { db } from "@/lib/database/client";
 import { getFileStorageAdapter } from "./get-file-storage-adapter";
 import { createLogger } from "@/lib/log";
@@ -148,6 +149,17 @@ export async function uploadRepositorySourceFilesFromSandbox(input: {
         outcome: "uploaded",
         fileId: storedFile.id,
         sourceFileVersionId: version.id,
+      });
+
+      await enqueueFileUploadedActivity({
+        actorCredentialId: null,
+        actorKind: "agent",
+        actorUserId: null,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourcePath: normalizedPath,
+        storedFileId: storedFile.id,
+        versionId: version.id,
       });
 
       void enqueueSourceFileIngestAfterUpload({

--- a/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
@@ -169,7 +169,7 @@ async function uploadNativeSourceFile(
     );
   });
 
-  void enqueueFileUploadedActivity({
+  await enqueueFileUploadedActivity({
     ...uploadActivityActor(input),
     organizationId: input.organizationId,
     projectId: input.project.id,
@@ -263,7 +263,7 @@ async function uploadExternalTmsSourceFile(
     return providerResult;
   }
 
-  void enqueueFileUploadedActivity({
+  await enqueueFileUploadedActivity({
     ...uploadActivityActor(input),
     organizationId: input.organizationId,
     projectId: input.project.id,

--- a/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
@@ -22,6 +22,10 @@ import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external
 import type { ExternalTmsSourceFileUploadError } from "@/lib/providers/jobs/tms-provider-types";
 import { resolveExternalTmsSecretMaterialForActor } from "@/lib/providers/shared/tms-provider-content";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import {
+  enqueueFileUploadedActivity,
+  uploadActivityActor,
+} from "@/lib/activity-log/file-segment-events";
 import { enqueueSourceFileIngestAfterUpload } from "./source-file-ingest";
 
 type ProjectRecord = typeof schema.projects.$inferSelect;
@@ -165,6 +169,15 @@ async function uploadNativeSourceFile(
     );
   });
 
+  void enqueueFileUploadedActivity({
+    ...uploadActivityActor(input),
+    organizationId: input.organizationId,
+    projectId: input.project.id,
+    sourcePath: input.sourcePath,
+    storedFileId: storedFile.id,
+    versionId: version.id,
+  });
+
   return {
     destination: "native",
     file: {
@@ -249,6 +262,14 @@ async function uploadExternalTmsSourceFile(
   if (isErr(providerResult)) {
     return providerResult;
   }
+
+  void enqueueFileUploadedActivity({
+    ...uploadActivityActor(input),
+    organizationId: input.organizationId,
+    projectId: input.project.id,
+    sourcePath: providerResult.value.sourcePath || input.sourcePath,
+    storedFileId: providerResult.value.externalResourceId,
+  });
 
   return ok({
     destination: "external_tms",

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-file-import.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-file-import.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { enqueueFileTranslationsImportedActivityMock } = vi.hoisted(() => ({
+  enqueueFileTranslationsImportedActivityMock: vi.fn(),
+}));
+
+vi.mock("@/lib/activity-log/file-segment-events", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/activity-log/file-segment-events")>();
+  return {
+    ...actual,
+    enqueueFileTranslationsImportedActivity: enqueueFileTranslationsImportedActivityMock,
+  };
+});
+
+import { enqueueFileTranslationsImportedActivityStep } from "./translation-file-import";
+
+describe("enqueueFileTranslationsImportedActivityStep", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records a completed translation import for the original actor", async () => {
+    enqueueFileTranslationsImportedActivityMock.mockResolvedValue(undefined);
+
+    await enqueueFileTranslationsImportedActivityStep({
+      actorUserId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+      sourcePath: "locales/en.json",
+      storedFileId: "file-1",
+      targetLocale: "fr",
+    });
+
+    expect(enqueueFileTranslationsImportedActivityMock).toHaveBeenCalledWith({
+      actorCredentialId: null,
+      actorKind: "user",
+      actorUserId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+      sourcePath: "locales/en.json",
+      storedFileId: "file-1",
+      targetLocale: "fr",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-file-import.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-file-import.ts
@@ -46,3 +46,24 @@ export async function importTranslationsFromEntriesStep(input: {
     actorUserId: input.actorUserId ?? null,
   });
 }
+
+export async function enqueueFileTranslationsImportedActivityStep(input: {
+  actorUserId?: string | null;
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  storedFileId?: string | null;
+  targetLocale: string;
+}) {
+  "use step";
+  const { enqueueFileTranslationsImportedActivity, sessionActivityActor } =
+    await import("@/lib/activity-log/file-segment-events");
+  await enqueueFileTranslationsImportedActivity({
+    ...sessionActivityActor(input.actorUserId),
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+    storedFileId: input.storedFileId,
+    targetLocale: input.targetLocale,
+  });
+}

--- a/apps/hyperlocalise-web/src/workflows/translation-file-import.ts
+++ b/apps/hyperlocalise-web/src/workflows/translation-file-import.ts
@@ -20,6 +20,7 @@ import {
 } from "./steps/source-file-ingest";
 import { getStoredFileContentStep } from "./steps/translation-job";
 import {
+  enqueueFileTranslationsImportedActivityStep,
   extractTranslationImportEntriesStep,
   importTranslationsFromEntriesStep,
 } from "./steps/translation-file-import";
@@ -67,6 +68,15 @@ export async function translationFileImportWorkflow(event: TranslationFileImport
       targetLocale: event.targetLocale,
       entries: hlEntriesPayloadToStringMap(extractedEntries),
       actorUserId: event.actorUserId ?? null,
+    });
+
+    await enqueueFileTranslationsImportedActivityStep({
+      actorUserId: event.actorUserId ?? null,
+      organizationId: event.organizationId,
+      projectId: event.projectId,
+      sourcePath: event.sourcePath,
+      storedFileId: event.storedFileId,
+      targetLocale: event.targetLocale,
     });
 
     return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Reuse the existing workspace activity log for high-signal file and string-segment events, and add a history icon in the file editor that opens a dialog of that activity.

New target kinds: `file` and `string_segment`.

Recorded events:

- `file_uploaded`
- `file_translations_imported`
- `string_segment_approved`
- `string_segment_status_changed`
- `string_segment_hidden` / `string_segment_unhidden`
- `string_segment_locked` / `string_segment_unlocked`
- `string_segment_commented`

Draft saves stay out of the log. Payloads stay privacy-safe (project id, source path, file name, optional ids, locale, item counts, statuses). Linguistic content is never stored.

Settings → Activity logs still requires `activity_logs:read`. The file editor dialog uses a project-scoped CAT GET that any project member can read, filtered to these event types and the current file.

## How to test

- `vp test` and `vp check --fix` in `apps/hyperlocalise-web` (903 files / 6573 tests passed)
- Open a project file in the content editor and click the history icon in the header
- Confirm the dialog lists file/string events for that source path
- Confirm Settings → Activity logs includes the new Files and Strings event types

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07fbc-398a-7eab-af2c-acb569bd98a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07fbc-398a-7eab-af2c-acb569bd98a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

