### PR TITLE
feat(mcp): add download_translations tool to the hosted MCP server

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-download-translations.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-download-translations.schema.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+import { downloadPublicTranslationsQuerySchema } from "@/api/routes/public-translations/public-translations.schema";
+import { projectIdSchema } from "@/lib/projects/identity/project-id";
+
+const sourceDownloadShape = downloadPublicTranslationsQuerySchema.shape;
+
+export const mcpDownloadTranslationsInputSchema = z.object({
+  projectId: projectIdSchema.describe("ID of the accessible Hyperlocalise project."),
+  sourcePath: sourceDownloadShape.sourcePath.describe(
+    "Repository-relative path of the source file.",
+  ),
+  locale: sourceDownloadShape.locale.describe(
+    "Target locale whose reconstructed translation file should be returned.",
+  ),
+});

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-download-translations.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-download-translations.ts
@@ -16,6 +16,7 @@ import {
   getRepositorySourceFileByPath,
   loadProjectTranslationsAsPrefilledEntries,
 } from "@/lib/projects/translations/project-translation-service";
+import { inferSupportedTranslationFileFormat } from "@/lib/translation/file-formats";
 
 export type McpDownloadTranslationsDetail = {
   filename: string;
@@ -65,6 +66,14 @@ export async function downloadMcpTranslations(input: {
     return {
       ok: false,
       error: "source_file_not_found",
+    };
+  }
+
+  const sourceFormat = inferSupportedTranslationFileFormat(input.sourcePath);
+  if (sourceFormat !== "json" && sourceFormat !== "jsonc" && sourceFormat !== "arb") {
+    return {
+      ok: false,
+      error: "unsupported_binary_download",
     };
   }
 

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-download-translations.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-download-translations.ts
@@ -33,12 +33,12 @@ export type McpDownloadTranslationsResult =
     }
   | {
       ok: false;
-      error:
-        | "source_file_not_found"
-        | "translations_not_found"
-        | "source_file_too_large"
-        | "unsupported_binary_download";
-      maxKeyCount?: number;
+      error: "source_file_not_found" | "translations_not_found" | "unsupported_binary_download";
+    }
+  | {
+      ok: false;
+      error: "source_file_too_large";
+      maxKeyCount: number;
     };
 
 /** Builds the target filename used by the public translation download endpoint. */

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-download-translations.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-download-translations.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import path from "node:path";
+
+import {
+  getRepositorySourceFileByPath,
+  loadProjectTranslationsAsPrefilledEntries,
+} from "@/lib/projects/translations/project-translation-service";
+
+export type McpDownloadTranslationsDetail = {
+  filename: string;
+  contentType: string;
+  locale: string;
+  sourcePath: string;
+  content: string;
+};
+
+export type McpDownloadTranslationsResult =
+  | {
+      ok: true;
+      value: McpDownloadTranslationsDetail;
+    }
+  | {
+      ok: false;
+      error:
+        | "source_file_not_found"
+        | "translations_not_found"
+        | "source_file_too_large"
+        | "unsupported_binary_download";
+      maxKeyCount?: number;
+    };
+
+/** Builds the target filename used by the public translation download endpoint. */
+function downloadFilename(sourcePath: string, locale: string) {
+  const extension = path.extname(sourcePath);
+  const baseName = path.basename(sourcePath, extension);
+  const suffix = baseName.endsWith(`-${locale}`) ? baseName : `${baseName}-${locale}`;
+
+  return extension ? `${suffix}${extension}` : `${suffix}.json`;
+}
+
+export async function downloadMcpTranslations(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  locale: string;
+}): Promise<McpDownloadTranslationsResult> {
+  const sourceFile = await getRepositorySourceFileByPath({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+  });
+
+  if (!sourceFile) {
+    return {
+      ok: false,
+      error: "source_file_not_found",
+    };
+  }
+
+  const result = await loadProjectTranslationsAsPrefilledEntries({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+    targetLocale: input.locale,
+    includeAllSourceKeys: true,
+  });
+
+  if (result.truncated) {
+    return {
+      ok: false,
+      error: "source_file_too_large",
+      maxKeyCount: result.maxKeyCount,
+    };
+  }
+
+  if (result.loadedKeyCount === 0) {
+    return {
+      ok: false,
+      error: "translations_not_found",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      filename: downloadFilename(input.sourcePath, input.locale),
+      contentType: "application/json; charset=utf-8",
+      locale: input.locale,
+      sourcePath: input.sourcePath,
+      content: `${JSON.stringify(result.prefilled, null, 2)}\n`,
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -12,7 +12,7 @@
  */
 import "dotenv/config";
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
@@ -7126,5 +7126,386 @@ describe("mcpRoutes", () => {
       .limit(1);
 
     expect(saved).toBeUndefined();
+  });
+
+  it("advertises download_translations with bounded file inputs", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list",
+            params: {},
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "download_translations");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("translation");
+
+    expect(tool?.inputSchema?.required).toEqual(
+      expect.arrayContaining(["projectId", "sourcePath", "locale"]),
+    );
+
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      projectId: {
+        type: "string",
+      },
+      sourcePath: {
+        type: "string",
+        minLength: 1,
+        maxLength: 2048,
+      },
+      locale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 32,
+      },
+    });
+  });
+
+  it("downloads a reconstructed translation file with source fallbacks", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const sourcePath = "locales/en.json";
+
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath,
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        {
+          key: "greeting",
+          text: "Hello",
+          context: null,
+        },
+        {
+          key: "farewell",
+          text: "Goodbye",
+          context: null,
+        },
+      ],
+    });
+
+    const [greetingKey] = await db
+      .select({
+        id: schema.projectTranslationKeys.id,
+      })
+      .from(schema.projectTranslationKeys)
+      .where(
+        and(
+          eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id),
+          eq(schema.projectTranslationKeys.key, "greeting"),
+        ),
+      )
+      .limit(1);
+
+    if (!greetingKey) {
+      throw new Error("expected greeting translation key fixture");
+    }
+
+    await db.insert(schema.projectTranslations).values({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      translationKeyId: greetingKey.id,
+      targetLocale: "fr-FR",
+      text: "Bonjour",
+      status: "approved",
+      provenance: "import",
+    });
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "download_translations",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath,
+                locale: "fr-FR",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).not.toBe(true);
+
+    const output = JSON.parse(body.result?.content?.[0]?.text ?? "{}") as {
+      filename?: string;
+      contentType?: string;
+      locale?: string;
+      sourcePath?: string;
+      content?: string;
+    };
+
+    expect(output).toMatchObject({
+      filename: "en-fr-FR.json",
+      contentType: "application/json; charset=utf-8",
+      locale: "fr-FR",
+      sourcePath,
+    });
+
+    expect(JSON.parse(output.content ?? "{}")).toEqual({
+      greeting: "Bonjour",
+      farewell: "Goodbye",
+    });
+  });
+
+  it("returns project_not_found for a cross-organization download", async () => {
+    const accessible = await fixture.createStoredProjectFixture();
+    const inaccessible = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(accessible.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "download_translations",
+              arguments: {
+                projectId: inaccessible.project.id,
+                sourcePath: "locales/en.json",
+                locale: "fr-FR",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "project_not_found",
+    });
+  });
+
+  it("returns project_not_found when downloading from a missing project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "download_translations",
+              arguments: {
+                projectId: randomUUID(),
+                sourcePath: "locales/en.json",
+                locale: "fr-FR",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "project_not_found",
+    });
+  });
+
+  it("returns source_file_not_found for an unknown source path", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "download_translations",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath: "locales/missing.json",
+                locale: "fr-FR",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "source_file_not_found",
+    });
+  });
+
+  it("returns translations_not_found when the source file has no translation keys", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const sourcePath = "locales/empty.json";
+
+    await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath,
+    });
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "download_translations",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath,
+                locale: "fr-FR",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "translations_not_found",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -7508,4 +7508,146 @@ describe("mcpRoutes", () => {
       error: "translations_not_found",
     });
   });
+
+  it("rejects download_translations when locale is missing", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "download_translations",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath: "locales/en.json",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toContain("locale");
+  });
+
+  it("keeps run_workflow reserved", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {},
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "not_implemented",
+      tool: "run_workflow",
+    });
+  });
+
+  it("rejects source formats without a supported UTF-8 reconstruction", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const sourcePath = "locales/messages.po";
+
+    await ensureRepositorySourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      sourcePath,
+    });
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "download_translations",
+              arguments: {
+                projectId: stored.project.id,
+                sourcePath,
+                locale: "fr-FR",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "unsupported_binary_download",
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -68,6 +68,7 @@ import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
 import { db, schema } from "@/lib/database/client";
 import { env } from "@/lib/env";
 import { resolveMcpClientMetadata } from "@/api/auth/mcp-client-metadata";
+import { assertNever } from "@/lib/primitives/assert-never/assert-never";
 import { isErr } from "@/lib/primitives/result/results";
 import {
   issueSheetCreateIssueBodySchema,
@@ -2162,7 +2163,9 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
       });
 
       if (!result.ok) {
-        switch (result.error) {
+        const downloadError = result.error;
+
+        switch (downloadError) {
           case "source_file_not_found":
             return mcpToolError("source_file_not_found", "Source file not found");
 
@@ -2183,6 +2186,9 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
               "unsupported_binary_download",
               "The reconstructed translation file is not supported as UTF-8 text",
             );
+
+          default:
+            return assertNever(downloadError);
         }
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -123,6 +123,8 @@ import { uploadSourceFile } from "@/lib/projects/files/source-file-upload-servic
 import { ensureOrganizationProjectRecord } from "@/lib/projects/organization/organization-project-service";
 import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats";
 import { updateMcpTranslation } from "./mcp-update-translation";
+import { downloadPublicTranslationsQuerySchema } from "../public-translations/public-translations.schema";
+import { downloadMcpTranslations } from "./mcp-download-translations";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -777,6 +779,20 @@ const mcpUploadSourcesInputSchema = z.object({
   commitSha: sourceUploadShape.commitSha.describe("Optional repository commit SHA."),
 
   workflowRunId: sourceUploadShape.workflowRunId.describe("Optional workflow run identifier."),
+});
+
+const sourceDownloadShape = downloadPublicTranslationsQuerySchema.shape;
+
+const mcpDownloadTranslationsInputSchema = z.object({
+  projectId: projectIdSchema.describe("ID of the accessible Hyperlocalise project."),
+
+  sourcePath: sourceDownloadShape.sourcePath.describe(
+    "Repository-relative path of the source file.",
+  ),
+
+  locale: sourceDownloadShape.locale.describe(
+    "Target locale whose reconstructed translation file should be returned.",
+  ),
 });
 
 function decodeMcpBase64(value: string): Uint8Array | null {
@@ -1821,7 +1837,7 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
     },
   );
 
-  for (const name of ["download_translations", "run_workflow"] as const) {
+  for (const name of ["run_workflow"] as const) {
     server.registerTool(
       name,
       {
@@ -2126,6 +2142,69 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
                 destination: result.value.destination,
               },
             }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "download_translations",
+    {
+      description:
+        "Download a reconstructed UTF-8 target translation file from an accessible Hyperlocalise project.",
+      inputSchema: mcpDownloadTranslationsInputSchema,
+    },
+    async ({ projectId, sourcePath, locale }) => {
+      const [project] = await db
+        .select({
+          id: schema.projects.id,
+        })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      const result = await downloadMcpTranslations({
+        organizationId: apiAuth.organization.localOrganizationId,
+        projectId: project.id,
+        sourcePath,
+        locale,
+      });
+
+      if (!result.ok) {
+        switch (result.error) {
+          case "source_file_not_found":
+            return mcpToolError("source_file_not_found", "Source file not found");
+
+          case "translations_not_found":
+            return mcpToolError(
+              "translations_not_found",
+              "No translations are available for this source file and locale",
+            );
+
+          case "source_file_too_large":
+            return mcpToolError(
+              "source_file_too_large",
+              `Translation export exceeds the ${result.maxKeyCount} key limit`,
+            );
+
+          case "unsupported_binary_download":
+            return mcpToolError(
+              "unsupported_binary_download",
+              "The reconstructed translation file is not supported as UTF-8 text",
+            );
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result.value),
           },
         ],
       };

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -123,8 +123,8 @@ import { uploadSourceFile } from "@/lib/projects/files/source-file-upload-servic
 import { ensureOrganizationProjectRecord } from "@/lib/projects/organization/organization-project-service";
 import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats";
 import { updateMcpTranslation } from "./mcp-update-translation";
-import { downloadPublicTranslationsQuerySchema } from "../public-translations/public-translations.schema";
 import { downloadMcpTranslations } from "./mcp-download-translations";
+import { mcpDownloadTranslationsInputSchema } from "./mcp-download-translations.schema";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -779,20 +779,6 @@ const mcpUploadSourcesInputSchema = z.object({
   commitSha: sourceUploadShape.commitSha.describe("Optional repository commit SHA."),
 
   workflowRunId: sourceUploadShape.workflowRunId.describe("Optional workflow run identifier."),
-});
-
-const sourceDownloadShape = downloadPublicTranslationsQuerySchema.shape;
-
-const mcpDownloadTranslationsInputSchema = z.object({
-  projectId: projectIdSchema.describe("ID of the accessible Hyperlocalise project."),
-
-  sourcePath: sourceDownloadShape.sourcePath.describe(
-    "Repository-relative path of the source file.",
-  ),
-
-  locale: sourceDownloadShape.locale.describe(
-    "Target locale whose reconstructed translation file should be returned.",
-  ),
 });
 
 function decodeMcpBase64(value: string): Uint8Array | null {

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -67,7 +67,7 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 
 `upload_sources` uploads one source file using the same native or external TMS path as `POST /v1/files`. Provide exactly one of `content` or `contentBase64`. Native uploads are queued for background ingestion so their keys become available to `list_translations`. The maximum payload size is 25 MiB. This tool does not create a translation job; use `run_workflow` for that.
 
-`download_translations` reconstructs a target file using the same native translation data as the public API and CLI `sync pull`. The response includes `filename`, `contentType`, `locale`, `sourcePath`, and UTF-8 `content`. Keys without a target translation use their source text as a fallback. Binary and image downloads are not supported.
+`download_translations` reconstructs a JSON-compatible target file using the same native translation data as the public API and CLI `sync pull`. The response includes `filename`, `contentType`, `locale`, `sourcePath`, and UTF-8 `content`. Keys without a target translation use their source text as a fallback. Formats without a supported UTF-8 reconstruction path return `unsupported_binary_download` instead of JSON content with an incorrect extension.
 
 Optional filters match the Content Editor queue:
 

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -57,6 +57,7 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | `get_glossary_entries` | Concept-linked terms for a `glossaryId` (`limit`, default 50, max 100)                                                                                                  |
 | `query_glossary`       | Ranked concept-linked hits for a source string and locale pair                                                                                                          |
 | `upload_sources`       | Upload a source file to a project using UTF-8 `content` or binary `contentBase64`                                                                                       |
+| `download_translations` | Download a reconstructed UTF-8 target file (`projectId`, `sourcePath`, `locale`)                                                                                         |
 
 `list_files` returns metadata only: `id` (stored file or source-file id), `sourcePath`, `filename`, `contentType`, `byteSize`, `updatedAt`, and `sourceLocale` when known. Pagination includes `total`, `limit`, `offset`, `hasMore`, and `nextOffset`. The tool does not return file contents. Inaccessible projects return `project_not_found`. Use the listed `sourcePath` values for later upload, download, or `run_workflow` calls.
 
@@ -65,6 +66,8 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 `get_translation` is the detail view for a translation returned by `list_translations`. Pass the row's `id` as `translationKeyId` together with its `projectId` and `targetLocale`. The tool returns source and target text, locales, status, context, maximum length, and linked Board issue identifiers. A key without a target translation is returned with `targetText` and `status` set to `null`.
 
 `upload_sources` uploads one source file using the same native or external TMS path as `POST /v1/files`. Provide exactly one of `content` or `contentBase64`. Native uploads are queued for background ingestion so their keys become available to `list_translations`. The maximum payload size is 25 MiB. This tool does not create a translation job; use `run_workflow` for that.
+
+`download_translations` reconstructs a target file using the same native translation data as the public API and CLI `sync pull`. The response includes `filename`, `contentType`, `locale`, `sourcePath`, and UTF-8 `content`. Keys without a target translation use their source text as a fallback. Binary and image downloads are not supported.
 
 Optional filters match the Content Editor queue:
 
@@ -139,10 +142,9 @@ Missing or inaccessible jobs, including jobs from another organization, return `
 
 These tools are advertised but return `not_implemented` today:
 
-- `download_translations`
 - `run_workflow`
 
-Use the [public API](/platform/api) or [CLI](/platform/cli) for file upload, download, and job orchestration until these tools are wired.
+Use the [public API](/platform/api) or [CLI](/platform/cli) for job orchestration until this tool is wired.
 
 ## Outbound MCP in automations
 
@@ -180,6 +182,10 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `invalid_file_payload`                         | Upload content is missing, malformed, oversized, or contains conflicting input fields                                  |
 | `unsupported_file`                             | The uploaded source path uses an unsupported translation file format                                                   |
 | `source_upload_failed`                         | The native or external TMS source upload failed                                                                        |
+| `source_file_not_found`                        | The requested source path does not exist in the accessible project                                                     |
+| `translations_not_found`                       | The source file has no translation keys available to reconstruct                                                       |
+| `source_file_too_large`                        | The translation reconstruction exceeds the public API key limit                                                        |
+| `unsupported_binary_download`                  | The reconstructed file cannot be returned as UTF-8 text                                                                 |
 
 ## Next
 


### PR DESCRIPTION
## What changed

- Replaced the reserved download_translations MCP stub with a functional tool.
- Reused the public API translation pipeline to reconstruct UTF-8 target files.
- Added support for projectId, sourcePath, and target locale.
- Returned filename, contentType, locale, sourcePath, and reconstructed content.
- Preserved source-text fallbacks when target translations are unavailable.
- Added stable errors for inaccessible projects, missing source files, missing translation keys, oversized exports, and unsupported binary downloads.
- Added project isolation and input validation coverage.
- Kept run_workflow reserved and unchanged.
- Updated the MCP platform documentation.

## How to test

From apps/hyperlocalise-web:
```bash
vp check --fix
vp test src/api/routes/mcp/mcp.route.test.ts
vp run build
```

From the repository root:
```bash
git diff --check
```


## Checklist
- [X] I ran relevant checks locally (vp check --fix, MCP route tests, and web build)
- [X] I updated docs, comments, or examples when needed
- [X] This PR is scoped and ready for review
