### PR TITLE
feat(i18n): switch image localization to GPT Image 2.5 Flare

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/image-generation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/image-generation.test.ts
@@ -14,7 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const { generateImageMock, getManagedImageModelMock } = vi.hoisted(() => ({
   generateImageMock: vi.fn(),
-  getManagedImageModelMock: vi.fn(() => "openai/gpt-image-2"),
+  getManagedImageModelMock: vi.fn(() => "openai/gpt-image-2.5-flare"),
 }));
 
 vi.mock("ai", async () => {
@@ -53,7 +53,7 @@ describe("image generation", () => {
     expect(getManagedImageModelMock).toHaveBeenCalledOnce();
     expect(generateImageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: "openai/gpt-image-2",
+        model: "openai/gpt-image-2.5-flare",
         prompt: {
           images: [Buffer.from("source")],
           text: "Localize this screenshot into Japanese",

--- a/apps/hyperlocalise-web/src/lib/providers/language-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/language-model.test.ts
@@ -46,7 +46,7 @@ describe("managed language model", () => {
     expect(getManagedImageModel()).toBe(hyperlocaliseImageModelId);
     expect(getManagedVideoModel()).toBe(hyperlocaliseVideoModelId);
     expect(hyperlocaliseManagedGatewayModelId).toBe("openai/gpt-5.6-luna");
-    expect(hyperlocaliseImageModelId).toBe("openai/gpt-image-2");
+    expect(hyperlocaliseImageModelId).toBe("openai/gpt-image-2.5-flare");
     expect(hyperlocaliseVideoModelId).toBe("bytedance/seedance-2.5");
     expect(createOpenAIMock).not.toHaveBeenCalled();
     expect(createAnthropicMock).not.toHaveBeenCalled();

--- a/apps/hyperlocalise-web/src/lib/providers/language-model.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/language-model.ts
@@ -18,7 +18,7 @@ import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
 import type { LlmProvider } from "@/lib/database/types";
 
 export const hyperlocaliseManagedGatewayModelId = `openai/${hyperlocaliseAgentModelId}`;
-export const hyperlocaliseImageModelId = "openai/gpt-image-2";
+export const hyperlocaliseImageModelId = "openai/gpt-image-2.5-flare";
 export const hyperlocaliseVideoModelId = "bytedance/seedance-2.5";
 
 export type AgentLanguageModelSource = LlmProvider | "gateway";

--- a/internal/i18n/translator/types.go
+++ b/internal/i18n/translator/types.go
@@ -20,7 +20,7 @@ const (
 	ProviderAIGateway   = "ai_gateway"
 )
 
-const OpenAIImageModel = "gpt-image-2-2026-04-21"
+const OpenAIImageModel = "gpt-image-2.5-flare-2026-09-08"
 
 type Request struct {
 	Source         string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

OpenAI released GPT Image 2.5. Image localization now uses **GPT Image 2.5 Flare**, the default everyday successor to GPT Image 2.

- CLI / Go translator: `gpt-image-2-2026-04-21` → `gpt-image-2.5-flare-2026-09-08` (dated snapshot, same pinning style as before)
- Web managed Gateway path: `openai/gpt-image-2` → `openai/gpt-image-2.5-flare`

Flare is the recommended default: higher quality than GPT Image 2, about 50% lower latency, and the same token rates. Sunburst stays unused; it is the slower, higher-precision variant for premium creative work.

## How to test

- `go test ./internal/i18n/translator ./apps/cli/internal/i18n/runsvc` — pass
- `go test ./...` — pass (`make test` still warns about missing `covdata`; tests themselves pass)
- `make fmt` and `make lint` — pass
- In `apps/hyperlocalise-web`: `vp test` on the language-model and image-generation tests, plus `vp check --fix` — pass

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a085ef-7295-7076-a3b8-61472c1deef0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a085ef-7295-7076-a3b8-61472c1deef0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

