### PR TITLE
feat(web): ship Multilingual Content Studio product page

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/page.tsx
@@ -11,13 +11,16 @@
  * Version 2.0 or later.
  */
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
+import { Suspense } from "react";
 
 import { ProductPage } from "@/components/marketing/product/product-page";
+import { MultilingualContentStudioPage } from "@/components/marketing/product/multilingual-content-studio-page";
 import {
   productPagesBySlug,
   productSlugs,
 } from "@/components/marketing/product/product-page-content";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 import {
   DEFAULT_APP_LOCALE,
@@ -43,6 +46,9 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: ProductRouteProps): Promise<Metadata> {
   const { lang, slug } = await params;
+  if (slug === "next-gen-cat-tool") {
+    return {};
+  }
   const content = productPagesBySlug[slug as keyof typeof productPagesBySlug];
 
   if (!content) {
@@ -72,8 +78,24 @@ export async function generateMetadata({ params }: ProductRouteProps): Promise<M
   };
 }
 
-export default async function ProductRoutePage({ params }: ProductRouteProps) {
-  const { slug } = await params;
+export default function ProductRoutePage({ params }: ProductRouteProps) {
+  return (
+    <Suspense fallback={<ProductRouteFallback />}>
+      <ProductRouteContent params={params} />
+    </Suspense>
+  );
+}
+
+async function ProductRouteContent({ params }: ProductRouteProps) {
+  const { lang, slug } = await params;
+
+  if (slug === "next-gen-cat-tool") {
+    permanentRedirect(`/${lang}/product/multilingual-content-studio`);
+  }
+
+  if (slug === "multilingual-content-studio") {
+    return <MultilingualContentStudioPage />;
+  }
   const content = productPagesBySlug[slug as keyof typeof productPagesBySlug];
 
   if (!content) {
@@ -81,4 +103,23 @@ export default async function ProductRoutePage({ params }: ProductRouteProps) {
   }
 
   return <ProductPage content={content} />;
+}
+
+function ProductRouteFallback() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-7xl">
+        <section className="px-5 py-20 sm:px-8 sm:py-24 lg:px-10 lg:py-20">
+          <div className="mx-auto flex w-full max-w-6xl flex-col items-center gap-8">
+            <Skeleton className="h-16 w-3/4 max-w-2xl" />
+            <Skeleton className="h-8 w-1/2 max-w-md" />
+            <Skeleton className="h-11 w-40" />
+          </div>
+        </section>
+        <section className="px-3 pb-20 sm:px-6 lg:px-8">
+          <Skeleton className="mx-auto h-[28rem] w-full max-w-6xl" />
+        </section>
+      </div>
+    </div>
+  );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
@@ -28,19 +28,18 @@ export function getProductRouteMetadata(slug: string, intl: IntlShape) {
           description: "Meta description for the agents automation product page",
         }),
       };
-    case "next-gen-cat-tool":
+    case "multilingual-content-studio":
       return {
         title: intl.formatMessage({
-          defaultMessage:
-            "Review Translations Without Guessing What the String Means | Hyperlocalise",
-          id: "jeP5GjQn+Q",
-          description: "Page title for the next-gen CAT tool product page",
+          defaultMessage: "Multilingual Content Studio | Hyperlocalise",
+          id: "8GHZDPEhIo",
+          description: "Page title for the multilingual Content Studio product page",
         }),
         description: intl.formatMessage({
           defaultMessage:
-            "Give reviewers the source, target, product context, glossary guidance, AI notes, comments, and quality checks in one translation workspace.",
-          id: "fdVXMcsjuq",
-          description: "Meta description for the next-gen CAT tool product page",
+            "Create and adapt text, documents, slides, images, and video in one multilingual workspace with shared context and human review.",
+          id: "yfyxggCpJF",
+          description: "Meta description for the multilingual Content Studio product page",
         }),
       };
     case "self-evolving-knowledge":

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
@@ -32,7 +32,7 @@ describe("llms.txt route", () => {
       "[Agent Automation](https://www.hyperlocalise.com/en/product/agents-automation): Stop chasing localisation work across tools.",
     );
     expect(body).toContain(
-      "[Next-gen CAT Tool](https://www.hyperlocalise.com/en/product/next-gen-cat-tool): Review translations without guessing what the string means.",
+      "[Multilingual Content Studio](https://www.hyperlocalise.com/en/product/multilingual-content-studio): Create and adapt every content format in one multilingual workspace.",
     );
     expect(body).toContain(
       "[Self-evolving Knowledge](https://www.hyperlocalise.com/en/product/self-evolving-knowledge): Stop repeating the same localisation feedback.",

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.ts
@@ -25,9 +25,9 @@ const productLinks: LlmsLink[] = [
     description: "Stop chasing localisation work across tools",
   },
   {
-    title: "Next-gen CAT Tool",
-    href: `${SITE_URL}/en/product/next-gen-cat-tool`,
-    description: "Review translations without guessing what the string means",
+    title: "Multilingual Content Studio",
+    href: `${SITE_URL}/en/product/multilingual-content-studio`,
+    description: "Create and adapt every content format in one multilingual workspace",
   },
   {
     title: "Self-evolving Knowledge",

--- a/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-ai-recommendation.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/editor/content-editor-editor-ai-recommendation.tsx
@@ -42,32 +42,59 @@ export function ContentEditorEditorAiRecommendation({
 }) {
   const upgradeHref = useAiFeaturesUpgradeHref();
   const hasSuggestion = Boolean(intelligence.aiSuggestion);
+  const showActions = hasSuggestion || Boolean(onGenerateAiRecommendation) || Boolean(upgradeHref);
 
   return (
     <aside
       className={cn(
-        "rounded-xl border px-3.5 py-3 transition-opacity",
-        hasSuggestion ? "border-grove-300/35 bg-grove-500/[0.07]" : "border-border/80 bg-muted/50",
+        "overflow-hidden rounded-2xl bg-muted/50 px-3.5 py-3 ring-1 ring-inset ring-border/50",
         isLoading && "opacity-80",
         className,
       )}
       aria-busy={isLoading}
     >
-      <div className="mb-2.5 flex items-center justify-between gap-3">
-        <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-          <HugeiconsIcon
-            icon={SparklesIcon}
-            className={cn(
-              "size-3.5 shrink-0",
-              hasSuggestion ? "text-grove-300" : "text-grove-300/70",
-            )}
-            aria-hidden
-          />
+      <div className="flex items-center gap-1.5">
+        <HugeiconsIcon
+          icon={SparklesIcon}
+          className="size-3.5 shrink-0 text-grove-400"
+          aria-hidden
+        />
+        <p className="text-xs font-medium text-muted-foreground">
           <FormattedMessage {...contentEditorEditorPanelMessages.aiRecommendation} />
         </p>
-        <div className="flex items-center gap-1.5">
+      </div>
+
+      <div className="mt-2.5">
+        {error ? (
+          <p className="text-sm leading-relaxed text-flame-100">{error}</p>
+        ) : hasSuggestion ? (
+          <div className="space-y-2">
+            <p className="text-sm leading-relaxed text-foreground">{intelligence.aiSuggestion}</p>
+            {intelligence.aiReasoning ? (
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                <FormattedMessage
+                  {...contentEditorEditorPanelMessages.aiReasoning}
+                  values={{
+                    reasoning: intelligence.aiReasoning,
+                    b: (chunks) => (
+                      <span className="font-medium text-subtle-foreground">{chunks}</span>
+                    ),
+                  }}
+                />
+              </p>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            <FormattedMessage {...contentEditorEditorPanelMessages.aiSuggestionEmpty} />
+          </p>
+        )}
+      </div>
+
+      {showActions ? (
+        <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/50 pt-3">
           {hasSuggestion ? (
-            <Button variant="ghost" size="xs" onClick={onUseAiSuggestion} disabled={isLoading}>
+            <Button variant="outline" size="xs" onClick={onUseAiSuggestion} disabled={isLoading}>
               <HugeiconsIcon icon={Tick02Icon} className="size-3" aria-hidden />
               <FormattedMessage {...contentEditorEditorPanelMessages.use} />
             </Button>
@@ -80,7 +107,7 @@ export function ContentEditorEditorAiRecommendation({
             />
           ) : onGenerateAiRecommendation ? (
             <Button
-              variant="outline"
+              variant={hasSuggestion ? "ghost" : "outline"}
               size="xs"
               onClick={onGenerateAiRecommendation}
               disabled={isLoading}
@@ -98,31 +125,7 @@ export function ContentEditorEditorAiRecommendation({
             </Button>
           ) : null}
         </div>
-      </div>
-      {error ? (
-        <p className="text-sm leading-relaxed text-flame-100">{error}</p>
-      ) : hasSuggestion ? (
-        <div className="space-y-2">
-          <p className="text-sm leading-relaxed text-foreground">{intelligence.aiSuggestion}</p>
-          {intelligence.aiReasoning ? (
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              <FormattedMessage
-                {...contentEditorEditorPanelMessages.aiReasoning}
-                values={{
-                  reasoning: intelligence.aiReasoning,
-                  b: (chunks) => (
-                    <span className="font-medium text-subtle-foreground">{chunks}</span>
-                  ),
-                }}
-              />
-            </p>
-          ) : null}
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground">
-          <FormattedMessage {...contentEditorEditorPanelMessages.aiSuggestionEmpty} />
-        </p>
-      )}
+      ) : null}
     </aside>
   );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/queue/content-editor-queue-toolbar-connected.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/queue/content-editor-queue-toolbar-connected.tsx
@@ -150,7 +150,11 @@ export const ContentEditorQueueToolbarConnected = observer(
     }
 
     if (!host) {
-      return toolbar;
+      return (
+        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-2">
+          {toolbar}
+        </div>
+      );
     }
 
     return createPortal(toolbar, host);

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
@@ -303,6 +303,7 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
         resetKeys={[viewMode, queueSearch, queueFilter, editorSegment.id]}
       >
         <ContentEditorSideBySidePanel
+          className="min-h-0 flex-1"
           segments={queueSegments}
           focusedSegmentId={editorSegment.id}
           intelligenceSegment={intelligenceSegment}

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-editor-panel.tsx
@@ -129,7 +129,7 @@ export function ContentOpsEditorPanel({ pauseAutoplay = false }: { pauseAutoplay
       <ClientHeroFrame
         key={scene}
         layout="contained"
-        className="rounded-none border-0 shadow-none"
+        className="h-full min-h-0 flex-1 rounded-none border-0 shadow-none"
         initialSelectedSegmentId={SCENE_SEGMENT[scene]}
         workspaceClassName={CONTENT_OPS_EDITOR_WORKSPACE_CLASSNAME}
       />

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-app-shell.tsx
@@ -13,10 +13,12 @@
  * Version 2.0 or later.
  */
 import type { ReactNode } from "react";
+import { useState } from "react";
 import Image from "next/image";
 import {
   BookOpenTextIcon,
   Bookmark01Icon,
+  Cancel01Icon,
   Chat01Icon,
   CheckmarkCircle02Icon,
   Copy01Icon,
@@ -40,7 +42,11 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/primitives/cn";
 
-import { CONTENT_OPS_MOCK_SHELL_CLASSNAME } from "./content-ops-mock-stage.constants";
+import {
+  CONTENT_OPS_MOCK_SHELL_DEFAULT_HEIGHT_CLASSNAME,
+  CONTENT_OPS_MOCK_SHELL_SURFACE_CLASSNAME,
+  CONTENT_OPS_MOCK_SHELL_VIEWPORT_HEIGHT_CLASSNAME,
+} from "./content-ops-mock-stage.constants";
 import {
   contentOpsMockStageMessages,
   type ContentOpsMockTabId,
@@ -107,85 +113,296 @@ const MOCK_EDITOR_GLOSSARY_PREFERRED = 1;
 const MOCK_EDITOR_GLOSSARY_NOT_RECOMMENDED = 1;
 const MOCK_EDITOR_OPEN_ISSUES = 2;
 
-function MockEditorFooter() {
+type MockEditorFooterPanel = "glossary" | "issues" | "chat";
+
+function MockFloatingFooterPanel({
+  title,
+  onClose,
+  children,
+  closeLabel,
+}: {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+  closeLabel: string;
+}) {
   return (
-    <footer className="flex h-10 shrink-0 items-stretch border-t border-border px-2">
-      <div className="flex h-10 w-full min-w-0 items-center gap-2">
-        <Button type="button" variant="outline" size="xs" tabIndex={-1} className="shrink-0">
-          <HugeiconsIcon icon={CreditCardIcon} strokeWidth={2} data-icon="inline-start" />
-          <span className="max-w-40 truncate">
-            <FormattedMessage {...contentOpsMockStageMessages.mockShellPlanButton} />
-          </span>
-        </Button>
+    <section className="absolute right-2 bottom-11 z-30 flex max-h-[min(16rem,42vh)] w-[min(24rem,calc(100%-1rem))] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/20">
+      <header className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-3">
+        <h3 className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{title}</h3>
+        <button
+          type="button"
+          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label={closeLabel}
+          onClick={onClose}
+        >
+          <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+        </button>
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+    </section>
+  );
+}
 
-        <div className="ms-auto flex min-w-0 items-center gap-2 overflow-x-auto">
+function MockEditorGlossaryPanel({
+  onClose,
+  closeLabel,
+}: {
+  onClose: () => void;
+  closeLabel: string;
+}) {
+  const intl = useIntl();
+
+  const terms = [
+    {
+      term: intl.formatMessage(contentOpsMockStageMessages.editorGlossaryPreferredTerm),
+      note: intl.formatMessage(contentOpsMockStageMessages.editorGlossaryPreferredNote),
+      tone: "preferred" as const,
+    },
+    {
+      term: intl.formatMessage(contentOpsMockStageMessages.editorGlossaryNotRecommendedTerm),
+      note: intl.formatMessage(contentOpsMockStageMessages.editorGlossaryNotRecommendedNote),
+      tone: "not-recommended" as const,
+    },
+  ];
+
+  return (
+    <MockFloatingFooterPanel
+      title={intl.formatMessage(contentOpsMockStageMessages.editorGlossaryPanelTitle)}
+      onClose={onClose}
+      closeLabel={closeLabel}
+    >
+      <ul className="space-y-2 p-2">
+        {terms.map((entry) => (
+          <li
+            key={entry.term}
+            className="rounded-lg border border-border/70 bg-muted/20 px-3 py-2.5"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <span className="text-sm font-medium text-foreground">{entry.term}</span>
+              {entry.tone === "preferred" ? (
+                <HugeiconsIcon
+                  icon={CheckmarkCircle02Icon}
+                  className="size-4 shrink-0 text-emerald-500"
+                  aria-hidden
+                />
+              ) : (
+                <HugeiconsIcon
+                  icon={MinusSignCircleIcon}
+                  className="size-4 shrink-0 text-rose-500"
+                  aria-hidden
+                />
+              )}
+            </div>
+            <p className="mt-1 text-[11px] text-muted-foreground">{entry.note}</p>
+          </li>
+        ))}
+      </ul>
+    </MockFloatingFooterPanel>
+  );
+}
+
+function MockEditorIssuesPanel({
+  onClose,
+  closeLabel,
+}: {
+  onClose: () => void;
+  closeLabel: string;
+}) {
+  const intl = useIntl();
+
+  const issues = [
+    {
+      id: "web-2",
+      identifier: "WEB-2",
+      title: intl.formatMessage(contentOpsMockStageMessages.issueWeb2Title),
+      detail: intl.formatMessage(contentOpsMockStageMessages.issueWeb2Detail),
+      status: intl.formatMessage(contentOpsMockStageMessages.statusInProgress),
+    },
+    {
+      id: "mob-1",
+      identifier: "MOB-1",
+      title: intl.formatMessage(contentOpsMockStageMessages.issueMob1Title),
+      detail: intl.formatMessage(contentOpsMockStageMessages.issueMob1Detail),
+      status: intl.formatMessage(contentOpsMockStageMessages.statusOpen),
+    },
+  ];
+
+  return (
+    <MockFloatingFooterPanel
+      title={intl.formatMessage(contentOpsMockStageMessages.editorIssuesPanelTitle)}
+      onClose={onClose}
+      closeLabel={closeLabel}
+    >
+      <ul className="space-y-2 p-2">
+        {issues.map((issue) => (
+          <li key={issue.id} className="rounded-lg border border-border/70 bg-muted/20 px-3 py-2.5">
+            <div className="flex items-start justify-between gap-2">
+              <span className="font-mono text-[10px] font-medium text-muted-foreground">
+                {issue.identifier}
+              </span>
+              <span className="shrink-0 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:text-amber-200">
+                {issue.status}
+              </span>
+            </div>
+            <p className="mt-1 text-xs font-medium text-foreground">{issue.title}</p>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">{issue.detail}</p>
+          </li>
+        ))}
+      </ul>
+    </MockFloatingFooterPanel>
+  );
+}
+
+function MockEditorChatPanel({ onClose, closeLabel }: { onClose: () => void; closeLabel: string }) {
+  const intl = useIntl();
+  const [started, setStarted] = useState(false);
+  const suggestion = intl.formatMessage(contentOpsMockStageMessages.editorChatSuggestion);
+  const answer = intl.formatMessage(contentOpsMockStageMessages.editorChatAnswer);
+
+  return (
+    <MockFloatingFooterPanel
+      title={intl.formatMessage(chatDockMessages.newChat)}
+      onClose={onClose}
+      closeLabel={closeLabel}
+    >
+      {started ? (
+        <div className="flex flex-col gap-3 p-3">
+          <div className="ms-auto max-w-[92%] rounded-2xl bg-muted px-3 py-2 text-pretty text-xs leading-5 text-foreground">
+            {suggestion}
+          </div>
+          <p className="text-pretty text-xs leading-5 text-foreground">{answer}</p>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-3 px-4 py-6 text-center">
+          <div className="flex size-9 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+            <HugeiconsIcon icon={Chat01Icon} strokeWidth={1.8} className="size-4" />
+          </div>
+          <div className="max-w-xs space-y-1">
+            <p className="text-sm font-medium text-foreground">
+              <FormattedMessage {...chatDockMessages.emptyTitle} />
+            </p>
+            <p className="text-pretty text-xs leading-5 text-muted-foreground">
+              <FormattedMessage {...chatDockMessages.emptySubtitle} />
+            </p>
+          </div>
           <Button
             type="button"
-            variant="ghost"
-            size="xs"
-            tabIndex={-1}
-            className="shrink-0 gap-1.5 px-2"
+            variant="outline"
+            size="sm"
+            className="h-8 max-w-full text-pretty text-xs"
+            onClick={() => setStarted(true)}
           >
-            <HugeiconsIcon icon={BookOpenTextIcon} strokeWidth={2} className="size-3.5" />
-            <FormattedMessage {...appShellFooterMessages.glossaryGuidanceLabel} />
-            <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-500">
-              <HugeiconsIcon
-                icon={CheckmarkCircle02Icon}
-                strokeWidth={2}
-                className="size-4"
-                aria-hidden="true"
-              />
-              <span className="tabular-nums">{MOCK_EDITOR_GLOSSARY_PREFERRED}</span>
-            </span>
-            <span className="inline-flex items-center gap-0.5 text-xs font-medium text-rose-500">
-              <HugeiconsIcon
-                icon={MinusSignCircleIcon}
-                strokeWidth={2}
-                className="size-4"
-                aria-hidden="true"
-              />
-              <span className="tabular-nums">{MOCK_EDITOR_GLOSSARY_NOT_RECOMMENDED}</span>
-            </span>
-          </Button>
-
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            tabIndex={-1}
-            className="shrink-0 gap-1.5 px-2"
-          >
-            <HugeiconsIcon icon={Copy01Icon} strokeWidth={2} className="size-3.5" />
-            <FormattedMessage {...appShellFooterMessages.issueGuidanceLabel} />
-            <span className="tabular-nums text-xs font-medium text-flame-900 dark:text-flame-100">
-              {MOCK_EDITOR_OPEN_ISSUES}
-            </span>
-          </Button>
-
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            tabIndex={-1}
-            className="shrink-0 gap-1.5 px-2"
-          >
-            <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} className="size-3.5" />
-            <FormattedMessage {...chatDockMessages.newChat} />
-          </Button>
-
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            tabIndex={-1}
-            className="shrink-0 gap-1.5 px-2"
-          >
-            <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} className="size-3.5" />
-            <FormattedMessage {...appShellFooterMessages.supportLabel} />
+            {suggestion}
           </Button>
         </div>
-      </div>
-    </footer>
+      )}
+    </MockFloatingFooterPanel>
+  );
+}
+
+function MockEditorFooter() {
+  const intl = useIntl();
+  const [openPanel, setOpenPanel] = useState<MockEditorFooterPanel | null>(null);
+  const closeLabel = intl.formatMessage(contentOpsMockStageMessages.editorFooterPanelClose);
+
+  const togglePanel = (panel: MockEditorFooterPanel) => {
+    setOpenPanel((current) => (current === panel ? null : panel));
+  };
+
+  return (
+    <>
+      {openPanel === "glossary" ? (
+        <MockEditorGlossaryPanel onClose={() => setOpenPanel(null)} closeLabel={closeLabel} />
+      ) : null}
+      {openPanel === "issues" ? (
+        <MockEditorIssuesPanel onClose={() => setOpenPanel(null)} closeLabel={closeLabel} />
+      ) : null}
+      {openPanel === "chat" ? (
+        <MockEditorChatPanel onClose={() => setOpenPanel(null)} closeLabel={closeLabel} />
+      ) : null}
+
+      <footer className="flex h-10 shrink-0 items-stretch border-t border-border px-2">
+        <div className="flex h-10 w-full min-w-0 items-center gap-2">
+          <Button type="button" variant="outline" size="xs" tabIndex={-1} className="shrink-0">
+            <HugeiconsIcon icon={CreditCardIcon} strokeWidth={2} data-icon="inline-start" />
+            <span className="max-w-40 truncate">
+              <FormattedMessage {...contentOpsMockStageMessages.mockShellPlanButton} />
+            </span>
+          </Button>
+
+          <div className="ms-auto flex min-w-0 items-center gap-2 overflow-x-auto">
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="shrink-0 gap-1.5 px-2"
+              aria-expanded={openPanel === "glossary"}
+              onClick={() => togglePanel("glossary")}
+            >
+              <HugeiconsIcon icon={BookOpenTextIcon} strokeWidth={2} className="size-3.5" />
+              <FormattedMessage {...appShellFooterMessages.glossaryGuidanceLabel} />
+              <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-500">
+                <HugeiconsIcon
+                  icon={CheckmarkCircle02Icon}
+                  strokeWidth={2}
+                  className="size-4"
+                  aria-hidden="true"
+                />
+                <span className="tabular-nums">{MOCK_EDITOR_GLOSSARY_PREFERRED}</span>
+              </span>
+              <span className="inline-flex items-center gap-0.5 text-xs font-medium text-rose-500">
+                <HugeiconsIcon
+                  icon={MinusSignCircleIcon}
+                  strokeWidth={2}
+                  className="size-4"
+                  aria-hidden="true"
+                />
+                <span className="tabular-nums">{MOCK_EDITOR_GLOSSARY_NOT_RECOMMENDED}</span>
+              </span>
+            </Button>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="shrink-0 gap-1.5 px-2"
+              aria-expanded={openPanel === "issues"}
+              onClick={() => togglePanel("issues")}
+            >
+              <HugeiconsIcon icon={Copy01Icon} strokeWidth={2} className="size-3.5" />
+              <FormattedMessage {...appShellFooterMessages.issueGuidanceLabel} />
+              <span className="tabular-nums text-xs font-medium text-flame-900 dark:text-flame-100">
+                {MOCK_EDITOR_OPEN_ISSUES}
+              </span>
+            </Button>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="shrink-0 gap-1.5 px-2"
+              aria-expanded={openPanel === "chat"}
+              onClick={() => togglePanel("chat")}
+            >
+              <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} className="size-3.5" />
+              <FormattedMessage {...chatDockMessages.newChat} />
+            </Button>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              tabIndex={-1}
+              className="shrink-0 gap-1.5 px-2"
+            >
+              <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} className="size-3.5" />
+              <FormattedMessage {...appShellFooterMessages.supportLabel} />
+            </Button>
+          </div>
+        </div>
+      </footer>
+    </>
   );
 }
 
@@ -205,9 +422,14 @@ function MockDefaultFooter() {
 export function ContentOpsMockAppShell({
   activeTab,
   children,
+  className,
+  size = "default",
 }: {
   activeTab: ContentOpsMockTabId;
   children: ReactNode;
+  className?: string;
+  /** `viewport` fills up to 80% of the screen — used on the Multilingual Content Studio page. */
+  size?: "default" | "viewport";
 }) {
   const intl = useIntl();
   const activeNavId = ACTIVE_NAV_BY_TAB[activeTab];
@@ -215,8 +437,16 @@ export function ContentOpsMockAppShell({
     contentOpsMockStageMessages[BREADCRUMB_KEY_BY_TAB[activeTab]],
   );
 
+  const heightClassName =
+    size === "viewport"
+      ? CONTENT_OPS_MOCK_SHELL_VIEWPORT_HEIGHT_CLASSNAME
+      : CONTENT_OPS_MOCK_SHELL_DEFAULT_HEIGHT_CLASSNAME;
+
   return (
-    <div className={CONTENT_OPS_MOCK_SHELL_CLASSNAME} aria-hidden>
+    <div
+      className={cn(CONTENT_OPS_MOCK_SHELL_SURFACE_CLASSNAME, heightClassName, className)}
+      aria-hidden
+    >
       <div className="flex h-full min-h-0">
         <aside
           className="hidden w-12 shrink-0 flex-col overflow-hidden border-r border-sidebar-border bg-sidebar sm:flex"
@@ -247,7 +477,7 @@ export function ContentOpsMockAppShell({
           </div>
         </aside>
 
-        <div className="flex min-w-0 flex-1 flex-col bg-background">
+        <div className="relative flex min-w-0 flex-1 flex-col bg-background">
           <header className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border px-4 sm:px-5">
             <div className="flex min-w-0 items-center gap-2">
               <span className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground sm:hidden">

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.constants.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.constants.ts
@@ -1,7 +1,15 @@
-export const CONTENT_OPS_MOCK_SHELL_CLASSNAME =
-  "h-[min(42rem,78svh)] min-h-136 w-full overflow-hidden rounded-2xl border border-border bg-background shadow-2xl shadow-[0_24px_64px_rgba(0,0,0,0.28)]";
+export const CONTENT_OPS_MOCK_SHELL_SURFACE_CLASSNAME =
+  "w-full overflow-hidden rounded-2xl border border-border bg-background shadow-2xl shadow-[0_24px_64px_rgba(0,0,0,0.28)]";
+
+export const CONTENT_OPS_MOCK_SHELL_DEFAULT_HEIGHT_CLASSNAME = "h-[min(42rem,78svh)] min-h-136";
+
+export const CONTENT_OPS_MOCK_SHELL_CLASSNAME = `${CONTENT_OPS_MOCK_SHELL_SURFACE_CLASSNAME} ${CONTENT_OPS_MOCK_SHELL_DEFAULT_HEIGHT_CLASSNAME}`;
+
+export const CONTENT_OPS_MOCK_SHELL_VIEWPORT_HEIGHT_CLASSNAME =
+  "h-[80svh] max-h-[80vh] min-h-[32rem]";
 
 export const CONTENT_OPS_MOCK_INNER_CLASSNAME =
   "flex min-h-0 flex-1 flex-col overflow-hidden bg-background";
 
-export const CONTENT_OPS_EDITOR_WORKSPACE_CLASSNAME = "flex min-h-0 flex-1 flex-col";
+export const CONTENT_OPS_EDITOR_WORKSPACE_CLASSNAME =
+  "flex h-full min-h-0 flex-1 flex-col overflow-hidden";

--- a/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/content-ops/content-ops-mock-stage.messages.ts
@@ -158,6 +158,47 @@ export const contentOpsMockStageMessages = defineMessages({
     id: "g1U3NC/CnC",
     description: "Title on the editor mock Queries overlay",
   },
+  editorGlossaryPanelTitle: {
+    defaultMessage: "Glossary guidance",
+    id: "WtFmZHHKpF",
+    description: "Title on the editor mock glossary footer panel",
+  },
+  editorGlossaryPreferredTerm: {
+    defaultMessage: "Daylight",
+    id: "Yo96f8fXbJ",
+    description: "Preferred glossary term in editor mock footer panel",
+  },
+  editorGlossaryPreferredNote: {
+    defaultMessage: "Preferred · keep in every language",
+    id: "KHhslFYk0s",
+    description: "Note for preferred glossary term in editor mock footer panel",
+  },
+  editorGlossaryNotRecommendedTerm: {
+    defaultMessage: "Launch globally",
+    id: "N/7JtE/mmo",
+    description: "Not recommended glossary term in editor mock footer panel",
+  },
+  editorGlossaryNotRecommendedNote: {
+    defaultMessage: "Not recommended · use approved market phrase",
+    id: "vsGtnGOHlx",
+    description: "Note for not recommended glossary term in editor mock footer panel",
+  },
+  editorChatSuggestion: {
+    defaultMessage: "Does this French headline match our voice?",
+    id: "lJreXyrXC1",
+    description: "Suggested prompt in editor mock chat footer panel",
+  },
+  editorChatAnswer: {
+    defaultMessage:
+      "Yes — keep it direct and confident. The approved FR launch copy uses active verbs and avoids literal calques from English.",
+    id: "cZaYlDA8+F",
+    description: "Assistant reply in editor mock chat footer panel",
+  },
+  editorFooterPanelClose: {
+    defaultMessage: "Close panel",
+    id: "VgCemC5cLg",
+    description: "Accessible label for closing an editor mock footer panel",
+  },
   editorHighlightEditor: {
     defaultMessage: "File editor",
     id: "/ApELcd47S",

--- a/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
@@ -17,6 +17,7 @@ import type { IntlShape } from "react-intl";
 import { useIntl } from "react-intl";
 
 import { ContentEditorWorkspaceContainer } from "@/components/content-editor/workspace/content-editor-workspace-container";
+import type { ContentEditorWorkspaceViewMode } from "@/components/content-editor/workspace/content-editor-workspace-view-mode";
 import { toQueueSegment } from "@/components/content-editor/workspace/store/content-editor-segment-view";
 import type {
   ContentEditorFormatCheck,
@@ -36,6 +37,8 @@ type HeroFrameProps = {
   initialSelectedSegmentId?: string;
   /** Override the workspace viewport height (contained layouts). */
   workspaceClassName?: string;
+  /** Lock the demo workspace to a view mode without touching persisted preferences. */
+  initialViewMode?: ContentEditorWorkspaceViewMode;
 };
 
 const DEFAULT_WORKSPACE_CLASSNAME =
@@ -727,6 +730,7 @@ export function HeroFrame({
   className,
   initialSelectedSegmentId,
   workspaceClassName = DEFAULT_WORKSPACE_CLASSNAME,
+  initialViewMode = "comfortable",
 }: HeroFrameProps) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion();
@@ -741,18 +745,24 @@ export function HeroFrame({
     className,
   );
   const workspace = (
-    <div className={workspaceClassName}>
+    <div
+      className={cn(
+        workspaceClassName,
+        layout === "contained" && "flex h-full min-h-0 flex-col overflow-hidden",
+      )}
+    >
       <ContentEditorWorkspaceContainer
         initialState={initialState}
-        initialViewMode="comfortable"
+        initialViewMode={initialViewMode}
         services={services}
+        className={layout === "contained" ? "min-h-0 flex-1" : undefined}
       />
     </div>
   );
 
   // Contained layout is staged by the parent (e.g. whileInView); skip mount animation.
   if (layout === "contained") {
-    return <div className={frameClassName}>{workspace}</div>;
+    return <div className={cn(frameClassName, "flex h-full min-h-0 flex-col")}>{workspace}</div>;
   }
 
   return (

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.tsx
@@ -15,6 +15,7 @@
 import { Add01Icon, ArrowUpRight01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 import type { HomepageFaqItem } from "@/components/marketing/homepage-faq-content";
@@ -33,9 +34,11 @@ import { homepageFaqSectionMessages } from "./homepage-faq-section.messages";
 
 type HomepageFaqSectionProps = {
   items: readonly HomepageFaqItem[];
+  heading?: ReactNode;
+  subheading?: ReactNode;
 };
 
-export function HomepageFaqSection({ items }: HomepageFaqSectionProps) {
+export function HomepageFaqSection({ items, heading, subheading }: HomepageFaqSectionProps) {
   const locale = useAppLocale();
 
   return (
@@ -50,10 +53,10 @@ export function HomepageFaqSection({ items }: HomepageFaqSectionProps) {
             id="homepage-faq-heading"
             className="pb-0 text-balance text-[clamp(2.75rem,6vw,4.5rem)] leading-[1.02] font-semibold tracking-[-0.04em] normal-case text-foreground"
           >
-            <FormattedMessage {...homepageFaqSectionMessages.heading} />
+            {heading ?? <FormattedMessage {...homepageFaqSectionMessages.heading} />}
           </TypographyH2>
           <p className="mt-4 font-sans text-2xl font-medium tracking-tight text-muted-foreground sm:text-3xl">
-            <FormattedMessage {...homepageFaqSectionMessages.subheading} />
+            {subheading ?? <FormattedMessage {...homepageFaqSectionMessages.subheading} />}
           </p>
         </div>
 

--- a/apps/hyperlocalise-web/src/components/marketing/homepage/platform-homepage.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage/platform-homepage.tsx
@@ -522,7 +522,11 @@ export function PlatformHomepage({ children, plans }: { children: ReactNode; pla
           {PRODUCTS.map((product, index) => (
             <a
               key={product.id}
-              href="#explore"
+              href={
+                product.href.startsWith("/")
+                  ? rewriteAppLocalePath(product.href, locale)
+                  : product.href
+              }
               className="group flex flex-col overflow-hidden rounded-xl border border-border focus-visible:outline-2 focus-visible:outline-offset-4"
             >
               <div className="relative isolate flex h-44 items-center justify-between overflow-hidden px-6 text-white">

--- a/apps/hyperlocalise-web/src/components/marketing/homepage/product-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage/product-preview.tsx
@@ -24,6 +24,7 @@ export function hasProductPreviewVideoUrl(url: string | null | undefined): boole
 export const PRODUCTS = [
   {
     id: "studio",
+    href: "/product/multilingual-content-studio",
     title: m.studioCardTitle,
     short: m.studioShort,
     body: m.studioBody,
@@ -31,6 +32,7 @@ export const PRODUCTS = [
   },
   {
     id: "automation",
+    href: "#explore",
     title: m.automationCardTitle,
     short: m.automationShort,
     body: m.automationBody,
@@ -38,6 +40,7 @@ export const PRODUCTS = [
   },
   {
     id: "domains",
+    href: "#explore",
     title: m.domainsCardTitle,
     short: m.domainsShort,
     body: m.domainsBody,
@@ -45,6 +48,7 @@ export const PRODUCTS = [
   },
   {
     id: "hyperlab",
+    href: "#explore",
     title: m.hyperlabCardTitle,
     short: m.hyperlabShort,
     body: m.hyperlabBody,
@@ -52,6 +56,7 @@ export const PRODUCTS = [
   },
   {
     id: "guidelines",
+    href: "#explore",
     title: m.guidelinesCardTitle,
     short: m.guidelinesShort,
     body: m.guidelinesBody,

--- a/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.messages.ts
@@ -1,0 +1,520 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const multilingualContentStudioPageMessages = defineMessages({
+  heroEyebrow: {
+    defaultMessage: "Multilingual Content Studio",
+    id: "d0ATgb33fq",
+    description: "Hero eyebrow for the multilingual Content Studio product page",
+  },
+  heroHeadline: {
+    defaultMessage: "One workspace.\nEvery language.",
+    id: "PsuANqhGSg",
+    description: "Hero headline for the multilingual Content Studio product page",
+  },
+  heroSubcopy: {
+    defaultMessage:
+      "Create and adapt text, documents, slides, images, and video. Keep your context, your voice, and your team together.",
+    id: "Y9uUKekkpa",
+    description: "Hero description for the multilingual Content Studio product page",
+  },
+  requestDemo: {
+    defaultMessage: "Request a Demo",
+    id: "WuOMg44dT2",
+    description: "Call-to-action to request a Content Studio demo",
+  },
+  exploreStudio: {
+    defaultMessage: "Explore the studio",
+    id: "0cglRpvqFz",
+    description: "Anchor link from the Content Studio hero to the studio preview",
+  },
+  fromDraftToReview: {
+    defaultMessage: "From the first draft to the final review.",
+    id: "eDTK5TLRPI",
+    description: "Caption under the Content Studio preview",
+  },
+  stepCreate: {
+    defaultMessage: "01 Create",
+    id: "xpMULNdb04",
+    description: "Content Studio workflow step 1",
+  },
+  stepAdapt: {
+    defaultMessage: "02 Adapt",
+    id: "0njV/b+hso",
+    description: "Content Studio workflow step 2",
+  },
+  stepReview: {
+    defaultMessage: "03 Review",
+    id: "bhFZvUICCV",
+    description: "Content Studio workflow step 3",
+  },
+  stepReady: {
+    defaultMessage: "04 Ready for your market",
+    id: "dXqj3V56mP",
+    description: "Content Studio workflow step 4",
+  },
+  formatsEyebrow: {
+    defaultMessage: "Made for your content",
+    id: "tLb8BuElrp",
+    description: "Eyebrow for the Content Studio formats section",
+  },
+  formatsHeadline: {
+    defaultMessage: "More than words.\nYour whole campaign.",
+    id: "tqJRWwDupO",
+    description: "Headline for the Content Studio formats section",
+  },
+  formatsBody: {
+    defaultMessage:
+      "Bring every part of your story into one workspace, with an editing experience that fits the format.",
+    id: "82yO8++nrp",
+    description: "Body copy for the Content Studio formats section",
+  },
+  formatsAriaLabel: {
+    defaultMessage: "Content formats",
+    id: "+EaeyANHgn",
+    description: "Accessible label for the Content Studio format tabs",
+  },
+  formatText: {
+    defaultMessage: "Text & documents",
+    id: "hj+HpjmXDL",
+    description: "Content Studio format tab for text and documents",
+  },
+  formatSlides: {
+    defaultMessage: "Slides",
+    id: "ceF41648YF",
+    description: "Content Studio format tab for slides",
+  },
+  formatImages: {
+    defaultMessage: "Images",
+    id: "gMIZAR6HUF",
+    description: "Content Studio format tab for images",
+  },
+  formatVideo: {
+    defaultMessage: "Video",
+    id: "iqtybHn407",
+    description: "Content Studio format tab for video",
+  },
+  formatTextTitle: {
+    defaultMessage: "Keep the meaning.\nKeep the structure.",
+    id: "lGHZQiNbmr",
+    description: "Title for the text and documents format panel",
+  },
+  formatTextBody: {
+    defaultMessage:
+      "Work on source and translated content side by side. Refine the language while keeping headings, formatting, and context in view.",
+    id: "gYY0k8FFO9",
+    description: "Body for the text and documents format panel",
+  },
+  formatTextLink: {
+    defaultMessage: "From product copy to long-form stories",
+    id: "nQ/dkYYamv",
+    description: "Supporting link line for the text and documents format panel",
+  },
+  formatSlidesTitle: {
+    defaultMessage: "Your story.\nThe same impact.",
+    id: "9LD3POhUor",
+    description: "Title for the slides format panel",
+  },
+  formatSlidesBody: {
+    defaultMessage:
+      "Adapt every slide together. Keep the layout, refine the message, and present it in any language.",
+    id: "kn7ATogig+",
+    description: "Body for the slides format panel",
+  },
+  formatSlidesLink: {
+    defaultMessage: "From pitch decks to keynotes",
+    id: "WIHinYIhc4",
+    description: "Supporting link line for the slides format panel",
+  },
+  formatImagesTitle: {
+    defaultMessage: "One visual.\nA local point of view.",
+    id: "iagx5dCcQh",
+    description: "Title for the images format panel",
+  },
+  formatImagesBody: {
+    defaultMessage:
+      "Adapt the words inside your images. Refine each market’s message while keeping your visual identity.",
+    id: "mZUHzvJrS8",
+    description: "Body for the images format panel",
+  },
+  formatImagesLink: {
+    defaultMessage: "From social posts to campaigns",
+    id: "ovj4Hc0MYp",
+    description: "Supporting link line for the images format panel",
+  },
+  formatVideoTitle: {
+    defaultMessage: "Your story.\nIn sync everywhere.",
+    id: "Dn9lhDiLkD",
+    description: "Title for the video format panel",
+  },
+  formatVideoBody: {
+    defaultMessage:
+      "Translate your subtitles. Refine each line in context, and keep every word in time with your story.",
+    id: "7HLNE1VQKG",
+    description: "Body for the video format panel",
+  },
+  formatVideoLink: {
+    defaultMessage: "From product demos to campaigns",
+    id: "e4Xzg6LTW9",
+    description: "Supporting link line for the video format panel",
+  },
+  previewSubtitles: {
+    defaultMessage: "Subtitles",
+    id: "8xWtqhNe5Z",
+    description: "Label for the video format mock subtitle panel",
+  },
+  previewSelectedCount: {
+    defaultMessage: "{selected} / {total} selected",
+    id: "5o3YTJGgiG",
+    description: "Selected item count in a Content Studio format mock",
+  },
+  previewEnglishSource: {
+    defaultMessage: "ENGLISH · SOURCE",
+    id: "ldsa6EOMk/",
+    description: "Source-language label in a Content Studio format mock",
+  },
+  previewFrenchTranslation: {
+    defaultMessage: "FRENCH · TRANSLATION",
+    id: "XH27tSt/JN",
+    description: "French translation label in a Content Studio format mock",
+  },
+  previewTimingPreserved: {
+    defaultMessage: "Timing preserved",
+    id: "TjFXSXtMQ3",
+    description: "Status line in the video format mock",
+  },
+  previewExportSubtitles: {
+    defaultMessage: "Export subtitles",
+    id: "Eu5Sh1lJHw",
+    description: "Export action in the video format mock",
+  },
+  previewTextLayers: {
+    defaultMessage: "Text layers",
+    id: "ln7JKojYPi",
+    description: "Label for the image format mock layers panel",
+  },
+  previewHeadlineSelected: {
+    defaultMessage: "{index} / Headline selected",
+    id: "83cJ0Qff+x",
+    description: "Selected layer status in the image format mock",
+  },
+  previewSourceEnglish: {
+    defaultMessage: "SOURCE · ENGLISH",
+    id: "/Vytq8laTc",
+    description: "Source-language label in the image format mock",
+  },
+  previewVietnameseAdapted: {
+    defaultMessage: "VIETNAMESE · ADAPTED",
+    id: "2fjmQhrN05",
+    description: "Vietnamese adaptation label in the image format mock",
+  },
+  contextEyebrow: {
+    defaultMessage: "Context in. Confidence out.",
+    id: "fgo8+NGFAV",
+    description: "Eyebrow for the Content Studio context section",
+  },
+  contextHeadline: {
+    defaultMessage: "Keep every draft aligned\nwith your content standards.",
+    id: "CX0QAoWQz1",
+    description: "Headline for the Content Studio context section",
+  },
+  contextBody: {
+    defaultMessage:
+      "Give AI and your team clear rules to follow, from approved terminology to market-specific requirements, so content is easier to review and approve.",
+    id: "bV29A4VqV7",
+    description: "Body for the Content Studio context section",
+  },
+  exploreGuidelines: {
+    defaultMessage: "Explore Guidelines",
+    id: "qAENVVTQnI",
+    description: "Link from Content Studio to the Guidelines product page",
+  },
+  campaignContext: {
+    defaultMessage: "Campaign context",
+    id: "pyFu72KXFM",
+    description: "Title of the campaign context mock card",
+  },
+  appliedToDraft: {
+    defaultMessage: "Applied to this draft",
+    id: "7tPiM+8vOJ",
+    description: "Status on the campaign context mock card",
+  },
+  brandVoice: {
+    defaultMessage: "Brand voice",
+    id: "2CQAb/Wvw0",
+    description: "Brand voice row label in the campaign context mock",
+  },
+  brandVoiceValue: {
+    defaultMessage: "Clear. Human. Confident.",
+    id: "ow+0+l1ZrI",
+    description: "Brand voice example in the campaign context mock",
+  },
+  terminology: {
+    defaultMessage: "Terminology",
+    id: "JSHjNwtBB0",
+    description: "Terminology row label in the campaign context mock",
+  },
+  terminologyValue: {
+    defaultMessage: "Keep “Daylight” in every language.",
+    id: "ya2E3z8gto",
+    description: "Terminology example in the campaign context mock",
+  },
+  marketContext: {
+    defaultMessage: "Market context",
+    id: "IkCkDVLrow",
+    description: "Market context row label in the campaign context mock",
+  },
+  marketContextValue: {
+    defaultMessage: "France · Conversational, use “vous”.",
+    id: "8nvnmIvxt+",
+    description: "Market context example in the campaign context mock",
+  },
+  sharedContext: {
+    defaultMessage: "One shared source of context",
+    id: "e+MvZA0TTv",
+    description: "Footer line on the campaign context mock card",
+  },
+  reviewEyebrow: {
+    defaultMessage: "Review and approval",
+    id: "Qrwlw6Dfd/",
+    description: "Eyebrow for the Content Studio review section",
+  },
+  reviewHeadline: {
+    defaultMessage: "Your team has the final say.",
+    id: "/7Y7qcmjyZ",
+    description: "Headline for the Content Studio review section",
+  },
+  reviewBody: {
+    defaultMessage:
+      "Review AI drafts and translations side by side. Check for accuracy, make changes, and approve content when it meets your standards.",
+    id: "6OX4GFk9EP",
+    description: "Body for the Content Studio review section",
+  },
+  reviewCompare: {
+    defaultMessage: "Compare side by side · Refine in context",
+    id: "21S/RyUHaa",
+    description: "Supporting line for Content Studio review capabilities",
+  },
+  reviewLoop: {
+    defaultMessage: "Keep people in the review loop",
+    id: "dLBcaBGQjS",
+    description: "Supporting line for keeping humans in Content Studio review",
+  },
+  summerCampaign: {
+    defaultMessage: "Summer campaign",
+    id: "+l38vFeeBu",
+    description: "Campaign name in the language review mock",
+  },
+  languageReview: {
+    defaultMessage: "Language review",
+    id: "i1PMbnhRAE",
+    description: "Status heading in the language review mock",
+  },
+  languageFrench: {
+    defaultMessage: "French",
+    id: "5+8B2Tn+yG",
+    description: "French locale name in the language review mock",
+  },
+  languageGerman: {
+    defaultMessage: "German",
+    id: "jKKc2sCkP4",
+    description: "German locale name in the language review mock",
+  },
+  languageJapanese: {
+    defaultMessage: "Japanese",
+    id: "pZ59Fsnn9/",
+    description: "Japanese locale name in the language review mock",
+  },
+  statusApproved: {
+    defaultMessage: "Approved",
+    id: "MGO8MFzpRG",
+    description: "Approved review status in the language review mock",
+  },
+  statusInReview: {
+    defaultMessage: "In review",
+    id: "CNPbYe/F7H",
+    description: "In-review status in the language review mock",
+  },
+  statusNeedsReview: {
+    defaultMessage: "Needs review",
+    id: "kNO9FnuZT5",
+    description: "Needs-review status in the language review mock",
+  },
+  publishEyebrow: {
+    defaultMessage: "Publish to the web",
+    id: "t9KG4W2FU+",
+    description: "Eyebrow for the Content Studio web publishing section",
+  },
+  publishHeadline: {
+    defaultMessage: "Turn your content into a live webpage.",
+    id: "+6ZAiLLMdQ",
+    description: "Headline for the Content Studio web publishing section",
+  },
+  publishBody: {
+    defaultMessage:
+      "Publish articles, guides, and landing pages directly from Content Studio. Manage your content and translations in one place, then share a link with your audience.",
+    id: "zU54dIP7FC",
+    description: "Body for the Content Studio web publishing section",
+  },
+  publishedPreviewCaption: {
+    defaultMessage: "Published webpage preview",
+    id: "Yt1RZ0FH89",
+    description: "Caption above the published webpage preview",
+  },
+  publishedStatus: {
+    defaultMessage: "Published",
+    id: "ofjXB5MTLN",
+    description: "Published status badge in the webpage preview",
+  },
+  languageLabel: {
+    defaultMessage: "Language",
+    id: "J7cTAVBjzv",
+    description: "Label for the language selector in the webpage preview",
+  },
+  connectedHeadline: {
+    defaultMessage: "A studio connected to the bigger picture.",
+    id: "Vfgm2yT4Or",
+    description: "Headline for the Content Studio connected-products section",
+  },
+  connectedBody: {
+    defaultMessage: "Turn repeatable work into workflows. Take approved content to your markets.",
+    id: "76/g24/Q69",
+    description: "Body for the Content Studio connected-products section",
+  },
+  automationWorkflow: {
+    defaultMessage: "Automation Workflow",
+    id: "v//TLtlSQz",
+    description: "Link from Content Studio to the automation product page",
+  },
+  guidelines: {
+    defaultMessage: "Guidelines",
+    id: "BJpPKh03Ub",
+    description: "Link from Content Studio to the Guidelines product page",
+  },
+  faqHeading: {
+    defaultMessage: "A few things\nyou might ask.",
+    id: "pS4CYtUU3j",
+    description: "FAQ heading on the multilingual Content Studio product page",
+  },
+  faqSubheading: {
+    defaultMessage: "Getting to know Content Studio.",
+    id: "+3eUjtxudU",
+    description: "FAQ subheading on the multilingual Content Studio product page",
+  },
+  faqCreateQuestion: {
+    defaultMessage: "What can I create in Content Studio?",
+    id: "dznTTN8Ymt",
+    description: "Content Studio FAQ question about supported formats",
+  },
+  faqCreateAnswer: {
+    defaultMessage:
+      "Create and adapt text, documents, slides, images, and video in one shared multilingual workspace—so every format in a campaign stays together.",
+    id: "F2Mfo5rtgk",
+    description: "Content Studio FAQ answer about supported formats",
+  },
+  faqEditorQuestion: {
+    defaultMessage: "How does the editor help translators work faster?",
+    id: "2bIgjVHpIr",
+    description: "Content Studio FAQ question about the editor",
+  },
+  faqEditorAnswer: {
+    defaultMessage:
+      "Review source and target side by side, with translation memory matches, AI suggestions, glossary checks, and visual context for each string in the same view.",
+    id: "uQThnP+5M7",
+    description: "Content Studio FAQ answer about the editor",
+  },
+  faqTmQuestion: {
+    defaultMessage: "Does Content Studio include translation memory and glossaries?",
+    id: "5tFadU6T26",
+    description: "Content Studio FAQ question about TM and glossaries",
+  },
+  faqTmAnswer: {
+    defaultMessage:
+      "Yes. Approved terminology and past translations surface as you work, so reviewers catch conflicts early instead of after content ships.",
+    id: "N9Db20xFJr",
+    description: "Content Studio FAQ answer about TM and glossaries",
+  },
+  faqContextQuestion: {
+    defaultMessage: "What context do reviewers see beyond the text?",
+    id: "ceYYf6k52c",
+    description: "Content Studio FAQ question about reviewer context",
+  },
+  faqContextAnswer: {
+    defaultMessage:
+      "Product meaning, screenshots, brand guidance, market notes, and issue history—so reviewers understand intent before they choose wording.",
+    id: "ML8rZ08xO0",
+    description: "Content Studio FAQ answer about reviewer context",
+  },
+  faqAiQuestion: {
+    defaultMessage: "Can my team review AI-generated content?",
+    id: "Od0MLRTrMp",
+    description: "Content Studio FAQ question about AI review",
+  },
+  faqAiAnswer: {
+    defaultMessage:
+      "Yes. AI moves drafts forward while reviewers compare, refine, comment, and make the final approval decision.",
+    id: "tCw1pmceT2",
+    description: "Content Studio FAQ answer about AI review",
+  },
+  faqStatusQuestion: {
+    defaultMessage: "Can we manage review status across languages?",
+    id: "6Iy982Sau4",
+    description: "Content Studio FAQ question about review status",
+  },
+  faqStatusAnswer: {
+    defaultMessage:
+      "Track every locale in one campaign—who is reviewing, what is approved, and what still needs attention—without switching tools.",
+    id: "QG31S8uFy7",
+    description: "Content Studio FAQ answer about review status",
+  },
+  faqBrandQuestion: {
+    defaultMessage: "How do we keep our brand voice consistent?",
+    id: "H9XcqBCX7n",
+    description: "Content Studio FAQ question about brand voice",
+  },
+  faqBrandAnswer: {
+    defaultMessage:
+      "Attach approved terminology, brand guidance, and market context so every person and agent works from the same source of truth.",
+    id: "pPpG4zo8Yj",
+    description: "Content Studio FAQ answer about brand voice",
+  },
+  faqFitQuestion: {
+    defaultMessage: "How does Content Studio fit with the rest of Hyperlocalise?",
+    id: "b2dI5BHWEO",
+    description: "Content Studio FAQ question about product fit",
+  },
+  faqFitAnswer: {
+    defaultMessage:
+      "Content Studio connects to Automation Workflow and Domains so approved content can move into repeatable workflows and reach every market.",
+    id: "wqX73vSqoO",
+    description: "Content Studio FAQ answer about product fit",
+  },
+  ctaHeadline: {
+    defaultMessage: "Your next story.\nReady for the world.",
+    id: "iSz2hKqv1Z",
+    description: "Bottom CTA headline on the multilingual Content Studio product page",
+  },
+  ctaBody: {
+    defaultMessage: "Bring your content and your team into one studio.",
+    id: "7PBZ6NZm7K",
+    description: "Bottom CTA body on the multilingual Content Studio product page",
+  },
+  ctaNote: {
+    defaultMessage: "Build your multilingual workflow.",
+    id: "zR0I34Xobx",
+    description: "Supporting note under the Content Studio bottom CTA",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.tsx
@@ -1,0 +1,829 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { ArrowRight01Icon, PlayIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+
+import { ContentOpsEditorPanel } from "@/components/marketing/content-ops/content-ops-editor-panel";
+import { ContentOpsMockAppShell } from "@/components/marketing/content-ops/content-ops-mock-app-shell";
+import {
+  BLUSH_MESH_GRADIENT_SRC,
+  DUSK_MESH_GRADIENT_SRC,
+  LAVENDER_MESH_GRADIENT_SRC,
+  MeshStage,
+  ROSE_MESH_GRADIENT_SRC,
+  SEAFOAM_MESH_GRADIENT_SRC,
+  SectionMeshBackground,
+} from "@/components/marketing/hero-frame-mesh-stage";
+import { HomepageFaqSection } from "@/components/marketing/homepage-faq-section";
+import { MarketingFooter } from "@/components/marketing/marketing-footer";
+import { footerColumns } from "@/components/marketing/marketing-page-content";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
+import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
+import { cn } from "@/lib/primitives/cn";
+
+const formats = ["Text & documents", "Slides", "Images", "Video"] as const;
+type Format = (typeof formats)[number];
+
+const formatCopy: Record<Format, { title: string; body: string; link: string }> = {
+  "Text & documents": {
+    title: "Keep the meaning.\nKeep the structure.",
+    body: "Work on source and translated content side by side. Refine the language while keeping headings, formatting, and context in view.",
+    link: "From product copy to long-form stories",
+  },
+  Slides: {
+    title: "Your story.\nThe same impact.",
+    body: "Adapt every slide together. Keep the layout, refine the message, and present it in any language.",
+    link: "From pitch decks to keynotes",
+  },
+  Images: {
+    title: "One visual.\nA local point of view.",
+    body: "Adapt the words inside your images. Refine each market’s message while keeping your visual identity.",
+    link: "From social posts to campaigns",
+  },
+  Video: {
+    title: "Your story.\nIn sync everywhere.",
+    body: "Translate your subtitles. Refine each line in context, and keep every word in time with your story.",
+    link: "From product demos to campaigns",
+  },
+};
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return <p className="text-xs font-medium text-muted-foreground">{children}</p>;
+}
+
+const PUBLISHED_PAGE_COPY = {
+  en: {
+    languageName: "English",
+    category: "Daylight journal",
+    title: "See the world in a different light.",
+    introduction:
+      "Every light has a story. Explore the places, people, and everyday moments that connect us across the world.",
+    heading: "A new perspective on familiar places",
+    body: "From above, borders fade and cities become constellations. Back on the ground, it is the neighbourhood cafés, late-night conversations, and local traditions that bring each place to life.",
+    meta: "8 September 2026 · 4 min read",
+    imageAlt: "City lights across Earth at night, photographed from space",
+  },
+  "fr-FR": {
+    languageName: "Français",
+    category: "Le journal Daylight",
+    title: "Voyez le monde sous un autre jour.",
+    introduction:
+      "Chaque lumière raconte une histoire. Découvrez les lieux, les personnes et les instants du quotidien qui nous relient à travers le monde.",
+    heading: "Un regard neuf sur des lieux familiers",
+    body: "Vues du ciel, les frontières s’effacent et les villes deviennent des constellations. Au sol, ce sont les cafés de quartier, les conversations nocturnes et les traditions locales qui donnent vie à chaque lieu.",
+    meta: "8 septembre 2026 · 4 min de lecture",
+    imageAlt: "Les lumières des villes sur Terre la nuit, photographiées depuis l’espace",
+  },
+  "de-DE": {
+    languageName: "Deutsch",
+    category: "Das Daylight Journal",
+    title: "Die Welt in einem neuen Licht sehen.",
+    introduction:
+      "Jedes Licht erzählt eine Geschichte. Entdecken Sie die Orte, Menschen und alltäglichen Momente, die uns weltweit verbinden.",
+    heading: "Ein neuer Blick auf vertraute Orte",
+    body: "Von oben verschwinden Grenzen und Städte werden zu Sternbildern. Am Boden sind es die Cafés im Viertel, die Gespräche bis spät in die Nacht und die lokalen Traditionen, die jedem Ort Leben verleihen.",
+    meta: "8. September 2026 · 4 Min. Lesezeit",
+    imageAlt: "Nächtliche Lichter der Städte auf der Erde, aus dem Weltraum fotografiert",
+  },
+  ja: {
+    languageName: "日本語",
+    category: "Daylight ジャーナル",
+    title: "いつもと違う光で、世界を見つめる。",
+    introduction:
+      "一つひとつの光に、物語があります。世界中の私たちをつなぐ場所や人々、日常のひとときを訪ねてみましょう。",
+    heading: "見慣れた場所に、新しい発見を",
+    body: "空から眺めると、国境は見えなくなり、街は星座のように輝きます。地上に降りれば、近所のカフェや夜更けの会話、地域の伝統が、その場所ならではの表情をつくっています。",
+    meta: "2026年9月8日 · 読了まで約4分",
+    imageAlt: "宇宙から撮影した、夜の地球に輝く街の明かり",
+  },
+  "zh-CN": {
+    languageName: "简体中文",
+    category: "Daylight 日志",
+    title: "换个角度，看见不一样的世界。",
+    introduction:
+      "每一束光都有一个故事。探索世界各地的人与风景，发现日常生活中将我们紧密相连的瞬间。",
+    heading: "在熟悉的地方，发现新的风景",
+    body: "从高空俯瞰，边界渐渐隐去，城市宛如璀璨的星座。回到地面，街角的咖啡馆、深夜的交谈和当地的传统，让每个地方都有了独特的生命力。",
+    meta: "2026年9月8日 · 阅读约需4分钟",
+    imageAlt: "从太空拍摄的地球夜景，城市灯火闪耀",
+  },
+  "vi-VN": {
+    languageName: "Tiếng Việt",
+    category: "Nhật ký Daylight",
+    title: "Nhìn thế giới dưới một ánh sáng khác.",
+    introduction:
+      "Mỗi ánh đèn đều có một câu chuyện. Khám phá những vùng đất, con người và khoảnh khắc đời thường kết nối chúng ta trên khắp thế giới.",
+    heading: "Một góc nhìn mới về những nơi quen thuộc",
+    body: "Nhìn từ trên cao, những đường biên mờ đi và các thành phố hóa thành những chòm sao. Trở lại mặt đất, chính những quán cà phê trong khu phố, những cuộc trò chuyện đêm muộn và truyền thống địa phương đã thổi hồn vào mỗi vùng đất.",
+    meta: "8 tháng 9, 2026 · 4 phút đọc",
+    imageAlt: "Ánh đèn thành phố trên Trái Đất về đêm, được chụp từ không gian",
+  },
+} as const satisfies Record<AppLocale | "ja", unknown>;
+
+const PUBLISHED_PAGE_LOCALES = Object.keys(PUBLISHED_PAGE_COPY) as Array<
+  keyof typeof PUBLISHED_PAGE_COPY
+>;
+
+function WebPublishingSection() {
+  const locale = useAppLocale();
+  const [language, setLanguage] = useState<keyof typeof PUBLISHED_PAGE_COPY>(locale);
+  const orderedLocales = [locale, ...PUBLISHED_PAGE_LOCALES.filter((value) => value !== locale)];
+  const article = PUBLISHED_PAGE_COPY[language];
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto flex max-w-7xl flex-col gap-10 sm:gap-12">
+        <div className="mx-auto max-w-3xl text-center">
+          <Eyebrow>Publish to the web</Eyebrow>
+          <h2 className="mt-5 text-balance font-heading text-4xl leading-tight sm:text-5xl">
+            Turn your content into a live webpage.
+          </h2>
+          <p className="mt-6 text-pretty text-lg leading-8 text-muted-foreground">
+            Publish articles, guides, and landing pages directly from Content Studio. Manage your
+            content and translations in one place, then share a link with your audience.
+          </p>
+        </div>
+        <figure className="relative isolate min-w-0 overflow-hidden rounded-xl p-4 sm:p-8 lg:p-12">
+          <SectionMeshBackground src={SEAFOAM_MESH_GRADIENT_SRC} className="opacity-80" />
+          <figcaption className="relative mb-3 text-center text-xs text-foreground">
+            Published webpage preview
+          </figcaption>
+          <div className="relative mx-auto max-w-5xl overflow-hidden rounded-xl border border-border bg-card text-card-foreground">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-muted/50 px-5 py-4 text-xs">
+              <span className="min-w-0 break-all text-muted-foreground">
+                daylight.example.com/{language}/journal/a-different-light
+              </span>
+              <span className="inline-flex items-center gap-2 font-medium text-primary">
+                <span aria-hidden="true" className="size-1.5 rounded-full bg-current" />
+                Published
+              </span>
+            </div>
+            <div className="p-5 sm:p-8 lg:px-12">
+              <div className="flex flex-wrap items-center justify-between gap-4 border-b border-border pb-5">
+                <span className="font-heading text-xl">Daylight</span>
+                <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                  Language
+                  <select
+                    value={language}
+                    onChange={(event) => {
+                      const value = PUBLISHED_PAGE_LOCALES.find(
+                        (value) => value === event.target.value,
+                      );
+                      if (value) {
+                        setLanguage(value);
+                      }
+                    }}
+                    className="min-h-11 rounded-md border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                  >
+                    {orderedLocales.map((value) => (
+                      <option key={value} value={value}>
+                        {PUBLISHED_PAGE_COPY[value].languageName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <article
+                lang={language}
+                className="mx-auto max-w-3xl py-8 sm:py-12"
+                aria-live="polite"
+              >
+                <p className="text-xs font-medium text-primary">{article.category}</p>
+                <h3 className="mt-4 max-w-2xl text-balance font-heading text-3xl leading-tight sm:text-5xl">
+                  {article.title}
+                </h3>
+                <p className="mt-5 text-pretty text-sm leading-7 text-muted-foreground">
+                  {article.introduction}
+                </p>
+                <div className="mt-5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">Alex Morgan</span>
+                  <span>{article.meta}</span>
+                </div>
+                <figure className="mt-6">
+                  <Image
+                    src="/images/nasa-Q1p7bh3SHj8-unsplash.jpg"
+                    alt={article.imageAlt}
+                    width={4256}
+                    height={2832}
+                    sizes="(min-width: 1024px) 768px, (min-width: 640px) 80vw, 90vw"
+                    className="aspect-[2/1] w-full rounded-lg object-cover"
+                  />
+                  <figcaption className="mt-2 text-xs text-muted-foreground">
+                    NASA / Unsplash
+                  </figcaption>
+                </figure>
+                <h4 className="mt-8 text-base font-medium">{article.heading}</h4>
+                <p className="mt-3 text-pretty text-sm leading-7 text-muted-foreground">
+                  {article.body}
+                </p>
+              </article>
+            </div>
+          </div>
+        </figure>
+      </div>
+    </section>
+  );
+}
+
+function FloatingWelcome({
+  greeting,
+  code,
+  phrase,
+  colorClassName,
+  greetingClassName,
+  positionClassName,
+  hiddenOnMobile = false,
+}: {
+  greeting: string;
+  code: string;
+  phrase: string;
+  colorClassName: string;
+  greetingClassName: string;
+  positionClassName: string;
+  hiddenOnMobile?: boolean;
+}) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "absolute flex flex-col gap-2.5 text-left",
+        colorClassName,
+        positionClassName,
+        hiddenOnMobile && "hidden sm:flex",
+      )}
+    >
+      <p className={`font-heading ${greetingClassName}`}>{greeting}</p>
+      <p className="text-[11px] leading-relaxed opacity-80">
+        <span className="font-medium tracking-wide">{code}</span>
+        <span className="mx-1.5 opacity-50">·</span>
+        {phrase}
+      </p>
+    </div>
+  );
+}
+
+const floatingWelcomes = [
+  {
+    greeting: "Xin chào.",
+    code: "Vi",
+    phrase: "Rất vui gặp bạn",
+    colorClassName: "text-[#744966]",
+    greetingClassName: "text-3xl",
+    positionClassName: "left-[6%] top-16 -rotate-6",
+  },
+  {
+    greeting: "สวัสดี.",
+    code: "Th",
+    phrase: "ยินดีที่ได้รู้จัก",
+    colorClassName: "text-[#8b6914]",
+    greetingClassName: "text-3xl",
+    positionClassName: "left-[5%] top-[42%] rotate-6",
+    hiddenOnMobile: true,
+  },
+  {
+    greeting: "Bonjour.",
+    code: "Fr",
+    phrase: "Enchanté",
+    colorClassName: "text-[#6b7244]",
+    greetingClassName: "text-3xl",
+    positionClassName: "left-[8%] bottom-24 rotate-3",
+    hiddenOnMobile: true,
+  },
+  {
+    greeting: "Hallo.",
+    code: "De",
+    phrase: "Schön, dich zu sehen",
+    colorClassName: "text-[#4a6678]",
+    greetingClassName: "text-2xl",
+    positionClassName: "right-[11%] top-16 -rotate-12",
+    hiddenOnMobile: true,
+  },
+  {
+    greeting: "你好。",
+    code: "Zh",
+    phrase: "欢迎回来",
+    colorClassName: "text-[#365383]",
+    greetingClassName: "text-4xl",
+    positionClassName: "right-[6%] top-[38%] rotate-6",
+  },
+  {
+    greeting: "Hola.",
+    code: "Es",
+    phrase: "¿Qué tal?",
+    colorClassName: "text-[#9a4d67]",
+    greetingClassName: "text-3xl",
+    positionClassName: "right-[5%] bottom-20 -rotate-6",
+    hiddenOnMobile: true,
+  },
+] as const;
+
+function CampaignArtwork() {
+  return (
+    <div className="relative min-h-56 overflow-hidden bg-[#172541] p-5 text-white sm:min-h-64">
+      <div className="absolute -right-12 -top-12 size-44 rounded-full bg-[#d77da2]" />
+      <div className="absolute -bottom-12 right-0 h-36 w-72 rounded-[50%] bg-[#2458b4]" />
+      <p className="relative text-[10px] tracking-[0.14em] text-[#ebc36a]">
+        DAYLIGHT / SUMMER STORIES
+      </p>
+      <p className="relative mt-8 font-heading text-3xl leading-tight sm:text-4xl">
+        A little further.
+        <br />A little closer.
+      </p>
+    </div>
+  );
+}
+
+function StudioPreview() {
+  return (
+    <div id="studio" className="mx-auto max-w-6xl">
+      <MeshStage
+        className="w-full"
+        contentClassName="px-3 pt-3 pb-0 sm:px-8 sm:pt-8 lg:px-10 lg:pt-10"
+        meshSrc={SEAFOAM_MESH_GRADIENT_SRC}
+        priority
+      >
+        <ContentOpsMockAppShell
+          activeTab="editor"
+          size="viewport"
+          className="rounded-t-xl rounded-b-none border-0 shadow-2xl shadow-[#172541]/20"
+        >
+          <ContentOpsEditorPanel pauseAutoplay />
+        </ContentOpsMockAppShell>
+      </MeshStage>
+    </div>
+  );
+}
+
+function FormatPreview({ format }: { format: Format }) {
+  if (format === "Video") {
+    return (
+      <div className="grid min-h-80 flex-1 bg-[#dfe7f2] p-4 lg:grid-cols-[1.15fr_.85fr] lg:p-6">
+        <div className="overflow-hidden rounded-md">
+          <CampaignArtwork />
+          <div className="flex items-center gap-3 bg-white p-3 text-xs text-[#43556c]">
+            <HugeiconsIcon icon={PlayIcon} className="size-4 text-[#172541]" />
+            <span>00:08 / 00:30</span>
+            <div className="h-1 flex-1 bg-[#cae7ff]">
+              <div className="h-1 w-2/5 bg-[#006bff]" />
+            </div>
+            <span className="text-[#006bff]">CC · FR</span>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4 rounded-md bg-white p-5 text-[#0b121b]">
+          <div className="flex justify-between text-xs">
+            <b>Subtitles</b>
+            <span className="text-[#006bff]">02 / 08 selected</span>
+          </div>
+          <div>
+            <p className="font-mono text-[11px] text-[#5f7188]">00:06.400 → 00:11.200</p>
+            <p className="mt-2 text-[10px] tracking-wider text-[#5f7188]">ENGLISH · SOURCE</p>
+            <p className="mt-1 text-sm">A little further. A little closer to you.</p>
+          </div>
+          <div className="rounded-sm border border-[#94ccff] bg-[#f0f7ff] p-3">
+            <p className="text-[10px] tracking-wider text-[#002359]">FRENCH · TRANSLATION</p>
+            <p className="mt-2 text-sm">Un peu plus loin. Un peu plus près.</p>
+          </div>
+          <div className="mt-auto flex justify-between text-xs">
+            <span className="text-green-700">✓ Timing preserved</span>
+            <span className="text-[#006bff]">Export subtitles ↗</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (format === "Images") {
+    return (
+      <div className="grid min-h-80 flex-1 gap-5 bg-[#ebcbd8] p-5 sm:grid-cols-[16rem_1fr]">
+        <div className="relative min-h-64 overflow-hidden bg-[#efc667] p-5 text-[#172541]">
+          <div className="absolute -right-10 -top-10 size-36 rounded-full bg-[#d77da2]" />
+          <p className="relative text-[10px] tracking-wider">DAYLIGHT / SUMMER STORIES</p>
+          <p className="relative mt-12 font-heading text-3xl">
+            Đi xa hơn.
+            <br />
+            Gần nhau hơn.
+          </p>
+          <div className="absolute inset-x-0 bottom-0 h-24 rounded-[50%_50%_0_0] bg-[#2458b4]" />
+        </div>
+        <div className="rounded-md bg-white p-5 text-[#0b121b]">
+          <div className="flex justify-between text-xs">
+            <b>Text layers</b>
+            <span className="text-[#006bff]">02 / Headline selected</span>
+          </div>
+          <p className="mt-6 text-[10px] tracking-wider text-[#5f7188]">SOURCE · ENGLISH</p>
+          <p className="mt-1 text-sm">A little further. A little closer to you.</p>
+          <div className="mt-5 rounded-sm border border-[#94ccff] bg-[#f0f7ff] p-3">
+            <p className="text-[10px] tracking-wider text-[#002359]">VIETNAMESE · ADAPTED</p>
+            <p className="mt-2">Đi xa hơn. Gần nhau hơn.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (format === "Slides") {
+    return (
+      <div className="grid min-h-80 flex-1 bg-[#ddd9ec] p-5 sm:grid-cols-[5rem_1fr]">
+        <div className="hidden flex-col gap-3 pr-4 sm:flex">
+          {["01 / Bonjour", "02 / Explorer", "03 / Ensemble"].map((slide, index) => (
+            <div
+              key={slide}
+              className={
+                index === 0
+                  ? "border border-[#006bff] bg-[#172541] p-2 text-[10px] text-white"
+                  : "bg-white/50 p-2 text-[10px] text-[#172541]"
+              }
+            >
+              {slide}
+            </div>
+          ))}
+        </div>
+        <div className="relative min-h-64 overflow-hidden bg-[#172541] p-6 text-white">
+          <p className="text-[10px] tracking-wider text-[#ebc36a]">DAYLIGHT / ÉTÉ 2026</p>
+          <p className="mt-12 max-w-sm border border-[#94ccff] p-3 font-heading text-3xl">
+            Un peu plus loin.
+            <br />
+            Un peu plus près.
+          </p>
+          <div className="absolute right-12 top-14 size-28 rounded-full border-[22px] border-[#d77da2] bg-[#ebc36a]" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative isolate grid min-h-80 flex-1 gap-5 overflow-hidden p-5 sm:grid-cols-2">
+      <SectionMeshBackground src={BLUSH_MESH_GRADIENT_SRC} className="opacity-80" />
+      <article className="relative rounded-t-md bg-white p-6 text-[#0b121b]">
+        <p className="text-[10px] tracking-wider text-[#5f7188]">ENGLISH · SOURCE</p>
+        <h3 className="mt-5 font-heading text-3xl">
+          A guide to
+          <br />
+          slowing down.
+        </h3>
+        <p className="mt-5 text-sm leading-6 text-[#5f7188]">
+          Make room for the moments that matter. Start with a little less, and discover a little
+          more.
+        </p>
+      </article>
+      <article className="relative rounded-t-md border border-[#94ccff] bg-white p-6 text-[#0b121b]">
+        <p className="text-[10px] tracking-wider text-[#006bff]">FRENCH · TRANSLATION</p>
+        <h3 className="mt-5 font-heading text-3xl">
+          L’art de
+          <br />
+          ralentir.
+        </h3>
+        <p className="mt-5 text-sm leading-6 text-[#5f7188]">
+          Faites place aux instants qui comptent. Commencez avec un peu moins, découvrez un peu
+          plus.
+        </p>
+      </article>
+    </div>
+  );
+}
+
+function ContentFormats() {
+  const [format, setFormat] = useState<Format>("Text & documents");
+  const copy = formatCopy[format];
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto max-w-7xl">
+        <div className="flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
+          <div>
+            <Eyebrow>Made for your content</Eyebrow>
+            <h2 className="mt-5 font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+              More than words.
+              <br />
+              Your whole campaign.
+            </h2>
+          </div>
+          <p className="max-w-md text-lg leading-8 text-muted-foreground">
+            Bring every part of your story into one workspace, with an editing experience that fits
+            the format.
+          </p>
+        </div>
+        <div
+          className="mt-10 flex gap-7 overflow-x-auto"
+          role="tablist"
+          aria-label="Content formats"
+        >
+          {formats.map((item) => (
+            <button
+              key={item}
+              type="button"
+              role="tab"
+              aria-selected={format === item}
+              onClick={() => setFormat(item)}
+              className={
+                format === item
+                  ? "shrink-0 border-b-2 border-primary pb-3 text-sm text-primary"
+                  : "shrink-0 pb-3 text-sm text-muted-foreground hover:text-foreground"
+              }
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+        <div className="mt-6 overflow-hidden rounded-xl bg-muted lg:flex">
+          <div className="flex w-full shrink-0 flex-col justify-center gap-5 bg-background/55 p-8 lg:w-[34%] lg:p-12">
+            <h3 className="whitespace-pre-line text-2xl leading-8 font-semibold tracking-tight">
+              {copy.title}
+            </h3>
+            <p className="text-base leading-7 text-muted-foreground">{copy.body}</p>
+            <p className="pt-2 text-sm text-primary">{copy.link} ↗</p>
+          </div>
+          <FormatPreview format={format} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const faqItems = [
+  [
+    "What can I create in Content Studio?",
+    "Create and adapt text, documents, slides, images, and video in one shared multilingual workspace—so every format in a campaign stays together.",
+  ],
+  [
+    "How does the editor help translators work faster?",
+    "Review source and target side by side, with translation memory matches, AI suggestions, glossary checks, and visual context for each string in the same view.",
+  ],
+  [
+    "Does Content Studio include translation memory and glossaries?",
+    "Yes. Approved terminology and past translations surface as you work, so reviewers catch conflicts early instead of after content ships.",
+  ],
+  [
+    "What context do reviewers see beyond the text?",
+    "Product meaning, screenshots, brand guidance, market notes, and issue history—so reviewers understand intent before they choose wording.",
+  ],
+  [
+    "Can my team review AI-generated content?",
+    "Yes. AI moves drafts forward while reviewers compare, refine, comment, and make the final approval decision.",
+  ],
+  [
+    "Can we manage review status across languages?",
+    "Track every locale in one campaign—who is reviewing, what is approved, and what still needs attention—without switching tools.",
+  ],
+  [
+    "How do we keep our brand voice consistent?",
+    "Attach approved terminology, brand guidance, and market context so every person and agent works from the same source of truth.",
+  ],
+  [
+    "How does Content Studio fit with the rest of Hyperlocalise?",
+    "Content Studio connects to Automation Workflow and Domains so approved content can move into repeatable workflows and reach every market.",
+  ],
+] as const;
+
+export function MultilingualContentStudioPage() {
+  const locale = useAppLocale();
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div>
+        <section className="relative bg-background px-5 py-20 text-center text-foreground sm:px-8 sm:py-24 lg:px-10">
+          {floatingWelcomes.map((welcome) => (
+            <FloatingWelcome key={welcome.code} {...welcome} />
+          ))}
+          <div className="relative mx-auto flex max-w-3xl flex-col items-center">
+            <Eyebrow>Multilingual Content Studio</Eyebrow>
+            <h1 className="mt-6 font-heading text-[clamp(3rem,7vw,5.5rem)] leading-[0.98] tracking-[-0.045em]">
+              One workspace.
+              <br />
+              Every language.
+            </h1>
+            <p className="mt-7 max-w-2xl text-lg leading-8 text-[#344564] sm:text-xl">
+              Create and adapt text, documents, slides, images, and video.
+              <br className="hidden sm:block" /> Keep your context, your voice, and your team
+              together.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button
+                size="lg"
+                nativeButton={false}
+                render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+              >
+                Request a Demo <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                nativeButton={false}
+                render={<a href="#studio" />}
+              >
+                Explore the studio ↓
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-3 pb-0 sm:px-6 lg:px-8">
+          <StudioPreview />
+          <div className="mx-auto flex max-w-6xl flex-col justify-between gap-4 border-b border-border py-7 text-sm text-muted-foreground sm:flex-row">
+            <span>From the first draft to the final review.</span>
+            <span className="flex flex-wrap gap-x-7 gap-y-2">
+              <span>01　Create</span>
+              <span>02　Adapt</span>
+              <span>03　Review</span>
+              <span>04　Ready for your market</span>
+            </span>
+          </div>
+        </section>
+
+        <ContentFormats />
+
+        <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+          <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[.85fr_1.15fr] lg:items-center">
+            <div className="max-w-xl">
+              <Eyebrow>Context in. Confidence out.</Eyebrow>
+              <h2 className="mt-5 font-heading text-4xl leading-tight tracking-tight text-foreground sm:text-5xl">
+                Keep every draft aligned
+                <br />
+                with your content standards.
+              </h2>
+              <p className="mt-6 text-lg leading-8 text-muted-foreground">
+                Give AI and your team clear rules to follow, from approved terminology to
+                market-specific requirements, so content is easier to review and approve.
+              </p>
+              <Link
+                href={rewriteAppLocalePath("/product/self-evolving-knowledge", locale)}
+                className="mt-5 inline-flex text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                Explore Guidelines ↗
+              </Link>
+            </div>
+            <div className="relative isolate overflow-hidden rounded-xl p-4 sm:p-5">
+              <SectionMeshBackground src={LAVENDER_MESH_GRADIENT_SRC} className="opacity-80" />
+              <div className="relative rounded-xl border border-border bg-card p-6 text-card-foreground sm:p-8">
+                <div className="flex justify-between gap-3 border-b border-border pb-6 text-sm">
+                  <b>Campaign context</b>
+                  <span className="text-primary">Applied to this draft ✓</span>
+                </div>
+                {[
+                  ["Brand voice", "Clear. Human. Confident."],
+                  ["Terminology", "Keep “Daylight” in every language."],
+                  ["Market context", "France · Conversational, use “vous”."],
+                ].map(([label, value]) => (
+                  <div key={label} className="grid gap-2 pt-5 text-sm sm:grid-cols-[8rem_1fr]">
+                    <span className="text-muted-foreground">{label}</span>
+                    <span>{value}</span>
+                  </div>
+                ))}
+                <div className="mt-6 flex gap-3 border-t border-border pt-5 text-xs text-muted-foreground">
+                  <span>EN</span>
+                  <span>→</span>
+                  <span className="text-primary">FR</span>
+                  <span>DE</span>
+                  <span>JA</span>
+                  <span className="ml-auto hidden sm:block">One shared source of context</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+          <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[1.05fr_.95fr] lg:items-center">
+            <div className="relative isolate overflow-hidden rounded-xl p-4 sm:p-5">
+              <SectionMeshBackground src={ROSE_MESH_GRADIENT_SRC} className="opacity-75" />
+              <div className="relative overflow-hidden rounded-lg border border-border bg-card">
+                <div className="flex justify-between bg-muted/60 p-5 text-sm">
+                  <b>Summer campaign</b>
+                  <span className="text-muted-foreground">Language review</span>
+                </div>
+                {[
+                  ["FR", "French", "Alex", "Approved", "bg-green-100 text-green-800"],
+                  ["DE", "German", "Jamie", "In review", "bg-blue-100 text-blue-800"],
+                  ["JA", "Japanese", "Minh", "Needs review", "bg-amber-100 text-amber-800"],
+                ].map(([code, language, reviewer, status, tone]) => (
+                  <div
+                    key={code}
+                    className="grid grid-cols-[2rem_1fr_auto] items-center gap-4 border-t border-border p-5 text-sm sm:grid-cols-[2rem_1fr_7rem_8rem_auto]"
+                  >
+                    <span className="text-xs text-muted-foreground">{code}</span>
+                    <b>{language}</b>
+                    <span className="hidden text-muted-foreground sm:block">{reviewer}</span>
+                    <span className={`rounded-full px-3 py-1 text-xs ${tone}`}>{status}</span>
+                    <span>↗</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div>
+              <Eyebrow>Review and approval</Eyebrow>
+              <h2 className="mt-5 font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+                Your team has the final say.
+              </h2>
+              <p className="mt-6 text-lg leading-8 text-muted-foreground">
+                Review AI drafts and translations side by side. Check for accuracy, make changes,
+                and approve content when it meets your standards.
+              </p>
+              <p className="mt-5 text-sm leading-7 text-muted-foreground">
+                Compare side by side　·　Refine in context
+                <br />
+                Keep people in the review loop
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <WebPublishingSection key={locale} />
+
+        <section className="mx-auto max-w-7xl border-y border-border px-5 py-10 sm:px-8 lg:px-10">
+          <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-center">
+            <div>
+              <h2 className="text-2xl font-medium tracking-tight">
+                A studio connected to the bigger picture.
+              </h2>
+              <p className="mt-2 text-base text-muted-foreground">
+                Turn repeatable work into workflows. Take approved content to your markets.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-6">
+              <Link
+                href={rewriteAppLocalePath("/product/agents-automation", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                Automation Workflow ↗
+              </Link>
+              <Link
+                href={rewriteAppLocalePath("/product/self-evolving-knowledge", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                Guidelines ↗
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+          <HomepageFaqSection
+            items={faqItems.map(([question, answer]) => ({ question, answer }))}
+            heading={
+              <>
+                <span>A few things</span>
+                <br />
+                <span>you might ask.</span>
+              </>
+            }
+            subheading="Getting to know Content Studio."
+          />
+        </div>
+
+        <section className="px-5 pb-20 sm:px-8 lg:px-10">
+          <MeshStage
+            className="mx-auto max-w-7xl"
+            contentClassName="p-0"
+            meshSrc={DUSK_MESH_GRADIENT_SRC}
+            mixSrc={ROSE_MESH_GRADIENT_SRC}
+          >
+            <div className="flex flex-col justify-between gap-10 bg-[#172541]/45 p-8 text-[#f8f0f5] sm:p-12 lg:flex-row lg:items-center lg:p-16">
+              <div>
+                <h2 className="font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+                  Your next story.
+                  <br />
+                  Ready for the world.
+                </h2>
+                <p className="mt-5 text-lg text-[#e5edf9]">
+                  Bring your content and your team into one studio.
+                </p>
+              </div>
+              <div className="flex flex-col items-start gap-3 lg:items-center">
+                <Button
+                  size="lg"
+                  className="bg-[#ebc36a] text-[#172541] hover:bg-[#f2db9b]"
+                  nativeButton={false}
+                  render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+                >
+                  Request a Demo <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+                </Button>
+                <span className="text-xs text-[#e5edf9]">Build your multilingual workflow.</span>
+              </div>
+            </div>
+          </MeshStage>
+        </section>
+
+        <section className="border-t border-border px-5 pt-16 sm:px-8 lg:px-10">
+          <MarketingFooter columns={footerColumns} />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.tsx
@@ -17,6 +17,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { ContentOpsEditorPanel } from "@/components/marketing/content-ops/content-ops-editor-panel";
 import { ContentOpsMockAppShell } from "@/components/marketing/content-ops/content-ops-mock-app-shell";
@@ -39,31 +40,40 @@ import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
 import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
 import { cn } from "@/lib/primitives/cn";
 
-const formats = ["Text & documents", "Slides", "Images", "Video"] as const;
-type Format = (typeof formats)[number];
+import { multilingualContentStudioPageMessages as messages } from "./multilingual-content-studio-page.messages";
 
-const formatCopy: Record<Format, { title: string; body: string; link: string }> = {
-  "Text & documents": {
-    title: "Keep the meaning.\nKeep the structure.",
-    body: "Work on source and translated content side by side. Refine the language while keeping headings, formatting, and context in view.",
-    link: "From product copy to long-form stories",
+const formatIds = ["text", "slides", "images", "video"] as const;
+type FormatId = (typeof formatIds)[number];
+
+const formatLabelKeys = {
+  text: "formatText",
+  slides: "formatSlides",
+  images: "formatImages",
+  video: "formatVideo",
+} as const;
+
+const formatCopyKeys = {
+  text: {
+    title: "formatTextTitle",
+    body: "formatTextBody",
+    link: "formatTextLink",
   },
-  Slides: {
-    title: "Your story.\nThe same impact.",
-    body: "Adapt every slide together. Keep the layout, refine the message, and present it in any language.",
-    link: "From pitch decks to keynotes",
+  slides: {
+    title: "formatSlidesTitle",
+    body: "formatSlidesBody",
+    link: "formatSlidesLink",
   },
-  Images: {
-    title: "One visual.\nA local point of view.",
-    body: "Adapt the words inside your images. Refine each market’s message while keeping your visual identity.",
-    link: "From social posts to campaigns",
+  images: {
+    title: "formatImagesTitle",
+    body: "formatImagesBody",
+    link: "formatImagesLink",
   },
-  Video: {
-    title: "Your story.\nIn sync everywhere.",
-    body: "Translate your subtitles. Refine each line in context, and keep every word in time with your story.",
-    link: "From product demos to campaigns",
+  video: {
+    title: "formatVideoTitle",
+    body: "formatVideoBody",
+    link: "formatVideoLink",
   },
-};
+} as const;
 
 function Eyebrow({ children }: { children: React.ReactNode }) {
   return <p className="text-xs font-medium text-muted-foreground">{children}</p>;
@@ -152,19 +162,20 @@ function WebPublishingSection() {
     <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
       <div className="mx-auto flex max-w-7xl flex-col gap-10 sm:gap-12">
         <div className="mx-auto max-w-3xl text-center">
-          <Eyebrow>Publish to the web</Eyebrow>
+          <Eyebrow>
+            <FormattedMessage {...messages.publishEyebrow} />
+          </Eyebrow>
           <h2 className="mt-5 text-balance font-heading text-4xl leading-tight sm:text-5xl">
-            Turn your content into a live webpage.
+            <FormattedMessage {...messages.publishHeadline} />
           </h2>
           <p className="mt-6 text-pretty text-lg leading-8 text-muted-foreground">
-            Publish articles, guides, and landing pages directly from Content Studio. Manage your
-            content and translations in one place, then share a link with your audience.
+            <FormattedMessage {...messages.publishBody} />
           </p>
         </div>
         <figure className="relative isolate min-w-0 overflow-hidden rounded-xl p-4 sm:p-8 lg:p-12">
           <SectionMeshBackground src={SEAFOAM_MESH_GRADIENT_SRC} className="opacity-80" />
           <figcaption className="relative mb-3 text-center text-xs text-foreground">
-            Published webpage preview
+            <FormattedMessage {...messages.publishedPreviewCaption} />
           </figcaption>
           <div className="relative mx-auto max-w-5xl overflow-hidden rounded-xl border border-border bg-card text-card-foreground">
             <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-muted/50 px-5 py-4 text-xs">
@@ -173,14 +184,14 @@ function WebPublishingSection() {
               </span>
               <span className="inline-flex items-center gap-2 font-medium text-primary">
                 <span aria-hidden="true" className="size-1.5 rounded-full bg-current" />
-                Published
+                <FormattedMessage {...messages.publishedStatus} />
               </span>
             </div>
             <div className="p-5 sm:p-8 lg:px-12">
               <div className="flex flex-wrap items-center justify-between gap-4 border-b border-border pb-5">
                 <span className="font-heading text-xl">Daylight</span>
                 <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                  Language
+                  <FormattedMessage {...messages.languageLabel} />
                   <select
                     value={language}
                     onChange={(event) => {
@@ -372,8 +383,8 @@ function StudioPreview() {
   );
 }
 
-function FormatPreview({ format }: { format: Format }) {
-  if (format === "Video") {
+function FormatPreview({ format }: { format: FormatId }) {
+  if (format === "video") {
     return (
       <div className="grid min-h-80 flex-1 bg-[#dfe7f2] p-4 lg:grid-cols-[1.15fr_.85fr] lg:p-6">
         <div className="overflow-hidden rounded-md">
@@ -389,28 +400,43 @@ function FormatPreview({ format }: { format: Format }) {
         </div>
         <div className="flex flex-col gap-4 rounded-md bg-white p-5 text-[#0b121b]">
           <div className="flex justify-between text-xs">
-            <b>Subtitles</b>
-            <span className="text-[#006bff]">02 / 08 selected</span>
+            <b>
+              <FormattedMessage {...messages.previewSubtitles} />
+            </b>
+            <span className="text-[#006bff]">
+              <FormattedMessage
+                {...messages.previewSelectedCount}
+                values={{ selected: "02", total: "08" }}
+              />
+            </span>
           </div>
           <div>
             <p className="font-mono text-[11px] text-[#5f7188]">00:06.400 → 00:11.200</p>
-            <p className="mt-2 text-[10px] tracking-wider text-[#5f7188]">ENGLISH · SOURCE</p>
+            <p className="mt-2 text-[10px] tracking-wider text-[#5f7188]">
+              <FormattedMessage {...messages.previewEnglishSource} />
+            </p>
             <p className="mt-1 text-sm">A little further. A little closer to you.</p>
           </div>
           <div className="rounded-sm border border-[#94ccff] bg-[#f0f7ff] p-3">
-            <p className="text-[10px] tracking-wider text-[#002359]">FRENCH · TRANSLATION</p>
+            <p className="text-[10px] tracking-wider text-[#002359]">
+              <FormattedMessage {...messages.previewFrenchTranslation} />
+            </p>
             <p className="mt-2 text-sm">Un peu plus loin. Un peu plus près.</p>
           </div>
           <div className="mt-auto flex justify-between text-xs">
-            <span className="text-green-700">✓ Timing preserved</span>
-            <span className="text-[#006bff]">Export subtitles ↗</span>
+            <span className="text-green-700">
+              ✓ <FormattedMessage {...messages.previewTimingPreserved} />
+            </span>
+            <span className="text-[#006bff]">
+              <FormattedMessage {...messages.previewExportSubtitles} /> ↗
+            </span>
           </div>
         </div>
       </div>
     );
   }
 
-  if (format === "Images") {
+  if (format === "images") {
     return (
       <div className="grid min-h-80 flex-1 gap-5 bg-[#ebcbd8] p-5 sm:grid-cols-[16rem_1fr]">
         <div className="relative min-h-64 overflow-hidden bg-[#efc667] p-5 text-[#172541]">
@@ -425,13 +451,21 @@ function FormatPreview({ format }: { format: Format }) {
         </div>
         <div className="rounded-md bg-white p-5 text-[#0b121b]">
           <div className="flex justify-between text-xs">
-            <b>Text layers</b>
-            <span className="text-[#006bff]">02 / Headline selected</span>
+            <b>
+              <FormattedMessage {...messages.previewTextLayers} />
+            </b>
+            <span className="text-[#006bff]">
+              <FormattedMessage {...messages.previewHeadlineSelected} values={{ index: "02" }} />
+            </span>
           </div>
-          <p className="mt-6 text-[10px] tracking-wider text-[#5f7188]">SOURCE · ENGLISH</p>
+          <p className="mt-6 text-[10px] tracking-wider text-[#5f7188]">
+            <FormattedMessage {...messages.previewSourceEnglish} />
+          </p>
           <p className="mt-1 text-sm">A little further. A little closer to you.</p>
           <div className="mt-5 rounded-sm border border-[#94ccff] bg-[#f0f7ff] p-3">
-            <p className="text-[10px] tracking-wider text-[#002359]">VIETNAMESE · ADAPTED</p>
+            <p className="text-[10px] tracking-wider text-[#002359]">
+              <FormattedMessage {...messages.previewVietnameseAdapted} />
+            </p>
             <p className="mt-2">Đi xa hơn. Gần nhau hơn.</p>
           </div>
         </div>
@@ -439,7 +473,7 @@ function FormatPreview({ format }: { format: Format }) {
     );
   }
 
-  if (format === "Slides") {
+  if (format === "slides") {
     return (
       <div className="grid min-h-80 flex-1 bg-[#ddd9ec] p-5 sm:grid-cols-[5rem_1fr]">
         <div className="hidden flex-col gap-3 pr-4 sm:flex">
@@ -473,7 +507,9 @@ function FormatPreview({ format }: { format: Format }) {
     <div className="relative isolate grid min-h-80 flex-1 gap-5 overflow-hidden p-5 sm:grid-cols-2">
       <SectionMeshBackground src={BLUSH_MESH_GRADIENT_SRC} className="opacity-80" />
       <article className="relative rounded-t-md bg-white p-6 text-[#0b121b]">
-        <p className="text-[10px] tracking-wider text-[#5f7188]">ENGLISH · SOURCE</p>
+        <p className="text-[10px] tracking-wider text-[#5f7188]">
+          <FormattedMessage {...messages.previewEnglishSource} />
+        </p>
         <h3 className="mt-5 font-heading text-3xl">
           A guide to
           <br />
@@ -485,7 +521,9 @@ function FormatPreview({ format }: { format: Format }) {
         </p>
       </article>
       <article className="relative rounded-t-md border border-[#94ccff] bg-white p-6 text-[#0b121b]">
-        <p className="text-[10px] tracking-wider text-[#006bff]">FRENCH · TRANSLATION</p>
+        <p className="text-[10px] tracking-wider text-[#006bff]">
+          <FormattedMessage {...messages.previewFrenchTranslation} />
+        </p>
         <h3 className="mt-5 font-heading text-3xl">
           L’art de
           <br />
@@ -501,32 +539,32 @@ function FormatPreview({ format }: { format: Format }) {
 }
 
 function ContentFormats() {
-  const [format, setFormat] = useState<Format>("Text & documents");
-  const copy = formatCopy[format];
+  const intl = useIntl();
+  const [format, setFormat] = useState<FormatId>("text");
+  const copy = formatCopyKeys[format];
 
   return (
     <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
       <div className="mx-auto max-w-7xl">
         <div className="flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
           <div>
-            <Eyebrow>Made for your content</Eyebrow>
-            <h2 className="mt-5 font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
-              More than words.
-              <br />
-              Your whole campaign.
+            <Eyebrow>
+              <FormattedMessage {...messages.formatsEyebrow} />
+            </Eyebrow>
+            <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+              <FormattedMessage {...messages.formatsHeadline} />
             </h2>
           </div>
           <p className="max-w-md text-lg leading-8 text-muted-foreground">
-            Bring every part of your story into one workspace, with an editing experience that fits
-            the format.
+            <FormattedMessage {...messages.formatsBody} />
           </p>
         </div>
         <div
           className="mt-10 flex gap-7 overflow-x-auto"
           role="tablist"
-          aria-label="Content formats"
+          aria-label={intl.formatMessage(messages.formatsAriaLabel)}
         >
-          {formats.map((item) => (
+          {formatIds.map((item) => (
             <button
               key={item}
               type="button"
@@ -539,17 +577,21 @@ function ContentFormats() {
                   : "shrink-0 pb-3 text-sm text-muted-foreground hover:text-foreground"
               }
             >
-              {item}
+              <FormattedMessage {...messages[formatLabelKeys[item]]} />
             </button>
           ))}
         </div>
         <div className="mt-6 overflow-hidden rounded-xl bg-muted lg:flex">
           <div className="flex w-full shrink-0 flex-col justify-center gap-5 bg-background/55 p-8 lg:w-[34%] lg:p-12">
             <h3 className="whitespace-pre-line text-2xl leading-8 font-semibold tracking-tight">
-              {copy.title}
+              <FormattedMessage {...messages[copy.title]} />
             </h3>
-            <p className="text-base leading-7 text-muted-foreground">{copy.body}</p>
-            <p className="pt-2 text-sm text-primary">{copy.link} ↗</p>
+            <p className="text-base leading-7 text-muted-foreground">
+              <FormattedMessage {...messages[copy.body]} />
+            </p>
+            <p className="pt-2 text-sm text-primary">
+              <FormattedMessage {...messages[copy.link]} /> ↗
+            </p>
           </div>
           <FormatPreview format={format} />
         </div>
@@ -558,43 +600,55 @@ function ContentFormats() {
   );
 }
 
-const faqItems = [
-  [
-    "What can I create in Content Studio?",
-    "Create and adapt text, documents, slides, images, and video in one shared multilingual workspace—so every format in a campaign stays together.",
-  ],
-  [
-    "How does the editor help translators work faster?",
-    "Review source and target side by side, with translation memory matches, AI suggestions, glossary checks, and visual context for each string in the same view.",
-  ],
-  [
-    "Does Content Studio include translation memory and glossaries?",
-    "Yes. Approved terminology and past translations surface as you work, so reviewers catch conflicts early instead of after content ships.",
-  ],
-  [
-    "What context do reviewers see beyond the text?",
-    "Product meaning, screenshots, brand guidance, market notes, and issue history—so reviewers understand intent before they choose wording.",
-  ],
-  [
-    "Can my team review AI-generated content?",
-    "Yes. AI moves drafts forward while reviewers compare, refine, comment, and make the final approval decision.",
-  ],
-  [
-    "Can we manage review status across languages?",
-    "Track every locale in one campaign—who is reviewing, what is approved, and what still needs attention—without switching tools.",
-  ],
-  [
-    "How do we keep our brand voice consistent?",
-    "Attach approved terminology, brand guidance, and market context so every person and agent works from the same source of truth.",
-  ],
-  [
-    "How does Content Studio fit with the rest of Hyperlocalise?",
-    "Content Studio connects to Automation Workflow and Domains so approved content can move into repeatable workflows and reach every market.",
-  ],
+const faqMessageKeys = [
+  ["faqCreateQuestion", "faqCreateAnswer"],
+  ["faqEditorQuestion", "faqEditorAnswer"],
+  ["faqTmQuestion", "faqTmAnswer"],
+  ["faqContextQuestion", "faqContextAnswer"],
+  ["faqAiQuestion", "faqAiAnswer"],
+  ["faqStatusQuestion", "faqStatusAnswer"],
+  ["faqBrandQuestion", "faqBrandAnswer"],
+  ["faqFitQuestion", "faqFitAnswer"],
+] as const;
+
+const reviewRows = [
+  {
+    code: "FR",
+    language: "languageFrench",
+    reviewer: "Alex",
+    status: "statusApproved",
+    tone: "bg-green-100 text-green-800",
+  },
+  {
+    code: "DE",
+    language: "languageGerman",
+    reviewer: "Jamie",
+    status: "statusInReview",
+    tone: "bg-blue-100 text-blue-800",
+  },
+  {
+    code: "JA",
+    language: "languageJapanese",
+    reviewer: "Minh",
+    status: "statusNeedsReview",
+    tone: "bg-amber-100 text-amber-800",
+  },
+] as const;
+
+const contextRows = [
+  ["brandVoice", "brandVoiceValue"],
+  ["terminology", "terminologyValue"],
+  ["marketContext", "marketContextValue"],
 ] as const;
 
 export function MultilingualContentStudioPage() {
   const locale = useAppLocale();
+  const intl = useIntl();
+  const faqItems = faqMessageKeys.map(([question, answer]) => ({
+    question: intl.formatMessage(messages[question]),
+    answer: intl.formatMessage(messages[answer]),
+  }));
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div>
@@ -603,16 +657,14 @@ export function MultilingualContentStudioPage() {
             <FloatingWelcome key={welcome.code} {...welcome} />
           ))}
           <div className="relative mx-auto flex max-w-3xl flex-col items-center">
-            <Eyebrow>Multilingual Content Studio</Eyebrow>
-            <h1 className="mt-6 font-heading text-[clamp(3rem,7vw,5.5rem)] leading-[0.98] tracking-[-0.045em]">
-              One workspace.
-              <br />
-              Every language.
+            <Eyebrow>
+              <FormattedMessage {...messages.heroEyebrow} />
+            </Eyebrow>
+            <h1 className="mt-6 whitespace-pre-line font-heading text-[clamp(3rem,7vw,5.5rem)] leading-[0.98] tracking-[-0.045em]">
+              <FormattedMessage {...messages.heroHeadline} />
             </h1>
             <p className="mt-7 max-w-2xl text-lg leading-8 text-[#344564] sm:text-xl">
-              Create and adapt text, documents, slides, images, and video.
-              <br className="hidden sm:block" /> Keep your context, your voice, and your team
-              together.
+              <FormattedMessage {...messages.heroSubcopy} />
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
               <Button
@@ -620,7 +672,8 @@ export function MultilingualContentStudioPage() {
                 nativeButton={false}
                 render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
               >
-                Request a Demo <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+                <FormattedMessage {...messages.requestDemo} />{" "}
+                <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
               </Button>
               <Button
                 size="lg"
@@ -628,7 +681,7 @@ export function MultilingualContentStudioPage() {
                 nativeButton={false}
                 render={<a href="#studio" />}
               >
-                Explore the studio ↓
+                <FormattedMessage {...messages.exploreStudio} /> ↓
               </Button>
             </div>
           </div>
@@ -637,12 +690,22 @@ export function MultilingualContentStudioPage() {
         <section className="px-3 pb-0 sm:px-6 lg:px-8">
           <StudioPreview />
           <div className="mx-auto flex max-w-6xl flex-col justify-between gap-4 border-b border-border py-7 text-sm text-muted-foreground sm:flex-row">
-            <span>From the first draft to the final review.</span>
+            <span>
+              <FormattedMessage {...messages.fromDraftToReview} />
+            </span>
             <span className="flex flex-wrap gap-x-7 gap-y-2">
-              <span>01　Create</span>
-              <span>02　Adapt</span>
-              <span>03　Review</span>
-              <span>04　Ready for your market</span>
+              <span>
+                <FormattedMessage {...messages.stepCreate} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepAdapt} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepReview} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepReady} />
+              </span>
             </span>
           </div>
         </section>
@@ -652,38 +715,41 @@ export function MultilingualContentStudioPage() {
         <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
           <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[.85fr_1.15fr] lg:items-center">
             <div className="max-w-xl">
-              <Eyebrow>Context in. Confidence out.</Eyebrow>
-              <h2 className="mt-5 font-heading text-4xl leading-tight tracking-tight text-foreground sm:text-5xl">
-                Keep every draft aligned
-                <br />
-                with your content standards.
+              <Eyebrow>
+                <FormattedMessage {...messages.contextEyebrow} />
+              </Eyebrow>
+              <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight text-foreground sm:text-5xl">
+                <FormattedMessage {...messages.contextHeadline} />
               </h2>
               <p className="mt-6 text-lg leading-8 text-muted-foreground">
-                Give AI and your team clear rules to follow, from approved terminology to
-                market-specific requirements, so content is easier to review and approve.
+                <FormattedMessage {...messages.contextBody} />
               </p>
               <Link
                 href={rewriteAppLocalePath("/product/self-evolving-knowledge", locale)}
                 className="mt-5 inline-flex text-sm font-medium text-foreground underline-offset-4 hover:underline"
               >
-                Explore Guidelines ↗
+                <FormattedMessage {...messages.exploreGuidelines} /> ↗
               </Link>
             </div>
             <div className="relative isolate overflow-hidden rounded-xl p-4 sm:p-5">
               <SectionMeshBackground src={LAVENDER_MESH_GRADIENT_SRC} className="opacity-80" />
               <div className="relative rounded-xl border border-border bg-card p-6 text-card-foreground sm:p-8">
                 <div className="flex justify-between gap-3 border-b border-border pb-6 text-sm">
-                  <b>Campaign context</b>
-                  <span className="text-primary">Applied to this draft ✓</span>
+                  <b>
+                    <FormattedMessage {...messages.campaignContext} />
+                  </b>
+                  <span className="text-primary">
+                    <FormattedMessage {...messages.appliedToDraft} /> ✓
+                  </span>
                 </div>
-                {[
-                  ["Brand voice", "Clear. Human. Confident."],
-                  ["Terminology", "Keep “Daylight” in every language."],
-                  ["Market context", "France · Conversational, use “vous”."],
-                ].map(([label, value]) => (
+                {contextRows.map(([label, value]) => (
                   <div key={label} className="grid gap-2 pt-5 text-sm sm:grid-cols-[8rem_1fr]">
-                    <span className="text-muted-foreground">{label}</span>
-                    <span>{value}</span>
+                    <span className="text-muted-foreground">
+                      <FormattedMessage {...messages[label]} />
+                    </span>
+                    <span>
+                      <FormattedMessage {...messages[value]} />
+                    </span>
                   </div>
                 ))}
                 <div className="mt-6 flex gap-3 border-t border-border pt-5 text-xs text-muted-foreground">
@@ -692,7 +758,9 @@ export function MultilingualContentStudioPage() {
                   <span className="text-primary">FR</span>
                   <span>DE</span>
                   <span>JA</span>
-                  <span className="ml-auto hidden sm:block">One shared source of context</span>
+                  <span className="ms-auto hidden sm:block">
+                    <FormattedMessage {...messages.sharedContext} />
+                  </span>
                 </div>
               </div>
             </div>
@@ -705,40 +773,45 @@ export function MultilingualContentStudioPage() {
               <SectionMeshBackground src={ROSE_MESH_GRADIENT_SRC} className="opacity-75" />
               <div className="relative overflow-hidden rounded-lg border border-border bg-card">
                 <div className="flex justify-between bg-muted/60 p-5 text-sm">
-                  <b>Summer campaign</b>
-                  <span className="text-muted-foreground">Language review</span>
+                  <b>
+                    <FormattedMessage {...messages.summerCampaign} />
+                  </b>
+                  <span className="text-muted-foreground">
+                    <FormattedMessage {...messages.languageReview} />
+                  </span>
                 </div>
-                {[
-                  ["FR", "French", "Alex", "Approved", "bg-green-100 text-green-800"],
-                  ["DE", "German", "Jamie", "In review", "bg-blue-100 text-blue-800"],
-                  ["JA", "Japanese", "Minh", "Needs review", "bg-amber-100 text-amber-800"],
-                ].map(([code, language, reviewer, status, tone]) => (
+                {reviewRows.map((row) => (
                   <div
-                    key={code}
+                    key={row.code}
                     className="grid grid-cols-[2rem_1fr_auto] items-center gap-4 border-t border-border p-5 text-sm sm:grid-cols-[2rem_1fr_7rem_8rem_auto]"
                   >
-                    <span className="text-xs text-muted-foreground">{code}</span>
-                    <b>{language}</b>
-                    <span className="hidden text-muted-foreground sm:block">{reviewer}</span>
-                    <span className={`rounded-full px-3 py-1 text-xs ${tone}`}>{status}</span>
+                    <span className="text-xs text-muted-foreground">{row.code}</span>
+                    <b>
+                      <FormattedMessage {...messages[row.language]} />
+                    </b>
+                    <span className="hidden text-muted-foreground sm:block">{row.reviewer}</span>
+                    <span className={`rounded-full px-3 py-1 text-xs ${row.tone}`}>
+                      <FormattedMessage {...messages[row.status]} />
+                    </span>
                     <span>↗</span>
                   </div>
                 ))}
               </div>
             </div>
             <div>
-              <Eyebrow>Review and approval</Eyebrow>
+              <Eyebrow>
+                <FormattedMessage {...messages.reviewEyebrow} />
+              </Eyebrow>
               <h2 className="mt-5 font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
-                Your team has the final say.
+                <FormattedMessage {...messages.reviewHeadline} />
               </h2>
               <p className="mt-6 text-lg leading-8 text-muted-foreground">
-                Review AI drafts and translations side by side. Check for accuracy, make changes,
-                and approve content when it meets your standards.
+                <FormattedMessage {...messages.reviewBody} />
               </p>
               <p className="mt-5 text-sm leading-7 text-muted-foreground">
-                Compare side by side　·　Refine in context
+                <FormattedMessage {...messages.reviewCompare} />
                 <br />
-                Keep people in the review loop
+                <FormattedMessage {...messages.reviewLoop} />
               </p>
             </div>
           </div>
@@ -750,10 +823,10 @@ export function MultilingualContentStudioPage() {
           <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-center">
             <div>
               <h2 className="text-2xl font-medium tracking-tight">
-                A studio connected to the bigger picture.
+                <FormattedMessage {...messages.connectedHeadline} />
               </h2>
               <p className="mt-2 text-base text-muted-foreground">
-                Turn repeatable work into workflows. Take approved content to your markets.
+                <FormattedMessage {...messages.connectedBody} />
               </p>
             </div>
             <div className="flex flex-wrap gap-6">
@@ -761,13 +834,13 @@ export function MultilingualContentStudioPage() {
                 href={rewriteAppLocalePath("/product/agents-automation", locale)}
                 className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
               >
-                Automation Workflow ↗
+                <FormattedMessage {...messages.automationWorkflow} /> ↗
               </Link>
               <Link
                 href={rewriteAppLocalePath("/product/self-evolving-knowledge", locale)}
                 className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
               >
-                Guidelines ↗
+                <FormattedMessage {...messages.guidelines} /> ↗
               </Link>
             </div>
           </div>
@@ -775,15 +848,13 @@ export function MultilingualContentStudioPage() {
 
         <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
           <HomepageFaqSection
-            items={faqItems.map(([question, answer]) => ({ question, answer }))}
+            items={faqItems}
             heading={
-              <>
-                <span>A few things</span>
-                <br />
-                <span>you might ask.</span>
-              </>
+              <span className="whitespace-pre-line">
+                <FormattedMessage {...messages.faqHeading} />
+              </span>
             }
-            subheading="Getting to know Content Studio."
+            subheading={<FormattedMessage {...messages.faqSubheading} />}
           />
         </div>
 
@@ -796,13 +867,11 @@ export function MultilingualContentStudioPage() {
           >
             <div className="flex flex-col justify-between gap-10 bg-[#172541]/45 p-8 text-[#f8f0f5] sm:p-12 lg:flex-row lg:items-center lg:p-16">
               <div>
-                <h2 className="font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
-                  Your next story.
-                  <br />
-                  Ready for the world.
+                <h2 className="whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+                  <FormattedMessage {...messages.ctaHeadline} />
                 </h2>
                 <p className="mt-5 text-lg text-[#e5edf9]">
-                  Bring your content and your team into one studio.
+                  <FormattedMessage {...messages.ctaBody} />
                 </p>
               </div>
               <div className="flex flex-col items-start gap-3 lg:items-center">
@@ -812,9 +881,12 @@ export function MultilingualContentStudioPage() {
                   nativeButton={false}
                   render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
                 >
-                  Request a Demo <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+                  <FormattedMessage {...messages.requestDemo} />{" "}
+                  <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
                 </Button>
-                <span className="text-xs text-[#e5edf9]">Build your multilingual workflow.</span>
+                <span className="text-xs text-[#e5edf9]">
+                  <FormattedMessage {...messages.ctaNote} />
+                </span>
               </div>
             </div>
           </MeshStage>

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
@@ -50,6 +50,11 @@ export const productPageMessages = defineMessages({
     id: "gI9FpYYW4p",
     description: "Navigation label for the next-gen CAT tool product page",
   },
+  productNavContentStudio: {
+    defaultMessage: "Multilingual Content Studio",
+    id: "JNXXTToFFQ",
+    description: "Navigation label for the multilingual Content Studio product page",
+  },
   productNavSelfEvolvingKnowledge: {
     defaultMessage: "Self-evolving Knowledge",
     id: "Ktkp7Xxut2",
@@ -287,6 +292,33 @@ export const productPageMessages = defineMessages({
     defaultMessage: "Review Translations Without Guessing What the String Means | Hyperlocalise",
     id: "jeP5GjQn+Q",
     description: "Page title for the next-gen CAT tool product page",
+  },
+  contentStudioMetadataTitle: {
+    defaultMessage: "Multilingual Content Studio | Hyperlocalise",
+    id: "8GHZDPEhIo",
+    description: "Page title for the multilingual Content Studio product page",
+  },
+  contentStudioMetadataDescription: {
+    defaultMessage:
+      "Create and adapt text, documents, slides, images, and video in one multilingual workspace with shared context and human review.",
+    id: "yfyxggCpJF",
+    description: "Meta description for the multilingual Content Studio product page",
+  },
+  contentStudioHeroEyebrow: {
+    defaultMessage: "Multilingual Content Studio",
+    id: "d0ATgb33fq",
+    description: "Hero eyebrow for the multilingual Content Studio product page",
+  },
+  contentStudioHeroHeadline: {
+    defaultMessage: "One workspace. Every language.",
+    id: "/7ItNZTY2W",
+    description: "Hero headline for the multilingual Content Studio product page",
+  },
+  contentStudioHeroSubcopy: {
+    defaultMessage:
+      "Create and adapt text, documents, slides, images, and video. Keep your context, your voice, and your team together.",
+    id: "Y9uUKekkpa",
+    description: "Hero description for the multilingual Content Studio product page",
   },
   nextGenCatToolMetadataDescription: {
     defaultMessage:

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.ts
@@ -14,7 +14,10 @@ import type { ProductMessageKey } from "./product-page-content.messages";
 
 export type { ProductMessageKey } from "./product-page-content.messages";
 
-export type ProductPageSlug = "agents-automation" | "next-gen-cat-tool" | "self-evolving-knowledge";
+export type ProductPageSlug =
+  | "agents-automation"
+  | "multilingual-content-studio"
+  | "self-evolving-knowledge";
 
 export type ProductVisualKind = "automation" | "cat" | "knowledge";
 
@@ -89,27 +92,27 @@ export const productPages: ProductPageContent[] = [
       descriptionKey: "agentsAutomationCtaDescription",
     },
     related: [
-      { labelKey: "productNavNextGenCatTool", href: "/product/next-gen-cat-tool" },
+      { labelKey: "productNavContentStudio", href: "/product/multilingual-content-studio" },
       { labelKey: "productNavSelfEvolvingKnowledge", href: "/product/self-evolving-knowledge" },
     ],
   },
   {
-    slug: "next-gen-cat-tool",
+    slug: "multilingual-content-studio",
     metadata: {
-      titleKey: "nextGenCatToolMetadataTitle",
-      descriptionKey: "nextGenCatToolMetadataDescription",
+      titleKey: "contentStudioMetadataTitle",
+      descriptionKey: "contentStudioMetadataDescription",
       keywords: [
-        "next-gen CAT tool",
-        "AI assisted translation",
-        "human in the loop translation",
-        "localisation quality checks",
+        "multilingual content studio",
+        "multilingual content creation",
+        "AI content localisation",
+        "multilingual campaign workflow",
       ],
     },
     visualKind: "cat",
     hero: {
-      eyebrowKey: "nextGenCatToolHeroEyebrow",
-      headlineKey: "nextGenCatToolHeroHeadline",
-      subcopyKey: "nextGenCatToolHeroSubcopy",
+      eyebrowKey: "contentStudioHeroEyebrow",
+      headlineKey: "contentStudioHeroHeadline",
+      subcopyKey: "contentStudioHeroSubcopy",
     },
     detailsHeadlineKey: "nextGenCatToolDetailsHeadline",
     summaryKey: "nextGenCatToolSummary",
@@ -176,7 +179,7 @@ export const productPages: ProductPageContent[] = [
     },
     related: [
       { labelKey: "productNavAgentsAutomation", href: "/product/agents-automation" },
-      { labelKey: "productNavNextGenCatTool", href: "/product/next-gen-cat-tool" },
+      { labelKey: "productNavContentStudio", href: "/product/multilingual-content-studio" },
     ],
   },
 ];

--- a/docs/adr/2026-09-08-content-studio-web-publishing-design.md
+++ b/docs/adr/2026-09-08-content-studio-web-publishing-design.md
@@ -1,0 +1,19 @@
+# Content Studio web publishing section
+
+Add a marketing section after review and approval, before the connected workflows section. The user approved the copy and a webpage preview with a public URL, language selector, and Published status.
+
+## Copy
+
+Eyebrow: Publish to the web
+
+Heading: Turn your content into a live webpage.
+
+Body: Publish articles, guides, and landing pages directly from Content Studio. Manage your content and translations in one place, then share a link with your audience.
+
+## Presentation
+
+Use the existing typography and theme tokens in a full-width stacked section, with centered introductory copy above the preview. Center the preview caption as well. A native language selector includes all five supported app locales and Japanese, with the visitor's current app locale selected and listed first. Switching languages updates the article, example URL, date, reading time, and image description. The preview uses the existing seafoam mesh treatment, an author byline, and a credited NASA photo already in the repository. Clearly label this as a preview and use an example.com address. No publishing backend is involved.
+
+## Validation
+
+Run the web app's required `vp check --fix` and `vp test` commands. Check that the preview uses an accessible language selector, marks the article language, and fits narrow viewports.


### PR DESCRIPTION
## Summary
- Replace the next-gen CAT tool marketing page with a dedicated Multilingual Content Studio page, and permanently redirect `/product/next-gen-cat-tool` to the new slug.
- Update homepage product cards, llms.txt, and related product navigation so they point at Content Studio.
- Keep product route `params` behind a Suspense boundary so instant navigations stay valid, and include editor/mock-shell polish that landed with this work.

## Test plan
- [ ] Open `/en/product/multilingual-content-studio` and confirm the new page renders (hero, formats, mock studio, FAQ, footer).
- [ ] Visit `/en/product/next-gen-cat-tool` and confirm a 308 redirect to `/en/product/multilingual-content-studio`.
- [ ] Check sibling product routes (`/en/product/agents-automation`, `/en/product/self-evolving-knowledge`) still render and link to Content Studio.
- [ ] Confirm the homepage studio card goes to the new product page.
- [ ] Confirm `/llms.txt` lists Multilingual Content Studio instead of Next-gen CAT Tool.


Made with [Cursor](https://cursor.com)