### PR TITLE
fix(web): show recent jobs on project overview

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_email.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_email.test.ts
@@ -12,7 +12,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { err, ok } from "@/lib/primitives/result/results";
+import { ok } from "@/lib/primitives/result/results";
 import type {
   WorkspaceAutomationRecord,
   WorkspaceAutomationRunRecord,

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -66,6 +66,10 @@ const mineQuerySchema = z.object({
     .enum(["true", "false"])
     .optional()
     .transform((value) => value === "true"),
+  recent: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((value) => value === "true"),
 });
 
 const externalProjectIdQuerySchema = z.object({
@@ -316,6 +320,7 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
             mine: query.mine,
             assigneeCandidates,
             actorUserId: c.var.auth.user.localUserId,
+            orderByRecentActivity: query.recent,
           },
         );
         return c.json({ jobs }, 200);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -167,7 +167,7 @@ function ReadOnlyValue({
   className?: string;
 }) {
   return (
-    <TypographyP className="leading-5" size="small" tone="content">
+    <TypographyP className={cn("leading-5", className)} size="small" tone="content">
       {value?.trim() ? value : empty}
     </TypographyP>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -179,7 +179,7 @@ async function fetchTmsWorkspaceJobs(
 ) {
   const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs.$get({
     param: { organizationSlug },
-    query: { mine: mine ? "true" : "false" },
+    query: { mine: mine ? "true" : "false", recent: "false" },
   });
 
   return readTmsProviderListResponse<JobListResponse>(response, "jobs", loadTmsJobsFailedMessage);
@@ -195,7 +195,7 @@ async function fetchTmsProjectJobs(
     ":externalProjectId"
   ].jobs.$get({
     param: { organizationSlug, externalProjectId },
-    query: { mine: mine ? "true" : "false" },
+    query: { mine: mine ? "true" : "false", recent: "false" },
   });
 
   return readTmsProviderListResponse<JobListResponse>(response, "jobs", loadTmsJobsFailedMessage);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
@@ -68,7 +68,22 @@ export const projectOverviewPageContentMessages = defineMessages({
   statusRunning: {
     defaultMessage: "Running",
     id: "82QjeMOgLE",
-    description: "Status label for a queued or running job on project overview",
+    description: "Status label for a running job on project overview",
+  },
+  statusQueued: {
+    defaultMessage: "Queued",
+    id: "k8mP2nQxRt",
+    description: "Status label for a queued job on project overview",
+  },
+  statusSucceeded: {
+    defaultMessage: "Succeeded",
+    id: "v7nQ3pRySu",
+    description: "Status label for a succeeded job on project overview",
+  },
+  statusCancelled: {
+    defaultMessage: "Cancelled",
+    id: "w8oR4qSzTv",
+    description: "Status label for a cancelled job on project overview",
   },
   statusGuidance: {
     defaultMessage: "Guidance",
@@ -76,14 +91,14 @@ export const projectOverviewPageContentMessages = defineMessages({
     description: "Status label when translation guidance is missing on project overview",
   },
   triageEmptyTitle: {
-    defaultMessage: "No reviews waiting",
+    defaultMessage: "No jobs yet",
     id: "TVxvj2B1bk",
-    description: "Title when the triage band has no urgent items",
+    description: "Title when the project overview has no recent jobs",
   },
   triageEmptyDescription: {
-    defaultMessage: "Open Files for coverage, or create a job when you are ready.",
+    defaultMessage: "Create a job to start translating, or open Files to review coverage.",
     id: "85veKzf/Q7",
-    description: "Description when the triage band has no urgent items",
+    description: "Description when the project overview has no recent jobs",
   },
   reviewCta: {
     defaultMessage: "Review",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
@@ -67,22 +67,22 @@ export const projectOverviewPageContentMessages = defineMessages({
   },
   statusRunning: {
     defaultMessage: "Running",
-    id: "82QjeMOgLE",
+    id: "RB1IMX1IND",
     description: "Status label for a running job on project overview",
   },
   statusQueued: {
     defaultMessage: "Queued",
-    id: "k8mP2nQxRt",
+    id: "LTsQcuBGvj",
     description: "Status label for a queued job on project overview",
   },
   statusSucceeded: {
     defaultMessage: "Succeeded",
-    id: "v7nQ3pRySu",
+    id: "CbiqfTdoAd",
     description: "Status label for a succeeded job on project overview",
   },
   statusCancelled: {
     defaultMessage: "Cancelled",
-    id: "w8oR4qSzTv",
+    id: "vT2hvp2ZbB",
     description: "Status label for a cancelled job on project overview",
   },
   statusGuidance: {
@@ -92,12 +92,12 @@ export const projectOverviewPageContentMessages = defineMessages({
   },
   triageEmptyTitle: {
     defaultMessage: "No jobs yet",
-    id: "TVxvj2B1bk",
+    id: "RvnnjnXuP8",
     description: "Title when the project overview has no recent jobs",
   },
   triageEmptyDescription: {
     defaultMessage: "Create a job to start translating, or open Files to review coverage.",
-    id: "85veKzf/Q7",
+    id: "p5wVg4GDmZ",
     description: "Description when the project overview has no recent jobs",
   },
   reviewCta: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
@@ -53,9 +53,9 @@ export const Default: Story = {
     await expect(canvas.getByRole("link", { name: "Projects" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Create job" })).toBeInTheDocument();
     await expect(canvas.getByText("Today")).toBeInTheDocument();
+    await expect(canvas.getByText("Running")).toBeInTheDocument();
     await expect(canvas.getByText("Review")).toBeInTheDocument();
     await expect(canvas.getByText("Failed")).toBeInTheDocument();
-    await expect(canvas.getByText("Running")).toBeInTheDocument();
     await expect(
       canvas.getByText((content) => content.includes("fr-FR") && content.includes("Otto")),
     ).toBeInTheDocument();
@@ -81,9 +81,9 @@ export const CaughtUp: Story = {
     jobs: [],
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("No reviews waiting")).toBeInTheDocument();
+    await expect(canvas.getByText("No jobs yet")).toBeInTheDocument();
     await expect(
-      canvas.getByText("Open Files for coverage, or create a job when you are ready."),
+      canvas.getByText("Create a job to start translating, or open Files to review coverage."),
     ).toBeInTheDocument();
     await expect(canvas.getByText("0")).toBeInTheDocument();
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -35,6 +35,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import type { ProjectLocaleProgressRow } from "@/api/routes/project/project.schema";
+import { assertNever } from "@/lib/primitives/assert-never/assert-never";
 import { supportsContentEditorAllFilesProvider } from "@/lib/projects/content-editor-all-files";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
@@ -94,10 +95,8 @@ function jobStatusLabel(kind: ProjectOverviewJobKind, intl: ReturnType<typeof us
       return intl.formatMessage(messages.statusCancelled);
     case "guidance":
       return intl.formatMessage(messages.statusGuidance);
-    default: {
-      const _exhaustive: never = kind;
-      return _exhaustive;
-    }
+    default:
+      return assertNever(kind);
   }
 }
 
@@ -116,10 +115,8 @@ function jobStatusClassName(kind: ProjectOverviewJobKind) {
       return "text-muted-foreground";
     case "guidance":
       return "text-muted-foreground";
-    default: {
-      const _exhaustive: never = kind;
-      return _exhaustive;
-    }
+    default:
+      return assertNever(kind);
   }
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -51,10 +51,10 @@ import { ProjectPageShell, useProjectPageQuery } from "./project-page-shell";
 import { useProjectLocaleProgressQuery } from "./use-project-locale-progress";
 import { useProjectOverviewJobsQuery } from "./use-project-overview-jobs";
 import {
-  buildProjectOverviewTriageItems,
+  buildProjectOverviewJobItems,
   formatProjectLocaleRoute,
-  type ProjectOverviewTriageItem,
-  type ProjectOverviewTriageKind,
+  type ProjectOverviewJobItem,
+  type ProjectOverviewJobKind,
 } from "./project-overview-view-model";
 
 function buildProjectJobHref(organizationSlug: string, projectId: string, jobId: string) {
@@ -78,14 +78,20 @@ function resolveTriageJobMeta(
   return taskDetailSummary(job, intl);
 }
 
-function triageStatusLabel(kind: ProjectOverviewTriageKind, intl: ReturnType<typeof useIntl>) {
+function jobStatusLabel(kind: ProjectOverviewJobKind, intl: ReturnType<typeof useIntl>) {
   switch (kind) {
     case "review":
       return intl.formatMessage(messages.statusReview);
     case "failed":
       return intl.formatMessage(messages.statusFailed);
-    case "job":
+    case "running":
       return intl.formatMessage(messages.statusRunning);
+    case "queued":
+      return intl.formatMessage(messages.statusQueued);
+    case "succeeded":
+      return intl.formatMessage(messages.statusSucceeded);
+    case "cancelled":
+      return intl.formatMessage(messages.statusCancelled);
     case "guidance":
       return intl.formatMessage(messages.statusGuidance);
     default: {
@@ -95,14 +101,19 @@ function triageStatusLabel(kind: ProjectOverviewTriageKind, intl: ReturnType<typ
   }
 }
 
-function triageStatusClassName(kind: ProjectOverviewTriageKind) {
+function jobStatusClassName(kind: ProjectOverviewJobKind) {
   switch (kind) {
     case "review":
       return "text-amber-900";
     case "failed":
       return "text-red-800";
-    case "job":
+    case "running":
+    case "queued":
       return "text-primary";
+    case "succeeded":
+      return "text-emerald-800";
+    case "cancelled":
+      return "text-muted-foreground";
     case "guidance":
       return "text-muted-foreground";
     default: {
@@ -112,14 +123,17 @@ function triageStatusClassName(kind: ProjectOverviewTriageKind) {
   }
 }
 
-function resolveTriageCopy(
-  item: ProjectOverviewTriageItem,
+function resolveJobRowCopy(
+  item: ProjectOverviewJobItem,
   intl: ReturnType<typeof useIntl>,
 ): { title: string; meta: string | null; cta: string } {
   switch (item.kind) {
     case "review":
     case "failed":
-    case "job":
+    case "running":
+    case "queued":
+    case "succeeded":
+    case "cancelled":
       return {
         title: getJobName(item.job!, intl),
         meta: resolveTriageJobMeta(item.job, intl),
@@ -322,8 +336,8 @@ export function ProjectOverviewPageContentView({
     parseProviderProjectId(projectId)?.providerKind,
   );
 
-  const triageItems = project
-    ? buildProjectOverviewTriageItems({
+  const recentJobItems = project
+    ? buildProjectOverviewJobItems({
         jobs,
         isNative: isNative ?? false,
         hasTranslationGuidance,
@@ -454,7 +468,7 @@ export function ProjectOverviewPageContentView({
                             <FormattedMessage {...messages.todayTitle} />
                           </ProjectOverviewSectionLabel>
                           <span className="text-xs font-medium tracking-wider text-muted-foreground uppercase tabular-nums">
-                            {triageItems.length}
+                            {recentJobItems.length}
                           </span>
                         </Row>
                       </Box>
@@ -464,10 +478,10 @@ export function ProjectOverviewPageContentView({
                         <Box paddingTop="3u">
                           <Skeleton className="h-24 w-full" />
                         </Box>
-                      ) : triageItems.length > 0 ? (
+                      ) : recentJobItems.length > 0 ? (
                         <>
-                          {triageItems.map((item) => {
-                            const copy = resolveTriageCopy(item, intl);
+                          {recentJobItems.map((item) => {
+                            const copy = resolveJobRowCopy(item, intl);
                             const href =
                               item.kind === "guidance"
                                 ? settingsHref
@@ -479,8 +493,8 @@ export function ProjectOverviewPageContentView({
                               <div key={item.id}>
                                 <ProjectOverviewTriageRow
                                   href={href}
-                                  statusLabel={triageStatusLabel(item.kind, intl)}
-                                  statusClassName={triageStatusClassName(item.kind)}
+                                  statusLabel={jobStatusLabel(item.kind, intl)}
+                                  statusClassName={jobStatusClassName(item.kind)}
                                   title={copy.title}
                                   meta={copy.meta}
                                   cta={copy.cta}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
 import {
-  buildProjectOverviewTriageItems,
+  buildProjectOverviewJobItems,
   formatProjectLocaleRoute,
   projectOverviewMeshTone,
 } from "./project-overview-view-model";
@@ -51,25 +51,53 @@ function job(partial: Partial<ApiJob> & Pick<ApiJob, "id" | "status">): ApiJob {
   };
 }
 
-describe("buildProjectOverviewTriageItems", () => {
-  it("orders review, failed, missing guidance, then other jobs", () => {
-    const items = buildProjectOverviewTriageItems({
+describe("buildProjectOverviewJobItems", () => {
+  it("orders jobs by most recently updated", () => {
+    const items = buildProjectOverviewJobItems({
       jobs: [
-        job({ id: "running", status: "running" }),
-        job({ id: "failed", status: "failed" }),
-        job({ id: "review", status: "waiting_for_review" }),
+        job({
+          id: "running",
+          status: "running",
+          updatedAt: "2026-07-02T00:00:08.000Z",
+        }),
+        job({
+          id: "failed",
+          status: "failed",
+          updatedAt: "2026-07-02T00:00:10.000Z",
+        }),
+        job({
+          id: "review",
+          status: "waiting_for_review",
+          updatedAt: "2026-07-02T00:00:09.000Z",
+        }),
+        job({
+          id: "succeeded",
+          status: "succeeded",
+          updatedAt: "2026-07-02T00:00:11.000Z",
+        }),
       ],
       isNative: true,
-      hasTranslationGuidance: false,
+      hasTranslationGuidance: true,
       limit: 10,
     });
 
-    expect(items.map((item) => item.kind)).toEqual(["review", "failed", "guidance", "job"]);
+    expect(items.map((item) => item.job?.id)).toEqual(["succeeded", "failed", "review", "running"]);
+  });
+
+  it("appends missing guidance when there is room under the cap", () => {
+    const items = buildProjectOverviewJobItems({
+      jobs: [job({ id: "failed", status: "failed" })],
+      isNative: true,
+      hasTranslationGuidance: false,
+      limit: 5,
+    });
+
+    expect(items.map((item) => item.kind)).toEqual(["failed", "guidance"]);
   });
 
   it("omits guidance when set or when the project is not native", () => {
     expect(
-      buildProjectOverviewTriageItems({
+      buildProjectOverviewJobItems({
         jobs: [],
         isNative: true,
         hasTranslationGuidance: true,
@@ -77,7 +105,7 @@ describe("buildProjectOverviewTriageItems", () => {
     ).toEqual([]);
 
     expect(
-      buildProjectOverviewTriageItems({
+      buildProjectOverviewJobItems({
         jobs: [],
         isNative: false,
         hasTranslationGuidance: false,
@@ -85,67 +113,19 @@ describe("buildProjectOverviewTriageItems", () => {
     ).toEqual([]);
   });
 
-  it("does not include file-based triage items", () => {
-    const items = buildProjectOverviewTriageItems({
-      jobs: [job({ id: "review", status: "waiting_for_review" })],
-      isNative: true,
-      hasTranslationGuidance: true,
-    });
-
-    expect(items.every((item) => item.kind !== ("file" as string))).toBe(true);
-  });
-
-  it("keeps older review jobs ahead of newer in-progress work when capping", () => {
-    const items = buildProjectOverviewTriageItems({
+  it("caps the number of recent jobs shown", () => {
+    const items = buildProjectOverviewJobItems({
       jobs: [
-        job({
-          id: "running-new",
-          status: "running",
-          updatedAt: "2026-07-02T00:00:10.000Z",
-        }),
-        job({
-          id: "queued-new",
-          status: "queued",
-          updatedAt: "2026-07-02T00:00:09.000Z",
-        }),
-        job({
-          id: "running-2",
-          status: "running",
-          updatedAt: "2026-07-02T00:00:08.000Z",
-        }),
-        job({
-          id: "queued-2",
-          status: "queued",
-          updatedAt: "2026-07-02T00:00:07.000Z",
-        }),
-        job({
-          id: "running-3",
-          status: "running",
-          updatedAt: "2026-07-02T00:00:06.000Z",
-        }),
-        job({
-          id: "review-old",
-          status: "waiting_for_review",
-          updatedAt: "2026-07-01T00:00:00.000Z",
-        }),
-        job({
-          id: "failed-old",
-          status: "failed",
-          updatedAt: "2026-07-01T00:00:01.000Z",
-        }),
+        job({ id: "job-1", status: "running", updatedAt: "2026-07-02T00:00:10.000Z" }),
+        job({ id: "job-2", status: "queued", updatedAt: "2026-07-02T00:00:09.000Z" }),
+        job({ id: "job-3", status: "failed", updatedAt: "2026-07-02T00:00:08.000Z" }),
       ],
       isNative: true,
       hasTranslationGuidance: true,
-      limit: 5,
+      limit: 2,
     });
 
-    expect(items.map((item) => item.job?.id)).toEqual([
-      "review-old",
-      "failed-old",
-      "running-new",
-      "queued-new",
-      "running-2",
-    ]);
+    expect(items.map((item) => item.job?.id)).toEqual(["job-1", "job-2"]);
   });
 });
 
@@ -157,7 +137,7 @@ describe("formatProjectLocaleRoute", () => {
 });
 
 describe("projectOverviewMeshTone", () => {
-  it("uses action tone when triage items exist", () => {
+  it("uses action tone when recent jobs exist", () => {
     expect(projectOverviewMeshTone(2)).toBe("action");
     expect(projectOverviewMeshTone(0)).toBe("calm");
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.ts
@@ -12,80 +12,68 @@
  */
 import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
 
-export const PROJECT_OVERVIEW_TRIAGE_LIMIT = 5;
+export const PROJECT_OVERVIEW_JOBS_LIMIT = 5;
 
-export type ProjectOverviewTriageKind = "review" | "failed" | "guidance" | "job";
+export type ProjectOverviewJobKind =
+  | "review"
+  | "failed"
+  | "running"
+  | "queued"
+  | "succeeded"
+  | "cancelled"
+  | "guidance";
 
-export type ProjectOverviewTriageItem = {
+export type ProjectOverviewJobItem = {
   id: string;
-  kind: ProjectOverviewTriageKind;
+  kind: ProjectOverviewJobKind;
   job?: ApiJob;
 };
 
-function triageRank(kind: ProjectOverviewTriageKind) {
-  switch (kind) {
-    case "review":
-      return 0;
+function projectOverviewJobKindFromStatus(status: ApiJob["status"]): ProjectOverviewJobKind {
+  switch (status) {
+    case "waiting_for_review":
+      return "review";
     case "failed":
-      return 1;
-    case "guidance":
-      return 2;
-    case "job":
-      return 3;
+      return "failed";
+    case "running":
+      return "running";
+    case "queued":
+      return "queued";
+    case "succeeded":
+      return "succeeded";
+    case "cancelled":
+      return "cancelled";
     default: {
-      const _exhaustive: never = kind;
+      const _exhaustive: never = status;
       return _exhaustive;
     }
   }
 }
 
-export function buildProjectOverviewTriageItems(input: {
+export function buildProjectOverviewJobItems(input: {
   jobs: readonly ApiJob[];
   isNative: boolean;
   hasTranslationGuidance: boolean;
   limit?: number;
-}): ProjectOverviewTriageItem[] {
-  const limit = input.limit ?? PROJECT_OVERVIEW_TRIAGE_LIMIT;
-  const items: ProjectOverviewTriageItem[] = [];
-
-  const reviewJobs = input.jobs.filter((job) => job.status === "waiting_for_review");
-  const failedJobs = input.jobs.filter((job) => job.status === "failed");
-  const otherJobs = input.jobs.filter((job) => job.status === "queued" || job.status === "running");
-
-  for (const job of reviewJobs) {
-    items.push({
-      id: `review:${job.id}`,
-      kind: "review",
+}): ProjectOverviewJobItem[] {
+  const limit = input.limit ?? PROJECT_OVERVIEW_JOBS_LIMIT;
+  const items: ProjectOverviewJobItem[] = input.jobs
+    .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+    .slice(0, limit)
+    .map((job) => ({
+      id: `job:${job.id}`,
+      kind: projectOverviewJobKindFromStatus(job.status),
       job,
-    });
-  }
+    }));
 
-  for (const job of failedJobs) {
-    items.push({
-      id: `failed:${job.id}`,
-      kind: "failed",
-      job,
-    });
-  }
-
-  if (input.isNative && !input.hasTranslationGuidance) {
+  if (input.isNative && !input.hasTranslationGuidance && items.length < limit) {
     items.push({
       id: "guidance:missing",
       kind: "guidance",
     });
   }
 
-  for (const job of otherJobs) {
-    items.push({
-      id: `job:${job.id}`,
-      kind: "job",
-      job,
-    });
-  }
-
-  return items
-    .toSorted((left, right) => triageRank(left.kind) - triageRank(right.kind))
-    .slice(0, limit);
+  return items;
 }
 
 export function formatProjectLocaleRoute(
@@ -102,6 +90,6 @@ export function formatProjectLocaleRoute(
   return `${source} → ${preview}${suffix}`;
 }
 
-export function projectOverviewMeshTone(triageCount: number): "action" | "calm" {
-  return triageCount > 0 ? "action" : "calm";
+export function projectOverviewMeshTone(jobCount: number): "action" | "calm" {
+  return jobCount > 0 ? "action" : "calm";
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.ts
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
+import { assertNever } from "@/lib/primitives/assert-never/assert-never";
 
 export const PROJECT_OVERVIEW_JOBS_LIMIT = 5;
 
@@ -43,10 +44,8 @@ function projectOverviewJobKindFromStatus(status: ApiJob["status"]): ProjectOver
       return "succeeded";
     case "cancelled":
       return "cancelled";
-    default: {
-      const _exhaustive: never = status;
-      return _exhaustive;
-    }
+    default:
+      return assertNever(status);
   }
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-overview-jobs.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-overview-jobs.ts
@@ -17,13 +17,13 @@ import { useQuery } from "@tanstack/react-query";
 import {
   fetchNativeProjectJobs,
   fetchTmsProjectJobs,
-  selectOverviewTriageProjectJobs,
+  selectRecentProjectJobs,
 } from "@/lib/projects/jobs/fetch-project-jobs";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
 
-import { PROJECT_OVERVIEW_TRIAGE_LIMIT } from "./project-overview-view-model";
+import { PROJECT_OVERVIEW_JOBS_LIMIT } from "./project-overview-view-model";
 
 export function useProjectOverviewJobsQuery(
   organizationSlug: string,
@@ -46,15 +46,11 @@ export function useProjectOverviewJobsQuery(
           organizationSlug,
           parsedProviderProject.externalProjectId,
         );
-        return selectOverviewTriageProjectJobs(jobs, PROJECT_OVERVIEW_TRIAGE_LIMIT) as ApiJob[];
+        return selectRecentProjectJobs(jobs, PROJECT_OVERVIEW_JOBS_LIMIT) as ApiJob[];
       }
 
-      // Server keeps jobs updated in the last 7 days, then orders by triage
-      // priority before applying the cap so older waiting_for_review / failed
-      // jobs are not displaced by newer queued work.
       return (await fetchNativeProjectJobs(organizationSlug, projectId, {
-        triage: true,
-        limit: PROJECT_OVERVIEW_TRIAGE_LIMIT,
+        limit: PROJECT_OVERVIEW_JOBS_LIMIT,
       })) as ApiJob[];
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-overview-jobs.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-overview-jobs.ts
@@ -45,6 +45,7 @@ export function useProjectOverviewJobsQuery(
         const jobs = await fetchTmsProjectJobs(
           organizationSlug,
           parsedProviderProject.externalProjectId,
+          { recent: true },
         );
         return selectRecentProjectJobs(jobs, PROJECT_OVERVIEW_JOBS_LIMIT) as ApiJob[];
       }

--- a/apps/hyperlocalise-web/src/app/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/layout.tsx
@@ -10,7 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Analytics } from "@vercel/analytics/next";
 import type { Metadata } from "next";
 
 import { RootHtml } from "@/components/root-layout/root-html";

--- a/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
@@ -79,13 +79,13 @@ export const ArtifactClose = ({
 export type ArtifactTitleProps = HTMLAttributes<HTMLParagraphElement>;
 
 export const ArtifactTitle = ({ className, ...props }: ArtifactTitleProps) => (
-  <TypographyP {...props} weight="medium" tone="content" size="small" />
+  <TypographyP className={className} {...props} weight="medium" tone="content" size="small" />
 );
 
 export type ArtifactDescriptionProps = HTMLAttributes<HTMLParagraphElement>;
 
 export const ArtifactDescription = ({ className, ...props }: ArtifactDescriptionProps) => (
-  <TypographyP {...props} tone="subtle" size="small" />
+  <TypographyP className={className} {...props} tone="subtle" size="small" />
 );
 
 export type ArtifactActionsProps = HTMLAttributes<HTMLDivElement>;

--- a/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
@@ -106,7 +106,7 @@ export const EnvironmentVariablesTitle = ({
   const intl = useIntl();
 
   return (
-    <TypographyH3 {...props} weight="medium" size="small">
+    <TypographyH3 className={className} {...props} weight="medium" size="small">
       {children ?? intl.formatMessage(environmentVariablesMessages.title)}
     </TypographyH3>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/package-info.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/package-info.tsx
@@ -187,7 +187,7 @@ export const PackageInfoDescription = ({
   children,
   ...props
 }: PackageInfoDescriptionProps) => (
-  <TypographyP className="mt-2" {...props} tone="subtle" size="small">
+  <TypographyP className={cn("mt-2", className)} {...props} tone="subtle" size="small">
     {children}
   </TypographyP>
 );

--- a/apps/hyperlocalise-web/src/components/ai-elements/schema-display.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/schema-display.tsx
@@ -139,7 +139,12 @@ export const SchemaDisplayDescription = ({
   const { description } = useContext(SchemaDisplayContext);
 
   return (
-    <TypographyP className="border-b px-4 py-3" {...props} tone="subtle" size="small">
+    <TypographyP
+      className={cn("border-b px-4 py-3", className)}
+      {...props}
+      tone="subtle"
+      size="small"
+    >
       {children ?? description}
     </TypographyP>
   );

--- a/apps/hyperlocalise-web/src/components/ui/typography.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/typography.tsx
@@ -407,7 +407,7 @@ function TypographyBlockquote({
     <Text
       tagName={tagName}
       wrapStyle={wrapStyle}
-      className="mt-6 border-l-2 pl-6 italic"
+      className={cn("mt-6 border-l-2 pl-6 italic", className)}
       {...props}
     />
   );

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.test.ts
@@ -52,6 +52,7 @@ import {
   filterOpenProjectJobs,
   filterOverviewTriageProjectJobs,
   selectOverviewTriageProjectJobs,
+  selectRecentProjectJobs,
 } from "./fetch-project-jobs";
 
 function jsonResponse(body: unknown, status = 200) {
@@ -246,6 +247,19 @@ describe("fetchProjectJobs", () => {
     expect(selectOverviewTriageProjectJobs(jobs, 5, nowMs).map((job) => job.id)).toEqual([
       "recent-review",
       "recent-queued",
+    ]);
+  });
+
+  it("keeps the most recently updated jobs for project overview", () => {
+    const jobs = [
+      { id: "older-failed", status: "failed", updatedAt: "2026-07-01T00:00:00.000Z" },
+      { id: "newer-succeeded", status: "succeeded", updatedAt: "2026-07-02T00:00:10.000Z" },
+      { id: "middle-running", status: "running", updatedAt: "2026-07-02T00:00:05.000Z" },
+    ];
+
+    expect(selectRecentProjectJobs(jobs, 2).map((job) => job.id)).toEqual([
+      "newer-succeeded",
+      "middle-running",
     ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.test.ts
@@ -159,7 +159,18 @@ describe("fetchProjectJobs", () => {
 
     expect(tmsJobsGetMock).toHaveBeenCalledWith({
       param: { organizationSlug: "acme", externalProjectId: "902807" },
-      query: { mine: "true" },
+      query: { mine: "true", recent: "false" },
+    });
+  });
+
+  it("requests recent TMS project jobs ordered by provider activity", async () => {
+    tmsJobsGetMock.mockResolvedValue(jsonResponse({ jobs: [] }));
+
+    await fetchTmsProjectJobs("acme", "902807", { recent: true });
+
+    expect(tmsJobsGetMock).toHaveBeenCalledWith({
+      param: { organizationSlug: "acme", externalProjectId: "902807" },
+      query: { mine: "false", recent: "true" },
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.ts
@@ -72,13 +72,16 @@ export async function fetchNativeProjectJobs(
 export async function fetchTmsProjectJobs(
   organizationSlug: string,
   externalProjectId: string,
-  options?: { mine?: boolean },
+  options?: { mine?: boolean; recent?: boolean },
 ) {
   const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
     ":externalProjectId"
   ].jobs.$get({
     param: { organizationSlug, externalProjectId },
-    query: { mine: options?.mine ? "true" : "false" },
+    query: {
+      mine: options?.mine ? "true" : "false",
+      recent: options?.recent ? "true" : "false",
+    },
   });
 
   return readTmsProviderListResponse<ProjectJobRecord>(response, "jobs", "Failed to load TMS jobs");

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.ts
@@ -118,3 +118,13 @@ export function selectOverviewTriageProjectJobs<T extends ProjectJobRecord>(
     })
     .slice(0, limit);
 }
+
+/** Keeps the most recently updated jobs for project Overview. */
+export function selectRecentProjectJobs<T extends ProjectJobRecord>(
+  jobs: readonly T[],
+  limit: number,
+): T[] {
+  return jobs
+    .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+    .slice(0, limit);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -1230,6 +1230,19 @@ describe("CrowdinApiClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("supports ordering project tasks by updatedAt", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const requestUrl = new URL(String(url));
+      expect(requestUrl.pathname).toBe("/api/v2/projects/1/tasks");
+      expect(requestUrl.searchParams.get("orderBy")).toBe("updatedAt desc");
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    await client.listTasks(1, { orderBy: "updatedAt desc" });
+  });
+
   it("lists user tasks with live list defaults", async () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -179,6 +179,7 @@ export const CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT = 500;
 
 export const CROWDIN_LIVE_TASK_LIST_LIMIT = 50;
 export const CROWDIN_LIVE_TASK_LIST_ORDER_BY = "createdAt desc";
+export const CROWDIN_RECENT_TASK_LIST_ORDER_BY = "updatedAt desc";
 export const CROWDIN_PROJECT_LIST_ORDER_BY = "lastActivity desc";
 export const CROWDIN_GLOSSARY_LIST_LIMIT = 25;
 export const CROWDIN_GLOSSARY_LIST_ORDER_BY = "createdAt desc,name";
@@ -331,6 +332,10 @@ export interface CrowdinTask {
   assignees: Array<{ id: number; username: string }> | null;
   deadline: string | null;
   webUrl: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  startedAt?: string | null;
+  resolvedAt?: string | null;
 }
 
 export interface CrowdinLanguageProgress {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.test.ts
@@ -45,6 +45,8 @@ describe("fetchCrowdinJobTasks", () => {
                   fileIds: [101],
                   assignees: [{ id: 1, username: "translator1" }],
                   deadline: "2026-06-01T00:00:00Z",
+                  createdAt: "2026-05-20T10:00:00Z",
+                  updatedAt: "2026-05-21T12:00:00Z",
                   webUrl: "https://crowdin.com/project/1/tasks/2001",
                 },
               },
@@ -96,6 +98,8 @@ describe("fetchCrowdinJobTasks", () => {
       targetLocales: ["fr"],
       assignedUsers: ["translator1"],
       kind: "translation",
+      createdAt: "2026-05-20T10:00:00Z",
+      updatedAt: "2026-05-21T12:00:00Z",
     });
     expect(result[0]?.providerPayload).toMatchObject({
       localeReadiness: {
@@ -155,6 +159,54 @@ describe("fetchCrowdinJobTasks", () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.providerPayload).toMatchObject({
       localeReadiness: null,
+    });
+  });
+
+  it("orders Crowdin tasks by updatedAt when recent activity is requested", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.includes("/tasks?")) {
+        expect(path).toContain("orderBy=updatedAt%20desc");
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 2001,
+                  projectId: 1,
+                  type: 0,
+                  status: "in_progress",
+                  title: "French translations",
+                  description: "Translate homepage",
+                  languageId: "fr",
+                  fileIds: [101],
+                  assignees: [],
+                  deadline: null,
+                  createdAt: "2026-01-01T00:00:00Z",
+                  updatedAt: "2026-02-01T00:00:00Z",
+                  webUrl: "https://crowdin.com/project/1/tasks/2001",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    await crowdinTmsProvider.fetchJobTasks({
+      organizationId: "org-1",
+      projectId: "project-1",
+      externalProjectId: "1",
+      credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+      project: {} as never,
+      secretMaterial: "test-token",
+      orderByRecentActivity: true,
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -33,6 +33,7 @@ import {
 } from "@/lib/providers/adapters/source-file-upload-shared";
 import {
   CROWDIN_GLOSSARY_LIST_LIMIT,
+  CROWDIN_RECENT_TASK_LIST_ORDER_BY,
   CrowdinApiClient,
   CrowdinApiError,
   escapeCrowdinCroqlString,
@@ -606,6 +607,7 @@ export class CrowdinTmsProvider extends TmsProvider {
     try {
       tasks = await client.listTasks(projectId, {
         fetchAll: scope.fetchAllTasks ?? false,
+        orderBy: scope.orderByRecentActivity ? CROWDIN_RECENT_TASK_LIST_ORDER_BY : undefined,
       });
     } catch (error) {
       this.rethrowAuthError(error);
@@ -2160,6 +2162,10 @@ export class CrowdinTmsProvider extends TmsProvider {
     const primaryLanguageId = this.extractTaskPrimaryLanguageId(task);
     const localeReadinessKey = primaryLanguageId ?? targetLocales[0] ?? null;
 
+    const createdAt = task.createdAt?.trim() || null;
+    const updatedAt =
+      task.updatedAt?.trim() || task.resolvedAt?.trim() || task.startedAt?.trim() || createdAt;
+
     return {
       externalJobId: String(task.id),
       externalTaskId: null,
@@ -2171,6 +2177,9 @@ export class CrowdinTmsProvider extends TmsProvider {
         task.assignees?.map((assignee) =>
           assignee.username ? assignee.username : String(assignee.id),
         ) ?? [],
+      createdAt,
+      updatedAt,
+      completedAt: task.resolvedAt?.trim() ? task.resolvedAt : null,
       externalUrl: task.webUrl,
       providerPayload: {
         projectId: task.projectId,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-provider.ts
@@ -297,6 +297,9 @@ export class LokaliseTmsProvider extends TmsProvider {
     return tasks.map((task) => {
       const completedAtMs = getLokaliseTaskCompletionMs(task);
 
+      const createdAt = task.createdAt?.trim() || null;
+      const completedAt = completedAtMs != null ? new Date(completedAtMs).toISOString() : null;
+
       return {
         externalJobId: String(task.taskId),
         externalTaskId: null,
@@ -306,7 +309,9 @@ export class LokaliseTmsProvider extends TmsProvider {
         targetLocales: collectLokaliseTaskTargetLocales(task),
         assignedUsers: collectLokaliseTaskAssignees(task),
         externalUrl: buildLokaliseTaskUrl(scope.externalProjectId, task.taskId),
-        completedAt: completedAtMs != null ? new Date(completedAtMs).toISOString() : null,
+        createdAt,
+        updatedAt: completedAt ?? createdAt,
+        completedAt,
         providerPayload: {
           taskType: task.taskType,
           description: task.description,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
@@ -597,6 +597,8 @@ export class PhraseTmsProvider extends TmsProvider {
           jobPart.owner?.email?.trim(),
         ].filter((value): value is string => Boolean(value));
 
+        const createdAt = jobPart.dateCreated?.trim() || null;
+
         return {
           externalJobId,
           externalTaskId: jobPart.uid,
@@ -605,6 +607,8 @@ export class PhraseTmsProvider extends TmsProvider {
           dueDate: jobPart.dateDue ? new Date(jobPart.dateDue) : null,
           targetLocales: targetLocale ? [targetLocale] : [],
           assignedUsers,
+          createdAt,
+          updatedAt: createdAt,
           externalUrl: this.buildPhraseTmsJobUrl(
             client.resolvedBaseUrl,
             tmsProjectUid,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-provider.ts
@@ -583,6 +583,9 @@ export class SmartlingTmsProvider extends TmsProvider {
             ));
         }
 
+        const createdAt = job.createdDate?.trim() || null;
+        const updatedAt = job.modifiedDate?.trim() || createdAt;
+
         return {
           externalJobId: job.translationJobUid,
           externalTaskId: null,
@@ -591,6 +594,8 @@ export class SmartlingTmsProvider extends TmsProvider {
           dueDate: job.dueDate ? new Date(job.dueDate) : null,
           targetLocales: job.targetLocaleIds,
           assignedUsers: [],
+          createdAt,
+          updatedAt,
           externalUrl: buildSmartlingJobUrl(
             accountUid,
             scope.externalProjectId,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/tms-provider-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/tms-provider-registry.ts
@@ -114,6 +114,7 @@ function asJobTaskFetcher(provider: TmsProvider): ExternalTmsJobTaskFetcher {
       enrichResources: input.enrichResources,
       includeLocaleProgress: input.includeLocaleProgress,
       fetchAllTasks: input.fetchAllTasks,
+      orderByRecentActivity: input.orderByRecentActivity,
     });
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider.ts
@@ -55,6 +55,7 @@ export type TmsProviderProjectScope = TmsProviderContext & {
   enrichResources?: boolean;
   includeLocaleProgress?: boolean;
   fetchAllTasks?: boolean;
+  orderByRecentActivity?: boolean;
   signal?: AbortSignal;
 };
 

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -714,13 +714,66 @@ function normalizeExternalTimestamp(value: Date | string | null | undefined): st
   return null;
 }
 
+const UNKNOWN_LIVE_JOB_ACTIVITY_AT = "1970-01-01T00:00:00.000Z";
+
+function readProviderPayloadTimestamp(
+  payload: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): string | null {
+  if (!payload) {
+    return null;
+  }
+
+  for (const key of keys) {
+    const normalized = normalizeExternalTimestamp(payload[key] as Date | string | null | undefined);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return null;
+}
+
+function resolveLiveJobTimestamps(task: ExternalTmsJobTaskMetadata): {
+  createdAt: string;
+  updatedAt: string;
+} {
+  const updatedAt =
+    normalizeExternalTimestamp(task.updatedAt) ??
+    normalizeExternalTimestamp(task.completedAt) ??
+    readProviderPayloadTimestamp(task.providerPayload, [
+      "updatedAt",
+      "modifiedDate",
+      "dateModified",
+      "completedAt",
+    ]) ??
+    normalizeExternalTimestamp(task.createdAt) ??
+    readProviderPayloadTimestamp(task.providerPayload, [
+      "createdAt",
+      "createdDate",
+      "dateCreated",
+    ]) ??
+    UNKNOWN_LIVE_JOB_ACTIVITY_AT;
+
+  const createdAt =
+    normalizeExternalTimestamp(task.createdAt) ??
+    readProviderPayloadTimestamp(task.providerPayload, [
+      "createdAt",
+      "createdDate",
+      "dateCreated",
+    ]) ??
+    updatedAt;
+
+  return { createdAt, updatedAt };
+}
+
 function mapLiveJob(input: {
   providerKind: ExternalTmsProviderKind;
   externalProjectId: string;
   projectName: string;
   task: ExternalTmsJobTaskMetadata;
 }): TmsProviderLiveJob {
-  const timestamp = new Date().toISOString();
+  const { createdAt, updatedAt } = resolveLiveJobTimestamps(input.task);
   const status = mapProviderStatusToNormalized(input.providerKind, input.task.externalStatus);
   const targetLocales = input.task.targetLocales ?? [];
   const assignedUsers = input.task.assignedUsers ?? [];
@@ -746,8 +799,8 @@ function mapLiveJob(input: {
     kind: input.task.kind ?? "translation",
     type: null,
     status,
-    createdAt: timestamp,
-    updatedAt: timestamp,
+    createdAt,
+    updatedAt,
     completedAt:
       status === "succeeded" || status === "failed"
         ? normalizeExternalTimestamp(input.task.completedAt)
@@ -1977,6 +2030,7 @@ export async function listTmsProviderLiveJobsForProject(
     projects?: ExternalTmsProjectMetadata[];
     actorUserId?: string | null;
     enrichResources?: boolean;
+    orderByRecentActivity?: boolean;
   },
 ): Promise<TmsProviderLiveJob[]> {
   const context =
@@ -2029,6 +2083,7 @@ export async function listTmsProviderLiveJobsForProject(
       project: liveProject,
       secretMaterial: context.secretMaterial,
       enrichResources: options?.enrichResources ?? false,
+      orderByRecentActivity: options?.orderByRecentActivity ?? false,
     });
   } catch (error) {
     rethrowProviderFetcherError(error);
@@ -3266,6 +3321,8 @@ function mapSmartlingJobToLiveTaskMetadata(input: {
     dueDate: input.job.dueDate ? new Date(input.job.dueDate) : null,
     targetLocales: input.job.targetLocaleIds,
     assignedUsers: [],
+    createdAt: input.job.createdDate?.trim() || null,
+    updatedAt: input.job.modifiedDate?.trim() || input.job.createdDate?.trim() || null,
     externalUrl: `https://dashboard.smartling.com/app/accounts/${encodeURIComponent(input.projectDetails.accountUid)}/project/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.job.translationJobUid)}`,
     providerPayload: {
       description: input.job.description,

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-types.ts
@@ -120,6 +120,8 @@ export type ExternalTmsJobTaskMetadata = {
   dueDate?: Date | string | null;
   targetLocales?: string[];
   assignedUsers?: string[];
+  createdAt?: Date | string | null;
+  updatedAt?: Date | string | null;
   completedAt?: Date | string | null;
   externalUrl?: string | null;
   providerPayload?: Record<string, unknown>;
@@ -203,6 +205,7 @@ export type ExternalTmsJobTaskFetcher = (input: {
   enrichResources?: boolean;
   includeLocaleProgress?: boolean;
   fetchAllTasks?: boolean;
+  orderByRecentActivity?: boolean;
 }) => Promise<ExternalTmsJobTaskMetadata[]>;
 
 export type ExternalTmsGlossaryTermMetadata = {


### PR DESCRIPTION
## What changed

The project overview **Today** section previously used triage mode, which filtered to actionable statuses and ranked failed/review jobs ahead of newer activity. It now loads the five most recently updated jobs (all statuses) and renders them in recency order with labels for queued, succeeded, and cancelled states.

## How to test

- [ ] Open a native project overview with a mix of succeeded, running, and failed jobs — verify the list is ordered by most recent activity, not failed-first.
- [ ] Open a TMS project overview and confirm recent provider jobs appear the same way.
- [ ] Confirm the empty state reads "No jobs yet" when a project has no jobs.
- [ ] Run `vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.test.ts src/lib/projects/jobs/fetch-project-jobs.test.ts`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review