### PR TITLE
refactor(web): trim overlapping links in marketing Resources menu

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-view.tsx
@@ -32,10 +32,8 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import {
-  cliDocsUrl,
   contactUrl,
   docsUrl,
-  githubActionUrl,
   githubRepoUrl,
   trustCenterUrl,
 } from "@/components/marketing/marketing-page-content";
@@ -115,12 +113,10 @@ const companyPageLink: NavLink = {
 
 const resourceLinks: NavLink[] = [
   { href: docsUrl, kind: "navbar", labelKey: "navDocumentation", external: true },
-  { href: cliDocsUrl, kind: "navbar", labelKey: "navCliDocs", external: true },
-  { href: "/localisation-audit", kind: "navbar", labelKey: "navLocalisationAudit" },
-  { href: "/integrations", kind: "navbar", labelKey: "navIntegrations" },
   { href: "/blog", kind: "navbar", labelKey: "navBlog" },
+  { href: "/integrations", kind: "navbar", labelKey: "navIntegrations" },
+  { href: "/localisation-audit", kind: "navbar", labelKey: "navLocalisationAudit" },
   { href: "/startups", kind: "navbar", labelKey: "navStartups" },
-  { href: githubActionUrl, kind: "navbar", labelKey: "navGitHubAction", external: true },
   { href: githubRepoUrl, kind: "navbar", labelKey: "navGitHub", external: true },
 ];
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.messages.ts
@@ -36,8 +36,8 @@ export const navbarMessages = defineMessages({
     description: "Category heading above use-case links in the marketing navbar mega-menu",
   },
   navResourcesHeading: {
-    defaultMessage: "Resources",
-    id: "xEVW32kNCM",
+    defaultMessage: "Explore",
+    id: 'pgDkQXMb01',
     description: "Category heading above resource links in the marketing navbar mega-menu",
   },
   navLegalHeading: {
@@ -79,16 +79,6 @@ export const navbarMessages = defineMessages({
     defaultMessage: "Documentation",
     id: "zuCO/3GiEh",
     description: "Marketing navbar link to product documentation",
-  },
-  navCliDocs: {
-    defaultMessage: "CLI docs",
-    id: "PACHUU2LVi",
-    description: "Marketing navbar link to CLI documentation",
-  },
-  navGitHubAction: {
-    defaultMessage: "GitHub Action",
-    id: "siHRtHWO8x",
-    description: "Marketing navbar link to the Hyperlocalise GitHub Action",
   },
   navGitHub: {
     defaultMessage: "GitHub",

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.messages.ts
@@ -37,7 +37,7 @@ export const navbarMessages = defineMessages({
   },
   navResourcesHeading: {
     defaultMessage: "Explore",
-    id: 'pgDkQXMb01',
+    id: "pgDkQXMb01",
     description: "Category heading above resource links in the marketing navbar mega-menu",
   },
   navLegalHeading: {


### PR DESCRIPTION
## What changed

Trimmed the marketing header Resources dropdown by removing overlapping links:

- **CLI docs** — already covered by Documentation
- **GitHub Action** — already covered by GitHub

Renamed the inner mega-menu column heading from "Resources" to "Explore" so it no longer duplicates the menu trigger label.

Footer links are unchanged.

## How to test

- Open the marketing site and click **Resources** in the header
- Confirm the dropdown shows Documentation, Blog, Integrations, Localisation audit, Startups, and GitHub (no CLI docs or GitHub Action)
- Confirm the left column heading reads **Explore** and the Legal column is unchanged
- Check mobile navigation shows the same trimmed list under Resources

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review