### PR TITLE
feat(web): ship Guidelines product page around connected docs

### DIFF
--- a/apps/hyperlocalise-web/_posts/de-DE/from-translation-management-to-translation-intelligence.md
+++ b/apps/hyperlocalise-web/_posts/de-DE/from-translation-management-to-translation-intelligence.md
@@ -280,7 +280,7 @@ Von statischen linguistischen Ressourcen zu sich selbst weiterentwickelndem Wiss
 
 Von der Übersetzungsverwaltung zur Übersetzungsintelligenz.
 
-Hyperlocalise arbeitet auf diese Zukunft hin mit [KI-Agenten](/product/agents-automation), einer [CAT-Erfahrung der nächsten Generation](/product/next-gen-cat-tool) und einer [selbstlernenden Context-Engine](/product/self-evolving-knowledge), die globalen Teams dabei helfen soll, bessere Übersetzungen mit weniger manueller Recherche zu erstellen.
+Hyperlocalise arbeitet auf diese Zukunft hin mit [KI-Agenten](/product/agents-automation), einer [CAT-Erfahrung der nächsten Generation](/product/next-gen-cat-tool) und einer [selbstlernenden Context-Engine](/product/guidelines), die globalen Teams dabei helfen soll, bessere Übersetzungen mit weniger manueller Recherche zu erstellen.
 
 Die nächste Generation von Lokalisierungssoftware wird nicht einfach nur Übersetzungen verwalten.
 

--- a/apps/hyperlocalise-web/_posts/de-DE/hyperlocalisation-why-global-growth-needs-more-than-translation.md
+++ b/apps/hyperlocalise-web/_posts/de-DE/hyperlocalisation-why-global-growth-needs-more-than-translation.md
@@ -129,7 +129,7 @@ Wir sind der Überzeugung, dass Wissen wiederverwendbar werden sollte.
 
 Ein Lokalisierungssystem sollte aus der Art und Weise lernen, wie ein Unternehmen kommuniziert. Es sollte sich merken, wie Begriffe produktübergreifend verwendet werden. Es sollte verstehen, wie Prüfer Entscheidungen treffen. Es sollte Muster im Marktfeedback erkennen. Es sollte Teams dabei helfen, die richtigen Regeln und den richtigen Kontext anzuwenden, ohne jedes Mal denselben manuellen Aufwand zu erfordern.
 
-Das ist gemeint mit [selbstentwickelnder Lokalisierungsintelligenz](/product/self-evolving-knowledge).
+Das ist gemeint mit [selbstentwickelnder Lokalisierungsintelligenz](/product/guidelines).
 
 Das System sollte mit jedem Projekt nützlicher werden. Es sollte wiederholte Fragen reduzieren, die Konsistenz verbessern und Teams im Laufe der Zeit dabei helfen, bessere Entscheidungen zu treffen. Je mehr ein Unternehmen lokalisiert, desto stärker sollte seine Lokalisierungsintelligenz werden.
 

--- a/apps/hyperlocalise-web/_posts/en/from-translation-management-to-translation-intelligence.md
+++ b/apps/hyperlocalise-web/_posts/en/from-translation-management-to-translation-intelligence.md
@@ -280,7 +280,7 @@ From static linguistic assets to self-evolving knowledge.
 
 From Translation Management to Translation Intelligence.
 
-Hyperlocalise is building toward this future through [AI agents](/product/agents-automation), a [next-generation CAT experience](/product/next-gen-cat-tool), and a [self-evolving context engine](/product/self-evolving-knowledge) designed to help global teams produce better translations with less manual investigation.
+Hyperlocalise is building toward this future through [AI agents](/product/agents-automation), a [next-generation CAT experience](/product/next-gen-cat-tool), and a [self-evolving context engine](/product/guidelines) designed to help global teams produce better translations with less manual investigation.
 
 The next generation of localisation software will not simply manage translation.
 

--- a/apps/hyperlocalise-web/_posts/en/hyperlocalisation-why-global-growth-needs-more-than-translation.md
+++ b/apps/hyperlocalise-web/_posts/en/hyperlocalisation-why-global-growth-needs-more-than-translation.md
@@ -129,7 +129,7 @@ We believe that knowledge should become reusable.
 
 A localisation system should learn from how a company communicates. It should remember how terms are used across products. It should understand how reviewers make decisions. It should recognise patterns in market feedback. It should help teams apply the right rules and context without requiring the same manual setup every time.
 
-This is what we mean by [self-evolving localisation intelligence](/product/self-evolving-knowledge).
+This is what we mean by [self-evolving localisation intelligence](/product/guidelines).
 
 The system should become more useful with every project. It should reduce repeated questions, improve consistency, and help teams make better decisions over time. The more a company localises, the stronger its localisation intelligence should become.
 

--- a/apps/hyperlocalise-web/_posts/fr-FR/from-translation-management-to-translation-intelligence.md
+++ b/apps/hyperlocalise-web/_posts/fr-FR/from-translation-management-to-translation-intelligence.md
@@ -280,7 +280,7 @@ Des actifs linguistiques statiques à une connaissance auto-évolutive.
 
 De la gestion de la traduction à l’intelligence de la traduction.
 
-Hyperlocalise construit cet avenir grâce à [agents d’IA](/product/agents-automation), une [expérience CAT de nouvelle génération](/product/next-gen-cat-tool) et un [moteur de contexte auto-évolutif](/product/self-evolving-knowledge) conçu pour aider les équipes internationales à produire de meilleures traductions avec moins d’investigations manuelles.
+Hyperlocalise construit cet avenir grâce à [agents d’IA](/product/agents-automation), une [expérience CAT de nouvelle génération](/product/next-gen-cat-tool) et un [moteur de contexte auto-évolutif](/product/guidelines) conçu pour aider les équipes internationales à produire de meilleures traductions avec moins d’investigations manuelles.
 
 La prochaine génération de logiciels de localisation ne se contentera pas de gérer la traduction.
 

--- a/apps/hyperlocalise-web/_posts/fr-FR/hyperlocalisation-why-global-growth-needs-more-than-translation.md
+++ b/apps/hyperlocalise-web/_posts/fr-FR/hyperlocalisation-why-global-growth-needs-more-than-translation.md
@@ -129,7 +129,7 @@ Nous pensons que le savoir doit devenir réutilisable.
 
 Un système de localisation doit apprendre de la manière dont une entreprise communique. Il doit se souvenir de la façon dont les termes sont utilisés dans l’ensemble des produits. Il doit comprendre comment les relecteurs prennent leurs décisions. Il doit reconnaître les tendances dans les retours du marché. Il doit aider les équipes à appliquer les bonnes règles et le bon contexte sans exiger la même configuration manuelle à chaque fois.
 
-C’est ce que nous entendons par [intelligence de localisation auto-évolutive](/product/self-evolving-knowledge).
+C’est ce que nous entendons par [intelligence de localisation auto-évolutive](/product/guidelines).
 
 Le système devrait devenir plus utile à chaque projet. Il devrait réduire les questions répétées, améliorer la cohérence et aider les équipes à prendre de meilleures décisions au fil du temps. Plus une entreprise localise, plus son intelligence de localisation devrait se renforcer.
 

--- a/apps/hyperlocalise-web/_posts/vi-VN/from-translation-management-to-translation-intelligence.md
+++ b/apps/hyperlocalise-web/_posts/vi-VN/from-translation-management-to-translation-intelligence.md
@@ -280,7 +280,7 @@ Từ các tài sản ngôn ngữ tĩnh đến tri thức tự tiến hóa.
 
 Từ quản lý dịch thuật đến trí tuệ dịch thuật.
 
-Hyperlocalise đang hướng tới tương lai này thông qua [các tác nhân AI](/product/agents-automation), một [trải nghiệm CAT thế hệ mới](/product/next-gen-cat-tool), và một [công cụ ngữ cảnh tự tiến hóa](/product/self-evolving-knowledge) được thiết kế để giúp các nhóm toàn cầu tạo ra bản dịch tốt hơn với ít công sức dò tìm thủ công hơn.
+Hyperlocalise đang hướng tới tương lai này thông qua [các tác nhân AI](/product/agents-automation), một [trải nghiệm CAT thế hệ mới](/product/next-gen-cat-tool), và một [công cụ ngữ cảnh tự tiến hóa](/product/guidelines) được thiết kế để giúp các nhóm toàn cầu tạo ra bản dịch tốt hơn với ít công sức dò tìm thủ công hơn.
 
 Phần mềm bản địa hóa thế hệ tiếp theo sẽ không chỉ đơn thuần quản lý việc dịch thuật.
 

--- a/apps/hyperlocalise-web/_posts/vi-VN/hyperlocalisation-why-global-growth-needs-more-than-translation.md
+++ b/apps/hyperlocalise-web/_posts/vi-VN/hyperlocalisation-why-global-growth-needs-more-than-translation.md
@@ -129,7 +129,7 @@ Chúng tôi tin rằng kiến thức nên có thể được tái sử dụng.
 
 Một hệ thống bản địa hóa nên học từ cách một công ty giao tiếp. Nó nên ghi nhớ cách các thuật ngữ được sử dụng xuyên suốt các sản phẩm. Nó nên hiểu cách những người duyệt nội dung đưa ra quyết định. Nó nên nhận ra các mẫu trong phản hồi thị trường. Nó nên giúp các nhóm áp dụng đúng quy tắc và ngữ cảnh mà không cần thiết lập thủ công giống nhau mỗi lần.
 
-Đây là điều chúng tôi muốn nói bằng [trí tuệ bản địa hoá tự tiến hoá](/product/self-evolving-knowledge).
+Đây là điều chúng tôi muốn nói bằng [trí tuệ bản địa hoá tự tiến hoá](/product/guidelines).
 
 Hệ thống nên trở nên hữu ích hơn với mỗi dự án. Nó nên giảm bớt các câu hỏi lặp lại, cải thiện tính nhất quán và giúp các nhóm đưa ra quyết định tốt hơn theo thời gian. Càng một công ty bản địa hoá nhiều, trí tuệ bản địa hoá của công ty đó càng nên mạnh hơn.
 

--- a/apps/hyperlocalise-web/_posts/zh-CN/from-translation-management-to-translation-intelligence.md
+++ b/apps/hyperlocalise-web/_posts/zh-CN/from-translation-management-to-translation-intelligence.md
@@ -280,7 +280,7 @@ Translation Intelligence 将评估贯穿整个流程。
 
 从翻译管理到翻译智能。
 
-Hyperlocalise 正在通过[AI 代理](/product/agents-automation)、[下一代 CAT 体验](/product/next-gen-cat-tool)以及[一个自我演进的上下文引擎](/product/self-evolving-knowledge)来构建这一未来，旨在帮助全球团队以更少的人工调查产出更优质的翻译。
+Hyperlocalise 正在通过[AI 代理](/product/agents-automation)、[下一代 CAT 体验](/product/next-gen-cat-tool)以及[一个自我演进的上下文引擎](/product/guidelines)来构建这一未来，旨在帮助全球团队以更少的人工调查产出更优质的翻译。
 
 下一代本地化软件将不仅仅管理翻译。
 

--- a/apps/hyperlocalise-web/_posts/zh-CN/hyperlocalisation-why-global-growth-needs-more-than-translation.md
+++ b/apps/hyperlocalise-web/_posts/zh-CN/hyperlocalisation-why-global-growth-needs-more-than-translation.md
@@ -129,7 +129,7 @@ Hyperlocalise 的长期愿景是为全球沟通创建一个动态智能层。
 
 本地化系统应从公司的沟通方式中学习。它应记住术语在不同产品中的使用方式。它应理解审校人员如何做出决策。它应识别市场反馈中的模式。它应帮助团队应用正确的规则和上下文，而无需每次都进行相同的手动设置。
 
-这就是我们所说的 [self-evolving localisation intelligence](/product/self-evolving-knowledge)。
+这就是我们所说的 [self-evolving localisation intelligence](/product/guidelines)。
 
 系统应随着每个项目变得更加实用。它应减少重复提问，提高一致性，并帮助团队随着时间推移做出更好的决策。公司本地化得越多，其本地化智能就应越强。
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/page.tsx
@@ -15,6 +15,7 @@ import { notFound, permanentRedirect } from "next/navigation";
 import { Suspense } from "react";
 
 import { ProductPage } from "@/components/marketing/product/product-page";
+import { GuidelinesPage } from "@/components/marketing/product/guidelines-page";
 import { MultilingualContentStudioPage } from "@/components/marketing/product/multilingual-content-studio-page";
 import {
   productPagesBySlug,
@@ -41,12 +42,13 @@ type ProductRouteProps = {
 };
 
 export function generateStaticParams() {
-  return SUPPORTED_APP_LOCALES.flatMap((lang) => productSlugs.map((slug) => ({ lang, slug })));
+  const slugs = [...productSlugs, "next-gen-cat-tool", "self-evolving-knowledge"];
+  return SUPPORTED_APP_LOCALES.flatMap((lang) => slugs.map((slug) => ({ lang, slug })));
 }
 
 export async function generateMetadata({ params }: ProductRouteProps): Promise<Metadata> {
   const { lang, slug } = await params;
-  if (slug === "next-gen-cat-tool") {
+  if (slug === "next-gen-cat-tool" || slug === "self-evolving-knowledge") {
     return {};
   }
   const content = productPagesBySlug[slug as keyof typeof productPagesBySlug];
@@ -93,8 +95,16 @@ async function ProductRouteContent({ params }: ProductRouteProps) {
     permanentRedirect(`/${lang}/product/multilingual-content-studio`);
   }
 
+  if (slug === "self-evolving-knowledge") {
+    permanentRedirect(`/${lang}/product/guidelines`);
+  }
+
   if (slug === "multilingual-content-studio") {
     return <MultilingualContentStudioPage />;
+  }
+
+  if (slug === "guidelines") {
+    return <GuidelinesPage />;
   }
   const content = productPagesBySlug[slug as keyof typeof productPagesBySlug];
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
@@ -51,8 +51,8 @@ export function getProductRouteMetadata(slug: string, intl: IntlShape) {
         }),
         description: intl.formatMessage({
           defaultMessage:
-            "Connect Google Drive, Notion, and SharePoint. Agents check drafts against the brand and compliance files your team already maintains.",
-          id: "2HF+fAMIDb",
+            "Connect Google Drive, Notion, and SharePoint, or type guidelines in. Agents check drafts against the brand and compliance files your team already maintains.",
+          id: "wwKiGsumAM",
           description: "Meta description for the Guidelines product page",
         }),
       };

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
@@ -46,13 +46,13 @@ export function getProductRouteMetadata(slug: string, intl: IntlShape) {
       return {
         title: intl.formatMessage({
           defaultMessage: "Keep the Docs You Have. Put Them to Work. | Hyperlocalise",
-          id: 'qqzc5HNRQF',
+          id: "qqzc5HNRQF",
           description: "Page title for the Guidelines product page",
         }),
         description: intl.formatMessage({
           defaultMessage:
             "Connect Google Drive, Notion, and SharePoint. Agents check drafts against the brand and compliance files your team already maintains.",
-          id: '2HF+fAMIDb',
+          id: "2HF+fAMIDb",
           description: "Meta description for the Guidelines product page",
         }),
       };

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
@@ -42,18 +42,18 @@ export function getProductRouteMetadata(slug: string, intl: IntlShape) {
           description: "Meta description for the multilingual Content Studio product page",
         }),
       };
-    case "self-evolving-knowledge":
+    case "guidelines":
       return {
         title: intl.formatMessage({
-          defaultMessage: "Stop Repeating the Same Localisation Feedback | Hyperlocalise",
-          id: "Ov7k7O9mR3",
-          description: "Page title for the self-evolving knowledge product page",
+          defaultMessage: "Keep the Docs You Have. Put Them to Work. | Hyperlocalise",
+          id: 'qqzc5HNRQF',
+          description: "Page title for the Guidelines product page",
         }),
         description: intl.formatMessage({
           defaultMessage:
-            "Capture reviewer corrections, glossary decisions, product context, and market preferences so every localisation workflow starts smarter.",
-          id: "G1is+5n2E6",
-          description: "Meta description for the self-evolving knowledge product page",
+            "Connect Google Drive, Notion, and SharePoint. Agents check drafts against the brand and compliance files your team already maintains.",
+          id: '2HF+fAMIDb',
+          description: "Meta description for the Guidelines product page",
         }),
       };
     default:

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
@@ -35,7 +35,7 @@ describe("llms.txt route", () => {
       "[Multilingual Content Studio](https://www.hyperlocalise.com/en/product/multilingual-content-studio): Create and adapt every content format in one multilingual workspace.",
     );
     expect(body).toContain(
-      "[Self-evolving Knowledge](https://www.hyperlocalise.com/en/product/self-evolving-knowledge): Stop repeating the same localisation feedback.",
+      "[Guidelines](https://www.hyperlocalise.com/en/product/guidelines): Connect Google Drive, Notion, and SharePoint so agents can check drafts against your files.",
     );
     expect(body).toContain("https://www.hyperlocalise.com/en/use-cases/");
     expect(body).toContain("https://hyperlocalise.dev");

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
@@ -35,7 +35,7 @@ describe("llms.txt route", () => {
       "[Multilingual Content Studio](https://www.hyperlocalise.com/en/product/multilingual-content-studio): Create and adapt every content format in one multilingual workspace.",
     );
     expect(body).toContain(
-      "[Guidelines](https://www.hyperlocalise.com/en/product/guidelines): Connect Google Drive, Notion, and SharePoint so agents can check drafts against your files.",
+      "[Guidelines](https://www.hyperlocalise.com/en/product/guidelines): Connect Google Drive, Notion, and SharePoint, or type guidelines in, so agents can check drafts against your files.",
     );
     expect(body).toContain("https://www.hyperlocalise.com/en/use-cases/");
     expect(body).toContain("https://hyperlocalise.dev");

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.ts
@@ -33,7 +33,7 @@ const productLinks: LlmsLink[] = [
     title: "Guidelines",
     href: `${SITE_URL}/en/product/guidelines`,
     description:
-      "Connect Google Drive, Notion, and SharePoint so agents can check drafts against your files",
+      "Connect Google Drive, Notion, and SharePoint, or type guidelines in, so agents can check drafts against your files",
   },
 ];
 

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.ts
@@ -30,9 +30,10 @@ const productLinks: LlmsLink[] = [
     description: "Create and adapt every content format in one multilingual workspace",
   },
   {
-    title: "Self-evolving Knowledge",
-    href: `${SITE_URL}/en/product/self-evolving-knowledge`,
-    description: "Stop repeating the same localisation feedback",
+    title: "Guidelines",
+    href: `${SITE_URL}/en/product/guidelines`,
+    description:
+      "Connect Google Drive, Notion, and SharePoint so agents can check drafts against your files",
   },
 ];
 
@@ -80,7 +81,7 @@ function buildLlmsTxt(): string {
 
 Hyperlocalise gives localisation teams an AI workforce that understands market nuance, then translates, reviews, and syncs product copy with real context. Instead of chasing strings across tools, localisation managers assign agents to the work, keep human review first-class, and ship multilingual launches with confidence.
 
-The product experience is designed for localisation managers who need control without busywork: clear workflows, trustworthy context, and review loops that scale with every release. Hyperlocalise combines agent automation, a next-gen CAT workspace, and self-evolving knowledge so every launch starts with product meaning, glossary decisions, and reviewer intent already attached. Stay flexible across LLM providers and TMS platforms while keeping localisation quality under control.
+The product experience is designed for localisation managers who need control without busywork: clear workflows, trustworthy context, and review loops that scale with every release. Hyperlocalise combines agent automation, a next-gen CAT workspace, and shared guidelines so every launch starts with product meaning, glossary decisions, and reviewer intent already attached. Stay flexible across LLM providers and TMS platforms while keeping localisation quality under control.
 
 Use the pages below as the canonical overview of Hyperlocalise. Prefer these curated links over crawling the full site.
 

--- a/apps/hyperlocalise-web/src/components/marketing/homepage/homepage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage/homepage.messages.ts
@@ -115,8 +115,9 @@ export const homepageMessages = defineMessages({
     description: "Marketing homepage hyperlabShort",
   },
   guidelinesShort: {
-    defaultMessage: "Keep every output on-brand, compliant, and consistent across markets.",
-    id: "mTRhHwVIHd",
+    defaultMessage:
+      "Connect Google Drive, Notion, and SharePoint. Agents check the files you already have.",
+    id: 'KvdvawHM1m',
     description: "Marketing homepage guidelinesShort",
   },
   studioBody: {
@@ -145,8 +146,8 @@ export const homepageMessages = defineMessages({
   },
   guidelinesBody: {
     defaultMessage:
-      "Give your team and agents shared brand guidance, terminology, and market context.",
-    id: "tSAM5aO3Q/",
+      "Leave brand PDFs, market notes, and policy libraries where they live. Agents flag what does not match.",
+    id: 'Y38gH31xOM',
     description: "Marketing homepage guidelinesBody",
   },
   agentsEyebrow: {

--- a/apps/hyperlocalise-web/src/components/marketing/homepage/homepage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage/homepage.messages.ts
@@ -117,7 +117,7 @@ export const homepageMessages = defineMessages({
   guidelinesShort: {
     defaultMessage:
       "Connect Google Drive, Notion, and SharePoint. Agents check the files you already have.",
-    id: 'KvdvawHM1m',
+    id: "KvdvawHM1m",
     description: "Marketing homepage guidelinesShort",
   },
   studioBody: {
@@ -147,7 +147,7 @@ export const homepageMessages = defineMessages({
   guidelinesBody: {
     defaultMessage:
       "Leave brand PDFs, market notes, and policy libraries where they live. Agents flag what does not match.",
-    id: 'Y38gH31xOM',
+    id: "Y38gH31xOM",
     description: "Marketing homepage guidelinesBody",
   },
   agentsEyebrow: {

--- a/apps/hyperlocalise-web/src/components/marketing/homepage/homepage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage/homepage.messages.ts
@@ -116,8 +116,8 @@ export const homepageMessages = defineMessages({
   },
   guidelinesShort: {
     defaultMessage:
-      "Connect Google Drive, Notion, and SharePoint. Agents check the files you already have.",
-    id: "KvdvawHM1m",
+      "Connect Google Drive, Notion, and SharePoint, or type guidelines in. Agents check the files you already have.",
+    id: "xQjhAYVKZT",
     description: "Marketing homepage guidelinesShort",
   },
   studioBody: {
@@ -146,8 +146,8 @@ export const homepageMessages = defineMessages({
   },
   guidelinesBody: {
     defaultMessage:
-      "Leave brand PDFs, market notes, and policy libraries where they live. Agents flag what does not match.",
-    id: "Y38gH31xOM",
+      "Leave brand PDFs, market notes, and policy libraries where they live, or type guidelines in. Agents flag what does not match.",
+    id: "JCbR6p89qW",
     description: "Marketing homepage guidelinesBody",
   },
   agentsEyebrow: {

--- a/apps/hyperlocalise-web/src/components/marketing/homepage/product-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage/product-preview.tsx
@@ -56,7 +56,7 @@ export const PRODUCTS = [
   },
   {
     id: "guidelines",
-    href: "#explore",
+    href: "/product/guidelines",
     title: m.guidelinesCardTitle,
     short: m.guidelinesShort,
     body: m.guidelinesBody,

--- a/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guideline-mock-ui.tsx
@@ -38,7 +38,7 @@ const COMPLIANCE_ITEM_COUNT = 3;
 
 type SceneId = "style-guides" | "market-knowledge" | "compliance";
 
-function StyleGuidePanel({ activeRuleIndex }: { activeRuleIndex: number }) {
+export function StyleGuidePanel({ activeRuleIndex }: { activeRuleIndex: number }) {
   const intl = useIntl();
   const rules = useMemo(
     () => [
@@ -145,7 +145,7 @@ function StyleGuidePanel({ activeRuleIndex }: { activeRuleIndex: number }) {
   );
 }
 
-function MarketKnowledgePanel({ activeMarketIndex }: { activeMarketIndex: number }) {
+export function MarketKnowledgePanel({ activeMarketIndex }: { activeMarketIndex: number }) {
   const intl = useIntl();
   const markets = useMemo(
     () => [
@@ -242,7 +242,7 @@ function MarketKnowledgePanel({ activeMarketIndex }: { activeMarketIndex: number
   );
 }
 
-function CompliancePanel({ checkedCount }: { checkedCount: number }) {
+export function CompliancePanel({ checkedCount }: { checkedCount: number }) {
   const intl = useIntl();
   const items = useMemo(
     () => [
@@ -352,6 +352,7 @@ export function GuidelineMockUI({
   variant = "full",
   aside,
   meshPosition = "left",
+  className,
 }: {
   priority?: boolean;
   pauseAutoplay?: boolean;
@@ -359,6 +360,7 @@ export function GuidelineMockUI({
   variant?: MarketingMockVariant;
   aside?: ReactNode;
   meshPosition?: MarketingMockMeshPosition;
+  className?: string;
 }) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion();
@@ -508,6 +510,7 @@ export function GuidelineMockUI({
       priority={priority}
       variant={variant}
       meshPosition={meshPosition}
+      className={className}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-board-mock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-board-mock.messages.ts
@@ -17,235 +17,235 @@ import { defineMessages } from "react-intl";
 export const guidelinesBoardMockMessages = defineMessages({
   boardTitle: {
     defaultMessage: "Connected guidelines",
-    id: 'VS0VH/0762',
+    id: "VS0VH/0762",
     description: "Title of the connected guidelines file board",
   },
   boardSubtitle: {
     defaultMessage: "Drive, Notion, and SharePoint stay the source of truth",
-    id: 'oNw/Do5A5A',
+    id: "oNw/Do5A5A",
     description: "Subtitle of the connected guidelines file board",
   },
   driveName: {
     defaultMessage: "Google Drive",
-    id: 'mhbklWULOm',
+    id: "mhbklWULOm",
     description: "Google Drive source name on the guidelines board",
   },
   driveFile: {
     defaultMessage: "Brand-claims-policy.pdf",
-    id: 'CQEmCrymE3',
+    id: "CQEmCrymE3",
     description: "Google Drive PDF filename on the guidelines board",
   },
   driveMeta: {
     defaultMessage: "PDF · 6 pages · Legal",
-    id: 'BVHeBhvF9c',
+    id: "BVHeBhvF9c",
     description: "Google Drive file metadata on the guidelines board",
   },
   notionName: {
     defaultMessage: "Notion",
-    id: 'hzccK8c1vn',
+    id: "hzccK8c1vn",
     description: "Notion source name on the guidelines board",
   },
   notionFile: {
     defaultMessage: "Japan market notes",
-    id: 'TZ3ud06CD+',
+    id: "TZ3ud06CD+",
     description: "Notion page title on the guidelines board",
   },
   notionMeta: {
     defaultMessage: "Page · GTM · Updated this week",
-    id: 'Oy/qd39Day',
+    id: "Oy/qd39Day",
     description: "Notion page metadata on the guidelines board",
   },
   sharepointName: {
     defaultMessage: "SharePoint",
-    id: 'JC6yhq1JP6',
+    id: "JC6yhq1JP6",
     description: "SharePoint source name on the guidelines board",
   },
   sharepointFile: {
     defaultMessage: "EU disclosures library",
-    id: 'pFQ34kvcvg',
+    id: "pFQ34kvcvg",
     description: "SharePoint library name on the guidelines board",
   },
   sharepointMeta: {
     defaultMessage: "Library · Compliance · 18 files",
-    id: 'MjeUyFbT8y',
+    id: "MjeUyFbT8y",
     description: "SharePoint library metadata on the guidelines board",
   },
   pdfTitle: {
     defaultMessage: "Brand & claims policy",
-    id: 'iEesyqaQVt',
+    id: "iEesyqaQVt",
     description: "Title shown on the fake guidelines PDF",
   },
   pdfMeta: {
     defaultMessage: "Confidential · Page 2 of 6",
-    id: 'o76L/3NXxQ',
+    id: "o76L/3NXxQ",
     description: "Meta line on the fake guidelines PDF",
   },
   pdfIntro: {
     defaultMessage:
       "Use this policy when reviewing campaign copy. Agents must cite the clause that applies.",
-    id: 'y/2/+8rxbw',
+    id: "y/2/+8rxbw",
     description: "Intro paragraph on the fake guidelines PDF",
   },
   clauseHealthTitle: {
     defaultMessage: "2.1 Health claims",
-    id: 'eXGK8mxaRF',
+    id: "eXGK8mxaRF",
     description: "PDF clause title for health claims",
   },
   clauseHealthBody: {
     defaultMessage:
       'Do not use "clinically proven" or "klinisch erwiesen" unless the wording is on the approved claims list.',
-    id: 'zEhmEZ0r+l',
+    id: "zEhmEZ0r+l",
     description: "PDF clause body for health claims",
   },
   clauseGermanTitle: {
     defaultMessage: "3.2 German advertising",
-    id: '4xfa2MgxvC',
+    id: "4xfa2MgxvC",
     description: "PDF clause title for German advertising",
   },
   clauseGermanBody: {
     defaultMessage:
       "Do not use superlatives such as einzigartig, beste, or sensationell in German ads.",
-    id: 'VmCEhPgA0d',
+    id: "VmCEhPgA0d",
     description: "PDF clause body for German advertising",
   },
   clauseAiTitle: {
     defaultMessage: "4.3 AI features",
-    id: 'eZwaIz7tNc',
+    id: "eZwaIz7tNc",
     description: "PDF clause title for AI disclosures",
   },
   clauseAiBody: {
     defaultMessage:
       "Pages that mention KI or AI must include the EU AI Act disclosure from this policy.",
-    id: 'iCZtn2vyra',
+    id: "iCZtn2vyra",
     description: "PDF clause body for AI disclosures",
   },
   notionPreviewLabel: {
     defaultMessage: "Page preview",
-    id: 'igXJErVret',
+    id: "igXJErVret",
     description: "Label above the Notion guideline preview",
   },
   notionPreviewBody: {
     defaultMessage:
       "Lead with trust signals and social proof. Do not use aggressive discount language or urgency tactics.",
-    id: 'UsjppO5ENO',
+    id: "UsjppO5ENO",
     description: "Body of the Notion guideline preview",
   },
   sharepointPreviewLabel: {
     defaultMessage: "Library preview",
-    id: 'gWJIlIDF6/',
+    id: "gWJIlIDF6/",
     description: "Label above the SharePoint guideline preview",
   },
   sharepointPreviewBody: {
     defaultMessage:
       "Approved EU AI Act disclosure, GDPR marketing claims, and health-claim wording live in this library.",
-    id: 'X+8j5AXyLj',
+    id: "X+8j5AXyLj",
     description: "Body of the SharePoint guideline preview",
   },
   chatTitle: {
     defaultMessage: "Guideline check",
-    id: 'w8q/KN/ZqF',
+    id: "w8q/KN/ZqF",
     description: "Chat header title in the guidelines board mock",
   },
   chatEmptyTitle: {
     defaultMessage: "Check copy against the PDF",
-    id: 'rPN3Y2jfH0',
+    id: "rPN3Y2jfH0",
     description: "Empty-state title in the guidelines board chat",
   },
   chatEmptySubtitle: {
     defaultMessage:
       "Ask the agent to read Brand-claims-policy.pdf and flag anything that breaks a clause.",
-    id: 'pe8wOIBCi/',
+    id: "pe8wOIBCi/",
     description: "Empty-state subtitle in the guidelines board chat",
   },
   chatSuggestion: {
     defaultMessage: "Review this German launch line",
-    id: 'Dr6q7soTm3',
+    id: "Dr6q7soTm3",
     description: "Suggestion button in the guidelines board chat",
   },
   chatPrompt: {
     defaultMessage:
       'Check this German launch line against Brand-claims-policy.pdf: "Unsere einzigartige KI-Plattform ist klinisch erwiesen."',
-    id: '4p/SsmkJuR',
+    id: "4p/SsmkJuR",
     description: "User prompt in the guidelines board chat",
   },
   chatCollapse: {
     defaultMessage: "Collapse",
-    id: 'JY9Ed02KEb',
+    id: "JY9Ed02KEb",
     description: "Accessible label to collapse the guidelines board chat",
   },
   chatClose: {
     defaultMessage: "Close",
-    id: 'D2D16fgUkP',
+    id: "D2D16fgUkP",
     description: "Accessible label to close the guidelines board chat",
   },
   toolName: {
     defaultMessage: "Read guideline",
-    id: 'SE8vhhcRvh',
+    id: "SE8vhhcRvh",
     description: "Tool name while the agent reads the PDF",
   },
   toolDetail: {
     defaultMessage: "Brand-claims-policy.pdf · Google Drive",
-    id: 'mgqDzjgTSc',
+    id: "mgqDzjgTSc",
     description: "Tool detail while the agent reads the PDF",
   },
   replyIntro: {
     defaultMessage: "Three clauses in the Drive PDF are broken. Open a flag to see it in the file.",
-    id: 'PZZ/+9b/45',
+    id: "PZZ/+9b/45",
     description: "Agent reply intro after reading the PDF",
   },
   flagGermanTitle: {
     defaultMessage: "Superlative in DE copy",
-    id: 'YZiaFZNuPi',
+    id: "YZiaFZNuPi",
     description: "First compliance flag title",
   },
   flagGermanBody: {
     defaultMessage: '"einzigartige" is blocked by clause 3.2.',
-    id: 'IW6zsfvtOy',
+    id: "IW6zsfvtOy",
     description: "First compliance flag body",
   },
   flagHealthTitle: {
     defaultMessage: "Unapproved health claim",
-    id: 'kvUTmvykXa',
+    id: "kvUTmvykXa",
     description: "Second compliance flag title",
   },
   flagHealthBody: {
     defaultMessage: '"klinisch erwiesen" is not on the approved list in clause 2.1.',
-    id: '071psyOiAM',
+    id: "071psyOiAM",
     description: "Second compliance flag body",
   },
   flagAiTitle: {
     defaultMessage: "Missing AI disclosure",
-    id: 'd2A2zGHowt',
+    id: "d2A2zGHowt",
     description: "Third compliance flag title",
   },
   flagAiBody: {
     defaultMessage: "Mentioning KI requires the EU AI Act wording in clause 4.3.",
-    id: 'n3fs1Skt3S',
+    id: "n3fs1Skt3S",
     description: "Third compliance flag body",
   },
   contextPill: {
     defaultMessage: "Brand-claims-policy.pdf",
-    id: 'UgXh/JEfra',
+    id: "UgXh/JEfra",
     description: "Context chip in the guidelines board composer",
   },
   composerPlaceholder: {
     defaultMessage: "Ask to check another line against the connected files",
-    id: '7eizbN+V+O',
+    id: "7eizbN+V+O",
     description: "Placeholder in the guidelines board composer after send",
   },
   send: {
     defaultMessage: "Send",
-    id: 'h4qqRHFDUX',
+    id: "h4qqRHFDUX",
     description: "Send button in the guidelines board chat",
   },
   replay: {
     defaultMessage: "Replay",
-    id: 'qjnIHRqIL8',
+    id: "qjnIHRqIL8",
     description: "Replay button in the guidelines board chat",
   },
   sourceAriaLabel: {
     defaultMessage: "Connected guideline sources",
-    id: 'RNFkjkR2en',
+    id: "RNFkjkR2en",
     description: "Accessible label for the guidelines board file list",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-board-mock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-board-mock.messages.ts
@@ -1,0 +1,251 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const guidelinesBoardMockMessages = defineMessages({
+  boardTitle: {
+    defaultMessage: "Connected guidelines",
+    id: 'VS0VH/0762',
+    description: "Title of the connected guidelines file board",
+  },
+  boardSubtitle: {
+    defaultMessage: "Drive, Notion, and SharePoint stay the source of truth",
+    id: 'oNw/Do5A5A',
+    description: "Subtitle of the connected guidelines file board",
+  },
+  driveName: {
+    defaultMessage: "Google Drive",
+    id: 'mhbklWULOm',
+    description: "Google Drive source name on the guidelines board",
+  },
+  driveFile: {
+    defaultMessage: "Brand-claims-policy.pdf",
+    id: 'CQEmCrymE3',
+    description: "Google Drive PDF filename on the guidelines board",
+  },
+  driveMeta: {
+    defaultMessage: "PDF · 6 pages · Legal",
+    id: 'BVHeBhvF9c',
+    description: "Google Drive file metadata on the guidelines board",
+  },
+  notionName: {
+    defaultMessage: "Notion",
+    id: 'hzccK8c1vn',
+    description: "Notion source name on the guidelines board",
+  },
+  notionFile: {
+    defaultMessage: "Japan market notes",
+    id: 'TZ3ud06CD+',
+    description: "Notion page title on the guidelines board",
+  },
+  notionMeta: {
+    defaultMessage: "Page · GTM · Updated this week",
+    id: 'Oy/qd39Day',
+    description: "Notion page metadata on the guidelines board",
+  },
+  sharepointName: {
+    defaultMessage: "SharePoint",
+    id: 'JC6yhq1JP6',
+    description: "SharePoint source name on the guidelines board",
+  },
+  sharepointFile: {
+    defaultMessage: "EU disclosures library",
+    id: 'pFQ34kvcvg',
+    description: "SharePoint library name on the guidelines board",
+  },
+  sharepointMeta: {
+    defaultMessage: "Library · Compliance · 18 files",
+    id: 'MjeUyFbT8y',
+    description: "SharePoint library metadata on the guidelines board",
+  },
+  pdfTitle: {
+    defaultMessage: "Brand & claims policy",
+    id: 'iEesyqaQVt',
+    description: "Title shown on the fake guidelines PDF",
+  },
+  pdfMeta: {
+    defaultMessage: "Confidential · Page 2 of 6",
+    id: 'o76L/3NXxQ',
+    description: "Meta line on the fake guidelines PDF",
+  },
+  pdfIntro: {
+    defaultMessage:
+      "Use this policy when reviewing campaign copy. Agents must cite the clause that applies.",
+    id: 'y/2/+8rxbw',
+    description: "Intro paragraph on the fake guidelines PDF",
+  },
+  clauseHealthTitle: {
+    defaultMessage: "2.1 Health claims",
+    id: 'eXGK8mxaRF',
+    description: "PDF clause title for health claims",
+  },
+  clauseHealthBody: {
+    defaultMessage:
+      'Do not use "clinically proven" or "klinisch erwiesen" unless the wording is on the approved claims list.',
+    id: 'zEhmEZ0r+l',
+    description: "PDF clause body for health claims",
+  },
+  clauseGermanTitle: {
+    defaultMessage: "3.2 German advertising",
+    id: '4xfa2MgxvC',
+    description: "PDF clause title for German advertising",
+  },
+  clauseGermanBody: {
+    defaultMessage:
+      "Do not use superlatives such as einzigartig, beste, or sensationell in German ads.",
+    id: 'VmCEhPgA0d',
+    description: "PDF clause body for German advertising",
+  },
+  clauseAiTitle: {
+    defaultMessage: "4.3 AI features",
+    id: 'eZwaIz7tNc',
+    description: "PDF clause title for AI disclosures",
+  },
+  clauseAiBody: {
+    defaultMessage:
+      "Pages that mention KI or AI must include the EU AI Act disclosure from this policy.",
+    id: 'iCZtn2vyra',
+    description: "PDF clause body for AI disclosures",
+  },
+  notionPreviewLabel: {
+    defaultMessage: "Page preview",
+    id: 'igXJErVret',
+    description: "Label above the Notion guideline preview",
+  },
+  notionPreviewBody: {
+    defaultMessage:
+      "Lead with trust signals and social proof. Do not use aggressive discount language or urgency tactics.",
+    id: 'UsjppO5ENO',
+    description: "Body of the Notion guideline preview",
+  },
+  sharepointPreviewLabel: {
+    defaultMessage: "Library preview",
+    id: 'gWJIlIDF6/',
+    description: "Label above the SharePoint guideline preview",
+  },
+  sharepointPreviewBody: {
+    defaultMessage:
+      "Approved EU AI Act disclosure, GDPR marketing claims, and health-claim wording live in this library.",
+    id: 'X+8j5AXyLj',
+    description: "Body of the SharePoint guideline preview",
+  },
+  chatTitle: {
+    defaultMessage: "Guideline check",
+    id: 'w8q/KN/ZqF',
+    description: "Chat header title in the guidelines board mock",
+  },
+  chatEmptyTitle: {
+    defaultMessage: "Check copy against the PDF",
+    id: 'rPN3Y2jfH0',
+    description: "Empty-state title in the guidelines board chat",
+  },
+  chatEmptySubtitle: {
+    defaultMessage:
+      "Ask the agent to read Brand-claims-policy.pdf and flag anything that breaks a clause.",
+    id: 'pe8wOIBCi/',
+    description: "Empty-state subtitle in the guidelines board chat",
+  },
+  chatSuggestion: {
+    defaultMessage: "Review this German launch line",
+    id: 'Dr6q7soTm3',
+    description: "Suggestion button in the guidelines board chat",
+  },
+  chatPrompt: {
+    defaultMessage:
+      'Check this German launch line against Brand-claims-policy.pdf: "Unsere einzigartige KI-Plattform ist klinisch erwiesen."',
+    id: '4p/SsmkJuR',
+    description: "User prompt in the guidelines board chat",
+  },
+  chatCollapse: {
+    defaultMessage: "Collapse",
+    id: 'JY9Ed02KEb',
+    description: "Accessible label to collapse the guidelines board chat",
+  },
+  chatClose: {
+    defaultMessage: "Close",
+    id: 'D2D16fgUkP',
+    description: "Accessible label to close the guidelines board chat",
+  },
+  toolName: {
+    defaultMessage: "Read guideline",
+    id: 'SE8vhhcRvh',
+    description: "Tool name while the agent reads the PDF",
+  },
+  toolDetail: {
+    defaultMessage: "Brand-claims-policy.pdf · Google Drive",
+    id: 'mgqDzjgTSc',
+    description: "Tool detail while the agent reads the PDF",
+  },
+  replyIntro: {
+    defaultMessage: "Three clauses in the Drive PDF are broken. Open a flag to see it in the file.",
+    id: 'PZZ/+9b/45',
+    description: "Agent reply intro after reading the PDF",
+  },
+  flagGermanTitle: {
+    defaultMessage: "Superlative in DE copy",
+    id: 'YZiaFZNuPi',
+    description: "First compliance flag title",
+  },
+  flagGermanBody: {
+    defaultMessage: '"einzigartige" is blocked by clause 3.2.',
+    id: 'IW6zsfvtOy',
+    description: "First compliance flag body",
+  },
+  flagHealthTitle: {
+    defaultMessage: "Unapproved health claim",
+    id: 'kvUTmvykXa',
+    description: "Second compliance flag title",
+  },
+  flagHealthBody: {
+    defaultMessage: '"klinisch erwiesen" is not on the approved list in clause 2.1.',
+    id: '071psyOiAM',
+    description: "Second compliance flag body",
+  },
+  flagAiTitle: {
+    defaultMessage: "Missing AI disclosure",
+    id: 'd2A2zGHowt',
+    description: "Third compliance flag title",
+  },
+  flagAiBody: {
+    defaultMessage: "Mentioning KI requires the EU AI Act wording in clause 4.3.",
+    id: 'n3fs1Skt3S',
+    description: "Third compliance flag body",
+  },
+  contextPill: {
+    defaultMessage: "Brand-claims-policy.pdf",
+    id: 'UgXh/JEfra',
+    description: "Context chip in the guidelines board composer",
+  },
+  composerPlaceholder: {
+    defaultMessage: "Ask to check another line against the connected files",
+    id: '7eizbN+V+O',
+    description: "Placeholder in the guidelines board composer after send",
+  },
+  send: {
+    defaultMessage: "Send",
+    id: 'h4qqRHFDUX',
+    description: "Send button in the guidelines board chat",
+  },
+  replay: {
+    defaultMessage: "Replay",
+    id: 'qjnIHRqIL8',
+    description: "Replay button in the guidelines board chat",
+  },
+  sourceAriaLabel: {
+    defaultMessage: "Connected guideline sources",
+    id: 'RNFkjkR2en',
+    description: "Accessible label for the guidelines board file list",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-board-mock.test.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-board-mock.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { GuidelinesBoardMock } from "./guidelines-board-mock";
+
+describe("GuidelinesBoardMock", () => {
+  it("flags the PDF clauses after send and highlights the matching clause", async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <GuidelinesBoardMock autoStart={false} />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByText("Check copy against the PDF")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(
+      screen.getByText(
+        'Check this German launch line against Brand-claims-policy.pdf: "Unsere einzigartige KI-Plattform ist klinisch erwiesen."',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Check copy against the PDF")).not.toBeInTheDocument();
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByText("Superlative in DE copy")).toBeInTheDocument();
+    expect(screen.getByText("Unapproved health claim")).toBeInTheDocument();
+    expect(screen.getByText("Missing AI disclosure")).toBeInTheDocument();
+    expect(document.getElementById("guideline-clause-german")).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+
+    await user.click(screen.getByRole("button", { name: /Unapproved health claim/ }));
+
+    expect(document.getElementById("guideline-clause-health")).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+    expect(document.getElementById("guideline-clause-german")).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("button", { name: "Replay" })).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("starts playback from the empty-state suggestion", async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <GuidelinesBoardMock autoStart={false} />
+      </IntlProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Review this German launch line" }));
+
+    expect(screen.queryByText("Check copy against the PDF")).not.toBeInTheDocument();
+    expect(screen.queryByText("Superlative in DE copy")).not.toBeInTheDocument();
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByText("Superlative in DE copy")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("opens the Drive PDF when a flag is selected from another source", async () => {
+    vi.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <GuidelinesBoardMock autoStart={false} />
+      </IntlProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Japan market notes/ }));
+    expect(screen.getByText("Page preview")).toBeInTheDocument();
+    expect(document.getElementById("guideline-clause-ai")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Missing AI disclosure/ }));
+
+    expect(document.getElementById("guideline-clause-ai")).toHaveAttribute("aria-current", "true");
+    expect(screen.getByText("4.3 AI features")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-board-mock.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-board-mock.tsx
@@ -1,0 +1,552 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Cancel01Icon,
+  Chat01Icon,
+  File01Icon,
+  FileSearchIcon,
+  RefreshIcon,
+  SentIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Tool, ToolHeader } from "@/components/ai-elements/tool";
+import { IntegrationLogoMark } from "@/components/marketing/integrations/integration-logo-mark";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { guidelinesBoardMockMessages as messages } from "./guidelines-board-mock.messages";
+
+const TOOL_RESOLVE_MS = 640;
+const STEP_MS = 780;
+const EASE_OUT = [0.19, 1, 0.22, 1] as const;
+const COLLAPSE_GLYPH = "−";
+const MENTION_GLYPH = "@";
+
+type SourceId = "drive" | "notion" | "sharepoint";
+type ClauseId = "health" | "german" | "ai";
+type PlaybackPhase = "idle" | "playing" | "done";
+
+const SOURCE_FILES = [
+  {
+    id: "drive" as const,
+    nameKey: "driveName",
+    fileKey: "driveFile",
+    metaKey: "driveMeta",
+    iconKey: "googledrive" as const,
+  },
+  {
+    id: "notion" as const,
+    nameKey: "notionName",
+    fileKey: "notionFile",
+    metaKey: "notionMeta",
+    iconKey: "notion" as const,
+  },
+  {
+    id: "sharepoint" as const,
+    nameKey: "sharepointName",
+    fileKey: "sharepointFile",
+    metaKey: "sharepointMeta",
+    logoSrc: "/images/sharepoint-logo.svg",
+  },
+] as const;
+
+const PDF_CLAUSES = [
+  { id: "health" as const, titleKey: "clauseHealthTitle", bodyKey: "clauseHealthBody" },
+  { id: "german" as const, titleKey: "clauseGermanTitle", bodyKey: "clauseGermanBody" },
+  { id: "ai" as const, titleKey: "clauseAiTitle", bodyKey: "clauseAiBody" },
+] as const;
+
+const FLAGS = [
+  { id: "german" as const, titleKey: "flagGermanTitle", bodyKey: "flagGermanBody" },
+  { id: "health" as const, titleKey: "flagHealthTitle", bodyKey: "flagHealthBody" },
+  { id: "ai" as const, titleKey: "flagAiTitle", bodyKey: "flagAiBody" },
+] as const;
+
+function SourceFileButton({
+  file,
+  selected,
+  onSelect,
+}: {
+  file: (typeof SOURCE_FILES)[number];
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors",
+        selected
+          ? "border-primary/40 bg-primary/10"
+          : "border-border/70 bg-background hover:border-border hover:bg-muted/40",
+      )}
+    >
+      <IntegrationLogoMark
+        name={intl.formatMessage(messages[file.nameKey])}
+        iconKey={"iconKey" in file ? file.iconKey : undefined}
+        logoSrc={"logoSrc" in file ? file.logoSrc : undefined}
+        size="sm"
+      />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-foreground">
+          <FormattedMessage {...messages[file.fileKey]} />
+        </span>
+        <span className="block truncate text-[11px] text-muted-foreground">
+          <FormattedMessage {...messages[file.metaKey]} />
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function ClaimsPdf({ highlightedClause }: { highlightedClause: ClauseId | null }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/70 bg-[#f7f4ee] text-[#1d1a16] shadow-sm">
+      <div className="flex items-center justify-between border-b border-[#d9d2c3] px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} className="size-4 text-[#8a3b2a]" />
+          <p className="text-xs font-semibold tracking-wide uppercase">
+            <FormattedMessage {...messages.pdfTitle} />
+          </p>
+        </div>
+        <p className="text-[10px] text-[#6f675c]">
+          <FormattedMessage {...messages.pdfMeta} />
+        </p>
+      </div>
+      <div className="space-y-3 p-4">
+        <p className="text-[11px] leading-5 text-[#5c564c]">
+          <FormattedMessage {...messages.pdfIntro} />
+        </p>
+        {PDF_CLAUSES.map((clause) => {
+          const isHighlighted = highlightedClause === clause.id;
+          return (
+            <div
+              key={clause.id}
+              id={`guideline-clause-${clause.id}`}
+              aria-current={isHighlighted ? "true" : undefined}
+              className={cn(
+                "rounded-md border px-3 py-2.5 transition-colors",
+                isHighlighted ? "border-[#c45c3e] bg-[#f3d7cc]" : "border-[#e4ddd0] bg-white/70",
+              )}
+            >
+              <p className="text-[10px] font-semibold tracking-wide uppercase text-[#8a3b2a]">
+                <FormattedMessage {...messages[clause.titleKey]} />
+              </p>
+              <p className="mt-1 text-xs leading-5">
+                <FormattedMessage {...messages[clause.bodyKey]} />
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function PagePreview({
+  labelKey,
+  bodyKey,
+}: {
+  labelKey: "notionPreviewLabel" | "sharepointPreviewLabel";
+  bodyKey: "notionPreviewBody" | "sharepointPreviewBody";
+}) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-background p-4">
+      <p className="text-[10px] font-semibold tracking-wide uppercase text-muted-foreground">
+        <FormattedMessage {...messages[labelKey]} />
+      </p>
+      <p className="mt-3 text-sm leading-6 text-foreground">
+        <FormattedMessage {...messages[bodyKey]} />
+      </p>
+    </div>
+  );
+}
+
+function GuidelinesChat({
+  phase,
+  showTool,
+  toolResolved,
+  showAnswer,
+  activeFlag,
+  onSelectFlag,
+  onStart,
+  onReplay,
+}: {
+  phase: PlaybackPhase;
+  showTool: boolean;
+  toolResolved: boolean;
+  showAnswer: boolean;
+  activeFlag: ClauseId | null;
+  onSelectFlag: (id: ClauseId) => void;
+  onStart: () => void;
+  onReplay: () => void;
+}) {
+  const intl = useIntl();
+  const shouldReduceMotion = useReducedMotion() ?? false;
+  const transcriptRef = useRef<HTMLDivElement>(null);
+  const prompt = intl.formatMessage(messages.chatPrompt);
+  const isBusy = phase === "playing";
+
+  useEffect(() => {
+    if (!transcriptRef.current) {
+      return;
+    }
+    transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
+  }, [showTool, toolResolved, showAnswer, activeFlag]);
+
+  return (
+    <div
+      className="flex min-h-96 min-w-0 flex-1 flex-col overflow-hidden p-3 lg:min-h-0 lg:p-4"
+      role="region"
+      aria-label={intl.formatMessage(messages.chatTitle)}
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15">
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
+          <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+            <FormattedMessage {...messages.chatTitle} />
+          </p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            tabIndex={-1}
+            aria-label={intl.formatMessage(messages.chatCollapse)}
+          >
+            <span aria-hidden className="text-base leading-none">
+              {COLLAPSE_GLYPH}
+            </span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            tabIndex={-1}
+            aria-label={intl.formatMessage(messages.chatClose)}
+          >
+            <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+          </Button>
+        </header>
+
+        <div ref={transcriptRef} className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          {phase === "idle" ? (
+            <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-5 px-5 py-8 text-center">
+              <div className="flex size-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <HugeiconsIcon icon={Chat01Icon} strokeWidth={1.8} className="size-5" />
+              </div>
+              <div className="max-w-sm space-y-1">
+                <h3 className="text-balance text-sm font-semibold text-foreground">
+                  <FormattedMessage {...messages.chatEmptyTitle} />
+                </h3>
+                <p className="text-pretty text-sm text-muted-foreground">
+                  <FormattedMessage {...messages.chatEmptySubtitle} />
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 rounded-full bg-background text-xs font-medium"
+                onClick={onStart}
+              >
+                <HugeiconsIcon icon={FileSearchIcon} strokeWidth={1.8} className="size-3.5" />
+                <FormattedMessage {...messages.chatSuggestion} />
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4 px-4 py-5">
+              <div className="ms-auto max-w-[90%] rounded-2xl bg-muted px-3.5 py-2.5 text-pretty text-sm leading-6 text-foreground">
+                {prompt}
+              </div>
+              <div className="space-y-3">
+                <AnimatePresence initial={false}>
+                  {showTool ? (
+                    <motion.div
+                      key="guideline-tool"
+                      initial={shouldReduceMotion ? false : { opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{
+                        duration: shouldReduceMotion ? 0 : 0.28,
+                        ease: EASE_OUT,
+                      }}
+                      className="rounded-lg border border-border/70 bg-muted/20 px-3 py-2"
+                    >
+                      <Tool defaultOpen={toolResolved}>
+                        <ToolHeader
+                          type="dynamic-tool"
+                          toolName={intl.formatMessage(messages.toolName)}
+                          state={toolResolved ? "output-available" : "input-available"}
+                          detail={intl.formatMessage(messages.toolDetail)}
+                          input={{ file: "Brand-claims-policy.pdf" }}
+                        />
+                      </Tool>
+                    </motion.div>
+                  ) : null}
+                </AnimatePresence>
+                {showAnswer ? (
+                  <motion.div
+                    initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: shouldReduceMotion ? 0 : 0.35, ease: EASE_OUT }}
+                    className="space-y-3 text-sm leading-6 text-foreground"
+                  >
+                    <p className="text-pretty text-muted-foreground">
+                      <FormattedMessage {...messages.replyIntro} />
+                    </p>
+                    <div className="space-y-2">
+                      {FLAGS.map((flag) => {
+                        const selected = activeFlag === flag.id;
+                        return (
+                          <button
+                            key={flag.id}
+                            type="button"
+                            aria-pressed={selected}
+                            onClick={() => onSelectFlag(flag.id)}
+                            className={cn(
+                              "w-full rounded-lg border px-3 py-2.5 text-left transition-colors",
+                              selected
+                                ? "border-destructive/40 bg-destructive/10"
+                                : "border-border/70 bg-background hover:bg-muted/40",
+                            )}
+                          >
+                            <span className="block text-xs font-semibold text-destructive">
+                              <FormattedMessage {...messages[flag.titleKey]} />
+                            </span>
+                            <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                              <FormattedMessage {...messages[flag.bodyKey]} />
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </motion.div>
+                ) : null}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <form
+          className="shrink-0 border-t border-border bg-background p-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (phase === "done") {
+              onReplay();
+              return;
+            }
+            onStart();
+          }}
+        >
+          <div className="overflow-hidden rounded-xl border border-border bg-muted/30 shadow-sm">
+            <div className="flex flex-wrap gap-1.5 px-3 pt-3">
+              <span className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-0.5 text-[0.7rem] text-muted-foreground">
+                {MENTION_GLYPH}
+              </span>
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2 py-0.5 text-[0.7rem] text-foreground">
+                <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} className="size-3" />
+                <FormattedMessage {...messages.contextPill} />
+              </span>
+            </div>
+            <div className="flex items-end gap-2 px-3 py-3">
+              <p className="min-w-0 flex-1 text-pretty text-sm leading-5 text-foreground">
+                {phase === "idle" ? (
+                  prompt
+                ) : (
+                  <span className="text-muted-foreground">
+                    <FormattedMessage {...messages.composerPlaceholder} />
+                  </span>
+                )}
+              </p>
+              {phase === "done" ? (
+                <Button
+                  type="submit"
+                  size="sm"
+                  variant="secondary"
+                  className="h-8 rounded-full px-3"
+                >
+                  <HugeiconsIcon
+                    data-icon="inline-start"
+                    icon={RefreshIcon}
+                    strokeWidth={2}
+                    className="size-3.5"
+                  />
+                  <FormattedMessage {...messages.replay} />
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  size="sm"
+                  className="h-8 rounded-full px-3"
+                  disabled={isBusy}
+                  aria-label={intl.formatMessage(messages.send)}
+                >
+                  <HugeiconsIcon
+                    data-icon="inline-start"
+                    icon={SentIcon}
+                    strokeWidth={2}
+                    className="size-3.5"
+                  />
+                  <FormattedMessage {...messages.send} />
+                </Button>
+              )}
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export function GuidelinesBoardMock({
+  autoStart = true,
+  pauseAutoplay = false,
+}: {
+  autoStart?: boolean;
+  pauseAutoplay?: boolean;
+}) {
+  const intl = useIntl();
+  const shouldReduceMotion = useReducedMotion() ?? false;
+  const hasAutoStartedRef = useRef(false);
+  const playingRef = useRef(false);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const [source, setSource] = useState<SourceId>("drive");
+  const [phase, setPhase] = useState<PlaybackPhase>("idle");
+  const [showTool, setShowTool] = useState(false);
+  const [toolResolved, setToolResolved] = useState(false);
+  const [showAnswer, setShowAnswer] = useState(false);
+  const [activeFlag, setActiveFlag] = useState<ClauseId | null>(null);
+
+  const clearTimers = () => {
+    for (const timer of timersRef.current) {
+      clearTimeout(timer);
+    }
+    timersRef.current = [];
+  };
+
+  const startPlayback = useCallback(() => {
+    if (playingRef.current) {
+      return;
+    }
+
+    playingRef.current = true;
+    clearTimers();
+    setSource("drive");
+    setPhase("playing");
+    setShowTool(false);
+    setToolResolved(false);
+    setShowAnswer(false);
+    setActiveFlag(null);
+
+    const schedule = (fn: () => void, delay: number) => {
+      const timer = setTimeout(fn, delay);
+      timersRef.current.push(timer);
+    };
+
+    let elapsed = shouldReduceMotion ? 0 : 180;
+    schedule(() => setShowTool(true), elapsed);
+    elapsed += shouldReduceMotion ? 0 : TOOL_RESOLVE_MS;
+    schedule(() => setToolResolved(true), elapsed);
+    elapsed += shouldReduceMotion ? 0 : STEP_MS;
+    schedule(() => {
+      setShowAnswer(true);
+      setActiveFlag("german");
+      setPhase("done");
+      playingRef.current = false;
+    }, elapsed);
+  }, [shouldReduceMotion]);
+
+  useEffect(() => {
+    if (!autoStart || pauseAutoplay) {
+      return;
+    }
+
+    const timer = setTimeout(
+      () => {
+        if (hasAutoStartedRef.current) {
+          return;
+        }
+        hasAutoStartedRef.current = true;
+        startPlayback();
+      },
+      shouldReduceMotion ? 0 : 500,
+    );
+
+    return () => clearTimeout(timer);
+  }, [autoStart, pauseAutoplay, shouldReduceMotion, startPlayback]);
+
+  useEffect(() => () => clearTimers(), []);
+
+  function handleSelectFlag(id: ClauseId) {
+    setSource("drive");
+    setActiveFlag(id);
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background lg:grid lg:grid-cols-[1.05fr_0.95fr]">
+      <div className="flex min-h-0 max-h-80 flex-col overflow-y-auto border-b border-border/50 lg:max-h-none lg:border-b-0 lg:border-r">
+        <div className="border-b border-border/50 px-5 py-4">
+          <p className="text-base font-semibold text-foreground">
+            <FormattedMessage {...messages.boardTitle} />
+          </p>
+          <p className="mt-1 text-pretty text-xs text-muted-foreground">
+            <FormattedMessage {...messages.boardSubtitle} />
+          </p>
+        </div>
+        <div className="space-y-4 p-4">
+          <div
+            className="space-y-2"
+            role="list"
+            aria-label={intl.formatMessage(messages.sourceAriaLabel)}
+          >
+            {SOURCE_FILES.map((file) => (
+              <SourceFileButton
+                key={file.id}
+                file={file}
+                selected={source === file.id}
+                onSelect={() => setSource(file.id)}
+              />
+            ))}
+          </div>
+          {source === "drive" ? (
+            <ClaimsPdf highlightedClause={showAnswer ? activeFlag : null} />
+          ) : null}
+          {source === "notion" ? (
+            <PagePreview labelKey="notionPreviewLabel" bodyKey="notionPreviewBody" />
+          ) : null}
+          {source === "sharepoint" ? (
+            <PagePreview labelKey="sharepointPreviewLabel" bodyKey="sharepointPreviewBody" />
+          ) : null}
+        </div>
+      </div>
+      <GuidelinesChat
+        phase={phase}
+        showTool={showTool}
+        toolResolved={toolResolved}
+        showAnswer={showAnswer}
+        activeFlag={activeFlag}
+        onSelectFlag={handleSelectFlag}
+        onStart={startPlayback}
+        onReplay={startPlayback}
+      />
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.messages.ts
@@ -22,13 +22,13 @@ export const guidelinesPageMessages = defineMessages({
   },
   heroHeadline: {
     defaultMessage: "Keep the docs you have.\nPut them to work.",
-    id: 'sMO5kn7k5p',
+    id: "sMO5kn7k5p",
     description: "Hero headline for the Guidelines product page",
   },
   heroSubcopy: {
     defaultMessage:
       "Connect Google Drive, Notion, and SharePoint. Agents read the brand and compliance files your team already maintains and flag what does not match.",
-    id: 'GtjItsMfqV',
+    id: "WqdPR2o5QO",
     description: "Hero description for the Guidelines product page",
   },
   requestDemo: {
@@ -38,167 +38,167 @@ export const guidelinesPageMessages = defineMessages({
   },
   exploreGuidelines: {
     defaultMessage: "See a guideline check",
-    id: 'QIAc4hvHDk',
+    id: "QIAc4hvHDk",
     description: "Anchor link from the Guidelines hero to the product preview",
   },
   fromRulesToDrafts: {
     defaultMessage: "From Drive, Notion, and SharePoint into every draft.",
-    id: '05WQ9chsaJ',
+    id: "05WQ9chsaJ",
     description: "Caption under the Guidelines preview",
   },
   stepConnect: {
     defaultMessage: "01 Connect",
-    id: '/2vDnBJJnU',
+    id: "/2vDnBJJnU",
     description: "Guidelines workflow step 1",
   },
   stepRead: {
     defaultMessage: "02 Read the file",
-    id: 'IdXW81ey7i',
+    id: "IdXW81ey7i",
     description: "Guidelines workflow step 2",
   },
   stepFlag: {
     defaultMessage: "03 Flag the issues",
-    id: 'nIxPibE5kf',
+    id: "nIxPibE5kf",
     description: "Guidelines workflow step 3",
   },
   stepShip: {
     defaultMessage: "04 Ship",
-    id: 'L09pgcuANE',
+    id: "L09pgcuANE",
     description: "Guidelines workflow step 4",
   },
   sourcesEyebrow: {
     defaultMessage: "Where your guidelines already live",
-    id: 'BTimRLPa1I',
+    id: "BTimRLPa1I",
     description: "Eyebrow for the Guidelines sources section",
   },
   sourcesHeadline: {
     defaultMessage: "Drive. Notion.\nSharePoint.",
-    id: 'pym2jLFt91',
+    id: "pym2jLFt91",
     description: "Headline for the Guidelines sources section",
   },
   sourcesBody: {
     defaultMessage:
       "Leave brand PDFs, market notes, and policy libraries where legal and brand already keep them. Hyperlocalise reads those files instead of asking you to rebuild a second playbook.",
-    id: '5VP6QS58Jl',
+    id: "5VP6QS58Jl",
     description: "Body copy for the Guidelines sources section",
   },
   sourcesAriaLabel: {
     defaultMessage: "Guideline sources",
-    id: 'LguOyBNnte',
+    id: "LguOyBNnte",
     description: "Accessible label for the Guidelines source tabs",
   },
   sourceDrive: {
     defaultMessage: "Google Drive",
-    id: 'I4iH2T3OLx',
+    id: "I4iH2T3OLx",
     description: "Guidelines source tab for Google Drive",
   },
   sourceNotion: {
     defaultMessage: "Notion",
-    id: '4nr1WS9kIp',
+    id: "4nr1WS9kIp",
     description: "Guidelines source tab for Notion",
   },
   sourceSharepoint: {
     defaultMessage: "SharePoint",
-    id: '1kGndGN4wG',
+    id: "1kGndGN4wG",
     description: "Guidelines source tab for SharePoint",
   },
   sourceDriveTitle: {
     defaultMessage: "The PDF stays\nin Drive.",
-    id: 'SbXclIFUB9',
+    id: "SbXclIFUB9",
     description: "Title for the Google Drive source panel",
   },
   sourceDriveBody: {
     defaultMessage:
       "Connect brand-voice and claims PDFs from Google Drive. Agents cite the clause in the file when they flag a draft.",
-    id: 'oNE0YnvOn0',
+    id: "oNE0YnvOn0",
     description: "Body for the Google Drive source panel",
   },
   sourceDriveLink: {
     defaultMessage: "From style guides to claims policies",
-    id: 'XcvWJmyVfR',
+    id: "XcvWJmyVfR",
     description: "Supporting link line for the Google Drive source panel",
   },
   sourceNotionTitle: {
     defaultMessage: "Market notes\nstay in Notion.",
-    id: 'dGJ4DQ8pi3',
+    id: "dGJ4DQ8pi3",
     description: "Title for the Notion source panel",
   },
   sourceNotionBody: {
     defaultMessage:
       "Import the pages your GTM team already writes: dos and don'ts, proof points, and the tone that works in each market.",
-    id: '0roQJLdsUq',
+    id: "0roQJLdsUq",
     description: "Body for the Notion source panel",
   },
   sourceNotionLink: {
     defaultMessage: "From wiki pages to agent context",
-    id: 'KwEv4D6hGN',
+    id: "KwEv4D6hGN",
     description: "Supporting link line for the Notion source panel",
   },
   sourceSharepointTitle: {
     defaultMessage: "Legal keeps\nthe library.",
-    id: 'DbGIc4sGDx',
+    id: "DbGIc4sGDx",
     description: "Title for the SharePoint source panel",
   },
   sourceSharepointBody: {
     defaultMessage:
       "Point Hyperlocalise at the SharePoint library that already holds disclosures, approved wording, and regulated claims.",
-    id: 'buVScYQI5w',
+    id: "buVScYQI5w",
     description: "Body for the SharePoint source panel",
   },
   sourceSharepointLink: {
     defaultMessage: "From policy libraries to pre-publish checks",
-    id: 'chTXcZSMoe',
+    id: "chTXcZSMoe",
     description: "Supporting link line for the SharePoint source panel",
   },
   sourceDriveFile: {
     defaultMessage: "Brand-claims-policy.pdf",
-    id: 'yxDI0UUubE',
+    id: "yxDI0UUubE",
     description: "Example Drive filename in the source preview",
   },
   sourceDriveDetail: {
     defaultMessage: "Legal · 6 pages · Connected",
-    id: '7t3FQ5TrY6',
+    id: "7t3FQ5TrY6",
     description: "Example Drive file detail in the source preview",
   },
   sourceDriveClause: {
     defaultMessage: "3.2 German advertising — no superlatives",
-    id: 'u/BgSogOwb',
+    id: "u/BgSogOwb",
     description: "Highlighted PDF clause in the Google Drive source preview",
   },
   sourceNotionFile: {
     defaultMessage: "Japan market notes",
-    id: 'hXu3TQ7nei',
+    id: "hXu3TQ7nei",
     description: "Example Notion page title in the source preview",
   },
   sourceNotionDetail: {
     defaultMessage: "GTM wiki · Updated this week",
-    id: 'KaF5SxLR8X',
+    id: "KaF5SxLR8X",
     description: "Example Notion page detail in the source preview",
   },
   sourceSharepointFile: {
     defaultMessage: "EU disclosures library",
-    id: 'zdNwM1KXY3',
+    id: "zdNwM1KXY3",
     description: "Example SharePoint library name in the source preview",
   },
   sourceSharepointDetail: {
     defaultMessage: "18 policy files · Compliance",
-    id: 'PRW9ZtkzIN',
+    id: "PRW9ZtkzIN",
     description: "Example SharePoint library detail in the source preview",
   },
   appliedEyebrow: {
     defaultMessage: "Used while you work",
-    id: 'gu7P/76etG',
+    id: "gu7P/76etG",
     description: "Eyebrow for the Guidelines applied-in-studio section",
   },
   appliedHeadline: {
     defaultMessage: "The file is the source\nof truth.",
-    id: 'wwGzx8T1wq',
+    id: "wwGzx8T1wq",
     description: "Headline for the Guidelines applied-in-studio section",
   },
   appliedBody: {
     defaultMessage:
       "When a draft opens in Content Studio, the connected Drive PDF, Notion page, or SharePoint policy sits beside it. Reviewers and agents read the same document.",
-    id: 'w9pu7kC+rH',
+    id: "w9pu7kC+rH",
     description: "Body for the Guidelines applied-in-studio section",
   },
   exploreStudio: {
@@ -208,133 +208,133 @@ export const guidelinesPageMessages = defineMessages({
   },
   campaignGuidelines: {
     defaultMessage: "Attached to this draft",
-    id: 'cJoA3WyajT',
+    id: "cJoA3WyajT",
     description: "Title of the attached guidelines mock card",
   },
   appliedToDraft: {
     defaultMessage: "From Google Drive",
-    id: '0B4ezwZ7oK',
+    id: "0B4ezwZ7oK",
     description: "Status on the attached guidelines mock card",
   },
   attachedFile: {
     defaultMessage: "File",
-    id: 'rOvqLQGma3',
+    id: "rOvqLQGma3",
     description: "File row label in the attached guidelines mock",
   },
   attachedFileValue: {
     defaultMessage: "Brand-claims-policy.pdf",
-    id: 'IIohVs/IF0',
+    id: "IIohVs/IF0",
     description: "File row value in the attached guidelines mock",
   },
   attachedClause: {
     defaultMessage: "Last cited",
-    id: 'rJ5ZNEEfrR',
+    id: "rJ5ZNEEfrR",
     description: "Clause row label in the attached guidelines mock",
   },
   attachedClauseValue: {
     defaultMessage: "3.2 German advertising — no superlatives",
-    id: 'b95XI61qEi',
+    id: "b95XI61qEi",
     description: "Clause row value in the attached guidelines mock",
   },
   attachedStatus: {
     defaultMessage: "Status",
-    id: 'x9lPZa0R66',
+    id: "x9lPZa0R66",
     description: "Status row label in the attached guidelines mock",
   },
   attachedStatusValue: {
     defaultMessage: "Two flags still open on this draft",
-    id: 'CXZaVZ1tZ8',
+    id: "CXZaVZ1tZ8",
     description: "Status row value in the attached guidelines mock",
   },
   auditEyebrow: {
     defaultMessage: "Automations",
-    id: "gpAuditEye",
+    id: "rXIITR1I9M",
     description: "Eyebrow for the Guidelines daily-audit section",
   },
   auditHeadline: {
     defaultMessage: "Audit product and the website.\nEvery day.",
-    id: "gpAuditHead",
+    id: "csK4Zbn9gk",
     description: "Headline for the Guidelines daily-audit section",
   },
   auditBody: {
     defaultMessage:
       "Schedule an Automation to check live pages and product copy against the same Drive, Notion, or SharePoint files. Flags show up in the morning instead of after a launch.",
-    id: "gpAuditBody",
+    id: "XwyHRK/RCH",
     description: "Body for the Guidelines daily-audit section",
   },
   exploreAutomations: {
     defaultMessage: "Explore Automations",
-    id: "gpAuditLink",
+    id: "PDQi8zzuSM",
     description: "Link from Guidelines to the Automations product page",
   },
   auditCardTitle: {
     defaultMessage: "Daily compliance audit",
-    id: "gpAuditCard",
+    id: "d0PnxJ1PQM",
     description: "Title of the daily compliance audit mock card",
   },
   auditCardSchedule: {
     defaultMessage: "Every day at 07:00",
-    id: "gpAuditSched",
+    id: "O5n4exVoSO",
     description: "Schedule on the daily compliance audit mock card",
   },
   auditChecks: {
     defaultMessage: "Checks",
-    id: "gpAuditChecks",
+    id: "NW1SDAit+W",
     description: "Checks label on the daily compliance audit mock card",
   },
   auditCheckProduct: {
     defaultMessage: "Product copy · app and CMS strings",
-    id: "gpAuditProd",
+    id: "yid8b+P/VX",
     description: "Product check row on the daily compliance audit mock card",
   },
   auditCheckWebsite: {
     defaultMessage: "Website · live pages",
-    id: "gpAuditWeb",
+    id: "dBfjJqRtAx",
     description: "Website check row on the daily compliance audit mock card",
   },
   auditAgainst: {
     defaultMessage: "Against",
-    id: "gpAuditAgainst",
+    id: "T1Sk0Af2ER",
     description: "Guidelines label on the daily compliance audit mock card",
   },
   auditAgainstFile: {
     defaultMessage: "Brand-claims-policy.pdf · Google Drive",
-    id: "gpAuditFile",
+    id: "8qg+o4BfKa",
     description: "Guideline file on the daily compliance audit mock card",
   },
   auditLastRun: {
     defaultMessage: "Last run · this morning",
-    id: "gpAuditRun",
+    id: "p5YTxqry+c",
     description: "Last-run label on the daily compliance audit mock card",
   },
   auditFindingDe: {
     defaultMessage: "DE homepage",
-    id: "gpAuditDe",
+    id: "vQdLFmWq8o",
     description: "German finding target on the daily compliance audit mock card",
   },
   auditFindingDeFlags: {
     defaultMessage: "3 flags · clause 3.2",
-    id: "gpAuditDeF",
+    id: "hujEaVVQkb",
     description: "German finding result on the daily compliance audit mock card",
   },
   auditFindingJp: {
     defaultMessage: "JP product page",
-    id: "gpAuditJp",
+    id: "SRAb4hnti/",
     description: "Japanese finding target on the daily compliance audit mock card",
   },
   auditFindingJpFlags: {
     defaultMessage: "1 flag · clause 2.1",
-    id: "gpAuditJpF",
+    id: "w9Jksgm8Dg",
     description: "Japanese finding result on the daily compliance audit mock card",
   },
   auditFindingFr: {
     defaultMessage: "FR website",
-    id: "gpAuditFr",
+    id: "YzyMyGmYFN",
     description: "French finding target on the daily compliance audit mock card",
   },
   auditFindingFrFlags: {
     defaultMessage: "Clear",
-    id: "gpAuditFrF",
+    id: "ooufH8cRvw",
     description: "French finding result on the daily compliance audit mock card",
   },
   connectedHeadline: {
@@ -344,7 +344,7 @@ export const guidelinesPageMessages = defineMessages({
   },
   connectedBody: {
     defaultMessage: "Apply the same files in the studio. Automate the checks in your workflows.",
-    id: '5r5QUAR3/o',
+    id: "5r5QUAR3/o",
     description: "Body for the Guidelines connected-products section",
   },
   contentStudio: {
@@ -369,57 +369,57 @@ export const guidelinesPageMessages = defineMessages({
   },
   faqWhereQuestion: {
     defaultMessage: "Do we have to move our guidelines into Hyperlocalise?",
-    id: '1t3wSermT8',
+    id: "1t3wSermT8",
     description: "Guidelines FAQ question about moving files",
   },
   faqWhereAnswer: {
     defaultMessage:
       "No. Connect Google Drive, Notion, or SharePoint and leave the files where brand and legal already keep them. Agents read those sources.",
-    id: 'bOpIXEky0N',
+    id: "bOpIXEky0N",
     description: "Guidelines FAQ answer about moving files",
   },
   faqWhatQuestion: {
     defaultMessage: "What kinds of files can agents use?",
-    id: '11Fkff+o29',
+    id: "11Fkff+o29",
     description: "Guidelines FAQ question about file types",
   },
   faqWhatAnswer: {
     defaultMessage:
       "Brand-voice PDFs, claims policies, Notion market notes, and SharePoint disclosure libraries. If your team already treats it as the rule, connect it.",
-    id: 'LNwKJ8Zkta',
+    id: "LNwKJ8Zkta",
     description: "Guidelines FAQ answer about file types",
   },
   faqAgentsQuestion: {
     defaultMessage: "How does an agent flag a compliance issue?",
-    id: 'nPSlG6dRhe',
+    id: "nPSlG6dRhe",
     description: "Guidelines FAQ question about agent flags",
   },
   faqAgentsAnswer: {
     defaultMessage:
       "It reads the connected file, cites the clause, and flags the line that breaks it—so a reviewer can open the PDF instead of re-explaining the rule.",
-    id: '8zHJojmnLS',
+    id: "8zHJojmnLS",
     description: "Guidelines FAQ answer about agent flags",
   },
   faqAuditQuestion: {
     defaultMessage: "Can Automations audit the product and website every day?",
-    id: "gpFaqAudQ",
+    id: "LW2UZg0KZP",
     description: "Guidelines FAQ question about daily Automations audits",
   },
   faqAuditAnswer: {
     defaultMessage:
       "Yes. Schedule a daily Automation to check product copy and live pages against the connected guideline files. Reviewers see the flags in the morning.",
-    id: "gpFaqAudA",
+    id: "/LUmtjuJsT",
     description: "Guidelines FAQ answer about daily Automations audits",
   },
   faqUpdateQuestion: {
     defaultMessage: "What happens when legal updates the PDF?",
-    id: 'yyQsNyHMHz',
+    id: "yyQsNyHMHz",
     description: "Guidelines FAQ question about file updates",
   },
   faqUpdateAnswer: {
     defaultMessage:
       "The connected file is the source of truth. When Drive or SharePoint changes, the next check uses the updated wording.",
-    id: 'h/TaCp7kf5',
+    id: "h/TaCp7kf5",
     description: "Guidelines FAQ answer about file updates",
   },
   faqStudioQuestion: {
@@ -430,18 +430,18 @@ export const guidelinesPageMessages = defineMessages({
   faqStudioAnswer: {
     defaultMessage:
       "Attach a connected file to a campaign or draft. Reviewers see the PDF or page beside the copy, and agent suggestions cite the same clauses.",
-    id: 'K1TC/ecjoE',
+    id: "K1TC/ecjoE",
     description: "Guidelines FAQ answer about Content Studio",
   },
   faqSourcesQuestion: {
     defaultMessage: "Can we use more than one source?",
-    id: 'ryd9aeww4k',
+    id: "ryd9aeww4k",
     description: "Guidelines FAQ question about multiple sources",
   },
   faqSourcesAnswer: {
     defaultMessage:
       "Yes. Keep claims PDFs in Drive, market notes in Notion, and disclosures in SharePoint. Agents check the files that apply to that draft.",
-    id: 'SnsLWu5goL',
+    id: "SnsLWu5goL",
     description: "Guidelines FAQ answer about multiple sources",
   },
   faqFitQuestion: {
@@ -452,34 +452,34 @@ export const guidelinesPageMessages = defineMessages({
   faqFitAnswer: {
     defaultMessage:
       "Guidelines is the connected file layer. Content Studio applies it while you create and review. Automation Workflow uses it when agents run repeatable jobs.",
-    id: 'doe6TBv1GS',
+    id: "doe6TBv1GS",
     description: "Guidelines FAQ answer about product fit",
   },
   faqWhoQuestion: {
     defaultMessage: "Who should own the connected files?",
-    id: 'nqWsz/vBZ6',
+    id: "nqWsz/vBZ6",
     description: "Guidelines FAQ question about ownership",
   },
   faqWhoAnswer: {
     defaultMessage:
       "Whoever already owns them—usually brand, legal, or localisation. Hyperlocalise does not replace that library. It reads it.",
-    id: 'TUhxc0TwuH',
+    id: "TUhxc0TwuH",
     description: "Guidelines FAQ answer about ownership",
   },
   ctaHeadline: {
     defaultMessage: "Leave the guidelines where they are.\nLet agents read them.",
-    id: 'zWj2+vAiX7',
+    id: "G94O+ZUEet",
     description: "Bottom CTA headline on the Guidelines product page",
   },
   ctaBody: {
     defaultMessage:
       "Connect Drive, Notion, or SharePoint and check the next draft against the real file.",
-    id: '3MyXNc43TJ',
+    id: "3MyXNc43TJ",
     description: "Bottom CTA body on the Guidelines product page",
   },
   ctaNote: {
     defaultMessage: "No second playbook to maintain.",
-    id: '76D+ZZX3Tn',
+    id: "76D+ZZX3Tn",
     description: "Supporting note under the Guidelines bottom CTA",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.messages.ts
@@ -27,8 +27,8 @@ export const guidelinesPageMessages = defineMessages({
   },
   heroSubcopy: {
     defaultMessage:
-      "Connect Google Drive, Notion, and SharePoint. Agents read the brand and compliance files your team already maintains and flag what does not match.",
-    id: "WqdPR2o5QO",
+      "Connect Google Drive, Notion, and SharePoint, or type guidelines in. Agents read them and flag what does not match.",
+    id: "MmdCe+3eSk",
     description: "Hero description for the Guidelines product page",
   },
   requestDemo: {
@@ -42,8 +42,8 @@ export const guidelinesPageMessages = defineMessages({
     description: "Anchor link from the Guidelines hero to the product preview",
   },
   fromRulesToDrafts: {
-    defaultMessage: "From Drive, Notion, and SharePoint into every draft.",
-    id: "05WQ9chsaJ",
+    defaultMessage: "From Drive, Notion, SharePoint, or typed guidelines into every draft.",
+    id: "ePfYPq2DH8",
     description: "Caption under the Guidelines preview",
   },
   stepConnect: {
@@ -78,8 +78,8 @@ export const guidelinesPageMessages = defineMessages({
   },
   sourcesBody: {
     defaultMessage:
-      "Leave brand PDFs, market notes, and policy libraries where legal and brand already keep them. Hyperlocalise reads those files instead of asking you to rebuild a second playbook.",
-    id: "5VP6QS58Jl",
+      "Leave brand PDFs, market notes, and policy libraries where legal and brand already keep them. Or type a guideline in Hyperlocalise. Agents read either one.",
+    id: "FkOEgV248R",
     description: "Body copy for the Guidelines sources section",
   },
   sourcesAriaLabel: {
@@ -374,8 +374,8 @@ export const guidelinesPageMessages = defineMessages({
   },
   faqWhereAnswer: {
     defaultMessage:
-      "No. Connect Google Drive, Notion, or SharePoint and leave the files where brand and legal already keep them. Agents read those sources.",
-    id: "bOpIXEky0N",
+      "No. Connect Google Drive, Notion, or SharePoint and leave the files where brand and legal already keep them. You can also type guidelines directly in Hyperlocalise.",
+    id: "QawNHvJsXE",
     description: "Guidelines FAQ answer about moving files",
   },
   faqWhatQuestion: {
@@ -385,8 +385,8 @@ export const guidelinesPageMessages = defineMessages({
   },
   faqWhatAnswer: {
     defaultMessage:
-      "Brand-voice PDFs, claims policies, Notion market notes, and SharePoint disclosure libraries. If your team already treats it as the rule, connect it.",
-    id: "LNwKJ8Zkta",
+      "Brand-voice PDFs, claims policies, Notion market notes, SharePoint disclosure libraries, and guidelines you type in Hyperlocalise.",
+    id: "CbRYAHGDV4",
     description: "Guidelines FAQ answer about file types",
   },
   faqAgentsQuestion: {
@@ -440,8 +440,8 @@ export const guidelinesPageMessages = defineMessages({
   },
   faqSourcesAnswer: {
     defaultMessage:
-      "Yes. Keep claims PDFs in Drive, market notes in Notion, and disclosures in SharePoint. Agents check the files that apply to that draft.",
-    id: "SnsLWu5goL",
+      "Yes. Keep claims PDFs in Drive, market notes in Notion, and disclosures in SharePoint, or type a guideline in Hyperlocalise. Agents check the ones that apply to that draft.",
+    id: "Ya2igat4Ug",
     description: "Guidelines FAQ answer about multiple sources",
   },
   faqFitQuestion: {
@@ -473,8 +473,8 @@ export const guidelinesPageMessages = defineMessages({
   },
   ctaBody: {
     defaultMessage:
-      "Connect Drive, Notion, or SharePoint and check the next draft against the real file.",
-    id: "3MyXNc43TJ",
+      "Connect Drive, Notion, or SharePoint, or type guidelines in, and check the next draft against them.",
+    id: "ddhlBSQ8lR",
     description: "Bottom CTA body on the Guidelines product page",
   },
   ctaNote: {

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.messages.ts
@@ -1,0 +1,485 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const guidelinesPageMessages = defineMessages({
+  heroEyebrow: {
+    defaultMessage: "Guidelines",
+    id: "es92Uya8hG",
+    description: "Hero eyebrow for the Guidelines product page",
+  },
+  heroHeadline: {
+    defaultMessage: "Keep the docs you have.\nPut them to work.",
+    id: 'sMO5kn7k5p',
+    description: "Hero headline for the Guidelines product page",
+  },
+  heroSubcopy: {
+    defaultMessage:
+      "Connect Google Drive, Notion, and SharePoint. Agents read the brand and compliance files your team already maintains and flag what does not match.",
+    id: 'GtjItsMfqV',
+    description: "Hero description for the Guidelines product page",
+  },
+  requestDemo: {
+    defaultMessage: "Request a Demo",
+    id: "lSPsuv9k/H",
+    description: "Call-to-action to request a Guidelines demo",
+  },
+  exploreGuidelines: {
+    defaultMessage: "See a guideline check",
+    id: 'QIAc4hvHDk',
+    description: "Anchor link from the Guidelines hero to the product preview",
+  },
+  fromRulesToDrafts: {
+    defaultMessage: "From Drive, Notion, and SharePoint into every draft.",
+    id: '05WQ9chsaJ',
+    description: "Caption under the Guidelines preview",
+  },
+  stepConnect: {
+    defaultMessage: "01 Connect",
+    id: '/2vDnBJJnU',
+    description: "Guidelines workflow step 1",
+  },
+  stepRead: {
+    defaultMessage: "02 Read the file",
+    id: 'IdXW81ey7i',
+    description: "Guidelines workflow step 2",
+  },
+  stepFlag: {
+    defaultMessage: "03 Flag the issues",
+    id: 'nIxPibE5kf',
+    description: "Guidelines workflow step 3",
+  },
+  stepShip: {
+    defaultMessage: "04 Ship",
+    id: 'L09pgcuANE',
+    description: "Guidelines workflow step 4",
+  },
+  sourcesEyebrow: {
+    defaultMessage: "Where your guidelines already live",
+    id: 'BTimRLPa1I',
+    description: "Eyebrow for the Guidelines sources section",
+  },
+  sourcesHeadline: {
+    defaultMessage: "Drive. Notion.\nSharePoint.",
+    id: 'pym2jLFt91',
+    description: "Headline for the Guidelines sources section",
+  },
+  sourcesBody: {
+    defaultMessage:
+      "Leave brand PDFs, market notes, and policy libraries where legal and brand already keep them. Hyperlocalise reads those files instead of asking you to rebuild a second playbook.",
+    id: '5VP6QS58Jl',
+    description: "Body copy for the Guidelines sources section",
+  },
+  sourcesAriaLabel: {
+    defaultMessage: "Guideline sources",
+    id: 'LguOyBNnte',
+    description: "Accessible label for the Guidelines source tabs",
+  },
+  sourceDrive: {
+    defaultMessage: "Google Drive",
+    id: 'I4iH2T3OLx',
+    description: "Guidelines source tab for Google Drive",
+  },
+  sourceNotion: {
+    defaultMessage: "Notion",
+    id: '4nr1WS9kIp',
+    description: "Guidelines source tab for Notion",
+  },
+  sourceSharepoint: {
+    defaultMessage: "SharePoint",
+    id: '1kGndGN4wG',
+    description: "Guidelines source tab for SharePoint",
+  },
+  sourceDriveTitle: {
+    defaultMessage: "The PDF stays\nin Drive.",
+    id: 'SbXclIFUB9',
+    description: "Title for the Google Drive source panel",
+  },
+  sourceDriveBody: {
+    defaultMessage:
+      "Connect brand-voice and claims PDFs from Google Drive. Agents cite the clause in the file when they flag a draft.",
+    id: 'oNE0YnvOn0',
+    description: "Body for the Google Drive source panel",
+  },
+  sourceDriveLink: {
+    defaultMessage: "From style guides to claims policies",
+    id: 'XcvWJmyVfR',
+    description: "Supporting link line for the Google Drive source panel",
+  },
+  sourceNotionTitle: {
+    defaultMessage: "Market notes\nstay in Notion.",
+    id: 'dGJ4DQ8pi3',
+    description: "Title for the Notion source panel",
+  },
+  sourceNotionBody: {
+    defaultMessage:
+      "Import the pages your GTM team already writes: dos and don'ts, proof points, and the tone that works in each market.",
+    id: '0roQJLdsUq',
+    description: "Body for the Notion source panel",
+  },
+  sourceNotionLink: {
+    defaultMessage: "From wiki pages to agent context",
+    id: 'KwEv4D6hGN',
+    description: "Supporting link line for the Notion source panel",
+  },
+  sourceSharepointTitle: {
+    defaultMessage: "Legal keeps\nthe library.",
+    id: 'DbGIc4sGDx',
+    description: "Title for the SharePoint source panel",
+  },
+  sourceSharepointBody: {
+    defaultMessage:
+      "Point Hyperlocalise at the SharePoint library that already holds disclosures, approved wording, and regulated claims.",
+    id: 'buVScYQI5w',
+    description: "Body for the SharePoint source panel",
+  },
+  sourceSharepointLink: {
+    defaultMessage: "From policy libraries to pre-publish checks",
+    id: 'chTXcZSMoe',
+    description: "Supporting link line for the SharePoint source panel",
+  },
+  sourceDriveFile: {
+    defaultMessage: "Brand-claims-policy.pdf",
+    id: 'yxDI0UUubE',
+    description: "Example Drive filename in the source preview",
+  },
+  sourceDriveDetail: {
+    defaultMessage: "Legal · 6 pages · Connected",
+    id: '7t3FQ5TrY6',
+    description: "Example Drive file detail in the source preview",
+  },
+  sourceDriveClause: {
+    defaultMessage: "3.2 German advertising — no superlatives",
+    id: 'u/BgSogOwb',
+    description: "Highlighted PDF clause in the Google Drive source preview",
+  },
+  sourceNotionFile: {
+    defaultMessage: "Japan market notes",
+    id: 'hXu3TQ7nei',
+    description: "Example Notion page title in the source preview",
+  },
+  sourceNotionDetail: {
+    defaultMessage: "GTM wiki · Updated this week",
+    id: 'KaF5SxLR8X',
+    description: "Example Notion page detail in the source preview",
+  },
+  sourceSharepointFile: {
+    defaultMessage: "EU disclosures library",
+    id: 'zdNwM1KXY3',
+    description: "Example SharePoint library name in the source preview",
+  },
+  sourceSharepointDetail: {
+    defaultMessage: "18 policy files · Compliance",
+    id: 'PRW9ZtkzIN',
+    description: "Example SharePoint library detail in the source preview",
+  },
+  appliedEyebrow: {
+    defaultMessage: "Used while you work",
+    id: 'gu7P/76etG',
+    description: "Eyebrow for the Guidelines applied-in-studio section",
+  },
+  appliedHeadline: {
+    defaultMessage: "The file is the source\nof truth.",
+    id: 'wwGzx8T1wq',
+    description: "Headline for the Guidelines applied-in-studio section",
+  },
+  appliedBody: {
+    defaultMessage:
+      "When a draft opens in Content Studio, the connected Drive PDF, Notion page, or SharePoint policy sits beside it. Reviewers and agents read the same document.",
+    id: 'w9pu7kC+rH',
+    description: "Body for the Guidelines applied-in-studio section",
+  },
+  exploreStudio: {
+    defaultMessage: "Explore Content Studio",
+    id: "ZTwQhpeJIW",
+    description: "Link from Guidelines to the Content Studio product page",
+  },
+  campaignGuidelines: {
+    defaultMessage: "Attached to this draft",
+    id: 'cJoA3WyajT',
+    description: "Title of the attached guidelines mock card",
+  },
+  appliedToDraft: {
+    defaultMessage: "From Google Drive",
+    id: '0B4ezwZ7oK',
+    description: "Status on the attached guidelines mock card",
+  },
+  attachedFile: {
+    defaultMessage: "File",
+    id: 'rOvqLQGma3',
+    description: "File row label in the attached guidelines mock",
+  },
+  attachedFileValue: {
+    defaultMessage: "Brand-claims-policy.pdf",
+    id: 'IIohVs/IF0',
+    description: "File row value in the attached guidelines mock",
+  },
+  attachedClause: {
+    defaultMessage: "Last cited",
+    id: 'rJ5ZNEEfrR',
+    description: "Clause row label in the attached guidelines mock",
+  },
+  attachedClauseValue: {
+    defaultMessage: "3.2 German advertising — no superlatives",
+    id: 'b95XI61qEi',
+    description: "Clause row value in the attached guidelines mock",
+  },
+  attachedStatus: {
+    defaultMessage: "Status",
+    id: 'x9lPZa0R66',
+    description: "Status row label in the attached guidelines mock",
+  },
+  attachedStatusValue: {
+    defaultMessage: "Two flags still open on this draft",
+    id: 'CXZaVZ1tZ8',
+    description: "Status row value in the attached guidelines mock",
+  },
+  auditEyebrow: {
+    defaultMessage: "Automations",
+    id: "gpAuditEye",
+    description: "Eyebrow for the Guidelines daily-audit section",
+  },
+  auditHeadline: {
+    defaultMessage: "Audit product and the website.\nEvery day.",
+    id: "gpAuditHead",
+    description: "Headline for the Guidelines daily-audit section",
+  },
+  auditBody: {
+    defaultMessage:
+      "Schedule an Automation to check live pages and product copy against the same Drive, Notion, or SharePoint files. Flags show up in the morning instead of after a launch.",
+    id: "gpAuditBody",
+    description: "Body for the Guidelines daily-audit section",
+  },
+  exploreAutomations: {
+    defaultMessage: "Explore Automations",
+    id: "gpAuditLink",
+    description: "Link from Guidelines to the Automations product page",
+  },
+  auditCardTitle: {
+    defaultMessage: "Daily compliance audit",
+    id: "gpAuditCard",
+    description: "Title of the daily compliance audit mock card",
+  },
+  auditCardSchedule: {
+    defaultMessage: "Every day at 07:00",
+    id: "gpAuditSched",
+    description: "Schedule on the daily compliance audit mock card",
+  },
+  auditChecks: {
+    defaultMessage: "Checks",
+    id: "gpAuditChecks",
+    description: "Checks label on the daily compliance audit mock card",
+  },
+  auditCheckProduct: {
+    defaultMessage: "Product copy · app and CMS strings",
+    id: "gpAuditProd",
+    description: "Product check row on the daily compliance audit mock card",
+  },
+  auditCheckWebsite: {
+    defaultMessage: "Website · live pages",
+    id: "gpAuditWeb",
+    description: "Website check row on the daily compliance audit mock card",
+  },
+  auditAgainst: {
+    defaultMessage: "Against",
+    id: "gpAuditAgainst",
+    description: "Guidelines label on the daily compliance audit mock card",
+  },
+  auditAgainstFile: {
+    defaultMessage: "Brand-claims-policy.pdf · Google Drive",
+    id: "gpAuditFile",
+    description: "Guideline file on the daily compliance audit mock card",
+  },
+  auditLastRun: {
+    defaultMessage: "Last run · this morning",
+    id: "gpAuditRun",
+    description: "Last-run label on the daily compliance audit mock card",
+  },
+  auditFindingDe: {
+    defaultMessage: "DE homepage",
+    id: "gpAuditDe",
+    description: "German finding target on the daily compliance audit mock card",
+  },
+  auditFindingDeFlags: {
+    defaultMessage: "3 flags · clause 3.2",
+    id: "gpAuditDeF",
+    description: "German finding result on the daily compliance audit mock card",
+  },
+  auditFindingJp: {
+    defaultMessage: "JP product page",
+    id: "gpAuditJp",
+    description: "Japanese finding target on the daily compliance audit mock card",
+  },
+  auditFindingJpFlags: {
+    defaultMessage: "1 flag · clause 2.1",
+    id: "gpAuditJpF",
+    description: "Japanese finding result on the daily compliance audit mock card",
+  },
+  auditFindingFr: {
+    defaultMessage: "FR website",
+    id: "gpAuditFr",
+    description: "French finding target on the daily compliance audit mock card",
+  },
+  auditFindingFrFlags: {
+    defaultMessage: "Clear",
+    id: "gpAuditFrF",
+    description: "French finding result on the daily compliance audit mock card",
+  },
+  connectedHeadline: {
+    defaultMessage: "Guidelines that travel with the work.",
+    id: "1Hzp15bVmL",
+    description: "Headline for the Guidelines connected-products section",
+  },
+  connectedBody: {
+    defaultMessage: "Apply the same files in the studio. Automate the checks in your workflows.",
+    id: '5r5QUAR3/o',
+    description: "Body for the Guidelines connected-products section",
+  },
+  contentStudio: {
+    defaultMessage: "Multilingual Content Studio",
+    id: "o9VQDmuCLQ",
+    description: "Link from Guidelines to the Content Studio product page",
+  },
+  automationWorkflow: {
+    defaultMessage: "Automation Workflow",
+    id: "nXCktzp8yW",
+    description: "Link from Guidelines to the automation product page",
+  },
+  faqHeading: {
+    defaultMessage: "A few things\nyou might ask.",
+    id: "jSvr21uwu7",
+    description: "FAQ heading on the Guidelines product page",
+  },
+  faqSubheading: {
+    defaultMessage: "Getting to know Guidelines.",
+    id: "aaULJeFGWL",
+    description: "FAQ subheading on the Guidelines product page",
+  },
+  faqWhereQuestion: {
+    defaultMessage: "Do we have to move our guidelines into Hyperlocalise?",
+    id: '1t3wSermT8',
+    description: "Guidelines FAQ question about moving files",
+  },
+  faqWhereAnswer: {
+    defaultMessage:
+      "No. Connect Google Drive, Notion, or SharePoint and leave the files where brand and legal already keep them. Agents read those sources.",
+    id: 'bOpIXEky0N',
+    description: "Guidelines FAQ answer about moving files",
+  },
+  faqWhatQuestion: {
+    defaultMessage: "What kinds of files can agents use?",
+    id: '11Fkff+o29',
+    description: "Guidelines FAQ question about file types",
+  },
+  faqWhatAnswer: {
+    defaultMessage:
+      "Brand-voice PDFs, claims policies, Notion market notes, and SharePoint disclosure libraries. If your team already treats it as the rule, connect it.",
+    id: 'LNwKJ8Zkta',
+    description: "Guidelines FAQ answer about file types",
+  },
+  faqAgentsQuestion: {
+    defaultMessage: "How does an agent flag a compliance issue?",
+    id: 'nPSlG6dRhe',
+    description: "Guidelines FAQ question about agent flags",
+  },
+  faqAgentsAnswer: {
+    defaultMessage:
+      "It reads the connected file, cites the clause, and flags the line that breaks it—so a reviewer can open the PDF instead of re-explaining the rule.",
+    id: '8zHJojmnLS',
+    description: "Guidelines FAQ answer about agent flags",
+  },
+  faqAuditQuestion: {
+    defaultMessage: "Can Automations audit the product and website every day?",
+    id: "gpFaqAudQ",
+    description: "Guidelines FAQ question about daily Automations audits",
+  },
+  faqAuditAnswer: {
+    defaultMessage:
+      "Yes. Schedule a daily Automation to check product copy and live pages against the connected guideline files. Reviewers see the flags in the morning.",
+    id: "gpFaqAudA",
+    description: "Guidelines FAQ answer about daily Automations audits",
+  },
+  faqUpdateQuestion: {
+    defaultMessage: "What happens when legal updates the PDF?",
+    id: 'yyQsNyHMHz',
+    description: "Guidelines FAQ question about file updates",
+  },
+  faqUpdateAnswer: {
+    defaultMessage:
+      "The connected file is the source of truth. When Drive or SharePoint changes, the next check uses the updated wording.",
+    id: 'h/TaCp7kf5',
+    description: "Guidelines FAQ answer about file updates",
+  },
+  faqStudioQuestion: {
+    defaultMessage: "How do Guidelines work with Content Studio?",
+    id: "CSpuSDILYV",
+    description: "Guidelines FAQ question about Content Studio",
+  },
+  faqStudioAnswer: {
+    defaultMessage:
+      "Attach a connected file to a campaign or draft. Reviewers see the PDF or page beside the copy, and agent suggestions cite the same clauses.",
+    id: 'K1TC/ecjoE',
+    description: "Guidelines FAQ answer about Content Studio",
+  },
+  faqSourcesQuestion: {
+    defaultMessage: "Can we use more than one source?",
+    id: 'ryd9aeww4k',
+    description: "Guidelines FAQ question about multiple sources",
+  },
+  faqSourcesAnswer: {
+    defaultMessage:
+      "Yes. Keep claims PDFs in Drive, market notes in Notion, and disclosures in SharePoint. Agents check the files that apply to that draft.",
+    id: 'SnsLWu5goL',
+    description: "Guidelines FAQ answer about multiple sources",
+  },
+  faqFitQuestion: {
+    defaultMessage: "How does Guidelines fit with the rest of Hyperlocalise?",
+    id: "k/A4aI77+z",
+    description: "Guidelines FAQ question about product fit",
+  },
+  faqFitAnswer: {
+    defaultMessage:
+      "Guidelines is the connected file layer. Content Studio applies it while you create and review. Automation Workflow uses it when agents run repeatable jobs.",
+    id: 'doe6TBv1GS',
+    description: "Guidelines FAQ answer about product fit",
+  },
+  faqWhoQuestion: {
+    defaultMessage: "Who should own the connected files?",
+    id: 'nqWsz/vBZ6',
+    description: "Guidelines FAQ question about ownership",
+  },
+  faqWhoAnswer: {
+    defaultMessage:
+      "Whoever already owns them—usually brand, legal, or localisation. Hyperlocalise does not replace that library. It reads it.",
+    id: 'TUhxc0TwuH',
+    description: "Guidelines FAQ answer about ownership",
+  },
+  ctaHeadline: {
+    defaultMessage: "Leave the guidelines where they are.\nLet agents read them.",
+    id: 'zWj2+vAiX7',
+    description: "Bottom CTA headline on the Guidelines product page",
+  },
+  ctaBody: {
+    defaultMessage:
+      "Connect Drive, Notion, or SharePoint and check the next draft against the real file.",
+    id: '3MyXNc43TJ',
+    description: "Bottom CTA body on the Guidelines product page",
+  },
+  ctaNote: {
+    defaultMessage: "No second playbook to maintain.",
+    id: '76D+ZZX3Tn',
+    description: "Supporting note under the Guidelines bottom CTA",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.tsx
@@ -369,7 +369,7 @@ export function GuidelinesPage() {
                 </Button>
                 <Button
                   size="lg"
-                  variant="outline"
+                  variant="secondary"
                   nativeButton={false}
                   render={<a href="#guidelines" />}
                 >

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { ContentOpsMockAppShell } from "@/components/marketing/content-ops/content-ops-mock-app-shell";
+import {
+  DUSK_MESH_GRADIENT_SRC,
+  LAVENDER_MESH_GRADIENT_SRC,
+  MeshStage,
+  ROSE_MESH_GRADIENT_SRC,
+  SAGE_MESH_GRADIENT_SRC,
+  SectionMeshBackground,
+} from "@/components/marketing/hero-frame-mesh-stage";
+import { HomepageFaqSection } from "@/components/marketing/homepage-faq-section";
+import { IntegrationLogoMark } from "@/components/marketing/integrations/integration-logo-mark";
+import { MarketingFooter } from "@/components/marketing/marketing-footer";
+import { footerColumns } from "@/components/marketing/marketing-page-content";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
+import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
+import type { AppLocale } from "@/lib/app-i18n/locales";
+
+import { GuidelinesBoardMock } from "./guidelines-board-mock";
+import { guidelinesPageMessages as messages } from "./guidelines-page.messages";
+import { KnowledgeWaveGlobe } from "./knowledge-wave-globe";
+
+const sourceIds = ["drive", "notion", "sharepoint"] as const;
+type SourceId = (typeof sourceIds)[number];
+
+const sourceLabelKeys = {
+  drive: "sourceDrive",
+  notion: "sourceNotion",
+  sharepoint: "sourceSharepoint",
+} as const;
+
+const sourceCopyKeys = {
+  drive: {
+    title: "sourceDriveTitle",
+    body: "sourceDriveBody",
+    link: "sourceDriveLink",
+  },
+  notion: {
+    title: "sourceNotionTitle",
+    body: "sourceNotionBody",
+    link: "sourceNotionLink",
+  },
+  sharepoint: {
+    title: "sourceSharepointTitle",
+    body: "sourceSharepointBody",
+    link: "sourceSharepointLink",
+  },
+} as const;
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return <p className="text-xs font-medium text-muted-foreground">{children}</p>;
+}
+
+function GuidelinesPreview() {
+  return (
+    <div id="guidelines" className="mx-auto max-w-6xl">
+      <MeshStage
+        className="w-full"
+        contentClassName="px-3 pt-3 pb-0 sm:px-8 sm:pt-8 lg:px-10 lg:pt-10"
+        meshSrc={SAGE_MESH_GRADIENT_SRC}
+        priority
+      >
+        <ContentOpsMockAppShell
+          activeTab="brand"
+          size="viewport"
+          className="rounded-t-xl rounded-b-none border-0 shadow-2xl shadow-[#172541]/20"
+        >
+          <GuidelinesBoardMock />
+        </ContentOpsMockAppShell>
+      </MeshStage>
+    </div>
+  );
+}
+
+function SourcePreview({ source }: { source: SourceId }) {
+  if (source === "notion") {
+    return (
+      <div className="relative isolate flex min-h-80 flex-1 items-center overflow-hidden p-5 sm:p-8">
+        <SectionMeshBackground src={LAVENDER_MESH_GRADIENT_SRC} className="opacity-80" />
+        <div className="relative w-full rounded-xl border border-border bg-card p-6 text-card-foreground shadow-sm">
+          <IntegrationLogoMark name="Notion" iconKey="notion" size="md" />
+          <p className="mt-5 text-lg font-semibold">
+            <FormattedMessage {...messages.sourceNotionFile} />
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            <FormattedMessage {...messages.sourceNotionDetail} />
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (source === "sharepoint") {
+    return (
+      <div className="relative isolate flex min-h-80 flex-1 items-center overflow-hidden p-5 sm:p-8">
+        <SectionMeshBackground src={ROSE_MESH_GRADIENT_SRC} className="opacity-75" />
+        <div className="relative w-full rounded-xl border border-border bg-card p-6 text-card-foreground shadow-sm">
+          <IntegrationLogoMark name="SharePoint" logoSrc="/images/sharepoint-logo.svg" size="md" />
+          <p className="mt-5 text-lg font-semibold">
+            <FormattedMessage {...messages.sourceSharepointFile} />
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            <FormattedMessage {...messages.sourceSharepointDetail} />
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative isolate flex min-h-80 flex-1 items-center overflow-hidden p-5 sm:p-8">
+      <SectionMeshBackground src={SAGE_MESH_GRADIENT_SRC} className="opacity-80" />
+      <div className="relative w-full overflow-hidden rounded-xl border border-[#d9d2c3] bg-[#f7f4ee] p-6 text-[#1d1a16] shadow-sm">
+        <div className="flex items-center gap-3">
+          <IntegrationLogoMark name="Google Drive" iconKey="googledrive" size="md" />
+          <div>
+            <p className="text-sm font-semibold">
+              <FormattedMessage {...messages.sourceDriveFile} />
+            </p>
+            <p className="text-xs text-[#6f675c]">
+              <FormattedMessage {...messages.sourceDriveDetail} />
+            </p>
+          </div>
+        </div>
+        <div className="mt-6 space-y-2">
+          <div className="h-2 w-2/3 rounded bg-[#e4ddd0]" />
+          <div className="h-2 w-full rounded bg-[#e4ddd0]" />
+          <div className="rounded-md border border-[#c45c3e] bg-[#f3d7cc] px-3 py-2 text-xs leading-5">
+            <FormattedMessage {...messages.sourceDriveClause} />
+          </div>
+          <div className="h-2 w-5/6 rounded bg-[#e4ddd0]" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function GuidelineSources() {
+  const intl = useIntl();
+  const [source, setSource] = useState<SourceId>("drive");
+  const copy = sourceCopyKeys[source];
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto max-w-7xl">
+        <div className="flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
+          <div>
+            <Eyebrow>
+              <FormattedMessage {...messages.sourcesEyebrow} />
+            </Eyebrow>
+            <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+              <FormattedMessage {...messages.sourcesHeadline} />
+            </h2>
+          </div>
+          <p className="max-w-md text-lg leading-8 text-muted-foreground">
+            <FormattedMessage {...messages.sourcesBody} />
+          </p>
+        </div>
+        <div
+          className="mt-10 flex gap-7 overflow-x-auto"
+          role="tablist"
+          aria-label={intl.formatMessage(messages.sourcesAriaLabel)}
+        >
+          {sourceIds.map((item) => (
+            <button
+              key={item}
+              type="button"
+              role="tab"
+              aria-selected={source === item}
+              onClick={() => setSource(item)}
+              className={
+                source === item
+                  ? "shrink-0 border-b-2 border-primary pb-3 text-sm text-primary"
+                  : "shrink-0 pb-3 text-sm text-muted-foreground hover:text-foreground"
+              }
+            >
+              <FormattedMessage {...messages[sourceLabelKeys[item]]} />
+            </button>
+          ))}
+        </div>
+        <div className="mt-6 overflow-hidden rounded-xl bg-muted lg:flex">
+          <div className="flex w-full shrink-0 flex-col justify-center gap-5 bg-background/55 p-8 lg:w-[34%] lg:p-12">
+            <h3 className="whitespace-pre-line text-2xl leading-8 font-semibold tracking-tight">
+              <FormattedMessage {...messages[copy.title]} />
+            </h3>
+            <p className="text-base leading-7 text-muted-foreground">
+              <FormattedMessage {...messages[copy.body]} />
+            </p>
+            <p className="pt-2 text-sm text-primary">
+              <FormattedMessage {...messages[copy.link]} /> ↗
+            </p>
+          </div>
+          <SourcePreview source={source} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const faqMessageKeys = [
+  ["faqWhereQuestion", "faqWhereAnswer"],
+  ["faqWhatQuestion", "faqWhatAnswer"],
+  ["faqAgentsQuestion", "faqAgentsAnswer"],
+  ["faqAuditQuestion", "faqAuditAnswer"],
+  ["faqUpdateQuestion", "faqUpdateAnswer"],
+  ["faqStudioQuestion", "faqStudioAnswer"],
+  ["faqSourcesQuestion", "faqSourcesAnswer"],
+  ["faqFitQuestion", "faqFitAnswer"],
+  ["faqWhoQuestion", "faqWhoAnswer"],
+] as const;
+
+const attachedRows = [
+  ["attachedFile", "attachedFileValue"],
+  ["attachedClause", "attachedClauseValue"],
+  ["attachedStatus", "attachedStatusValue"],
+] as const;
+
+const auditFindings = [
+  {
+    target: "auditFindingDe",
+    result: "auditFindingDeFlags",
+    flagged: true,
+  },
+  {
+    target: "auditFindingJp",
+    result: "auditFindingJpFlags",
+    flagged: true,
+  },
+  {
+    target: "auditFindingFr",
+    result: "auditFindingFrFlags",
+    flagged: false,
+  },
+] as const;
+
+function DailyAuditSection({ locale }: { locale: AppLocale }) {
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[1.15fr_.85fr] lg:items-center">
+        <div className="relative isolate overflow-hidden rounded-xl p-4 sm:p-5">
+          <SectionMeshBackground src={ROSE_MESH_GRADIENT_SRC} className="opacity-75" />
+          <div className="relative rounded-xl border border-border bg-card p-6 text-card-foreground sm:p-8">
+            <div className="flex justify-between gap-3 border-b border-border pb-6 text-sm">
+              <b>
+                <FormattedMessage {...messages.auditCardTitle} />
+              </b>
+              <span className="text-primary">
+                <FormattedMessage {...messages.auditCardSchedule} />
+              </span>
+            </div>
+            <div className="grid gap-2 pt-5 text-sm sm:grid-cols-[8rem_1fr]">
+              <span className="text-muted-foreground">
+                <FormattedMessage {...messages.auditChecks} />
+              </span>
+              <span className="space-y-1">
+                <span className="block">
+                  <FormattedMessage {...messages.auditCheckProduct} />
+                </span>
+                <span className="block">
+                  <FormattedMessage {...messages.auditCheckWebsite} />
+                </span>
+              </span>
+            </div>
+            <div className="grid gap-2 pt-5 text-sm sm:grid-cols-[8rem_1fr]">
+              <span className="text-muted-foreground">
+                <FormattedMessage {...messages.auditAgainst} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.auditAgainstFile} />
+              </span>
+            </div>
+            <div className="mt-6 border-t border-border pt-5">
+              <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                <FormattedMessage {...messages.auditLastRun} />
+              </p>
+              <div className="mt-3 space-y-3">
+                {auditFindings.map((finding) => (
+                  <div
+                    key={finding.target}
+                    className="flex items-center justify-between gap-3 text-sm"
+                  >
+                    <span>
+                      <FormattedMessage {...messages[finding.target]} />
+                    </span>
+                    <span
+                      className={
+                        finding.flagged ? "text-destructive" : "text-primary"
+                      }
+                    >
+                      <FormattedMessage {...messages[finding.result]} />
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="max-w-xl">
+          <Eyebrow>
+            <FormattedMessage {...messages.auditEyebrow} />
+          </Eyebrow>
+          <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight text-foreground sm:text-5xl">
+            <FormattedMessage {...messages.auditHeadline} />
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            <FormattedMessage {...messages.auditBody} />
+          </p>
+          <Link
+            href={rewriteAppLocalePath("/product/agents-automation", locale)}
+            className="mt-5 inline-flex text-sm font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            <FormattedMessage {...messages.exploreAutomations} /> ↗
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function GuidelinesPage() {
+  const locale = useAppLocale();
+  const intl = useIntl();
+  const faqItems = faqMessageKeys.map(([question, answer]) => ({
+    question: intl.formatMessage(messages[question]),
+    answer: intl.formatMessage(messages[answer]),
+  }));
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div>
+        <section className="relative isolate mx-auto w-full max-w-6xl overflow-hidden bg-background">
+          <KnowledgeWaveGlobe />
+          <div className="relative z-10 flex min-h-[80vh] flex-col items-center justify-center px-5 py-20 text-center sm:px-10 sm:py-24 lg:px-10">
+            <div className="mx-auto flex max-w-3xl flex-col items-center">
+              <Eyebrow>
+                <FormattedMessage {...messages.heroEyebrow} />
+              </Eyebrow>
+              <h1 className="mt-6 whitespace-pre-line font-heading text-[clamp(3rem,7vw,5.5rem)] leading-[0.98] tracking-[-0.045em]">
+                <FormattedMessage {...messages.heroHeadline} />
+              </h1>
+              <p className="mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+                <FormattedMessage {...messages.heroSubcopy} />
+              </p>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Button
+                  size="lg"
+                  nativeButton={false}
+                  render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+                >
+                  <FormattedMessage {...messages.requestDemo} />{" "}
+                  <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+                </Button>
+                <Button
+                  size="lg"
+                  variant="outline"
+                  nativeButton={false}
+                  render={<a href="#guidelines" />}
+                >
+                  <FormattedMessage {...messages.exploreGuidelines} /> ↓
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-3 pb-0 sm:px-6 lg:px-8">
+          <GuidelinesPreview />
+          <div className="mx-auto flex max-w-6xl flex-col justify-between gap-4 border-b border-border py-7 text-sm text-muted-foreground sm:flex-row">
+            <span>
+              <FormattedMessage {...messages.fromRulesToDrafts} />
+            </span>
+            <span className="flex flex-wrap gap-x-7 gap-y-2">
+              <span>
+                <FormattedMessage {...messages.stepConnect} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepRead} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepFlag} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepShip} />
+              </span>
+            </span>
+          </div>
+        </section>
+
+        <GuidelineSources />
+
+        <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+          <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[.85fr_1.15fr] lg:items-center">
+            <div className="max-w-xl">
+              <Eyebrow>
+                <FormattedMessage {...messages.appliedEyebrow} />
+              </Eyebrow>
+              <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight text-foreground sm:text-5xl">
+                <FormattedMessage {...messages.appliedHeadline} />
+              </h2>
+              <p className="mt-6 text-lg leading-8 text-muted-foreground">
+                <FormattedMessage {...messages.appliedBody} />
+              </p>
+              <Link
+                href={rewriteAppLocalePath("/product/multilingual-content-studio", locale)}
+                className="mt-5 inline-flex text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.exploreStudio} /> ↗
+              </Link>
+            </div>
+            <div className="relative isolate overflow-hidden rounded-xl p-4 sm:p-5">
+              <SectionMeshBackground src={LAVENDER_MESH_GRADIENT_SRC} className="opacity-80" />
+              <div className="relative rounded-xl border border-border bg-card p-6 text-card-foreground sm:p-8">
+                <div className="flex justify-between gap-3 border-b border-border pb-6 text-sm">
+                  <b>
+                    <FormattedMessage {...messages.campaignGuidelines} />
+                  </b>
+                  <span className="text-primary">
+                    <FormattedMessage {...messages.appliedToDraft} /> ✓
+                  </span>
+                </div>
+                {attachedRows.map(([label, value]) => (
+                  <div key={label} className="grid gap-2 pt-5 text-sm sm:grid-cols-[8rem_1fr]">
+                    <span className="text-muted-foreground">
+                      <FormattedMessage {...messages[label]} />
+                    </span>
+                    <span>
+                      <FormattedMessage {...messages[value]} />
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <DailyAuditSection locale={locale} />
+
+        <section className="mx-auto max-w-7xl border-y border-border px-5 py-10 sm:px-8 lg:px-10">
+          <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-center">
+            <div>
+              <h2 className="text-2xl font-medium tracking-tight">
+                <FormattedMessage {...messages.connectedHeadline} />
+              </h2>
+              <p className="mt-2 text-base text-muted-foreground">
+                <FormattedMessage {...messages.connectedBody} />
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-6">
+              <Link
+                href={rewriteAppLocalePath("/product/multilingual-content-studio", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.contentStudio} /> ↗
+              </Link>
+              <Link
+                href={rewriteAppLocalePath("/product/agents-automation", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.automationWorkflow} /> ↗
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+          <HomepageFaqSection
+            items={faqItems}
+            heading={
+              <span className="whitespace-pre-line">
+                <FormattedMessage {...messages.faqHeading} />
+              </span>
+            }
+            subheading={<FormattedMessage {...messages.faqSubheading} />}
+          />
+        </div>
+
+        <section className="px-5 pb-20 sm:px-8 lg:px-10">
+          <MeshStage
+            className="mx-auto max-w-7xl"
+            contentClassName="p-0"
+            meshSrc={DUSK_MESH_GRADIENT_SRC}
+            mixSrc={ROSE_MESH_GRADIENT_SRC}
+          >
+            <div className="flex flex-col justify-between gap-10 bg-[#172541]/45 p-8 text-[#f8f0f5] sm:p-12 lg:flex-row lg:items-center lg:p-16">
+              <div>
+                <h2 className="whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+                  <FormattedMessage {...messages.ctaHeadline} />
+                </h2>
+                <p className="mt-5 text-lg text-[#e5edf9]">
+                  <FormattedMessage {...messages.ctaBody} />
+                </p>
+              </div>
+              <div className="flex flex-col items-start gap-3 lg:items-center">
+                <Button
+                  size="lg"
+                  className="bg-[#ebc36a] text-[#172541] hover:bg-[#f2db9b]"
+                  nativeButton={false}
+                  render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+                >
+                  <FormattedMessage {...messages.requestDemo} />{" "}
+                  <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+                </Button>
+                <span className="text-xs text-[#e5edf9]">
+                  <FormattedMessage {...messages.ctaNote} />
+                </span>
+              </div>
+            </div>
+          </MeshStage>
+        </section>
+
+        <section className="border-t border-border px-5 pt-16 sm:px-8 lg:px-10">
+          <MarketingFooter columns={footerColumns} />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/guidelines-page.tsx
@@ -303,11 +303,7 @@ function DailyAuditSection({ locale }: { locale: AppLocale }) {
                     <span>
                       <FormattedMessage {...messages[finding.target]} />
                     </span>
-                    <span
-                      className={
-                        finding.flagged ? "text-destructive" : "text-primary"
-                      }
-                    >
+                    <span className={finding.flagged ? "text-destructive" : "text-primary"}>
                       <FormattedMessage {...messages[finding.result]} />
                     </span>
                   </div>

--- a/apps/hyperlocalise-web/src/components/marketing/product/knowledge-mock-ui.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/knowledge-mock-ui.messages.ts
@@ -16,8 +16,8 @@ import { defineMessages } from "react-intl";
 
 export const knowledgeMockMessages = defineMessages({
   eyebrow: {
-    defaultMessage: "Self-evolving Knowledge",
-    id: "IyzX73LnS8",
+    defaultMessage: "Guidelines",
+    id: "MPOlaJ9dCq",
     description: "Knowledge mock UI eyebrow label",
   },
   headline: {

--- a/apps/hyperlocalise-web/src/components/marketing/product/knowledge-wave-globe.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/knowledge-wave-globe.tsx
@@ -15,6 +15,28 @@
 import { useEffect, useRef } from "react";
 import { useReducedMotion } from "motion/react";
 
+const GLYPHS = Array.from(
+  "AÁĂÅÆĐÉĘĞÍŁÑØŐŚŞÚÜÝŹaáăåæđéęğıłñøőśşúüýź" +
+    "АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЫЭЮЯабвгдежзийклмнопрстуфхцчшщыэюя" +
+    "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικλμνξοπρστυφχψω" +
+    "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん" +
+    "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン" +
+    "文語世界本漢字翻訳市場品質本地化中日韓" +
+    "한글글자번역시장품질세계언어" +
+    "אבגדהוזחטיךכלםמןנסעףפץצקרשת" +
+    "ابتثجحخدذرزسشصضطظعغفقكلمنهوي" +
+    "अआइईउऊकखगघचजटडतथदधनपबभमयरलवशषसह" +
+    "กขคงจชซญดตถทนบปผพฟมยรลวสหอ" +
+    "აბგდევზთიკლმნოპრსტუფქღყშჩცძწჭხჯჰ" +
+    "ԱԲԳԴԵԶԷԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖ",
+);
+
+function glyphFor(lat: number, lon: number) {
+  let hash = Math.imul(lat + 1, 2654435761);
+  hash = Math.imul(hash ^ Math.imul(lon + 1, 1597334677), 2246822519);
+  return GLYPHS[(hash >>> 0) % GLYPHS.length] ?? "文";
+}
+
 export function KnowledgeWaveGlobe() {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -83,7 +105,6 @@ export function KnowledgeWaveGlobe() {
       Math.sin((x + z) * 0.8 + t * 0.6) * 0.7 +
       Math.cos(y * 0.5 - z * 0.9 + t * 0.4) * 0.5;
 
-    const CHARS = " .·:+*#%@";
     const LAT_STEPS = 36;
     const LON_STEPS = 72;
 
@@ -100,8 +121,8 @@ export function KnowledgeWaveGlobe() {
       const rotY = s * 0.18;
       const rotX = Math.sin(s * 0.07) * 0.25;
 
-      const cell = Math.max(8, Math.min(W, H) * 0.022);
-      ctx.font = `500 ${cell}px ui-monospace, SFMono-Regular, Menlo, monospace`;
+      const cell = Math.max(9, Math.min(W, H) * 0.02);
+      ctx.font = `500 ${cell}px ui-sans-serif, system-ui, "PingFang SC", "Hiragino Sans", "Apple SD Gothic Neo", "Noto Sans", sans-serif`;
       ctx.textBaseline = "middle";
       ctx.textAlign = "center";
 
@@ -179,8 +200,9 @@ export function KnowledgeWaveGlobe() {
 
           const w = noise3(x0 * 3, y0 * 3, z0 * 3, s * 0.4) + waveBoost * 0.18;
           const normalized = Math.max(0, Math.min(1, (w + 1.5) / 2.8));
-          const ch = CHARS[Math.floor(normalized * (CHARS.length - 1))];
-          if (ch === " ") continue;
+          if (normalized < 0.2) continue;
+
+          const ch = glyphFor(lat, lon);
 
           const depth = (z0 + 0.1) / 1.1;
           const strong = normalized > 0.5;

--- a/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.tsx
@@ -725,7 +725,7 @@ export function MultilingualContentStudioPage() {
                 <FormattedMessage {...messages.contextBody} />
               </p>
               <Link
-                href={rewriteAppLocalePath("/product/self-evolving-knowledge", locale)}
+                href={rewriteAppLocalePath("/product/guidelines", locale)}
                 className="mt-5 inline-flex text-sm font-medium text-foreground underline-offset-4 hover:underline"
               >
                 <FormattedMessage {...messages.exploreGuidelines} /> ↗
@@ -837,7 +837,7 @@ export function MultilingualContentStudioPage() {
                 <FormattedMessage {...messages.automationWorkflow} /> ↗
               </Link>
               <Link
-                href={rewriteAppLocalePath("/product/self-evolving-knowledge", locale)}
+                href={rewriteAppLocalePath("/product/guidelines", locale)}
                 className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
               >
                 <FormattedMessage {...messages.guidelines} /> ↗

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
@@ -399,13 +399,13 @@ export const productPageMessages = defineMessages({
   },
   guidelinesMetadataTitle: {
     defaultMessage: "Keep the Docs You Have. Put Them to Work. | Hyperlocalise",
-    id: 'qqzc5HNRQF',
+    id: "qqzc5HNRQF",
     description: "Page title for the Guidelines product page",
   },
   guidelinesMetadataDescription: {
     defaultMessage:
       "Connect Google Drive, Notion, and SharePoint. Agents check drafts against the brand and compliance files your team already maintains.",
-    id: '2HF+fAMIDb',
+    id: "2HF+fAMIDb",
     description: "Meta description for the Guidelines product page",
   },
   guidelinesHeroEyebrow: {
@@ -415,66 +415,66 @@ export const productPageMessages = defineMessages({
   },
   guidelinesHeroHeadline: {
     defaultMessage: "Keep the docs you have. Put them to work.",
-    id: '60zsYx+OAc',
+    id: "60zsYx+OAc",
     description: "Hero headline for the Guidelines product page",
   },
   guidelinesHeroSubcopy: {
     defaultMessage:
       "Connect Google Drive, Notion, and SharePoint. Agents read the brand and compliance files your team already maintains and flag what does not match.",
-    id: 'CihbYTYKi/',
+    id: "0aO5cDtCkQ",
     description: "Hero subcopy for the Guidelines product page",
   },
   guidelinesDetailsHeadline: {
     defaultMessage: "Leave the guidelines where they are. Let agents read them.",
-    id: 'nfMyedI5a6',
+    id: "bwRkCyVWjg",
     description: "Details section headline for the Guidelines product page",
   },
   guidelinesSummary: {
     defaultMessage:
       "Connect Google Drive, Notion, and SharePoint so agents check drafts against the files brand and legal already maintain.",
-    id: 'ZhqgSTt9NF',
+    id: "ZhqgSTt9NF",
     description: "Details section summary for the Guidelines product page",
   },
   guidelinesProof0Title: {
     defaultMessage: "Keep them in Drive",
-    id: '8ubp0pkM3E',
+    id: "8ubp0pkM3E",
     description: "Proof point 1 title for the Guidelines product page",
   },
   guidelinesProof0Body: {
     defaultMessage:
       "Brand-voice and claims PDFs stay in Google Drive. Agents cite the clause when they flag a draft.",
-    id: 'IaGMAEBgFR',
+    id: "IaGMAEBgFR",
     description: "Proof point 1 body for the Guidelines product page",
   },
   guidelinesProof1Title: {
     defaultMessage: "Keep notes in Notion",
-    id: 'E+gsjwOkn+',
+    id: "E+gsjwOkn+",
     description: "Proof point 2 title for the Guidelines product page",
   },
   guidelinesProof1Body: {
     defaultMessage: "Market dos and don'ts stay on the pages your GTM team already writes.",
-    id: 'iu8wk5djA0',
+    id: "iu8wk5djA0",
     description: "Proof point 2 body for the Guidelines product page",
   },
   guidelinesProof2Title: {
     defaultMessage: "Keep policy in SharePoint",
-    id: '9Hmj8F68fv',
+    id: "9Hmj8F68fv",
     description: "Proof point 3 title for the Guidelines product page",
   },
   guidelinesProof2Body: {
     defaultMessage: "Disclosures and approved wording stay in the library legal already owns.",
-    id: 'WATviG34Qf',
+    id: "WATviG34Qf",
     description: "Proof point 3 body for the Guidelines product page",
   },
   guidelinesCtaHeadline: {
     defaultMessage: "Leave the guidelines where they are. Let agents read them.",
-    id: 'ggY8ufdyFe',
+    id: "p5U71/xQBI",
     description: "Bottom CTA headline for the Guidelines product page",
   },
   guidelinesCtaDescription: {
     defaultMessage:
       "Connect Drive, Notion, or SharePoint and check the next draft against the real file.",
-    id: 'b4qmyBy/VI',
+    id: "b4qmyBy/VI",
     description: "Bottom CTA description for the Guidelines product page",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
@@ -55,10 +55,10 @@ export const productPageMessages = defineMessages({
     id: "JNXXTToFFQ",
     description: "Navigation label for the multilingual Content Studio product page",
   },
-  productNavSelfEvolvingKnowledge: {
-    defaultMessage: "Self-evolving Knowledge",
-    id: "Ktkp7Xxut2",
-    description: "Navigation label for the self-evolving knowledge product page",
+  productNavGuidelines: {
+    defaultMessage: "Guidelines",
+    id: "gtD9AzyGIn",
+    description: "Navigation label for the Guidelines product page",
   },
   visualAutomationLaunchRequest: {
     defaultMessage: "Launch request",
@@ -397,88 +397,85 @@ export const productPageMessages = defineMessages({
     id: "Icd4dfBmnK",
     description: "Bottom CTA description for the next-gen CAT tool product page",
   },
-  selfEvolvingKnowledgeMetadataTitle: {
-    defaultMessage: "Stop Repeating the Same Localisation Feedback | Hyperlocalise",
-    id: "Ov7k7O9mR3",
-    description: "Page title for the self-evolving knowledge product page",
+  guidelinesMetadataTitle: {
+    defaultMessage: "Keep the Docs You Have. Put Them to Work. | Hyperlocalise",
+    id: 'qqzc5HNRQF',
+    description: "Page title for the Guidelines product page",
   },
-  selfEvolvingKnowledgeMetadataDescription: {
+  guidelinesMetadataDescription: {
     defaultMessage:
-      "Capture reviewer corrections, glossary decisions, product context, and market preferences so every localisation workflow starts smarter.",
-    id: "G1is+5n2E6",
-    description: "Meta description for the self-evolving knowledge product page",
+      "Connect Google Drive, Notion, and SharePoint. Agents check drafts against the brand and compliance files your team already maintains.",
+    id: '2HF+fAMIDb',
+    description: "Meta description for the Guidelines product page",
   },
-  selfEvolvingKnowledgeHeroEyebrow: {
-    defaultMessage: "Self-evolving Knowledge",
-    id: "XlVRjq3zhp",
-    description: "Hero eyebrow for the self-evolving knowledge product page",
+  guidelinesHeroEyebrow: {
+    defaultMessage: "Guidelines",
+    id: "es92Uya8hG",
+    description: "Hero eyebrow for the Guidelines product page",
   },
-  selfEvolvingKnowledgeHeroHeadline: {
-    defaultMessage: "Stop repeating the same localisation feedback",
-    id: "GuBuwlp/SU",
-    description: "Hero headline for the self-evolving knowledge product page",
+  guidelinesHeroHeadline: {
+    defaultMessage: "Keep the docs you have. Put them to work.",
+    id: '60zsYx+OAc',
+    description: "Hero headline for the Guidelines product page",
   },
-  selfEvolvingKnowledgeHeroSubcopy: {
+  guidelinesHeroSubcopy: {
     defaultMessage:
-      "Stop explaining the same rules twice. Hyperlocalise turns every review into reusable context",
-    id: "WabecnK7ou",
-    description: "Hero subcopy for the self-evolving knowledge product page",
+      "Connect Google Drive, Notion, and SharePoint. Agents read the brand and compliance files your team already maintains and flag what does not match.",
+    id: 'CihbYTYKi/',
+    description: "Hero subcopy for the Guidelines product page",
   },
-  selfEvolvingKnowledgeDetailsHeadline: {
+  guidelinesDetailsHeadline: {
+    defaultMessage: "Leave the guidelines where they are. Let agents read them.",
+    id: 'nfMyedI5a6',
+    description: "Details section headline for the Guidelines product page",
+  },
+  guidelinesSummary: {
     defaultMessage:
-      "If the last review taught the team something, the next workflow should know it.",
-    id: "n2pk6Y4oGA",
-    description: "Details section headline for the self-evolving knowledge product page",
+      "Connect Google Drive, Notion, and SharePoint so agents check drafts against the files brand and legal already maintain.",
+    id: 'ZhqgSTt9NF',
+    description: "Details section summary for the Guidelines product page",
   },
-  selfEvolvingKnowledgeSummary: {
+  guidelinesProof0Title: {
+    defaultMessage: "Keep them in Drive",
+    id: '8ubp0pkM3E',
+    description: "Proof point 1 title for the Guidelines product page",
+  },
+  guidelinesProof0Body: {
     defaultMessage:
-      "Every approved translation, reviewer correction, glossary choice, and market-specific decision becomes context that agents and humans can reuse on the next job.",
-    id: "xCstEdPlMf",
-    description: "Details section summary for the self-evolving knowledge product page",
+      "Brand-voice and claims PDFs stay in Google Drive. Agents cite the clause when they flag a draft.",
+    id: 'IaGMAEBgFR',
+    description: "Proof point 1 body for the Guidelines product page",
   },
-  selfEvolvingKnowledgeProof0Title: {
-    defaultMessage: "Keep the decision",
-    id: "OHKDUsYT8n",
-    description: "Proof point 1 title for the self-evolving knowledge product page",
+  guidelinesProof1Title: {
+    defaultMessage: "Keep notes in Notion",
+    id: 'E+gsjwOkn+',
+    description: "Proof point 2 title for the Guidelines product page",
   },
-  selfEvolvingKnowledgeProof0Body: {
+  guidelinesProof1Body: {
+    defaultMessage: "Market dos and don'ts stay on the pages your GTM team already writes.",
+    id: 'iu8wk5djA0',
+    description: "Proof point 2 body for the Guidelines product page",
+  },
+  guidelinesProof2Title: {
+    defaultMessage: "Keep policy in SharePoint",
+    id: '9Hmj8F68fv',
+    description: "Proof point 3 title for the Guidelines product page",
+  },
+  guidelinesProof2Body: {
+    defaultMessage: "Disclosures and approved wording stay in the library legal already owns.",
+    id: 'WATviG34Qf',
+    description: "Proof point 3 body for the Guidelines product page",
+  },
+  guidelinesCtaHeadline: {
+    defaultMessage: "Leave the guidelines where they are. Let agents read them.",
+    id: 'ggY8ufdyFe',
+    description: "Bottom CTA headline for the Guidelines product page",
+  },
+  guidelinesCtaDescription: {
     defaultMessage:
-      "Corrections, terminology choices, and product context stop disappearing into old comments.",
-    id: "SmMQDr7bGf",
-    description: "Proof point 1 body for the self-evolving knowledge product page",
-  },
-  selfEvolvingKnowledgeProof1Title: {
-    defaultMessage: "Reuse the nuance",
-    id: "4tk5H2G6vH",
-    description: "Proof point 2 title for the self-evolving knowledge product page",
-  },
-  selfEvolvingKnowledgeProof1Body: {
-    defaultMessage:
-      "Future suggestions can start from what the team already approved instead of asking again.",
-    id: "bgORmzhoWV",
-    description: "Proof point 2 body for the self-evolving knowledge product page",
-  },
-  selfEvolvingKnowledgeProof2Title: {
-    defaultMessage: "Reduce review churn",
-    id: "6g9RHsjL+m",
-    description: "Proof point 3 title for the self-evolving knowledge product page",
-  },
-  selfEvolvingKnowledgeProof2Body: {
-    defaultMessage:
-      "Market rules, voice preferences, and repeated mistakes stay visible across workflows.",
-    id: "VWQFJ0pM9H",
-    description: "Proof point 3 body for the self-evolving knowledge product page",
-  },
-  selfEvolvingKnowledgeCtaHeadline: {
-    defaultMessage: "Make every review improve the next one.",
-    id: "QTY8pCBi2f",
-    description: "Bottom CTA headline for the self-evolving knowledge product page",
-  },
-  selfEvolvingKnowledgeCtaDescription: {
-    defaultMessage:
-      "Capture the context and corrections your team already creates, then make them available when the next launch starts.",
-    id: "19Yj5RY029",
-    description: "Bottom CTA description for the self-evolving knowledge product page",
+      "Connect Drive, Notion, or SharePoint and check the next draft against the real file.",
+    id: 'b4qmyBy/VI',
+    description: "Bottom CTA description for the Guidelines product page",
   },
 });
 

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
@@ -404,8 +404,8 @@ export const productPageMessages = defineMessages({
   },
   guidelinesMetadataDescription: {
     defaultMessage:
-      "Connect Google Drive, Notion, and SharePoint. Agents check drafts against the brand and compliance files your team already maintains.",
-    id: "2HF+fAMIDb",
+      "Connect Google Drive, Notion, and SharePoint, or type guidelines in. Agents check drafts against the brand and compliance files your team already maintains.",
+    id: "wwKiGsumAM",
     description: "Meta description for the Guidelines product page",
   },
   guidelinesHeroEyebrow: {
@@ -420,8 +420,8 @@ export const productPageMessages = defineMessages({
   },
   guidelinesHeroSubcopy: {
     defaultMessage:
-      "Connect Google Drive, Notion, and SharePoint. Agents read the brand and compliance files your team already maintains and flag what does not match.",
-    id: "0aO5cDtCkQ",
+      "Connect Google Drive, Notion, and SharePoint, or type guidelines in. Agents read them and flag what does not match.",
+    id: "lNHTcG3rKm",
     description: "Hero subcopy for the Guidelines product page",
   },
   guidelinesDetailsHeadline: {
@@ -431,8 +431,8 @@ export const productPageMessages = defineMessages({
   },
   guidelinesSummary: {
     defaultMessage:
-      "Connect Google Drive, Notion, and SharePoint so agents check drafts against the files brand and legal already maintain.",
-    id: "ZhqgSTt9NF",
+      "Connect Google Drive, Notion, and SharePoint, or type guidelines in, so agents check drafts against the files brand and legal already maintain.",
+    id: "Zz6wbG5K6M",
     description: "Details section summary for the Guidelines product page",
   },
   guidelinesProof0Title: {
@@ -473,8 +473,8 @@ export const productPageMessages = defineMessages({
   },
   guidelinesCtaDescription: {
     defaultMessage:
-      "Connect Drive, Notion, or SharePoint and check the next draft against the real file.",
-    id: "b4qmyBy/VI",
+      "Connect Drive, Notion, or SharePoint, or type guidelines in, and check the next draft against them.",
+    id: "cqdHse07GI",
     description: "Bottom CTA description for the Guidelines product page",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.ts
@@ -14,10 +14,7 @@ import type { ProductMessageKey } from "./product-page-content.messages";
 
 export type { ProductMessageKey } from "./product-page-content.messages";
 
-export type ProductPageSlug =
-  | "agents-automation"
-  | "multilingual-content-studio"
-  | "self-evolving-knowledge";
+export type ProductPageSlug = "agents-automation" | "multilingual-content-studio" | "guidelines";
 
 export type ProductVisualKind = "automation" | "cat" | "knowledge";
 
@@ -93,7 +90,7 @@ export const productPages: ProductPageContent[] = [
     },
     related: [
       { labelKey: "productNavContentStudio", href: "/product/multilingual-content-studio" },
-      { labelKey: "productNavSelfEvolvingKnowledge", href: "/product/self-evolving-knowledge" },
+      { labelKey: "productNavGuidelines", href: "/product/guidelines" },
     ],
   },
   {
@@ -136,46 +133,48 @@ export const productPages: ProductPageContent[] = [
     },
     related: [
       { labelKey: "productNavAgentsAutomation", href: "/product/agents-automation" },
-      { labelKey: "productNavSelfEvolvingKnowledge", href: "/product/self-evolving-knowledge" },
+      { labelKey: "productNavGuidelines", href: "/product/guidelines" },
     ],
   },
   {
-    slug: "self-evolving-knowledge",
+    slug: "guidelines",
     metadata: {
-      titleKey: "selfEvolvingKnowledgeMetadataTitle",
-      descriptionKey: "selfEvolvingKnowledgeMetadataDescription",
+      titleKey: "guidelinesMetadataTitle",
+      descriptionKey: "guidelinesMetadataDescription",
       keywords: [
-        "localisation knowledge",
-        "translation memory",
-        "localisation glossary",
-        "AI translation context",
+        "brand guidelines",
+        "Google Drive",
+        "Notion",
+        "SharePoint",
+        "compliance PDF",
+        "market compliance",
       ],
     },
     visualKind: "knowledge",
     hero: {
-      eyebrowKey: "selfEvolvingKnowledgeHeroEyebrow",
-      headlineKey: "selfEvolvingKnowledgeHeroHeadline",
-      subcopyKey: "selfEvolvingKnowledgeHeroSubcopy",
+      eyebrowKey: "guidelinesHeroEyebrow",
+      headlineKey: "guidelinesHeroHeadline",
+      subcopyKey: "guidelinesHeroSubcopy",
     },
-    detailsHeadlineKey: "selfEvolvingKnowledgeDetailsHeadline",
-    summaryKey: "selfEvolvingKnowledgeSummary",
+    detailsHeadlineKey: "guidelinesDetailsHeadline",
+    summaryKey: "guidelinesSummary",
     proofPoints: [
       {
-        titleKey: "selfEvolvingKnowledgeProof0Title",
-        bodyKey: "selfEvolvingKnowledgeProof0Body",
+        titleKey: "guidelinesProof0Title",
+        bodyKey: "guidelinesProof0Body",
       },
       {
-        titleKey: "selfEvolvingKnowledgeProof1Title",
-        bodyKey: "selfEvolvingKnowledgeProof1Body",
+        titleKey: "guidelinesProof1Title",
+        bodyKey: "guidelinesProof1Body",
       },
       {
-        titleKey: "selfEvolvingKnowledgeProof2Title",
-        bodyKey: "selfEvolvingKnowledgeProof2Body",
+        titleKey: "guidelinesProof2Title",
+        bodyKey: "guidelinesProof2Body",
       },
     ],
     cta: {
-      headlineKey: "selfEvolvingKnowledgeCtaHeadline",
-      descriptionKey: "selfEvolvingKnowledgeCtaDescription",
+      headlineKey: "guidelinesCtaHeadline",
+      descriptionKey: "guidelinesCtaDescription",
     },
     related: [
       { labelKey: "productNavAgentsAutomation", href: "/product/agents-automation" },


### PR DESCRIPTION
## What changed

Replaces the self-evolving knowledge product page with **Guidelines**, focused on Google Drive, Notion, and SharePoint as the source of truth.

- New `/product/guidelines` page with globe hero, connected-file mock, interactive compliance chat against a fake PDF, and a daily Automations audit section
- Redirects `/product/self-evolving-knowledge` to `/product/guidelines`
- Updates homepage, Content Studio links, `llms.txt`, and blog post URLs

## How to test

- Open `/en/product/guidelines` and confirm the hero, Drive/Notion/SharePoint tabs, PDF flag chat, and daily audit section
- Confirm `/en/product/self-evolving-knowledge` redirects to `/en/product/guidelines`
- Click a compliance flag in the hero mock and confirm the matching PDF clause highlights
- `vp test src/components/marketing/product/guidelines-board-mock.test.tsx src/app/llms.txt/route.test.ts`

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)