### PR TITLE
feat(auth): add WorkOS AuthKit agent registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint
   WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
   NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
   WORKOS_COOKIE_PASSWORD=this-is-a-test-cookie-password-at-least-32-characters
+  # Optional. AuthKit host for agent registration (`/auth.md` rewrite + JWT issuer).
+  # WORKOS_AUTHKIT_DOMAIN=hyperlocalise.authkit.app
   AUTUMN_API_KEY=am_sk_test_placeholder
   # Optional. Slack Connect invites from the Hyperlocalise workspace (Overview banner).
   # SLACK_CONNECT_BOT_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,18 @@ go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint
 - Run `vp run db:migrate` after starting Postgres to apply Drizzle migrations.
 - The `make test` target uses coverage flags that may warn about a missing `covdata` tool — all actual tests still pass. Use `go test ./...` if you want a clean exit code without coverage.
 
+### WorkOS Agent Registration (dashboard)
+
+Enable Agent Registration on the WorkOS environment (account team if the feature is missing). Under **Authentication → Agents**:
+
+- Methods: **Service auth** on, **Anonymous** off.
+- Credential type: short-lived **access token** JWT.
+- Trusted (post-claim) permissions: the same PAT scopes as `/api/v1` (`files:read`, `files:write`, `jobs:read`, `jobs:write`) plus `mcp`.
+- Host `auth.md`: copy the AuthKit hostname into `WORKOS_AUTHKIT_DOMAIN` (no scheme). The app rewrites `/auth.md` to `https://$WORKOS_AUTHKIT_DOMAIN/agent/auth.md`.
+- OAuth well-known: protected resource is Hyperlocalise (`/api/v1`). Authorization server is AuthKit. Do not add AuthKit as the first authorization server on MCP protected-resource metadata.
+
+The local WorkOS emulator does not implement agent registration. Unit tests sign fixture JWTs. Live claim is verified against staging AuthKit.
+
 ### Web app dev server caveat
 
 The `withWorkflow` plugin in `next.config.ts` may crash `vp run dev` and `vp run build` with a `workflow-node-module-error` about `node:crypto` in `src/lib/agents/github/app.ts`. This does not affect `vp test` or `vp check`. If you only need to run tests or lint, proceed normally. CI builds pass because the workflow bundler behaves differently in that environment.

--- a/apps/hyperlocalise-web/.env.e2e.example
+++ b/apps/hyperlocalise-web/.env.e2e.example
@@ -18,4 +18,6 @@ WORKOS_WEBHOOK_SECRET=whsec_e2e_local
 
 E2E_BASE_URL=http://localhost:3000
 
+# Optional. AuthKit host for agent registration (`/auth.md` rewrite + JWT issuer).
+# WORKOS_AUTHKIT_DOMAIN=hyperlocalise.authkit.app
 AUTUMN_API_KEY=am_sk_test_placeholder

--- a/apps/hyperlocalise-web/next.config.ts
+++ b/apps/hyperlocalise-web/next.config.ts
@@ -28,6 +28,19 @@ const nextConfig: NextConfig = {
   experimental: {
     exposeTestingApiInProductionBuild: true,
   },
+  async rewrites() {
+    const authkitDomain = process.env.WORKOS_AUTHKIT_DOMAIN;
+    if (!authkitDomain) {
+      return [];
+    }
+
+    return [
+      {
+        source: "/auth.md",
+        destination: `https://${authkitDomain}/agent/auth.md`,
+      },
+    ];
+  },
   // View transitions work without config in Next.js 16.3+ (experimental.viewTransition removed).
   // Agent prompts load from src/agents/**/*.md at runtime via process.cwd() (see paths.ts).
   outputFileTracingIncludes: {

--- a/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
+++ b/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
@@ -63,6 +63,16 @@ full WorkOS identity model.
    role, team access, and capabilities. Do not accept WorkOS sealed sessions,
    `X-Hyperlocalise-Figma-Session`, or `Authorization: Bearer` as Figma
    integration auth. Do not mint a Figma-specific identity token.
+   9d. **WorkOS agent JWTs are an explicit alternate channel for MCP and
+   `/api/v1` only.** Agents register through AuthKit (`service_auth`), complete
+   the hosted claim ceremony, and present a short-lived access token as
+   `Authorization: Bearer`. The JWT must carry `act.sub` (claimed user) and
+   `org_id`. Access is the token `scope` ∩ the claimed user's live WorkOS
+   membership, role, team access, and capabilities. Tokens without a claim,
+   unknown users/orgs, and unauthoritative memberships fail closed. Do not
+   accept these JWTs on Figma, Crowdin embed, org-scoped session routes, or
+   native Mac session channels. Keep first-party MCP OAuth (`hl_mcp_*`) and
+   PATs (`x-api-key`) as separate channels.
 10. **Org slug must match an active membership.** Requested
     `organizationSlug` must resolve to a membership returned after the access
     gate; otherwise return `organization_access_denied` or picker/unresolvable

--- a/apps/hyperlocalise-web/src/api/auth/api-key.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key.ts
@@ -44,6 +44,15 @@ export function storedOrganizationApiKeyId(auth: ApiKeyAuthVariables["auth"]): s
   return auth.apiKey.kind === "pat" ? auth.apiKey.id : undefined;
 }
 
+/** Activity provenance for `/api/v1` jobs: PAT vs claimed WorkOS agent JWT. */
+export function publicApiActivityActor(auth: ApiKeyAuthVariables["auth"]) {
+  return {
+    actorCredentialId: auth.apiKey.id,
+    actorKind: auth.apiKey.kind === "agent" ? ("agent" as const) : ("api_key" as const),
+    actorUserId: auth.teamAccess.user.localUserId,
+  };
+}
+
 /** Shared 401 for unknown, revoked, and ownerless tokens. Do not distinguish them. */
 export const INVALID_OR_REVOKED_API_KEY_MESSAGE = "Invalid or revoked API key";
 

--- a/apps/hyperlocalise-web/src/api/auth/api-key.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key.ts
@@ -14,6 +14,7 @@ import { createHash } from "node:crypto";
 
 import { eq } from "drizzle-orm";
 import { createMiddleware } from "hono/factory";
+import type { Context } from "hono";
 import type { EvlogVariables } from "evlog/hono";
 
 import { resolveApiKeyTeamAccessContext } from "@/api/auth/api-key-access";
@@ -70,6 +71,73 @@ export function touchApiKeyLastUsedAt(apiKeyId: string) {
     .catch(() => {});
 }
 
+export async function authenticatePresentedApiKey(
+  c: Context<{ Variables: ApiKeyAuthVariables }>,
+  next: () => Promise<void>,
+  apiKey: string,
+) {
+  const keyHash = hashApiKey(apiKey);
+
+  const [keyRecord] = await db
+    .select({
+      id: schema.organizationApiKeys.id,
+      organizationId: schema.organizationApiKeys.organizationId,
+      keyPrefix: schema.organizationApiKeys.keyPrefix,
+      permissions: schema.organizationApiKeys.permissions,
+      createdByUserId: schema.organizationApiKeys.createdByUserId,
+      revokedAt: schema.organizationApiKeys.revokedAt,
+      lifecycleStatus: schema.organizations.lifecycleStatus,
+    })
+    .from(schema.organizationApiKeys)
+    .innerJoin(
+      schema.organizations,
+      eq(schema.organizationApiKeys.organizationId, schema.organizations.id),
+    )
+    .where(eq(schema.organizationApiKeys.keyHash, keyHash))
+    .limit(1);
+
+  // Unknown, revoked, and ownerless tokens share one 401 so callers cannot
+  // probe whether a secret hashes to a stored row.
+  if (!keyRecord || keyRecord.revokedAt || !keyRecord.createdByUserId) {
+    return unauthorizedResponse(c, "unauthorized", INVALID_OR_REVOKED_API_KEY_MESSAGE);
+  }
+
+  if (keyRecord.lifecycleStatus !== "active") {
+    return forbiddenResponse(c, "workspace_archived", "This workspace has been archived");
+  }
+
+  const teamAccess = await resolveApiKeyTeamAccessContext({
+    organizationId: keyRecord.organizationId,
+    createdByUserId: keyRecord.createdByUserId,
+  });
+
+  if (!teamAccess) {
+    return forbiddenResponse(
+      c,
+      "forbidden",
+      "API key creator is not authorized for this workspace",
+    );
+  }
+
+  // Telemetry only. Never block the request, and never write on a rejected
+  // credential — lastUsedAt is set only after authentication succeeds.
+  touchApiKeyLastUsedAt(keyRecord.id);
+
+  c.set("auth", {
+    organization: {
+      localOrganizationId: keyRecord.organizationId,
+    },
+    apiKey: {
+      id: keyRecord.id,
+      permissions: keyRecord.permissions,
+    },
+    teamAccess,
+  });
+  c.get("log").set(apiKeyAuthLogContext(keyRecord));
+
+  await next();
+}
+
 export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVariables }>(
   async (c, next) => {
     const apiKey = c.req.header("x-api-key");
@@ -78,66 +146,7 @@ export const apiKeyAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVari
       return unauthorizedResponse(c, "unauthorized", "API key is required");
     }
 
-    const keyHash = hashApiKey(apiKey);
-
-    const [keyRecord] = await db
-      .select({
-        id: schema.organizationApiKeys.id,
-        organizationId: schema.organizationApiKeys.organizationId,
-        keyPrefix: schema.organizationApiKeys.keyPrefix,
-        permissions: schema.organizationApiKeys.permissions,
-        createdByUserId: schema.organizationApiKeys.createdByUserId,
-        revokedAt: schema.organizationApiKeys.revokedAt,
-        lifecycleStatus: schema.organizations.lifecycleStatus,
-      })
-      .from(schema.organizationApiKeys)
-      .innerJoin(
-        schema.organizations,
-        eq(schema.organizationApiKeys.organizationId, schema.organizations.id),
-      )
-      .where(eq(schema.organizationApiKeys.keyHash, keyHash))
-      .limit(1);
-
-    // Unknown, revoked, and ownerless tokens share one 401 so callers cannot
-    // probe whether a secret hashes to a stored row.
-    if (!keyRecord || keyRecord.revokedAt || !keyRecord.createdByUserId) {
-      return unauthorizedResponse(c, "unauthorized", INVALID_OR_REVOKED_API_KEY_MESSAGE);
-    }
-
-    if (keyRecord.lifecycleStatus !== "active") {
-      return forbiddenResponse(c, "workspace_archived", "This workspace has been archived");
-    }
-
-    const teamAccess = await resolveApiKeyTeamAccessContext({
-      organizationId: keyRecord.organizationId,
-      createdByUserId: keyRecord.createdByUserId,
-    });
-
-    if (!teamAccess) {
-      return forbiddenResponse(
-        c,
-        "forbidden",
-        "API key creator is not authorized for this workspace",
-      );
-    }
-
-    // Telemetry only. Never block the request, and never write on a rejected
-    // credential — lastUsedAt is set only after authentication succeeds.
-    touchApiKeyLastUsedAt(keyRecord.id);
-
-    c.set("auth", {
-      organization: {
-        localOrganizationId: keyRecord.organizationId,
-      },
-      apiKey: {
-        id: keyRecord.id,
-        permissions: keyRecord.permissions,
-      },
-      teamAccess,
-    });
-    c.get("log").set(apiKeyAuthLogContext(keyRecord));
-
-    await next();
+    return authenticatePresentedApiKey(c, next, apiKey);
   },
 );
 

--- a/apps/hyperlocalise-web/src/api/auth/api-key.ts
+++ b/apps/hyperlocalise-web/src/api/auth/api-key.ts
@@ -23,6 +23,8 @@ import { ownerCanExerciseApiKeyPermission } from "@/api/routes/api-key/api-key.p
 import { forbiddenResponse, unauthorizedResponse } from "@/api/response.schema";
 import { db, schema } from "@/lib/database/client";
 
+export type PublicApiCredentialKind = "pat" | "agent";
+
 export type ApiKeyAuthVariables = EvlogVariables["Variables"] & {
   auth: {
     organization: {
@@ -31,10 +33,16 @@ export type ApiKeyAuthVariables = EvlogVariables["Variables"] & {
     apiKey: {
       id: string;
       permissions: string[];
+      kind: PublicApiCredentialKind;
     };
     teamAccess: ApiAuthContext;
   };
 };
+
+/** PAT ids are UUIDs stored on jobs/files. Agent registration ids are not. */
+export function storedOrganizationApiKeyId(auth: ApiKeyAuthVariables["auth"]): string | undefined {
+  return auth.apiKey.kind === "pat" ? auth.apiKey.id : undefined;
+}
 
 /** Shared 401 for unknown, revoked, and ownerless tokens. Do not distinguish them. */
 export const INVALID_OR_REVOKED_API_KEY_MESSAGE = "Invalid or revoked API key";
@@ -130,6 +138,7 @@ export async function authenticatePresentedApiKey(
     apiKey: {
       id: keyRecord.id,
       permissions: keyRecord.permissions,
+      kind: "pat",
     },
     teamAccess,
   });

--- a/apps/hyperlocalise-web/src/api/auth/mcp.ts
+++ b/apps/hyperlocalise-web/src/api/auth/mcp.ts
@@ -24,6 +24,7 @@ import { createMiddleware } from "hono/factory";
 import type { EvlogVariables } from "evlog/hono";
 
 import { forbiddenResponse } from "@/api/response.schema";
+import { authenticateMcpAgentBearer } from "@/api/auth/workos-agent";
 import {
   isMembershipReconcileFresh,
   reconcileWorkosMembershipsForUser,
@@ -32,6 +33,7 @@ import { db, schema } from "@/lib/database/client";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { env } from "@/lib/env";
 import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
+import { isCompactJwt } from "@/lib/workos/agent-access-token";
 
 export type McpAuthVariables = EvlogVariables["Variables"] & {
   mcpAuth: {
@@ -420,6 +422,34 @@ export const mcpBearerAuthMiddleware = createMiddleware<{ Variables: McpAuthVari
 
     if (!token) {
       return unauthorizedResponse();
+    }
+
+    if (isCompactJwt(token)) {
+      const agentAuth = await authenticateMcpAgentBearer(token);
+
+      if (agentAuth.status === "workspace_archived") {
+        return forbiddenResponse(c, "workspace_archived", "This workspace has been archived");
+      }
+
+      if (agentAuth.status === "forbidden") {
+        return forbiddenResponse(c, "forbidden", "Missing required permission: mcp");
+      }
+
+      if (agentAuth.status !== "authorized") {
+        return unauthorizedResponse();
+      }
+
+      c.set("mcpAuth", agentAuth.auth);
+      c.get("log").set({
+        auth: {
+          agentRegistrationId: agentAuth.auth.session.id,
+          localUserId: agentAuth.auth.user.localUserId,
+          localOrganizationId: agentAuth.auth.organization.localOrganizationId,
+        },
+      });
+
+      await next();
+      return;
     }
 
     const [session] = await db

--- a/apps/hyperlocalise-web/src/api/auth/workos-agent.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-agent.test.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { generateKeyPairSync } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import jwt from "jsonwebtoken";
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { ensureAiFeaturesAllowedMock, enqueueJobCreatedActivityMock } = vi.hoisted(() => ({
+  ensureAiFeaturesAllowedMock: vi.fn(),
+  enqueueJobCreatedActivityMock: vi.fn(),
+}));
+
+vi.mock("@/lib/billing/ai-features", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/billing/ai-features")>();
+  return {
+    ...actual,
+    ensureAiFeaturesAllowed: ensureAiFeaturesAllowedMock,
+  };
+});
+
+vi.mock("@/lib/activity-log/job-automation-events", () => ({
+  enqueueJobCreatedActivity: enqueueJobCreatedActivityMock,
+  enqueueJobFailedActivity: vi.fn(),
+}));
+
+const { reconcileWorkosMembershipsForUserMock } = vi.hoisted(() => ({
+  reconcileWorkosMembershipsForUserMock: vi.fn(),
+}));
+
+vi.mock("@/api/auth/workos-membership-reconcile", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-membership-reconcile")>();
+
+  return {
+    ...actual,
+    reconcileWorkosMembershipsForUser: reconcileWorkosMembershipsForUserMock,
+  };
+});
+
+import { createApp } from "@/api/app";
+import type { AppType } from "@/api/typed-app";
+import { createMcpTestApp } from "@/api/routes/mcp/mcp.fixture";
+import {
+  cleanupPublicApiFixture,
+  createPublicApiFixture,
+} from "@/api/routes/public-jobs/public-jobs.fixture";
+import { db, schema } from "@/lib/database/client";
+import { env } from "@/lib/env";
+import { ok } from "@/lib/primitives/result/results";
+import type { TranslationJobEventData } from "@/lib/workflow/types";
+import { setAgentAccessTokenPublicKeyResolverForTest } from "@/lib/workos/agent-access-token";
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+const enqueueJob = vi.fn(async (event: TranslationJobEventData) => ({
+  ids: [event.jobId],
+}));
+
+const client = testClient<AppType>(
+  createApp({
+    jobQueue: {
+      enqueue: enqueueJob,
+    },
+  }),
+);
+
+const mcpApp = createMcpTestApp();
+
+function signAgentToken(claims: Record<string, unknown>) {
+  return jwt.sign(claims, privateKey, {
+    algorithm: "RS256",
+    expiresIn: "5m",
+    keyid: "test-kid",
+  });
+}
+
+async function claimedAgentToken(input: {
+  organizationId: string;
+  workosUserId: string;
+  scope: string;
+  registrationId: string;
+}) {
+  const [organization] = await db
+    .select({ workosOrganizationId: schema.organizations.workosOrganizationId })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.id, input.organizationId))
+    .limit(1);
+
+  if (!organization) {
+    throw new Error("organization not found");
+  }
+
+  return signAgentToken({
+    iss: "https://authkit.test",
+    aud: env.WORKOS_CLIENT_ID,
+    sub: input.registrationId,
+    org_id: organization.workosOrganizationId,
+    scope: input.scope,
+    act: { sub: input.workosUserId },
+  });
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+beforeEach(() => {
+  reconcileWorkosMembershipsForUserMock.mockResolvedValue({ status: "skipped" });
+  ensureAiFeaturesAllowedMock.mockResolvedValue(ok(undefined));
+  setAgentAccessTokenPublicKeyResolverForTest(async () =>
+    publicKey.export({ type: "spki", format: "pem" }).toString(),
+  );
+});
+
+afterEach(async () => {
+  reconcileWorkosMembershipsForUserMock.mockClear();
+  enqueueJob.mockClear();
+  setAgentAccessTokenPublicKeyResolverForTest(null);
+  await cleanupPublicApiFixture();
+});
+
+describe("WorkOS agent JWT on /api/v1", () => {
+  it("accepts a claimed agent JWT and still accepts PATs", async () => {
+    const { apiKey, project, user } = await createPublicApiFixture({
+      permissions: ["jobs:read", "jobs:write"],
+    });
+
+    const claimedToken = await claimedAgentToken({
+      organizationId: project.organizationId,
+      workosUserId: user.workosUserId,
+      scope: "jobs:read jobs:write",
+      registrationId: "agent_reg_01API",
+    });
+
+    const jwtResponse = await client.api.v1.jobs.$post(
+      {
+        json: {
+          type: "string",
+          projectId: project.id,
+          stringInput: {
+            sourceText: "Hello",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      { headers: { Authorization: `Bearer ${claimedToken}` } },
+    );
+
+    expect(jwtResponse.status).toBe(201);
+
+    const patResponse = await client.api.v1.jobs.$post(
+      {
+        json: {
+          type: "string",
+          projectId: project.id,
+          stringInput: {
+            sourceText: "Hello",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(patResponse.status).toBe(201);
+  });
+
+  it("challenges missing credentials with public API resource metadata", async () => {
+    const response = await client.api.v1.jobs.$post({
+      json: {
+        type: "string",
+        projectId: "project_missing",
+        stringInput: {
+          sourceText: "Hello",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toContain(
+      "/.well-known/oauth-protected-resource/api/v1",
+    );
+  });
+
+  it("fails closed when the claimed membership is gone", async () => {
+    const { project, user } = await createPublicApiFixture();
+
+    await db
+      .delete(schema.organizationMemberships)
+      .where(eq(schema.organizationMemberships.userId, user.id));
+
+    const claimedToken = await claimedAgentToken({
+      organizationId: project.organizationId,
+      workosUserId: user.workosUserId,
+      scope: "jobs:write",
+      registrationId: "agent_reg_01GONE",
+    });
+
+    const response = await client.api.v1.jobs.$post(
+      {
+        json: {
+          type: "string",
+          projectId: project.id,
+          stringInput: {
+            sourceText: "Hello",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      { headers: { Authorization: `Bearer ${claimedToken}` } },
+    );
+
+    expect(response.status).toBe(403);
+  });
+});
+
+describe("WorkOS agent JWT on MCP", () => {
+  it("authorizes MCP when the token includes the mcp scope", async () => {
+    const { project, user } = await createPublicApiFixture();
+    const claimedToken = await claimedAgentToken({
+      organizationId: project.organizationId,
+      workosUserId: user.workosUserId,
+      scope: "mcp jobs:read",
+      registrationId: "agent_reg_01MCP",
+    });
+
+    const response = await mcpApp.request("http://localhost/mcp", {
+      headers: {
+        authorization: `Bearer ${claimedToken}`,
+      },
+    });
+
+    expect(response.status).not.toBe(401);
+    expect(response.status).not.toBe(403);
+  });
+
+  it("keeps the MCP resource_metadata challenge for opaque tokens", async () => {
+    const response = await mcpApp.request("http://localhost/mcp", {
+      headers: {
+        authorization: "Bearer hl_mcp_not_a_session",
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toBe(
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource", scope="mcp"',
+    );
+  });
+
+  it("rejects claimed JWTs that omit the mcp scope", async () => {
+    const { project, user } = await createPublicApiFixture();
+    const claimedToken = await claimedAgentToken({
+      organizationId: project.organizationId,
+      workosUserId: user.workosUserId,
+      scope: "jobs:read",
+      registrationId: "agent_reg_01NOMCP",
+    });
+
+    const response = await mcpApp.request("http://localhost/mcp", {
+      headers: {
+        authorization: `Bearer ${claimedToken}`,
+      },
+    });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/auth/workos-agent.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-agent.test.ts
@@ -230,6 +230,33 @@ describe("WorkOS agent JWT on /api/v1", () => {
 
     expect(response.status).toBe(403);
   });
+
+  it("does not grant job writes when the token only has files:read", async () => {
+    const { project, user } = await createPublicApiFixture();
+    const claimedToken = await claimedAgentToken({
+      organizationId: project.organizationId,
+      workosUserId: user.workosUserId,
+      scope: "files:read",
+      registrationId: "agent_reg_01SCOPE",
+    });
+
+    const response = await client.api.v1.jobs.$post(
+      {
+        json: {
+          type: "string",
+          projectId: project.id,
+          stringInput: {
+            sourceText: "Hello",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      { headers: { Authorization: `Bearer ${claimedToken}` } },
+    );
+
+    expect(response.status).toBe(403);
+  });
 });
 
 describe("WorkOS agent JWT on MCP", () => {

--- a/apps/hyperlocalise-web/src/api/auth/workos-agent.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-agent.test.ts
@@ -120,6 +120,7 @@ beforeAll(async () => {
 beforeEach(() => {
   reconcileWorkosMembershipsForUserMock.mockResolvedValue({ status: "skipped" });
   ensureAiFeaturesAllowedMock.mockResolvedValue(ok(undefined));
+  enqueueJobCreatedActivityMock.mockClear();
   setAgentAccessTokenPublicKeyResolverForTest(async () =>
     publicKey.export({ type: "spki", format: "pem" }).toString(),
   );
@@ -161,6 +162,14 @@ describe("WorkOS agent JWT on /api/v1", () => {
     );
 
     expect(jwtResponse.status).toBe(201);
+    expect(enqueueJobCreatedActivityMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorKind: "agent",
+        actorCredentialId: "agent_reg_01API",
+      }),
+    );
+
+    enqueueJobCreatedActivityMock.mockClear();
 
     const patResponse = await client.api.v1.jobs.$post(
       {
@@ -178,6 +187,11 @@ describe("WorkOS agent JWT on /api/v1", () => {
     );
 
     expect(patResponse.status).toBe(201);
+    expect(enqueueJobCreatedActivityMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorKind: "api_key",
+      }),
+    );
   });
 
   it("challenges missing credentials with public API resource metadata", async () => {

--- a/apps/hyperlocalise-web/src/api/auth/workos-agent.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-agent.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { eq } from "drizzle-orm";
+import { createMiddleware } from "hono/factory";
+
+import { resolveApiKeyTeamAccessContext } from "@/api/auth/api-key-access";
+import { authenticatePresentedApiKey, type ApiKeyAuthVariables } from "@/api/auth/api-key";
+import type { McpAuthVariables } from "@/api/auth/mcp";
+import { forbiddenResponse } from "@/api/response.schema";
+import { db, schema } from "@/lib/database/client";
+import { isErr } from "@/lib/primitives/result/results";
+import {
+  isCompactJwt,
+  MCP_AGENT_SCOPE,
+  publicApiWwwAuthenticate,
+  verifyWorkosAgentAccessToken,
+  type AgentAccessTokenClaims,
+} from "@/lib/workos/agent-access-token";
+
+export function agentAuthLogContext(input: {
+  registrationId: string;
+  localUserId: string;
+  localOrganizationId: string;
+}) {
+  return {
+    auth: {
+      agentRegistrationId: input.registrationId,
+      localOrganizationId: input.localOrganizationId,
+      localUserId: input.localUserId,
+    },
+  };
+}
+
+export async function resolveAgentAccessContext(claims: AgentAccessTokenClaims) {
+  const [user] = await db
+    .select({
+      id: schema.users.id,
+      workosUserId: schema.users.workosUserId,
+      email: schema.users.email,
+    })
+    .from(schema.users)
+    .where(eq(schema.users.workosUserId, claims.workosUserId))
+    .limit(1);
+
+  const [organization] = await db
+    .select({
+      id: schema.organizations.id,
+      workosOrganizationId: schema.organizations.workosOrganizationId,
+      name: schema.organizations.name,
+      slug: schema.organizations.slug,
+      lifecycleStatus: schema.organizations.lifecycleStatus,
+    })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.workosOrganizationId, claims.workosOrganizationId))
+    .limit(1);
+
+  if (!user || !organization) {
+    return { status: "unauthorized" as const };
+  }
+
+  if (organization.lifecycleStatus !== "active") {
+    return { status: "workspace_archived" as const };
+  }
+
+  const teamAccess = await resolveApiKeyTeamAccessContext({
+    organizationId: organization.id,
+    createdByUserId: user.id,
+  });
+
+  if (!teamAccess) {
+    return { status: "unauthorized" as const };
+  }
+
+  return {
+    status: "authorized" as const,
+    claims,
+    user,
+    organization,
+    teamAccess,
+  };
+}
+
+export const publicApiAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthVariables }>(
+  async (c, next) => {
+    const apiKey = c.req.header("x-api-key");
+    if (apiKey) {
+      return authenticatePresentedApiKey(c, next, apiKey);
+    }
+
+    const authorization = c.req.header("authorization");
+    const token = authorization?.startsWith("Bearer ")
+      ? authorization.slice("Bearer ".length)
+      : null;
+
+    if (!token || !isCompactJwt(token)) {
+      return c.json(
+        { error: "unauthorized", message: "Authentication required" },
+        401,
+        { "WWW-Authenticate": publicApiWwwAuthenticate(c.req.url) },
+      );
+    }
+
+    const verified = await verifyWorkosAgentAccessToken(token);
+    if (isErr(verified)) {
+      return c.json(
+        { error: "unauthorized", message: "Authentication required" },
+        401,
+        { "WWW-Authenticate": publicApiWwwAuthenticate(c.req.url) },
+      );
+    }
+
+    const resolved = await resolveAgentAccessContext(verified.value);
+    if (resolved.status === "workspace_archived") {
+      return forbiddenResponse(c, "workspace_archived", "This workspace has been archived");
+    }
+
+    if (resolved.status !== "authorized") {
+      return forbiddenResponse(
+        c,
+        "forbidden",
+        "Agent is not authorized for this workspace",
+      );
+    }
+
+    c.set("auth", {
+      organization: {
+        localOrganizationId: resolved.organization.id,
+      },
+      apiKey: {
+        id: resolved.claims.registrationId,
+        permissions: resolved.claims.scopes,
+      },
+      teamAccess: resolved.teamAccess,
+    });
+    c.get("log").set(
+      agentAuthLogContext({
+        registrationId: resolved.claims.registrationId,
+        localUserId: resolved.user.id,
+        localOrganizationId: resolved.organization.id,
+      }),
+    );
+
+    await next();
+  },
+);
+
+export async function authenticateMcpAgentBearer(
+  token: string,
+): Promise<
+  | { status: "authorized"; auth: McpAuthVariables["mcpAuth"] }
+  | { status: "unauthorized" }
+  | { status: "workspace_archived" }
+  | { status: "forbidden" }
+> {
+  if (!isCompactJwt(token)) {
+    return { status: "unauthorized" };
+  }
+
+  const verified = await verifyWorkosAgentAccessToken(token);
+  if (isErr(verified)) {
+    return { status: "unauthorized" };
+  }
+
+  if (!verified.value.scopes.includes(MCP_AGENT_SCOPE)) {
+    return { status: "forbidden" };
+  }
+
+  const resolved = await resolveAgentAccessContext(verified.value);
+  if (resolved.status !== "authorized") {
+    return resolved;
+  }
+
+  return {
+    status: "authorized",
+    auth: {
+      user: {
+        localUserId: resolved.user.id,
+        workosUserId: resolved.user.workosUserId,
+        email: resolved.user.email,
+      },
+      organization: {
+        localOrganizationId: resolved.organization.id,
+        workosOrganizationId: resolved.organization.workosOrganizationId,
+        name: resolved.organization.name,
+        slug: resolved.organization.slug,
+      },
+      membership: {
+        workosMembershipId: resolved.teamAccess.membership.workosMembershipId,
+        role: resolved.teamAccess.membership.role,
+      },
+      session: {
+        id: resolved.claims.registrationId,
+      },
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/api/auth/workos-agent.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-agent.ts
@@ -103,20 +103,16 @@ export const publicApiAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthV
       : null;
 
     if (!token || !isCompactJwt(token)) {
-      return c.json(
-        { error: "unauthorized", message: "Authentication required" },
-        401,
-        { "WWW-Authenticate": publicApiWwwAuthenticate(c.req.url) },
-      );
+      return c.json({ error: "unauthorized", message: "Authentication required" }, 401, {
+        "WWW-Authenticate": publicApiWwwAuthenticate(c.req.url),
+      });
     }
 
     const verified = await verifyWorkosAgentAccessToken(token);
     if (isErr(verified)) {
-      return c.json(
-        { error: "unauthorized", message: "Authentication required" },
-        401,
-        { "WWW-Authenticate": publicApiWwwAuthenticate(c.req.url) },
-      );
+      return c.json({ error: "unauthorized", message: "Authentication required" }, 401, {
+        "WWW-Authenticate": publicApiWwwAuthenticate(c.req.url),
+      });
     }
 
     const resolved = await resolveAgentAccessContext(verified.value);
@@ -125,11 +121,7 @@ export const publicApiAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthV
     }
 
     if (resolved.status !== "authorized") {
-      return forbiddenResponse(
-        c,
-        "forbidden",
-        "Agent is not authorized for this workspace",
-      );
+      return forbiddenResponse(c, "forbidden", "Agent is not authorized for this workspace");
     }
 
     c.set("auth", {
@@ -139,6 +131,7 @@ export const publicApiAuthMiddleware = createMiddleware<{ Variables: ApiKeyAuthV
       apiKey: {
         id: resolved.claims.registrationId,
         permissions: resolved.claims.scopes,
+        kind: "agent",
       },
       teamAccess: resolved.teamAccess,
     });
@@ -195,7 +188,7 @@ export async function authenticateMcpAgentBearer(
         slug: resolved.organization.slug,
       },
       membership: {
-        workosMembershipId: resolved.teamAccess.membership.workosMembershipId,
+        workosMembershipId: resolved.teamAccess.membership.workosMembershipId ?? null,
         role: resolved.teamAccess.membership.role,
       },
       session: {

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
@@ -14,12 +14,9 @@ import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 
+import { requireApiKeyPermission, type ApiKeyAuthVariables } from "@/api/auth/api-key";
 import { getAccessibleProjectForApiKey } from "@/api/auth/api-key-access";
-import {
-  apiKeyAuthMiddleware,
-  requireApiKeyPermission,
-  type ApiKeyAuthVariables,
-} from "@/api/auth/api-key";
+import { publicApiAuthMiddleware } from "@/api/auth/workos-agent";
 import { canAccessStoredFile } from "@/api/auth/team-access";
 import { db, schema } from "@/lib/database/client";
 import { getFileStorageAdapter } from "@/lib/file-storage/get-file-storage-adapter";
@@ -84,7 +81,7 @@ function sourceUploadErrorResponse(
 
 export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = {}) {
   return new Hono<{ Variables: ApiKeyAuthVariables }>()
-    .use("*", apiKeyAuthMiddleware)
+    .use("*", publicApiAuthMiddleware)
     .post(
       "/",
       requireApiKeyPermission("files:write"),

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
@@ -14,7 +14,11 @@ import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 
-import { requireApiKeyPermission, type ApiKeyAuthVariables } from "@/api/auth/api-key";
+import {
+  requireApiKeyPermission,
+  storedOrganizationApiKeyId,
+  type ApiKeyAuthVariables,
+} from "@/api/auth/api-key";
 import { getAccessibleProjectForApiKey } from "@/api/auth/api-key-access";
 import { publicApiAuthMiddleware } from "@/api/auth/workos-agent";
 import { canAccessStoredFile } from "@/api/auth/team-access";
@@ -142,7 +146,7 @@ export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = 
           format: parsed.data.format,
           branch: parsed.data.branch,
           uploadSurface: "public_api",
-          uploadedByApiKeyId: c.var.auth.apiKey.id,
+          uploadedByApiKeyId: storedOrganizationApiKeyId(c.var.auth),
           actorUserId: c.var.auth.teamAccess.user.localUserId,
           fileStorageAdapter: options.fileStorageAdapter,
         });

--- a/apps/hyperlocalise-web/src/api/routes/public-images/public-images.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-images/public-images.route.ts
@@ -15,12 +15,9 @@ import { Hono } from "hono";
 import path from "node:path";
 import { validator } from "hono/validator";
 
-import {
-  apiKeyAuthMiddleware,
-  requireApiKeyPermission,
-  type ApiKeyAuthVariables,
-} from "@/api/auth/api-key";
+import { requireApiKeyPermission, type ApiKeyAuthVariables } from "@/api/auth/api-key";
 import { getAccessibleProjectForApiKey } from "@/api/auth/api-key-access";
+import { publicApiAuthMiddleware } from "@/api/auth/workos-agent";
 import { db, schema } from "@/lib/database/client";
 import { getFileStorageAdapter } from "@/lib/file-storage/get-file-storage-adapter";
 import type { FileStorageAdapter } from "@/lib/file-storage/types";
@@ -126,7 +123,7 @@ async function loadProjectFileVariant(input: {
 
 export function createPublicImageRoutes(options: CreatePublicImageRoutesOptions = {}) {
   return new Hono<{ Variables: ApiKeyAuthVariables }>()
-    .use("*", apiKeyAuthMiddleware)
+    .use("*", publicApiAuthMiddleware)
     .get(
       "/:projectId/files/download",
       requireApiKeyPermission("files:read"),

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -18,6 +18,7 @@ import { bodyLimit } from "hono/body-limit";
 import { validator } from "hono/validator";
 
 import {
+  publicApiActivityActor,
   requireApiKeyPermission,
   storedOrganizationApiKeyId,
   type ApiKeyAuthVariables,
@@ -315,9 +316,7 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
         }
 
         await enqueueJobCreatedActivity({
-          actorCredentialId: c.var.auth.apiKey.id,
-          actorKind: "api_key",
-          actorUserId: c.var.auth.teamAccess.user.localUserId,
+          ...publicApiActivityActor(c.var.auth),
           jobId: job.id,
           kind: job.kind,
           organizationId,
@@ -344,9 +343,7 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
               .where(eq(schema.jobs.id, job.id));
 
             await enqueueJobFailedActivity({
-              actorCredentialId: c.var.auth.apiKey.id,
-              actorKind: "api_key",
-              actorUserId: c.var.auth.teamAccess.user.localUserId,
+              ...publicApiActivityActor(c.var.auth),
               errorCode: "queue_unavailable",
               jobId: job.id,
               kind: job.kind,

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -17,7 +17,11 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { validator } from "hono/validator";
 
-import { requireApiKeyPermission, type ApiKeyAuthVariables } from "@/api/auth/api-key";
+import {
+  requireApiKeyPermission,
+  storedOrganizationApiKeyId,
+  type ApiKeyAuthVariables,
+} from "@/api/auth/api-key";
 import { publicApiAuthMiddleware } from "@/api/auth/workos-agent";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { getAccessibleProjectIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
@@ -272,7 +276,7 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
                 kind: "translation",
                 status: "queued",
                 inputPayload,
-                apiKeyId: c.var.auth.apiKey.id,
+                apiKeyId: storedOrganizationApiKeyId(c.var.auth),
               })
               .returning();
 

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -17,11 +17,8 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { validator } from "hono/validator";
 
-import {
-  apiKeyAuthMiddleware,
-  requireApiKeyPermission,
-  type ApiKeyAuthVariables,
-} from "@/api/auth/api-key";
+import { requireApiKeyPermission, type ApiKeyAuthVariables } from "@/api/auth/api-key";
+import { publicApiAuthMiddleware } from "@/api/auth/workos-agent";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { getAccessibleProjectIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
 import { badRequestResponse } from "@/api/response.schema";
@@ -181,7 +178,7 @@ function buildAccessibleJobsWhereFromProjectScope(scope: ApiKeyProjectAccessScop
 
 export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}) {
   return new Hono<{ Variables: ApiKeyAuthVariables }>()
-    .use("*", apiKeyAuthMiddleware)
+    .use("*", publicApiAuthMiddleware)
     .post(
       "/",
       requireApiKeyPermission("jobs:write"),

--- a/apps/hyperlocalise-web/src/api/routes/public-translations/public-translations.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-translations/public-translations.route.ts
@@ -14,12 +14,9 @@ import { Hono } from "hono";
 import path from "node:path";
 import { validator } from "hono/validator";
 
-import {
-  apiKeyAuthMiddleware,
-  requireApiKeyPermission,
-  type ApiKeyAuthVariables,
-} from "@/api/auth/api-key";
+import { requireApiKeyPermission, type ApiKeyAuthVariables } from "@/api/auth/api-key";
 import { getAccessibleProjectForApiKey } from "@/api/auth/api-key-access";
+import { publicApiAuthMiddleware } from "@/api/auth/workos-agent";
 import {
   getRepositorySourceFileByPath,
   loadProjectTranslationsAsPrefilledEntries,
@@ -62,7 +59,7 @@ function downloadFilename(sourcePath: string, locale: string) {
 
 export function createPublicTranslationRoutes() {
   return new Hono<{ Variables: ApiKeyAuthVariables }>()
-    .use("*", apiKeyAuthMiddleware)
+    .use("*", publicApiAuthMiddleware)
     .get(
       "/:projectId/translations/download",
       requireApiKeyPermission("files:read"),

--- a/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/api/v1/route.test.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/api/v1/route.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { GET } from "./route";
+
+describe("public API OAuth protected resource metadata", () => {
+  it("points authorization_servers at AuthKit and leaves MCP metadata elsewhere", async () => {
+    const response = GET(
+      new Request("https://www.hyperlocalise.com/.well-known/oauth-protected-resource/api/v1"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      resource: "https://www.hyperlocalise.com/api/v1",
+      authorization_servers: ["https://authkit.test"],
+      scopes_supported: ["jobs:read", "jobs:write", "files:read", "files:write", "mcp"],
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/api/v1/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/api/v1/route.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { getPublicApiProtectedResourceMetadata } from "@/lib/workos/agent-access-token";
+import { getWorkosAuthkitIssuerUrl } from "@/lib/workos/config";
+
+export function GET(request: Request) {
+  if (!getWorkosAuthkitIssuerUrl()) {
+    return new Response(null, { status: 404 });
+  }
+
+  const origin = new URL(request.url).origin;
+  return Response.json(getPublicApiProtectedResourceMetadata(origin));
+}

--- a/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/api/v1/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/oauth-protected-resource/api/v1/route.ts
@@ -10,8 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { getPublicApiProtectedResourceMetadata } from "@/lib/workos/agent-access-token";
-import { getWorkosAuthkitIssuerUrl } from "@/lib/workos/config";
+import { getPublicApiProtectedResourceMetadata } from "../../../../../lib/workos/agent-access-token";
+import { getWorkosAuthkitIssuerUrl } from "../../../../../lib/workos/config";
 
 export function GET(request: Request) {
   if (!getWorkosAuthkitIssuerUrl()) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.messages.ts
@@ -67,12 +67,12 @@ export const overviewConnectAgentCardMessages = defineMessages({
   },
   authMdGuide: {
     defaultMessage: "Or follow {link} to register an agent with AuthKit.",
-    id: "k8nQ2pL0wR",
+    id: "JfG/xfnGBv",
     description: "Overview card link to the WorkOS agent registration skill document",
   },
   authMdLabel: {
     defaultMessage: "/auth.md",
-    id: "n3tR9vC4sM",
+    id: "bvPNfnGgVD",
     description: "Visible path for the agent registration skill document",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.messages.ts
@@ -65,4 +65,14 @@ export const overviewConnectAgentCardMessages = defineMessages({
     id: "V9ow5L2f7M",
     description: "Next step after copying the Hyperlocalise MCP config for Cursor",
   },
+  authMdGuide: {
+    defaultMessage: "Or follow {link} to register an agent with AuthKit.",
+    id: "k8nQ2pL0wR",
+    description: "Overview card link to the WorkOS agent registration skill document",
+  },
+  authMdLabel: {
+    defaultMessage: "/auth.md",
+    id: "n3tR9vC4sM",
+    description: "Visible path for the agent registration skill document",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.stories.tsx
@@ -22,6 +22,7 @@ const meta = {
   component: OverviewConnectAgentCard,
   args: {
     mcpUrl,
+    showAuthMdRegistration: true,
   },
   parameters: {
     layout: "padded",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.test.tsx
@@ -63,6 +63,10 @@ describe("OverviewConnectAgentCard", () => {
     expect(
       screen.getByText("Add this to ~/.cursor/mcp.json, then open Settings → MCP and click Login."),
     ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "/auth.md" })).toHaveAttribute(
+      "href",
+      expect.stringMatching(/\/auth\.md$/),
+    );
   });
 
   it("copies the selected install snippet", async () => {
@@ -93,5 +97,6 @@ describe("OverviewConnectAgentCard", () => {
       screen.queryByText("Access your Hyperlocalise workspace from MCP clients."),
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Then run")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "/auth.md" })).not.toBeInTheDocument();
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.test.tsx
@@ -23,11 +23,11 @@ import { OverviewConnectAgentCard } from "./overview-connect-agent-card";
 
 const mcpUrl = "https://www.hyperlocalise.com/mcp";
 
-function renderCard() {
+function renderCard(showAuthMdRegistration = true) {
   return render(
     <IntlProvider locale="en" messages={{}}>
       <TooltipProvider>
-        <OverviewConnectAgentCard mcpUrl={mcpUrl} />
+        <OverviewConnectAgentCard mcpUrl={mcpUrl} showAuthMdRegistration={showAuthMdRegistration} />
       </TooltipProvider>
     </IntlProvider>,
   );
@@ -67,6 +67,12 @@ describe("OverviewConnectAgentCard", () => {
       "href",
       expect.stringMatching(/\/auth\.md$/),
     );
+  });
+
+  it("hides the AuthKit registration link until it is enabled", () => {
+    renderCard(false);
+
+    expect(screen.queryByRole("link", { name: "/auth.md" })).not.toBeInTheDocument();
   });
 
   it("copies the selected install snippet", async () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.tsx
@@ -133,6 +133,7 @@ export function OverviewConnectAgentCard({
   const intl = useIntl();
   const origin = useBrowserOrigin();
   const mcpUrl = mcpUrlProp ?? (origin ? buildHyperlocaliseMcpUrl(origin) : "");
+  const authMdUrl = origin ? new URL("/auth.md", origin).toString() : "/auth.md";
   const [client, setClient] = useState<McpAgentClient>("claude");
   const snippet = mcpUrl ? buildMcpAgentSnippet(client, mcpUrl) : "";
   const clientLabel = intl.formatMessage(
@@ -224,6 +225,24 @@ export function OverviewConnectAgentCard({
         {compact ? null : (
           <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <ClientNextStep client={client} />
+          </TypographyP>
+        )}
+
+        {compact ? null : (
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
+            <FormattedMessage
+              {...messages.authMdGuide}
+              values={{
+                link: (
+                  <a
+                    className="font-medium text-primary underline-offset-4 hover:underline"
+                    href={authMdUrl}
+                  >
+                    <FormattedMessage {...messages.authMdLabel} />
+                  </a>
+                ),
+              }}
+            />
           </TypographyP>
         )}
       </CardContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-connect-agent-card.tsx
@@ -125,10 +125,12 @@ export function OverviewConnectAgentCard({
   mcpUrl: mcpUrlProp,
   className,
   compact = false,
+  showAuthMdRegistration = false,
 }: {
   mcpUrl?: string;
   className?: string;
   compact?: boolean;
+  showAuthMdRegistration?: boolean;
 }) {
   const intl = useIntl();
   const origin = useBrowserOrigin();
@@ -228,7 +230,7 @@ export function OverviewConnectAgentCard({
           </TypographyP>
         )}
 
-        {compact ? null : (
+        {compact || !showAuthMdRegistration ? null : (
           <TypographyP wrapStyle="pretty" size="small" tone="subtle">
             <FormattedMessage
               {...messages.authMdGuide}

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
@@ -39,6 +39,9 @@ describe("llms.txt route", () => {
     );
     expect(body).toContain("https://www.hyperlocalise.com/en/use-cases/");
     expect(body).toContain("https://hyperlocalise.dev");
+    expect(body).toContain("## Agents");
+    expect(body).toContain("[Agent registration](https://www.hyperlocalise.com/auth.md)");
+    expect(body).toContain("register a coding agent with AuthKit");
     expect(body).toContain(
       "[Contact](https://www.hyperlocalise.com/en/contact): Reach the Hyperlocalise team.",
     );

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
@@ -10,11 +10,25 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { getWorkosAuthkitIssuerUrl } from "@/lib/workos/config";
 
 import { GET } from "./route";
 
+vi.mock("@/lib/workos/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/workos/config")>();
+  return {
+    ...actual,
+    getWorkosAuthkitIssuerUrl: vi.fn(),
+  };
+});
+
 describe("llms.txt route", () => {
+  beforeEach(() => {
+    vi.mocked(getWorkosAuthkitIssuerUrl).mockReturnValue("https://authkit.test");
+  });
+
   it("returns a spec-shaped markdown index for agents", async () => {
     const response = GET();
     const body = await response.text();
@@ -47,5 +61,15 @@ describe("llms.txt route", () => {
     );
     expect(body).not.toContain("github.com/hyperlocalise");
     expect(body).not.toContain("mailto:minh@hyperlocalise.com");
+  });
+
+  it("omits AuthKit registration when the AuthKit domain is unset", async () => {
+    vi.mocked(getWorkosAuthkitIssuerUrl).mockReturnValue(null);
+
+    const body = await GET().text();
+
+    expect(body).not.toContain("## Agents");
+    expect(body).not.toContain("/auth.md");
+    expect(body).toContain("## Product");
   });
 });

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.ts
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import { SITE_URL } from "@/lib/seo/site-url";
+import { getWorkosAuthkitIssuerUrl } from "@/lib/workos/config";
 
 type LlmsLink = {
   title: string;
@@ -73,6 +74,18 @@ function formatLinks(links: LlmsLink[]): string {
   return links.map((link) => `- [${link.title}](${link.href}): ${link.description}.`).join("\n");
 }
 
+function agentRegistrationSection(): string {
+  if (!getWorkosAuthkitIssuerUrl()) {
+    return "";
+  }
+
+  return `## Agents
+
+- [Agent registration](${SITE_URL}/auth.md): Follow this skill to register a coding agent with AuthKit, complete the hosted claim, and use the JWT on MCP and /api/v1.
+
+`;
+}
+
 function buildLlmsTxt(): string {
   return `# Hyperlocalise
 
@@ -84,11 +97,7 @@ The product experience is designed for localisation managers who need control wi
 
 Use the pages below as the canonical overview of Hyperlocalise. Prefer these curated links over crawling the full site.
 
-## Agents
-
-- [Agent registration](${SITE_URL}/auth.md): Follow this skill to register a coding agent with AuthKit, complete the hosted claim, and use the JWT on MCP and /api/v1.
-
-## Product
+${agentRegistrationSection()}## Product
 
 ${formatLinks(productLinks)}
 

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.ts
@@ -84,6 +84,10 @@ The product experience is designed for localisation managers who need control wi
 
 Use the pages below as the canonical overview of Hyperlocalise. Prefer these curated links over crawling the full site.
 
+## Agents
+
+- [Agent registration](${SITE_URL}/auth.md): Follow this skill to register a coding agent with AuthKit, complete the hosted claim, and use the JWT on MCP and /api/v1.
+
 ## Product
 
 ${formatLinks(productLinks)}

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -94,6 +94,16 @@ export const env = createEnv({
     /** Optional WorkOS API port override (e.g. `4100` for workos-emulate). */
     WORKOS_API_PORT: z.coerce.number().int().positive().optional(),
 
+    /**
+     * AuthKit domain for agent registration (host only, no scheme).
+     * Used to reverse-proxy `/auth.md` and to verify agent access-token JWTs.
+     * Example: `hyperlocalise.authkit.app`
+     */
+    WORKOS_AUTHKIT_DOMAIN: z
+      .string()
+      .regex(/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/i, "AuthKit domain must be a hostname")
+      .optional(),
+
     /** Secret used by Flags SDK for toolbar overrides and encrypted flag values. */
     FLAGS_SECRET: z.string().min(32).optional(),
 
@@ -314,6 +324,8 @@ export const env = createEnv({
     WORKOS_API_HOSTNAME: process.env.WORKOS_API_HOSTNAME,
     WORKOS_API_HTTPS: process.env.WORKOS_API_HTTPS as "true" | "false" | undefined,
     WORKOS_API_PORT: process.env.WORKOS_API_PORT,
+    WORKOS_AUTHKIT_DOMAIN:
+      process.env.WORKOS_AUTHKIT_DOMAIN ?? (isTestEnv ? "authkit.test" : undefined),
     FLAGS_SECRET:
       process.env.FLAGS_SECRET ??
       (isTestEnv ? "test-flags-secret-at-least-32-characters-long" : undefined),

--- a/apps/hyperlocalise-web/src/lib/workos/IDENTITY.md
+++ b/apps/hyperlocalise-web/src/lib/workos/IDENTITY.md
@@ -58,6 +58,24 @@ It runs:
 
 `users.workos_memberships_reconciled_at` records the last successful reconcile. If WorkOS lookup fails and the timestamp is older than five minutes, access is denied instead of trusting stale local membership rows.
 
+## Agent registration
+
+AuthKit Agent Registration is a third credential channel for MCP and `/api/v1`.
+Agents discover AuthKit through `/auth.md` (reverse-proxied from the AuthKit
+domain in `WORKOS_AUTHKIT_DOMAIN`). After a hosted `service_auth` claim, they
+exchange an identity assertion for a JWT. Hyperlocalise verifies the JWT locally
+(`iss` = AuthKit issuer, `aud` = client id or public resource URI), maps
+`act.sub` and `org_id` to local user/org rows, then applies the same live
+membership gate as personal access tokens.
+
+Do not enable anonymous registration. MCP OAuth metadata continues to list
+Hyperlocalise as the first authorization server. The public API advertises
+AuthKit at `/.well-known/oauth-protected-resource/api/v1`.
+
+Dashboard: Authentication → Agents — service auth on, anonymous off, access
+token credentials, trusted permissions matching PAT scopes plus `mcp`. See
+[`docs/adr/2026-09-08-workos-agent-registration-design.md`](../../../../docs/adr/2026-09-08-workos-agent-registration-design.md).
+
 ## Placeholder users
 
 Invited users who have not signed in use `users.workos_user_id` values prefixed with `invited_user_`. They may have pending local membership rows for member management UI, but they never receive `workos_authoritative` access until WorkOS confirms membership and the placeholder id is promoted on `user.created`.

--- a/apps/hyperlocalise-web/src/lib/workos/agent-access-token.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/agent-access-token.test.ts
@@ -57,7 +57,9 @@ describe("agent access tokens", () => {
   });
 
   it("accepts a claimed token signed for the AuthKit issuer", async () => {
-    setAgentAccessTokenPublicKeyResolverForTest(async () => publicKey.export({ type: "spki", format: "pem" }).toString());
+    setAgentAccessTokenPublicKeyResolverForTest(async () =>
+      publicKey.export({ type: "spki", format: "pem" }).toString(),
+    );
 
     const token = signAgentToken({
       iss: "https://authkit.test",
@@ -81,9 +83,11 @@ describe("agent access tokens", () => {
   });
 
   it("rejects expired tokens, wrong audiences, and unclaimed tokens", async () => {
-    setAgentAccessTokenPublicKeyResolverForTest(async () => publicKey.export({ type: "spki", format: "pem" }).toString());
+    setAgentAccessTokenPublicKeyResolverForTest(async () =>
+      publicKey.export({ type: "spki", format: "pem" }).toString(),
+    );
 
-    const expired = signAgentToken(
+    const expired = jwt.sign(
       {
         iss: "https://authkit.test",
         aud: env.WORKOS_CLIENT_ID,
@@ -94,7 +98,11 @@ describe("agent access tokens", () => {
         iat: Math.floor(Date.now() / 1000) - 120,
         exp: Math.floor(Date.now() / 1000) - 60,
       },
-      undefined,
+      privateKey,
+      {
+        algorithm: "RS256",
+        keyid: "test-kid",
+      },
     );
     expect(isErr(await verifyWorkosAgentAccessToken(expired))).toBe(true);
 
@@ -116,5 +124,26 @@ describe("agent access tokens", () => {
       scope: "mcp",
     });
     expect(isErr(await verifyWorkosAgentAccessToken(unclaimed))).toBe(true);
+  });
+
+  it("keeps only recognized PAT and mcp scopes from the token", async () => {
+    setAgentAccessTokenPublicKeyResolverForTest(async () =>
+      publicKey.export({ type: "spki", format: "pem" }).toString(),
+    );
+
+    const token = signAgentToken({
+      iss: "https://authkit.test",
+      aud: env.WORKOS_CLIENT_ID,
+      sub: "agent_reg_01TEST",
+      org_id: "org_claimed",
+      scope: "mcp jobs:read anonymous unknown:scope",
+      act: { sub: "user_claimed" },
+    });
+
+    const result = await verifyWorkosAgentAccessToken(token);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value.scopes).toEqual(["mcp", "jobs:read"]);
+    }
   });
 });

--- a/apps/hyperlocalise-web/src/lib/workos/agent-access-token.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/agent-access-token.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { generateKeyPairSync } from "node:crypto";
+
+import jwt from "jsonwebtoken";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { env } from "@/lib/env";
+import { isErr, isOk } from "@/lib/primitives/result/results";
+import {
+  getPublicApiProtectedResourceMetadata,
+  isCompactJwt,
+  setAgentAccessTokenPublicKeyResolverForTest,
+  verifyWorkosAgentAccessToken,
+} from "@/lib/workos/agent-access-token";
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+function signAgentToken(
+  claims: Record<string, unknown>,
+  expiresIn: jwt.SignOptions["expiresIn"] | undefined = "5m",
+) {
+  return jwt.sign(claims, privateKey, {
+    algorithm: "RS256",
+    keyid: "test-kid",
+    ...(expiresIn ? { expiresIn } : {}),
+  });
+}
+
+describe("agent access tokens", () => {
+  afterEach(() => {
+    setAgentAccessTokenPublicKeyResolverForTest(null);
+  });
+
+  it("detects compact JWTs and rejects opaque tokens", () => {
+    expect(isCompactJwt("aaa.bbb.ccc")).toBe(true);
+    expect(isCompactJwt("hl_mcp_opaque")).toBe(false);
+    expect(isCompactJwt("a.b")).toBe(false);
+  });
+
+  it("advertises AuthKit as the public API authorization server", () => {
+    expect(getPublicApiProtectedResourceMetadata("https://www.hyperlocalise.com")).toMatchObject({
+      resource: "https://www.hyperlocalise.com/api/v1",
+      authorization_servers: ["https://authkit.test"],
+      scopes_supported: ["jobs:read", "jobs:write", "files:read", "files:write", "mcp"],
+    });
+  });
+
+  it("accepts a claimed token signed for the AuthKit issuer", async () => {
+    setAgentAccessTokenPublicKeyResolverForTest(async () => publicKey.export({ type: "spki", format: "pem" }).toString());
+
+    const token = signAgentToken({
+      iss: "https://authkit.test",
+      aud: env.WORKOS_CLIENT_ID,
+      sub: "agent_reg_01TEST",
+      org_id: "org_claimed",
+      scope: "mcp jobs:read",
+      act: { sub: "user_claimed" },
+    });
+
+    const result = await verifyWorkosAgentAccessToken(token);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value).toEqual({
+        registrationId: "agent_reg_01TEST",
+        workosUserId: "user_claimed",
+        workosOrganizationId: "org_claimed",
+        scopes: ["mcp", "jobs:read"],
+      });
+    }
+  });
+
+  it("rejects expired tokens, wrong audiences, and unclaimed tokens", async () => {
+    setAgentAccessTokenPublicKeyResolverForTest(async () => publicKey.export({ type: "spki", format: "pem" }).toString());
+
+    const expired = signAgentToken(
+      {
+        iss: "https://authkit.test",
+        aud: env.WORKOS_CLIENT_ID,
+        sub: "agent_reg_01TEST",
+        org_id: "org_claimed",
+        scope: "mcp",
+        act: { sub: "user_claimed" },
+        iat: Math.floor(Date.now() / 1000) - 120,
+        exp: Math.floor(Date.now() / 1000) - 60,
+      },
+      undefined,
+    );
+    expect(isErr(await verifyWorkosAgentAccessToken(expired))).toBe(true);
+
+    const wrongAud = signAgentToken({
+      iss: "https://authkit.test",
+      aud: "client_other",
+      sub: "agent_reg_01TEST",
+      org_id: "org_claimed",
+      scope: "mcp",
+      act: { sub: "user_claimed" },
+    });
+    expect(isErr(await verifyWorkosAgentAccessToken(wrongAud))).toBe(true);
+
+    const unclaimed = signAgentToken({
+      iss: "https://authkit.test",
+      aud: env.WORKOS_CLIENT_ID,
+      sub: "agent_reg_01TEST",
+      org_id: "org_claimed",
+      scope: "mcp",
+    });
+    expect(isErr(await verifyWorkosAgentAccessToken(unclaimed))).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/workos/agent-access-token.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/agent-access-token.ts
@@ -122,6 +122,15 @@ async function resolvePublicKey(kid: string, issuer: string): Promise<string> {
   return signingKey.getPublicKey();
 }
 
+function audienceMatches(aud: jwt.JwtPayload["aud"], allowed: string[]): boolean {
+  if (!aud) {
+    return false;
+  }
+
+  const values = Array.isArray(aud) ? aud : [aud];
+  return values.some((value) => allowed.includes(value));
+}
+
 export async function verifyWorkosAgentAccessToken(
   token: string,
 ): Promise<Result<AgentAccessTokenClaims, AgentAccessTokenError>> {
@@ -143,17 +152,22 @@ export async function verifyWorkosAgentAccessToken(
     const payload = jwt.verify(token, publicKey, {
       algorithms: ["RS256"],
       issuer,
-      audience: audiences,
     });
 
     if (typeof payload !== "object" || payload === null) {
       return err({ code: "invalid_agent_access_token" });
     }
 
-    const registrationId = typeof payload.sub === "string" ? payload.sub : null;
-    const workosOrganizationId = typeof payload.org_id === "string" ? payload.org_id : null;
-    const workosUserId = parseActSubject(payload.act);
-    const scopes = parseScope(payload.scope);
+    const claims = payload as jwt.JwtPayload & { org_id?: unknown; act?: unknown };
+    if (!audienceMatches(claims.aud, audiences)) {
+      return err({ code: "invalid_agent_access_token" });
+    }
+
+    const registrationId = typeof claims.sub === "string" ? claims.sub : null;
+    const workosOrganizationId = typeof claims.org_id === "string" ? claims.org_id : null;
+    const workosUserId = parseActSubject(claims.act);
+    const allowedScopes = new Set<string>(AGENT_ACCESS_SCOPES);
+    const scopes = parseScope(claims.scope).filter((scope) => allowedScopes.has(scope));
 
     if (!registrationId || !workosOrganizationId || !workosUserId) {
       return err({ code: "invalid_agent_access_token" });

--- a/apps/hyperlocalise-web/src/lib/workos/agent-access-token.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/agent-access-token.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import jwt from "jsonwebtoken";
+import jwksClient from "jwks-rsa";
+
+import { defaultApiKeyPermissions } from "@/api/routes/api-key/api-key.schema";
+import { env } from "@/lib/env";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+import { getWorkosAuthkitIssuerUrl } from "@/lib/workos/config";
+
+export const MCP_AGENT_SCOPE = "mcp";
+
+export const AGENT_ACCESS_SCOPES = [...defaultApiKeyPermissions, MCP_AGENT_SCOPE] as const;
+
+export const PUBLIC_API_PROTECTED_RESOURCE_PATH = "/.well-known/oauth-protected-resource/api/v1";
+
+export type AgentAccessTokenClaims = {
+  registrationId: string;
+  workosUserId: string;
+  workosOrganizationId: string;
+  scopes: string[];
+};
+
+export type AgentAccessTokenError = { code: "invalid_agent_access_token" };
+
+type PublicKeyResolver = (kid: string) => Promise<string>;
+
+const JWKS_CACHE_MS = 10 * 60 * 1000;
+
+const jwksClients = new Map<string, ReturnType<typeof jwksClient>>();
+let publicKeyResolverForTest: PublicKeyResolver | null = null;
+
+export function isCompactJwt(token: string): boolean {
+  const parts = token.split(".");
+  return parts.length === 3 && parts.every((part) => part.length > 0);
+}
+
+export function setAgentAccessTokenPublicKeyResolverForTest(resolver: PublicKeyResolver | null) {
+  publicKeyResolverForTest = resolver;
+}
+
+export function getPublicApiProtectedResourceMetadata(origin: string) {
+  const authorizationServer = getWorkosAuthkitIssuerUrl();
+
+  return {
+    resource: `${origin}/api/v1`,
+    authorization_servers: authorizationServer ? [authorizationServer] : [],
+    scopes_supported: [...AGENT_ACCESS_SCOPES],
+    bearer_methods_supported: ["header"],
+  };
+}
+
+export function publicApiWwwAuthenticate(requestUrl: string): string {
+  const resourceMetadataUrl = new URL(PUBLIC_API_PROTECTED_RESOURCE_PATH, requestUrl);
+  return `Bearer resource_metadata="${resourceMetadataUrl.toString()}"`;
+}
+
+function parseAudiences(): string[] {
+  const audiences = new Set<string>();
+  if (env.WORKOS_CLIENT_ID) {
+    audiences.add(env.WORKOS_CLIENT_ID);
+  }
+
+  const publicAppUrl = env.HYPERLOCALISE_PUBLIC_APP_URL;
+  if (publicAppUrl) {
+    audiences.add(new URL("/api/v1", publicAppUrl).toString().replace(/\/$/, ""));
+    audiences.add(new URL("/mcp", publicAppUrl).toString().replace(/\/$/, ""));
+  }
+
+  return [...audiences];
+}
+
+function parseScope(scope: unknown): string[] {
+  if (typeof scope !== "string") {
+    return [];
+  }
+
+  return scope
+    .split(/\s+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function parseActSubject(act: unknown): string | null {
+  if (!act || typeof act !== "object" || !("sub" in act)) {
+    return null;
+  }
+
+  return typeof act.sub === "string" && act.sub.length > 0 ? act.sub : null;
+}
+
+function getJwksClientForIssuer(issuer: string) {
+  let client = jwksClients.get(issuer);
+  if (!client) {
+    client = jwksClient({
+      jwksUri: `${issuer}/.well-known/jwks.json`,
+      cache: true,
+      cacheMaxAge: JWKS_CACHE_MS,
+      rateLimit: true,
+    });
+    jwksClients.set(issuer, client);
+  }
+  return client;
+}
+
+async function resolvePublicKey(kid: string, issuer: string): Promise<string> {
+  if (publicKeyResolverForTest) {
+    return publicKeyResolverForTest(kid);
+  }
+
+  const signingKey = await getJwksClientForIssuer(issuer).getSigningKey(kid);
+  return signingKey.getPublicKey();
+}
+
+export async function verifyWorkosAgentAccessToken(
+  token: string,
+): Promise<Result<AgentAccessTokenClaims, AgentAccessTokenError>> {
+  const issuer = getWorkosAuthkitIssuerUrl();
+  const audiences = parseAudiences();
+
+  if (!issuer || audiences.length === 0 || !isCompactJwt(token)) {
+    return err({ code: "invalid_agent_access_token" });
+  }
+
+  try {
+    const decodedHeader = jwt.decode(token, { complete: true });
+    const keyId = decodedHeader?.header.kid;
+    if (!keyId) {
+      return err({ code: "invalid_agent_access_token" });
+    }
+
+    const publicKey = await resolvePublicKey(keyId, issuer);
+    const payload = jwt.verify(token, publicKey, {
+      algorithms: ["RS256"],
+      issuer,
+      audience: audiences,
+    });
+
+    if (typeof payload !== "object" || payload === null) {
+      return err({ code: "invalid_agent_access_token" });
+    }
+
+    const registrationId = typeof payload.sub === "string" ? payload.sub : null;
+    const workosOrganizationId = typeof payload.org_id === "string" ? payload.org_id : null;
+    const workosUserId = parseActSubject(payload.act);
+    const scopes = parseScope(payload.scope);
+
+    if (!registrationId || !workosOrganizationId || !workosUserId) {
+      return err({ code: "invalid_agent_access_token" });
+    }
+
+    return ok({
+      registrationId,
+      workosUserId,
+      workosOrganizationId,
+      scopes,
+    });
+  } catch {
+    return err({ code: "invalid_agent_access_token" });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/workos/config.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/config.ts
@@ -40,3 +40,13 @@ export function getWorkosAuthKitConfig(): WorkosAuthKitConfig | null {
     ...hostOptions,
   };
 }
+
+/** AuthKit host used for agent registration discovery and JWT issuer checks. */
+export function getWorkosAuthkitDomain(): string | null {
+  return env.WORKOS_AUTHKIT_DOMAIN ?? null;
+}
+
+export function getWorkosAuthkitIssuerUrl(): string | null {
+  const domain = getWorkosAuthkitDomain();
+  return domain ? `https://${domain}` : null;
+}

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { buildCrowdinAppFrameAncestorsCsp } from "@/lib/crowdin-app/frame-ancestors";
 import { APP_LOCALE_HEADER_NAME } from "@/lib/app-i18n/locales";
 import { REQUEST_URL_HEADER } from "@/lib/workos/request-url-header";
-import proxy, { ensureRequestUrlHeader, isUnsupportedLocalePath } from "./proxy";
+import proxy, { config, ensureRequestUrlHeader, isUnsupportedLocalePath } from "./proxy";
 
 const { authkitProxyMock } = vi.hoisted(() => ({
   authkitProxyMock: vi.fn(),
@@ -264,5 +264,15 @@ describe("proxy", () => {
       buildCrowdinAppFrameAncestorsCsp(),
     );
     expect(response?.headers.get("X-Frame-Options")).toBeNull();
+  });
+});
+
+describe("proxy matcher", () => {
+  it("excludes /auth.md from the locale AuthKit matcher", () => {
+    const [localeMatcher] = config.matcher;
+    const regex = new RegExp(`^${localeMatcher}$`);
+
+    expect(regex.test("/auth.md")).toBe(false);
+    expect(regex.test("/en/org/acme/dashboard")).toBe(true);
   });
 });

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -273,6 +273,7 @@ describe("proxy matcher", () => {
     const regex = new RegExp(`^${localeMatcher}$`);
 
     expect(regex.test("/auth.md")).toBe(false);
+    expect(regex.test("/llms.txt")).toBe(false);
     expect(regex.test("/en/org/acme/dashboard")).toBe(true);
   });
 });

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -280,7 +280,8 @@ export default async function proxy(request: NextRequest, event: NextFetchEvent)
 export const config = {
   matcher: [
     // Exclude opaque UUID roots (BotID challenge scripts) so locale proxy does not 404 them.
-    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|\\.well-known|install|sitemap\\.xml|robots\\.txt|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}).*)",
+    // Exclude /auth.md so the AuthKit agent skill is not wrapped in a session proxy.
+    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|auth\\.md|\\.well-known|install|sitemap\\.xml|robots\\.txt|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}).*)",
     "/api/:path*",
   ],
 };

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -281,7 +281,8 @@ export const config = {
   matcher: [
     // Exclude opaque UUID roots (BotID challenge scripts) so locale proxy does not 404 them.
     // Exclude /auth.md so the AuthKit agent skill is not wrapped in a session proxy.
-    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|auth\\.md|\\.well-known|install|sitemap\\.xml|robots\\.txt|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}).*)",
+    // Exclude /llms.txt so coding agents can read the public index without locale 404s.
+    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|auth\\.md|llms\\.txt|\\.well-known|install|sitemap\\.xml|robots\\.txt|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}).*)",
     "/api/:path*",
   ],
 };

--- a/docs/adr/2026-09-08-workos-agent-registration-design.md
+++ b/docs/adr/2026-09-08-workos-agent-registration-design.md
@@ -1,0 +1,46 @@
+# WorkOS Agent Registration
+
+## Date
+
+2026-09-08
+
+## Status
+
+Accepted
+
+## Context
+
+Coding agents need a standards-based way to obtain credentials for Hyperlocalise.
+AuthKit Agent Registration (discovery, `service_auth` registration, hosted claim,
+JWT exchange) is that protocol. Hyperlocalise already authenticates humans with
+AuthKit sessions, MCP clients with first-party OAuth (`hl_mcp_*`), and the
+public REST API with personal access tokens (`x-api-key`).
+
+Anonymous/pre-claim agents would skip the WorkOS membership gate. MCP clients
+discover authorization servers from protected-resource metadata and use the
+first listed server. Adding AuthKit there would send Claude, Codex, and Cursor
+through AuthKit's human OAuth instead of `/mcp/authorize`.
+
+## Decision
+
+Agent registration, claim, and token minting stay on AuthKit. Hyperlocalise
+hosts `/auth.md`, advertises a separate RFC 9728 document for `/api/v1`, and
+validates claimed agent JWTs on MCP and `/api/v1`.
+
+- Enable **service auth** only. Do not enable anonymous registration.
+- Use the hosted AuthKit claim page. Do not implement the standalone claim API.
+- Issue short-lived access-token JWTs. Verify them locally with AuthKit JWKS.
+- Keep MCP OAuth and PATs. Figma stays PAT-only.
+- Leave MCP protected-resource metadata pointing at Hyperlocalise. Add
+  `/.well-known/oauth-protected-resource/api/v1` for AuthKit.
+- Effective access is token `scope` intersected with the claimed user's live
+  membership and capabilities. Tokens without `act.sub` are rejected.
+
+## Consequences
+
+Dashboard setup is required before the live flow works: Agent Registration
+enabled, service auth on, access-token credentials, trusted permissions matching
+PAT scopes plus `mcp`, and the AuthKit domain in `WORKOS_AUTHKIT_DOMAIN`.
+
+The local WorkOS emulator does not implement agent registration. Unit tests sign
+fixture JWTs; the hosted claim is verified against staging AuthKit.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds WorkOS AuthKit Agent Registration as a third credential channel for MCP and `/api/v1`.

Agents discover AuthKit at `/auth.md` (rewritten to the AuthKit host), complete a hosted `service_auth` claim, and present a short-lived JWT. Hyperlocalise verifies the JWT locally (JWKS, issuer, audience, `act.sub`, `org_id`), maps onto live WorkOS membership, and intersects token scopes with PAT plus `mcp` capabilities.

Existing first-party MCP OAuth (`hl_mcp_*`) and PATs (`x-api-key`) stay. Figma stays PAT-only. MCP protected-resource metadata still lists Hyperlocalise first; `/api/v1` advertises AuthKit at `/.well-known/oauth-protected-resource/api/v1`.

`/llms.txt` and the overview card advertise `/auth.md` only when `WORKOS_AUTHKIT_DOMAIN` is set. Public job activity uses `actorKind: "agent"` for claimed JWTs.

## How to test

- `vp test` and `vp check --fix` in `apps/hyperlocalise-web`
- `GET /llms.txt` includes `/auth.md` only when AuthKit is configured
- Dashboard (staging): Authentication → Agents — service auth on, anonymous off, access-token JWT, PAT scopes plus `mcp`, `WORKOS_AUTHKIT_DOMAIN` set
- Prompt an agent to follow `https://<staging>/auth.md`, complete hosted claim, then call MCP and one `/api/v1` route with the same JWT
- Confirm MCP install snippets and PATs still work
- Agent-created `/api/v1` jobs show as agent activity, not API-key activity

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e62f3473-1fac-4814-9a64-62cad895ac3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e62f3473-1fac-4814-9a64-62cad895ac3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

