### PR TITLE
feat(mcp): add upload_sources tool to the hosted MCP server

### DIFF
--- a/.github/workflows/web-evals.yml
+++ b/.github/workflows/web-evals.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
         with:
+          working-directory: apps/hyperlocalise-web
           cache: true
+          run-install: false
 
       - name: Install hyperlocalise-web dependencies
         run: vp install --frozen-lockfile

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
         with:
+          working-directory: apps/hyperlocalise-web
           cache: true
+          run-install: false
 
       - name: Install hyperlocalise-web dependencies
         run: vp install --frozen-lockfile
@@ -105,7 +107,9 @@ jobs:
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
         with:
+          working-directory: apps/hyperlocalise-web
           cache: true
+          run-install: false
 
       - name: Install hyperlocalise-web dependencies
         run: vp install --frozen-lockfile

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -55,6 +55,7 @@ import { uniqueTestProjectIdentifier } from "@/lib/projects/issue-identifier/tes
 import { setCatSegmentLocks } from "@/lib/projects/content-editor/content-editor-segment-lock-service";
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
+import { maxPublicUploadBytes } from "@/api/routes/public-files/public-files.schema";
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
@@ -6572,6 +6573,554 @@ describe("mcpRoutes", () => {
           eq(schema.projectTranslations.projectId, stored.project.id),
           eq(schema.projectTranslations.translationKeyId, translationKey.id),
           eq(schema.projectTranslations.targetLocale, "fr-FR"),
+        ),
+      )
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("advertises upload_sources with bounded file inputs", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list",
+            params: {},
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "upload_sources");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("source file");
+
+    expect(tool?.inputSchema?.required).toEqual(
+      expect.arrayContaining(["projectId", "sourcePath"]),
+    );
+
+    // content/contentBase64 cannot both be globally required because
+    // the tool accepts exactly one of them.
+    expect(tool?.inputSchema?.required).not.toContain("content");
+    expect(tool?.inputSchema?.required).not.toContain("contentBase64");
+
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+      },
+      sourcePath: {
+        type: "string",
+        minLength: 1,
+        maxLength: 2048,
+      },
+      content: {
+        type: "string",
+      },
+      contentBase64: {
+        type: "string",
+      },
+      sourceLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 32,
+      },
+      format: {
+        type: "string",
+        minLength: 1,
+        maxLength: 64,
+      },
+      branch: {
+        type: "string",
+        minLength: 1,
+        maxLength: 256,
+      },
+      sourceHash: {
+        type: "string",
+        minLength: 1,
+        maxLength: 256,
+      },
+      commitSha: {
+        type: "string",
+        minLength: 1,
+        maxLength: 256,
+      },
+      workflowRunId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 256,
+      },
+    });
+  });
+
+  it.each([
+    {
+      label: "neither content field",
+      arguments: {},
+    },
+    {
+      label: "both content fields",
+      arguments: {
+        content: '{"hello":"Hello"}',
+        contentBase64: Buffer.from('{"hello":"Hello"}').toString("base64"),
+      },
+    },
+  ])("returns invalid_file_payload for $label", async ({ arguments: contentArguments }) => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "upload_sources",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath: "locales/en.json",
+                ...contentArguments,
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "invalid_file_payload",
+    });
+  });
+
+  it("uploads a UTF-8 source file to a native project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "upload_sources",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath: "locales/en.json",
+                content: JSON.stringify({
+                  greeting: "Hello",
+                }),
+                sourceLocale: "en-AU",
+                branch: "main",
+                commitSha: "abc123",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+
+    const output = JSON.parse(body.result?.content?.[0]?.text ?? "{}");
+
+    expect(output).toMatchObject({
+      file: {
+        id: expect.any(String),
+        sourceFileVersionId: expect.any(String),
+        filename: "en.json",
+        contentType: "application/json",
+        byteSize: expect.any(Number),
+        sha256: expect.any(String),
+        destination: "native",
+      },
+    });
+
+    const [storedFile] = await db
+      .select({
+        id: schema.storedFiles.id,
+        projectId: schema.storedFiles.projectId,
+        filename: schema.storedFiles.filename,
+        contentType: schema.storedFiles.contentType,
+        createdByUserId: schema.storedFiles.createdByUserId,
+      })
+      .from(schema.storedFiles)
+      .where(eq(schema.storedFiles.id, output.file.id))
+      .limit(1);
+
+    expect(storedFile).toMatchObject({
+      projectId: stored.project.id,
+      filename: "en.json",
+      contentType: "application/json",
+      createdByUserId: auth.user.localUserId,
+    });
+
+    const [sourceVersion] = await db
+      .select({
+        id: schema.repositorySourceFileVersions.id,
+        sourcePath: schema.repositorySourceFileVersions.sourcePath,
+        commitSha: schema.repositorySourceFileVersions.commitSha,
+        uploadSurface: schema.repositorySourceFileVersions.uploadSurface,
+        ingestState: schema.repositorySourceFileVersions.ingestState,
+      })
+      .from(schema.repositorySourceFileVersions)
+      .where(eq(schema.repositorySourceFileVersions.id, output.file.sourceFileVersionId))
+      .limit(1);
+
+    expect(sourceVersion).toMatchObject({
+      id: output.file.sourceFileVersionId,
+      sourcePath: "locales/en.json",
+      commitSha: "abc123",
+      uploadSurface: "mcp",
+      ingestState: "pending",
+    });
+  });
+
+  it("uploads base64 source content to a native project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const fileContent = Buffer.from('{"greeting":"Hello"}');
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "upload_sources",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath: "locales/base64.json",
+                contentBase64: fileContent.toString("base64"),
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      file: {
+        filename: "base64.json",
+        contentType: "application/json",
+        byteSize: fileContent.byteLength,
+        sha256: createHash("sha256").update(fileContent).digest("hex"),
+        destination: "native",
+      },
+    });
+  });
+
+  it("returns forbidden when a read-only member uploads a source file", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+
+    const memberIdentity = fixture.createWorkosIdentityForOrganization(
+      stored.identity.organization,
+      "member",
+    );
+
+    const headers = await authenticatedMcpHeaders(memberIdentity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "upload_sources",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath: "locales/forbidden.json",
+                content: '{"hello":"Hello"}',
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "forbidden",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.storedFiles.id })
+      .from(schema.storedFiles)
+      .where(eq(schema.storedFiles.projectId, stored.project.id))
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("returns project_not_found for a project from another organization", async () => {
+    const accessible = await fixture.createStoredProjectFixture();
+    const inaccessible = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(accessible.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "upload_sources",
+              arguments: {
+                projectId: inaccessible.project.id,
+                sourcePath: "locales/isolation.json",
+                content: '{"hello":"Hello"}',
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "project_not_found",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.storedFiles.id })
+      .from(schema.storedFiles)
+      .where(eq(schema.storedFiles.projectId, inaccessible.project.id))
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  });
+
+  it("rejects oversized source content before storage", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "upload_sources",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath: "locales/oversized.json",
+                content: "x".repeat(maxPublicUploadBytes + 1),
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "invalid_file_payload",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.storedFiles.id })
+      .from(schema.storedFiles)
+      .where(
+        and(
+          eq(schema.storedFiles.projectId, stored.project.id),
+          eq(schema.storedFiles.filename, "oversized.json"),
+        ),
+      )
+      .limit(1);
+
+    expect(saved).toBeUndefined();
+  }, 15_000);
+
+  it("returns invalid_file_payload for malformed base64 content", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "upload_sources",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath: "locales/invalid-base64.json",
+                contentBase64: "this-is-not-valid-base64!",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "invalid_file_payload",
+    });
+
+    const [saved] = await db
+      .select({ id: schema.storedFiles.id })
+      .from(schema.storedFiles)
+      .where(
+        and(
+          eq(schema.storedFiles.projectId, stored.project.id),
+          eq(schema.storedFiles.filename, "invalid-base64.json"),
         ),
       )
       .limit(1);

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -120,6 +120,7 @@ import {
 } from "@/api/routes/public-files/public-files.schema";
 import { sourceContentType, sourceFilename } from "@/lib/file-storage/source-file-metadata";
 import { uploadSourceFile } from "@/lib/projects/files/source-file-upload-service";
+import { ensureOrganizationProjectRecord } from "@/lib/projects/organization/organization-project-service";
 import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats";
 import { updateMcpTranslation } from "./mcp-update-translation";
 
@@ -2039,11 +2040,37 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
         return mcpToolError("unsupported_file", "Source file format is not supported");
       }
 
-      const [project] = await db
-        .select()
-        .from(schema.projects)
-        .where(await ownedProjectWhere(apiAuth, projectId))
-        .limit(1);
+      const target = await resolveProjectResourceTarget(apiAuth, projectId);
+
+      if (target.kind === "provider_unavailable") {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      let resolvedProjectId = target.kind === "native" ? target.projectId : projectId;
+
+      if (target.kind === "provider") {
+        const ensuredProject = await ensureOrganizationProjectRecord({
+          organizationId: apiAuth.organization.localOrganizationId,
+          projectId,
+          userId: apiAuth.user.localUserId,
+        });
+
+        if (isErr(ensuredProject)) {
+          return mcpToolError("project_not_found", "Project not found or inaccessible");
+        }
+
+        resolvedProjectId = ensuredProject.value;
+      }
+
+      const projectWhere =
+        target.kind === "provider"
+          ? and(
+              eq(schema.projects.organizationId, apiAuth.organization.localOrganizationId),
+              eq(schema.projects.id, resolvedProjectId),
+            )
+          : await ownedProjectWhere(apiAuth, resolvedProjectId);
+
+      const [project] = await db.select().from(schema.projects).where(projectWhere).limit(1);
 
       if (!project) {
         return mcpToolError("project_not_found", "Project not found or inaccessible");

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -79,6 +79,7 @@ import {
   type IssueSheetIssue,
 } from "@/lib/projects/issue-sheet/issue-sheet-service";
 import {
+  isJobCreateAllowed,
   isWriteBackApproveAllowed,
   isWriteBackTranslationAllowed,
 } from "@/api/auth/capability-guards";
@@ -113,6 +114,13 @@ import { resolveProjectResourceTarget } from "@/api/routes/project/project.share
 import type { ToolContext } from "@/lib/tools/types";
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
+import {
+  maxPublicUploadBytes,
+  uploadBodySchema,
+} from "@/api/routes/public-files/public-files.schema";
+import { sourceContentType, sourceFilename } from "@/lib/file-storage/source-file-metadata";
+import { uploadSourceFile } from "@/lib/projects/files/source-file-upload-service";
+import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats";
 import { updateMcpTranslation } from "./mcp-update-translation";
 
 const authorizationQuerySchema = z.object({
@@ -733,6 +741,62 @@ const mcpGetTranslationInputSchema = z.object({
 
   targetLocale: z.string().min(1).max(50).describe("BCP-47 target locale tag."),
 });
+
+const sourceUploadShape = uploadBodySchema.shape;
+
+const mcpUploadSourcesInputSchema = z.object({
+  projectId: sourceUploadShape.projectId.describe("ID of the accessible Hyperlocalise project."),
+
+  sourcePath: sourceUploadShape.sourcePath.describe("Repository-relative path of the source file."),
+
+  content: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Source file bytes represented as UTF-8 text. Provide exactly one of content or contentBase64.",
+    ),
+
+  contentBase64: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Source file bytes encoded as base64. Provide exactly one of content or contentBase64.",
+    ),
+
+  sourceLocale: sourceUploadShape.sourceLocale.describe("Optional source locale."),
+
+  format: sourceUploadShape.format.describe("Optional explicit source file format."),
+
+  branch: sourceUploadShape.branch.describe("Optional repository branch."),
+
+  sourceHash: sourceUploadShape.sourceHash.describe("Optional caller-provided source hash."),
+
+  commitSha: sourceUploadShape.commitSha.describe("Optional repository commit SHA."),
+
+  workflowRunId: sourceUploadShape.workflowRunId.describe("Optional workflow run identifier."),
+});
+
+function decodeMcpBase64(value: string): Uint8Array | null {
+  const normalized = value.trim();
+
+  if (
+    normalized.length === 0 ||
+    normalized.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
+  ) {
+    return null;
+  }
+
+  const decoded = Buffer.from(normalized, "base64");
+
+  if (decoded.toString("base64") !== normalized) {
+    return null;
+  }
+
+  return new Uint8Array(decoded);
+}
 
 function mcpToolContext(apiAuth: ApiAuthContext): ToolContext {
   return {
@@ -1756,7 +1820,7 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
     },
   );
 
-  for (const name of ["upload_sources", "download_translations", "run_workflow"] as const) {
+  for (const name of ["download_translations", "run_workflow"] as const) {
     server.registerTool(
       name,
       {
@@ -1908,6 +1972,133 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
           {
             type: "text",
             text: JSON.stringify(result.value),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "upload_sources",
+    {
+      description: "Upload one source file to an accessible Hyperlocalise project.",
+      inputSchema: mcpUploadSourcesInputSchema,
+    },
+    async ({
+      projectId,
+      sourcePath,
+      content,
+      contentBase64,
+      sourceLocale,
+      format,
+      branch,
+      sourceHash,
+      commitSha,
+      workflowRunId,
+    }) => {
+      if (!isJobCreateAllowed(apiAuth.membership.role)) {
+        return mcpToolError("forbidden", "Insufficient permissions to upload source files");
+      }
+
+      const hasTextContent = content !== undefined;
+      const hasBase64Content = contentBase64 !== undefined;
+
+      if (hasTextContent === hasBase64Content) {
+        return mcpToolError(
+          "invalid_file_payload",
+          "Provide exactly one of content or contentBase64",
+        );
+      }
+
+      let fileBytes: Uint8Array;
+
+      if (content !== undefined) {
+        fileBytes = new TextEncoder().encode(content);
+      } else {
+        if (contentBase64 === undefined) {
+          return mcpToolError(
+            "invalid_file_payload",
+            "Provide exactly one of content or contentBase64",
+          );
+        }
+
+        const decoded = decodeMcpBase64(contentBase64);
+
+        if (!decoded) {
+          return mcpToolError("invalid_file_payload", "contentBase64 must contain valid base64");
+        }
+
+        fileBytes = decoded;
+      }
+
+      if (fileBytes.byteLength > maxPublicUploadBytes) {
+        return mcpToolError("invalid_file_payload", "Source file exceeds the 25 MiB upload limit");
+      }
+
+      if (!inferSupportedSourceUploadFormat(sourcePath)) {
+        return mcpToolError("unsupported_file", "Source file format is not supported");
+      }
+
+      const [project] = await db
+        .select()
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      const result = await uploadSourceFile({
+        organizationId: apiAuth.organization.localOrganizationId,
+        project,
+        file: {
+          filename: sourceFilename(sourcePath),
+          contentType: sourceContentType(sourcePath),
+          content: fileBytes,
+        },
+        sourcePath,
+        sourceHash,
+        commitSha,
+        workflowRunId,
+        sourceLocale,
+        format,
+        branch,
+        uploadSurface: "mcp",
+        uploadedByUserId: apiAuth.user.localUserId,
+        actorUserId: apiAuth.user.localUserId,
+      });
+
+      if (isErr(result)) {
+        switch (result.error.code) {
+          case "external_tms_project_not_found":
+            return mcpToolError("project_not_found", "Project not found or inaccessible");
+
+          case "source_upload_failed":
+            return mcpToolError("source_upload_failed", "Source file upload failed");
+
+          case "provider_credential_not_found":
+          case "invalid_crowdin_project_id":
+          case "crowdin_branch_not_found":
+          case "phrase_source_locale_not_found":
+          case "phrase_source_file_format_required":
+          case "lokalise_source_locale_required":
+          case "lokalise_source_file_format_required":
+          case "smartling_source_file_type_required":
+            return mcpToolError("invalid_file_payload", "Source file payload is invalid");
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              file: {
+                ...result.value.file,
+                destination: result.value.destination,
+              },
+            }),
           },
         ],
       };

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -51,17 +51,20 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | `list_files`           | List source files in a project (`projectId`, `limit` default 20 max 50, `offset`, optional `search`)                                                                    |
 | `list_translations`    | Paginated CAT queue of translation keys (`projectId`, optional `sourcePath`, `targetLocale`, `search`, `queueFilter`, `queueSort`, `limit` default 20 max 50, `offset`) |
 | `get_translation`      | Full CAT detail for one translation key (`projectId`, `translationKeyId`, `targetLocale`)                                                                               |
-| `update_translation`   | Save a target translation and optionally approve it (`projectId`, `translationKeyId`, `targetLocale`, `targetText`, optional `approve`)                                |
+| `update_translation`   | Save a target translation and optionally approve it (`projectId`, `translationKeyId`, `targetLocale`, `targetText`, optional `approve`)                                 |
 | `get_project_status`   | Locale coverage counts by `projectId`, with optional `sourcePath`                                                                                                       |
 | `list_glossaries`      | List glossaries linked to accessible projects                                                                                                                           |
 | `get_glossary_entries` | Concept-linked terms for a `glossaryId` (`limit`, default 50, max 100)                                                                                                  |
 | `query_glossary`       | Ranked concept-linked hits for a source string and locale pair                                                                                                          |
+| `upload_sources`       | Upload a source file to a project using UTF-8 `content` or binary `contentBase64`                                                                                       |
 
 `list_files` returns metadata only: `id` (stored file or source-file id), `sourcePath`, `filename`, `contentType`, `byteSize`, `updatedAt`, and `sourceLocale` when known. Pagination includes `total`, `limit`, `offset`, `hasMore`, and `nextOffset`. The tool does not return file contents. Inaccessible projects return `project_not_found`. Use the listed `sourcePath` values for later upload, download, or `run_workflow` calls.
 
 `list_translations` is the CAT queue for agents. It lists native overlay keys so you can find untranslated, needs-review, or matching strings without opening the Content Editor. Each row is compact: `id`, `key`, `sourcePath`, `sourceText`, `targetLocale`, `targetText`, `status`, `maxLength`, and `isHidden`. The response includes `total`, pagination (`hasMore`, `nextOffset`), and `coverageSource: "native_overlay"`. It does not include TM or glossary hits.
 
 `get_translation` is the detail view for a translation returned by `list_translations`. Pass the row's `id` as `translationKeyId` together with its `projectId` and `targetLocale`. The tool returns source and target text, locales, status, context, maximum length, and linked Board issue identifiers. A key without a target translation is returned with `targetText` and `status` set to `null`.
+
+`upload_sources` uploads one source file using the same native or external TMS path as `POST /v1/files`. Provide exactly one of `content` or `contentBase64`. Native uploads are queued for background ingestion so their keys become available to `list_translations`. The maximum payload size is 25 MiB. This tool does not create a translation job; use `run_workflow` for that.
 
 Optional filters match the Content Editor queue:
 
@@ -136,7 +139,6 @@ Missing or inaccessible jobs, including jobs from another organization, return `
 
 These tools are advertised but return `not_implemented` today:
 
-- `upload_sources`
 - `download_translations`
 - `run_workflow`
 
@@ -175,6 +177,9 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `invalid_translation`                          | Target text has a blocking placeholder or ICU validation error                                                         |
 | `provider_cat_unsupported`                     | The requested operation targets a provider-only live CAT string without a supported native overlay                     |
 | Agent cannot reach local Cloud                 | Use `http://localhost:3000/mcp` and ensure the dev server is running                                                   |
+| `invalid_file_payload`                         | Upload content is missing, malformed, oversized, or contains conflicting input fields                                  |
+| `unsupported_file`                             | The uploaded source path uses an unsupported translation file format                                                   |
+| `source_upload_failed`                         | The native or external TMS source upload failed                                                                        |
 
 ## Next
 


### PR DESCRIPTION
## Summary

- replace the reserved `upload_sources` MCP stub with a functional source upload tool
- support UTF-8 text and strict base64 payloads
- reuse the existing native and external TMS source upload service
- enforce file-write permissions, project isolation, supported formats, and the 25 MiB upload limit
- enqueue native uploads for background ingestion
- document the tool and its stable MCP error contracts

## Validation

- `vp check --fix`
- `vp test src/api/routes/mcp/mcp.route.test.ts`
- `git diff --check`

## Test coverage

- tool advertisement and bounded input schema
- UTF-8 and base64 uploads
- mutually exclusive content fields
- malformed base64
- unsupported formats
- oversized payloads
- read-only permissions
- cross-organization isolation
- native upload metadata and pending ingest state