### PR TITLE
feat(web): add Hyperlab and Domains marketing product pages

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/page.tsx
@@ -15,7 +15,9 @@ import { notFound, permanentRedirect } from "next/navigation";
 import { Suspense } from "react";
 
 import { ProductPage } from "@/components/marketing/product/product-page";
+import { DomainsPage } from "@/components/marketing/product/domains-page";
 import { GuidelinesPage } from "@/components/marketing/product/guidelines-page";
+import { HyperlabPage } from "@/components/marketing/product/hyperlab-page";
 import { MultilingualContentStudioPage } from "@/components/marketing/product/multilingual-content-studio-page";
 import {
   productPagesBySlug,
@@ -105,6 +107,14 @@ async function ProductRouteContent({ params }: ProductRouteProps) {
 
   if (slug === "guidelines") {
     return <GuidelinesPage />;
+  }
+
+  if (slug === "domains") {
+    return <DomainsPage />;
+  }
+
+  if (slug === "hyperlab") {
+    return <HyperlabPage />;
   }
   const content = productPagesBySlug[slug as keyof typeof productPagesBySlug];
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/product-route-metadata.ts
@@ -56,6 +56,34 @@ export function getProductRouteMetadata(slug: string, intl: IntlShape) {
           description: "Meta description for the Guidelines product page",
         }),
       };
+    case "domains":
+      return {
+        title: intl.formatMessage({
+          defaultMessage: "Publish Once. Get Found Everywhere. | Hyperlocalise",
+          id: "0wVg6cogQx",
+          description: "Page title for the Domains product page",
+        }),
+        description: intl.formatMessage({
+          defaultMessage:
+            "Publish multilingual pages, then check localisation, search, and AI answers so people can find them in every market.",
+          id: "HdHkhWUK6b",
+          description: "Meta description for the Domains product page",
+        }),
+      };
+    case "hyperlab":
+      return {
+        title: intl.formatMessage({
+          defaultMessage: "Try It in One Market. Keep What Works. | Hyperlocalise",
+          id: "t6xBRSvtG0",
+          description: "Page title for the Hyperlab product page",
+        }),
+        description: intl.formatMessage({
+          defaultMessage:
+            "Run market experiments and show different features by country. Hyperlab tells you what works, then you take that version everywhere.",
+          id: "EKVrW1yga/",
+          description: "Meta description for the Hyperlab product page",
+        }),
+      };
     default:
       return null;
   }

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.test.ts
@@ -52,6 +52,12 @@ describe("llms.txt route", () => {
     expect(body).toContain(
       "[Guidelines](https://www.hyperlocalise.com/en/product/guidelines): Connect Google Drive, Notion, and SharePoint, or type guidelines in, so agents can check drafts against your files.",
     );
+    expect(body).toContain(
+      "[Domains](https://www.hyperlocalise.com/en/product/domains): Publish once. Get found everywhere.",
+    );
+    expect(body).toContain(
+      "[Hyperlab](https://www.hyperlocalise.com/en/product/hyperlab): Try it in one market. Keep what works.",
+    );
     expect(body).toContain("https://www.hyperlocalise.com/en/use-cases/");
     expect(body).toContain("https://hyperlocalise.dev");
     expect(body).toContain("## Agents");

--- a/apps/hyperlocalise-web/src/app/llms.txt/route.ts
+++ b/apps/hyperlocalise-web/src/app/llms.txt/route.ts
@@ -36,6 +36,16 @@ const productLinks: LlmsLink[] = [
     description:
       "Connect Google Drive, Notion, and SharePoint, or type guidelines in, so agents can check drafts against your files",
   },
+  {
+    title: "Domains",
+    href: `${SITE_URL}/en/product/domains`,
+    description: "Publish once. Get found everywhere",
+  },
+  {
+    title: "Hyperlab",
+    href: `${SITE_URL}/en/product/hyperlab`,
+    description: "Try it in one market. Keep what works",
+  },
 ];
 
 const useCaseLinks: LlmsLink[] = [

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.ts
@@ -83,8 +83,8 @@ export function getHomepageFaqItems(locale: string): HomepageFaqItem[] {
       }),
       answer: intl.formatMessage({
         defaultMessage:
-          "Hyperlab provides A/B testing for your CMS and distribution, so your team can compare content variants and learn what performs.",
-        id: "3vl9Ga2VYG",
+          "Hyperlab lets you run market experiments and show different features by country, so you learn what works before every market sees it.",
+        id: "URyMqNCJY6",
         description: "Homepage FAQ answer about platform topic 5",
       }),
     },

--- a/apps/hyperlocalise-web/src/components/marketing/homepage/homepage.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage/homepage.messages.ts
@@ -140,8 +140,8 @@ export const homepageMessages = defineMessages({
   },
   hyperlabBody: {
     defaultMessage:
-      "A/B test content across your CMS and distribution to learn what works for your audience.",
-    id: "hkGU6Oegi5",
+      "Run market experiments and ship different features by country, then take the winner everywhere.",
+    id: "QFVMAeajBY",
     description: "Marketing homepage hyperlabBody",
   },
   guidelinesBody: {

--- a/apps/hyperlocalise-web/src/components/marketing/homepage/product-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage/product-preview.tsx
@@ -32,7 +32,7 @@ export const PRODUCTS = [
   },
   {
     id: "automation",
-    href: "#explore",
+    href: "/product/agents-automation",
     title: m.automationCardTitle,
     short: m.automationShort,
     body: m.automationBody,
@@ -40,7 +40,7 @@ export const PRODUCTS = [
   },
   {
     id: "domains",
-    href: "#explore",
+    href: "/product/domains",
     title: m.domainsCardTitle,
     short: m.domainsShort,
     body: m.domainsBody,
@@ -48,7 +48,7 @@ export const PRODUCTS = [
   },
   {
     id: "hyperlab",
-    href: "#explore",
+    href: "/product/hyperlab",
     title: m.hyperlabCardTitle,
     short: m.hyperlabShort,
     body: m.hyperlabBody,

--- a/apps/hyperlocalise-web/src/components/marketing/product/domains-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/domains-mock-ui.tsx
@@ -30,7 +30,9 @@ import { MarketingMockUseCaseSelector } from "./marketing-mock-use-case-selector
 
 type AuditFocus = "localisation" | "seo" | "aeo";
 
-function DomainsAuditDashboard({ focus }: { focus: AuditFocus }) {
+export type DomainsAuditFocus = AuditFocus;
+
+export function DomainsAuditDashboard({ focus }: { focus: AuditFocus }) {
   const intl = useIntl();
 
   const dimensions = useMemo(
@@ -166,6 +168,8 @@ export function DomainsMockUI({
   variant = "full",
   aside,
   meshPosition = "left",
+  showMesh = true,
+  className,
 }: {
   priority?: boolean;
   pauseAutoplay?: boolean;
@@ -173,6 +177,8 @@ export function DomainsMockUI({
   variant?: MarketingMockVariant;
   aside?: ReactNode;
   meshPosition?: MarketingMockMeshPosition;
+  showMesh?: boolean;
+  className?: string;
 }) {
   const intl = useIntl();
 
@@ -241,6 +247,8 @@ export function DomainsMockUI({
       priority={priority}
       variant={variant}
       meshPosition={meshPosition}
+      showMesh={showMesh}
+      className={className}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/product/domains-page.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/domains-page.messages.ts
@@ -1,0 +1,430 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainsPageMessages = defineMessages({
+  heroEyebrow: {
+    defaultMessage: "Domains",
+    id: "q82hDvskBV",
+    description: "Hero eyebrow for the Domains product page",
+  },
+  heroHeadline: {
+    defaultMessage: "Publish once.\nGet found everywhere.",
+    id: "BbOj+wUXk0",
+    description: "Hero headline for the Domains product page",
+  },
+  heroSubcopy: {
+    defaultMessage:
+      "Put your pages live in every language. Domains watches search and AI answers, then shows you what to fix.",
+    id: "44qNLsa5bU",
+    description: "Hero description for the Domains product page",
+  },
+  requestDemo: {
+    defaultMessage: "Request a Demo",
+    id: "Lj3BZpxg6f",
+    description: "Call-to-action to request a Domains demo",
+  },
+  exploreDomains: {
+    defaultMessage: "See a site audit",
+    id: "bjsHedIAkd",
+    description: "Anchor link from the Domains hero to the product preview",
+  },
+  fromPublishToFound: {
+    defaultMessage: "From a live page to a page people can find.",
+    id: "Rxt6SwzGmb",
+    description: "Caption under the Domains preview",
+  },
+  stepPublish: {
+    defaultMessage: "01 Publish",
+    id: "BPMUoJXbTa",
+    description: "Domains workflow step 1",
+  },
+  stepLanguages: {
+    defaultMessage: "02 Check every language",
+    id: "DMziALn6m4",
+    description: "Domains workflow step 2",
+  },
+  stepSearch: {
+    defaultMessage: "03 Fix what search misses",
+    id: "gXZfoeQ6KB",
+    description: "Domains workflow step 3",
+  },
+  stepFound: {
+    defaultMessage: "04 Get found",
+    id: "L2f4AH9U80",
+    description: "Domains workflow step 4",
+  },
+  solutionsEyebrow: {
+    defaultMessage: "What Domains checks",
+    id: "BH3cs7sGM9",
+    description: "Eyebrow for the Domains solutions section",
+  },
+  solutionsHeadline: {
+    defaultMessage: "Languages.\nSearch.\nAI answers.",
+    id: "4Aefl4GjbY",
+    description: "Headline for the Domains solutions section",
+  },
+  solutionsBody: {
+    defaultMessage:
+      "A page can be live and still be invisible. Domains shows the gaps in each language, in search, and in AI answers.",
+    id: "FaT5oUwQOq",
+    description: "Body copy for the Domains solutions section",
+  },
+  solutionsAriaLabel: {
+    defaultMessage: "Domains solutions",
+    id: "K/SUM2c9Dk",
+    description: "Accessible label for the Domains solution tabs",
+  },
+  solutionLocalisation: {
+    defaultMessage: "Every language",
+    id: "aFsNlAnIlu",
+    description: "Domains solution tab for localisation",
+  },
+  solutionSeo: {
+    defaultMessage: "Search",
+    id: "f46AmI9URt",
+    description: "Domains solution tab for SEO",
+  },
+  solutionAeo: {
+    defaultMessage: "AI answers",
+    id: "w/OKtwjgIh",
+    description: "Domains solution tab for AEO",
+  },
+  localisationTitle: {
+    defaultMessage: "Every language.\nThe right page.",
+    id: "w1aJulNG2a",
+    description: "Title for the Domains localisation solution panel",
+  },
+  localisationBody: {
+    defaultMessage:
+      "If French visitors land on English, or a language is missing, Domains flags it before a customer does.",
+    id: "7Mb6b+z2q1",
+    description: "Body for the Domains localisation solution panel",
+  },
+  localisationLink: {
+    defaultMessage: "From hreflang to locale coverage",
+    id: "Un7mRcQrna",
+    description: "Supporting line for the Domains localisation solution panel",
+  },
+  seoTitle: {
+    defaultMessage: "Help Google find you.",
+    id: "aBdSYSGyjv",
+    description: "Title for the Domains SEO solution panel",
+  },
+  seoBody: {
+    defaultMessage:
+      "Titles, descriptions, and indexability are checked in every market, not only in English.",
+    id: "J/4xcmgL1G",
+    description: "Body for the Domains SEO solution panel",
+  },
+  seoLink: {
+    defaultMessage: "From meta tags to market snippets",
+    id: "W5R39QzczX",
+    description: "Supporting line for the Domains SEO solution panel",
+  },
+  aeoTitle: {
+    defaultMessage: "Help AI answer with your page.",
+    id: "3yZFMdlOT1",
+    description: "Title for the Domains AEO solution panel",
+  },
+  aeoBody: {
+    defaultMessage:
+      "When someone asks ChatGPT or another AI search tool, they should still find you. Domains checks the structured answers that make that possible.",
+    id: "zjUi7Y6uS4",
+    description: "Body for the Domains AEO solution panel",
+  },
+  aeoLink: {
+    defaultMessage: "From FAQ schema to cited answers",
+    id: "OSLEez1pTU",
+    description: "Supporting line for the Domains AEO solution panel",
+  },
+  liveEyebrow: {
+    defaultMessage: "Your live site",
+    id: "Llo60/JvXZ",
+    description: "Eyebrow for the Domains live page section",
+  },
+  liveHeadline: {
+    defaultMessage: "Switch language.\nSee what is broken.",
+    id: "2+iIGrGb+G",
+    description: "Headline for the Domains live page section",
+  },
+  liveBody: {
+    defaultMessage:
+      "This is the published page. Change the language, then tap an issue to see what search or AI would miss.",
+    id: "dvW1qhsF0A",
+    description: "Body for the Domains live page section",
+  },
+  liveCaption: {
+    defaultMessage: "Published webpage preview",
+    id: "ja9cL+H+5B",
+    description: "Caption above the Domains published webpage preview",
+  },
+  liveStatus: {
+    defaultMessage: "Published",
+    id: "lMu61NG0z5",
+    description: "Published status badge in the Domains webpage preview",
+  },
+  languageLabel: {
+    defaultMessage: "Language",
+    id: "eNUY3a6dwA",
+    description: "Label for the language selector in the Domains webpage preview",
+  },
+  issuesHeading: {
+    defaultMessage: "Open issues",
+    id: "o/m/oSG780",
+    description: "Heading for clickable audit issues on the Domains live preview",
+  },
+  issueHreflang: {
+    defaultMessage: "French page is missing a language link",
+    id: "t0biooOCbM",
+    description: "Localisation issue in the Domains live preview",
+  },
+  issueMeta: {
+    defaultMessage: "German page has no search description",
+    id: "H0hPMXRA/Z",
+    description: "SEO issue in the Domains live preview",
+  },
+  issueFaq: {
+    defaultMessage: "English page has no FAQ for AI answers",
+    id: "REMUySaHTw",
+    description: "AEO issue in the Domains live preview",
+  },
+  highlightHreflang: {
+    defaultMessage: "Language links on this URL do not match the French page.",
+    id: "yrOEOBNsM7",
+    description: "Highlight copy for a localisation issue on the live preview",
+  },
+  highlightMeta: {
+    defaultMessage: "Search has no description to show under this title.",
+    id: "muiA0TtFN7",
+    description: "Highlight copy for an SEO issue on the live preview",
+  },
+  highlightFaq: {
+    defaultMessage: "AI search has no FAQ block to quote from this page.",
+    id: "M0znNdV8EN",
+    description: "Highlight copy for an AEO issue on the live preview",
+  },
+  articleCategory: {
+    defaultMessage: "Daylight journal",
+    id: "OebStHzX3X",
+    description: "Sample article category in the Domains live preview",
+  },
+  articleTitleEn: {
+    defaultMessage: "See the world in a different light.",
+    id: "DjyFDSQhTb",
+    description: "English sample article title in the Domains live preview",
+  },
+  articleTitleFr: {
+    defaultMessage: "Voyez le monde sous un autre jour.",
+    id: "e3o5ny2S7S",
+    description: "French sample article title in the Domains live preview",
+  },
+  articleTitleDe: {
+    defaultMessage: "Die Welt in einem neuen Licht sehen.",
+    id: "F3LRM6/D0t",
+    description: "German sample article title in the Domains live preview",
+  },
+  articleIntroEn: {
+    defaultMessage:
+      "Every light has a story. Explore the places, people, and everyday moments that connect us across the world.",
+    id: "ELdhYF24XP",
+    description: "English sample article intro in the Domains live preview",
+  },
+  articleIntroFr: {
+    defaultMessage:
+      "Chaque lumière raconte une histoire. Découvrez les lieux, les personnes et les instants du quotidien qui nous relient.",
+    id: "IeIy523DjY",
+    description: "French sample article intro in the Domains live preview",
+  },
+  articleIntroDe: {
+    defaultMessage:
+      "Jedes Licht erzählt eine Geschichte. Entdecken Sie die Orte, Menschen und alltäglichen Momente, die uns verbinden.",
+    id: "1n6nJH8E8P",
+    description: "German sample article intro in the Domains live preview",
+  },
+  languageEnglish: {
+    defaultMessage: "English",
+    id: "CNDMCn/RSf",
+    description: "English language name in the Domains live preview",
+  },
+  languageFrench: {
+    defaultMessage: "Français",
+    id: "d/WdYnGJ3q",
+    description: "French language name in the Domains live preview",
+  },
+  languageGerman: {
+    defaultMessage: "Deutsch",
+    id: "NYvATJF9mO",
+    description: "German language name in the Domains live preview",
+  },
+  searchEyebrow: {
+    defaultMessage: "What people see",
+    id: "D25ih6b6HA",
+    description: "Eyebrow for the Domains search snippet section",
+  },
+  searchHeadline: {
+    defaultMessage: "If search cannot read it,\nnobody clicks it.",
+    id: "x0RZIzLSzE",
+    description: "Headline for the Domains search snippet section",
+  },
+  searchBody: {
+    defaultMessage:
+      "This is the snippet Google would show. Missing descriptions and mixed languages are the usual reason a market never shows up.",
+    id: "mQ36/6Ov5o",
+    description: "Body for the Domains search snippet section",
+  },
+  searchUrl: {
+    defaultMessage: "daylight.example.com › journal › a-different-light",
+    id: "u5OvRKaeK4",
+    description: "Sample search result URL in the Domains snippet mock",
+  },
+  searchMissing: {
+    defaultMessage: "No description",
+    id: "Tnbbm0vypB",
+    description: "Missing meta description state in the Domains snippet mock",
+  },
+  connectedHeadline: {
+    defaultMessage: "A site connected to the bigger picture.",
+    id: "5yG0VUhaH4",
+    description: "Headline for the Domains connected-products section",
+  },
+  connectedBody: {
+    defaultMessage: "Write in Content Studio. Test what works in Hyperlab. Publish here.",
+    id: "bnlEPVXJKa",
+    description: "Body for the Domains connected-products section",
+  },
+  contentStudio: {
+    defaultMessage: "Content Studio",
+    id: "Nf32FGPaYc",
+    description: "Link from Domains to the Content Studio product page",
+  },
+  hyperlab: {
+    defaultMessage: "Hyperlab",
+    id: "dDwlwYf96x",
+    description: "Link from Domains to the Hyperlab product page",
+  },
+  faqHeading: {
+    defaultMessage: "A few things\nyou might ask.",
+    id: "+Dso3VFqcL",
+    description: "FAQ heading on the Domains product page",
+  },
+  faqSubheading: {
+    defaultMessage: "Getting to know Domains.",
+    id: "+1fRGei56f",
+    description: "FAQ subheading on the Domains product page",
+  },
+  faqWhatQuestion: {
+    defaultMessage: "What is Domains, in one sentence?",
+    id: "cLcD+lmoNa",
+    description: "Domains FAQ question explaining the product",
+  },
+  faqWhatAnswer: {
+    defaultMessage:
+      "The place your live pages live, in every language, with checks so people can find them.",
+    id: "4MIivcOetH",
+    description: "Domains FAQ answer explaining the product",
+  },
+  faqLocalisationQuestion: {
+    defaultMessage: "What does a localisation check look for?",
+    id: "fdSqGVpQes",
+    description: "Domains FAQ question about localisation audits",
+  },
+  faqLocalisationAnswer: {
+    defaultMessage:
+      "That each language has a page, and that the links between those pages are correct, so French visitors do not land on English.",
+    id: "i/I7Lluh9S",
+    description: "Domains FAQ answer about localisation audits",
+  },
+  faqSeoQuestion: {
+    defaultMessage: "What does SEO mean here?",
+    id: "NMY+NPW/Lt",
+    description: "Domains FAQ question about SEO",
+  },
+  faqSeoAnswer: {
+    defaultMessage:
+      "Helping Google find and understand your pages in every market: titles, descriptions, and whether the page can be indexed.",
+    id: "v4RjrMdGP3",
+    description: "Domains FAQ answer about SEO",
+  },
+  faqAeoQuestion: {
+    defaultMessage: "What is AEO?",
+    id: "YokJOF4NZE",
+    description: "Domains FAQ question about AEO",
+  },
+  faqAeoAnswer: {
+    defaultMessage:
+      "Answer engine optimisation. When someone asks an AI search tool, they can still get your page as the answer, not a competitor’s.",
+    id: "oDluyiLepj",
+    description: "Domains FAQ answer about AEO",
+  },
+  faqReplaceQuestion: {
+    defaultMessage: "Do I need a new website?",
+    id: "WLfXppMtrs",
+    description: "Domains FAQ question about replacing a website",
+  },
+  faqReplaceAnswer: {
+    defaultMessage:
+      "No. Connect the site you already have. Domains publishes and checks it. You can also publish from Content Studio.",
+    id: "16sYDMkqBx",
+    description: "Domains FAQ answer about replacing a website",
+  },
+  faqFitQuestion: {
+    defaultMessage: "How does Domains fit with the rest of Hyperlocalise?",
+    id: "AbW9TjZ1cT",
+    description: "Domains FAQ question about product fit",
+  },
+  faqFitAnswer: {
+    defaultMessage:
+      "Write in Content Studio. Test headlines in Hyperlab. Domains is where the live pages live and get found.",
+    id: "0uaklEAkIh",
+    description: "Domains FAQ answer about product fit",
+  },
+  faqWhoQuestion: {
+    defaultMessage: "Who is Domains for?",
+    id: "+nZWq6LHzf",
+    description: "Domains FAQ question about audience",
+  },
+  faqWhoAnswer: {
+    defaultMessage:
+      "Teams who publish multilingual sites and care that search and AI can still find them.",
+    id: "FBY0e+rFtV",
+    description: "Domains FAQ answer about audience",
+  },
+  faqStartQuestion: {
+    defaultMessage: "How can we get started?",
+    id: "cCKX0XS/5C",
+    description: "Domains FAQ question about getting started",
+  },
+  faqStartAnswer: {
+    defaultMessage: "Request a demo. We will connect a domain and walk through the first audit.",
+    id: "KZ/vDQOwnm",
+    description: "Domains FAQ answer about getting started",
+  },
+  ctaHeadline: {
+    defaultMessage: "Your site.\nReady for every market.",
+    id: "lpOI0sCQXl",
+    description: "Bottom CTA headline on the Domains product page",
+  },
+  ctaBody: {
+    defaultMessage: "Publish the pages you already have, then fix what search and AI still miss.",
+    id: "BDqDQOB6we",
+    description: "Bottom CTA body on the Domains product page",
+  },
+  ctaNote: {
+    defaultMessage: "Build your publishing workflow.",
+    id: "NIhlMUMura",
+    description: "Supporting note under the Domains bottom CTA",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/domains-page.test.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/domains-page.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it } from "vite-plus/test";
+
+import { DomainsPage } from "./domains-page";
+
+describe("DomainsPage", () => {
+  it("highlights the matching live-page issue when an audit finding is selected", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <DomainsPage />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: /Publish once/i })).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /German page has no search description/i }),
+    );
+
+    expect(
+      screen.getByText("Search has no description to show under this title."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/domains-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/domains-page.tsx
@@ -1,0 +1,578 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import {
+  DUSK_MESH_GRADIENT_SRC,
+  ROSE_MESH_GRADIENT_SRC,
+  SAGE_MESH_GRADIENT_SRC,
+  SEAFOAM_MESH_GRADIENT_SRC,
+  SectionMeshBackground,
+  MeshStage,
+} from "@/components/marketing/hero-frame-mesh-stage";
+import { HomepageFaqSection } from "@/components/marketing/homepage-faq-section";
+import { MarketingFooter } from "@/components/marketing/marketing-footer";
+import { footerColumns } from "@/components/marketing/marketing-page-content";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
+import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
+import { cn } from "@/lib/primitives/cn";
+
+import { DomainsAuditDashboard, DomainsMockUI, type DomainsAuditFocus } from "./domains-mock-ui";
+import { domainsPageMessages as messages } from "./domains-page.messages";
+
+const solutionIds = ["localisation", "seo", "aeo"] as const satisfies readonly DomainsAuditFocus[];
+
+const solutionLabelKeys = {
+  localisation: "solutionLocalisation",
+  seo: "solutionSeo",
+  aeo: "solutionAeo",
+} as const;
+
+const solutionCopyKeys = {
+  localisation: {
+    title: "localisationTitle",
+    body: "localisationBody",
+    link: "localisationLink",
+  },
+  seo: {
+    title: "seoTitle",
+    body: "seoBody",
+    link: "seoLink",
+  },
+  aeo: {
+    title: "aeoTitle",
+    body: "aeoBody",
+    link: "aeoLink",
+  },
+} as const;
+
+const faqMessageKeys = [
+  ["faqWhatQuestion", "faqWhatAnswer"],
+  ["faqLocalisationQuestion", "faqLocalisationAnswer"],
+  ["faqSeoQuestion", "faqSeoAnswer"],
+  ["faqAeoQuestion", "faqAeoAnswer"],
+  ["faqReplaceQuestion", "faqReplaceAnswer"],
+  ["faqFitQuestion", "faqFitAnswer"],
+  ["faqWhoQuestion", "faqWhoAnswer"],
+  ["faqStartQuestion", "faqStartAnswer"],
+] as const;
+
+type PreviewLanguage = "en" | "fr-FR" | "de-DE";
+type AuditIssue = "hreflang" | "meta" | "faq";
+
+const previewLanguages: Array<{
+  id: PreviewLanguage;
+  name: "languageEnglish" | "languageFrench" | "languageGerman";
+  path: string;
+}> = [
+  { id: "en", name: "languageEnglish", path: "en" },
+  { id: "fr-FR", name: "languageFrench", path: "fr-FR" },
+  { id: "de-DE", name: "languageGerman", path: "de-DE" },
+];
+
+const articleCopy = {
+  en: { title: "articleTitleEn", intro: "articleIntroEn" },
+  "fr-FR": { title: "articleTitleFr", intro: "articleIntroFr" },
+  "de-DE": { title: "articleTitleDe", intro: "articleIntroDe" },
+} as const;
+
+const issues: Array<{
+  id: AuditIssue;
+  language: PreviewLanguage;
+  label: "issueHreflang" | "issueMeta" | "issueFaq";
+  highlight: "highlightHreflang" | "highlightMeta" | "highlightFaq";
+}> = [
+  {
+    id: "hreflang",
+    language: "fr-FR",
+    label: "issueHreflang",
+    highlight: "highlightHreflang",
+  },
+  {
+    id: "meta",
+    language: "de-DE",
+    label: "issueMeta",
+    highlight: "highlightMeta",
+  },
+  {
+    id: "faq",
+    language: "en",
+    label: "issueFaq",
+    highlight: "highlightFaq",
+  },
+];
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return <p className="text-xs font-medium text-muted-foreground">{children}</p>;
+}
+
+function DomainsPreview() {
+  return (
+    <div id="domains" className="mx-auto max-w-6xl">
+      <MeshStage
+        className="w-full"
+        contentClassName="px-3 pt-3 pb-0 sm:px-8 sm:pt-8 lg:px-10 lg:pt-10"
+        meshSrc={SEAFOAM_MESH_GRADIENT_SRC}
+        priority
+      >
+        <DomainsMockUI
+          priority
+          showMesh={false}
+          className="rounded-t-xl rounded-b-none border-0 shadow-2xl shadow-[#172541]/20"
+        />
+      </MeshStage>
+    </div>
+  );
+}
+
+function DomainsSolutions() {
+  const intl = useIntl();
+  const [solution, setSolution] = useState<DomainsAuditFocus>("localisation");
+  const copy = solutionCopyKeys[solution];
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto max-w-7xl">
+        <div className="flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
+          <div>
+            <Eyebrow>
+              <FormattedMessage {...messages.solutionsEyebrow} />
+            </Eyebrow>
+            <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+              <FormattedMessage {...messages.solutionsHeadline} />
+            </h2>
+          </div>
+          <p className="max-w-md text-lg leading-8 text-muted-foreground">
+            <FormattedMessage {...messages.solutionsBody} />
+          </p>
+        </div>
+        <div
+          className="mt-10 flex gap-7 overflow-x-auto"
+          role="tablist"
+          aria-label={intl.formatMessage(messages.solutionsAriaLabel)}
+        >
+          {solutionIds.map((item) => (
+            <button
+              key={item}
+              type="button"
+              role="tab"
+              aria-selected={solution === item}
+              onClick={() => setSolution(item)}
+              className={
+                solution === item
+                  ? "shrink-0 border-b-2 border-primary pb-3 text-sm text-primary"
+                  : "shrink-0 pb-3 text-sm text-muted-foreground hover:text-foreground"
+              }
+            >
+              <FormattedMessage {...messages[solutionLabelKeys[item]]} />
+            </button>
+          ))}
+        </div>
+        <div className="mt-6 overflow-hidden rounded-xl bg-muted lg:flex">
+          <div className="flex w-full shrink-0 flex-col justify-center gap-5 bg-background/55 p-8 lg:w-[34%] lg:p-12">
+            <h3 className="whitespace-pre-line text-2xl leading-8 font-semibold tracking-tight">
+              <FormattedMessage {...messages[copy.title]} />
+            </h3>
+            <p className="text-base leading-7 text-muted-foreground">
+              <FormattedMessage {...messages[copy.body]} />
+            </p>
+            <p className="pt-2 text-sm text-primary">
+              <FormattedMessage {...messages[copy.link]} /> ↗
+            </p>
+          </div>
+          <div className="relative isolate flex min-h-80 flex-1 items-center overflow-hidden p-4 sm:p-6">
+            <SectionMeshBackground
+              src={
+                solution === "seo"
+                  ? ROSE_MESH_GRADIENT_SRC
+                  : solution === "aeo"
+                    ? SAGE_MESH_GRADIENT_SRC
+                    : SEAFOAM_MESH_GRADIENT_SRC
+              }
+              className="opacity-80"
+            />
+            <div className="relative w-full">
+              <DomainsAuditDashboard focus={solution} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LiveSiteSection() {
+  const intl = useIntl();
+  const [language, setLanguage] = useState<PreviewLanguage>("en");
+  const [issue, setIssue] = useState<AuditIssue>("hreflang");
+  const article = articleCopy[language];
+  const activeIssue = issues.find((item) => item.id === issue)!;
+  const highlightOnPage = activeIssue.language === language;
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto flex max-w-7xl flex-col gap-10 sm:gap-12">
+        <div className="mx-auto max-w-3xl text-center">
+          <Eyebrow>
+            <FormattedMessage {...messages.liveEyebrow} />
+          </Eyebrow>
+          <h2 className="mt-5 text-balance font-heading text-4xl leading-tight sm:text-5xl">
+            <FormattedMessage {...messages.liveHeadline} />
+          </h2>
+          <p className="mt-6 text-pretty text-lg leading-8 text-muted-foreground">
+            <FormattedMessage {...messages.liveBody} />
+          </p>
+        </div>
+        <figure className="relative isolate min-w-0 overflow-hidden rounded-xl p-4 sm:p-8 lg:p-12">
+          <SectionMeshBackground src={SEAFOAM_MESH_GRADIENT_SRC} className="opacity-80" />
+          <figcaption className="relative mb-3 text-center text-xs text-foreground">
+            <FormattedMessage {...messages.liveCaption} />
+          </figcaption>
+          <div className="relative mx-auto grid max-w-5xl gap-4 lg:grid-cols-[minmax(0,1fr)_16rem]">
+            <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-muted/50 px-5 py-4 text-xs">
+                <span className="min-w-0 break-all text-muted-foreground">
+                  daylight.example.com/{previewLanguages.find((item) => item.id === language)?.path}
+                  /journal/a-different-light
+                </span>
+                <span className="inline-flex items-center gap-2 font-medium text-primary">
+                  <span aria-hidden="true" className="size-1.5 rounded-full bg-current" />
+                  <FormattedMessage {...messages.liveStatus} />
+                </span>
+              </div>
+              <div className="p-5 sm:p-8">
+                <div className="flex flex-wrap items-center justify-between gap-4 border-b border-border pb-5">
+                  <span className="font-heading text-xl">Daylight</span>
+                  <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <FormattedMessage {...messages.languageLabel} />
+                    <select
+                      value={language}
+                      onChange={(event) => {
+                        const value = previewLanguages.find(
+                          (item) => item.id === event.target.value,
+                        )?.id;
+                        if (value) {
+                          setLanguage(value);
+                        }
+                      }}
+                      className="min-h-11 rounded-md border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                    >
+                      {previewLanguages.map((item) => (
+                        <option key={item.id} value={item.id}>
+                          {intl.formatMessage(messages[item.name])}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <article lang={language} className="mx-auto max-w-3xl py-8" aria-live="polite">
+                  <p className="text-xs font-medium text-primary">
+                    <FormattedMessage {...messages.articleCategory} />
+                  </p>
+                  <h3
+                    className={cn(
+                      "mt-4 max-w-2xl text-balance font-heading text-3xl leading-tight sm:text-5xl",
+                      highlightOnPage &&
+                        issue === "meta" &&
+                        "rounded-md ring-2 ring-destructive/50",
+                    )}
+                  >
+                    <FormattedMessage {...messages[article.title]} />
+                  </h3>
+                  <p
+                    className={cn(
+                      "mt-5 text-pretty text-sm leading-7 text-muted-foreground",
+                      highlightOnPage &&
+                        issue === "hreflang" &&
+                        "rounded-md bg-destructive/10 p-3 text-destructive",
+                    )}
+                  >
+                    {highlightOnPage && issue === "hreflang" ? (
+                      <FormattedMessage {...messages.highlightHreflang} />
+                    ) : highlightOnPage && issue === "meta" ? (
+                      <FormattedMessage {...messages.highlightMeta} />
+                    ) : (
+                      <FormattedMessage {...messages[article.intro]} />
+                    )}
+                  </p>
+                  {highlightOnPage && issue === "faq" ? (
+                    <p className="mt-5 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                      <FormattedMessage {...messages.highlightFaq} />
+                    </p>
+                  ) : null}
+                  <figure className="mt-6">
+                    <Image
+                      src="/images/nasa-Q1p7bh3SHj8-unsplash.jpg"
+                      alt={intl.formatMessage(messages[article.title])}
+                      width={4256}
+                      height={2832}
+                      sizes="(min-width: 1024px) 768px, (min-width: 640px) 80vw, 90vw"
+                      className="aspect-[2/1] w-full rounded-lg object-cover"
+                    />
+                  </figure>
+                </article>
+              </div>
+            </div>
+            <div className="rounded-xl border border-border bg-card p-5 text-card-foreground">
+              <p className="text-sm font-semibold">
+                <FormattedMessage {...messages.issuesHeading} />
+              </p>
+              <ul className="mt-4 space-y-2">
+                {issues.map((item) => (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setIssue(item.id);
+                        setLanguage(item.language);
+                      }}
+                      className={cn(
+                        "w-full rounded-md px-3 py-2 text-left text-xs leading-5",
+                        issue === item.id
+                          ? "border border-destructive/25 bg-destructive/10 text-destructive"
+                          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                      )}
+                    >
+                      <FormattedMessage {...messages[item.label]} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </figure>
+      </div>
+    </section>
+  );
+}
+
+function SearchSnippetSection() {
+  const [market, setMarket] = useState<PreviewLanguage>("en");
+  const article = articleCopy[market];
+  const missing = market === "de-DE";
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[.85fr_1.15fr] lg:items-center">
+        <div className="max-w-xl">
+          <Eyebrow>
+            <FormattedMessage {...messages.searchEyebrow} />
+          </Eyebrow>
+          <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+            <FormattedMessage {...messages.searchHeadline} />
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            <FormattedMessage {...messages.searchBody} />
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {previewLanguages.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setMarket(item.id)}
+                className={cn(
+                  "rounded-full px-3 py-1 text-xs",
+                  market === item.id
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground",
+                )}
+              >
+                <FormattedMessage {...messages[item.name]} />
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="relative isolate overflow-hidden rounded-xl p-4 sm:p-5">
+          <SectionMeshBackground src={SAGE_MESH_GRADIENT_SRC} className="opacity-80" />
+          <div className="relative rounded-xl border border-border bg-card p-6 text-card-foreground sm:p-8">
+            <p className="text-xs text-muted-foreground">
+              <FormattedMessage {...messages.searchUrl} />
+            </p>
+            <p className="mt-2 text-lg text-[#1a0dab] dark:text-primary">
+              <FormattedMessage {...messages[article.title]} />
+            </p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              {missing ? (
+                <span className="text-destructive">
+                  <FormattedMessage {...messages.searchMissing} />
+                </span>
+              ) : (
+                <FormattedMessage {...messages[article.intro]} />
+              )}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function DomainsPage() {
+  const locale = useAppLocale();
+  const intl = useIntl();
+  const faqItems = faqMessageKeys.map(([question, answer]) => ({
+    question: intl.formatMessage(messages[question]),
+    answer: intl.formatMessage(messages[answer]),
+  }));
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div>
+        <section className="bg-background px-5 py-20 text-center text-foreground sm:px-8 sm:py-24 lg:px-10">
+          <div className="mx-auto flex max-w-3xl flex-col items-center">
+            <Eyebrow>
+              <FormattedMessage {...messages.heroEyebrow} />
+            </Eyebrow>
+            <h1 className="mt-6 whitespace-pre-line font-heading text-[clamp(3rem,7vw,5.5rem)] leading-[0.98] tracking-[-0.045em]">
+              <FormattedMessage {...messages.heroHeadline} />
+            </h1>
+            <p className="mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+              <FormattedMessage {...messages.heroSubcopy} />
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button
+                size="lg"
+                nativeButton={false}
+                render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+              >
+                <FormattedMessage {...messages.requestDemo} />{" "}
+                <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                nativeButton={false}
+                render={<a href="#domains" />}
+              >
+                <FormattedMessage {...messages.exploreDomains} /> ↓
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-3 pb-0 sm:px-6 lg:px-8">
+          <DomainsPreview />
+          <div className="mx-auto flex max-w-6xl flex-col justify-between gap-4 border-b border-border py-7 text-sm text-muted-foreground sm:flex-row">
+            <span>
+              <FormattedMessage {...messages.fromPublishToFound} />
+            </span>
+            <span className="flex flex-wrap gap-x-7 gap-y-2">
+              <span>
+                <FormattedMessage {...messages.stepPublish} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepLanguages} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepSearch} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepFound} />
+              </span>
+            </span>
+          </div>
+        </section>
+
+        <DomainsSolutions />
+        <LiveSiteSection />
+        <SearchSnippetSection />
+
+        <section className="mx-auto max-w-7xl border-y border-border px-5 py-10 sm:px-8 lg:px-10">
+          <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-center">
+            <div>
+              <h2 className="text-2xl font-medium tracking-tight">
+                <FormattedMessage {...messages.connectedHeadline} />
+              </h2>
+              <p className="mt-2 text-base text-muted-foreground">
+                <FormattedMessage {...messages.connectedBody} />
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-6">
+              <Link
+                href={rewriteAppLocalePath("/product/multilingual-content-studio", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.contentStudio} /> ↗
+              </Link>
+              <Link
+                href={rewriteAppLocalePath("/product/hyperlab", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.hyperlab} /> ↗
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+          <HomepageFaqSection
+            items={faqItems}
+            heading={
+              <span className="whitespace-pre-line">
+                <FormattedMessage {...messages.faqHeading} />
+              </span>
+            }
+            subheading={<FormattedMessage {...messages.faqSubheading} />}
+          />
+        </div>
+
+        <section className="px-5 pb-20 sm:px-8 lg:px-10">
+          <MeshStage
+            className="mx-auto max-w-7xl"
+            contentClassName="p-0"
+            meshSrc={DUSK_MESH_GRADIENT_SRC}
+            mixSrc={ROSE_MESH_GRADIENT_SRC}
+          >
+            <div className="flex flex-col justify-between gap-10 bg-[#172541]/45 p-8 text-[#f8f0f5] sm:p-12 lg:flex-row lg:items-center lg:p-16">
+              <div>
+                <h2 className="whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+                  <FormattedMessage {...messages.ctaHeadline} />
+                </h2>
+                <p className="mt-5 text-lg text-[#e5edf9]">
+                  <FormattedMessage {...messages.ctaBody} />
+                </p>
+              </div>
+              <div className="flex flex-col items-start gap-3 lg:items-center">
+                <Button
+                  size="lg"
+                  className="bg-[#ebc36a] text-[#172541] hover:bg-[#f2db9b]"
+                  nativeButton={false}
+                  render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+                >
+                  <FormattedMessage {...messages.requestDemo} />{" "}
+                  <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+                </Button>
+                <span className="text-xs text-[#e5edf9]">
+                  <FormattedMessage {...messages.ctaNote} />
+                </span>
+              </div>
+            </div>
+          </MeshStage>
+        </section>
+
+        <section className="border-t border-border px-5 pt-16 sm:px-8 lg:px-10">
+          <MarketingFooter columns={footerColumns} />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.messages.ts
@@ -21,8 +21,8 @@ export const hyperlabMockMessages = defineMessages({
     description: "Hyperlab mock UI eyebrow label",
   },
   headline: {
-    defaultMessage: "Flags, experiments, and live evaluation in one workspace",
-    id: "gwEqR0+wNr",
+    defaultMessage: "Market experiments and market features in one workspace",
+    id: "P5eAlY/2+j",
     description: "Hyperlab mock UI section heading",
   },
   requestDemo: {
@@ -32,33 +32,33 @@ export const hyperlabMockMessages = defineMessages({
   },
 
   useCaseFlagsTitle: {
-    defaultMessage: "Feature flags",
-    id: "m17mlZ3/Yb",
+    defaultMessage: "Market features",
+    id: "bFtb6TziqW",
     description: "Hyperlab mock UI flags use case title",
   },
   useCaseFlagsDescription: {
-    defaultMessage: "Experiment and config flags scoped to your workspace",
-    id: "Lnk8DKi9bA",
+    defaultMessage: "A different checkout, price, or flow in Japan than in France",
+    id: "RepySojGxT",
     description: "Hyperlab mock UI flags use case description",
   },
   useCaseExperimentsTitle: {
-    defaultMessage: "A/B experiments",
-    id: "Jg5QWOEhGR",
+    defaultMessage: "Market experiments",
+    id: "bVFugH0E33",
     description: "Hyperlab mock UI experiments use case title",
   },
   useCaseExperimentsDescription: {
-    defaultMessage: "Split traffic, set rollout %, and activate when ready",
-    id: "JoFuLmCZ9Z",
+    defaultMessage: "Test in one country, then roll the winner to the rest",
+    id: "SoBpyZvv53",
     description: "Hyperlab mock UI experiments use case description",
   },
   useCaseAudiencesTitle: {
-    defaultMessage: "Audience targeting",
-    id: "t7vmy3s2y1",
+    defaultMessage: "One market first",
+    id: "ui5MGrW8sq",
     description: "Hyperlab mock UI audiences use case title",
   },
   useCaseAudiencesDescription: {
-    defaultMessage: "Attribute rules evaluated live on every request",
-    id: "bBNT4RDo7G",
+    defaultMessage: "Show the change only to visitors in France, Germany, or Japan",
+    id: "p82IGMKijr",
     description: "Hyperlab mock UI audiences use case description",
   },
 
@@ -94,8 +94,8 @@ export const hyperlabMockMessages = defineMessages({
     description: "Hyperlab mock UI flags panel title",
   },
   flagsPanelSubtitle: {
-    defaultMessage: "3 flags · 2 experiment, 1 config",
-    id: "PNw9tng+1C",
+    defaultMessage: "3 features · Japan, France, Germany",
+    id: "dUEmby2xEU",
     description: "Hyperlab mock UI flags panel subtitle",
   },
   flagCheckoutCta: {
@@ -130,8 +130,8 @@ export const hyperlabMockMessages = defineMessages({
     description: "Hyperlab mock UI experiments panel title",
   },
   experimentsPanelSubtitle: {
-    defaultMessage: "checkout-cta-test · A/B · Active",
-    id: "bLqYNXsXHH",
+    defaultMessage: "checkout-cta-jp · Japan A/B · Active",
+    id: "D+amXRmj7m",
     description: "Hyperlab mock UI experiments panel subtitle",
   },
   statusActive: {
@@ -161,18 +161,18 @@ export const hyperlabMockMessages = defineMessages({
     description: "Hyperlab mock UI audiences panel title",
   },
   audiencesPanelSubtitle: {
-    defaultMessage: "Pro users · 1 rule",
-    id: "75wQzkw69+",
+    defaultMessage: "Japan · 1 rule",
+    id: "NTrz53RFvO",
     description: "Hyperlab mock UI audiences panel subtitle",
   },
   audienceProUsers: {
-    defaultMessage: "Pro users",
-    id: "GMgwhbm+0k",
+    defaultMessage: "Japan",
+    id: "kiy9KSpjzE",
     description: "Hyperlab mock UI audience name",
   },
   criterionAttribute: {
-    defaultMessage: "plan",
-    id: "x1FhjXZK5S",
+    defaultMessage: "market",
+    id: "ms5PNFzyT0",
     description: "Hyperlab mock UI criterion attribute",
   },
   criterionMatch: {
@@ -181,8 +181,8 @@ export const hyperlabMockMessages = defineMessages({
     description: "Hyperlab mock UI criterion match operator",
   },
   criterionValue: {
-    defaultMessage: "pro",
-    id: "cVva7Hlu9m",
+    defaultMessage: "jp",
+    id: "FgAI7cwA3S",
     description: "Hyperlab mock UI criterion value",
   },
   evaluateTitle: {

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.stories.tsx
@@ -38,12 +38,12 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(
       canvas.getByRole("heading", {
-        name: "Flags, experiments, and live evaluation in one workspace",
+        name: "Market experiments and market features in one workspace",
       }),
     ).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Feature flags" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "A/B experiments" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Audience targeting" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Market features" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Market experiments" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "One market first" })).toBeInTheDocument();
     await expect(canvas.getByText("checkout-cta")).toBeInTheDocument();
     await expect(canvas.getByRole("link", { name: "Request a Demo" })).toBeInTheDocument();
   },

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-mock-ui.tsx
@@ -31,6 +31,8 @@ import { MarketingMockUseCaseSelector } from "./marketing-mock-use-case-selector
 
 type SceneId = "flags" | "experiments" | "audiences";
 
+export type HyperlabSceneId = SceneId;
+
 const SCENE_HOLD_MS = 3200;
 const ROLLOUT_STEP_MS = 700;
 
@@ -64,7 +66,7 @@ function MockNav({ active }: { active: SceneId }) {
   );
 }
 
-function FlagsPanel() {
+export function HyperlabFlagsPanel() {
   const intl = useIntl();
 
   const flags = useMemo(
@@ -128,7 +130,7 @@ function FlagsPanel() {
   );
 }
 
-function ExperimentsPanel({ rolloutPercent }: { rolloutPercent: number }) {
+export function HyperlabExperimentsPanel({ rolloutPercent }: { rolloutPercent: number }) {
   const intl = useIntl();
 
   const variants = useMemo(
@@ -189,7 +191,7 @@ function ExperimentsPanel({ rolloutPercent }: { rolloutPercent: number }) {
   );
 }
 
-function AudiencesPanel({ showEvaluate }: { showEvaluate: boolean }) {
+export function HyperlabAudiencesPanel({ showEvaluate }: { showEvaluate: boolean }) {
   const intl = useIntl();
 
   return (
@@ -251,6 +253,8 @@ export function HyperlabMockUI({
   variant = "full",
   aside,
   meshPosition = "left",
+  showMesh = true,
+  className,
 }: {
   priority?: boolean;
   pauseAutoplay?: boolean;
@@ -258,6 +262,8 @@ export function HyperlabMockUI({
   variant?: MarketingMockVariant;
   aside?: ReactNode;
   meshPosition?: MarketingMockMeshPosition;
+  showMesh?: boolean;
+  className?: string;
 }) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion();
@@ -352,11 +358,13 @@ export function HyperlabMockUI({
         transition={{ duration: 0.32, ease: [0.19, 1, 0.22, 1] }}
         className="w-full"
       >
-        {activeScene === "flags" ? <FlagsPanel /> : null}
+        {activeScene === "flags" ? <HyperlabFlagsPanel /> : null}
         {activeScene === "experiments" ? (
-          <ExperimentsPanel rolloutPercent={rolloutPercent} />
+          <HyperlabExperimentsPanel rolloutPercent={rolloutPercent} />
         ) : null}
-        {activeScene === "audiences" ? <AudiencesPanel showEvaluate={showEvaluate} /> : null}
+        {activeScene === "audiences" ? (
+          <HyperlabAudiencesPanel showEvaluate={showEvaluate} />
+        ) : null}
       </motion.div>
     </AnimatePresence>
   );
@@ -396,6 +404,8 @@ export function HyperlabMockUI({
       priority={priority}
       variant={variant}
       meshPosition={meshPosition}
+      showMesh={showMesh}
+      className={className}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-page.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-page.messages.ts
@@ -1,0 +1,404 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const hyperlabPageMessages = defineMessages({
+  heroEyebrow: {
+    defaultMessage: "Hyperlab",
+    id: "CDwxGsD+Cm",
+    description: "Hero eyebrow for the Hyperlab product page",
+  },
+  heroHeadline: {
+    defaultMessage: "Try it in one market.\nKeep what works.",
+    id: "AvgC2HJ861",
+    description: "Hero headline for the Hyperlab product page",
+  },
+  heroSubcopy: {
+    defaultMessage:
+      "Give Japan a different headline, checkout, or feature. Hyperlab shows if people there like it. Then you can take that version everywhere.",
+    id: "ZOtHEDGurR",
+    description: "Hero description for the Hyperlab product page",
+  },
+  requestDemo: {
+    defaultMessage: "Request a Demo",
+    id: "TMv6YqkMvj",
+    description: "Call-to-action to request a Hyperlab demo",
+  },
+  exploreHyperlab: {
+    defaultMessage: "See a market test",
+    id: "kMsw+6lY8Y",
+    description: "Anchor link from the Hyperlab hero to the product preview",
+  },
+  fromFlagToWinner: {
+    defaultMessage: "From one market to the version you keep.",
+    id: "liO7uk+9UW",
+    description: "Caption under the Hyperlab preview",
+  },
+  stepFlag: {
+    defaultMessage: "01 Different by market",
+    id: "FFZzZvy0kN",
+    description: "Hyperlab workflow step 1",
+  },
+  stepSplit: {
+    defaultMessage: "02 Test in one country",
+    id: "+WCxVTeO3+",
+    description: "Hyperlab workflow step 2",
+  },
+  stepAudience: {
+    defaultMessage: "03 Count what wins",
+    id: "kca9z02Mat",
+    description: "Hyperlab workflow step 3",
+  },
+  stepKeep: {
+    defaultMessage: "04 Take it everywhere",
+    id: "lMe/pmUjEJ",
+    description: "Hyperlab workflow step 4",
+  },
+  solutionsEyebrow: {
+    defaultMessage: "How a market test works",
+    id: "dAs6p/cC9Z",
+    description: "Eyebrow for the Hyperlab solutions section",
+  },
+  solutionsHeadline: {
+    defaultMessage: "Different features.\nOne market first.\nThen the rest.",
+    id: "N/RCvVM0YV",
+    description: "Headline for the Hyperlab solutions section",
+  },
+  solutionsBody: {
+    defaultMessage:
+      "Japan can try a new checkout while France keeps the original. Learn what works in one country before every market sees it.",
+    id: "SgbEZXiCwZ",
+    description: "Body copy for the Hyperlab solutions section",
+  },
+  solutionsAriaLabel: {
+    defaultMessage: "Hyperlab solutions",
+    id: "p7m/e5xqWF",
+    description: "Accessible label for the Hyperlab solution tabs",
+  },
+  solutionFlags: {
+    defaultMessage: "Different by market",
+    id: "p5qwf5gg9T",
+    description: "Hyperlab solution tab for flags",
+  },
+  solutionExperiments: {
+    defaultMessage: "Test in one market",
+    id: "gTXaucscnP",
+    description: "Hyperlab solution tab for experiments",
+  },
+  solutionAudiences: {
+    defaultMessage: "Then take it further",
+    id: "9VqlLubKvR",
+    description: "Hyperlab solution tab for audiences",
+  },
+  flagsTitle: {
+    defaultMessage: "Japan can have a different checkout.",
+    id: "HOUo411zIP",
+    description: "Title for the Hyperlab flags solution panel",
+  },
+  flagsBody: {
+    defaultMessage:
+      "Turn on a new feature for one country and leave every other market on the original. Flip it back if you do not like it.",
+    id: "6t36beYj9L",
+    description: "Body for the Hyperlab flags solution panel",
+  },
+  flagsLink: {
+    defaultMessage: "From a button label to a whole flow",
+    id: "WoJQD0Fykh",
+    description: "Supporting line for the Hyperlab flags solution panel",
+  },
+  experimentsTitle: {
+    defaultMessage: "Test in one market.\nCount what happens.",
+    id: "Sg0Mw2ebHp",
+    description: "Title for the Hyperlab experiments solution panel",
+  },
+  experimentsBody: {
+    defaultMessage:
+      "Show Germany a new headline. Keep France on the current one. Ship the version people actually use.",
+    id: "M50sgwhgz2",
+    description: "Body for the Hyperlab experiments solution panel",
+  },
+  experimentsLink: {
+    defaultMessage: "From one country to a full rollout",
+    id: "NsQEnPkjfU",
+    description: "Supporting line for the Hyperlab experiments solution panel",
+  },
+  audiencesTitle: {
+    defaultMessage: "Start in one country.",
+    id: "nguQzIA62o",
+    description: "Title for the Hyperlab audiences solution panel",
+  },
+  audiencesBody: {
+    defaultMessage:
+      "Run the test for visitors in France first. If it works, open Japan and Germany. If it does not, the rest of the world never saw it.",
+    id: "cy9+fmyi91",
+    description: "Body for the Hyperlab audiences solution panel",
+  },
+  audiencesLink: {
+    defaultMessage: "From one market to the whole world",
+    id: "8QLWjgu8y/",
+    description: "Supporting line for the Hyperlab audiences solution panel",
+  },
+  rollout25: {
+    defaultMessage: "25%",
+    id: "M/CX9tMhmy",
+    description: "Hyperlab experiment mock rollout control for 25 percent",
+  },
+  rollout50: {
+    defaultMessage: "50%",
+    id: "v3jXmIK6F3",
+    description: "Hyperlab experiment mock rollout control for 50 percent",
+  },
+  rollout75: {
+    defaultMessage: "75%",
+    id: "0LvMzIgqHs",
+    description: "Hyperlab experiment mock rollout control for 75 percent",
+  },
+  evaluateAction: {
+    defaultMessage: "See who matches",
+    id: "Lof8KeIU1O",
+    description: "Button to reveal the audience evaluate mock",
+  },
+  compareEyebrow: {
+    defaultMessage: "Same page. Two markets.",
+    id: "So4bx2xzG1",
+    description: "Eyebrow for the Hyperlab A/B comparison section",
+  },
+  compareHeadline: {
+    defaultMessage: "Tap the market version you would keep.",
+    id: "kRw106UBLA",
+    description: "Headline for the Hyperlab A/B comparison section",
+  },
+  compareBody: {
+    defaultMessage:
+      "France can keep the original. Japan can try a new line. Hyperlab does the same with real visitors in each country.",
+    id: "5wDjCytdZo",
+    description: "Body for the Hyperlab A/B comparison section",
+  },
+  compareVersionA: {
+    defaultMessage: "France",
+    id: "5dgeEUsPxT",
+    description: "Label for version A in the Hyperlab comparison mock",
+  },
+  compareVersionB: {
+    defaultMessage: "Japan",
+    id: "rCG1FEVOcs",
+    description: "Label for version B in the Hyperlab comparison mock",
+  },
+  compareHeadlineA: {
+    defaultMessage: "See the world in a different light.",
+    id: "5QHtbyWfn3",
+    description: "Sample headline A in the Hyperlab comparison mock",
+  },
+  compareHeadlineB: {
+    defaultMessage: "A little further. A little closer.",
+    id: "ujIWc70BPf",
+    description: "Sample headline B in the Hyperlab comparison mock",
+  },
+  compareCtaA: {
+    defaultMessage: "Get started",
+    id: "a+y3L+ar21",
+    description: "Sample button A in the Hyperlab comparison mock",
+  },
+  compareCtaB: {
+    defaultMessage: "Start free",
+    id: "BOsq0bvlqU",
+    description: "Sample button B in the Hyperlab comparison mock",
+  },
+  compareWinner: {
+    defaultMessage: "This version is winning",
+    id: "lcC1NvacAi",
+    description: "Winner badge in the Hyperlab comparison mock",
+  },
+  compareHint: {
+    defaultMessage: "Click a card to pick a market winner.",
+    id: "jwJxvtEYDr",
+    description: "Hint under the Hyperlab comparison mock",
+  },
+  audienceEyebrow: {
+    defaultMessage: "Who sees the new version",
+    id: "C5SziqsTbT",
+    description: "Eyebrow for the Hyperlab audience targeting section",
+  },
+  audienceHeadline: {
+    defaultMessage: "Start in one market.\nThen open the next.",
+    id: "NrjzWDSt6p",
+    description: "Headline for the Hyperlab audience targeting section",
+  },
+  audienceBody: {
+    defaultMessage:
+      "Run the change for Japan first. If it works, show it to every market. If it does not, nobody else ever saw it.",
+    id: "jUaILvHKPq",
+    description: "Body for the Hyperlab audience targeting section",
+  },
+  audienceEveryone: {
+    defaultMessage: "Every market",
+    id: "7ozFg2fpXs",
+    description: "Audience selector option for all visitors",
+  },
+  audienceProFrance: {
+    defaultMessage: "Japan only",
+    id: "WjB4ZUzNnv",
+    description: "Audience selector option for visitors in Japan",
+  },
+  audiencePreviewOriginal: {
+    defaultMessage: "Original page",
+    id: "7JjKbhttRR",
+    description: "Label when the visitor sees the original page",
+  },
+  audiencePreviewTreatment: {
+    defaultMessage: "New version",
+    id: "4OBGi64yDo",
+    description: "Label when the visitor sees the treatment page",
+  },
+  audienceVisitor: {
+    defaultMessage: "You are this visitor",
+    id: "k0BSdK37u2",
+    description: "Caption for the audience visitor toggle",
+  },
+  connectedHeadline: {
+    defaultMessage: "A lab connected to the bigger picture.",
+    id: "tAIkYXyE7a",
+    description: "Headline for the Hyperlab connected-products section",
+  },
+  connectedBody: {
+    defaultMessage:
+      "Write the versions in Content Studio. Publish them on Domains. Test them here, market by market.",
+    id: "Y31wArh4YG",
+    description: "Body for the Hyperlab connected-products section",
+  },
+  contentStudio: {
+    defaultMessage: "Content Studio",
+    id: "UCLrz7xtcS",
+    description: "Link from Hyperlab to the Content Studio product page",
+  },
+  domains: {
+    defaultMessage: "Domains",
+    id: "L3WOPNvG0H",
+    description: "Link from Hyperlab to the Domains product page",
+  },
+  faqHeading: {
+    defaultMessage: "A few things\nyou might ask.",
+    id: "xEFopjYrT0",
+    description: "FAQ heading on the Hyperlab product page",
+  },
+  faqSubheading: {
+    defaultMessage: "Getting to know Hyperlab.",
+    id: "29/DpR+ioc",
+    description: "FAQ subheading on the Hyperlab product page",
+  },
+  faqWhatQuestion: {
+    defaultMessage: "What is Hyperlab, in one sentence?",
+    id: "Vp/ZC71Tvv",
+    description: "Hyperlab FAQ question explaining the product",
+  },
+  faqWhatAnswer: {
+    defaultMessage:
+      "A place to try a different headline, page, or feature in one market, see if people there like it, and take the winner everywhere.",
+    id: "RSmeT10XK6",
+    description: "Hyperlab FAQ answer explaining the product",
+  },
+  faqFlagQuestion: {
+    defaultMessage: "Can each market have a different feature?",
+    id: "yQ/q3xyZ03",
+    description: "Hyperlab FAQ question about flags",
+  },
+  faqFlagAnswer: {
+    defaultMessage:
+      "Yes. Japan can see a new checkout while France stays on the original. You choose which markets get the change.",
+    id: "U4l3MJE1g3",
+    description: "Hyperlab FAQ answer about flags",
+  },
+  faqExperimentQuestion: {
+    defaultMessage: "What is a market experiment?",
+    id: "85aR9g7GOw",
+    description: "Hyperlab FAQ question about experiments",
+  },
+  faqExperimentAnswer: {
+    defaultMessage:
+      "Show one version in Germany and another in France, or split visitors inside one country. Keep the version that wins, then open more markets.",
+    id: "n8zbO6fRBk",
+    description: "Hyperlab FAQ answer about experiments",
+  },
+  faqAudienceQuestion: {
+    defaultMessage: "Do I have to test everywhere at once?",
+    id: "+EJBhhraYS",
+    description: "Hyperlab FAQ question about audiences",
+  },
+  faqAudienceAnswer: {
+    defaultMessage:
+      "No. Start with visitors in one country. If it works, show it to more markets. If it does not, nobody else saw it.",
+    id: "qeC3i4BZFh",
+    description: "Hyperlab FAQ answer about audiences",
+  },
+  faqCmsQuestion: {
+    defaultMessage: "Do I need to replace my CMS?",
+    id: "IsR/ITp9/m",
+    description: "Hyperlab FAQ question about CMS replacement",
+  },
+  faqCmsAnswer: {
+    defaultMessage:
+      "No. Hyperlab works with the site and content you already have. It decides which version each visitor sees.",
+    id: "QGaxqP2Jqi",
+    description: "Hyperlab FAQ answer about CMS replacement",
+  },
+  faqFitQuestion: {
+    defaultMessage: "How does Hyperlab fit with the rest of Hyperlocalise?",
+    id: "By3HvPtHju",
+    description: "Hyperlab FAQ question about product fit",
+  },
+  faqFitAnswer: {
+    defaultMessage:
+      "Content Studio writes the versions. Domains publishes them. Hyperlab tells you which market version to keep.",
+    id: "xp7a595BAV",
+    description: "Hyperlab FAQ answer about product fit",
+  },
+  faqWhoQuestion: {
+    defaultMessage: "Who is Hyperlab for?",
+    id: "GQEEdUz3IV",
+    description: "Hyperlab FAQ question about audience",
+  },
+  faqWhoAnswer: {
+    defaultMessage:
+      "Marketing, product, and localisation teams who would rather test a change in one market than guess for every country.",
+    id: "KQoHQk2Shn",
+    description: "Hyperlab FAQ answer about audience",
+  },
+  faqStartQuestion: {
+    defaultMessage: "How can we get started?",
+    id: "TdNvcRaC0s",
+    description: "Hyperlab FAQ question about getting started",
+  },
+  faqStartAnswer: {
+    defaultMessage:
+      "Request a demo. We will walk through a market experiment and a feature that only some countries see.",
+    id: "jfrmvbYbYG",
+    description: "Hyperlab FAQ answer about getting started",
+  },
+  ctaHeadline: {
+    defaultMessage: "Stop guessing\nwhat each market wants.",
+    id: "swCjOVTXG7",
+    description: "Bottom CTA headline on the Hyperlab product page",
+  },
+  ctaBody: {
+    defaultMessage: "Try the next checkout in Japan before every other market sees it.",
+    id: "ZDIt263djb",
+    description: "Bottom CTA body on the Hyperlab product page",
+  },
+  ctaNote: {
+    defaultMessage: "Build your market experiment workflow.",
+    id: "5Tu1c9nH3B",
+    description: "Supporting note under the Hyperlab bottom CTA",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-page.test.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-page.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it } from "vite-plus/test";
+
+import { HyperlabPage } from "./hyperlab-page";
+
+describe("HyperlabPage", () => {
+  it("lets visitors pick a winning headline", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <HyperlabPage />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: /Try it in one market/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Japan.*Start free/i }));
+
+    expect(screen.getByText("This version is winning")).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/hyperlab-page.tsx
@@ -1,0 +1,557 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+import { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import {
+  DUSK_MESH_GRADIENT_SRC,
+  LAVENDER_MESH_GRADIENT_SRC,
+  MeshStage,
+  ROSE_MESH_GRADIENT_SRC,
+  SAGE_MESH_GRADIENT_SRC,
+  SectionMeshBackground,
+} from "@/components/marketing/hero-frame-mesh-stage";
+import { HomepageFaqSection } from "@/components/marketing/homepage-faq-section";
+import { MarketingFooter } from "@/components/marketing/marketing-footer";
+import { footerColumns } from "@/components/marketing/marketing-page-content";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Button } from "@/components/ui/button";
+import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
+import { useAppLocale } from "@/lib/app-i18n/use-app-locale";
+import { cn } from "@/lib/primitives/cn";
+
+import {
+  HyperlabAudiencesPanel,
+  HyperlabExperimentsPanel,
+  HyperlabFlagsPanel,
+  HyperlabMockUI,
+  type HyperlabSceneId,
+} from "./hyperlab-mock-ui";
+import { hyperlabPageMessages as messages } from "./hyperlab-page.messages";
+
+const solutionIds = [
+  "flags",
+  "experiments",
+  "audiences",
+] as const satisfies readonly HyperlabSceneId[];
+
+const solutionLabelKeys = {
+  flags: "solutionFlags",
+  experiments: "solutionExperiments",
+  audiences: "solutionAudiences",
+} as const;
+
+const solutionCopyKeys = {
+  flags: {
+    title: "flagsTitle",
+    body: "flagsBody",
+    link: "flagsLink",
+  },
+  experiments: {
+    title: "experimentsTitle",
+    body: "experimentsBody",
+    link: "experimentsLink",
+  },
+  audiences: {
+    title: "audiencesTitle",
+    body: "audiencesBody",
+    link: "audiencesLink",
+  },
+} as const;
+
+const faqMessageKeys = [
+  ["faqWhatQuestion", "faqWhatAnswer"],
+  ["faqFlagQuestion", "faqFlagAnswer"],
+  ["faqExperimentQuestion", "faqExperimentAnswer"],
+  ["faqAudienceQuestion", "faqAudienceAnswer"],
+  ["faqCmsQuestion", "faqCmsAnswer"],
+  ["faqFitQuestion", "faqFitAnswer"],
+  ["faqWhoQuestion", "faqWhoAnswer"],
+  ["faqStartQuestion", "faqStartAnswer"],
+] as const;
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return <p className="text-xs font-medium text-muted-foreground">{children}</p>;
+}
+
+function HyperlabPreview() {
+  return (
+    <div id="hyperlab" className="mx-auto max-w-6xl">
+      <MeshStage
+        className="w-full"
+        contentClassName="px-3 pt-3 pb-0 sm:px-8 sm:pt-8 lg:px-10 lg:pt-10"
+        meshSrc={LAVENDER_MESH_GRADIENT_SRC}
+        priority
+      >
+        <HyperlabMockUI
+          priority
+          showMesh={false}
+          className="rounded-t-xl rounded-b-none border-0 shadow-2xl shadow-[#172541]/20"
+        />
+      </MeshStage>
+    </div>
+  );
+}
+
+function SolutionPreview({
+  solution,
+  rolloutPercent,
+  onRolloutChange,
+  showEvaluate,
+  onEvaluate,
+}: {
+  solution: HyperlabSceneId;
+  rolloutPercent: number;
+  onRolloutChange: (value: number) => void;
+  showEvaluate: boolean;
+  onEvaluate: () => void;
+}) {
+  const intl = useIntl();
+
+  if (solution === "experiments") {
+    return (
+      <div className="relative isolate flex min-h-80 flex-1 flex-col justify-center gap-4 overflow-hidden p-4 sm:p-6">
+        <SectionMeshBackground src={ROSE_MESH_GRADIENT_SRC} className="opacity-75" />
+        <div className="relative flex flex-wrap gap-2">
+          {([25, 50, 75] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onRolloutChange(value)}
+              className={cn(
+                "min-h-11 rounded-md border px-3 text-sm",
+                rolloutPercent === value
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border bg-background/80 text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <FormattedMessage
+                {...(value === 25
+                  ? messages.rollout25
+                  : value === 50
+                    ? messages.rollout50
+                    : messages.rollout75)}
+              />
+            </button>
+          ))}
+        </div>
+        <div className="relative">
+          <HyperlabExperimentsPanel rolloutPercent={rolloutPercent} />
+        </div>
+        <span className="sr-only">
+          {intl.formatMessage(messages.experimentsTitle)} {rolloutPercent}%
+        </span>
+      </div>
+    );
+  }
+
+  if (solution === "audiences") {
+    return (
+      <div className="relative isolate flex min-h-80 flex-1 flex-col justify-center gap-4 overflow-hidden p-4 sm:p-6">
+        <SectionMeshBackground src={SAGE_MESH_GRADIENT_SRC} className="opacity-80" />
+        <div className="relative">
+          <HyperlabAudiencesPanel showEvaluate={showEvaluate} />
+        </div>
+        {showEvaluate ? null : (
+          <div className="relative">
+            <Button type="button" variant="outline" onClick={onEvaluate}>
+              <FormattedMessage {...messages.evaluateAction} />
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative isolate flex min-h-80 flex-1 items-center overflow-hidden p-4 sm:p-6">
+      <SectionMeshBackground src={LAVENDER_MESH_GRADIENT_SRC} className="opacity-80" />
+      <div className="relative w-full">
+        <HyperlabFlagsPanel />
+      </div>
+    </div>
+  );
+}
+
+function HyperlabSolutions() {
+  const intl = useIntl();
+  const [solution, setSolution] = useState<HyperlabSceneId>("flags");
+  const [rolloutPercent, setRolloutPercent] = useState(50);
+  const [showEvaluate, setShowEvaluate] = useState(false);
+  const copy = solutionCopyKeys[solution];
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto max-w-7xl">
+        <div className="flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
+          <div>
+            <Eyebrow>
+              <FormattedMessage {...messages.solutionsEyebrow} />
+            </Eyebrow>
+            <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+              <FormattedMessage {...messages.solutionsHeadline} />
+            </h2>
+          </div>
+          <p className="max-w-md text-lg leading-8 text-muted-foreground">
+            <FormattedMessage {...messages.solutionsBody} />
+          </p>
+        </div>
+        <div
+          className="mt-10 flex gap-7 overflow-x-auto"
+          role="tablist"
+          aria-label={intl.formatMessage(messages.solutionsAriaLabel)}
+        >
+          {solutionIds.map((item) => (
+            <button
+              key={item}
+              type="button"
+              role="tab"
+              aria-selected={solution === item}
+              onClick={() => {
+                setSolution(item);
+                setShowEvaluate(false);
+              }}
+              className={
+                solution === item
+                  ? "shrink-0 border-b-2 border-primary pb-3 text-sm text-primary"
+                  : "shrink-0 pb-3 text-sm text-muted-foreground hover:text-foreground"
+              }
+            >
+              <FormattedMessage {...messages[solutionLabelKeys[item]]} />
+            </button>
+          ))}
+        </div>
+        <div className="mt-6 overflow-hidden rounded-xl bg-muted lg:flex">
+          <div className="flex w-full shrink-0 flex-col justify-center gap-5 bg-background/55 p-8 lg:w-[34%] lg:p-12">
+            <h3 className="whitespace-pre-line text-2xl leading-8 font-semibold tracking-tight">
+              <FormattedMessage {...messages[copy.title]} />
+            </h3>
+            <p className="text-base leading-7 text-muted-foreground">
+              <FormattedMessage {...messages[copy.body]} />
+            </p>
+            <p className="pt-2 text-sm text-primary">
+              <FormattedMessage {...messages[copy.link]} /> ↗
+            </p>
+          </div>
+          <SolutionPreview
+            solution={solution}
+            rolloutPercent={rolloutPercent}
+            onRolloutChange={setRolloutPercent}
+            showEvaluate={showEvaluate}
+            onEvaluate={() => setShowEvaluate(true)}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CompareSection() {
+  const [winner, setWinner] = useState<"a" | "b" | null>(null);
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[.85fr_1.15fr] lg:items-center">
+        <div className="max-w-xl">
+          <Eyebrow>
+            <FormattedMessage {...messages.compareEyebrow} />
+          </Eyebrow>
+          <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+            <FormattedMessage {...messages.compareHeadline} />
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            <FormattedMessage {...messages.compareBody} />
+          </p>
+          <p className="mt-5 text-sm text-muted-foreground">
+            <FormattedMessage {...messages.compareHint} />
+          </p>
+        </div>
+        <div className="relative isolate overflow-hidden rounded-xl p-4 sm:p-5">
+          <SectionMeshBackground src={LAVENDER_MESH_GRADIENT_SRC} className="opacity-80" />
+          <div className="relative grid gap-4 sm:grid-cols-2">
+            {(
+              [
+                ["a", "compareVersionA", "compareHeadlineA", "compareCtaA"],
+                ["b", "compareVersionB", "compareHeadlineB", "compareCtaB"],
+              ] as const
+            ).map(([id, version, headline, cta]) => {
+              const selected = winner === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setWinner(id)}
+                  className={cn(
+                    "rounded-xl border bg-card p-6 text-left text-card-foreground transition-colors",
+                    selected ? "border-primary ring-2 ring-primary/30" : "border-border",
+                  )}
+                >
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="font-medium text-muted-foreground">
+                      <FormattedMessage {...messages[version]} />
+                    </span>
+                    {selected ? (
+                      <span className="text-primary">
+                        <FormattedMessage {...messages.compareWinner} />
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="mt-5 font-heading text-2xl leading-tight">
+                    <FormattedMessage {...messages[headline]} />
+                  </p>
+                  <span className="mt-6 inline-flex rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground">
+                    <FormattedMessage {...messages[cta]} />
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AudienceSection() {
+  const [visitor, setVisitor] = useState<"everyone" | "pro">("everyone");
+  const seesTreatment = visitor === "pro";
+
+  return (
+    <section className="px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+      <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[1.05fr_.95fr] lg:items-center">
+        <div className="relative isolate overflow-hidden rounded-xl p-4 sm:p-5">
+          <SectionMeshBackground src={ROSE_MESH_GRADIENT_SRC} className="opacity-75" />
+          <div className="relative overflow-hidden rounded-lg border border-border bg-card">
+            <div className="flex flex-wrap justify-between gap-3 bg-muted/60 p-5 text-sm">
+              <b>
+                <FormattedMessage {...messages.audienceVisitor} />
+              </b>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setVisitor("everyone")}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-xs",
+                    visitor === "everyone"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-background text-muted-foreground",
+                  )}
+                >
+                  <FormattedMessage {...messages.audienceEveryone} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setVisitor("pro")}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-xs",
+                    visitor === "pro"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-background text-muted-foreground",
+                  )}
+                >
+                  <FormattedMessage {...messages.audienceProFrance} />
+                </button>
+              </div>
+            </div>
+            <div className="p-6 sm:p-8">
+              <p className="text-xs font-medium text-primary">
+                <FormattedMessage
+                  {...(seesTreatment
+                    ? messages.audiencePreviewTreatment
+                    : messages.audiencePreviewOriginal)}
+                />
+              </p>
+              <p className="mt-4 font-heading text-3xl leading-tight">
+                <FormattedMessage
+                  {...(seesTreatment ? messages.compareHeadlineB : messages.compareHeadlineA)}
+                />
+              </p>
+              <span className="mt-6 inline-flex rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground">
+                <FormattedMessage
+                  {...(seesTreatment ? messages.compareCtaB : messages.compareCtaA)}
+                />
+              </span>
+            </div>
+          </div>
+        </div>
+        <div>
+          <Eyebrow>
+            <FormattedMessage {...messages.audienceEyebrow} />
+          </Eyebrow>
+          <h2 className="mt-5 whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+            <FormattedMessage {...messages.audienceHeadline} />
+          </h2>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            <FormattedMessage {...messages.audienceBody} />
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function HyperlabPage() {
+  const locale = useAppLocale();
+  const intl = useIntl();
+  const faqItems = faqMessageKeys.map(([question, answer]) => ({
+    question: intl.formatMessage(messages[question]),
+    answer: intl.formatMessage(messages[answer]),
+  }));
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div>
+        <section className="bg-background px-5 py-20 text-center text-foreground sm:px-8 sm:py-24 lg:px-10">
+          <div className="mx-auto flex max-w-3xl flex-col items-center">
+            <Eyebrow>
+              <FormattedMessage {...messages.heroEyebrow} />
+            </Eyebrow>
+            <h1 className="mt-6 whitespace-pre-line font-heading text-[clamp(3rem,7vw,5.5rem)] leading-[0.98] tracking-[-0.045em]">
+              <FormattedMessage {...messages.heroHeadline} />
+            </h1>
+            <p className="mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+              <FormattedMessage {...messages.heroSubcopy} />
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button
+                size="lg"
+                nativeButton={false}
+                render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+              >
+                <FormattedMessage {...messages.requestDemo} />{" "}
+                <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                nativeButton={false}
+                render={<a href="#hyperlab" />}
+              >
+                <FormattedMessage {...messages.exploreHyperlab} /> ↓
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-3 pb-0 sm:px-6 lg:px-8">
+          <HyperlabPreview />
+          <div className="mx-auto flex max-w-6xl flex-col justify-between gap-4 border-b border-border py-7 text-sm text-muted-foreground sm:flex-row">
+            <span>
+              <FormattedMessage {...messages.fromFlagToWinner} />
+            </span>
+            <span className="flex flex-wrap gap-x-7 gap-y-2">
+              <span>
+                <FormattedMessage {...messages.stepFlag} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepSplit} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepAudience} />
+              </span>
+              <span>
+                <FormattedMessage {...messages.stepKeep} />
+              </span>
+            </span>
+          </div>
+        </section>
+
+        <HyperlabSolutions />
+        <CompareSection />
+        <AudienceSection />
+
+        <section className="mx-auto max-w-7xl border-y border-border px-5 py-10 sm:px-8 lg:px-10">
+          <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-center">
+            <div>
+              <h2 className="text-2xl font-medium tracking-tight">
+                <FormattedMessage {...messages.connectedHeadline} />
+              </h2>
+              <p className="mt-2 text-base text-muted-foreground">
+                <FormattedMessage {...messages.connectedBody} />
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-6">
+              <Link
+                href={rewriteAppLocalePath("/product/multilingual-content-studio", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.contentStudio} /> ↗
+              </Link>
+              <Link
+                href={rewriteAppLocalePath("/product/domains", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.domains} /> ↗
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-8 lg:px-10 lg:py-24">
+          <HomepageFaqSection
+            items={faqItems}
+            heading={
+              <span className="whitespace-pre-line">
+                <FormattedMessage {...messages.faqHeading} />
+              </span>
+            }
+            subheading={<FormattedMessage {...messages.faqSubheading} />}
+          />
+        </div>
+
+        <section className="px-5 pb-20 sm:px-8 lg:px-10">
+          <MeshStage
+            className="mx-auto max-w-7xl"
+            contentClassName="p-0"
+            meshSrc={DUSK_MESH_GRADIENT_SRC}
+            mixSrc={ROSE_MESH_GRADIENT_SRC}
+          >
+            <div className="flex flex-col justify-between gap-10 bg-[#172541]/45 p-8 text-[#f8f0f5] sm:p-12 lg:flex-row lg:items-center lg:p-16">
+              <div>
+                <h2 className="whitespace-pre-line font-heading text-4xl leading-tight tracking-tight sm:text-5xl">
+                  <FormattedMessage {...messages.ctaHeadline} />
+                </h2>
+                <p className="mt-5 text-lg text-[#e5edf9]">
+                  <FormattedMessage {...messages.ctaBody} />
+                </p>
+              </div>
+              <div className="flex flex-col items-start gap-3 lg:items-center">
+                <Button
+                  size="lg"
+                  className="bg-[#ebc36a] text-[#172541] hover:bg-[#f2db9b]"
+                  nativeButton={false}
+                  render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+                >
+                  <FormattedMessage {...messages.requestDemo} />{" "}
+                  <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+                </Button>
+                <span className="text-xs text-[#e5edf9]">
+                  <FormattedMessage {...messages.ctaNote} />
+                </span>
+              </div>
+            </div>
+          </MeshStage>
+        </section>
+
+        <section className="border-t border-border px-5 pt-16 sm:px-8 lg:px-10">
+          <MarketingFooter columns={footerColumns} />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/product/marketing-mock-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/marketing-mock-shell.tsx
@@ -28,6 +28,7 @@ export function MarketingMockShell({
   priority = false,
   variant = "full",
   meshPosition = "left",
+  showMesh = true,
   className,
 }: {
   visual: ReactNode;
@@ -37,6 +38,7 @@ export function MarketingMockShell({
   priority?: boolean;
   variant?: MarketingMockVariant;
   meshPosition?: MarketingMockMeshPosition;
+  showMesh?: boolean;
   className?: string;
 }) {
   const showSidebar = variant === "full" && sidebar && !aside;
@@ -52,16 +54,20 @@ export function MarketingMockShell({
         meshOnRight && isSplit && "md:border-l md:border-border",
       )}
     >
-      <Image
-        src={meshSrc}
-        alt=""
-        aria-hidden
-        fill
-        priority={priority}
-        sizes={isSplit ? "(min-width: 768px) 36rem, 100vw" : "100vw"}
-        className="pointer-events-none object-cover object-center"
-      />
-      {isSplit ? (
+      {showMesh ? (
+        <Image
+          src={meshSrc}
+          alt=""
+          aria-hidden
+          fill
+          priority={priority}
+          sizes={isSplit ? "(min-width: 768px) 36rem, 100vw" : "100vw"}
+          className="pointer-events-none object-cover object-center"
+        />
+      ) : (
+        <div aria-hidden className="absolute inset-0 bg-muted/40" />
+      )}
+      {showMesh && isSplit ? (
         <div
           aria-hidden
           className={cn(

--- a/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.messages.ts
@@ -404,6 +404,16 @@ export const multilingualContentStudioPageMessages = defineMessages({
     id: "BJpPKh03Ub",
     description: "Link from Content Studio to the Guidelines product page",
   },
+  domains: {
+    defaultMessage: "Domains",
+    id: "J8xBi9C1wa",
+    description: "Link from Content Studio to the Domains product page",
+  },
+  hyperlab: {
+    defaultMessage: "Hyperlab",
+    id: "sDAG01MYru",
+    description: "Link from Content Studio to the Hyperlab product page",
+  },
   faqHeading: {
     defaultMessage: "A few things\nyou might ask.",
     id: "pS4CYtUU3j",

--- a/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/multilingual-content-studio-page.tsx
@@ -842,6 +842,18 @@ export function MultilingualContentStudioPage() {
               >
                 <FormattedMessage {...messages.guidelines} /> ↗
               </Link>
+              <Link
+                href={rewriteAppLocalePath("/product/domains", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.domains} /> ↗
+              </Link>
+              <Link
+                href={rewriteAppLocalePath("/product/hyperlab", locale)}
+                className="text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <FormattedMessage {...messages.hyperlab} /> ↗
+              </Link>
             </div>
           </div>
         </section>

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.messages.ts
@@ -60,6 +60,16 @@ export const productPageMessages = defineMessages({
     id: "gtD9AzyGIn",
     description: "Navigation label for the Guidelines product page",
   },
+  productNavDomains: {
+    defaultMessage: "Domains",
+    id: "7xOUFwYHfE",
+    description: "Navigation label for the Domains product page",
+  },
+  productNavHyperlab: {
+    defaultMessage: "Hyperlab",
+    id: "wCH+Hr/sNP",
+    description: "Navigation label for the Hyperlab product page",
+  },
   visualAutomationLaunchRequest: {
     defaultMessage: "Launch request",
     id: "SmCgybn22Q",
@@ -481,6 +491,166 @@ export const productPageMessages = defineMessages({
       "Connect Drive, Notion, or SharePoint, or type guidelines in, and check the next draft against them.",
     id: "cqdHse07GI",
     description: "Bottom CTA description for the Guidelines product page",
+  },
+  domainsMetadataTitle: {
+    defaultMessage: "Publish Once. Get Found Everywhere. | Hyperlocalise",
+    id: "0wVg6cogQx",
+    description: "Page title for the Domains product page",
+  },
+  domainsMetadataDescription: {
+    defaultMessage:
+      "Publish multilingual pages, then check localisation, search, and AI answers so people can find them in every market.",
+    id: "HdHkhWUK6b",
+    description: "Meta description for the Domains product page",
+  },
+  domainsHeroEyebrow: {
+    defaultMessage: "Domains",
+    id: "q82hDvskBV",
+    description: "Hero eyebrow for the Domains product page",
+  },
+  domainsHeroHeadline: {
+    defaultMessage: "Publish once. Get found everywhere.",
+    id: "G3hsgHI8K5",
+    description: "Hero headline for the Domains product page",
+  },
+  domainsHeroSubcopy: {
+    defaultMessage:
+      "Put your pages live in every language. Domains watches search and AI answers, then shows you what to fix.",
+    id: "rOi9K00n5n",
+    description: "Hero subcopy for the Domains product page",
+  },
+  domainsDetailsHeadline: {
+    defaultMessage: "A live site is not enough if nobody can find it.",
+    id: "nbCxIw5Qbn",
+    description: "Details section headline for the Domains product page",
+  },
+  domainsSummary: {
+    defaultMessage:
+      "Domains hosts your multilingual pages and checks that each language, search snippet, and AI answer points to the right place.",
+    id: "fQnyk9TobX",
+    description: "Details section summary for the Domains product page",
+  },
+  domainsProof0Title: {
+    defaultMessage: "Every language has a page",
+    id: "BQNqLf7i/j",
+    description: "Proof point 1 title for the Domains product page",
+  },
+  domainsProof0Body: {
+    defaultMessage:
+      "Missing locales and broken language links show up before a customer hits a 404.",
+    id: "WpiT19K1oY",
+    description: "Proof point 1 body for the Domains product page",
+  },
+  domainsProof1Title: {
+    defaultMessage: "Search can read it",
+    id: "fxy2Q92Fyj",
+    description: "Proof point 2 title for the Domains product page",
+  },
+  domainsProof1Body: {
+    defaultMessage:
+      "Titles, descriptions, and indexability are checked per market, not only in English.",
+    id: "PDu1wBKWkk",
+    description: "Proof point 2 body for the Domains product page",
+  },
+  domainsProof2Title: {
+    defaultMessage: "AI can answer with it",
+    id: "FBbrFMvQnh",
+    description: "Proof point 3 title for the Domains product page",
+  },
+  domainsProof2Body: {
+    defaultMessage:
+      "FAQ and structured answers help AI search tools cite your page instead of a competitor.",
+    id: "PrUPxIA6cW",
+    description: "Proof point 3 body for the Domains product page",
+  },
+  domainsCtaHeadline: {
+    defaultMessage: "Your site. Ready for every market.",
+    id: "c5du4mwELJ",
+    description: "Bottom CTA headline for the Domains product page",
+  },
+  domainsCtaDescription: {
+    defaultMessage: "Publish the pages you already have, then fix what search and AI still miss.",
+    id: "O/p1Cca1WB",
+    description: "Bottom CTA description for the Domains product page",
+  },
+  hyperlabMetadataTitle: {
+    defaultMessage: "Try It in One Market. Keep What Works. | Hyperlocalise",
+    id: "t6xBRSvtG0",
+    description: "Page title for the Hyperlab product page",
+  },
+  hyperlabMetadataDescription: {
+    defaultMessage:
+      "Run market experiments and show different features by country. Hyperlab tells you what works, then you take that version everywhere.",
+    id: "EKVrW1yga/",
+    description: "Meta description for the Hyperlab product page",
+  },
+  hyperlabHeroEyebrow: {
+    defaultMessage: "Hyperlab",
+    id: "CDwxGsD+Cm",
+    description: "Hero eyebrow for the Hyperlab product page",
+  },
+  hyperlabHeroHeadline: {
+    defaultMessage: "Try it in one market. Keep what works.",
+    id: "AzSxI6EMSh",
+    description: "Hero headline for the Hyperlab product page",
+  },
+  hyperlabHeroSubcopy: {
+    defaultMessage:
+      "Give Japan a different headline, checkout, or feature. Hyperlab shows if people there like it. Then you can take that version everywhere.",
+    id: "K0+M6xQCc2",
+    description: "Hero subcopy for the Hyperlab product page",
+  },
+  hyperlabDetailsHeadline: {
+    defaultMessage: "Guessing is expensive. A small market test is not.",
+    id: "lzHNFV9Hx6",
+    description: "Details section headline for the Hyperlab product page",
+  },
+  hyperlabSummary: {
+    defaultMessage:
+      "Show a different feature in one country, test it against the original, and roll it out when that market likes it.",
+    id: "3uyKWUL6tX",
+    description: "Details section summary for the Hyperlab product page",
+  },
+  hyperlabProof0Title: {
+    defaultMessage: "Different by market",
+    id: "9tycO/UT27",
+    description: "Proof point 1 title for the Hyperlab product page",
+  },
+  hyperlabProof0Body: {
+    defaultMessage: "Japan can see a new checkout while France stays on the original.",
+    id: "qeiT6t1lgh",
+    description: "Proof point 1 body for the Hyperlab product page",
+  },
+  hyperlabProof1Title: {
+    defaultMessage: "Test in one country",
+    id: "DbMjwmxUeT",
+    description: "Proof point 2 title for the Hyperlab product page",
+  },
+  hyperlabProof1Body: {
+    defaultMessage:
+      "Show Germany a new headline. Keep the rest of the world on the current one. Ship the version people actually use.",
+    id: "UIHEuHtLtb",
+    description: "Proof point 2 body for the Hyperlab product page",
+  },
+  hyperlabProof2Title: {
+    defaultMessage: "Then take it further",
+    id: "/kd5MBjE0F",
+    description: "Proof point 3 title for the Hyperlab product page",
+  },
+  hyperlabProof2Body: {
+    defaultMessage: "Start with one market. Roll out when you like the result.",
+    id: "xaFOQHPZeN",
+    description: "Proof point 3 body for the Hyperlab product page",
+  },
+  hyperlabCtaHeadline: {
+    defaultMessage: "Stop guessing what each market wants.",
+    id: "g4pR2Tnesp",
+    description: "Bottom CTA headline for the Hyperlab product page",
+  },
+  hyperlabCtaDescription: {
+    defaultMessage: "Try the next checkout in Japan before every other market sees it.",
+    id: "YUiLI6Ae69",
+    description: "Bottom CTA description for the Hyperlab product page",
   },
 });
 

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.test.ts
@@ -12,8 +12,30 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { productPagesBySlug } from "./product-page-content";
+import { productFooterLinks, productPagesBySlug, productSlugs } from "./product-page-content";
 import { productPageMessages } from "./product-page-content.messages";
+
+describe("product page content", () => {
+  it("includes a marketing page for every product pillar", () => {
+    expect(productSlugs).toEqual([
+      "agents-automation",
+      "multilingual-content-studio",
+      "domains",
+      "hyperlab",
+      "guidelines",
+    ]);
+  });
+
+  it("exposes footer links for Domains and Hyperlab", () => {
+    expect(productFooterLinks.map((link) => link.href)).toEqual([
+      "/product/agents-automation",
+      "/product/multilingual-content-studio",
+      "/product/domains",
+      "/product/hyperlab",
+      "/product/guidelines",
+    ]);
+  });
+});
 
 describe("agents automation product copy", () => {
   it("names the product as a workflow for multilingual content operations", () => {

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page-content.ts
@@ -14,9 +14,14 @@ import type { ProductMessageKey } from "./product-page-content.messages";
 
 export type { ProductMessageKey } from "./product-page-content.messages";
 
-export type ProductPageSlug = "agents-automation" | "multilingual-content-studio" | "guidelines";
+export type ProductPageSlug =
+  | "agents-automation"
+  | "multilingual-content-studio"
+  | "domains"
+  | "hyperlab"
+  | "guidelines";
 
-export type ProductVisualKind = "automation" | "cat" | "knowledge";
+export type ProductVisualKind = "automation" | "cat" | "domains" | "hyperlab" | "knowledge";
 
 export type ProductPageLink = {
   labelKey: ProductMessageKey;
@@ -90,7 +95,7 @@ export const productPages: ProductPageContent[] = [
     },
     related: [
       { labelKey: "productNavContentStudio", href: "/product/multilingual-content-studio" },
-      { labelKey: "productNavGuidelines", href: "/product/guidelines" },
+      { labelKey: "productNavDomains", href: "/product/domains" },
     ],
   },
   {
@@ -133,6 +138,94 @@ export const productPages: ProductPageContent[] = [
     },
     related: [
       { labelKey: "productNavAgentsAutomation", href: "/product/agents-automation" },
+      { labelKey: "productNavDomains", href: "/product/domains" },
+    ],
+  },
+  {
+    slug: "domains",
+    metadata: {
+      titleKey: "domainsMetadataTitle",
+      descriptionKey: "domainsMetadataDescription",
+      keywords: [
+        "multilingual CMS",
+        "localisation audit",
+        "multilingual SEO",
+        "answer engine optimisation",
+        "AEO",
+      ],
+    },
+    visualKind: "domains",
+    hero: {
+      eyebrowKey: "domainsHeroEyebrow",
+      headlineKey: "domainsHeroHeadline",
+      subcopyKey: "domainsHeroSubcopy",
+    },
+    detailsHeadlineKey: "domainsDetailsHeadline",
+    summaryKey: "domainsSummary",
+    proofPoints: [
+      {
+        titleKey: "domainsProof0Title",
+        bodyKey: "domainsProof0Body",
+      },
+      {
+        titleKey: "domainsProof1Title",
+        bodyKey: "domainsProof1Body",
+      },
+      {
+        titleKey: "domainsProof2Title",
+        bodyKey: "domainsProof2Body",
+      },
+    ],
+    cta: {
+      headlineKey: "domainsCtaHeadline",
+      descriptionKey: "domainsCtaDescription",
+    },
+    related: [
+      { labelKey: "productNavContentStudio", href: "/product/multilingual-content-studio" },
+      { labelKey: "productNavHyperlab", href: "/product/hyperlab" },
+    ],
+  },
+  {
+    slug: "hyperlab",
+    metadata: {
+      titleKey: "hyperlabMetadataTitle",
+      descriptionKey: "hyperlabMetadataDescription",
+      keywords: [
+        "market experiments",
+        "market-specific features",
+        "multilingual experiments",
+        "A/B testing by country",
+        "OpenFeature",
+      ],
+    },
+    visualKind: "hyperlab",
+    hero: {
+      eyebrowKey: "hyperlabHeroEyebrow",
+      headlineKey: "hyperlabHeroHeadline",
+      subcopyKey: "hyperlabHeroSubcopy",
+    },
+    detailsHeadlineKey: "hyperlabDetailsHeadline",
+    summaryKey: "hyperlabSummary",
+    proofPoints: [
+      {
+        titleKey: "hyperlabProof0Title",
+        bodyKey: "hyperlabProof0Body",
+      },
+      {
+        titleKey: "hyperlabProof1Title",
+        bodyKey: "hyperlabProof1Body",
+      },
+      {
+        titleKey: "hyperlabProof2Title",
+        bodyKey: "hyperlabProof2Body",
+      },
+    ],
+    cta: {
+      headlineKey: "hyperlabCtaHeadline",
+      descriptionKey: "hyperlabCtaDescription",
+    },
+    related: [
+      { labelKey: "productNavDomains", href: "/product/domains" },
       { labelKey: "productNavGuidelines", href: "/product/guidelines" },
     ],
   },
@@ -177,8 +270,8 @@ export const productPages: ProductPageContent[] = [
       descriptionKey: "guidelinesCtaDescription",
     },
     related: [
-      { labelKey: "productNavAgentsAutomation", href: "/product/agents-automation" },
       { labelKey: "productNavContentStudio", href: "/product/multilingual-content-studio" },
+      { labelKey: "productNavHyperlab", href: "/product/hyperlab" },
     ],
   },
 ];

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
@@ -29,8 +29,10 @@ import type { ProductPageContent } from "./product-page-content";
 import { AutomationEditorMock } from "./automation-editor-mock";
 import { AutomationHowItWorksIntegrations } from "./automation-how-it-works-integrations";
 import { AutomationsMockUI } from "./automations-mock-ui";
+import { DomainsMockUI } from "./domains-mock-ui";
 import { GlobeHeroVisual } from "./globe-hero-visual";
 import { GuidelineMockUI } from "./guideline-mock-ui";
+import { HyperlabMockUI } from "./hyperlab-mock-ui";
 import { IntegrationStripSection } from "./integration-strip-section";
 import { KnowledgeHero } from "./knowledge-hero";
 import { KnowledgeMockUI } from "./knowledge-mock-ui";
@@ -144,6 +146,22 @@ function ProductShowcase({ content }: ProductPageProps) {
             <KnowledgeMockUI />
           </div>
         </div>
+      </div>
+    );
+  }
+
+  if (content.visualKind === "domains") {
+    return (
+      <div className="mx-auto max-w-6xl">
+        <DomainsMockUI priority />
+      </div>
+    );
+  }
+
+  if (content.visualKind === "hyperlab") {
+    return (
+      <div className="mx-auto max-w-6xl">
+        <HyperlabMockUI priority />
       </div>
     );
   }


### PR DESCRIPTION
## What changed

Adds dedicated marketing product pages for Hyperlab and Domains, matching the Multilingual Content Studio pattern: ELI5 copy, interactive mocks, and mesh backgrounds.

Hyperlab is framed around market experiments and per-market features (test in one country, then take the winner everywhere) rather than generic feature flags. Both pages are wired into nav, footer, homepage cards, metadata, and `llms.txt`.

## How to test

- Open `/en/product/hyperlab` and `/en/product/domains`.
- Confirm hero copy, mesh mock, solution tabs, and CTAs.
- On Hyperlab, pick a market version (France vs Japan) and toggle Japan-only vs every market.
- On Domains, change language and tap an audit issue to highlight the live-page mock.
- Confirm homepage product cards, footer, and `/llms.txt` link to both pages.
- `vp test src/components/marketing/product/hyperlab-page.test.tsx src/components/marketing/product/domains-page.test.tsx src/components/marketing/product/product-page-content.test.ts src/app/llms.txt/route.test.ts`
- `vp check --fix` on the edited web files

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)