### PR TITLE
feat(memory): support Crowdin CSV imports

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.test.ts
@@ -190,6 +190,59 @@ describe("memoryRoutes", () => {
     ]);
   });
 
+  it("imports Crowdin's locale-header CSV export", async () => {
+    const { identity, memory } = await fixture.createStoredMemoryFixture();
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.import.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: memory.id,
+        },
+        json: {
+          format: "csv",
+          content: ["en,vi", 'Discount,"Khuyến mãi hl"', '"Cancellation Reason","Lý do huỷ"'].join(
+            "\n",
+          ),
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      imported: number;
+      skipped: number;
+      memoryEntries: Array<{
+        sourceLocale: string;
+        targetLocale: string;
+        sourceText: string;
+        targetText: string;
+        matchScore: number;
+      }>;
+    };
+    expect(body).toMatchObject({ imported: 2, skipped: 0 });
+    expect(body.memoryEntries).toEqual([
+      expect.objectContaining({
+        sourceLocale: "en",
+        targetLocale: "vi",
+        sourceText: "Discount",
+        targetText: "Khuyến mãi hl",
+        matchScore: 100,
+      }),
+      expect.objectContaining({
+        sourceLocale: "en",
+        targetLocale: "vi",
+        sourceText: "Cancellation Reason",
+        targetText: "Lý do huỷ",
+        matchScore: 100,
+      }),
+    ]);
+  });
+
   it("emits product usage analytics when creating a translation memory", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});

--- a/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.csv.test.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.csv.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { isOk } from "@/lib/primitives/result/results";
+
+import { parseMemoryImportContent } from "./import-memory-entries";
+
+describe("parseMemoryImportContent CSV formats", () => {
+  it("parses Crowdin's locale-header CSV export", () => {
+    const parsed = parseMemoryImportContent({
+      format: "csv",
+      content: ["en,vi", 'Discount,"Khuyến mãi hl"', '"Cancellation Reason","Lý do huỷ"'].join(
+        "\n",
+      ),
+    });
+
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value).toMatchObject({
+      format: "csv",
+      totalRead: 2,
+      issues: [],
+    });
+    expect(parsed.value.candidates).toMatchObject([
+      {
+        sourceLocale: "en",
+        targetLocale: "vi",
+        sourceText: "Discount",
+        targetText: "Khuyến mãi hl",
+        matchScore: 100,
+      },
+      {
+        sourceLocale: "en",
+        targetLocale: "vi",
+        sourceText: "Cancellation Reason",
+        targetText: "Lý do huỷ",
+        matchScore: 100,
+      },
+    ]);
+  });
+
+  it("expands Crowdin exports with multiple target locales", () => {
+    const parsed = parseMemoryImportContent({
+      format: "csv",
+      content: ["en,fr,de", "Hello,Bonjour,Hallo"].join("\n"),
+    });
+
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value.candidates).toMatchObject([
+      { sourceLocale: "en", targetLocale: "fr", targetText: "Bonjour" },
+      { sourceLocale: "en", targetLocale: "de", targetText: "Hallo" },
+    ]);
+  });
+
+  it("keeps translated locales when a Crowdin target cell is blank", () => {
+    const parsed = parseMemoryImportContent({
+      format: "csv",
+      content: ["en,fr,de", "Hello,Bonjour,"].join("\n"),
+    });
+
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value.candidates).toMatchObject([
+      { sourceLocale: "en", targetLocale: "fr", targetText: "Bonjour" },
+    ]);
+  });
+
+  it("accepts underscore-separated Crowdin locale headers", () => {
+    const parsed = parseMemoryImportContent({
+      format: "csv",
+      content: ["en_US,fr_FR", "Hello,Bonjour"].join("\n"),
+    });
+
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value.candidates).toMatchObject([
+      {
+        sourceLocale: "en_US",
+        targetLocale: "fr_FR",
+        sourceText: "Hello",
+        targetText: "Bonjour",
+      },
+    ]);
+  });
+
+  it("does not misclassify a headerless generic row with locale-like text", () => {
+    const parsed = parseMemoryImportContent({
+      format: "csv",
+      content: ["en,fr,OK,OK", "en,fr,Hello,Bonjour"].join("\n"),
+    });
+
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value.candidates).toMatchObject([
+      { sourceLocale: "en", targetLocale: "fr", sourceText: "OK", targetText: "OK" },
+      { sourceLocale: "en", targetLocale: "fr", sourceText: "Hello", targetText: "Bonjour" },
+    ]);
+  });
+
+  it("keeps generic rows after a malformed two-cell preamble", () => {
+    const parsed = parseMemoryImportContent({
+      format: "csv",
+      content: ["en,fr", "en,fr,Hello,Bonjour,92"].join("\n"),
+    });
+
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value.candidates).toMatchObject([
+      {
+        sourceLocale: "en",
+        targetLocale: "fr",
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        matchScore: 92,
+      },
+    ]);
+    expect(parsed.value.issues).toHaveLength(1);
+  });
+
+  it("reports malformed rows in Crowdin's locale-header format", () => {
+    const parsed = parseMemoryImportContent({
+      format: "csv",
+      content: ["en,vi", ",Target", ",Another"].join("\n"),
+    });
+
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value.totalRead).toBe(2);
+    expect(parsed.value.candidates).toHaveLength(0);
+    expect(parsed.value.issues).toHaveLength(2);
+  });
+
+  it("keeps the existing generic CSV format", () => {
+    const parsed = parseMemoryImportContent({
+      format: "csv",
+      content: "sourceLocale,targetLocale,sourceText,targetText,score\nen,fr,Hello,Bonjour,92",
+    });
+
+    expect(isOk(parsed)).toBe(true);
+    if (!isOk(parsed)) return;
+
+    expect(parsed.value.candidates[0]).toMatchObject({
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      matchScore: 92,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/import-memory-entries.ts
@@ -74,9 +74,37 @@ function sourceKey(sourceLocale: string, targetLocale: string, sourceText: strin
   return `${sourceLocale}\u0000${targetLocale}\u0000${normalizeTranslationMemorySourceText(sourceText)}`;
 }
 
+function isLocaleIdentifier(value: string) {
+  const trimmed = value.trim();
+  if (!/^[a-z]{2,3}(?:[-_][a-z0-9]{2,8})*$/i.test(trimmed)) {
+    return false;
+  }
+
+  try {
+    const language = new Intl.Locale(trimmed.replaceAll("_", "-")).language;
+    const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(language);
+    return Boolean(languageName && languageName.toLowerCase() !== language.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+function isCrowdinCsvHeader(header: string[], rows: string[][]) {
+  return (
+    header.length >= 2 &&
+    header.every(isLocaleIdentifier) &&
+    rows.some((row) => row.length === header.length)
+  );
+}
+
 function parseCsvImport(content: string): ParsedMemoryImport {
   const rows = parseCsvRows(content);
   const [first, ...rest] = rows;
+  const firstRow = first?.map((cell, index) => (index === 0 ? cell.replace(/^\uFEFF/, "") : cell));
+  if (firstRow && isCrowdinCsvHeader(firstRow, rest)) {
+    return parseCrowdinCsvImport(firstRow, rest);
+  }
+
   const hasHeader = first?.some((cell) => /source|target|locale|text/i.test(cell)) ?? false;
   const dataRows = hasHeader ? rest : rows;
   const issues: TmxIssue[] = [];
@@ -114,6 +142,56 @@ function parseCsvImport(content: string): ParsedMemoryImport {
     candidates,
     issues,
     totalRead: dataRows.length,
+  };
+}
+
+function parseCrowdinCsvImport(header: string[], rows: string[][]): ParsedMemoryImport {
+  const [sourceLocale, ...targetLocales] = header.map((cell) => cell.trim());
+  const issues: TmxIssue[] = [];
+  const candidates: MemoryImportCandidate[] = [];
+
+  rows.forEach((row, index) => {
+    const unitIndex = index + 1;
+    const [sourceText, ...targetTexts] = row;
+    if (
+      row.length !== header.length ||
+      sourceText === undefined ||
+      sourceText.trim().length === 0
+    ) {
+      issues.push({
+        severity: "error",
+        code: "invalid_csv_row",
+        message: "Row is missing a source text or target text",
+        unitIndex,
+      });
+      return;
+    }
+
+    targetLocales.forEach((targetLocale, targetIndex) => {
+      const targetText = targetTexts[targetIndex];
+      if (targetText === undefined || targetText.trim().length === 0) {
+        return;
+      }
+
+      candidates.push({
+        sourceLocale,
+        targetLocale,
+        sourceText,
+        targetText,
+        matchScore: 100,
+        externalKey: null,
+        metadata: {},
+        unitIndex,
+        isVariant: false,
+      });
+    });
+  });
+
+  return {
+    format: "csv",
+    candidates,
+    issues,
+    totalRead: rows.length,
   };
 }
 


### PR DESCRIPTION
## Summary
- support Crowdin translation-memory CSV exports with a locale header row
- preserve the existing generic CSV import format
- add parser and route coverage for valid and malformed Crowdin rows

## Validation
- `vp test run src/lib/memory/import-memory-entries.csv.test.ts src/api/routes/memory/memory.route.test.ts` (9 tests passed)
- `vp check --fix` passed with 9 pre-existing warnings
- full `vp test` was not completed because unrelated auth/MCP suites were failing in the local environment