### PR TITLE
feat(mcp): add update_translation tool to the hosted MCP server

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-update-translation.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-update-translation.ts
@@ -28,6 +28,12 @@ export type McpUpdateTranslationDetail = {
   updatedAt: string;
 };
 
+type McpTranslationValidationIssue =
+  | ContentEditorMessageParityIssue
+  | {
+      kind: "empty-target";
+    };
+
 type McpUpdateTranslationResult =
   | {
       ok: true;
@@ -40,7 +46,7 @@ type McpUpdateTranslationResult =
   | {
       ok: false;
       error: "invalid_translation";
-      issues: ContentEditorMessageParityIssue[];
+      issues: McpTranslationValidationIssue[];
     };
 
 export async function updateMcpTranslation(input: {
@@ -77,6 +83,14 @@ export async function updateMcpTranslation(input: {
     return {
       ok: false,
       error: "translation_locked",
+    };
+  }
+
+  if (input.approve && !input.targetText.trim()) {
+    return {
+      ok: false,
+      error: "invalid_translation",
+      issues: [{ kind: "empty-target" }],
     };
   }
 

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-update-translation.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-update-translation.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { isCatSegmentLocked } from "@/lib/projects/content-editor/content-editor-segment-lock-service";
+import {
+  analyzeCatMessageFormat,
+  compareCatMessageFormats,
+  type ContentEditorMessageParityIssue,
+} from "@/components/content-editor/message-format/content-editor-message-format";
+import {
+  getNativeProjectContentEditorSegmentDetail,
+  saveNativeProjectContentEditorTranslation,
+} from "@/lib/projects/content-editor/native-content-editor-service";
+
+export type McpUpdateTranslationDetail = {
+  id: string;
+  targetText: string;
+  status: "draft" | "approved";
+  updatedAt: string;
+};
+
+type McpUpdateTranslationResult =
+  | {
+      ok: true;
+      value: McpUpdateTranslationDetail;
+    }
+  | {
+      ok: false;
+      error: "translation_not_found" | "translation_locked";
+    }
+  | {
+      ok: false;
+      error: "invalid_translation";
+      issues: ContentEditorMessageParityIssue[];
+    };
+
+export async function updateMcpTranslation(input: {
+  organizationId: string;
+  projectId: string;
+  translationKeyId: string;
+  targetLocale: string;
+  targetText: string;
+  approve?: boolean;
+  actorUserId: string;
+}): Promise<McpUpdateTranslationResult> {
+  const detail = await getNativeProjectContentEditorSegmentDetail({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    translationKeyId: input.translationKeyId,
+    targetLocale: input.targetLocale,
+  });
+
+  if (!detail) {
+    return {
+      ok: false,
+      error: "translation_not_found",
+    };
+  }
+
+  const locked = await isCatSegmentLocked({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    targetLocale: input.targetLocale,
+    externalStringId: input.translationKeyId,
+  });
+
+  if (locked) {
+    return {
+      ok: false,
+      error: "translation_locked",
+    };
+  }
+
+  const formatIssues = compareCatMessageFormats(
+    analyzeCatMessageFormat(detail.segment.sourceText),
+    analyzeCatMessageFormat(input.targetText),
+  ).filter((issue) => issue.kind !== "extra-token");
+
+  if (formatIssues.length > 0) {
+    return {
+      ok: false,
+      error: "invalid_translation",
+      issues: formatIssues,
+    };
+  }
+
+  const status = input.approve ? "approved" : "draft";
+  const saved = await saveNativeProjectContentEditorTranslation({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: detail.segment.sourcePath,
+    translationKeyId: input.translationKeyId,
+    targetLocale: input.targetLocale,
+    text: input.targetText,
+    approve: input.approve ?? false,
+    actorUserId: input.actorUserId,
+    provenance: "agent",
+  });
+
+  if (!saved) {
+    return {
+      ok: false,
+      error: "translation_not_found",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      id: input.translationKeyId,
+      targetText: saved.text,
+      status,
+      updatedAt: saved.updatedAt.toISOString(),
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -15,6 +15,7 @@ import "dotenv/config";
 import { createHash } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
+import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { OAuthProtectedResourceMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -86,6 +87,7 @@ vi.mock("@/api/auth/mcp-client-metadata", async (importOriginal) => {
 });
 
 const app = createMcpTestApp();
+const mcpClient = testClient(app);
 const apiApp = createApp();
 const fixture = createProjectTestFixture();
 const originalMcpAuthEnabled = env.MCP_AUTH_ENABLED;
@@ -5078,28 +5080,32 @@ describe("mcpRoutes", () => {
     ];
 
     for (const testCase of cases) {
-      const response = await app.request("http://localhost/mcp", {
-        method: "POST",
-        headers: {
-          ...headers,
-          accept: "application/json, text/event-stream",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: 1,
-          method: "tools/call",
-          params: {
-            name: "update_translation",
-            arguments: {
-              projectId: stored.project.id,
-              translationKeyId: translationKey.id,
-              targetLocale: "fr-FR",
-              targetText: testCase.targetText,
-            },
+      const response = await mcpClient.mcp.$post(
+        {},
+        {
+          headers: {
+            ...headers,
+            accept: "application/json, text/event-stream",
+            "content-type": "application/json",
           },
-        }),
-      });
+          init: {
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/call",
+              params: {
+                name: "update_translation",
+                arguments: {
+                  projectId: stored.project.id,
+                  translationKeyId: translationKey.id,
+                  targetLocale: "fr-FR",
+                  targetText: testCase.targetText,
+                },
+              },
+            }),
+          },
+        },
+      );
 
       expect(response.status).toBe(200);
 
@@ -5688,20 +5694,24 @@ describe("mcpRoutes", () => {
   it("advertises update_translation with bounded inputs", async () => {
     const headers = await authenticatedMcpHeaders();
 
-    const response = await app.request("http://localhost/mcp", {
-      method: "POST",
-      headers: {
-        ...headers,
-        accept: "application/json, text/event-stream",
-        "content-type": "application/json",
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list",
+            params: {},
+          }),
+        },
       },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/list",
-        params: {},
-      }),
-    });
+    );
 
     expect(response.status).toBe(200);
 

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -6360,4 +6360,212 @@ describe("mcpRoutes", () => {
       updatedAt: expect.any(Date),
     });
   });
+
+  it("returns forbidden when a translator attempts to approve a translation", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const translatorIdentity = fixture.createWorkosIdentityForOrganization(
+      stored.identity.organization,
+      "translator",
+    );
+    await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath: "locales/approved.json",
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        {
+          key: "approved.title",
+          text: "Approved title",
+          context: null,
+        },
+      ],
+    });
+
+    const [translationKey] = await db
+      .select({ id: schema.projectTranslationKeys.id })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    const headers = await authenticatedMcpHeaders(translatorIdentity);
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: stored.project.id,
+            translationKeyId: translationKey.id,
+            targetLocale: "fr-FR",
+            targetText: "Titre approuve",
+            approve: true,
+          },
+        },
+      }),
+    });
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "forbidden",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.projectTranslations.id })
+      .from(schema.projectTranslations)
+      .where(
+        and(
+          eq(schema.projectTranslations.organizationId, auth.organization.localOrganizationId),
+          eq(schema.projectTranslations.projectId, stored.project.id),
+          eq(schema.projectTranslations.translationKeyId, translationKey.id),
+          eq(schema.projectTranslations.targetLocale, "fr-FR"),
+        ),
+      )
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("rejects blank text when approving a translation", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    await db
+      .update(schema.projects)
+      .set({
+        sourceLocale: "en-AU",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath: "locales/blank-approval.json",
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        {
+          key: "blank.title",
+          text: "Title",
+          context: null,
+        },
+      ],
+    });
+
+    const [translationKey] = await db
+      .select({
+        id: schema.projectTranslationKeys.id,
+      })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: stored.project.id,
+            translationKeyId: translationKey.id,
+            targetLocale: "fr-FR",
+            targetText: "   ",
+            approve: true,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "invalid_translation",
+      issues: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "empty-target",
+        }),
+      ]),
+    });
+
+    const [saved] = await db
+      .select({
+        id: schema.projectTranslations.id,
+      })
+      .from(schema.projectTranslations)
+      .where(
+        and(
+          eq(schema.projectTranslations.organizationId, auth.organization.localOrganizationId),
+          eq(schema.projectTranslations.projectId, stored.project.id),
+          eq(schema.projectTranslations.translationKeyId, translationKey.id),
+          eq(schema.projectTranslations.targetLocale, "fr-FR"),
+        ),
+      )
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -51,6 +51,9 @@ import {
   upsertProjectTranslationKeysFromEntries,
 } from "@/lib/projects/translations/project-translation-service";
 import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/test-project-identifier";
+import { setCatSegmentLocks } from "@/lib/projects/content-editor/content-editor-segment-lock-service";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
@@ -1285,7 +1288,6 @@ describe("mcpRoutes", () => {
         params: {},
       }),
     });
-
     expect(response.status).toBe(200);
 
     const body = (await response.json()) as {
@@ -1514,7 +1516,6 @@ describe("mcpRoutes", () => {
         },
       }),
     });
-
     expect(response.status).toBe(200);
 
     const body = (await response.json()) as {
@@ -5019,6 +5020,112 @@ describe("mcpRoutes", () => {
     });
   });
 
+  it("returns invalid_translation for placeholder and ICU failures without saving", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    await db
+      .update(schema.projects)
+      .set({
+        sourceLocale: "en-AU",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath: "locales/validation.json",
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        {
+          key: "inbox.summary",
+          text: "Hello {name}, you have {count, plural, one {# message} other {# messages}}.",
+          context: null,
+        },
+      ],
+    });
+
+    const [translationKey] = await db
+      .select({ id: schema.projectTranslationKeys.id })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    const cases = [
+      {
+        targetText: "Vous avez {count, plural, one {# message} other {# messages}}.",
+        expectedIssue: { kind: "missing-token", tokens: ["{name}"] },
+      },
+      {
+        targetText: "Bonjour {name}, vous avez {count, plural, one {# message}",
+        expectedIssue: { kind: "parse-error", parseTarget: "target" },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const response = await app.request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "update_translation",
+            arguments: {
+              projectId: stored.project.id,
+              translationKeyId: translationKey.id,
+              targetLocale: "fr-FR",
+              targetText: testCase.targetText,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        result?: {
+          isError?: boolean;
+          content?: Array<{ text?: string }>;
+        };
+      };
+
+      expect(body.result?.isError).toBe(true);
+      expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+        error: "invalid_translation",
+        issues: expect.arrayContaining([expect.objectContaining(testCase.expectedIssue)]),
+      });
+    }
+
+    const [saved] = await db
+      .select({ id: schema.projectTranslations.id })
+      .from(schema.projectTranslations)
+      .where(eq(schema.projectTranslations.translationKeyId, translationKey.id))
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
   it("returns translation_not_found for a translation key from another project", async () => {
     const stored = await fixture.createStoredProjectFixture();
     const headers = await authenticatedMcpHeaders(stored.identity);
@@ -5575,6 +5682,682 @@ describe("mcpRoutes", () => {
           identifier: linkedIssue.identifier,
         },
       ],
+    });
+  });
+
+  it("advertises update_translation with bounded inputs", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "update_translation");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("translation");
+    expect(tool?.inputSchema?.required).toEqual(
+      expect.arrayContaining(["projectId", "translationKeyId", "targetLocale", "targetText"]),
+    );
+    expect(tool?.inputSchema?.required).not.toContain("approve");
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      translationKeyId: {
+        type: "string",
+        format: "uuid",
+      },
+      targetLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 32,
+      },
+      targetText: {
+        type: "string",
+        maxLength: 100_000,
+      },
+      approve: {
+        type: "boolean",
+      },
+    });
+  });
+
+  it("saves an updated translation as a draft", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    await db
+      .update(schema.projects)
+      .set({
+        sourceLocale: "en-AU",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath: "locales/home.json",
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        {
+          key: "home.title",
+          text: "Welcome",
+          context: null,
+        },
+      ],
+    });
+
+    const [translationKey] = await db
+      .select({ id: schema.projectTranslationKeys.id })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: stored.project.id,
+            translationKeyId: translationKey.id,
+            targetLocale: "fr-FR",
+            targetText: "Bienvenue",
+          },
+        },
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(trackSpy).toHaveBeenCalledWith(
+      PRODUCT_USAGE_ANALYTICS_EVENTS.contentEditorSegmentDraftSaved,
+      {
+        source: "native",
+        status: "draft",
+      },
+    );
+    trackSpy.mockRestore();
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+    const output = JSON.parse(body.result?.content?.[0]?.text ?? "{}") as {
+      updatedAt?: string;
+    };
+
+    expect(output).toMatchObject({
+      id: translationKey.id,
+      targetText: "Bienvenue",
+      status: "draft",
+      updatedAt: expect.any(String),
+    });
+    expect(Number.isNaN(Date.parse(output.updatedAt ?? ""))).toBe(false);
+
+    const [saved] = await db
+      .select({
+        text: schema.projectTranslations.text,
+        status: schema.projectTranslations.status,
+        provenance: schema.projectTranslations.provenance,
+        reviewedAt: schema.projectTranslations.reviewedAt,
+        reviewedByUserId: schema.projectTranslations.reviewedByUserId,
+        updatedAt: schema.projectTranslations.updatedAt,
+      })
+      .from(schema.projectTranslations)
+      .where(
+        and(
+          eq(schema.projectTranslations.organizationId, auth.organization.localOrganizationId),
+          eq(schema.projectTranslations.projectId, stored.project.id),
+          eq(schema.projectTranslations.translationKeyId, translationKey.id),
+          eq(schema.projectTranslations.targetLocale, "fr-FR"),
+        ),
+      )
+      .limit(1);
+
+    expect(saved).toMatchObject({
+      text: "Bienvenue",
+      status: "draft",
+      provenance: "agent",
+      reviewedAt: null,
+      reviewedByUserId: null,
+      updatedAt: expect.any(Date),
+    });
+  });
+
+  it("returns forbidden when a read-only member updates a translation", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const memberIdentity = fixture.createWorkosIdentityForOrganization(
+      stored.identity.organization,
+      "member",
+    );
+    const headers = await authenticatedMcpHeaders(memberIdentity);
+    const translationKeyId = crypto.randomUUID();
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: stored.project.id,
+            translationKeyId,
+            targetLocale: "fr-FR",
+            targetText: "Bienvenue",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "forbidden",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.projectTranslations.id })
+      .from(schema.projectTranslations)
+      .where(eq(schema.projectTranslations.translationKeyId, translationKeyId))
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("returns translation_locked without updating a locked translation", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath: "locales/locked.json",
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        {
+          key: "locked.title",
+          text: "Locked title",
+          context: null,
+        },
+      ],
+    });
+
+    const [translationKey] = await db
+      .select({ id: schema.projectTranslationKeys.id })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    await setCatSegmentLocks({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      targetLocale: "fr-FR",
+      externalStringIds: [translationKey.id],
+      isLocked: true,
+      actorUserId: auth.user.localUserId,
+    });
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: stored.project.id,
+            translationKeyId: translationKey.id,
+            targetLocale: "fr-FR",
+            targetText: "Titre verrouille",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "translation_locked",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.projectTranslations.id })
+      .from(schema.projectTranslations)
+      .where(
+        and(
+          eq(schema.projectTranslations.translationKeyId, translationKey.id),
+          eq(schema.projectTranslations.targetLocale, "fr-FR"),
+        ),
+      )
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("returns translation_not_found for a missing translation key", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const translationKeyId = crypto.randomUUID();
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: stored.project.id,
+            translationKeyId,
+            targetLocale: "fr-FR",
+            targetText: "Missing translation",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "translation_not_found",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.projectTranslations.id })
+      .from(schema.projectTranslations)
+      .where(eq(schema.projectTranslations.translationKeyId, translationKeyId))
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("returns translation_not_found for a translation key from another project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [secondProject] = await db
+      .insert(schema.projects)
+      .values({
+        id: `project_${crypto.randomUUID()}`,
+        identifier: uniqueTestProjectIdentifier(),
+        organizationId: auth.organization.localOrganizationId,
+        teamId: stored.project.teamId,
+        createdByUserId: auth.user.localUserId,
+        name: "Second project",
+        description: "",
+        translationContext: "",
+        sourceLocale: "en-AU",
+        targetLocales: ["fr-FR"],
+      })
+      .returning({ id: schema.projects.id });
+
+    if (!secondProject) {
+      throw new Error("expected second project fixture");
+    }
+
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath: "locales/isolation.json",
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        {
+          key: "isolation.title",
+          text: "Project one title",
+          context: null,
+        },
+      ],
+    });
+
+    const [translationKey] = await db
+      .select({ id: schema.projectTranslationKeys.id })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: secondProject.id,
+            translationKeyId: translationKey.id,
+            targetLocale: "fr-FR",
+            targetText: "Must not be saved",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "translation_not_found",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.projectTranslations.id })
+      .from(schema.projectTranslations)
+      .where(eq(schema.projectTranslations.translationKeyId, translationKey.id))
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("returns provider_cat_unsupported for a provider-only translation update", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const translationKeyId = crypto.randomUUID();
+
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: "ext:crowdin:42",
+            translationKeyId,
+            targetLocale: "fr-FR",
+            targetText: "Bienvenue",
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "provider_cat_unsupported",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.projectTranslations.id })
+      .from(schema.projectTranslations)
+      .where(eq(schema.projectTranslations.translationKeyId, translationKeyId))
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("saves and approves a translation as the MCP-authenticated user", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath: "locales/approved.json",
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        {
+          key: "approved.title",
+          text: "Approved title",
+          context: null,
+        },
+      ],
+    });
+
+    const [translationKey] = await db
+      .select({ id: schema.projectTranslationKeys.id })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+
+    if (!translationKey) {
+      throw new Error("expected translation key fixture");
+    }
+
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+    const response = await app.request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "update_translation",
+          arguments: {
+            projectId: stored.project.id,
+            translationKeyId: translationKey.id,
+            targetLocale: "fr-FR",
+            targetText: "Titre approuve",
+            approve: true,
+          },
+        },
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(trackSpy).toHaveBeenCalledWith(
+      PRODUCT_USAGE_ANALYTICS_EVENTS.contentEditorSegmentApproved,
+      {
+        source: "native",
+        status: "approved",
+      },
+    );
+    trackSpy.mockRestore();
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+    const output = JSON.parse(body.result?.content?.[0]?.text ?? "{}") as {
+      updatedAt?: string;
+    };
+
+    expect(output).toMatchObject({
+      id: translationKey.id,
+      targetText: "Titre approuve",
+      status: "approved",
+      updatedAt: expect.any(String),
+    });
+    expect(Number.isNaN(Date.parse(output.updatedAt ?? ""))).toBe(false);
+
+    const [saved] = await db
+      .select({
+        text: schema.projectTranslations.text,
+        status: schema.projectTranslations.status,
+        provenance: schema.projectTranslations.provenance,
+        reviewedAt: schema.projectTranslations.reviewedAt,
+        reviewedByUserId: schema.projectTranslations.reviewedByUserId,
+        updatedAt: schema.projectTranslations.updatedAt,
+      })
+      .from(schema.projectTranslations)
+      .where(
+        and(
+          eq(schema.projectTranslations.organizationId, auth.organization.localOrganizationId),
+          eq(schema.projectTranslations.projectId, stored.project.id),
+          eq(schema.projectTranslations.translationKeyId, translationKey.id),
+          eq(schema.projectTranslations.targetLocale, "fr-FR"),
+        ),
+      )
+      .limit(1);
+
+    expect(saved).toMatchObject({
+      text: "Titre approuve",
+      status: "approved",
+      provenance: "agent",
+      reviewedAt: expect.any(Date),
+      reviewedByUserId: auth.user.localUserId,
+      updatedAt: expect.any(Date),
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -81,6 +81,7 @@ import {
 import { isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
 import {
   projectFileCatQueueSortSchema,
+  projectFileCatTranslationBodySchema,
   type ProjectFileRecord,
 } from "@/api/routes/project/project.schema";
 import {
@@ -107,6 +108,9 @@ import {
 import { loadMcpTranslation } from "@/api/routes/mcp/mcp-get-translation";
 import { resolveProjectResourceTarget } from "@/api/routes/project/project.shared";
 import type { ToolContext } from "@/lib/tools/types";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
+import { updateMcpTranslation } from "./mcp-update-translation";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -701,6 +705,24 @@ const mcpQueryGlossaryInputSchema = z.object({
     .describe("Maximum number of ranked hits to return."),
 });
 
+const catTranslationShape = projectFileCatTranslationBodySchema.shape;
+
+const mcpUpdateTranslationInputSchema = z.object({
+  projectId: z.string().trim().min(1).max(128),
+
+  translationKeyId: z.uuid(),
+
+  targetLocale: catTranslationShape.targetLocale.describe(
+    "Target locale whose translation should be updated.",
+  ),
+
+  targetText: catTranslationShape.text.describe("New translated text to save."),
+
+  approve: catTranslationShape.approve.describe(
+    "Approve the translation after saving it. Defaults to false.",
+  ),
+});
+
 const mcpGetTranslationInputSchema = z.object({
   projectId: projectIdSchema.describe("ID of the accessible Hyperlocalise project."),
 
@@ -771,12 +793,12 @@ function mcpCreateIssueFingerprint(
   return createHash("sha256").update(JSON.stringify(canonicalPayload)).digest("hex");
 }
 
-function mcpToolError(code: string, message: string) {
+function mcpToolError(code: string, message: string, details?: Record<string, unknown>) {
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify({ error: code, message }),
+        text: JSON.stringify({ error: code, message, ...details }),
       },
     ],
     isError: true,
@@ -1797,6 +1819,88 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
           {
             type: "text",
             text: JSON.stringify(translation),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "update_translation",
+    {
+      description:
+        "Save and optionally approve a target translation in an accessible Hyperlocalise project.",
+      inputSchema: mcpUpdateTranslationInputSchema,
+    },
+    async ({ projectId, translationKeyId, targetLocale, targetText, approve }) => {
+      if (!isWriteBackTranslationAllowed(apiAuth.membership.role)) {
+        return mcpToolError("forbidden", "Insufficient permissions to update translations");
+      }
+
+      const target = await resolveProjectResourceTarget(apiAuth, projectId);
+
+      if (target.kind !== "native") {
+        return mcpToolError(
+          "provider_cat_unsupported",
+          "Provider-only CAT translations are not supported",
+        );
+      }
+
+      const [project] = await db
+        .select({
+          id: schema.projects.id,
+          targetLocales: schema.projects.targetLocales,
+        })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, target.projectId))
+        .limit(1);
+
+      if (!project || !project.targetLocales.includes(targetLocale)) {
+        return mcpToolError("translation_not_found", "Translation not found");
+      }
+
+      const result = await updateMcpTranslation({
+        organizationId: apiAuth.organization.localOrganizationId,
+        projectId: project.id,
+        translationKeyId,
+        targetLocale,
+        targetText,
+        approve,
+        actorUserId: apiAuth.user.localUserId,
+      });
+
+      if (!result.ok) {
+        switch (result.error) {
+          case "translation_not_found":
+            return mcpToolError("translation_not_found", "Translation not found");
+
+          case "translation_locked":
+            return mcpToolError("translation_locked", "This translation is locked");
+
+          case "invalid_translation":
+            return mcpToolError(
+              "invalid_translation",
+              "Translation has invalid placeholders or ICU syntax",
+              { issues: result.issues },
+            );
+        }
+      }
+
+      serverAnalytics.track(
+        approve
+          ? PRODUCT_USAGE_ANALYTICS_EVENTS.contentEditorSegmentApproved
+          : PRODUCT_USAGE_ANALYTICS_EVENTS.contentEditorSegmentDraftSaved,
+        {
+          source: "native",
+          status: result.value.status,
+        },
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result.value),
           },
         ],
       };

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -78,7 +78,10 @@ import {
   IssueSheetService,
   type IssueSheetIssue,
 } from "@/lib/projects/issue-sheet/issue-sheet-service";
-import { isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
+import {
+  isWriteBackApproveAllowed,
+  isWriteBackTranslationAllowed,
+} from "@/api/auth/capability-guards";
 import {
   projectFileCatQueueSortSchema,
   projectFileCatTranslationBodySchema,
@@ -1835,6 +1838,10 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
     async ({ projectId, translationKeyId, targetLocale, targetText, approve }) => {
       if (!isWriteBackTranslationAllowed(apiAuth.membership.role)) {
         return mcpToolError("forbidden", "Insufficient permissions to update translations");
+      }
+
+      if (approve && !isWriteBackApproveAllowed(apiAuth.membership.role)) {
+        return mcpToolError("forbidden", "Insufficient permissions to approve translations");
       }
 
       const target = await resolveProjectResourceTarget(apiAuth, projectId);

--- a/apps/hyperlocalise-web/src/lib/projects/content-editor/native-content-editor-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/content-editor/native-content-editor-service.ts
@@ -730,7 +730,7 @@ export class NativeContentEditorService extends ProjectServiceBase {
     actorUserId?: string;
     provenance?: "manual" | "translation_job" | "import" | "agent";
     sourceJobId?: string;
-  }): Promise<ProjectFileContentEditorTranslation | null> {
+  }): Promise<(ProjectFileContentEditorTranslation & { updatedAt: Date }) | null> {
     const sourceFile = await this.translations.getRepositorySourceFileByPath({
       organizationId: input.organizationId,
       projectId: input.projectId,
@@ -823,6 +823,7 @@ export class NativeContentEditorService extends ProjectServiceBase {
         id: schema.projectTranslations.id,
         text: schema.projectTranslations.text,
         status: schema.projectTranslations.status,
+        updatedAt: schema.projectTranslations.updatedAt,
       });
 
     if (!saved) {
@@ -848,7 +849,11 @@ export class NativeContentEditorService extends ProjectServiceBase {
         provenance: (input.provenance ?? "manual") === "manual" ? "human" : "automated",
         step: input.approve ? "review" : "translation",
       });
-    return toCatTranslation(saved);
+
+    return {
+      ...toCatTranslation(saved),
+      updatedAt: saved.updatedAt,
+    };
   }
 
   async updateTranslationStatus(input: {

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -173,8 +173,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `translation_not_found`                        | Wrong or inaccessible project, translation key, target locale, or a hidden key                                         |
 | `translation_locked`                           | The requested translation segment is locked in the Content Editor                                                      |
 | `invalid_translation`                          | Target text has a blocking placeholder or ICU validation error                                                         |
-| `provider_cat_unsupported`                     | The requested operation targets a provider-only live CAT string without a native overlay                              |
-| `provider_cat_unsupported`                     | The requested translation exists only in a live TMS provider and has no supported native overlay                       |
+| `provider_cat_unsupported`                     | The requested operation targets a provider-only live CAT string without a supported native overlay                     |
 | Agent cannot reach local Cloud                 | Use `http://localhost:3000/mcp` and ensure the dev server is running                                                   |
 
 ## Next

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -51,6 +51,7 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | `list_files`           | List source files in a project (`projectId`, `limit` default 20 max 50, `offset`, optional `search`)                                                                    |
 | `list_translations`    | Paginated CAT queue of translation keys (`projectId`, optional `sourcePath`, `targetLocale`, `search`, `queueFilter`, `queueSort`, `limit` default 20 max 50, `offset`) |
 | `get_translation`      | Full CAT detail for one translation key (`projectId`, `translationKeyId`, `targetLocale`)                                                                               |
+| `update_translation`   | Save a target translation and optionally approve it (`projectId`, `translationKeyId`, `targetLocale`, `targetText`, optional `approve`)                                |
 | `get_project_status`   | Locale coverage counts by `projectId`, with optional `sourcePath`                                                                                                       |
 | `list_glossaries`      | List glossaries linked to accessible projects                                                                                                                           |
 | `get_glossary_entries` | Concept-linked terms for a `glossaryId` (`limit`, default 50, max 100)                                                                                                  |
@@ -70,7 +71,9 @@ Optional filters match the Content Editor queue:
 - `queueFilter` — `all`, `untranslated`, `needs_review`, `approved` (same as CAT `reviewed`), `has_issues`, plus the other Content Editor filters.
 - `queueSort` — `file_order` (default) or `untranslated_first`.
 
-Read-only roles may list. Writes stay on `update_translation` when that tool is wired. Missing or inaccessible projects, including cross-team and cross-organization reads, return `project_not_found`.
+`update_translation` uses the same text constraints, segment locks, permissions, and native save/approve path as the Content Editor. It saves drafts by default; pass `approve: true` to save and approve as the authenticated MCP user. Placeholder or ICU failures return `invalid_translation` with structured `issues` and do not save. Provider-only live CAT writes return `provider_cat_unsupported` unless a native overlay is available.
+
+Read-only roles may list. Translation writes require an admin or localization manager. Missing or inaccessible projects, including cross-team and cross-organization reads, return `project_not_found`.
 
 For TMS-backed projects the tool still returns native overlay keys (`coverageSource: "native_overlay"`). Live Crowdin, Phrase, Lokalise, or Smartling listing is out of scope. Use the provider CAT or CLI for live provider strings.
 
@@ -168,6 +171,9 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `project_not_found`                            | Wrong `projectId` or missing project access on `list_files`, `list_translations`, `get_project_status`, or `list_jobs` |
 | `glossary_not_found`                           | Wrong `glossaryId`, missing glossary access, or a provider glossary on `query_glossary`                                |
 | `translation_not_found`                        | Wrong or inaccessible project, translation key, target locale, or a hidden key                                         |
+| `translation_locked`                           | The requested translation segment is locked in the Content Editor                                                      |
+| `invalid_translation`                          | Target text has a blocking placeholder or ICU validation error                                                         |
+| `provider_cat_unsupported`                     | The requested operation targets a provider-only live CAT string without a native overlay                              |
 | `provider_cat_unsupported`                     | The requested translation exists only in a live TMS provider and has no supported native overlay                       |
 | Agent cannot reach local Cloud                 | Use `http://localhost:3000/mcp` and ensure the dev server is running                                                   |
 


### PR DESCRIPTION
## What changed

- Added the hosted MCP `update_translation` tool for saving and optionally approving native CAT translations.
- Reused existing Content Editor validation, segment locking, permission, persistence, approval, analytics, and actor-attribution behavior.
- Added stable errors for forbidden writes, missing translations, locked segments, unsupported provider CAT writes, and invalid placeholder/ICU content.
- Returned the updated translation ID, target text, status, and timestamp.
- Added MCP route coverage for discovery, draft saves, approvals, permissions, locks, validation, provider-backed projects, and project isolation.
- Updated the MCP platform documentation.

## How to test

- `vp test src/api/routes/mcp/mcp.route.test.ts`
- `vp check`
- `vp run build`

Results:

- 117 MCP route tests passed.
- Build passed.
- `vp check` reported no errors; existing unrelated warnings remain.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
