### PR TITLE
fix(web): translate untranslated strings and reuse TM on file jobs

### DIFF
--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
@@ -281,6 +281,40 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
     expect(result.translatedKeyCount).toBe(0);
   });
 
+  it("prefills hidden keys with source text for file translation jobs", async () => {
+    repoLimitMock.mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }]);
+    offsetMock.mockResolvedValueOnce([
+      { id: "key_1", key: "hidden.copy", sourceText: "Do not translate", isHidden: true },
+      { id: "key_2", key: "greeting", sourceText: "Hello", isHidden: false },
+    ]);
+
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(
+      () => Promise.resolve([]) as unknown as { limit: typeof repoLimitMock; orderBy: typeof orderByMock },
+    );
+
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+    });
+
+    expect(result.prefilled).toEqual({
+      "hidden.copy": "Do not translate",
+    });
+    expect(result.retryKeys).toEqual([]);
+    expect(result.translatedKeyCount).toBe(0);
+    expect(result.loadedKeyCount).toBe(2);
+  });
+
   it("prefills hidden keys with existing translation or source fallback on export", async () => {
     repoLimitMock.mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }]);
     offsetMock.mockResolvedValueOnce([

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
@@ -297,7 +297,11 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
       orderBy: orderByMock,
     }));
     whereMock.mockImplementationOnce(
-      () => Promise.resolve([]) as unknown as { limit: typeof repoLimitMock; orderBy: typeof orderByMock },
+      () =>
+        Promise.resolve([]) as unknown as {
+          limit: typeof repoLimitMock;
+          orderBy: typeof orderByMock;
+        },
     );
 
     const result = await loadProjectTranslationsAsPrefilledEntries({

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
@@ -281,7 +281,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
     expect(result.translatedKeyCount).toBe(0);
   });
 
-  it("prefills hidden keys with existing translation or source and omits them from retryKeys", async () => {
+  it("prefills hidden keys with existing translation or source fallback on export", async () => {
     repoLimitMock.mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }]);
     offsetMock.mockResolvedValueOnce([
       { id: "key_1", key: "debug.id", sourceText: "Internal id", isHidden: true },
@@ -314,13 +314,14 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
       projectId: "project_1",
       sourcePath: "locales/en.json",
       targetLocale: "fr",
+      includeAllSourceKeys: true,
     });
 
     expect(result.prefilled).toEqual({
       "debug.id": "Id interne",
       "hidden.copy": "Do not translate",
+      greeting: "Hello",
     });
-    expect(result.retryKeys).toEqual([]);
     expect(result.loadedKeyCount).toBe(3);
     expect(result.translatedKeyCount).toBe(1);
   });

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -755,7 +755,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
           if (canPrefill) {
             prefilled[key.key] = translation!.text;
             translatedKeyCount += 1;
-          } else if (input.includeAllSourceKeys) {
+          } else {
             prefilled[key.key] = key.sourceText;
           }
           continue;

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -23,6 +23,7 @@ import { incrementMemoryEntryVersionSql } from "@/lib/memory/memory-entry-lifecy
 import { ProjectServiceBase } from "@/lib/projects/project-service-base";
 import { translationKeysQueueOrderBy } from "@/lib/projects/translations/project-translation-queue-order";
 import { shouldRetrySameAsSourcePrefill } from "@/lib/projects/translations/should-retry-same-as-source-prefill";
+import { shouldPrefillTranslation } from "@/lib/projects/translations/translation-prefill";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
 type ProjectKeysScopeInput = {
@@ -745,23 +746,23 @@ export class ProjectTranslationService extends ProjectServiceBase {
 
       for (const key of keys) {
         const translation = translationByKeyId.get(key.id);
-        const hasValidTranslation =
-          Boolean(translation?.text?.trim()) && translation?.status !== "rejected";
+        const canPrefill = shouldPrefillTranslation({
+          targetText: translation?.text,
+          status: translation?.status,
+        });
 
         if (key.isHidden) {
-          if (hasValidTranslation) {
+          if (canPrefill) {
             prefilled[key.key] = translation!.text;
             translatedKeyCount += 1;
-          } else {
+          } else if (input.includeAllSourceKeys) {
             prefilled[key.key] = key.sourceText;
           }
           continue;
         }
 
-        // Leave multi-word needs-review copies out of prefill so a later
-        // translate-with-agent run can try them again. Single-word copies stay.
         const retrySameAsSource =
-          hasValidTranslation &&
+          canPrefill &&
           shouldRetrySameAsSourcePrefill({
             sourceText: key.sourceText,
             targetText: translation!.text,
@@ -772,7 +773,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
           retryKeys.push(key.key);
         }
 
-        if (hasValidTranslation && !retrySameAsSource) {
+        if (canPrefill && !retrySameAsSource) {
           prefilled[key.key] = translation!.text;
           translatedKeyCount += 1;
           continue;

--- a/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts
@@ -89,11 +89,29 @@ describe("mergeTranslationPrefills", () => {
         },
         projectPrefilled: {
           greeting: "Salut",
+          farewell: "Au revoir",
         },
       }),
     ).toEqual({
       greeting: "Salut",
       farewell: "Au revoir",
+    });
+  });
+
+  it("reuses TM for untranslated keys while project translations win on overlap", () => {
+    expect(
+      mergeTranslationPrefills({
+        tmPrefilled: {
+          workspace_knowledge: "Activer les connaissances",
+          brand: "Hyperlocalise",
+        },
+        projectPrefilled: {
+          brand: "Hyperlocalise",
+        },
+      }),
+    ).toEqual({
+      workspace_knowledge: "Activer les connaissances",
+      brand: "Hyperlocalise",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.ts
@@ -44,6 +44,7 @@ export function shouldRetrySameAsSourcePrefill(input: {
   return countSourceWords(sourceText) >= MIN_SOURCE_WORDS_FOR_SAME_AS_SOURCE_RETRY;
 }
 
+/** Project translations win; TM fills untranslated keys when a reusable match exists. */
 export function mergeTranslationPrefills(input: {
   tmPrefilled: Record<string, string>;
   projectPrefilled: Record<string, string>;

--- a/apps/hyperlocalise-web/src/lib/projects/translations/translation-prefill.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/translation-prefill.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { isUntranslatedTranslation, shouldPrefillTranslation } from "./translation-prefill";
+
+describe("isUntranslatedTranslation", () => {
+  it("treats empty and whitespace-only targets as untranslated", () => {
+    expect(isUntranslatedTranslation({ targetText: null })).toBe(true);
+    expect(isUntranslatedTranslation({ targetText: "" })).toBe(true);
+    expect(isUntranslatedTranslation({ targetText: "   " })).toBe(true);
+  });
+
+  it("treats rejected rows as untranslated even when text is present", () => {
+    expect(isUntranslatedTranslation({ targetText: "Bonjour", status: "rejected" })).toBe(true);
+  });
+
+  it("treats non-empty approved and needs-review targets as translated", () => {
+    expect(isUntranslatedTranslation({ targetText: "Bonjour", status: "approved" })).toBe(false);
+    expect(isUntranslatedTranslation({ targetText: "Bonjour", status: "needs_review" })).toBe(
+      false,
+    );
+    expect(
+      isUntranslatedTranslation({
+        targetText: "Enable workspace knowledge",
+        status: "needs_review",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldPrefillTranslation", () => {
+  it("prefills only translated rows", () => {
+    expect(shouldPrefillTranslation({ targetText: "Bonjour", status: "approved" })).toBe(true);
+    expect(shouldPrefillTranslation({ targetText: "", status: "needs_review" })).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/translations/translation-prefill.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/translation-prefill.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+/** Matches native CAT "untranslated" / pending segments and the untranslated queue filter. */
+export function isUntranslatedTranslation(input: {
+  targetText?: string | null;
+  status?: string | null;
+}): boolean {
+  if (input.status === "rejected") {
+    return true;
+  }
+
+  return !input.targetText?.trim();
+}
+
+export function shouldPrefillTranslation(input: {
+  targetText?: string | null;
+  status?: string | null;
+}): boolean {
+  return !isUntranslatedTranslation(input);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
@@ -1004,11 +1004,7 @@ describe("translateProviderJobFiles", () => {
       return Buffer.from("{}", "utf8");
     });
     extractSandboxEntriesMock.mockImplementation(async (_sandboxId: string, path: string) => {
-      const fileId = path.includes("file-a")
-        ? "file-a"
-        : path.includes("file-b")
-          ? "file-b"
-          : null;
+      const fileId = path.includes("file-a") ? "file-a" : path.includes("file-b") ? "file-b" : null;
       if (fileId && path.includes("-fr")) {
         const count = (frenchExtractCountByFile.get(fileId) ?? 0) + 1;
         frenchExtractCountByFile.set(fileId, count);
@@ -1088,9 +1084,9 @@ describe("translateProviderJobFiles", () => {
         expect.objectContaining({ key: "save", to: "Sauver", fileId: "file-b" }),
       ]),
     );
-    expect(result.changedItems.some((item) => item.fileId === "file-a" && item.key === "save")).toBe(
-      false,
-    );
+    expect(
+      result.changedItems.some((item) => item.fileId === "file-a" && item.key === "save"),
+    ).toBe(false);
     expect(result.skippedExistingLocales).toBe(1);
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
@@ -347,7 +347,7 @@ describe("translateProviderJobFiles", () => {
       filename: "messages.json",
       fileFormat: "json",
     });
-    reuseFileTranslationMemoryEntriesMock.mockResolvedValue({});
+    reuseFileTranslationMemoryEntriesMock.mockResolvedValue({ prefilled: {}, matchesByKey: {} });
     createTranslationSandboxMock.mockResolvedValue({ sandboxId: "sandbox_shared" });
     prepareSandboxMock.mockResolvedValue(undefined);
     stopTranslationSandboxMock.mockResolvedValue(undefined);
@@ -821,6 +821,277 @@ describe("translateProviderJobFiles", () => {
         expect.stringContaining("File translation failed for a.json (fr)"),
       ]),
     );
+  });
+
+  it("carries translation memory provenance into file proposals", async () => {
+    reuseFileTranslationMemoryEntriesMock.mockResolvedValue({
+      prefilled: { hello: "Bonjour" },
+      matchesByKey: {
+        hello: [
+          {
+            memoryId: "memory_1",
+            memoryName: "Project TM",
+            sourceText: "Hello",
+            targetText: "Bonjour",
+            targetLocale: "fr",
+            matchScore: 100,
+            matchSource: "synced_database",
+            providerKind: null,
+            resourceId: "memory_1",
+            externalResourceId: null,
+          },
+        ],
+      },
+    });
+    readTranslatedFileMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.includes("file-1") && path.includes("-fr")) {
+        return Buffer.from('{"hello":"Bonjour"}', "utf8");
+      }
+      if (path.includes("file-1")) {
+        return Buffer.from('{"hello":"Hello"}', "utf8");
+      }
+      return Buffer.from("{}", "utf8");
+    });
+    extractSandboxEntriesMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.includes("file-1") && path.includes("-fr")) {
+        return { ok: true, entries: { hello: "Bonjour" } };
+      }
+      if (path.includes("file-1")) {
+        return { ok: true, entries: { hello: "Hello" } };
+      }
+      return { ok: true, entries: {} };
+    });
+
+    const result = await translateProviderJobFiles({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "crowdin",
+      sourceFiles: [
+        {
+          id: "file-1",
+          displayName: "a.json",
+          sourcePath: "locales/a.json",
+        },
+      ],
+      content: {
+        externalJobId: "task-1",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "hello",
+            sourceText: "Hello",
+            fileId: "file-1",
+            translations: [],
+          },
+        ],
+      },
+    });
+
+    expect(result.changedItems).toEqual([
+      expect.objectContaining({
+        key: "hello",
+        to: "Bonjour",
+        translationMemoryMatchesUsed: [
+          expect.objectContaining({
+            memoryId: "memory_1",
+            memoryName: "Project TM",
+            matchSource: "synced_database",
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("filters untranslated units from crowdin prefill while keeping translated exports", async () => {
+    downloadCrowdinTranslationsInSandboxMock.mockResolvedValue({ ok: true });
+    let mixedFrenchExtractCount = 0;
+    readTranslatedFileMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.includes("file-mixed") && path.includes("-fr")) {
+        return Buffer.from('{"hello":"Bonjour","pending":"En attente"}', "utf8");
+      }
+      if (path.includes("file-mixed")) {
+        return Buffer.from('{"hello":"Hello","pending":"Pending"}', "utf8");
+      }
+      return Buffer.from("{}", "utf8");
+    });
+    extractSandboxEntriesMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.includes("file-mixed") && path.includes("-fr")) {
+        mixedFrenchExtractCount += 1;
+        if (mixedFrenchExtractCount === 1) {
+          return {
+            ok: true,
+            entries: { hello: "Bonjour (crowdin)", pending: "En attente (crowdin)" },
+          };
+        }
+        return { ok: true, entries: { hello: "Bonjour", pending: "En attente" } };
+      }
+      if (path.includes("file-mixed")) {
+        return { ok: true, entries: { hello: "Hello", pending: "Pending" } };
+      }
+      return { ok: true, entries: {} };
+    });
+
+    const result = await translateProviderJobFiles({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "crowdin",
+      sourceFiles: [
+        {
+          id: "file-mixed",
+          displayName: "messages.json",
+          sourcePath: "locales/messages.json",
+        },
+      ],
+      content: {
+        externalJobId: "task-1",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "hello",
+            sourceText: "Hello",
+            fileId: "file-mixed",
+            translations: [{ locale: "fr", text: "Bonjour" }],
+          },
+          {
+            externalStringId: "2",
+            key: "pending",
+            sourceText: "Pending",
+            fileId: "file-mixed",
+            translations: [],
+          },
+        ],
+      },
+    });
+
+    expect(downloadCrowdinTranslationsInSandboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({ targetLocale: "fr", mergeApproved: true }),
+    );
+    const prefillWrite = writeFileToSandboxMock.mock.calls.find(
+      ([, path]) => path === "/tmp/prefilled-by-locale.json",
+    );
+    expect(prefillWrite).toBeDefined();
+    expect(JSON.parse(prefillWrite![2].toString("utf8"))).toEqual({
+      fr: { hello: "Bonjour" },
+    });
+    expect(result.changedItems).toEqual([
+      expect.objectContaining({ key: "pending", to: "En attente", fileId: "file-mixed" }),
+    ]);
+    expect(result.changedItems.some((item) => item.key === "hello")).toBe(false);
+  });
+
+  it("does not crowdin-prefill shared keys for files that still need translation", async () => {
+    downloadCrowdinTranslationsInSandboxMock.mockResolvedValue({ ok: true });
+    const frenchExtractCountByFile = new Map<string, number>();
+    readTranslatedFileMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.includes("-fr")) {
+        if (path.includes("file-a")) {
+          return Buffer.from('{"save":"Enregistrer","greeting":"Salut"}', "utf8");
+        }
+        if (path.includes("file-b")) {
+          return Buffer.from('{"save":"Sauver"}', "utf8");
+        }
+      }
+      if (path.includes("file-a")) {
+        return Buffer.from('{"save":"Save","greeting":"Hello"}', "utf8");
+      }
+      if (path.includes("file-b")) {
+        return Buffer.from('{"save":"Save"}', "utf8");
+      }
+      return Buffer.from("{}", "utf8");
+    });
+    extractSandboxEntriesMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      const fileId = path.includes("file-a")
+        ? "file-a"
+        : path.includes("file-b")
+          ? "file-b"
+          : null;
+      if (fileId && path.includes("-fr")) {
+        const count = (frenchExtractCountByFile.get(fileId) ?? 0) + 1;
+        frenchExtractCountByFile.set(fileId, count);
+        if (count === 1) {
+          return {
+            ok: true,
+            entries: { save: "Enregistrer (crowdin)", greeting: "Salut (crowdin)" },
+          };
+        }
+        if (fileId === "file-a") {
+          return { ok: true, entries: { save: "Enregistrer", greeting: "Salut" } };
+        }
+        return { ok: true, entries: { save: "Sauver" } };
+      }
+      if (path.includes("file-a")) {
+        return { ok: true, entries: { save: "Save", greeting: "Hello" } };
+      }
+      if (path.includes("file-b")) {
+        return { ok: true, entries: { save: "Save" } };
+      }
+      return { ok: true, entries: {} };
+    });
+
+    const result = await translateProviderJobFiles({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "crowdin",
+      sourceFiles: [
+        {
+          id: "file-a",
+          displayName: "a.json",
+          sourcePath: "locales/a.json",
+        },
+        {
+          id: "file-b",
+          displayName: "b.json",
+          sourcePath: "locales/b.json",
+        },
+      ],
+      content: {
+        externalJobId: "task-1",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "save",
+            sourceText: "Save",
+            fileId: "file-a",
+            translations: [{ locale: "fr", text: "Enregistrer" }],
+          },
+          {
+            externalStringId: "2",
+            key: "greeting",
+            sourceText: "Hello",
+            fileId: "file-a",
+            translations: [],
+          },
+          {
+            externalStringId: "3",
+            key: "save",
+            sourceText: "Save",
+            fileId: "file-b",
+            translations: [],
+          },
+        ],
+      },
+    });
+
+    const prefillWrite = writeFileToSandboxMock.mock.calls.find(
+      ([, path]) => path === "/tmp/prefilled-by-locale.json",
+    );
+    expect(prefillWrite).toBeUndefined();
+    expect(result.changedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "greeting", to: "Salut", fileId: "file-a" }),
+        expect.objectContaining({ key: "save", to: "Sauver", fileId: "file-b" }),
+      ]),
+    );
+    expect(result.changedItems.some((item) => item.fileId === "file-a" && item.key === "save")).toBe(
+      false,
+    );
+    expect(result.skippedExistingLocales).toBe(1);
   });
 
   it("continues the batch when one sandbox source download fails", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -36,6 +36,8 @@ import {
   listGlossaryTermsForProject,
   FILE_TRANSLATION_GLOSSARY_PAIR_LIMIT,
 } from "@/lib/glossary/query-glossary-terms";
+import { mergeTranslationPrefills } from "@/lib/projects/translations/should-retry-same-as-source-prefill";
+import { isUntranslatedTranslation } from "@/lib/projects/translations/translation-prefill";
 import { reuseFileTranslationMemoryEntries } from "@/lib/translation/file-memory";
 import type { SandboxTranslationContext } from "@/lib/translation/domain";
 import type { ExternalTmsProviderKind } from "@/lib/providers/credentials/organization-external-tms-provider-credentials";
@@ -101,7 +103,7 @@ function existingTranslationForLocale(unit: ExternalTmsTranslationUnit, locale: 
 function shouldSkipExistingTranslation(
   translation: ExternalTmsTranslationUnit["translations"][number] | null,
 ) {
-  return Boolean(translation?.text?.trim());
+  return !isUntranslatedTranslation({ targetText: translation?.text });
 }
 
 function unitsForFile(units: ExternalTmsTranslationUnit[], externalFileId: string) {
@@ -161,10 +163,10 @@ function buildPrefilledEntriesForLocale(input: {
   const prefilled: Record<string, string> = {};
   for (const unit of input.units) {
     const existing = existingTranslationForLocale(unit, input.targetLocale);
-    if (!existing?.text?.trim()) {
+    if (isUntranslatedTranslation({ targetText: existing?.text })) {
       continue;
     }
-    prefilled[unit.key] = existing.text;
+    prefilled[unit.key] = existing!.text;
   }
   return prefilled;
 }
@@ -705,7 +707,10 @@ export async function translateProviderJobFiles(input: {
                 sourceEntries: prepared.sourceEntries,
               });
             }
-            byLocale[targetLocale] = { ...tmPrefilled, ...existingPrefilled };
+            byLocale[targetLocale] = mergeTranslationPrefills({
+              tmPrefilled,
+              projectPrefilled: existingPrefilled,
+            });
           }
           filePrefills.push(byLocale);
         }
@@ -741,9 +746,17 @@ export async function translateProviderJobFiles(input: {
               if (!crowdinEntries.ok) {
                 continue;
               }
+              const unitsNeedingTranslation =
+                prepared.localesNeedingByLocale.get(targetLocale) ?? [];
+              const untranslatedKeys = new Set(unitsNeedingTranslation.map((unit) => unit.key));
+              const crowdinPrefill = Object.fromEntries(
+                Object.entries(hlEntriesPayloadToStringMap(crowdinEntries.entries)).filter(
+                  ([key]) => !untranslatedKeys.has(key),
+                ),
+              );
               // Existing/TM prefill wins over Crowdin prefill for the same key.
               filePrefills[index]![targetLocale] = {
-                ...hlEntriesPayloadToStringMap(crowdinEntries.entries),
+                ...crowdinPrefill,
                 ...filePrefills[index]![targetLocale],
               };
             }

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -38,7 +38,10 @@ import {
 } from "@/lib/glossary/query-glossary-terms";
 import { mergeTranslationPrefills } from "@/lib/projects/translations/should-retry-same-as-source-prefill";
 import { isUntranslatedTranslation } from "@/lib/projects/translations/translation-prefill";
-import { reuseFileTranslationMemoryEntries } from "@/lib/translation/file-memory";
+import {
+  type FileTranslationMemoryReuseResult,
+  reuseFileTranslationMemoryEntries,
+} from "@/lib/translation/file-memory";
 import type { SandboxTranslationContext } from "@/lib/translation/domain";
 import type { ExternalTmsProviderKind } from "@/lib/providers/credentials/organization-external-tms-provider-credentials";
 import { createLogger } from "@/lib/log";
@@ -691,28 +694,32 @@ export async function translateProviderJobFiles(input: {
         });
 
         const filePrefills: Array<Record<string, Record<string, string>>> = [];
+        const tmReuseByFileIndex: Array<Record<string, FileTranslationMemoryReuseResult>> = [];
         for (const prepared of preparedFiles) {
           const byLocale: Record<string, Record<string, string>> = {};
+          const tmReuseByLocale: Record<string, FileTranslationMemoryReuseResult> = {};
           for (const targetLocale of localesToRun) {
             const existingPrefilled = buildPrefilledEntriesForLocale({
               units: prepared.fileUnits,
               targetLocale,
             });
-            let tmPrefilled: Record<string, string> = {};
+            let tmReuse: FileTranslationMemoryReuseResult = { prefilled: {}, matchesByKey: {} };
             if (prepared.sourceEntries) {
-              tmPrefilled = await reuseFileTranslationMemoryEntries({
+              tmReuse = await reuseFileTranslationMemoryEntries({
                 projectId: input.projectId,
                 sourceLocale,
                 targetLocale,
                 sourceEntries: prepared.sourceEntries,
               });
             }
+            tmReuseByLocale[targetLocale] = tmReuse;
             byLocale[targetLocale] = mergeTranslationPrefills({
-              tmPrefilled,
+              tmPrefilled: tmReuse.prefilled,
               projectPrefilled: existingPrefilled,
             });
           }
           filePrefills.push(byLocale);
+          tmReuseByFileIndex.push(tmReuseByLocale);
         }
 
         if (crowdinContext?.ok) {
@@ -804,11 +811,13 @@ export async function translateProviderJobFiles(input: {
             caseSensitive: term.caseSensitive ?? null,
           }));
 
-          for (const prepared of preparedFiles) {
+          for (let preparedIndex = 0; preparedIndex < preparedFiles.length; preparedIndex += 1) {
+            const prepared = preparedFiles[preparedIndex]!;
             for (const [
               targetLocale,
               localesNeedingTranslation,
             ] of prepared.localesNeedingByLocale) {
+              const tmReuse = tmReuseByFileIndex[preparedIndex]?.[targetLocale];
               const outputFilename = getOutputFilename(prepared.workFilename, targetLocale);
               try {
                 const translatedContent = await readTranslatedFile(sandboxId, outputFilename);
@@ -866,6 +875,14 @@ export async function translateProviderJobFiles(input: {
                       })),
                   });
 
+                  const tmPrefilledText = tmReuse?.prefilled[unit.key];
+                  const translationMemoryMatchesUsed =
+                    tmPrefilledText &&
+                    to === tmPrefilledText &&
+                    tmReuse.matchesByKey[unit.key]?.length
+                      ? tmReuse.matchesByKey[unit.key]
+                      : undefined;
+
                   changedItems.push(
                     serializeAgentRunProposalItem({
                       itemId: buildAgentRunProposalItemId({
@@ -882,6 +899,7 @@ export async function translateProviderJobFiles(input: {
                       changedFields: deriveChangedFields(from, to),
                       warnings: proposalWarnings,
                       fileId: unit.fileId ?? prepared.sourceFile.id,
+                      translationMemoryMatchesUsed,
                     }),
                   );
                 }

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
@@ -40,6 +40,7 @@ import {
   summarizeProviderUnitFileIds,
   translateProviderJobFiles,
 } from "@/lib/providers/agent-runs/provider-agent-file-translate";
+import { isUntranslatedTranslation } from "@/lib/projects/translations/translation-prefill";
 import {
   assembleStringTranslationContextSnapshot,
   loadTranslationContextProject,
@@ -132,7 +133,7 @@ function existingTranslationForLocale(unit: ExternalTmsTranslationUnit, locale: 
 function shouldSkipExistingTranslation(
   translation: ExternalTmsTranslationUnit["translations"][number] | null,
 ) {
-  return Boolean(translation?.text?.trim());
+  return !isUntranslatedTranslation({ targetText: translation?.text });
 }
 
 function buildJobInputForUnit(input: {

--- a/apps/hyperlocalise-web/src/lib/translation/file-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-memory.ts
@@ -19,8 +19,23 @@ import {
   listAttachedProjectMemoryIds,
 } from "@/lib/memory/ensure-default-native-project-memory";
 import { incrementMemoryEntryVersionSql } from "@/lib/memory/memory-entry-lifecycle";
+import type { AgentRunTranslationMemoryMatchUsage } from "@/lib/providers/contracts/translation-memory-match";
+import {
+  normalizeSyncedDatabaseTranslationMemoryMatch,
+  toAgentRunTranslationMemoryMatchUsage,
+} from "@/lib/providers/contracts/translation-memory-match";
 import { listHiddenProjectTranslationKeysForSourcePath } from "@/lib/projects/translations/project-translation-service";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
+
+export type FileTranslationMemoryReuseResult = {
+  prefilled: Record<string, string>;
+  matchesByKey: Record<string, AgentRunTranslationMemoryMatchUsage[]>;
+};
+
+const emptyFileTranslationMemoryReuseResult = (): FileTranslationMemoryReuseResult => ({
+  prefilled: {},
+  matchesByKey: {},
+});
 
 function sourceTextHash(sourceText: string) {
   return createHash("sha256").update(sourceText, "utf8").digest("hex");
@@ -58,24 +73,34 @@ export class FileTranslationMemoryStore {
       }))
       .filter((unit) => unit.sourceText.trim().length > 0);
     if (units.length === 0) {
-      return {} as Record<string, string>;
+      return emptyFileTranslationMemoryReuseResult();
     }
 
     const memoryIds = await listAttachedProjectMemoryIds(input.projectId);
     if (memoryIds.length === 0) {
-      return {} as Record<string, string>;
+      return emptyFileTranslationMemoryReuseResult();
     }
 
     const normalizedSourceTexts = [...new Set(units.map((unit) => unit.normalizedSourceText))];
     const rows = await db
       .select({
+        id: schema.memoryEntries.id,
         memoryId: schema.memoryEntries.memoryId,
+        sourceText: schema.memoryEntries.sourceText,
         normalizedSourceText: schema.memoryEntries.normalizedSourceText,
+        sourceLocale: schema.memoryEntries.sourceLocale,
         targetLocale: schema.memoryEntries.targetLocale,
         targetText: schema.memoryEntries.targetText,
+        provenance: schema.memoryEntries.provenance,
+        matchScore: schema.memoryEntries.matchScore,
+        externalKey: schema.memoryEntries.externalKey,
         metadata: schema.memoryEntries.metadata,
+        memoryName: schema.memories.name,
+        externalProviderKind: schema.memories.externalProviderKind,
+        externalMemoryId: schema.memories.externalMemoryId,
       })
       .from(schema.memoryEntries)
+      .innerJoin(schema.memories, eq(schema.memoryEntries.memoryId, schema.memories.id))
       .where(
         and(
           eq(schema.memoryEntries.sourceLocale, input.sourceLocale),
@@ -86,7 +111,7 @@ export class FileTranslationMemoryStore {
         ),
       );
 
-    const reusableByUnit = new Map<string, string>();
+    const reusableByUnit = new Map<string, (typeof rows)[number]>();
     for (const row of rows) {
       const metadata = row.metadata as {
         segmentKey?: string;
@@ -103,14 +128,15 @@ export class FileTranslationMemoryStore {
           sourceTextHash: metadata.sourceTextHash,
           targetLocale: row.targetLocale,
         }),
-        row.targetText,
+        row,
       );
     }
 
-    const reusable: Record<string, string> = {};
+    const prefilled: Record<string, string> = {};
+    const matchesByKey: Record<string, AgentRunTranslationMemoryMatchUsage[]> = {};
     for (const unit of units) {
       for (const memoryId of memoryIds) {
-        const targetText = reusableByUnit.get(
+        const row = reusableByUnit.get(
           fileMemoryReuseKey({
             memoryId,
             normalizedSourceText: unit.normalizedSourceText,
@@ -119,14 +145,35 @@ export class FileTranslationMemoryStore {
             targetLocale: input.targetLocale,
           }),
         );
-        if (targetText) {
-          reusable[unit.key] = targetText;
-          break;
+        if (!row) {
+          continue;
         }
+
+        prefilled[unit.key] = row.targetText;
+        matchesByKey[unit.key] = [
+          toAgentRunTranslationMemoryMatchUsage(
+            normalizeSyncedDatabaseTranslationMemoryMatch({
+              id: row.id,
+              memoryId: row.memoryId,
+              memoryName: row.memoryName,
+              sourceText: row.sourceText,
+              targetText: row.targetText,
+              sourceLocale: row.sourceLocale,
+              targetLocale: row.targetLocale,
+              matchScore: row.matchScore,
+              provenance: row.provenance,
+              rank: 1,
+              providerKind: row.externalProviderKind,
+              externalResourceId: row.externalMemoryId,
+              externalSegmentId: row.externalKey,
+            }),
+          ),
+        ];
+        break;
       }
     }
 
-    return reusable;
+    return { prefilled, matchesByKey };
   }
 
   async persistEntries(input: {

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
@@ -23,7 +23,16 @@ type UpsertedMemoryEntry = {
 };
 
 type ReusableMemoryEntryRow = {
+  id: string;
   memoryId: string;
+  sourceText: string;
+  sourceLocale: string;
+  provenance: string;
+  matchScore: number;
+  externalKey: string | null;
+  memoryName: string;
+  externalProviderKind: string | null;
+  externalMemoryId: string | null;
   metadata?: {
     segmentKey: string;
     sourceTextHash: string;
@@ -53,10 +62,33 @@ const {
   }));
   const insertMock = vi.fn(() => ({ values: valuesMock }));
   const whereMock = vi.fn(async (): Promise<ReusableMemoryEntryRow[]> => [
-    { memoryId: "memory_1" },
-    { memoryId: "memory_2" },
+    {
+      id: "entry_1",
+      memoryId: "memory_1",
+      sourceText: "Hello",
+      sourceLocale: "en",
+      provenance: "file_job",
+      matchScore: 100,
+      externalKey: "job:fr:first",
+      memoryName: "Project TM",
+      externalProviderKind: null,
+      externalMemoryId: null,
+    },
+    {
+      id: "entry_2",
+      memoryId: "memory_2",
+      sourceText: "Hello",
+      sourceLocale: "en",
+      provenance: "file_job",
+      matchScore: 100,
+      externalKey: "job:de:first",
+      memoryName: "Secondary TM",
+      externalProviderKind: null,
+      externalMemoryId: null,
+    },
   ]);
-  const fromMock = vi.fn(() => ({ where: whereMock }));
+  const innerJoinMock = vi.fn(() => ({ where: whereMock }));
+  const fromMock = vi.fn(() => ({ innerJoin: innerJoinMock }));
   const selectMock = vi.fn(() => ({ from: fromMock }));
   const listHiddenKeysMock = vi.fn(async () => [] as string[]);
   const ensureDefaultMemoryIdsMock = vi.fn(async () => [] as string[]);
@@ -102,6 +134,8 @@ vi.mock("@/lib/database/client", () => ({
   schema: {
     memoryEntries: {
       externalKey: "externalKey",
+      id: "id",
+      matchScore: "matchScore",
       memoryId: "memoryId",
       metadata: "metadata",
       normalizedSourceText: "normalizedSourceText",
@@ -111,6 +145,12 @@ vi.mock("@/lib/database/client", () => ({
       sourceText: "sourceText",
       targetLocale: "targetLocale",
       targetText: "targetText",
+    },
+    memories: {
+      externalMemoryId: "externalMemoryId",
+      externalProviderKind: "externalProviderKind",
+      id: "id",
+      name: "name",
     },
     projectMemories: {
       memoryId: "memoryId",
@@ -315,7 +355,16 @@ describe("reuseFileTranslationMemoryEntries", () => {
   it("reuses only rows that match the target locale, segment key, and source hash", async () => {
     whereMock.mockResolvedValueOnce([
       {
+        id: "entry_1",
         memoryId: "memory_1",
+        sourceText: "Hello",
+        sourceLocale: "en",
+        provenance: "file_job",
+        matchScore: 100,
+        externalKey: "job:fr:first",
+        memoryName: "Project TM",
+        externalProviderKind: null,
+        externalMemoryId: null,
         metadata: {
           segmentKey: "first",
           sourceTextHash: createHash("sha256").update("Hello", "utf8").digest("hex"),
@@ -325,7 +374,16 @@ describe("reuseFileTranslationMemoryEntries", () => {
         targetText: "Bonjour",
       },
       {
+        id: "entry_2",
         memoryId: "memory_2",
+        sourceText: "Hello",
+        sourceLocale: "en",
+        provenance: "file_job",
+        matchScore: 100,
+        externalKey: "job:de:first",
+        memoryName: "Secondary TM",
+        externalProviderKind: null,
+        externalMemoryId: null,
         metadata: {
           segmentKey: "first",
           sourceTextHash: createHash("sha256").update("Hello", "utf8").digest("hex"),
@@ -343,6 +401,17 @@ describe("reuseFileTranslationMemoryEntries", () => {
       targetLocale: "fr",
     });
 
-    expect(result).toEqual({ first: "Bonjour" });
+    expect(result.prefilled).toEqual({ first: "Bonjour" });
+    expect(result.matchesByKey.first).toEqual([
+      expect.objectContaining({
+        memoryId: "memory_1",
+        memoryName: "Project TM",
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        targetLocale: "fr",
+        matchSource: "synced_database",
+        resourceId: "memory_1",
+      }),
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -887,12 +887,13 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           targetLocale,
           sourceEntries,
         });
-        tmPrefilled = await reuseFileTranslationMemoryEntriesStep({
+        const tmReuse = await reuseFileTranslationMemoryEntriesStep({
           projectId: claim.job.projectId,
           sourceLocale: parsedInput.sourceLocale,
           targetLocale,
           sourceEntries,
         });
+        tmPrefilled = tmReuse.prefilled;
         if (Object.keys(tmPrefilled).length > 0) {
           console.info("[file-translation-workflow] matched reusable translation memory entries", {
             jobId: claim.job.id,


### PR DESCRIPTION
## What changed

File and provider file translation now use translation status to decide whether a string should be prefilled or sent to the translator.

- **Untranslated** (empty or rejected) keys are no longer prefilled from existing project/TMS text, so they are actually translated.
- **Translation memory** is reused for empty keys when an approved match exists, then persisted through the normal file job output path (TM first, then AI for the rest).
- **Needs-review, multi-word, source=target** copies still skip prefill and are retranslated.
- **Single-word source=target** copies (brands, codes) are still left alone.
- **Provider/Crowdin file translation** no longer prefills untranslated keys from Crowdin export fallbacks.

This aligns the translate-with-agent workflow with the CAT **Untranslated** queue: empty strings get TM or AI, existing translations are preserved, and results land in **Needs review** for human approval.

## How to test

- [x] `vp test src/lib/projects/translations/ src/workflows/file-translation-job-pagination.test.ts src/lib/providers/agent-runs/provider-agent-file-translate.test.ts`
- [x] `vp check --fix`
- [ ] Run a native file translation job on a file with untranslated strings and confirm they move to needs review (from TM or AI).
- [ ] Re-run translate on a file with approved translations and confirm those strings are not overwritten.
- [ ] Run a Crowdin/provider file translation job and confirm untranslated units are translated instead of being skipped via source fallbacks.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review