### PR TITLE
fix(mt): honor context cancel between Amazon Translate calls

### DIFF
--- a/internal/mt/amazon.go
+++ b/internal/mt/amazon.go
@@ -107,6 +107,9 @@ func (c *AmazonClient) Translate(ctx context.Context, req Request) (Response, er
 
 	translations := make([]string, len(req.Sources))
 	for i, s := range req.Sources {
+		if err := ctx.Err(); err != nil {
+			return Response{}, err
+		}
 		translated, err := c.translateOne(ctx, sourceCode, targetCode, s)
 		if err != nil {
 			return Response{}, err
@@ -131,6 +134,10 @@ func (c *AmazonClient) translateOne(ctx context.Context, sourceCode, targetCode,
 }
 
 func (c *AmazonClient) request(ctx context.Context, body, out any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	encoded, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("mt: marshal amazon translate request: %w", err)

--- a/internal/mt/amazon_test.go
+++ b/internal/mt/amazon_test.go
@@ -373,7 +373,7 @@ func TestAmazonClientTranslateContextCanceledBetweenCalls(t *testing.T) {
 	defer cancel()
 
 	var calls int
-	client := newAmazonTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		calls++
 		require.Equal(t, 1, calls, "no request should be sent for a source after cancellation")
 
@@ -382,14 +382,30 @@ func TestAmazonClientTranslateContextCanceledBetweenCalls(t *testing.T) {
 		w.Header().Set("Content-Length", strconv.Itoa(len(respBody)))
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(respBody))
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
-		}
-
-		cancel()
 	})
+	cfg.AccessKeyID = "AKIATEST"
+	cfg.SecretAccessKey = "test-secret"
+	cfg.Region = "us-east-1"
 
-	_, err := client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"one", "two"}})
+	// Cancel after the first response is received on the client. Canceling from
+	// the server handler races: the client can start the next source before the
+	// handler runs cancel().
+	baseTransport := cfg.HTTPClient.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	cfg.HTTPClient = &http.Client{
+		Transport: amazonRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			resp, err := baseTransport.RoundTrip(req)
+			cancel()
+			return resp, err
+		}),
+	}
+
+	client, err := NewAmazonClient(cfg)
+	require.NoError(t, err)
+
+	_, err = client.Translate(ctx, Request{SourceLocale: "en", TargetLocale: "fr", Sources: []string{"one", "two"}})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.Canceled))
 	_, ok := AsError(err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`TestAmazonClientTranslateContextCanceledBetweenCalls` failed in CI Go Quality because Amazon Translate issued a second `TranslateText` request after the first response was flushed and before the test canceled the context.

Amazon Translate is one HTTP call per source. After the first call succeeded, `Translate` started the next source without checking `ctx.Err()`. On a fast runner that second request reached the handler (`calls == 2`).

This change:

- Returns `ctx.Err()` before each sequential `TranslateText` call, and again before building the HTTP request
- Cancels the between-calls test after the first response is received on the client, instead of from the server handler (that path raced with the next source)

## How to test

```
go test ./internal/mt -run TestAmazonClientTranslateContextCanceledBetweenCalls -count=200
make fmt
make lint
go test ./...
```

Local results:

- `TestAmazonClientTranslateContextCanceledBetweenCalls` passed 200 times
- `make fmt` and `make lint` passed
- `go test ./...` passed
- `make test` still exits 1 from the known missing `covdata` tool; the package tests themselves passed, including `internal/mt`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `go test ./...`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a082f7-f4dd-7d69-99da-3021e5998f31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a082f7-f4dd-7d69-99da-3021e5998f31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

