### PR TITLE
feat(project): show locale translation progress on overview

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-locale-progress.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-locale-progress.route.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { testClient } from "hono/testing";
+
+import { app } from "@/api/app";
+import type { AppType } from "@/api/typed-app";
+import { db, schema } from "@/lib/database/client";
+import { upsertOrganizationExternalTmsProviderCredential } from "@/lib/providers/credentials/organization-external-tms-provider-credentials";
+import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
+
+import { createProjectTestFixture } from "./project.fixture";
+import type { ProjectLocaleProgressResponse } from "./project.schema";
+
+const {
+  getTmsProviderLiveProjectMock,
+  getTmsProviderLiveProjectLocaleReadinessMock,
+  resolveApiAuthContextFromSessionMock,
+} = vi.hoisted(() => ({
+  getTmsProviderLiveProjectMock: vi.fn(),
+  getTmsProviderLiveProjectLocaleReadinessMock: vi.fn(),
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+vi.mock("@/lib/providers/jobs/tms-provider-live", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/providers/jobs/tms-provider-live")>();
+  return {
+    ...actual,
+    getTmsProviderLiveProject: getTmsProviderLiveProjectMock,
+    getTmsProviderLiveProjectLocaleReadiness: getTmsProviderLiveProjectLocaleReadinessMock,
+  };
+});
+
+const client = testClient<AppType>(app);
+const projectFixture = createProjectTestFixture(client);
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await projectFixture.cleanup();
+});
+
+describe("GET /projects/:projectId/locale-progress", () => {
+  it("aggregates native translation words and strings per locale", async () => {
+    const { identity, organization, project } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+
+    await db
+      .update(schema.projects)
+      .set({ targetLocales: ["fr-FR", "de-DE"] })
+      .where(eq(schema.projects.id, project.id));
+
+    const [hello, save, hidden] = await db
+      .insert(schema.projectTranslationKeys)
+      .values([
+        {
+          organizationId: organization.id,
+          projectId: project.id,
+          key: "hello",
+          sourceText: "Hello world",
+          normalizedSourceText: "hello world",
+        },
+        {
+          organizationId: organization.id,
+          projectId: project.id,
+          key: "save",
+          sourceText: "Save",
+          normalizedSourceText: "save",
+        },
+        {
+          organizationId: organization.id,
+          projectId: project.id,
+          key: "debug",
+          sourceText: "Internal id",
+          normalizedSourceText: "internal id",
+          isHidden: true,
+        },
+      ])
+      .returning();
+
+    await db.insert(schema.projectTranslations).values([
+      {
+        organizationId: organization.id,
+        projectId: project.id,
+        translationKeyId: hello!.id,
+        targetLocale: "fr-FR",
+        text: "Bonjour le monde",
+        status: "approved",
+      },
+      {
+        organizationId: organization.id,
+        projectId: project.id,
+        translationKeyId: save!.id,
+        targetLocale: "fr-FR",
+        text: "",
+        status: "draft",
+      },
+      {
+        organizationId: organization.id,
+        projectId: project.id,
+        translationKeyId: hidden!.id,
+        targetLocale: "fr-FR",
+        text: "id interne",
+        status: "approved",
+      },
+    ]);
+
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"][
+      "locale-progress"
+    ].$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug!,
+          projectId: project.id,
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectLocaleProgressResponse;
+    expect(body.locales).toEqual([
+      expect.objectContaining({
+        locale: "fr-FR",
+        translationProgress: 67,
+        approvalProgress: 67,
+        words: { total: 3, translated: 2, approved: 2 },
+        phrases: { total: 2, translated: 1, approved: 1 },
+      }),
+      expect.objectContaining({
+        locale: "de-DE",
+        translationProgress: 0,
+        approvalProgress: 0,
+        words: { total: 3, translated: 0, approved: 0 },
+        phrases: { total: 2, translated: 0, approved: 0 },
+        lastActivityAt: null,
+      }),
+    ]);
+    expect(body.locales[0]?.lastActivityAt).toBeTruthy();
+  });
+
+  it("maps live provider locale readiness onto target locales", async () => {
+    const admin = projectFixture.createWorkosIdentityWithRole("admin");
+    const headers = await projectFixture.authHeadersFor(admin);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+    const userId = globalThis.__testApiAuthContext!.user.localUserId;
+    const externalProjectId = "902809";
+    const projectId = encodeProviderProjectId({
+      providerKind: "crowdin",
+      externalProjectId,
+    });
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "admin",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "crowdin-secret",
+    });
+
+    getTmsProviderLiveProjectMock.mockResolvedValue({
+      id: projectId,
+      name: "Live Crowdin Project",
+      targetLocales: ["vi-VN"],
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId,
+    });
+    getTmsProviderLiveProjectLocaleReadinessMock.mockResolvedValue({
+      vi: {
+        translationProgress: 14,
+        approvalProgress: 0,
+        words: { total: 34, translated: 5, approved: 0 },
+        phrases: { total: 8, translated: 1, approved: 0 },
+      },
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"][
+      "locale-progress"
+    ].$get(
+      {
+        param: {
+          organizationSlug: admin.organization.slug ?? "missing-slug",
+          projectId,
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectLocaleProgressResponse;
+    expect(body.locales).toEqual([
+      {
+        locale: "vi-VN",
+        translationProgress: 14,
+        approvalProgress: 0,
+        words: { total: 34, translated: 5, approved: 0 },
+        phrases: { total: 8, translated: 1, approved: 0 },
+        lastActivityAt: null,
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -87,6 +87,7 @@ import {
   getTmsProviderLiveCatSegmentTarget,
   getTmsProviderLiveFileDetail,
   getTmsProviderLiveProject,
+  getTmsProviderLiveProjectLocaleReadiness,
   listTmsProviderLiveFilesForProject,
   listTmsProviderLiveProjectBranches,
   saveTmsProviderLiveCatTranslation,
@@ -94,6 +95,8 @@ import {
   setTmsProviderLiveCatStringsHidden,
   resolveTmsProviderLiveCatComment,
 } from "@/lib/providers/jobs/tms-provider-live";
+import { listNativeProjectLocaleProgress } from "@/lib/projects/locale-progress/native-project-locale-progress";
+import { normalizeProviderLocaleProgress } from "@/lib/projects/locale-progress/provider-locale-progress";
 import { listOrganizationProjects } from "@/lib/projects/organization/organization-project-service";
 import {
   getNativeProjectContentEditorFile,
@@ -3755,6 +3758,72 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         );
       },
     )
+    .get("/:projectId/locale-progress", validateProjectParams, async (c) => {
+      const params = c.req.valid("param");
+      const organizationId = c.var.auth.organization.localOrganizationId;
+      const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+
+      if (target.kind === "provider_unavailable") {
+        return providerProjectUnavailableResponse(c, target);
+      }
+
+      if (target.kind === "provider") {
+        try {
+          const [liveProject, localeReadiness] = await Promise.all([
+            getTmsProviderLiveProject(organizationId, target.externalProjectId, {
+              actorUserId: c.var.auth.user.localUserId,
+            }),
+            getTmsProviderLiveProjectLocaleReadiness(organizationId, target.externalProjectId, {
+              actorUserId: c.var.auth.user.localUserId,
+            }),
+          ]);
+
+          const materializedProject = liveProject
+            ? null
+            : await getOwnedProjectRecord(c.var.auth, params.projectId);
+          const targetLocales =
+            liveProject?.targetLocales ?? materializedProject?.targetLocales ?? [];
+
+          if (!liveProject && materializedProject?.source !== "external_tms") {
+            scheduleProjectNotFoundDiagnostics({
+              auth: c.var.auth,
+              projectId: params.projectId,
+              route: "project.locale_progress.provider",
+            });
+            return projectNotFoundResponse(c);
+          }
+
+          return c.json(
+            {
+              locales: normalizeProviderLocaleProgress({
+                targetLocales,
+                readiness: localeReadiness,
+              }),
+            },
+            200,
+          );
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      }
+
+      const project = await getOwnedProjectRecord(c.var.auth, params.projectId);
+      if (!project) {
+        scheduleProjectNotFoundDiagnostics({
+          auth: c.var.auth,
+          projectId: params.projectId,
+          route: "project.locale_progress",
+        });
+        return projectNotFoundResponse(c);
+      }
+
+      const locales = await listNativeProjectLocaleProgress({
+        organizationId,
+        projectId: project.id,
+        targetLocales: project.targetLocales,
+      });
+      return c.json({ locales }, 200);
+    })
     .get("/:projectId/open-job-count", validateProjectParams, async (c) => {
       const params = c.req.valid("param");
       const organizationId = c.var.auth.organization.localOrganizationId;

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -3820,6 +3820,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       const locales = await listNativeProjectLocaleProgress({
         organizationId,
         projectId: project.id,
+        sourceLocale: project.sourceLocale,
         targetLocales: project.targetLocales,
       });
       return c.json({ locales }, 200);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -166,6 +166,26 @@ export const projectOpenJobCountResponseSchema = z.object({
   openJobCount: z.number().int(),
 });
 
+export const projectLocaleProgressCountsSchema = z.object({
+  total: z.number().int().nonnegative(),
+  translated: z.number().int().nonnegative(),
+  approved: z.number().int().nonnegative(),
+});
+
+export const projectLocaleProgressRowSchema = z.object({
+  locale: z.string(),
+  translationProgress: z.number().min(0).max(100),
+  approvalProgress: z.number().min(0).max(100),
+  words: projectLocaleProgressCountsSchema,
+  phrases: projectLocaleProgressCountsSchema,
+  lastActivityAt: z.string().nullable(),
+});
+
+export const projectLocaleProgressResponseSchema = successEnvelopeSchema(
+  "locales",
+  z.array(projectLocaleProgressRowSchema),
+);
+
 export const projectsResponseSchema = z.object({
   projects: z.array(projectRecordSchema),
 });
@@ -828,6 +848,8 @@ export type CreateProjectBody = z.infer<typeof createProjectBodySchema>;
 export type UpdateProjectBody = z.infer<typeof updateProjectBodySchema>;
 export type ProjectRecord = z.infer<typeof projectRecordSchema>;
 export type ProjectResponse = z.infer<typeof projectResponseSchema>;
+export type ProjectLocaleProgressRow = z.infer<typeof projectLocaleProgressRowSchema>;
+export type ProjectLocaleProgressResponse = z.infer<typeof projectLocaleProgressResponseSchema>;
 export type ProjectsResponse = z.infer<typeof projectsResponseSchema>;
 export type ProjectFileRecord = z.infer<typeof projectFileRecordSchema>;
 export type ProjectFilesResponse = z.infer<typeof projectFilesResponseSchema>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list-model.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildLocaleEditorHref,
   filterAndSortLocaleProgress,
+  localeProgressPercents,
   remainingLocaleWork,
 } from "./project-locale-progress-list-model";
 import type { ProjectLocaleProgressRow } from "@/api/routes/project/project.schema";
@@ -67,6 +68,19 @@ describe("remainingLocaleWork", () => {
         words: { total: 0, translated: 0, approved: 0 },
       }),
     ).toBe(2);
+  });
+});
+
+describe("localeProgressPercents", () => {
+  it("derives percents from the selected words or strings bucket", () => {
+    expect(localeProgressPercents(rows[0]!, "words")).toEqual({
+      translation: 50,
+      approval: 10,
+    });
+    expect(localeProgressPercents(rows[0]!, "phrases")).toEqual({
+      translation: 50,
+      approval: 25,
+    });
   });
 });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list-model.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildLocaleEditorHref,
+  filterAndSortLocaleProgress,
+  remainingLocaleWork,
+} from "./project-locale-progress-list-model";
+import type { ProjectLocaleProgressRow } from "@/api/routes/project/project.schema";
+
+const rows: ProjectLocaleProgressRow[] = [
+  {
+    locale: "fr-FR",
+    translationProgress: 50,
+    approvalProgress: 10,
+    words: { total: 10, translated: 5, approved: 1 },
+    phrases: { total: 4, translated: 2, approved: 1 },
+    lastActivityAt: null,
+  },
+  {
+    locale: "de-DE",
+    translationProgress: 0,
+    approvalProgress: 0,
+    words: { total: 10, translated: 0, approved: 0 },
+    phrases: { total: 4, translated: 0, approved: 0 },
+    lastActivityAt: null,
+  },
+];
+
+describe("filterAndSortLocaleProgress", () => {
+  it("filters by locale code or label and sorts A–Z", () => {
+    expect(
+      filterAndSortLocaleProgress(rows, {
+        query: "german",
+        sort: "az",
+        getLabel: (locale) => (locale === "de-DE" ? "German (Germany)" : "French (France)"),
+      }).map((row) => row.locale),
+    ).toEqual(["de-DE"]);
+
+    expect(
+      filterAndSortLocaleProgress(rows, {
+        query: "",
+        sort: "az",
+        getLabel: (locale) => (locale === "de-DE" ? "German (Germany)" : "French (France)"),
+      }).map((row) => row.locale),
+    ).toEqual(["fr-FR", "de-DE"]);
+  });
+});
+
+describe("remainingLocaleWork", () => {
+  it("uses remaining words, then falls back to strings", () => {
+    expect(remainingLocaleWork(rows[0]!)).toBe(5);
+    expect(
+      remainingLocaleWork({
+        ...rows[0]!,
+        words: { total: 0, translated: 0, approved: 0 },
+      }),
+    ).toBe(2);
+  });
+});
+
+describe("buildLocaleEditorHref", () => {
+  it("sets locale and queue filter on the strings editor path", () => {
+    expect(
+      buildLocaleEditorHref({
+        stringsHref: "/org/acme/projects/p1/strings",
+        locale: "fr-FR",
+        queueFilter: "untranslated",
+      }),
+    ).toBe("/org/acme/projects/p1/strings?locale=fr-FR&queueFilter=untranslated");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list-model.ts
@@ -11,7 +11,10 @@
  * Version 2.0 or later.
  */
 import type { ProjectLocaleProgressRow } from "@/api/routes/project/project.schema";
-import { remainingCount } from "@/lib/projects/locale-progress/project-locale-progress";
+import {
+  remainingCount,
+  toProgressPercent,
+} from "@/lib/projects/locale-progress/project-locale-progress";
 
 export type LocaleProgressSort = "az" | "za";
 export type LocaleProgressUnit = "words" | "phrases";
@@ -55,6 +58,14 @@ export function remainingLocaleWork(
     return remainingCount(row.phrases);
   }
   return remainingCount(counts);
+}
+
+export function localeProgressPercents(row: ProjectLocaleProgressRow, unit: LocaleProgressUnit) {
+  const counts = localeProgressCounts(row, unit);
+  return {
+    translation: toProgressPercent(counts.translated, counts.total),
+    approval: toProgressPercent(counts.approved, counts.total),
+  };
 }
 
 export function buildLocaleEditorHref(input: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list-model.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ProjectLocaleProgressRow } from "@/api/routes/project/project.schema";
+import { remainingCount } from "@/lib/projects/locale-progress/project-locale-progress";
+
+export type LocaleProgressSort = "az" | "za";
+export type LocaleProgressUnit = "words" | "phrases";
+
+export function filterAndSortLocaleProgress(
+  rows: readonly ProjectLocaleProgressRow[],
+  input: {
+    query: string;
+    sort: LocaleProgressSort;
+    getLabel: (locale: string) => string;
+  },
+): ProjectLocaleProgressRow[] {
+  const query = input.query.trim().toLowerCase();
+  const filtered = query
+    ? rows.filter((row) => {
+        const label = input.getLabel(row.locale).toLowerCase();
+        return label.includes(query) || row.locale.toLowerCase().includes(query);
+      })
+    : [...rows];
+
+  const direction = input.sort === "za" ? -1 : 1;
+  return filtered.toSorted((left, right) => {
+    const byName = input.getLabel(left.locale).localeCompare(input.getLabel(right.locale));
+    if (byName !== 0) {
+      return byName * direction;
+    }
+    return left.locale.localeCompare(right.locale) * direction;
+  });
+}
+
+export function localeProgressCounts(row: ProjectLocaleProgressRow, unit: LocaleProgressUnit) {
+  return unit === "phrases" ? row.phrases : row.words;
+}
+
+export function remainingLocaleWork(
+  row: ProjectLocaleProgressRow,
+  unit: LocaleProgressUnit = "words",
+) {
+  const counts = localeProgressCounts(row, unit);
+  if (counts.total === 0 && unit === "words") {
+    return remainingCount(row.phrases);
+  }
+  return remainingCount(counts);
+}
+
+export function buildLocaleEditorHref(input: {
+  stringsHref: string;
+  locale: string;
+  queueFilter: "untranslated" | "needs_review";
+}) {
+  const url = new URL(input.stringsHref, "https://hyperlocalise.local");
+  url.searchParams.set("locale", input.locale);
+  url.searchParams.set("queueFilter", input.queueFilter);
+  return `${url.pathname}${url.search}`;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.messages.ts
@@ -1,0 +1,160 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const projectLocaleProgressListMessages = defineMessages({
+  title: {
+    defaultMessage: "Languages",
+    id: "zNif9FKga+",
+    description: "Heading for the project locale translation progress list",
+  },
+  searchPlaceholder: {
+    defaultMessage: "Search languages",
+    id: "NP4duQIbJD",
+    description: "Placeholder for filtering project locales by name or code",
+  },
+  sortAz: {
+    defaultMessage: "A–Z",
+    id: "NtrP9v6nQ4",
+    description: "Button label to sort locales alphabetically",
+  },
+  sortZa: {
+    defaultMessage: "Z–A",
+    id: "cpSIo6rBul",
+    description: "Button label to sort locales in reverse alphabetical order",
+  },
+  wordsTab: {
+    defaultMessage: "Words",
+    id: "TIlDexJ1Y8",
+    description: "Tab showing word-based translation progress",
+  },
+  stringsTab: {
+    defaultMessage: "Strings",
+    id: "yRuWK+QTKd",
+    description: "Tab showing string-based translation progress",
+  },
+  totalWords: {
+    defaultMessage:
+      "{count, plural, one {# translatable word in total} other {# translatable words in total}}",
+    id: "BGZhnA5Bkq",
+    description: "Total translatable word count in an expanded locale row",
+  },
+  totalStrings: {
+    defaultMessage:
+      "{count, plural, one {# translatable string in total} other {# translatable strings in total}}",
+    id: "93i6HvwXyA",
+    description: "Total translatable string count in an expanded locale row",
+  },
+  remainingWords: {
+    defaultMessage: "{count, plural, one {# word} other {# words}}",
+    id: "6SHDHgWJLa",
+    description: "Remaining untranslated word count on a collapsed locale row",
+  },
+  remainingStrings: {
+    defaultMessage: "{count, plural, one {# string} other {# strings}}",
+    id: "hL0sGC6Xoj",
+    description: "Remaining untranslated string count on a collapsed locale row",
+  },
+  translated: {
+    defaultMessage: "Translated",
+    id: "igKhQOsrv+",
+    description: "Progress table row label for translated work",
+  },
+  approved: {
+    defaultMessage: "Approved",
+    id: "CbuvPB6HCw",
+    description: "Progress table row label for approved work",
+  },
+  todo: {
+    defaultMessage: "Todo",
+    id: "/yrnrzsaf9",
+    description: "Column heading for remaining work in the locale progress table",
+  },
+  done: {
+    defaultMessage: "Done",
+    id: "i29Xh/8PGM",
+    description: "Column heading for completed work in the locale progress table",
+  },
+  lastActivity: {
+    defaultMessage: "Last activity {when}",
+    id: "RWUw6HKSvD",
+    description: "Relative timestamp of the latest translation activity for a locale",
+  },
+  lastActivityNever: {
+    defaultMessage: "No activity yet",
+    id: "QVvwDJw1I3",
+    description: "Shown when a locale has no translation updates",
+  },
+  translate: {
+    defaultMessage: "Translate",
+    id: "4ipjfzP7qr",
+    description: "Link from a locale row into the content editor untranslated queue",
+  },
+  proofread: {
+    defaultMessage: "Proofread",
+    id: "lsmpBVLKpZ",
+    description: "Link from a locale row into the content editor review queue",
+  },
+  expand: {
+    defaultMessage: "Show {locale} details",
+    id: "iDOdRMXYSX",
+    description: "Accessible label to expand a locale progress row",
+  },
+  collapse: {
+    defaultMessage: "Hide {locale} details",
+    id: "fEqp3yJRPt",
+    description: "Accessible label to collapse a locale progress row",
+  },
+  progressLabel: {
+    defaultMessage: "{locale} translation progress",
+    id: "BkbHzcKWkt",
+    description: "Accessible label for a locale translation progress bar",
+  },
+  emptyTitle: {
+    defaultMessage: "No target languages yet",
+    id: "tbWhMwM8OM",
+    description: "Empty-state title when a project has no target locales",
+  },
+  emptyDescription: {
+    defaultMessage: "Add target languages in settings to track translation progress here.",
+    id: "ZOC86/UJbR",
+    description: "Empty-state description when a project has no target locales",
+  },
+  noSearchResults: {
+    defaultMessage: "No languages match “{query}”.",
+    id: "a3n8jBbMmU",
+    description: "Shown when locale search filters out every row",
+  },
+  loadError: {
+    defaultMessage: "Unable to load language progress.",
+    id: "oFoqUqR3xA",
+    description: "Error message when locale progress fails to load",
+  },
+  translationPercent: {
+    defaultMessage: "{percent}%",
+    id: "mGQ8u5Lds5",
+    description: "Translated percent shown on a locale progress row",
+  },
+  approvalPercent: {
+    defaultMessage: "{percent}%",
+    id: "zCQhaHX3Xw",
+    description: "Approved percent shown on a locale progress row",
+  },
+  viewSettings: {
+    defaultMessage: "View settings",
+    id: "t7VshKcR+p",
+    description: "Link to project settings from the empty locale progress state",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.stories.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent } from "storybook/test";
+
+import { projectOverviewLocaleProgressFixture } from "./project-overview.fixture";
+import { ProjectLocaleProgressList } from "./project-locale-progress-list";
+
+const meta = {
+  title: "App/Project/Overview/LocaleProgress",
+  component: ProjectLocaleProgressList,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    locales: projectOverviewLocaleProgressFixture,
+    isLoading: false,
+    isError: false,
+    settingsHref: "/org/acme/projects/project_website/settings",
+    stringsHref: "/org/acme/projects/project_website/strings",
+  },
+} satisfies Meta<typeof ProjectLocaleProgressList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Languages")).toBeInTheDocument();
+    await expect(canvas.getByText("French (France)")).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("button", { name: "Show French (France) details" }));
+    await expect(canvas.getByText("Translated")).toBeInTheDocument();
+    await expect(canvas.getByText("Approved")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Translate" })).toHaveAttribute(
+      "href",
+      "/org/acme/projects/project_website/strings?locale=fr-FR&queueFilter=untranslated",
+    );
+    await expect(canvas.getByRole("link", { name: "Proofread" })).toHaveAttribute(
+      "href",
+      "/org/acme/projects/project_website/strings?locale=fr-FR&queueFilter=needs_review",
+    );
+    await userEvent.click(canvas.getByRole("tab", { name: "Strings" }));
+    await expect(canvas.getByText("40 translatable strings in total")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    locales: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No target languages yet")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "View settings" })).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    locales: [],
+    isLoading: true,
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.stories.tsx
@@ -51,6 +51,7 @@ export const Default: Story = {
     );
     await userEvent.click(canvas.getByRole("tab", { name: "Strings" }));
     await expect(canvas.getByText("40 translatable strings in total")).toBeInTheDocument();
+    await expect(canvas.getByText("25%")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ArrowDown01Icon, SearchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import type { ProjectLocaleProgressRow } from "@/api/routes/project/project.schema";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
+import { Box } from "@/components/ui/layout/box";
+import { Column } from "@/components/ui/layout/column";
+import { Columns } from "@/components/ui/layout/columns";
+import { Row } from "@/components/ui/layout/row";
+import { Rows } from "@/components/ui/layout/rows";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TypographyP } from "@/components/ui/typography";
+import { formatLocaleDisplayName } from "@/lib/i18n/locale-display-names.messages";
+import { localeBadgeCode } from "@/lib/projects/locale-progress/project-locale-progress";
+import { cn } from "@/lib/primitives/cn";
+
+import { formatRelativeTimestamp } from "../../../_components/workspace-files-shared";
+import { projectLocaleProgressListMessages as messages } from "./project-locale-progress-list.messages";
+import {
+  buildLocaleEditorHref,
+  filterAndSortLocaleProgress,
+  localeProgressCounts,
+  remainingLocaleWork,
+  type LocaleProgressSort,
+  type LocaleProgressUnit,
+} from "./project-locale-progress-list-model";
+
+export type ProjectLocaleProgressListProps = {
+  locales: readonly ProjectLocaleProgressRow[];
+  isLoading?: boolean;
+  isError?: boolean;
+  settingsHref: string;
+  stringsHref?: string | null;
+};
+
+function LocaleBadge({ locale }: { locale: string }) {
+  return (
+    <span className="inline-flex h-6 min-w-7 items-center justify-center rounded-md bg-muted px-1.5 font-mono text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
+      {localeBadgeCode(locale)}
+    </span>
+  );
+}
+
+function LocaleProgressBar({ value, label }: { value: number; label: string }) {
+  return (
+    <div
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={value}
+      className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+    >
+      <div
+        className="h-full rounded-full bg-primary transition-[width]"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  );
+}
+
+function ProgressDetailRow({
+  label,
+  tone,
+  todo,
+  done,
+  percent,
+}: {
+  label: string;
+  tone: "translated" | "approved";
+  todo: number;
+  done: number;
+  percent: number;
+}) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_4.5rem_4.5rem_3.5rem] items-center gap-2 text-sm">
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className={cn(
+            "size-1.5 shrink-0 rounded-full",
+            tone === "translated" ? "bg-primary" : "bg-emerald-600 dark:bg-emerald-500",
+          )}
+          aria-hidden
+        />
+        <span className="truncate text-foreground">{label}</span>
+      </div>
+      <span className="text-end font-mono text-[13px] tabular-nums text-muted-foreground">
+        {todo}
+      </span>
+      <span className="text-end font-mono text-[13px] tabular-nums text-foreground">{done}</span>
+      <span className="text-end font-mono text-[13px] tabular-nums text-muted-foreground">
+        {percent}%
+      </span>
+    </div>
+  );
+}
+
+function LocaleProgressDetails({
+  row,
+  unit,
+  onUnitChange,
+  stringsHref,
+}: {
+  row: ProjectLocaleProgressRow;
+  unit: LocaleProgressUnit;
+  onUnitChange: (unit: LocaleProgressUnit) => void;
+  stringsHref: string | null | undefined;
+}) {
+  const intl = useIntl();
+  const counts = localeProgressCounts(row, unit);
+  const translatedTodo = Math.max(0, counts.total - counts.translated);
+  const approvedTodo = Math.max(0, counts.total - counts.approved);
+  const lastActivity = row.lastActivityAt
+    ? intl.formatMessage(messages.lastActivity, {
+        when: formatRelativeTimestamp(row.lastActivityAt),
+      })
+    : intl.formatMessage(messages.lastActivityNever);
+  const translateHref = stringsHref
+    ? buildLocaleEditorHref({
+        stringsHref,
+        locale: row.locale,
+        queueFilter: "untranslated",
+      })
+    : null;
+  const proofreadHref = stringsHref
+    ? buildLocaleEditorHref({
+        stringsHref,
+        locale: row.locale,
+        queueFilter: "needs_review",
+      })
+    : null;
+
+  return (
+    <Rows spacing="2u">
+      <Tabs
+        value={unit}
+        onValueChange={(value) => {
+          if (value === "words" || value === "phrases") {
+            onUnitChange(value);
+          }
+        }}
+      >
+        <TabsList variant="line">
+          <TabsTrigger value="words">
+            <FormattedMessage {...messages.wordsTab} />
+          </TabsTrigger>
+          <TabsTrigger value="phrases">
+            <FormattedMessage {...messages.stringsTab} />
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <TypographyP size="small" tone="subtle">
+        {unit === "phrases" ? (
+          <FormattedMessage {...messages.totalStrings} values={{ count: counts.total }} />
+        ) : (
+          <FormattedMessage {...messages.totalWords} values={{ count: counts.total }} />
+        )}
+      </TypographyP>
+
+      <Rows spacing="1u">
+        <div className="grid grid-cols-[minmax(0,1fr)_4.5rem_4.5rem_3.5rem] gap-2 text-[11px] font-medium tracking-wider text-muted-foreground uppercase">
+          <span />
+          <span className="text-end">
+            <FormattedMessage {...messages.todo} />
+          </span>
+          <span className="text-end">
+            <FormattedMessage {...messages.done} />
+          </span>
+          <span />
+        </div>
+        <ProgressDetailRow
+          label={intl.formatMessage(messages.translated)}
+          tone="translated"
+          todo={translatedTodo}
+          done={counts.translated}
+          percent={row.translationProgress}
+        />
+        <ProgressDetailRow
+          label={intl.formatMessage(messages.approved)}
+          tone="approved"
+          todo={approvedTodo}
+          done={counts.approved}
+          percent={row.approvalProgress}
+        />
+      </Rows>
+
+      <Row spacing="1.5u" align="spaceBetween" alignY="center">
+        <span className="text-xs text-muted-foreground">{lastActivity}</span>
+        {translateHref && proofreadHref ? (
+          <Row spacing="1u" alignY="center">
+            <Button
+              nativeButton={false}
+              render={<Link href={translateHref} />}
+              size="sm"
+              variant="outline"
+            >
+              <FormattedMessage {...messages.translate} />
+            </Button>
+            <Button
+              nativeButton={false}
+              render={<Link href={proofreadHref} />}
+              size="sm"
+              variant="outline"
+            >
+              <FormattedMessage {...messages.proofread} />
+            </Button>
+          </Row>
+        ) : null}
+      </Row>
+    </Rows>
+  );
+}
+
+function LocaleProgressItem({
+  row,
+  stringsHref,
+}: {
+  row: ProjectLocaleProgressRow;
+  stringsHref: string | null | undefined;
+}) {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const [unit, setUnit] = useState<LocaleProgressUnit>("words");
+  const localeLabel = formatLocaleDisplayName(intl, row.locale);
+  const remaining = remainingLocaleWork(row);
+  const remainingMessage =
+    row.words.total > 0 || row.phrases.total === 0
+      ? messages.remainingWords
+      : messages.remainingStrings;
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <Box
+        border="standard"
+        borderRadius="large"
+        background={open ? "muted" : "transparent"}
+        paddingX="2u"
+        paddingY="1.5u"
+      >
+        <CollapsibleTrigger
+          className="flex w-full min-w-0 cursor-pointer flex-col gap-2 text-start outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          aria-label={intl.formatMessage(open ? messages.collapse : messages.expand, {
+            locale: localeLabel,
+          })}
+        >
+          <div className="flex w-full min-w-0 items-center gap-3">
+            <LocaleBadge locale={row.locale} />
+            <span className="w-36 shrink-0 truncate text-sm font-medium text-foreground">
+              {localeLabel}
+            </span>
+            <div className="hidden min-w-0 flex-1 sm:block">
+              <LocaleProgressBar
+                value={row.translationProgress}
+                label={intl.formatMessage(messages.progressLabel, {
+                  locale: localeLabel,
+                })}
+              />
+            </div>
+            <span className="shrink-0 font-mono text-[13px] tabular-nums text-muted-foreground">
+              <FormattedMessage
+                {...messages.translationPercent}
+                values={{ percent: row.translationProgress }}
+              />
+              <span aria-hidden> · </span>
+              <FormattedMessage
+                {...messages.approvalPercent}
+                values={{ percent: row.approvalProgress }}
+              />
+            </span>
+            <span className="hidden w-20 shrink-0 text-end font-mono text-[13px] tabular-nums text-muted-foreground sm:block">
+              <FormattedMessage {...remainingMessage} values={{ count: remaining }} />
+            </span>
+            <HugeiconsIcon
+              icon={ArrowDown01Icon}
+              strokeWidth={1.8}
+              className={cn(
+                "size-4 shrink-0 text-muted-foreground transition-transform",
+                open && "rotate-180",
+              )}
+            />
+          </div>
+          <div className="sm:hidden">
+            <LocaleProgressBar
+              value={row.translationProgress}
+              label={intl.formatMessage(messages.progressLabel, {
+                locale: localeLabel,
+              })}
+            />
+          </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <Box paddingTop="2u">
+            <LocaleProgressDetails
+              row={row}
+              unit={unit}
+              onUnitChange={setUnit}
+              stringsHref={stringsHref}
+            />
+          </Box>
+        </CollapsibleContent>
+      </Box>
+    </Collapsible>
+  );
+}
+
+export function ProjectLocaleProgressList({
+  locales,
+  isLoading = false,
+  isError = false,
+  settingsHref,
+  stringsHref,
+}: ProjectLocaleProgressListProps) {
+  const intl = useIntl();
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<LocaleProgressSort>("az");
+
+  const visibleLocales = useMemo(
+    () =>
+      filterAndSortLocaleProgress(locales, {
+        query,
+        sort,
+        getLabel: (locale) => formatLocaleDisplayName(intl, locale),
+      }),
+    [intl, locales, query, sort],
+  );
+
+  return (
+    <Rows spacing="1.5u">
+      <Row spacing="0" align="spaceBetween" alignY="baseline">
+        <span className="text-xs font-medium tracking-wider text-foreground uppercase">
+          <FormattedMessage {...messages.title} />
+        </span>
+        <span className="text-xs font-medium tracking-wider text-muted-foreground uppercase tabular-nums">
+          {locales.length}
+        </span>
+      </Row>
+      <Separator className="bg-foreground" />
+
+      {isLoading ? (
+        <Rows spacing="1u">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </Rows>
+      ) : isError ? (
+        <Box paddingTop="1u">
+          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
+            <FormattedMessage {...messages.loadError} />
+          </TypographyP>
+        </Box>
+      ) : locales.length === 0 ? (
+        <Box paddingTop="1u">
+          <Rows spacing="1u">
+            <TypographyP weight="medium" tone="content">
+              <FormattedMessage {...messages.emptyTitle} />
+            </TypographyP>
+            <TypographyP wrapStyle="pretty" size="small" tone="subtle">
+              <FormattedMessage {...messages.emptyDescription} />
+            </TypographyP>
+            <Link href={settingsHref} className="text-sm font-medium text-primary hover:underline">
+              <FormattedMessage {...messages.viewSettings} />
+            </Link>
+          </Rows>
+        </Box>
+      ) : (
+        <Rows spacing="1.5u">
+          <Columns spacing="1u" collapseBelow="small" alignY="center">
+            <Column width="fluid">
+              <InputGroup className="max-w-sm">
+                <InputGroupAddon>
+                  <HugeiconsIcon icon={SearchIcon} strokeWidth={1.8} className="size-4" />
+                </InputGroupAddon>
+                <InputGroupInput
+                  value={query}
+                  onChange={(event) => setQuery(event.currentTarget.value)}
+                  placeholder={intl.formatMessage(messages.searchPlaceholder)}
+                  aria-label={intl.formatMessage(messages.searchPlaceholder)}
+                />
+              </InputGroup>
+            </Column>
+            <Column width="content">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => setSort((current) => (current === "az" ? "za" : "az"))}
+              >
+                <FormattedMessage {...(sort === "az" ? messages.sortAz : messages.sortZa)} />
+              </Button>
+            </Column>
+          </Columns>
+
+          {visibleLocales.length === 0 ? (
+            <TypographyP wrapStyle="pretty" size="small" tone="subtle">
+              <FormattedMessage {...messages.noSearchResults} values={{ query }} />
+            </TypographyP>
+          ) : (
+            <Rows spacing="1u">
+              {visibleLocales.map((row) => (
+                <LocaleProgressItem key={row.locale} row={row} stringsHref={stringsHref} />
+              ))}
+            </Rows>
+          )}
+        </Rows>
+      )}
+    </Rows>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.tsx
@@ -41,6 +41,7 @@ import {
   buildLocaleEditorHref,
   filterAndSortLocaleProgress,
   localeProgressCounts,
+  localeProgressPercents,
   remainingLocaleWork,
   type LocaleProgressSort,
   type LocaleProgressUnit,
@@ -129,6 +130,7 @@ function LocaleProgressDetails({
 }) {
   const intl = useIntl();
   const counts = localeProgressCounts(row, unit);
+  const percents = localeProgressPercents(row, unit);
   const translatedTodo = Math.max(0, counts.total - counts.translated);
   const approvedTodo = Math.max(0, counts.total - counts.approved);
   const lastActivity = row.lastActivityAt
@@ -195,14 +197,14 @@ function LocaleProgressDetails({
           tone="translated"
           todo={translatedTodo}
           done={counts.translated}
-          percent={row.translationProgress}
+          percent={percents.translation}
         />
         <ProgressDetailRow
           label={intl.formatMessage(messages.approved)}
           tone="approved"
           todo={approvedTodo}
           done={counts.approved}
-          percent={row.approvalProgress}
+          percent={percents.approval}
         />
       </Rows>
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
@@ -17,6 +17,7 @@ import {
   projectOverviewCaughtUpFixture,
   projectOverviewFixture,
   projectOverviewJobsFixture,
+  projectOverviewLocaleProgressFixture,
   projectOverviewMissingGuidanceFixture,
   projectOverviewTmsFixture,
 } from "./project-overview.fixture";
@@ -37,6 +38,9 @@ const meta = {
     jobs: projectOverviewJobsFixture,
     isJobsLoading: false,
     isJobsError: false,
+    locales: projectOverviewLocaleProgressFixture,
+    isLocaleProgressLoading: false,
+    isLocaleProgressError: false,
   },
 } satisfies Meta<typeof ProjectOverviewPageContentView>;
 
@@ -63,6 +67,10 @@ export const Default: Story = {
     ).toBeInTheDocument();
     await expect(canvas.getByText("Guidance")).toBeInTheDocument();
     await expect(canvas.getByText("Sync")).toBeInTheDocument();
+    await expect(canvas.getByText("Languages")).toBeInTheDocument();
+    await expect(canvas.getByText("French (France)")).toBeInTheDocument();
+    await expect(canvas.getByText("German (Germany)")).toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText("Search languages")).toBeInTheDocument();
     await expect(canvas.queryByText("Locale health")).toBeNull();
   },
 };
@@ -116,7 +124,9 @@ export const Loading: Story = {
     project: null,
     isProjectLoading: true,
     isJobsLoading: true,
+    isLocaleProgressLoading: true,
     jobs: [],
+    locales: [],
   },
   play: async ({ canvas }) => {
     await expect(canvas.queryByRole("button", { name: "Create job" })).toBeNull();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -34,6 +34,7 @@ import { Rows } from "@/components/ui/layout/rows";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import type { ProjectLocaleProgressRow } from "@/api/routes/project/project.schema";
 import { supportsContentEditorAllFilesProvider } from "@/lib/projects/content-editor-all-files";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
@@ -44,8 +45,10 @@ import {
   type ApiJob,
 } from "../../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../_components/project-list";
+import { ProjectLocaleProgressList } from "./project-locale-progress-list";
 import { projectOverviewPageContentMessages as messages } from "./project-overview-page-content.messages";
 import { ProjectPageShell, useProjectPageQuery } from "./project-page-shell";
+import { useProjectLocaleProgressQuery } from "./use-project-locale-progress";
 import { useProjectOverviewJobsQuery } from "./use-project-overview-jobs";
 import {
   buildProjectOverviewTriageItems,
@@ -292,6 +295,9 @@ export type ProjectOverviewPageContentViewProps = {
   jobs: readonly ApiJob[];
   isJobsLoading: boolean;
   isJobsError: boolean;
+  locales: readonly ProjectLocaleProgressRow[];
+  isLocaleProgressLoading: boolean;
+  isLocaleProgressError: boolean;
   onCreateJob?: () => void;
 };
 
@@ -304,6 +310,9 @@ export function ProjectOverviewPageContentView({
   jobs,
   isJobsLoading,
   isJobsError,
+  locales,
+  isLocaleProgressLoading,
+  isLocaleProgressError,
   onCreateJob,
 }: ProjectOverviewPageContentViewProps) {
   const intl = useIntl();
@@ -422,125 +431,140 @@ export function ProjectOverviewPageContentView({
             ) : null}
           </Columns>
 
-          {isProjectLoading || isJobsLoading ? (
+          {isProjectLoading ? (
             <Skeleton className="min-h-56 w-full" />
           ) : project ? (
-            <Box paddingTop="1u">
-              <Columns spacing="4u" collapseBelow="large" alignY="start">
-                <Column width="fluid">
-                  <Rows spacing="0">
-                    <Box paddingBottom="1.5u">
-                      <Row spacing="0" align="spaceBetween" alignY="baseline">
-                        <ProjectOverviewSectionLabel>
-                          <FormattedMessage {...messages.todayTitle} />
-                        </ProjectOverviewSectionLabel>
-                        <span className="text-xs font-medium tracking-wider text-muted-foreground uppercase tabular-nums">
-                          {triageItems.length}
-                        </span>
-                      </Row>
-                    </Box>
-                    <Separator className="bg-foreground" />
+            <Rows spacing="4u">
+              <ProjectLocaleProgressList
+                locales={locales}
+                isLoading={isLocaleProgressLoading}
+                isError={isLocaleProgressError}
+                settingsHref={settingsHref}
+                stringsHref={
+                  showViewStrings ? buildProjectPath(organizationSlug, projectId, "strings") : null
+                }
+              />
+              <Box paddingTop="1u">
+                <Columns spacing="4u" collapseBelow="large" alignY="start">
+                  <Column width="fluid">
+                    <Rows spacing="0">
+                      <Box paddingBottom="1.5u">
+                        <Row spacing="0" align="spaceBetween" alignY="baseline">
+                          <ProjectOverviewSectionLabel>
+                            <FormattedMessage {...messages.todayTitle} />
+                          </ProjectOverviewSectionLabel>
+                          <span className="text-xs font-medium tracking-wider text-muted-foreground uppercase tabular-nums">
+                            {triageItems.length}
+                          </span>
+                        </Row>
+                      </Box>
+                      <Separator className="bg-foreground" />
 
-                    {triageItems.length > 0 ? (
-                      <>
-                        {triageItems.map((item) => {
-                          const copy = resolveTriageCopy(item, intl);
-                          const href =
-                            item.kind === "guidance"
-                              ? settingsHref
-                              : item.job
-                                ? buildProjectJobHref(organizationSlug, projectId, item.job.id)
-                                : jobsHref;
-
-                          return (
-                            <div key={item.id}>
-                              <ProjectOverviewTriageRow
-                                href={href}
-                                statusLabel={triageStatusLabel(item.kind, intl)}
-                                statusClassName={triageStatusClassName(item.kind)}
-                                title={copy.title}
-                                meta={copy.meta}
-                                cta={copy.cta}
-                              />
-                              <Separator />
-                            </div>
-                          );
-                        })}
-                        <Box paddingTop="2u">
-                          <Link
-                            href={jobsHref}
-                            className="inline-flex w-fit items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-                          >
-                            <FormattedMessage {...messages.viewAllJobs} />
-                            <HugeiconsIcon
-                              icon={ArrowRight01Icon}
-                              strokeWidth={1.8}
-                              className="size-4"
-                            />
-                          </Link>
+                      {isJobsLoading ? (
+                        <Box paddingTop="3u">
+                          <Skeleton className="h-24 w-full" />
                         </Box>
-                      </>
-                    ) : isJobsError ? (
-                      <Box paddingTop="3u">
-                        <Rows spacing="1u">
-                          <TypographyP weight="medium" tone="content">
-                            <FormattedMessage {...messages.jobsUnavailable} />
-                          </TypographyP>
-                          <TypographyP wrapStyle="pretty" size="small" tone="subtle">
-                            <FormattedMessage {...messages.jobsUnavailableDescription} />
-                          </TypographyP>
-                          <Button
-                            nativeButton={false}
-                            render={<Link href={jobsHref} />}
-                            variant="outline"
-                            size="sm"
-                          >
-                            <FormattedMessage {...messages.viewJobs} />
-                          </Button>
-                        </Rows>
-                      </Box>
-                    ) : (
-                      <Box paddingTop="3u" paddingBottom="1u">
-                        <Rows spacing="1u">
-                          <TypographyP weight="medium" tone="content">
-                            <FormattedMessage {...messages.triageEmptyTitle} />
-                          </TypographyP>
-                          <TypographyP
-                            className="max-w-md leading-snug"
-                            wrapStyle="pretty"
-                            size="small"
-                            tone="subtle"
-                          >
-                            <FormattedMessage {...messages.triageEmptyDescription} />
-                          </TypographyP>
-                        </Rows>
-                      </Box>
-                    )}
-                  </Rows>
-                </Column>
+                      ) : triageItems.length > 0 ? (
+                        <>
+                          {triageItems.map((item) => {
+                            const copy = resolveTriageCopy(item, intl);
+                            const href =
+                              item.kind === "guidance"
+                                ? settingsHref
+                                : item.job
+                                  ? buildProjectJobHref(organizationSlug, projectId, item.job.id)
+                                  : jobsHref;
 
-                {showSidebar ? (
-                  <>
-                    <Column width="content">
-                      <div className="hidden self-stretch lg:block">
-                        <Separator orientation="vertical" />
-                      </div>
-                    </Column>
-                    <Column width="1/4">
-                      <Box paddingTop="0.5u">
-                        <ProjectOverviewSidebar
-                          project={project}
-                          isNative={isNative ?? false}
-                          hasTranslationGuidance={hasTranslationGuidance}
-                          localeRoute={localeRoute}
-                          settingsHref={settingsHref}
-                        />
-                      </Box>
-                    </Column>
-                  </>
-                ) : null}
-              </Columns>
-            </Box>
+                            return (
+                              <div key={item.id}>
+                                <ProjectOverviewTriageRow
+                                  href={href}
+                                  statusLabel={triageStatusLabel(item.kind, intl)}
+                                  statusClassName={triageStatusClassName(item.kind)}
+                                  title={copy.title}
+                                  meta={copy.meta}
+                                  cta={copy.cta}
+                                />
+                                <Separator />
+                              </div>
+                            );
+                          })}
+                          <Box paddingTop="2u">
+                            <Link
+                              href={jobsHref}
+                              className="inline-flex w-fit items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                            >
+                              <FormattedMessage {...messages.viewAllJobs} />
+                              <HugeiconsIcon
+                                icon={ArrowRight01Icon}
+                                strokeWidth={1.8}
+                                className="size-4"
+                              />
+                            </Link>
+                          </Box>
+                        </>
+                      ) : isJobsError ? (
+                        <Box paddingTop="3u">
+                          <Rows spacing="1u">
+                            <TypographyP weight="medium" tone="content">
+                              <FormattedMessage {...messages.jobsUnavailable} />
+                            </TypographyP>
+                            <TypographyP wrapStyle="pretty" size="small" tone="subtle">
+                              <FormattedMessage {...messages.jobsUnavailableDescription} />
+                            </TypographyP>
+                            <Button
+                              nativeButton={false}
+                              render={<Link href={jobsHref} />}
+                              variant="outline"
+                              size="sm"
+                            >
+                              <FormattedMessage {...messages.viewJobs} />
+                            </Button>
+                          </Rows>
+                        </Box>
+                      ) : (
+                        <Box paddingTop="3u" paddingBottom="1u">
+                          <Rows spacing="1u">
+                            <TypographyP weight="medium" tone="content">
+                              <FormattedMessage {...messages.triageEmptyTitle} />
+                            </TypographyP>
+                            <TypographyP
+                              className="max-w-md leading-snug"
+                              wrapStyle="pretty"
+                              size="small"
+                              tone="subtle"
+                            >
+                              <FormattedMessage {...messages.triageEmptyDescription} />
+                            </TypographyP>
+                          </Rows>
+                        </Box>
+                      )}
+                    </Rows>
+                  </Column>
+
+                  {showSidebar ? (
+                    <>
+                      <Column width="content">
+                        <div className="hidden self-stretch lg:block">
+                          <Separator orientation="vertical" />
+                        </div>
+                      </Column>
+                      <Column width="1/4">
+                        <Box paddingTop="0.5u">
+                          <ProjectOverviewSidebar
+                            project={project}
+                            isNative={isNative ?? false}
+                            hasTranslationGuidance={hasTranslationGuidance}
+                            localeRoute={localeRoute}
+                            settingsHref={settingsHref}
+                          />
+                        </Box>
+                      </Column>
+                    </>
+                  ) : null}
+                </Columns>
+              </Box>
+            </Rows>
           ) : null}
         </Rows>
       </Box>
@@ -560,6 +584,9 @@ export function ProjectOverviewPageContent({
   const jobsQuery = useProjectOverviewJobsQuery(organizationSlug, projectId, {
     enabled: projectQuery.isSuccess,
   });
+  const localeProgressQuery = useProjectLocaleProgressQuery(organizationSlug, projectId, {
+    enabled: projectQuery.isSuccess,
+  });
 
   const sourceLocale = projectQuery.data?.sourceLocale?.trim() || "en";
   const targetLocales = projectQuery.data?.targetLocales ?? [];
@@ -575,6 +602,9 @@ export function ProjectOverviewPageContent({
         jobs={jobsQuery.data ?? []}
         isJobsLoading={jobsQuery.isLoading}
         isJobsError={jobsQuery.isError}
+        locales={localeProgressQuery.data ?? []}
+        isLocaleProgressLoading={localeProgressQuery.isLoading}
+        isLocaleProgressError={localeProgressQuery.isError}
         onCreateJob={() => setCreateJobOpen(true)}
       />
       <CreateJobDialog

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
@@ -12,6 +12,7 @@
  */
 import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../_components/project-list";
+import type { ProjectLocaleProgressRow } from "@/api/routes/project/project.schema";
 
 export const projectOverviewFixture: ProjectListRow = {
   id: "project_website",
@@ -59,6 +60,33 @@ export const projectOverviewMissingGuidanceFixture: ProjectListRow = {
   translationContextValue: "",
   openJobCount: 0,
 };
+
+export const projectOverviewLocaleProgressFixture: ProjectLocaleProgressRow[] = [
+  {
+    locale: "fr-FR",
+    translationProgress: 68,
+    approvalProgress: 24,
+    words: { total: 120, translated: 82, approved: 29 },
+    phrases: { total: 40, translated: 27, approved: 10 },
+    lastActivityAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    locale: "de-DE",
+    translationProgress: 12,
+    approvalProgress: 0,
+    words: { total: 120, translated: 14, approved: 0 },
+    phrases: { total: 40, translated: 5, approved: 0 },
+    lastActivityAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    locale: "es-ES",
+    translationProgress: 0,
+    approvalProgress: 0,
+    words: { total: 120, translated: 0, approved: 0 },
+    phrases: { total: 40, translated: 0, approved: 0 },
+    lastActivityAt: null,
+  },
+];
 
 export const projectOverviewJobsFixture: ApiJob[] = [
   {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-locale-progress.ts
@@ -1,0 +1,41 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useQuery } from "@tanstack/react-query";
+
+import type { ProjectLocaleProgressResponse } from "@/api/routes/project/project.schema";
+import { apiClient } from "@/lib/api-client-instance";
+
+export function useProjectLocaleProgressQuery(
+  organizationSlug: string,
+  projectId: string,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: ["project-locale-progress", organizationSlug, projectId],
+    enabled: options?.enabled ?? true,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"][
+        "locale-progress"
+      ].$get({
+        param: { organizationSlug, projectId },
+      });
+      if (response.status !== 200) {
+        throw new Error(`Failed to load locale progress (${response.status})`);
+      }
+      const body = (await response.json()) as ProjectLocaleProgressResponse;
+      return body.locales;
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/projects/locale-progress/native-project-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/locale-progress/native-project-locale-progress.ts
@@ -10,19 +10,30 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database/client";
+import { countSourceWords } from "@/lib/reporting/word-analysis";
 
 import { buildLocaleProgressRow, type ProjectLocaleProgressRow } from "./project-locale-progress";
 
-const sourceWordCountSql = sql<number>`case
-  when btrim(${schema.projectTranslationKeys.sourceText}) = '' then 0
-  else coalesce(
-    cardinality(regexp_split_to_array(btrim(${schema.projectTranslationKeys.sourceText}), '[[:space:]]+')),
-    0
-  )
-end`;
+function whitespaceWordCount(sourceText: string) {
+  const trimmed = sourceText.trim();
+  if (!trimmed) {
+    return 0;
+  }
+
+  return trimmed.split(/\s+/).length;
+}
+
+export function countNativeSourceWords(sourceText: string, sourceLocale: string) {
+  const trimmed = sourceText.trim();
+  if (!trimmed) {
+    return 0;
+  }
+
+  return countSourceWords(trimmed, sourceLocale) ?? whitespaceWordCount(trimmed);
+}
 
 function toIsoTimestamp(value: Date | string | null | undefined) {
   if (!value) {
@@ -37,64 +48,92 @@ function toIsoTimestamp(value: Date | string | null | undefined) {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
+type NativeLocaleStats = {
+  translatedPhrases: number;
+  approvedPhrases: number;
+  translatedWords: number;
+  approvedWords: number;
+  lastActivityAt: Date | string | null;
+};
+
 export async function listNativeProjectLocaleProgress(input: {
   organizationId: string;
   projectId: string;
+  sourceLocale?: string | null;
   targetLocales: readonly string[];
 }): Promise<ProjectLocaleProgressRow[]> {
-  const [totals] = await db
-    .select({
-      phraseTotal: sql<number>`count(*)::int`.mapWith(Number),
-      wordTotal: sql<number>`coalesce(sum(${sourceWordCountSql}), 0)::int`.mapWith(Number),
-    })
-    .from(schema.projectTranslationKeys)
-    .where(
-      and(
-        eq(schema.projectTranslationKeys.organizationId, input.organizationId),
-        eq(schema.projectTranslationKeys.projectId, input.projectId),
-        eq(schema.projectTranslationKeys.isHidden, false),
+  const sourceLocale = input.sourceLocale?.trim() || "en";
+
+  const [keys, translations] = await Promise.all([
+    db
+      .select({
+        id: schema.projectTranslationKeys.id,
+        sourceText: schema.projectTranslationKeys.sourceText,
+      })
+      .from(schema.projectTranslationKeys)
+      .where(
+        and(
+          eq(schema.projectTranslationKeys.organizationId, input.organizationId),
+          eq(schema.projectTranslationKeys.projectId, input.projectId),
+          eq(schema.projectTranslationKeys.isHidden, false),
+        ),
       ),
-    );
-
-  const phraseTotal = totals?.phraseTotal ?? 0;
-  const wordTotal = totals?.wordTotal ?? 0;
-
-  const localeStats = await db
-    .select({
-      targetLocale: schema.projectTranslations.targetLocale,
-      translatedPhrases:
-        sql<number>`count(*) filter (where btrim(${schema.projectTranslations.text}) <> '')::int`.mapWith(
-          Number,
+    db
+      .select({
+        translationKeyId: schema.projectTranslations.translationKeyId,
+        targetLocale: schema.projectTranslations.targetLocale,
+        text: schema.projectTranslations.text,
+        status: schema.projectTranslations.status,
+        updatedAt: schema.projectTranslations.updatedAt,
+      })
+      .from(schema.projectTranslations)
+      .innerJoin(
+        schema.projectTranslationKeys,
+        eq(schema.projectTranslations.translationKeyId, schema.projectTranslationKeys.id),
+      )
+      .where(
+        and(
+          eq(schema.projectTranslations.organizationId, input.organizationId),
+          eq(schema.projectTranslations.projectId, input.projectId),
+          eq(schema.projectTranslationKeys.isHidden, false),
         ),
-      approvedPhrases:
-        sql<number>`count(*) filter (where ${schema.projectTranslations.status} = 'approved')::int`.mapWith(
-          Number,
-        ),
-      translatedWords:
-        sql<number>`coalesce(sum(${sourceWordCountSql}) filter (where btrim(${schema.projectTranslations.text}) <> ''), 0)::int`.mapWith(
-          Number,
-        ),
-      approvedWords:
-        sql<number>`coalesce(sum(${sourceWordCountSql}) filter (where ${schema.projectTranslations.status} = 'approved'), 0)::int`.mapWith(
-          Number,
-        ),
-      lastActivityAt: sql<Date | string | null>`max(${schema.projectTranslations.updatedAt})`,
-    })
-    .from(schema.projectTranslations)
-    .innerJoin(
-      schema.projectTranslationKeys,
-      eq(schema.projectTranslations.translationKeyId, schema.projectTranslationKeys.id),
-    )
-    .where(
-      and(
-        eq(schema.projectTranslations.organizationId, input.organizationId),
-        eq(schema.projectTranslations.projectId, input.projectId),
-        eq(schema.projectTranslationKeys.isHidden, false),
       ),
-    )
-    .groupBy(schema.projectTranslations.targetLocale);
+  ]);
 
-  const statsByLocale = new Map(localeStats.map((row) => [row.targetLocale, row] as const));
+  const wordCountByKeyId = new Map(
+    keys.map((key) => [key.id, countNativeSourceWords(key.sourceText, sourceLocale)] as const),
+  );
+  const phraseTotal = keys.length;
+  const wordTotal = [...wordCountByKeyId.values()].reduce((sum, count) => sum + count, 0);
+
+  const statsByLocale = new Map<string, NativeLocaleStats>();
+  for (const translation of translations) {
+    const wordCount = wordCountByKeyId.get(translation.translationKeyId) ?? 0;
+    const current = statsByLocale.get(translation.targetLocale) ?? {
+      translatedPhrases: 0,
+      approvedPhrases: 0,
+      translatedWords: 0,
+      approvedWords: 0,
+      lastActivityAt: null,
+    };
+    const hasText = translation.text.trim() !== "";
+    if (hasText) {
+      current.translatedPhrases += 1;
+      current.translatedWords += wordCount;
+    }
+    if (translation.status === "approved") {
+      current.approvedPhrases += 1;
+      current.approvedWords += wordCount;
+    }
+    if (
+      !current.lastActivityAt ||
+      new Date(translation.updatedAt).getTime() > new Date(current.lastActivityAt).getTime()
+    ) {
+      current.lastActivityAt = translation.updatedAt;
+    }
+    statsByLocale.set(translation.targetLocale, current);
+  }
+
   const seen = new Set<string>();
   const rows: ProjectLocaleProgressRow[] = [];
 

--- a/apps/hyperlocalise-web/src/lib/projects/locale-progress/native-project-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/locale-progress/native-project-locale-progress.ts
@@ -18,7 +18,10 @@ import { buildLocaleProgressRow, type ProjectLocaleProgressRow } from "./project
 
 const sourceWordCountSql = sql<number>`case
   when btrim(${schema.projectTranslationKeys.sourceText}) = '' then 0
-  else coalesce(cardinality(regexp_split_to_array(btrim(${schema.projectTranslationKeys.sourceText}), E'\\s+')), 0)
+  else coalesce(
+    cardinality(regexp_split_to_array(btrim(${schema.projectTranslationKeys.sourceText}), '[[:space:]]+')),
+    0
+  )
 end`;
 
 function toIsoTimestamp(value: Date | string | null | undefined) {

--- a/apps/hyperlocalise-web/src/lib/projects/locale-progress/native-project-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/locale-progress/native-project-locale-progress.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq, sql } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database/client";
+
+import { buildLocaleProgressRow, type ProjectLocaleProgressRow } from "./project-locale-progress";
+
+const sourceWordCountSql = sql<number>`case
+  when btrim(${schema.projectTranslationKeys.sourceText}) = '' then 0
+  else coalesce(cardinality(regexp_split_to_array(btrim(${schema.projectTranslationKeys.sourceText}), E'\\s+')), 0)
+end`;
+
+function toIsoTimestamp(value: Date | string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export async function listNativeProjectLocaleProgress(input: {
+  organizationId: string;
+  projectId: string;
+  targetLocales: readonly string[];
+}): Promise<ProjectLocaleProgressRow[]> {
+  const [totals] = await db
+    .select({
+      phraseTotal: sql<number>`count(*)::int`.mapWith(Number),
+      wordTotal: sql<number>`coalesce(sum(${sourceWordCountSql}), 0)::int`.mapWith(Number),
+    })
+    .from(schema.projectTranslationKeys)
+    .where(
+      and(
+        eq(schema.projectTranslationKeys.organizationId, input.organizationId),
+        eq(schema.projectTranslationKeys.projectId, input.projectId),
+        eq(schema.projectTranslationKeys.isHidden, false),
+      ),
+    );
+
+  const phraseTotal = totals?.phraseTotal ?? 0;
+  const wordTotal = totals?.wordTotal ?? 0;
+
+  const localeStats = await db
+    .select({
+      targetLocale: schema.projectTranslations.targetLocale,
+      translatedPhrases:
+        sql<number>`count(*) filter (where btrim(${schema.projectTranslations.text}) <> '')::int`.mapWith(
+          Number,
+        ),
+      approvedPhrases:
+        sql<number>`count(*) filter (where ${schema.projectTranslations.status} = 'approved')::int`.mapWith(
+          Number,
+        ),
+      translatedWords:
+        sql<number>`coalesce(sum(${sourceWordCountSql}) filter (where btrim(${schema.projectTranslations.text}) <> ''), 0)::int`.mapWith(
+          Number,
+        ),
+      approvedWords:
+        sql<number>`coalesce(sum(${sourceWordCountSql}) filter (where ${schema.projectTranslations.status} = 'approved'), 0)::int`.mapWith(
+          Number,
+        ),
+      lastActivityAt: sql<Date | string | null>`max(${schema.projectTranslations.updatedAt})`,
+    })
+    .from(schema.projectTranslations)
+    .innerJoin(
+      schema.projectTranslationKeys,
+      eq(schema.projectTranslations.translationKeyId, schema.projectTranslationKeys.id),
+    )
+    .where(
+      and(
+        eq(schema.projectTranslations.organizationId, input.organizationId),
+        eq(schema.projectTranslations.projectId, input.projectId),
+        eq(schema.projectTranslationKeys.isHidden, false),
+      ),
+    )
+    .groupBy(schema.projectTranslations.targetLocale);
+
+  const statsByLocale = new Map(localeStats.map((row) => [row.targetLocale, row] as const));
+  const seen = new Set<string>();
+  const rows: ProjectLocaleProgressRow[] = [];
+
+  for (const locale of input.targetLocales) {
+    seen.add(locale);
+    const stats = statsByLocale.get(locale);
+    rows.push(
+      buildLocaleProgressRow({
+        locale,
+        words: {
+          total: wordTotal,
+          translated: stats?.translatedWords ?? 0,
+          approved: stats?.approvedWords ?? 0,
+        },
+        phrases: {
+          total: phraseTotal,
+          translated: stats?.translatedPhrases ?? 0,
+          approved: stats?.approvedPhrases ?? 0,
+        },
+        lastActivityAt: toIsoTimestamp(stats?.lastActivityAt),
+      }),
+    );
+  }
+
+  for (const [locale, stats] of statsByLocale) {
+    if (seen.has(locale)) {
+      continue;
+    }
+
+    rows.push(
+      buildLocaleProgressRow({
+        locale,
+        words: {
+          total: wordTotal,
+          translated: stats.translatedWords,
+          approved: stats.approvedWords,
+        },
+        phrases: {
+          total: phraseTotal,
+          translated: stats.translatedPhrases,
+          approved: stats.approvedPhrases,
+        },
+        lastActivityAt: toIsoTimestamp(stats.lastActivityAt),
+      }),
+    );
+  }
+
+  if (input.targetLocales.length === 0 && rows.length === 0 && phraseTotal === 0) {
+    return [];
+  }
+
+  return rows;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/locale-progress/project-locale-progress.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/locale-progress/project-locale-progress.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
+import { countNativeSourceWords } from "./native-project-locale-progress";
 import {
   buildLocaleProgressRow,
   emptyLocaleProgressRow,
@@ -20,6 +21,13 @@ import {
   remainingCount,
   toProgressPercent,
 } from "./project-locale-progress";
+
+describe("countNativeSourceWords", () => {
+  it("uses locale-aware segmentation instead of whitespace for Japanese", () => {
+    expect(countNativeSourceWords("Hello world", "en")).toBe(2);
+    expect(countNativeSourceWords("日本語の翻訳", "ja")).toBeGreaterThan(1);
+  });
+});
 
 describe("toProgressPercent", () => {
   it("rounds completed work against the total", () => {

--- a/apps/hyperlocalise-web/src/lib/projects/locale-progress/project-locale-progress.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/locale-progress/project-locale-progress.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildLocaleProgressRow,
+  emptyLocaleProgressRow,
+  findLocaleProgressRecord,
+  localeBadgeCode,
+  remainingCount,
+  toProgressPercent,
+} from "./project-locale-progress";
+
+describe("toProgressPercent", () => {
+  it("rounds completed work against the total", () => {
+    expect(toProgressPercent(5, 34)).toBe(15);
+    expect(toProgressPercent(0, 10)).toBe(0);
+    expect(toProgressPercent(10, 0)).toBe(0);
+  });
+});
+
+describe("remainingCount", () => {
+  it("returns unfinished work without going negative", () => {
+    expect(remainingCount({ total: 34, translated: 5, approved: 0 })).toBe(29);
+    expect(remainingCount({ total: 5, translated: 8, approved: 0 })).toBe(0);
+  });
+});
+
+describe("localeBadgeCode", () => {
+  it("uses the language subtag", () => {
+    expect(localeBadgeCode("vi-VN")).toBe("VI");
+    expect(localeBadgeCode("fr-FR")).toBe("FR");
+    expect(localeBadgeCode("zh-Hant-TW")).toBe("ZH");
+  });
+});
+
+describe("findLocaleProgressRecord", () => {
+  it("matches Crowdin language ids to BCP-47 tags", () => {
+    const records = { vi: { translationProgress: 14 } };
+    expect(findLocaleProgressRecord(records, "vi-VN")).toEqual({
+      key: "vi",
+      value: { translationProgress: 14 },
+    });
+    expect(findLocaleProgressRecord(records, "fr-FR")).toBeUndefined();
+  });
+});
+
+describe("buildLocaleProgressRow", () => {
+  it("derives percents from word counts when omitted", () => {
+    expect(
+      buildLocaleProgressRow({
+        locale: "vi-VN",
+        words: { total: 34, translated: 5, approved: 0 },
+        phrases: { total: 8, translated: 1, approved: 0 },
+      }),
+    ).toEqual({
+      locale: "vi-VN",
+      translationProgress: 15,
+      approvalProgress: 0,
+      words: { total: 34, translated: 5, approved: 0 },
+      phrases: { total: 8, translated: 1, approved: 0 },
+      lastActivityAt: null,
+    });
+  });
+
+  it("builds an empty row for a locale with no work yet", () => {
+    expect(emptyLocaleProgressRow("de-DE").locale).toBe("de-DE");
+    expect(emptyLocaleProgressRow("de-DE").words.total).toBe(0);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/locale-progress/project-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/locale-progress/project-locale-progress.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { canonicalizeLocale } from "@/lib/i18n/locales";
+
+export type ProjectLocaleProgressCounts = {
+  total: number;
+  translated: number;
+  approved: number;
+};
+
+export type ProjectLocaleProgressRow = {
+  locale: string;
+  translationProgress: number;
+  approvalProgress: number;
+  words: ProjectLocaleProgressCounts;
+  phrases: ProjectLocaleProgressCounts;
+  lastActivityAt: string | null;
+};
+
+export function toProgressPercent(completed: number, total: number) {
+  if (total <= 0) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, Math.round((completed / total) * 100)));
+}
+
+export function emptyProgressCounts(): ProjectLocaleProgressCounts {
+  return { total: 0, translated: 0, approved: 0 };
+}
+
+export function remainingCount(counts: ProjectLocaleProgressCounts) {
+  return Math.max(0, counts.total - counts.translated);
+}
+
+export function localeBadgeCode(locale: string) {
+  const canonical = canonicalizeLocale(locale) ?? locale.trim();
+  const language = canonical.split("-")[0] ?? canonical;
+  return language.slice(0, 3).toUpperCase();
+}
+
+export function buildLocaleProgressRow(input: {
+  locale: string;
+  words: ProjectLocaleProgressCounts;
+  phrases: ProjectLocaleProgressCounts;
+  lastActivityAt?: string | null;
+  translationProgress?: number;
+  approvalProgress?: number;
+}): ProjectLocaleProgressRow {
+  return {
+    locale: input.locale,
+    translationProgress:
+      input.translationProgress ?? toProgressPercent(input.words.translated, input.words.total),
+    approvalProgress:
+      input.approvalProgress ?? toProgressPercent(input.words.approved, input.words.total),
+    words: input.words,
+    phrases: input.phrases,
+    lastActivityAt: input.lastActivityAt ?? null,
+  };
+}
+
+export function emptyLocaleProgressRow(locale: string): ProjectLocaleProgressRow {
+  return buildLocaleProgressRow({
+    locale,
+    words: emptyProgressCounts(),
+    phrases: emptyProgressCounts(),
+  });
+}
+
+function localeMatchKey(locale: string) {
+  return (canonicalizeLocale(locale) ?? locale).trim().toLowerCase();
+}
+
+export function findLocaleProgressRecord<T>(
+  records: Record<string, T>,
+  locale: string,
+): { key: string; value: T } | undefined {
+  const exact = records[locale];
+  if (exact !== undefined) {
+    return { key: locale, value: exact };
+  }
+
+  const wanted = localeMatchKey(locale);
+  for (const [key, value] of Object.entries(records)) {
+    if (localeMatchKey(key) === wanted) {
+      return { key, value };
+    }
+  }
+
+  const language = wanted.split("-")[0];
+  if (!language) {
+    return undefined;
+  }
+
+  for (const [key, value] of Object.entries(records)) {
+    const candidate = localeMatchKey(key);
+    if (candidate === language || candidate.startsWith(`${language}-`)) {
+      return { key, value };
+    }
+  }
+
+  return undefined;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/locale-progress/provider-locale-progress.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/locale-progress/provider-locale-progress.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { normalizeProviderLocaleProgress } from "./provider-locale-progress";
+
+describe("normalizeProviderLocaleProgress", () => {
+  it("maps Crowdin language progress onto project locales", () => {
+    const rows = normalizeProviderLocaleProgress({
+      targetLocales: ["vi-VN", "fr-FR"],
+      readiness: {
+        vi: {
+          translationProgress: 14,
+          approvalProgress: 0,
+          words: { total: 34, translated: 5, approved: 0 },
+          phrases: { total: 8, translated: 1, approved: 0 },
+        },
+      },
+    });
+
+    expect(rows).toEqual([
+      {
+        locale: "vi-VN",
+        translationProgress: 14,
+        approvalProgress: 0,
+        words: { total: 34, translated: 5, approved: 0 },
+        phrases: { total: 8, translated: 1, approved: 0 },
+        lastActivityAt: null,
+      },
+      {
+        locale: "fr-FR",
+        translationProgress: 0,
+        approvalProgress: 0,
+        words: { total: 0, translated: 0, approved: 0 },
+        phrases: { total: 0, translated: 0, approved: 0 },
+        lastActivityAt: null,
+      },
+    ]);
+  });
+
+  it("maps Smartling completed and authorized string counts", () => {
+    const rows = normalizeProviderLocaleProgress({
+      targetLocales: ["fr-FR"],
+      readiness: {
+        "fr-FR": {
+          completedStringCount: 8,
+          authorizedStringCount: 20,
+          lastCompleted: "2026-08-19T01:42:00.000Z",
+        },
+      },
+    });
+
+    expect(rows[0]).toMatchObject({
+      locale: "fr-FR",
+      translationProgress: 40,
+      approvalProgress: 0,
+      phrases: { total: 20, translated: 8, approved: 0 },
+      lastActivityAt: "2026-08-19T01:42:00.000Z",
+    });
+  });
+
+  it("returns empty counts when readiness is missing", () => {
+    expect(
+      normalizeProviderLocaleProgress({
+        targetLocales: ["de-DE"],
+        readiness: null,
+      }),
+    ).toEqual([
+      {
+        locale: "de-DE",
+        translationProgress: 0,
+        approvalProgress: 0,
+        words: { total: 0, translated: 0, approved: 0 },
+        phrases: { total: 0, translated: 0, approved: 0 },
+        lastActivityAt: null,
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/locale-progress/provider-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/locale-progress/provider-locale-progress.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  buildLocaleProgressRow,
+  emptyLocaleProgressRow,
+  emptyProgressCounts,
+  findLocaleProgressRecord,
+  toProgressPercent,
+  type ProjectLocaleProgressCounts,
+  type ProjectLocaleProgressRow,
+} from "./project-locale-progress";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function asFiniteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asIsoTimestamp(value: unknown) {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function readCountBucket(value: unknown): ProjectLocaleProgressCounts | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const total = asFiniteNumber(record.total);
+  if (total === null) {
+    return null;
+  }
+
+  return {
+    total: Math.max(0, Math.round(total)),
+    translated: Math.max(0, Math.round(asFiniteNumber(record.translated) ?? 0)),
+    approved: Math.max(0, Math.round(asFiniteNumber(record.approved) ?? 0)),
+  };
+}
+
+function readSmartlingCounts(record: Record<string, unknown>): {
+  phrases: ProjectLocaleProgressCounts;
+  lastActivityAt: string | null;
+} | null {
+  const translated = asFiniteNumber(record.completedStringCount);
+  const authorized = asFiniteNumber(record.authorizedStringCount);
+  if (translated === null && authorized === null) {
+    return null;
+  }
+
+  const total = Math.max(0, Math.round(authorized ?? translated ?? 0));
+  const done = Math.max(0, Math.round(translated ?? 0));
+
+  return {
+    phrases: {
+      total,
+      translated: done,
+      approved: 0,
+    },
+    lastActivityAt: asIsoTimestamp(record.lastCompleted) ?? asIsoTimestamp(record.lastAuthorized),
+  };
+}
+
+function isLocaleReadinessMap(value: Record<string, unknown>) {
+  return Object.values(value).some((entry) => asRecord(entry) !== null);
+}
+
+export function normalizeProviderLocaleProgress(input: {
+  targetLocales: readonly string[];
+  readiness: Record<string, unknown> | null;
+}): ProjectLocaleProgressRow[] {
+  const readiness = input.readiness ?? {};
+  const readinessMap = isLocaleReadinessMap(readiness) ? readiness : {};
+  const usedKeys = new Set<string>();
+  const rows: ProjectLocaleProgressRow[] = [];
+
+  for (const locale of input.targetLocales) {
+    const match = findLocaleProgressRecord(readinessMap, locale);
+    if (!match) {
+      rows.push(emptyLocaleProgressRow(locale));
+      continue;
+    }
+
+    usedKeys.add(match.key);
+    rows.push(normalizeProviderLocaleProgressEntry(locale, match.value));
+  }
+
+  for (const [locale, value] of Object.entries(readinessMap)) {
+    if (usedKeys.has(locale)) {
+      continue;
+    }
+
+    rows.push(normalizeProviderLocaleProgressEntry(locale, value));
+  }
+
+  return rows;
+}
+
+export function normalizeProviderLocaleProgressEntry(
+  locale: string,
+  value: unknown,
+): ProjectLocaleProgressRow {
+  const record = asRecord(value);
+  if (!record) {
+    return emptyLocaleProgressRow(locale);
+  }
+
+  const words = readCountBucket(record.words);
+  const phrases = readCountBucket(record.phrases);
+  const smartling = readSmartlingCounts(record);
+  const translationProgress = asFiniteNumber(record.translationProgress);
+  const approvalProgress = asFiniteNumber(record.approvalProgress);
+  const resolvedCounts = words ?? phrases ?? smartling?.phrases ?? emptyProgressCounts();
+
+  return buildLocaleProgressRow({
+    locale,
+    words: words ?? resolvedCounts,
+    phrases: phrases ?? resolvedCounts,
+    lastActivityAt: smartling?.lastActivityAt ?? null,
+    translationProgress:
+      translationProgress ?? toProgressPercent(resolvedCounts.translated, resolvedCounts.total),
+    approvalProgress:
+      approvalProgress ?? toProgressPercent(resolvedCounts.approved, resolvedCounts.total),
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.test.ts
@@ -97,9 +97,51 @@ describe("PhraseApiClient", () => {
     const locales = await client.listLocales("proj-1");
 
     expect(locales).toEqual([
-      { id: "loc-en", name: "en", code: "en-US", default: true },
-      { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+      { id: "loc-en", name: "en", code: "en-US", default: true, statistics: null },
+      { id: "loc-fr", name: "fr", code: "fr-FR", default: false, statistics: null },
     ]);
+  });
+
+  it("loads locale statistics from the locale show endpoint", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          id: "loc-fr",
+          name: "fr",
+          code: "fr-FR",
+          default: false,
+          statistics: {
+            keys_total_count: 8,
+            keys_untranslated_count: 3,
+            words_total_count: 34,
+            translations_completed_count: 5,
+            translations_unverified_count: 1,
+            unverified_words_count: 4,
+            missing_words_count: 29,
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const locale = await client.getLocale("proj-1", "loc-fr");
+
+    expect(locale).toEqual({
+      id: "loc-fr",
+      name: "fr",
+      code: "fr-FR",
+      default: false,
+      statistics: {
+        keysTotalCount: 8,
+        keysUntranslatedCount: 3,
+        wordsTotalCount: 34,
+        translationsCompletedCount: 5,
+        translationsUnverifiedCount: 1,
+        unverifiedWordsCount: 4,
+        missingWordsCount: 29,
+      },
+    });
   });
 
   it("uses the US base URL when region is us", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
@@ -65,11 +65,22 @@ export interface PhraseProject {
   updatedAt: string | null;
 }
 
+export interface PhraseLocaleStatistics {
+  keysTotalCount: number;
+  keysUntranslatedCount: number;
+  wordsTotalCount: number;
+  translationsCompletedCount: number;
+  translationsUnverifiedCount: number;
+  unverifiedWordsCount: number;
+  missingWordsCount: number;
+}
+
 export interface PhraseLocale {
   id: string;
   name: string;
   code: string | null;
   default: boolean;
+  statistics?: PhraseLocaleStatistics | null;
 }
 
 export interface PhraseBranch {
@@ -323,6 +334,13 @@ export class PhraseApiClient {
         }),
       normalize: (record) => normalizePhraseLocale(record as PhraseLocaleApiRecord),
     });
+  }
+
+  async getLocale(projectId: string, localeId: string): Promise<PhraseLocale> {
+    const record = await this.get<PhraseLocaleApiRecord>(
+      `/projects/${encodeURIComponent(projectId)}/locales/${encodeURIComponent(localeId)}`,
+    );
+    return normalizePhraseLocale(record);
   }
 
   async listBranches(projectId: string): Promise<PhraseBranch[]> {
@@ -893,11 +911,22 @@ type PhraseProjectApiRecord = {
   updated_at?: string | null;
 };
 
+type PhraseLocaleStatisticsApiRecord = {
+  keys_total_count?: number | null;
+  keys_untranslated_count?: number | null;
+  words_total_count?: number | null;
+  translations_completed_count?: number | null;
+  translations_unverified_count?: number | null;
+  unverified_words_count?: number | null;
+  missing_words_count?: number | null;
+};
+
 type PhraseLocaleApiRecord = {
   id: string;
   name: string;
   code?: string | null;
   default?: boolean;
+  statistics?: PhraseLocaleStatisticsApiRecord | null;
 };
 
 type PhraseBranchApiRecord = {
@@ -1020,12 +1049,35 @@ function normalizePhraseProject(project: PhraseProjectApiRecord): PhraseProject 
   };
 }
 
+function asLocaleCount(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
+}
+
+function normalizePhraseLocaleStatistics(
+  statistics: PhraseLocaleStatisticsApiRecord | null | undefined,
+): PhraseLocaleStatistics | null {
+  if (!statistics) {
+    return null;
+  }
+
+  return {
+    keysTotalCount: asLocaleCount(statistics.keys_total_count),
+    keysUntranslatedCount: asLocaleCount(statistics.keys_untranslated_count),
+    wordsTotalCount: asLocaleCount(statistics.words_total_count),
+    translationsCompletedCount: asLocaleCount(statistics.translations_completed_count),
+    translationsUnverifiedCount: asLocaleCount(statistics.translations_unverified_count),
+    unverifiedWordsCount: asLocaleCount(statistics.unverified_words_count),
+    missingWordsCount: asLocaleCount(statistics.missing_words_count),
+  };
+}
+
 function normalizePhraseLocale(locale: PhraseLocaleApiRecord): PhraseLocale {
   return {
     id: locale.id,
     name: locale.name,
     code: locale.code ?? null,
     default: locale.default ?? false,
+    statistics: normalizePhraseLocaleStatistics(locale.statistics),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-locale-progress.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-locale-progress.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { phraseTmsProvider } from "./phrase-provider";
+
+describe("mapLocaleStatisticsToReadiness", () => {
+  it("maps Phrase locale statistics onto word and string progress", () => {
+    expect(
+      phraseTmsProvider.mapLocaleStatisticsToReadiness({
+        keysTotalCount: 8,
+        keysUntranslatedCount: 3,
+        wordsTotalCount: 34,
+        translationsCompletedCount: 5,
+        translationsUnverifiedCount: 1,
+        unverifiedWordsCount: 4,
+        missingWordsCount: 29,
+      }),
+    ).toEqual({
+      translationProgress: 15,
+      approvalProgress: 3,
+      words: { total: 34, translated: 5, approved: 1 },
+      phrases: { total: 8, translated: 5, approved: 4 },
+    });
+  });
+});
+
+describe("loadProjectLocaleReadiness", () => {
+  it("loads Phrase locale show statistics for target locales", async () => {
+    const client = {
+      listLocales: vi.fn(async () => [
+        { id: "loc-en", name: "en", code: "en-US", default: true, statistics: null },
+        { id: "loc-fr", name: "fr", code: "fr-FR", default: false, statistics: null },
+      ]),
+      getLocale: vi.fn(async () => ({
+        id: "loc-fr",
+        name: "fr",
+        code: "fr-FR",
+        default: false,
+        statistics: {
+          keysTotalCount: 8,
+          keysUntranslatedCount: 3,
+          wordsTotalCount: 34,
+          translationsCompletedCount: 5,
+          translationsUnverifiedCount: 1,
+          unverifiedWordsCount: 4,
+          missingWordsCount: 29,
+        },
+      })),
+    };
+
+    const readiness = await phraseTmsProvider.loadProjectLocaleReadiness({
+      client: client as never,
+      projectId: "proj-1",
+    });
+
+    expect(client.getLocale).toHaveBeenCalledWith("proj-1", "loc-fr");
+    expect(client.getLocale).not.toHaveBeenCalledWith("proj-1", "loc-en");
+    expect(readiness).toEqual({
+      "fr-FR": {
+        translationProgress: 15,
+        approvalProgress: 3,
+        words: { total: 34, translated: 5, approved: 1 },
+        phrases: { total: 8, translated: 5, approved: 4 },
+      },
+    });
+  });
+
+  it("returns a single locale when languageId matches the Phrase locale id", async () => {
+    const client = {
+      listLocales: vi.fn(async () => [
+        { id: "loc-fr", name: "fr", code: "fr-FR", default: false, statistics: null },
+      ]),
+      getLocale: vi.fn(async () => ({
+        id: "loc-fr",
+        name: "fr",
+        code: "fr-FR",
+        default: false,
+        statistics: {
+          keysTotalCount: 8,
+          keysUntranslatedCount: 3,
+          wordsTotalCount: 34,
+          translationsCompletedCount: 5,
+          translationsUnverifiedCount: 1,
+          unverifiedWordsCount: 4,
+          missingWordsCount: 29,
+        },
+      })),
+    };
+
+    await expect(
+      phraseTmsProvider.loadProjectLocaleReadiness({
+        client: client as never,
+        projectId: "proj-1",
+        languageId: "loc-fr",
+      }),
+    ).resolves.toEqual({
+      translationProgress: 15,
+      approvalProgress: 3,
+      words: { total: 34, translated: 5, approved: 1 },
+      phrases: { total: 8, translated: 5, approved: 4 },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
@@ -55,6 +55,7 @@ import {
   type ProjectFileContentEditorPaginationInput,
 } from "@/lib/projects/content-editor/project-file-content-editor-pagination";
 import type { TmsProviderLiveFile } from "@/lib/providers/jobs/tms-provider-live";
+import { toProgressPercent } from "@/lib/projects/locale-progress/project-locale-progress";
 import type { ExternalTmsApprovedTranslationUpload } from "@/lib/providers/jobs/tms-provider-types";
 import { buildProviderReviewThreadId } from "@/lib/providers/provider-job-review/build-thread-id";
 import type {
@@ -292,6 +293,115 @@ export class PhraseTmsProvider extends TmsProvider {
         };
       }
     });
+  }
+
+  /** Computes locale readiness percentages from Phrase locale statistics. */
+  async loadProjectLocaleReadiness(input: {
+    client: PhraseApiClient;
+    projectId: string;
+    languageId?: string;
+  }) {
+    if (!input.projectId.trim()) {
+      return {};
+    }
+
+    let locales: PhraseLocale[];
+    try {
+      locales = await input.client.listLocales(input.projectId);
+    } catch (error) {
+      this.rethrowStringsAuthError(error);
+    }
+
+    const requestedLanguageId = input.languageId?.trim();
+    const targetLocales = locales.filter((locale) => {
+      if (requestedLanguageId) {
+        return (
+          locale.id === requestedLanguageId ||
+          locale.code === requestedLanguageId ||
+          locale.name === requestedLanguageId
+        );
+      }
+      return !locale.default;
+    });
+
+    const localeDetails = await mapWithConcurrency(
+      targetLocales,
+      FILE_LOCALE_FETCH_CONCURRENCY,
+      async (locale) => {
+        if (locale.statistics) {
+          return locale;
+        }
+
+        try {
+          return await input.client.getLocale(input.projectId, locale.id);
+        } catch (error) {
+          if (error instanceof PhraseApiError && error.status === 401) {
+            this.rethrowStringsAuthError(error);
+          }
+          return locale;
+        }
+      },
+    );
+
+    const localeReadiness: Record<string, unknown> = {};
+    for (const locale of localeDetails) {
+      const localeKey = locale.code?.trim() || locale.name.trim() || locale.id;
+      if (!localeKey) {
+        continue;
+      }
+      localeReadiness[localeKey] = this.mapLocaleStatisticsToReadiness(locale.statistics);
+    }
+
+    if (requestedLanguageId) {
+      if (localeReadiness[requestedLanguageId]) {
+        return localeReadiness[requestedLanguageId] as Record<string, unknown>;
+      }
+
+      const entries = Object.values(localeReadiness);
+      if (entries.length === 1) {
+        return entries[0] as Record<string, unknown>;
+      }
+    }
+
+    return localeReadiness;
+  }
+
+  /** Maps Phrase locale statistics into Crowdin-compatible progress fields. */
+  mapLocaleStatisticsToReadiness(statistics: PhraseLocale["statistics"]) {
+    const phrases = {
+      total: statistics?.keysTotalCount ?? 0,
+      translated: Math.max(
+        0,
+        (statistics?.keysTotalCount ?? 0) - (statistics?.keysUntranslatedCount ?? 0),
+      ),
+      approved: Math.max(
+        0,
+        (statistics?.keysTotalCount ?? 0) -
+          (statistics?.keysUntranslatedCount ?? 0) -
+          (statistics?.translationsUnverifiedCount ?? 0),
+      ),
+    };
+    const words = {
+      total: statistics?.wordsTotalCount ?? 0,
+      translated: Math.max(
+        0,
+        (statistics?.wordsTotalCount ?? 0) - (statistics?.missingWordsCount ?? 0),
+      ),
+      approved: Math.max(
+        0,
+        (statistics?.wordsTotalCount ?? 0) -
+          (statistics?.missingWordsCount ?? 0) -
+          (statistics?.unverifiedWordsCount ?? 0),
+      ),
+    };
+    const percentCounts = words.total > 0 ? words : phrases;
+
+    return {
+      translationProgress: toProgressPercent(percentCounts.translated, percentCounts.total),
+      approvalProgress: toProgressPercent(percentCounts.approved, percentCounts.total),
+      words,
+      phrases,
+    };
   }
 
   /**

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -3344,6 +3344,34 @@ export async function getTmsProviderLiveProjectLocaleReadiness(
     }
   }
 
+  if (context.providerKind === "phrase") {
+    if (!externalProjectId.trim()) {
+      return null;
+    }
+
+    const client = new PhraseApiClient({
+      token: context.secretMaterial,
+      region: context.credential.region,
+      baseUrl: context.credential.baseUrl,
+    });
+
+    try {
+      return await phraseTmsProvider.loadProjectLocaleReadiness({
+        client,
+        projectId: externalProjectId,
+        languageId: options?.languageId,
+      });
+    } catch (error) {
+      if (error instanceof PhraseApiError && error.status === 401) {
+        throw new TmsProviderLiveError("phrase_auth_invalid", "Phrase credentials are invalid.");
+      }
+      if (error instanceof Error && error.message === "phrase_auth_invalid") {
+        throw new TmsProviderLiveError("phrase_auth_invalid", "Phrase credentials are invalid.");
+      }
+      throw error;
+    }
+  }
+
   if (context.providerKind !== "crowdin") {
     return null;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Project overview now includes a **Languages** list with translation progress:

- Collapsed rows show locale badge, language name, translated/approved percents, remaining words, and a progress bar
- Expanding a row reveals a Words/Strings table (Todo / Done / %), last activity, and Translate / Proofread links into the editor when All Files is supported
- Search and A–Z / Z–A sort
- Native projects aggregate word/string counts from stored keys (hidden strings excluded)
- External TMS projects map live provider locale readiness (including Crowdin language ids like `vi` onto `vi-VN`)

## How to test

1. Open a native project with target locales and some translations on the overview page
2. Confirm the Languages list, expand a locale, switch Words/Strings, and use Translate / Proofread
3. Search and sort the list
4. Open a Crowdin-linked project and confirm mapped locale progress

Automated (this branch):

- `vp check --fix` in `apps/hyperlocalise-web`
- `vp test` in `apps/hyperlocalise-web` — 908 files, 6589 tests passed

## Checklist

- [x] I ran relevant checks locally (`vp check --fix` and `vp test` in `apps/hyperlocalise-web`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ee08f44-d991-4bc9-970b-4e41298bac2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ee08f44-d991-4bc9-970b-4e41298bac2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

