### PR TITLE
feat(i18n): add MT profiles and translation routing

### DIFF
--- a/apps/cli/internal/i18n/runsvc/image_task_test.go
+++ b/apps/cli/internal/i18n/runsvc/image_task_test.go
@@ -124,6 +124,66 @@ func TestRunImageRejectsNonOpenAIProvider(t *testing.T) {
 	}
 }
 
+func TestRunImageRejectsMTRoutedGroup(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.png"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := imageTestConfig(sourcePath, "/tmp/fr/image.png")
+		cfg.MT = &config.MTConfig{
+			Profiles: map[string]config.MTProfile{
+				"google": {Provider: "google", APIKeyEnv: "GOOGLE_TRANSLATE_API_KEY"},
+			},
+		}
+		cfg.Translation = &config.TranslationConfig{
+			Default: config.TranslationSelection{Type: config.TranslationTypeMT, Profile: "google"},
+		}
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte("source-image"), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	_, err := svc.Run(context.Background(), Input{DryRun: true})
+	if err == nil {
+		t.Fatal("expected mt-routed image error")
+	}
+	if got := err.Error(); !strings.Contains(got, "image localization is only supported with type \"llm\"") || !strings.Contains(got, sourcePath) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunImageStillRequiresOpenAIProviderWhenTranslationPresent(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.png"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := imageTestConfig(sourcePath, "/tmp/fr/image.png")
+		profile := cfg.LLM.Profiles["default"]
+		profile.Provider = "anthropic"
+		cfg.LLM.Profiles["default"] = profile
+		cfg.Translation = &config.TranslationConfig{
+			Default: config.TranslationSelection{Type: config.TranslationTypeLLM, Profile: "default"},
+		}
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte("source-image"), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	_, err := svc.Run(context.Background(), Input{DryRun: true})
+	if err == nil {
+		t.Fatal("expected non-OpenAI provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "image localization is only supported with provider \"openai\"") || !strings.Contains(got, sourcePath) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunImageEditWritesLocalizedImage(t *testing.T) {
 	svc := newTestService()
 	sourcePath := "/tmp/source.png"

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -171,19 +171,20 @@ type Event struct {
 }
 
 type Task struct {
-	Kind         string `json:"kind,omitempty"`
-	SourceLocale string `json:"sourceLocale"`
-	TargetLocale string `json:"targetLocale"`
-	SourcePath   string `json:"sourcePath"`
-	TargetPath   string `json:"targetPath"`
-	EntryKey     string `json:"entryKey"`
-	SourceText   string `json:"sourceText"`
-	ProfileName  string `json:"profileName"`
-	Provider     string `json:"provider"`
-	Model        string `json:"model"`
-	SystemPrompt string `json:"systemPrompt,omitempty"`
-	UserPrompt   string `json:"userPrompt,omitempty"`
-	LegacyPrompt bool   `json:"-"`
+	Kind            string `json:"kind,omitempty"`
+	SourceLocale    string `json:"sourceLocale"`
+	TargetLocale    string `json:"targetLocale"`
+	SourcePath      string `json:"sourcePath"`
+	TargetPath      string `json:"targetPath"`
+	EntryKey        string `json:"entryKey"`
+	SourceText      string `json:"sourceText"`
+	ProfileName     string `json:"profileName"`
+	Provider        string `json:"provider"`
+	Model           string `json:"model"`
+	TranslationType string `json:"translationType,omitempty"`
+	SystemPrompt    string `json:"systemPrompt,omitempty"`
+	UserPrompt      string `json:"userPrompt,omitempty"`
+	LegacyPrompt    bool   `json:"-"`
 	// Prompt*Template are profile templates; SystemPrompt/UserPrompt are rendered lazily for memory.
 	PromptLegacyTemplate string `json:"-"`
 	PromptSystemTemplate string `json:"-"`
@@ -413,12 +414,17 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 			continue
 		}
 		group := cfg.Groups[groupName]
-		profileName, profile, err := resolveProfile(cfg, groupName)
+		selection, err := resolveTranslation(cfg, groupName)
 		if err != nil {
 			return nil, nil, err
 		}
-		contextProvider, contextModel := resolveContextMemoryModel(profile, cfg.LLM.ContextMemory)
-		promptVersion := resolvePromptVersion(profile)
+		profileName := selection.ProfileName
+
+		var contextProvider, contextModel, promptVersion string
+		if selection.Type == config.TranslationTypeLLM {
+			contextProvider, contextModel = resolveContextMemoryModel(selection.LLMProfile, cfg.LLM.ContextMemory)
+			promptVersion = resolvePromptVersion(selection.LLMProfile)
+		}
 
 		targets := group.Targets
 		if len(targets) == 0 {
@@ -486,8 +492,8 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 							return nil, nil, fmt.Errorf("planning tasks: read source image %q: %w", sourcePath, err)
 						}
 						sourceFingerprint := imageLockSourceHash(sourceContent)
-						if strings.ToLower(strings.TrimSpace(profile.Provider)) != translator.ProviderOpenAI {
-							return nil, nil, fmt.Errorf("planning tasks: image source %q uses profile %q with provider %q; image localization is only supported with provider %q", sourcePath, profileName, profile.Provider, translator.ProviderOpenAI)
+						if strings.ToLower(strings.TrimSpace(selection.LLMProfile.Provider)) != translator.ProviderOpenAI {
+							return nil, nil, fmt.Errorf("planning tasks: image source %q uses profile %q with provider %q; image localization is only supported with provider %q", sourcePath, profileName, selection.LLMProfile.Provider, translator.ProviderOpenAI)
 						}
 						if !filterFixes && cap(tasks)-len(tasks) < len(targets) {
 							tasks = slices.Grow(tasks, len(targets))
@@ -516,6 +522,7 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 								ProfileName:       profileName,
 								Provider:          translator.ProviderOpenAI,
 								Model:             translator.OpenAIImageModel,
+								TranslationType:   config.TranslationTypeLLM,
 								ContextProvider:   contextProvider,
 								ContextModel:      contextModel,
 								GroupName:         groupName,
@@ -571,8 +578,6 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 						}
 						for _, key := range keys {
 							sourceText := sourceEntries[key]
-							legacyRendered := renderPrompt(profile.Prompt, cfg.Locales.Source, target, sourceText)
-							legacyPromptUsed := strings.TrimSpace(legacyRendered) != "" && strings.TrimSpace(profile.SystemPrompt) == "" && strings.TrimSpace(profile.UserPrompt) == ""
 							task := Task{
 								SourceLocale:             cfg.Locales.Source,
 								TargetLocale:             target,
@@ -581,12 +586,7 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 								EntryKey:                 key,
 								SourceText:               sourceText,
 								ProfileName:              profileName,
-								Provider:                 profile.Provider,
-								Model:                    profile.Model,
-								LegacyPrompt:             legacyPromptUsed,
-								PromptLegacyTemplate:     profile.Prompt,
-								PromptSystemTemplate:     profile.SystemPrompt,
-								PromptUserTemplate:       profile.UserPrompt,
+								TranslationType:          selection.Type,
 								SourceContext:            sourceContextByKey[key],
 								ContextProvider:          contextProvider,
 								ContextModel:             contextModel,
@@ -597,6 +597,21 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 								sourceTextHash:           snapshot.sourceTextHashes[key],
 								sourceContextFingerprint: snapshot.sourceContextFingerprints[key],
 							}
+
+							switch selection.Type {
+							case config.TranslationTypeLLM:
+								legacyRendered := renderPrompt(selection.LLMProfile.Prompt, cfg.Locales.Source, target, sourceText)
+								legacyPromptUsed := strings.TrimSpace(legacyRendered) != "" && strings.TrimSpace(selection.LLMProfile.SystemPrompt) == "" && strings.TrimSpace(selection.LLMProfile.UserPrompt) == ""
+								task.Provider = selection.LLMProfile.Provider
+								task.Model = selection.LLMProfile.Model
+								task.LegacyPrompt = legacyPromptUsed
+								task.PromptLegacyTemplate = selection.LLMProfile.Prompt
+								task.PromptSystemTemplate = selection.LLMProfile.SystemPrompt
+								task.PromptUserTemplate = selection.LLMProfile.UserPrompt
+							case config.TranslationTypeMT:
+								task.Provider = selection.MTProfile.Provider
+							}
+
 							precomputeStableTaskCacheFields(&task)
 							if filterFixes {
 								mk := fixTargetMatchKey(task.SourcePath, task.TargetPath, task.TargetLocale, task.EntryKey)
@@ -895,6 +910,67 @@ func resolveProfile(cfg *config.I18NConfig, groupName string) (string, config.LL
 	}
 
 	return bestProfile, profile, nil
+}
+
+type translationSelection struct {
+	Type        string
+	ProfileName string
+	LLMProfile  config.LLMProfile
+	MTProfile   config.MTProfile
+}
+
+func resolveTranslation(cfg *config.I18NConfig, groupName string) (translationSelection, error) {
+	if cfg.Translation == nil {
+		profileName, profile, err := resolveProfile(cfg, groupName)
+		if err != nil {
+			return translationSelection{}, err
+		}
+		return translationSelection{
+			Type:        config.TranslationTypeLLM,
+			ProfileName: profileName,
+			LLMProfile:  profile,
+		}, nil
+	}
+
+	bestPriority := -1
+	bestType := ""
+	bestProfile := ""
+
+	for _, rule := range cfg.Translation.Rules {
+		if rule.Group != groupName {
+			continue
+		}
+		if rule.Priority > bestPriority {
+			bestPriority = rule.Priority
+			bestType = rule.Type
+			bestProfile = rule.Profile
+		}
+	}
+
+	if strings.TrimSpace(bestProfile) == "" {
+		bestType = cfg.Translation.Default.Type
+		bestProfile = cfg.Translation.Default.Profile
+	}
+
+	switch strings.ToLower(strings.TrimSpace(bestType)) {
+	case config.TranslationTypeLLM:
+		profile, ok := cfg.LLM.Profiles[bestProfile]
+		if !ok {
+			return translationSelection{}, fmt.Errorf("planning tasks: unresolvable llm profile %q for group %q", bestProfile, groupName)
+		}
+		return translationSelection{Type: config.TranslationTypeLLM, ProfileName: bestProfile, LLMProfile: profile}, nil
+	case config.TranslationTypeMT:
+		if cfg.MT == nil {
+			return translationSelection{}, fmt.Errorf("planning tasks: unresolvable mt profile %q for group %q", bestProfile, groupName)
+		}
+		profile, ok := cfg.MT.Profiles[bestProfile]
+		if !ok {
+			return translationSelection{}, fmt.Errorf("planning tasks: unresolvable mt profile %q for group %q", bestProfile, groupName)
+		}
+		return translationSelection{Type: config.TranslationTypeMT, ProfileName: bestProfile, MTProfile: profile}, nil
+	default:
+		return translationSelection{}, fmt.Errorf("planning tasks: unresolvable translation type %q for group %q", bestType, groupName)
+	}
 }
 
 func resolveContextMemoryModel(profile config.LLMProfile, contextProfile *config.LLMContextMemoryProfile) (provider, model string) {

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -492,6 +492,9 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 							return nil, nil, fmt.Errorf("planning tasks: read source image %q: %w", sourcePath, err)
 						}
 						sourceFingerprint := imageLockSourceHash(sourceContent)
+						if selection.Type != config.TranslationTypeLLM {
+							return nil, nil, fmt.Errorf("planning tasks: image source %q in group %q is routed to translation type %q; image localization is only supported with type %q", sourcePath, groupName, selection.Type, config.TranslationTypeLLM)
+						}
 						if strings.ToLower(strings.TrimSpace(selection.LLMProfile.Provider)) != translator.ProviderOpenAI {
 							return nil, nil, fmt.Errorf("planning tasks: image source %q uses profile %q with provider %q; image localization is only supported with provider %q", sourcePath, profileName, selection.LLMProfile.Provider, translator.ProviderOpenAI)
 						}

--- a/apps/cli/internal/i18n/runsvc/translation_routing_test.go
+++ b/apps/cli/internal/i18n/runsvc/translation_routing_test.go
@@ -1,6 +1,8 @@
 package runsvc
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
@@ -141,6 +143,112 @@ func TestPlanTasksMTGroupLeavesLLMFieldsZeroValued(t *testing.T) {
 	}
 	if task.PromptVersion != "" {
 		t.Fatalf("prompt version=%q, want empty", task.PromptVersion)
+	}
+}
+
+func TestPlanTasksMixedLLMAndMTGroupsResolveDeterministically(t *testing.T) {
+	dir := t.TempDir()
+	sourceUI := filepath.Join(dir, "ui", "en.json")
+	sourceDocs := filepath.Join(dir, "docs", "en.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourceUI), 0o755); err != nil {
+		t.Fatalf("mkdir ui source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sourceDocs), 0o755); err != nil {
+		t.Fatalf("mkdir docs source dir: %v", err)
+	}
+	if err := os.WriteFile(sourceUI, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write ui source: %v", err)
+	}
+	if err := os.WriteFile(sourceDocs, []byte(`{"doc":"Hello docs"}`), 0o644); err != nil {
+		t.Fatalf("write docs source: %v", err)
+	}
+
+	configPath := filepath.Join(dir, "i18n.yml")
+	configContent := `
+locales:
+  source: en
+  targets:
+    - fr
+groups:
+  bulk-ui:
+    targets:
+      - fr
+    buckets:
+      - ui
+  docs-team:
+    targets:
+      - fr
+    buckets:
+      - docs
+buckets:
+  ui:
+    files:
+      - from: ` + sourceUI + `
+        to: ` + filepath.Join(dir, "out", "ui", "{{target}}.json") + `
+  docs:
+    files:
+      - from: ` + sourceDocs + `
+        to: ` + filepath.Join(dir, "out", "docs", "{{target}}.json") + `
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: gpt-4.1-mini
+mt:
+  profiles:
+    google:
+      provider: google
+      api_key_env: GOOGLE_TRANSLATE_API_KEY
+translation:
+  default:
+    type: llm
+    profile: default
+  rules:
+    - priority: 100
+      group: bulk-ui
+      type: mt
+      profile: google
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	svc := newTestService()
+	svc.readFile = os.ReadFile
+
+	tasks, _, err := svc.planTasks(cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("task count=%d, want 2", len(tasks))
+	}
+
+	byGroup := make(map[string]Task, len(tasks))
+	for _, task := range tasks {
+		byGroup[task.GroupName] = task
+	}
+
+	uiTask, ok := byGroup["bulk-ui"]
+	if !ok {
+		t.Fatalf("missing task for group bulk-ui: %+v", tasks)
+	}
+	if uiTask.TranslationType != config.TranslationTypeMT || uiTask.Provider != "google" || uiTask.Model != "" {
+		t.Fatalf("unexpected bulk-ui task: %+v", uiTask)
+	}
+
+	docsTask, ok := byGroup["docs-team"]
+	if !ok {
+		t.Fatalf("missing task for group docs-team: %+v", tasks)
+	}
+	if docsTask.TranslationType != config.TranslationTypeLLM || docsTask.Provider != "openai" || docsTask.Model != "gpt-4.1-mini" {
+		t.Fatalf("unexpected docs-team task: %+v", docsTask)
 	}
 }
 

--- a/apps/cli/internal/i18n/runsvc/translation_routing_test.go
+++ b/apps/cli/internal/i18n/runsvc/translation_routing_test.go
@@ -1,0 +1,175 @@
+package runsvc
+
+import (
+	"testing"
+
+	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
+)
+
+func TestResolveTranslationFallsBackToLLMWhenTranslationNil(t *testing.T) {
+	cfg := testConfig("/tmp/source.json", "/tmp/out.json")
+
+	wantProfileName, wantProfile, err := resolveProfile(&cfg, "default")
+	if err != nil {
+		t.Fatalf("resolve profile: %v", err)
+	}
+
+	selection, err := resolveTranslation(&cfg, "default")
+	if err != nil {
+		t.Fatalf("resolve translation: %v", err)
+	}
+	if selection.Type != config.TranslationTypeLLM {
+		t.Fatalf("type=%q, want %q", selection.Type, config.TranslationTypeLLM)
+	}
+	if selection.ProfileName != wantProfileName {
+		t.Fatalf("profile name=%q, want %q", selection.ProfileName, wantProfileName)
+	}
+	if selection.LLMProfile != wantProfile {
+		t.Fatalf("llm profile=%+v, want %+v", selection.LLMProfile, wantProfile)
+	}
+}
+
+func TestResolveTranslationRulePriorityMixedLLMAndMT(t *testing.T) {
+	cfg := testConfig("/tmp/source.json", "/tmp/out.json")
+	cfg.MT = &config.MTConfig{
+		Profiles: map[string]config.MTProfile{
+			"google": {Provider: "google", APIKeyEnv: "GOOGLE_TRANSLATE_API_KEY"},
+		},
+	}
+	cfg.Translation = &config.TranslationConfig{
+		Default: config.TranslationSelection{Type: config.TranslationTypeLLM, Profile: "default"},
+		Rules: []config.TranslationRule{
+			{Priority: 1, Group: "default", Type: config.TranslationTypeLLM, Profile: "default"},
+			{Priority: 100, Group: "default", Type: config.TranslationTypeMT, Profile: "google"},
+		},
+	}
+
+	selection, err := resolveTranslation(&cfg, "default")
+	if err != nil {
+		t.Fatalf("resolve translation: %v", err)
+	}
+	if selection.Type != config.TranslationTypeMT {
+		t.Fatalf("type=%q, want %q", selection.Type, config.TranslationTypeMT)
+	}
+	if selection.ProfileName != "google" {
+		t.Fatalf("profile name=%q, want google", selection.ProfileName)
+	}
+	if selection.MTProfile.Provider != "google" {
+		t.Fatalf("mt profile provider=%q, want google", selection.MTProfile.Provider)
+	}
+
+	// No rule matches this group, so resolution falls back to translation.default.
+	fallback, err := resolveTranslation(&cfg, "unknown-group")
+	if err != nil {
+		t.Fatalf("resolve fallback translation: %v", err)
+	}
+	if fallback.Type != config.TranslationTypeLLM || fallback.ProfileName != "default" {
+		t.Fatalf("unexpected fallback selection: %+v", fallback)
+	}
+}
+
+func TestResolveTranslationSelectsMTProfileWithZeroValueLLMProfile(t *testing.T) {
+	cfg := testConfig("/tmp/source.json", "/tmp/out.json")
+	cfg.MT = &config.MTConfig{
+		Profiles: map[string]config.MTProfile{
+			"google": {Provider: "google", APIKeyEnv: "GOOGLE_TRANSLATE_API_KEY"},
+		},
+	}
+	cfg.Translation = &config.TranslationConfig{
+		Default: config.TranslationSelection{Type: config.TranslationTypeMT, Profile: "google"},
+	}
+
+	selection, err := resolveTranslation(&cfg, "default")
+	if err != nil {
+		t.Fatalf("resolve translation: %v", err)
+	}
+	if selection.Type != config.TranslationTypeMT {
+		t.Fatalf("type=%q, want %q", selection.Type, config.TranslationTypeMT)
+	}
+	if selection.MTProfile.Provider != "google" {
+		t.Fatalf("mt profile provider=%q, want google", selection.MTProfile.Provider)
+	}
+	if selection.LLMProfile != (config.LLMProfile{}) {
+		t.Fatalf("expected zero-value llm profile, got %+v", selection.LLMProfile)
+	}
+}
+
+func TestPlanTasksMTGroupLeavesLLMFieldsZeroValued(t *testing.T) {
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := testConfig(sourcePath, targetPath)
+	cfg.MT = &config.MTConfig{
+		Profiles: map[string]config.MTProfile{
+			"google": {Provider: "google", APIKeyEnv: "GOOGLE_TRANSLATE_API_KEY"},
+		},
+	}
+	cfg.Translation = &config.TranslationConfig{
+		Default: config.TranslationSelection{Type: config.TranslationTypeMT, Profile: "google"},
+	}
+
+	svc := newTestService()
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("task count=%d, want 1", len(tasks))
+	}
+
+	task := tasks[0]
+	if task.TranslationType != config.TranslationTypeMT {
+		t.Fatalf("translation type=%q, want %q", task.TranslationType, config.TranslationTypeMT)
+	}
+	if task.Provider != "google" {
+		t.Fatalf("provider=%q, want google", task.Provider)
+	}
+	if task.ProfileName != "google" {
+		t.Fatalf("profile name=%q, want google", task.ProfileName)
+	}
+	if task.Model != "" {
+		t.Fatalf("model=%q, want empty", task.Model)
+	}
+	if task.SystemPrompt != "" || task.UserPrompt != "" {
+		t.Fatalf("expected no prompts, got system=%q user=%q", task.SystemPrompt, task.UserPrompt)
+	}
+	if task.PromptLegacyTemplate != "" || task.PromptSystemTemplate != "" || task.PromptUserTemplate != "" {
+		t.Fatalf("expected no prompt templates, got legacy=%q system=%q user=%q", task.PromptLegacyTemplate, task.PromptSystemTemplate, task.PromptUserTemplate)
+	}
+	if task.LegacyPrompt {
+		t.Fatalf("expected LegacyPrompt=false for mt task")
+	}
+	if task.PromptVersion != "" {
+		t.Fatalf("prompt version=%q, want empty", task.PromptVersion)
+	}
+}
+
+func TestPlanTasksLLMGroupUnchangedWhenTranslationPresent(t *testing.T) {
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := testConfig(sourcePath, targetPath)
+	cfg.Translation = &config.TranslationConfig{
+		Default: config.TranslationSelection{Type: config.TranslationTypeLLM, Profile: "default"},
+	}
+
+	svc := newTestService()
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("task count=%d, want 1", len(tasks))
+	}
+
+	task := tasks[0]
+	if task.TranslationType != config.TranslationTypeLLM {
+		t.Fatalf("translation type=%q, want %q", task.TranslationType, config.TranslationTypeLLM)
+	}
+	if task.Provider != "openai" || task.Model != "gpt-4.1-mini" {
+		t.Fatalf("unexpected provider/model: provider=%q model=%q", task.Provider, task.Model)
+	}
+	if task.ProfileName != "default" {
+		t.Fatalf("profile name=%q, want default", task.ProfileName)
+	}
+}

--- a/pkg/i18nconfig/BUILD.bazel
+++ b/pkg/i18nconfig/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "i18n.go",
         "schema.go",
+        "translation.go",
         "version.go",
     ],
     importpath = "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig",

--- a/pkg/i18nconfig/i18n.go
+++ b/pkg/i18nconfig/i18n.go
@@ -45,6 +45,8 @@ type I18NConfig struct {
 	Buckets       map[string]BucketConfig `json:"buckets" jsonschema:"required"`
 	Groups        map[string]GroupConfig  `json:"groups,omitempty"`
 	LLM           LLMConfig               `json:"llm" jsonschema:"required"`
+	Translation   *TranslationConfig      `json:"translation,omitempty"`
+	MT            *MTConfig               `json:"mt,omitempty"`
 	Hyperlocalise *HyperlocaliseConfig    `json:"hyperlocalise,omitempty"`
 	Storage       *StorageConfig          `json:"storage,omitempty"`
 	Cache         CacheConfig             `json:"cache,omitempty"`
@@ -271,6 +273,13 @@ func (c I18NConfig) Validate() error {
 	}
 
 	if err := c.validateLLM(groupSet); err != nil {
+		return err
+	}
+
+	if err := c.validateMT(); err != nil {
+		return err
+	}
+	if err := c.validateTranslation(groupSet); err != nil {
 		return err
 	}
 

--- a/pkg/i18nconfig/translation.go
+++ b/pkg/i18nconfig/translation.go
@@ -1,0 +1,180 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	TranslationTypeLLM = "llm"
+	TranslationTypeMT = "mt"
+
+	mtProviderGoogle = "google"
+	mtProviderDeepL  = "deepl"
+)
+
+type TranslationConfig struct {
+	Default TranslationSelection `json:"default" jsonschema:"required"`
+	Rules   []TranslationRule    `json:"rules,omitempty"`
+}
+
+type TranslationSelection struct {
+	Type    string `json:"type" jsonschema:"required"`
+	Profile string `json:"profile" jsonschema:"required"`
+}
+
+type TranslationRule struct {
+	Priority int    `json:"priority" jsonschema:"required"`
+	Group    string `json:"group" jsonschema:"required"`
+	Type     string `json:"type" jsonschema:"required"`
+	Profile  string `json:"profile" jsonschema:"required"`
+}
+
+type MTConfig struct {
+	Profiles map[string]MTProfile `json:"profiles" jsonschema:"required"`
+}
+// MTProfile stores environment variable names.
+type MTProfile struct {
+	Provider           string `json:"provider" jsonschema:"required"`
+	APIKeyEnv          string `json:"api_key_env,omitempty"`
+	SubscriptionKeyEnv string `json:"subscription_key_env,omitempty"`
+	AccessKeyIDEnv     string `json:"access_key_id_env,omitempty"`
+	SecretAccessKeyEnv string `json:"secret_access_key_env,omitempty"`
+	SessionTokenEnv    string `json:"session_token_env,omitempty"`
+	Region             string `json:"region,omitempty"`
+	BaseURL            string `json:"base_url,omitempty"`
+	CustomModel        string `json:"custom_model,omitempty"`
+}
+
+func (c I18NConfig) validateMT() error {
+	if c.MT == nil {
+		return nil
+	}
+
+	if len(c.MT.Profiles) == 0 {
+		return fmt.Errorf("mt.profiles: must not be empty")
+	}
+
+	for profileName, profile := range c.MT.Profiles {
+		if strings.TrimSpace(profileName) == "" {
+			return fmt.Errorf("mt.profiles: profile name must not be empty")
+		}
+
+		if err := validateMTProfile("mt.profiles."+profileName, profile); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateMTProfile(fieldPrefix string, profile MTProfile) error {
+	provider := strings.ToLower(strings.TrimSpace(profile.Provider))
+	if provider == "" {
+		return fmt.Errorf("%s.provider: must not be empty", fieldPrefix)
+	}
+
+	switch provider {
+	case mtProviderGoogle:
+		if strings.TrimSpace(profile.APIKeyEnv) == "" {
+			return fmt.Errorf("%s.api_key_env: must not be empty", fieldPrefix)
+		}
+	case mtProviderDeepL:
+		if strings.TrimSpace(profile.APIKeyEnv) == "" {
+			return fmt.Errorf("%s.api_key_env: must not be empty", fieldPrefix)
+		}
+		if strings.TrimSpace(profile.BaseURL) == "" {
+			return fmt.Errorf("%s.base_url: must not be empty", fieldPrefix)
+		}
+	default:
+		return fmt.Errorf("%s.provider: unsupported provider %q", fieldPrefix, profile.Provider)
+	}
+
+	return nil
+}
+
+func (c I18NConfig) validateTranslation(groupSet map[string]struct{}) error {
+	if c.Translation == nil {
+		return nil
+	}
+
+	if len(c.Translation.Rules) > 0 && len(c.LLM.Rules) > 0 {
+		return fmt.Errorf("translation.rules: must not be combined with llm.rules; migrate llm.rules entries to translation.rules")
+	}
+
+	if err := validateTranslationSelection("translation.default", c.Translation.Default, c.LLM.Profiles, c.MT); err != nil {
+		return err
+	}
+
+	seenPriorityByGroup := make(map[string]map[int]struct{}, len(c.Translation.Rules))
+
+	for i, rule := range c.Translation.Rules {
+		if err := c.validateTranslationRule(i, rule, groupSet, seenPriorityByGroup); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateTranslationSelection(fieldPrefix string, selection TranslationSelection, llmProfiles map[string]LLMProfile, mtCfg *MTConfig) error {
+	selectionType := strings.ToLower(strings.TrimSpace(selection.Type))
+	if selectionType == "" {
+		return fmt.Errorf("%s.type: must not be empty", fieldPrefix)
+	}
+
+	if strings.TrimSpace(selection.Profile) == "" {
+		return fmt.Errorf("%s.profile: must not be empty", fieldPrefix)
+	}
+
+	switch selectionType {
+	case TranslationTypeLLM:
+		if _, exists := llmProfiles[selection.Profile]; !exists {
+			return fmt.Errorf("%s.profile: unknown llm profile %q", fieldPrefix, selection.Profile)
+		}
+	case TranslationTypeMT:
+		if mtCfg == nil {
+			return fmt.Errorf("%s.profile: unknown mt profile %q", fieldPrefix, selection.Profile)
+		}
+		if _, exists := mtCfg.Profiles[selection.Profile]; !exists {
+			return fmt.Errorf("%s.profile: unknown mt profile %q", fieldPrefix, selection.Profile)
+		}
+	default:
+		return fmt.Errorf("%s.type: unsupported type %q", fieldPrefix, selection.Type)
+	}
+
+	return nil
+}
+
+func (c I18NConfig) validateTranslationRule(index int, rule TranslationRule, groupSet map[string]struct{}, seenPriorityByGroup map[string]map[int]struct{}) error {
+	if rule.Priority < 0 {
+		return fmt.Errorf("translation.rules[%d].priority: must be >= 0", index)
+	}
+
+	if strings.TrimSpace(rule.Group) == "" {
+		return fmt.Errorf("translation.rules[%d].group: must not be empty", index)
+	}
+
+	if _, exists := groupSet[rule.Group]; !exists {
+		return fmt.Errorf("translation.rules[%d].group: unknown group %q", index, rule.Group)
+	}
+
+	selection := TranslationSelection{Type: rule.Type, Profile: rule.Profile}
+	if err := validateTranslationSelection(fmt.Sprintf("translation.rules[%d]", index), selection, c.LLM.Profiles, c.MT); err != nil {
+		return err
+	}
+
+	groupPriorities, ok := seenPriorityByGroup[rule.Group]
+	if !ok {
+		groupPriorities = make(map[int]struct{})
+		seenPriorityByGroup[rule.Group] = groupPriorities
+	}
+
+	if _, exists := groupPriorities[rule.Priority]; exists {
+		return fmt.Errorf("translation.rules[%d].priority: duplicate priority %d for group %q", index, rule.Priority, rule.Group)
+	}
+
+	groupPriorities[rule.Priority] = struct{}{}
+
+	return nil
+}

--- a/pkg/i18nconfig/translation.go
+++ b/pkg/i18nconfig/translation.go
@@ -99,7 +99,7 @@ func (c I18NConfig) validateTranslation(groupSet map[string]struct{}) error {
 		return nil
 	}
 
-	if len(c.Translation.Rules) > 0 && len(c.LLM.Rules) > 0 {
+	if len(c.LLM.Rules) > 0 {
 		return fmt.Errorf("translation.rules: must not be combined with llm.rules; migrate llm.rules entries to translation.rules")
 	}
 

--- a/pkg/i18nconfig/translation.go
+++ b/pkg/i18nconfig/translation.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	TranslationTypeLLM = "llm"
-	TranslationTypeMT = "mt"
+	TranslationTypeMT  = "mt"
 
 	mtProviderGoogle = "google"
 	mtProviderDeepL  = "deepl"
@@ -33,6 +33,7 @@ type TranslationRule struct {
 type MTConfig struct {
 	Profiles map[string]MTProfile `json:"profiles" jsonschema:"required"`
 }
+
 // MTProfile stores environment variable names.
 type MTProfile struct {
 	Provider           string `json:"provider" jsonschema:"required"`

--- a/pkg/i18nconfig/translation_test.go
+++ b/pkg/i18nconfig/translation_test.go
@@ -157,6 +157,20 @@ func TestLoadTranslationRouting(t *testing.T) {
 			errContains: "translation.rules: must not be combined with llm.rules",
 		},
 		{
+			name: "translation default with only legacy llm rules is rejected",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {
+			    "profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}},
+			    "rules": [{"priority": 100, "group": "g", "profile": "default"}]
+			  },
+			  "translation": {"default": {"type": "llm", "profile": "default"}}
+			}`,
+			errContains: "translation.rules: must not be combined with llm.rules",
+		},
+		{
 			name: "mt profile google missing api key env",
 			content: `{
 			  "locales": {"source": "en-US", "targets": ["es-ES"]},

--- a/pkg/i18nconfig/translation_test.go
+++ b/pkg/i18nconfig/translation_test.go
@@ -1,0 +1,316 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadTranslationRouting(t *testing.T) {
+	testCases := []struct {
+		name        string
+		content     string
+		errContains string
+	}{
+		{
+			name: "translation absent preserves legacy llm-only behavior",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {
+			    "profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}},
+			    "rules": [{"priority": 1, "group": "g", "profile": "default"}]
+			  }
+			}`,
+		},
+		{
+			name: "valid translation default llm and mt rule",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}, "bulk-ui": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {"google": {"provider": "google", "api_key_env": "GOOGLE_TRANSLATE_API_KEY"}}},
+			  "translation": {
+			    "default": {"type": "llm", "profile": "default"},
+			    "rules": [{"priority": 100, "group": "bulk-ui", "type": "mt", "profile": "google"}]
+			  }
+			}`,
+		},
+		{
+			name: "invalid translation default type",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "translation": {"default": {"type": "bogus", "profile": "default"}}
+			}`,
+			errContains: "translation.default.type: unsupported type",
+		},
+		{
+			name: "translation default references unknown llm profile",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "translation": {"default": {"type": "llm", "profile": "missing"}}
+			}`,
+			errContains: "translation.default.profile: unknown llm profile",
+		},
+		{
+			name: "translation rule references unknown mt profile",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {"google": {"provider": "google", "api_key_env": "K"}}},
+			  "translation": {
+			    "default": {"type": "llm", "profile": "default"},
+			    "rules": [{"priority": 1, "group": "g", "type": "mt", "profile": "missing"}]
+			  }
+			}`,
+			errContains: "translation.rules[0].profile: unknown mt profile",
+		},
+		{
+			name: "translation rule crosses namespace llm type referencing mt-only profile",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {"google": {"provider": "google", "api_key_env": "K"}}},
+			  "translation": {
+			    "default": {"type": "llm", "profile": "default"},
+			    "rules": [{"priority": 1, "group": "g", "type": "llm", "profile": "google"}]
+			  }
+			}`,
+			errContains: "translation.rules[0].profile: unknown llm profile",
+		},
+		{
+			name: "translation rule references unknown group",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "translation": {
+			    "default": {"type": "llm", "profile": "default"},
+			    "rules": [{"priority": 1, "group": "missing", "type": "llm", "profile": "default"}]
+			  }
+			}`,
+			errContains: "translation.rules[0].group: unknown group",
+		},
+		{
+			name: "translation rules reject duplicate priority within same group",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}, "other": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "translation": {
+			    "default": {"type": "llm", "profile": "default"},
+			    "rules": [
+			      {"priority": 100, "group": "g", "type": "llm", "profile": "default"},
+			      {"priority": 100, "group": "g", "type": "llm", "profile": "other"}
+			    ]
+			  }
+			}`,
+			errContains: "translation.rules[1].priority: duplicate priority",
+		},
+		{
+			name: "translation rules allow same priority across different groups",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {
+			    "g1": {"targets": ["es-ES"], "buckets": ["ui"]},
+			    "g2": {"targets": ["es-ES"], "buckets": ["ui"]}
+			  },
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "translation": {
+			    "default": {"type": "llm", "profile": "default"},
+			    "rules": [
+			      {"priority": 100, "group": "g1", "type": "llm", "profile": "default"},
+			      {"priority": 100, "group": "g2", "type": "llm", "profile": "default"}
+			    ]
+			  }
+			}`,
+		},
+		{
+			name: "translation rules combined with legacy llm rules is rejected",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {
+			    "profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}},
+			    "rules": [{"priority": 1, "group": "g", "profile": "default"}]
+			  },
+			  "translation": {
+			    "default": {"type": "llm", "profile": "default"},
+			    "rules": [{"priority": 1, "group": "g", "type": "llm", "profile": "default"}]
+			  }
+			}`,
+			errContains: "translation.rules: must not be combined with llm.rules",
+		},
+		{
+			name: "mt profile google missing api key env",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {"google": {"provider": "google"}}}
+			}`,
+			errContains: "mt.profiles.google.api_key_env: must not be empty",
+		},
+		{
+			name: "mt profile deepl missing api key env",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {"deepl": {"provider": "deepl", "base_url": "https://api-free.deepl.com"}}}
+			}`,
+			errContains: "mt.profiles.deepl.api_key_env: must not be empty",
+		},
+		{
+			name: "mt profile deepl missing base url",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {"deepl": {"provider": "deepl", "api_key_env": "DEEPL_API_KEY"}}}
+			}`,
+			errContains: "mt.profiles.deepl.base_url: must not be empty",
+		},
+		{
+			name: "mt profile amazon is not yet an accepted provider",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {"amazon": {"provider": "amazon", "access_key_id_env": "A", "secret_access_key_env": "S", "region": "us-east-1"}}}
+			}`,
+			errContains: "mt.profiles.amazon.provider: unsupported provider",
+		},
+		{
+			name: "mt profile microsoft is not yet an accepted provider",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {"microsoft": {"provider": "microsoft", "subscription_key_env": "K", "region": "westus"}}}
+			}`,
+			errContains: "mt.profiles.microsoft.provider: unsupported provider",
+		},
+		{
+			name: "mt profiles must not be empty when mt section present",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}},
+			  "mt": {"profiles": {}}
+			}`,
+			errContains: "mt.profiles: must not be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeConfigFile(t, tc.content)
+
+			_, err := Load(path)
+			if tc.errContains == "" {
+				if err != nil {
+					t.Fatalf("load config: %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.errContains)
+			}
+
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Fatalf("unexpected error: got %q want substring %q", err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
+func TestLoadTranslationRoutingYAML(t *testing.T) {
+	path := writeConfigFileNamed(t, "config.yml", `
+locales:
+  source: en-US
+  targets:
+    - es-ES
+buckets:
+  ui:
+    files:
+      - from: a
+        to: b
+groups:
+  bulk-ui:
+    targets:
+      - es-ES
+    buckets:
+      - ui
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: x
+      prompt: p
+translation:
+  default:
+    type: llm
+    profile: default
+  rules:
+    - priority: 100
+      group: bulk-ui
+      type: mt
+      profile: google
+mt:
+  profiles:
+    google:
+      provider: google
+      api_key_env: GOOGLE_TRANSLATE_API_KEY
+    deepl:
+      provider: deepl
+      api_key_env: DEEPL_API_KEY
+      base_url: https://api-free.deepl.com
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load yaml config: %v", err)
+	}
+
+	if cfg.Translation == nil {
+		t.Fatalf("expected translation config to be set")
+	}
+	if cfg.Translation.Default.Type != TranslationTypeLLM {
+		t.Fatalf("translation.default.type=%q, want %q", cfg.Translation.Default.Type, TranslationTypeLLM)
+	}
+	if len(cfg.Translation.Rules) != 1 || cfg.Translation.Rules[0].Type != TranslationTypeMT {
+		t.Fatalf("unexpected translation rules: %+v", cfg.Translation.Rules)
+	}
+	if cfg.MT == nil || len(cfg.MT.Profiles) != 2 {
+		t.Fatalf("expected 2 mt profiles, got %+v", cfg.MT)
+	}
+	if got := cfg.MT.Profiles["deepl"].BaseURL; got != "https://api-free.deepl.com" {
+		t.Fatalf("deepl base_url=%q", got)
+	}
+}


### PR DESCRIPTION
## What changed

- add typed MT profiles and `translation` routing for LLM/MT selection
- validate MT profiles, routing rules, profile/group references, and legacy rule conflicts
- resolve translation type/profile during task planning without fabricating LLM metadata for MT tasks
- reject MT-routed image tasks during planning
- preserve existing LLM-only config and planning behavior

## How to test

- `go test ./pkg/i18nconfig ./apps/cli/internal/i18n/runsvc`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
