### PR TITLE
feat(mcp): implement run workflow tool to the hosted MCP server

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-run-workflow.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-run-workflow.schema.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+import {
+  maxTranslationMetadataEntries,
+  maxTranslationTargetLocales,
+} from "@/api/routes/project/job.schema";
+import { projectIdSchema } from "@/lib/projects/identity/project-id";
+import { supportedFileTranslationFileFormats } from "@/lib/translation/file-formats";
+
+const metadataSchema = z
+  .record(z.string().max(100), z.string().max(1000))
+  .refine((metadata) => Object.keys(metadata).length <= maxTranslationMetadataEntries, {
+    message: `metadata must contain at most ${maxTranslationMetadataEntries} entries`,
+  })
+  .optional();
+
+export const mcpRunWorkflowInputSchema = z
+  .object({
+    type: z.enum(["string", "file"]).describe("Translation job type."),
+
+    projectId: projectIdSchema.describe("ID of the accessible Hyperlocalise project."),
+
+    sourceText: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100_000)
+      .optional()
+      .describe("Source text for a string translation job."),
+
+    sourceFileId: z
+      .string()
+      .trim()
+      .min(1)
+      .max(128)
+      .optional()
+      .describe("Source file ID for a file translation job."),
+
+    sourcePath: z
+      .string()
+      .trim()
+      .min(1)
+      .max(2048)
+      .optional()
+      .describe("Repository-relative source path for a file translation job."),
+
+    fileFormat: z
+      .enum(supportedFileTranslationFileFormats)
+      .optional()
+      .describe("Translation file format for a file job."),
+
+    sourceLocale: z
+      .string()
+      .trim()
+      .min(1)
+      .max(32)
+      .describe("BCP-47 source locale configured for the project."),
+
+    targetLocales: z
+      .array(z.string().trim().min(1).max(32))
+      .min(1)
+      .max(maxTranslationTargetLocales)
+      .describe("Target locales configured for the project."),
+
+    context: z
+      .string()
+      .max(20_000)
+      .optional()
+      .describe("Optional context for a string translation job."),
+
+    maxLength: z
+      .number()
+      .int()
+      .positive()
+      .max(100_000)
+      .optional()
+      .describe("Optional maximum output length for a string translation job."),
+
+    metadata: metadataSchema.describe("Optional job metadata."),
+
+    idempotencyKey: z
+      .string()
+      .trim()
+      .min(1)
+      .max(128)
+      .optional()
+      .describe("Stable retry key used to prevent duplicate jobs."),
+  })
+  .superRefine((input, ctx) => {
+    if (input.type === "string") {
+      if (!input.sourceText) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["sourceText"],
+          message: "sourceText is required for string jobs",
+        });
+      }
+
+      if (input.sourceFileId || input.sourcePath || input.fileFormat) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["type"],
+          message: "File inputs are not allowed for string jobs",
+        });
+      }
+
+      return;
+    }
+
+    if (!input.fileFormat) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["fileFormat"],
+        message: "fileFormat is required for file jobs",
+      });
+    }
+
+    const fileLocatorCount =
+      Number(Boolean(input.sourceFileId)) + Number(Boolean(input.sourcePath));
+
+    if (fileLocatorCount !== 1) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["sourceFileId"],
+        message: "Provide exactly one of sourceFileId or sourcePath",
+      });
+    }
+
+    if (input.sourceText || input.context || input.maxLength !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["type"],
+        message: "String inputs are not allowed for file jobs",
+      });
+    }
+  });
+
+export type McpRunWorkflowInput = z.infer<typeof mcpRunWorkflowInputSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -16,7 +16,7 @@ import { createHash, randomUUID } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { OAuthProtectedResourceMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -45,8 +45,12 @@ import { createProjectTestFixture } from "../project/project.fixture";
 import {
   insertCompletedPublicFileJob,
   insertPublicTranslationJob,
+  insertStoredSourceFile,
 } from "../public-jobs/public-jobs.fixture";
-import { ensureRepositorySourceFile } from "@/lib/file-storage/records";
+import {
+  createRepositorySourceFileVersion,
+  ensureRepositorySourceFile,
+} from "@/lib/file-storage/records";
 import {
   setProjectTranslationKeysHidden,
   upsertProjectTranslationKeysFromEntries,
@@ -56,6 +60,7 @@ import { setCatSegmentLocks } from "@/lib/projects/content-editor/content-editor
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
 import { maxPublicUploadBytes } from "@/api/routes/public-files/public-files.schema";
+import { err, ok } from "@/lib/primitives/result/results";
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
@@ -84,6 +89,37 @@ vi.mock("@/api/auth/mcp-client-metadata", async (importOriginal) => {
   return {
     ...actual,
     resolveMcpClientMetadata: resolveMcpClientMetadataMock,
+  };
+});
+
+const { translationJobEnqueueMock } = vi.hoisted(() => ({
+  translationJobEnqueueMock: vi.fn(async () => ({
+    ids: ["workflow_run_mcp_string"],
+  })),
+}));
+
+vi.mock("@/lib/workflow/queues", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/workflow/queues")>();
+
+  return {
+    ...actual,
+    createTranslationJobEventQueue: () => ({
+      enqueue: translationJobEnqueueMock,
+    }),
+  };
+});
+
+const { ensureAiFeaturesAllowedMock } = vi.hoisted(() => ({
+  ensureAiFeaturesAllowedMock:
+    vi.fn<typeof import("@/lib/billing/ai-features").ensureAiFeaturesAllowed>(),
+}));
+
+vi.mock("@/lib/billing/ai-features", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/billing/ai-features")>();
+
+  return {
+    ...actual,
+    ensureAiFeaturesAllowed: ensureAiFeaturesAllowedMock,
   };
 });
 
@@ -176,6 +212,12 @@ function setMcpAuthEnabled(value: boolean) {
 describe("mcpRoutes", () => {
   beforeAll(async () => {
     await db.$client.query("select 1");
+  });
+
+  beforeEach(() => {
+    translationJobEnqueueMock.mockClear();
+    ensureAiFeaturesAllowedMock.mockReset();
+    ensureAiFeaturesAllowedMock.mockResolvedValue(ok(undefined));
   });
 
   afterEach(async () => {
@@ -7551,8 +7593,115 @@ describe("mcpRoutes", () => {
     expect(body.result?.content?.[0]?.text).toContain("locale");
   });
 
-  it("keeps run_workflow reserved", async () => {
+  it("advertises run_workflow with bounded string and file job inputs", async () => {
     const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list",
+            params: {},
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "run_workflow");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("translation job");
+    expect(tool?.inputSchema?.required).toEqual(
+      expect.arrayContaining(["type", "projectId", "sourceLocale", "targetLocales"]),
+    );
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      type: {
+        type: "string",
+        enum: ["string", "file"],
+      },
+      projectId: {
+        type: "string",
+      },
+      sourceText: {
+        type: "string",
+        minLength: 1,
+        maxLength: 100_000,
+      },
+      sourceFileId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      sourcePath: {
+        type: "string",
+        minLength: 1,
+        maxLength: 2048,
+      },
+      fileFormat: {
+        type: "string",
+      },
+      sourceLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 32,
+      },
+      targetLocales: {
+        type: "array",
+        minItems: 1,
+        maxItems: 20,
+        items: {
+          type: "string",
+          minLength: 1,
+          maxLength: 32,
+        },
+      },
+      context: {
+        type: "string",
+        maxLength: 20_000,
+      },
+      maxLength: {
+        type: "integer",
+        exclusiveMinimum: 0,
+        maximum: 100_000,
+      },
+      idempotencyKey: {
+        type: "string",
+      },
+    });
+  });
+
+  it("returns forbidden when a read-only member runs a workflow", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+
+    const memberIdentity = fixture.createWorkosIdentityForOrganization(
+      stored.identity.organization,
+      "member",
+    );
+
+    const headers = await authenticatedMcpHeaders(memberIdentity);
 
     const response = await mcpClient.mcp.$post(
       {},
@@ -7569,7 +7718,14 @@ describe("mcpRoutes", () => {
             method: "tools/call",
             params: {
               name: "run_workflow",
-              arguments: {},
+              arguments: {
+                type: "string",
+                projectId: stored.project.id,
+                sourceText: "Welcome",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+                idempotencyKey: "mcp-forbidden-string-job",
+              },
             },
           }),
         },
@@ -7586,10 +7742,961 @@ describe("mcpRoutes", () => {
     };
 
     expect(body.result?.isError).toBe(true);
-
     expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
-      error: "not_implemented",
-      tool: "run_workflow",
+      error: "forbidden",
+    });
+
+    const [createdJob] = await db
+      .select({
+        id: schema.jobs.id,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, stored.project.id))
+      .limit(1);
+
+    expect(createdJob).toBeUndefined();
+  });
+
+  it("returns project_not_found when run_workflow targets another organization", async () => {
+    const accessible = await fixture.createStoredProjectFixture();
+    const inaccessible = await fixture.createStoredProjectFixture();
+
+    const headers = await authenticatedMcpHeaders(accessible.identity);
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "string",
+                projectId: inaccessible.project.id,
+                sourceText: "Welcome",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+                idempotencyKey: "mcp-cross-org-string-job",
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "project_not_found",
+    });
+
+    const [createdJob] = await db
+      .select({
+        id: schema.jobs.id,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, inaccessible.project.id))
+      .limit(1);
+
+    expect(createdJob).toBeUndefined();
+  });
+
+  it("returns project_not_found when run_workflow targets a missing project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const missingProjectId = crypto.randomUUID();
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "string",
+                projectId: missingProjectId,
+                sourceText: "Welcome",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "project_not_found",
+    });
+  });
+
+  it.each([
+    {
+      name: "source locale does not match the project",
+      sourceLocale: "de-DE",
+      targetLocales: ["fr-FR"],
+    },
+    {
+      name: "target locale is not configured on the project",
+      sourceLocale: "en-US",
+      targetLocales: ["ja-JP"],
+    },
+  ])("returns invalid_job_payload when $name", async ({ sourceLocale, targetLocales }) => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "string",
+                projectId: stored.project.id,
+                sourceText: "Welcome",
+                sourceLocale,
+                targetLocales,
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "invalid_job_payload",
+    });
+
+    const [createdJob] = await db
+      .select({
+        id: schema.jobs.id,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, stored.project.id))
+      .limit(1);
+
+    expect(createdJob).toBeUndefined();
+  });
+
+  it("does not create or enqueue a workflow when AI features are unavailable", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    ensureAiFeaturesAllowedMock.mockResolvedValueOnce(
+      err({
+        code: "ai_features_required",
+        message: "AI features are not included in your current plan.",
+      }),
+    );
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "string",
+                projectId: stored.project.id,
+                sourceText: "Welcome",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "ai_features_required",
+      message: "AI features are not included in your current plan.",
+    });
+
+    const createdJobs = await db
+      .select({ id: schema.jobs.id })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, stored.project.id));
+
+    expect(createdJobs).toEqual([]);
+    expect(translationJobEnqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("returns file_not_found when a workflow source file does not exist", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "file",
+                projectId: stored.project.id,
+                sourceFileId: "file_missing",
+                fileFormat: "json",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "file_not_found",
+    });
+
+    const [createdJob] = await db
+      .select({
+        id: schema.jobs.id,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, stored.project.id))
+      .limit(1);
+
+    expect(createdJob).toBeUndefined();
+  });
+
+  it("returns file_not_found when a workflow source path does not exist", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "file",
+                projectId: stored.project.id,
+                sourcePath: "locales/missing.json",
+                fileFormat: "json",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "file_not_found",
+    });
+
+    const [createdJob] = await db
+      .select({
+        id: schema.jobs.id,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, stored.project.id))
+      .limit(1);
+
+    expect(createdJob).toBeUndefined();
+  });
+
+  it("returns source_file_format_mismatch when the requested format does not match the file", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const sourceFile = await insertStoredSourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      filename: "messages.json",
+      contentType: "application/json",
+    });
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "file",
+                projectId: stored.project.id,
+                sourceFileId: sourceFile.id,
+                fileFormat: "xliff",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "source_file_format_mismatch",
+      expectedFileFormat: "json",
+    });
+
+    const [createdJob] = await db
+      .select({
+        id: schema.jobs.id,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, stored.project.id))
+      .limit(1);
+
+    expect(createdJob).toBeUndefined();
+  });
+
+  it("creates and enqueues a string translation workflow", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR", "de-DE"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    translationJobEnqueueMock.mockResolvedValueOnce({
+      ids: ["workflow_run_mcp_string"],
+    });
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "string",
+                projectId: stored.project.id,
+                sourceText: "Welcome to Hyperlocalise",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR", "de-DE"],
+                context: "Homepage heading",
+                maxLength: 80,
+                metadata: {
+                  surface: "mcp",
+                },
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    if (body.result?.isError) {
+      throw new Error(`run_workflow failed: ${body.result.content?.[0]?.text ?? "unknown error"}`);
+    }
+
+    const output = JSON.parse(body.result?.content?.[0]?.text ?? "{}") as {
+      jobId?: string;
+      type?: string;
+      status?: string;
+      workflowRunIds?: string[];
+    };
+
+    expect(output).toMatchObject({
+      jobId: expect.stringMatching(/^job_/),
+      type: "string",
+      status: "enqueued",
+      workflowRunIds: ["workflow_run_mcp_string"],
+    });
+
+    const [createdJob] = await db
+      .select({
+        id: schema.jobs.id,
+        organizationId: schema.jobs.organizationId,
+        projectId: schema.jobs.projectId,
+        kind: schema.jobs.kind,
+        status: schema.jobs.status,
+        inputPayload: schema.jobs.inputPayload,
+        workflowRunId: schema.jobs.workflowRunId,
+        interactionId: schema.jobs.interactionId,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.id, output.jobId ?? ""))
+      .limit(1);
+
+    expect(createdJob).toMatchObject({
+      id: output.jobId,
+      organizationId: globalThis.__testApiAuthContext?.organization.localOrganizationId,
+      projectId: stored.project.id,
+      kind: "translation",
+      status: "queued",
+      workflowRunId: "workflow_run_mcp_string",
+      inputPayload: {
+        sourceText: "Welcome to Hyperlocalise",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR", "de-DE"],
+        context: "Homepage heading",
+        maxLength: 80,
+        metadata: {
+          surface: "mcp",
+        },
+      },
+      interactionId: null,
+    });
+
+    const [details] = await db
+      .select({
+        type: schema.translationJobDetails.type,
+        sourceFileVersionId: schema.translationJobDetails.sourceFileVersionId,
+      })
+      .from(schema.translationJobDetails)
+      .where(eq(schema.translationJobDetails.jobId, output.jobId ?? ""))
+      .limit(1);
+
+    expect(details).toEqual({
+      type: "string",
+      sourceFileVersionId: null,
+    });
+
+    expect(translationJobEnqueueMock).toHaveBeenCalledTimes(1);
+    expect(translationJobEnqueueMock).toHaveBeenCalledWith({
+      kind: "translation",
+      jobId: output.jobId,
+      projectId: stored.project.id,
+      type: "string",
+    });
+  });
+
+  it("does not create or enqueue a duplicate workflow for the same idempotency key", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    translationJobEnqueueMock.mockResolvedValue({
+      ids: ["workflow_run_mcp_idempotent"],
+    });
+
+    const requestBody = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "run_workflow",
+        arguments: {
+          type: "string",
+          projectId: stored.project.id,
+          sourceText: "Welcome",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+          idempotencyKey: "mcp-idempotent-string-job",
+        },
+      },
+    });
+
+    const responses = await Promise.all([
+      mcpClient.mcp.$post(
+        {},
+        {
+          headers: {
+            ...headers,
+            accept: "application/json, text/event-stream",
+            "content-type": "application/json",
+          },
+          init: { body: requestBody },
+        },
+      ),
+      mcpClient.mcp.$post(
+        {},
+        {
+          headers: {
+            ...headers,
+            accept: "application/json, text/event-stream",
+            "content-type": "application/json",
+          },
+          init: { body: requestBody },
+        },
+      ),
+    ]);
+
+    const bodies = await Promise.all(
+      responses.map(
+        async (response) =>
+          (await response.json()) as {
+            result?: {
+              isError?: boolean;
+              content?: Array<{ text?: string }>;
+            };
+          },
+      ),
+    );
+
+    for (const body of bodies) {
+      if (body.result?.isError) {
+        throw new Error(
+          `run_workflow failed: ${body.result.content?.[0]?.text ?? "unknown error"}`,
+        );
+      }
+    }
+
+    const outputs = bodies.map(
+      (body) =>
+        JSON.parse(body.result?.content?.[0]?.text ?? "{}") as {
+          jobId?: string;
+        },
+    );
+
+    expect(outputs[0]?.jobId).toMatch(/^job_/);
+    expect(outputs[1]?.jobId).toBe(outputs[0]?.jobId);
+
+    const createdJobs = await db
+      .select({ id: schema.jobs.id })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, stored.project.id));
+
+    expect(createdJobs).toEqual([{ id: outputs[0]?.jobId }]);
+    expect(translationJobEnqueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates and enqueues a file translation workflow resolved by sourcePath", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    const storedFile = await insertStoredSourceFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      filename: "messages.json",
+      contentType: "application/json",
+      sourceKind: "repository_file",
+    });
+
+    const sourceVersion = await createRepositorySourceFileVersion({
+      storedFile,
+      sourcePath: "locales/en/messages.json",
+      uploadedByUserId: auth.user.localUserId,
+      uploadSurface: "mcp_test",
+    });
+
+    translationJobEnqueueMock.mockResolvedValueOnce({
+      ids: ["workflow_run_mcp_file"],
+    });
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "file",
+                projectId: stored.project.id,
+                sourcePath: "locales/en/messages.json",
+                fileFormat: "json",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+                metadata: {
+                  surface: "mcp",
+                },
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    if (body.result?.isError) {
+      throw new Error(`run_workflow failed: ${body.result.content?.[0]?.text ?? "unknown error"}`);
+    }
+
+    const output = JSON.parse(body.result?.content?.[0]?.text ?? "{}") as {
+      jobId?: string;
+      type?: string;
+      status?: string;
+      workflowRunIds?: string[];
+    };
+
+    expect(output).toMatchObject({
+      jobId: expect.stringMatching(/^job_/),
+      type: "file",
+      status: "enqueued",
+      workflowRunIds: ["workflow_run_mcp_file"],
+    });
+
+    const [createdJob] = await db
+      .select({
+        id: schema.jobs.id,
+        organizationId: schema.jobs.organizationId,
+        projectId: schema.jobs.projectId,
+        kind: schema.jobs.kind,
+        status: schema.jobs.status,
+        inputPayload: schema.jobs.inputPayload,
+        workflowRunId: schema.jobs.workflowRunId,
+        interactionId: schema.jobs.interactionId,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.id, output.jobId ?? ""))
+      .limit(1);
+
+    expect(createdJob).toMatchObject({
+      id: output.jobId,
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      kind: "translation",
+      status: "queued",
+      workflowRunId: "workflow_run_mcp_file",
+      interactionId: null,
+      inputPayload: {
+        sourceFileId: storedFile.id,
+        fileFormat: "json",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+        metadata: {
+          surface: "mcp",
+        },
+      },
+    });
+
+    const [details] = await db
+      .select({
+        type: schema.translationJobDetails.type,
+        sourceFileVersionId: schema.translationJobDetails.sourceFileVersionId,
+      })
+      .from(schema.translationJobDetails)
+      .where(eq(schema.translationJobDetails.jobId, output.jobId ?? ""))
+      .limit(1);
+
+    expect(details).toEqual({
+      type: "file",
+      sourceFileVersionId: sourceVersion.id,
+    });
+
+    expect(translationJobEnqueueMock).toHaveBeenCalledTimes(1);
+    expect(translationJobEnqueueMock).toHaveBeenCalledWith({
+      kind: "translation",
+      jobId: output.jobId,
+      projectId: stored.project.id,
+      type: "file",
+    });
+  });
+
+  it("marks the job failed when run_workflow cannot enqueue it", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+
+    await db
+      .update(schema.projects)
+      .set({
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      })
+      .where(eq(schema.projects.id, stored.project.id));
+
+    translationJobEnqueueMock.mockRejectedValueOnce(new Error("workflow service unavailable"));
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "run_workflow",
+              arguments: {
+                type: "string",
+                projectId: stored.project.id,
+                sourceText: "Welcome",
+                sourceLocale: "en-US",
+                targetLocales: ["fr-FR"],
+              },
+            },
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    expect(body.result?.isError).toBe(true);
+    expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
+      error: "job_queue_unavailable",
+    });
+
+    const [failedJob] = await db
+      .select({
+        id: schema.jobs.id,
+        kind: schema.jobs.kind,
+        status: schema.jobs.status,
+        lastError: schema.jobs.lastError,
+        workflowRunId: schema.jobs.workflowRunId,
+      })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.projectId, stored.project.id))
+      .limit(1);
+
+    expect(failedJob).toMatchObject({
+      id: expect.stringMatching(/^job_/),
+      kind: "translation",
+      status: "failed",
+      lastError: "workflow service unavailable",
+      workflowRunId: null,
+    });
+
+    expect(translationJobEnqueueMock).toHaveBeenCalledTimes(1);
+    expect(translationJobEnqueueMock).toHaveBeenCalledWith({
+      kind: "translation",
+      jobId: failedJob?.id,
+      projectId: stored.project.id,
+      type: "string",
     });
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -1998,6 +1998,9 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
           case "job_insert_failed":
             return mcpToolError("job_create_failed", jobError.message);
 
+          case "job_idempotency_conflict":
+            return mcpToolError("idempotency_conflict", jobError.message);
+
           default:
             return assertNever(errorCode);
         }

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -126,6 +126,15 @@ import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats
 import { updateMcpTranslation } from "./mcp-update-translation";
 import { downloadMcpTranslations } from "./mcp-download-translations";
 import { mcpDownloadTranslationsInputSchema } from "./mcp-download-translations.schema";
+import { mcpRunWorkflowInputSchema } from "./mcp-run-workflow.schema";
+import { validateJobLocalesAgainstProject } from "@/lib/i18n/project-job-locales";
+import {
+  getLatestRepositorySourceFileVersion,
+  getStoredFileForJobScope,
+} from "@/lib/file-storage/records";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
+import { createTranslationJob } from "@/lib/agent-runtime/tools/translation-tools";
+import { ensureAiFeaturesAllowed } from "@/lib/billing/ai-features";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -811,6 +820,18 @@ function mcpToolContext(apiAuth: ApiAuthContext): ToolContext {
     projectId: null,
     db,
   };
+}
+
+function mcpIdempotentJobId(organizationId: string, projectId: string, idempotencyKey: string) {
+  const digest = createHash("sha256")
+    .update(organizationId)
+    .update("\0")
+    .update(projectId)
+    .update("\0")
+    .update(idempotencyKey)
+    .digest("hex");
+
+  return `job_${digest}`;
 }
 
 function truncateMcpGlossaryDescription(description: string) {
@@ -1824,24 +1845,173 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
     },
   );
 
-  for (const name of ["run_workflow"] as const) {
-    server.registerTool(
-      name,
-      {
-        description: `${name} is reserved for the MCP surface and will be wired to the workflow layer next.`,
-        inputSchema: z.object({}),
-      },
-      async () => ({
-        isError: true,
+  server.registerTool(
+    "run_workflow",
+    {
+      description:
+        "Create and enqueue a string or file translation job in an accessible Hyperlocalise project.",
+      inputSchema: mcpRunWorkflowInputSchema,
+    },
+    async (input) => {
+      if (!isJobCreateAllowed(apiAuth.membership.role)) {
+        return mcpToolError("forbidden", "Insufficient permissions to create translation jobs");
+      }
+
+      const [project] = await db
+        .select({
+          id: schema.projects.id,
+          source: schema.projects.source,
+          sourceLocale: schema.projects.sourceLocale,
+          targetLocales: schema.projects.targetLocales,
+        })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(apiAuth, input.projectId))
+        .limit(1);
+
+      if (!project) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      const localeValidation = validateJobLocalesAgainstProject(project, {
+        sourceLocale: input.sourceLocale,
+        targetLocales: input.targetLocales,
+      });
+
+      if (isErr(localeValidation)) {
+        return mcpToolError("invalid_job_payload", localeValidation.error.message, {
+          reason: localeValidation.error.code,
+        });
+      }
+
+      const aiFeatures = await ensureAiFeaturesAllowed({
+        organizationId: apiAuth.organization.localOrganizationId,
+      });
+
+      if (isErr(aiFeatures)) {
+        return mcpToolError(aiFeatures.error.code, aiFeatures.error.message);
+      }
+
+      let resolvedSourceFileId: string | undefined;
+
+      if (input.type === "file") {
+        if (input.sourceFileId) {
+          resolvedSourceFileId = input.sourceFileId;
+        } else if (input.sourcePath) {
+          const latestVersion = await getLatestRepositorySourceFileVersion({
+            organizationId: apiAuth.organization.localOrganizationId,
+            projectId: project.id,
+            sourcePath: input.sourcePath,
+          });
+
+          resolvedSourceFileId = latestVersion?.storedFileId;
+        }
+
+        if (!resolvedSourceFileId) {
+          return mcpToolError("file_not_found", "Source file not found or inaccessible");
+        }
+
+        const sourceFile = await getStoredFileForJobScope({
+          organizationId: apiAuth.organization.localOrganizationId,
+          projectId: project.id,
+          fileId: resolvedSourceFileId,
+        });
+
+        if (!sourceFile) {
+          return mcpToolError("file_not_found", "Source file not found or inaccessible");
+        }
+
+        const inferredFileFormat = inferSupportedFileTranslationFileFormat(sourceFile.filename);
+
+        if (!inferredFileFormat) {
+          return mcpToolError(
+            "unsupported_source_file_format",
+            "Source file format is not supported for translation jobs",
+          );
+        }
+
+        if (inferredFileFormat !== input.fileFormat) {
+          return mcpToolError(
+            "source_file_format_mismatch",
+            "Source file format does not match the requested format",
+            {
+              expectedFileFormat: inferredFileFormat,
+            },
+          );
+        }
+      }
+
+      const jobResult = await createTranslationJob(
+        {
+          ...mcpToolContext(apiAuth),
+          projectId: project.id,
+        },
+        {
+          type: input.type,
+          sourceText: input.sourceText,
+          sourceFileId: resolvedSourceFileId,
+          fileFormat: input.fileFormat,
+          sourceLocale: input.sourceLocale,
+          targetLocales: input.targetLocales,
+          context: input.context,
+          metadata: input.metadata,
+          maxLength: input.maxLength,
+        },
+        {
+          jobId: input.idempotencyKey
+            ? mcpIdempotentJobId(
+                apiAuth.organization.localOrganizationId,
+                project.id,
+                input.idempotencyKey,
+              )
+            : undefined,
+          interactionId: null,
+        },
+      );
+
+      if (isErr(jobResult)) {
+        const jobError = jobResult.error;
+        const errorCode = jobError.code;
+
+        switch (errorCode) {
+          case "translation_job_permission_denied":
+          case "job_permission_denied":
+            return mcpToolError("forbidden", jobError.message);
+
+          case "translation_job_project_missing":
+          case "translation_job_project_inaccessible":
+            return mcpToolError("project_not_found", jobError.message);
+
+          case "translation_job_source_file_missing":
+            return mcpToolError("file_not_found", jobError.message);
+
+          case "translation_job_invalid_input":
+          case "translation_job_source_file_format_unsupported":
+            return mcpToolError("invalid_job_payload", jobError.message);
+
+          case "organization_job_budget_exceeded":
+          case "usage_event_reservation_failed":
+            return mcpToolError(errorCode, jobError.message);
+
+          case "translation_job_queue_unavailable":
+            return mcpToolError("job_queue_unavailable", jobError.message);
+
+          case "job_insert_failed":
+            return mcpToolError("job_create_failed", jobError.message);
+
+          default:
+            return assertNever(errorCode);
+        }
+      }
+      return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ error: "not_implemented", tool: name }, null, 2),
+            text: JSON.stringify(jobResult.value),
           },
         ],
-      }),
-    );
-  }
+      };
+    },
+  );
 
   server.registerTool(
     "get_translation",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
@@ -91,6 +91,7 @@ const reviewJobQueue = createReviewJobEventQueue();
 type JobCreationError =
   | { code: "job_permission_denied"; message: string }
   | { code: "job_insert_failed"; message: string }
+  | { code: "job_idempotency_conflict"; message: string }
   | { code: "organization_job_budget_exceeded"; message: string }
   | { code: "usage_event_reservation_failed"; message: string };
 
@@ -437,6 +438,24 @@ type PreparedTranslationJobInput = {
   inputPayload: unknown;
 };
 
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+
+    return `{${entries
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${canonicalJson(entryValue)}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value) ?? "undefined";
+}
+
 function translationJobInputError(message: string): TranslationJobError {
   return { code: "translation_job_invalid_input", message };
 }
@@ -582,6 +601,13 @@ async function createTranslationJobRecord(
 
         if (!existingJob) {
           rollbackJobCreation(jobInsertFailedError());
+        }
+
+        if (canonicalJson(existingJob.inputPayload) !== canonicalJson(preparedInput.inputPayload)) {
+          rollbackJobCreation({
+            code: "job_idempotency_conflict",
+            message: "The idempotency key is already associated with a different job payload.",
+          });
         }
 
         return { job: existingJob, created: false };
@@ -760,12 +786,14 @@ export async function createTranslationJob(
       });
     }
 
-    return ok({
-      jobId: job.id,
-      type: input.type,
-      status: job.workflowRunId ? "enqueued" : "queued",
-      workflowRunIds: job.workflowRunId ? [job.workflowRunId] : [],
-    });
+    if (job.workflowRunId) {
+      return ok({
+        jobId: job.id,
+        type: input.type,
+        status: "enqueued",
+        workflowRunIds: [job.workflowRunId],
+      });
+    }
   }
 
   const enqueueResult = await enqueueTranslationJob({

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
@@ -94,7 +94,7 @@ type JobCreationError =
   | { code: "organization_job_budget_exceeded"; message: string }
   | { code: "usage_event_reservation_failed"; message: string };
 
-type CreateTranslationJobToolError =
+export type TranslationJobError =
   | { code: "translation_job_permission_denied"; message: string }
   | { code: "translation_job_project_missing"; message: string }
   | { code: "translation_job_project_inaccessible"; message: string }
@@ -102,9 +102,12 @@ type CreateTranslationJobToolError =
   | { code: "translation_job_source_file_missing"; message: string }
   | { code: "translation_job_source_file_format_unsupported"; message: string }
   | { code: "translation_job_queue_unavailable"; message: string }
-  | { code: "review_job_project_missing"; message: string }
-  | { code: "review_job_queue_unavailable"; message: string }
   | JobCreationError;
+
+export type CreateTranslationJobToolError =
+  | TranslationJobError
+  | { code: "review_job_project_missing"; message: string }
+  | { code: "review_job_queue_unavailable"; message: string };
 
 class JobCreationRollbackError extends Error {
   constructor(readonly jobError: JobCreationError) {
@@ -163,6 +166,7 @@ async function reserveQueuedJobUsage(input: {
   ctx: ToolContext;
   job: Pick<JobRecord, "id">;
   kind: JobKind;
+  interactionId?: string | null;
 }): Promise<Result<void, JobCreationError>> {
   const billing = queuedJobUsageBilling(input.kind);
   const usageEventResult = await reserveUsageEvent({
@@ -172,7 +176,10 @@ async function reserveQueuedJobUsage(input: {
     operationKey: `job:${input.job.id}:${billing.operationKeySuffix}`,
     source: billing.source,
     jobId: input.job.id,
-    interactionId: input.ctx.conversationId ?? undefined,
+    interactionId:
+      input.interactionId === undefined
+        ? input.ctx.conversationId
+        : (input.interactionId ?? undefined),
     quantity: 1,
   });
 
@@ -296,19 +303,21 @@ async function getJobDetails(ctx: ToolContext, jobId: string) {
 function queuedJobValues(
   ctx: ToolContext,
   input: {
+    jobId?: string;
     kind: JobKind;
     projectId?: string | null;
     inputPayload: unknown;
+    interactionId?: string | null;
   },
 ) {
   return {
-    id: createJobId(),
+    id: input.jobId ?? createJobId(),
     organizationId: ctx.organizationId,
     projectId: getJobProjectId(ctx, input.projectId),
     kind: input.kind,
     status: "queued" as const,
     inputPayload: input.inputPayload,
-    interactionId: ctx.conversationId,
+    interactionId: input.interactionId === undefined ? ctx.conversationId : input.interactionId,
     createdByUserId: ctx.localUserId,
   };
 }
@@ -402,21 +411,40 @@ const createTranslationJobInputSchema = z.object({
     .describe("Optional maximum string length for string jobs."),
 });
 
-type CreateTranslationJobInput = z.infer<typeof createTranslationJobInputSchema>;
+export type CreateTranslationJobInput = z.infer<typeof createTranslationJobInputSchema>;
+
+export type CreateTranslationJobError = TranslationJobError;
+
+export type CreateTranslationJobResult = {
+  jobId: string;
+  type: CreateTranslationJobInput["type"];
+  status: "queued" | "enqueued";
+  workflowRunIds: string[];
+};
+
+type CreateTranslationJobOptions = {
+  jobId?: string;
+  interactionId?: string | null;
+};
+
+type TranslationJobRecordResult = {
+  job: JobRecord;
+  created: boolean;
+};
 
 type PreparedTranslationJobInput = {
   sourceFileId?: string;
   inputPayload: unknown;
 };
 
-function translationJobInputError(message: string): CreateTranslationJobToolError {
+function translationJobInputError(message: string): TranslationJobError {
   return { code: "translation_job_invalid_input", message };
 }
 
 async function prepareTranslationJobInput(
   ctx: ToolContext,
   input: CreateTranslationJobInput,
-): Promise<Result<PreparedTranslationJobInput, CreateTranslationJobToolError>> {
+): Promise<Result<PreparedTranslationJobInput, TranslationJobError>> {
   if (!isJobCreateAllowed(ctx.membershipRole)) {
     return err({
       code: "translation_job_permission_denied",
@@ -518,9 +546,47 @@ async function createTranslationJobRecord(
   ctx: ToolContext,
   input: CreateTranslationJobInput,
   preparedInput: PreparedTranslationJobInput,
-): Promise<Result<JobRecord, JobCreationError>> {
+  options?: CreateTranslationJobOptions,
+): Promise<Result<TranslationJobRecordResult, JobCreationError>> {
   try {
-    const job = await ctx.db.transaction(async (tx) => {
+    const recordResult = await ctx.db.transaction(async (tx) => {
+      const [createdJob] = await tx
+        .insert(schema.jobs)
+        .values(
+          queuedJobValues(ctx, {
+            jobId: options?.jobId,
+            kind: "translation",
+            inputPayload: preparedInput.inputPayload,
+            interactionId: options?.interactionId,
+          }),
+        )
+        .onConflictDoNothing({ target: schema.jobs.id })
+        .returning();
+
+      if (!createdJob) {
+        if (!options?.jobId) {
+          rollbackJobCreation(jobInsertFailedError());
+        }
+
+        const [existingJob] = await tx
+          .select()
+          .from(schema.jobs)
+          .where(
+            and(
+              eq(schema.jobs.id, options.jobId),
+              eq(schema.jobs.organizationId, ctx.organizationId),
+              eq(schema.jobs.kind, "translation"),
+            ),
+          )
+          .limit(1);
+
+        if (!existingJob) {
+          rollbackJobCreation(jobInsertFailedError());
+        }
+
+        return { job: existingJob, created: false };
+      }
+
       const budgetResult = await assertAgentOrganizationJobBudget(tx, ctx.organizationId);
       if (isErr(budgetResult)) {
         rollbackJobCreation(budgetResult.error);
@@ -535,20 +601,6 @@ async function createTranslationJobRecord(
           })
         : null;
 
-      const [createdJob] = await tx
-        .insert(schema.jobs)
-        .values(
-          queuedJobValues(ctx, {
-            kind: "translation",
-            inputPayload: preparedInput.inputPayload,
-          }),
-        )
-        .returning();
-
-      if (!createdJob) {
-        rollbackJobCreation(jobInsertFailedError());
-      }
-
       await tx.insert(schema.translationJobDetails).values({
         jobId: createdJob.id,
         type: input.type,
@@ -560,26 +612,29 @@ async function createTranslationJobRecord(
         ctx,
         job: createdJob,
         kind: "translation",
+        interactionId: options?.interactionId,
       });
       if (isErr(usageResult)) {
         rollbackJobCreation(usageResult.error);
       }
 
-      return createdJob;
+      return { job: createdJob, created: true };
     });
 
-    await enqueueJobCreatedActivity({
-      actorCredentialId: null,
-      actorKind: "agent",
-      actorUserId: ctx.localUserId ?? null,
-      jobId: job.id,
-      kind: job.kind,
-      organizationId: job.organizationId,
-      projectId: job.projectId,
-      status: job.status,
-    });
+    if (recordResult.created) {
+      await enqueueJobCreatedActivity({
+        actorCredentialId: null,
+        actorKind: "agent",
+        actorUserId: ctx.localUserId ?? null,
+        jobId: recordResult.job.id,
+        kind: recordResult.job.kind,
+        organizationId: recordResult.job.organizationId,
+        projectId: recordResult.job.projectId,
+        status: recordResult.job.status,
+      });
+    }
 
-    return ok(job);
+    return ok(recordResult);
   } catch (error) {
     if (error instanceof JobCreationRollbackError) {
       return err(error.jobError);
@@ -592,7 +647,7 @@ async function enqueueTranslationJob(input: {
   ctx: ToolContext;
   job: JobRecord;
   type: CreateTranslationJobInput["type"];
-}): Promise<Result<{ workflowRunIds: string[] }, CreateTranslationJobToolError>> {
+}): Promise<Result<{ workflowRunIds: string[] }, TranslationJobError>> {
   const projectId = input.job.projectId ?? input.ctx.projectId;
   if (!projectId) {
     return err({
@@ -673,12 +728,71 @@ async function enqueueTranslationJob(input: {
  *
  * Example usage: user says "Please translate these release notes into Japanese and Vietnamese."
  */
+export async function createTranslationJob(
+  ctx: ToolContext,
+  input: CreateTranslationJobInput,
+  options?: CreateTranslationJobOptions,
+): Promise<Result<CreateTranslationJobResult, CreateTranslationJobError>> {
+  const preparedInputResult = await prepareTranslationJobInput(ctx, input);
+
+  if (isErr(preparedInputResult)) {
+    return err(preparedInputResult.error);
+  }
+
+  const jobResult = await createTranslationJobRecord(
+    ctx,
+    input,
+    preparedInputResult.value,
+    options,
+  );
+
+  if (isErr(jobResult)) {
+    return err(jobResult.error);
+  }
+
+  const { job, created } = jobResult.value;
+
+  if (!created) {
+    if (job.status === "failed") {
+      return err({
+        code: "translation_job_queue_unavailable",
+        message: job.lastError ?? "Translation job queue unavailable.",
+      });
+    }
+
+    return ok({
+      jobId: job.id,
+      type: input.type,
+      status: job.workflowRunId ? "enqueued" : "queued",
+      workflowRunIds: job.workflowRunId ? [job.workflowRunId] : [],
+    });
+  }
+
+  const enqueueResult = await enqueueTranslationJob({
+    ctx,
+    job,
+    type: input.type,
+  });
+
+  if (isErr(enqueueResult)) {
+    return err(enqueueResult.error);
+  }
+
+  return ok({
+    jobId: job.id,
+    type: input.type,
+    status: "enqueued",
+    workflowRunIds: enqueueResult.value.workflowRunIds,
+  });
+}
+
 export function createTranslationJobTool(ctx: ToolContext) {
   return tool({
     description: "Create a durable translation job (string or file) and enqueue it for execution.",
     inputSchema: createTranslationJobInputSchema,
     execute: async (input) => {
       const preparedInputResult = await prepareTranslationJobInput(ctx, input);
+
       if (isErr(preparedInputResult)) {
         return {
           success: false,
@@ -687,6 +801,7 @@ export function createTranslationJobTool(ctx: ToolContext) {
       }
 
       const jobResult = await createTranslationJobRecord(ctx, input, preparedInputResult.value);
+
       if (isErr(jobResult)) {
         return {
           success: false,
@@ -694,8 +809,14 @@ export function createTranslationJobTool(ctx: ToolContext) {
         };
       }
 
-      const job = jobResult.value;
-      const enqueueResult = await enqueueTranslationJob({ ctx, job, type: input.type });
+      const job = jobResult.value.job;
+
+      const enqueueResult = await enqueueTranslationJob({
+        ctx,
+        job,
+        type: input.type,
+      });
+
       if (isErr(enqueueResult)) {
         return {
           success: false,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
@@ -12,7 +12,7 @@
  */
 import { randomUUID } from "node:crypto";
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { tool } from "ai";
 import { z } from "zod";
 
@@ -691,19 +691,39 @@ async function enqueueTranslationJob(input: {
       type: input.type,
     });
 
-    await input.ctx.db
+    const [claimedJob] = await input.ctx.db
       .update(schema.jobs)
       .set({ workflowRunId: result.ids[0] ?? null })
       .where(
         and(
           eq(schema.jobs.id, input.job.id),
           eq(schema.jobs.organizationId, input.ctx.organizationId),
+          eq(schema.jobs.status, "queued"),
+          isNull(schema.jobs.workflowRunId),
         ),
-      );
+      )
+      .returning({ workflowRunId: schema.jobs.workflowRunId });
 
-    return ok({ workflowRunIds: result.ids });
+    if (!claimedJob) {
+      const [ownedJob] = await input.ctx.db
+        .select({ workflowRunId: schema.jobs.workflowRunId })
+        .from(schema.jobs)
+        .where(
+          and(
+            eq(schema.jobs.id, input.job.id),
+            eq(schema.jobs.organizationId, input.ctx.organizationId),
+          ),
+        )
+        .limit(1);
+
+      return ok({ workflowRunIds: ownedJob?.workflowRunId ? [ownedJob.workflowRunId] : [] });
+    }
+
+    return ok({
+      workflowRunIds: claimedJob.workflowRunId ? [claimedJob.workflowRunId] : [],
+    });
   } catch (error) {
-    await input.ctx.db
+    const [failedJob] = await input.ctx.db
       .update(schema.jobs)
       .set({
         status: "failed",
@@ -713,8 +733,28 @@ async function enqueueTranslationJob(input: {
         and(
           eq(schema.jobs.id, input.job.id),
           eq(schema.jobs.organizationId, input.ctx.organizationId),
+          eq(schema.jobs.status, "queued"),
+          isNull(schema.jobs.workflowRunId),
         ),
-      );
+      )
+      .returning({ id: schema.jobs.id });
+
+    if (!failedJob) {
+      const [ownedJob] = await input.ctx.db
+        .select({ workflowRunId: schema.jobs.workflowRunId })
+        .from(schema.jobs)
+        .where(
+          and(
+            eq(schema.jobs.id, input.job.id),
+            eq(schema.jobs.organizationId, input.ctx.organizationId),
+          ),
+        )
+        .limit(1);
+
+      if (ownedJob?.workflowRunId) {
+        return ok({ workflowRunIds: [ownedJob.workflowRunId] });
+      }
+    }
 
     await enqueueJobFailedActivity({
       actorCredentialId: null,

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -129,7 +129,7 @@ Native pairs come from concept-linked terms. Leftover `source_term` / `target_te
 
 The response contains `jobId`, `type`, `status` (`queued` or `enqueued`), and `workflowRunIds` when the queue provides them. Poll `get_job` with the returned `jobId` for completion. For file jobs, use `list_files` to discover a source id or path first.
 
-Pass an optional `idempotencyKey` when a client may retry the same request. Reusing the key for the same organization and project returns the existing job instead of creating or enqueueing another one.
+Pass an optional `idempotencyKey` when a client may retry the same request. Reusing the key for the same organization, project, and payload returns the existing job instead of creating another one. Reusing it with a different payload returns `idempotency_conflict`. If a prior attempt committed the job but stopped before submitting it to the workflow queue, a retry submits that queued job.
 
 Creating jobs requires the same job-creation permission and AI feature availability as Cloud Jobs. Project and file lookups are scoped to the authenticated organization and project. Locale mismatches return `invalid_job_payload`; missing files return `file_not_found`. Usage or organization budget failures retain their existing billing error codes. Queue failures return `job_queue_unavailable`.
 
@@ -176,6 +176,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `invalid_job_payload`                          | Source or target locales do not match the project, or the translation job input is invalid                            |
 | `file_not_found`                               | The requested source file does not exist in the accessible project                                                     |
 | `job_queue_unavailable`                        | The translation job was created but could not be submitted to the workflow queue                                       |
+| `idempotency_conflict`                         | The supplied idempotency key is already associated with a different workflow payload                                  |
 | `ai_features_required`                         | AI translation features are not available for the organization                                                        |
 | `ai_features_check_failed`                     | Hyperlocalise could not verify AI feature availability                                                                |
 | `project_not_found`                            | Wrong `projectId` or missing project access on `list_files`, `list_translations`, `get_project_status`, or `list_jobs` |

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -119,10 +119,19 @@ Native pairs come from concept-linked terms. Leftover `source_term` / `target_te
 
 ### Jobs
 
-| Tool        | Description                                                                                        |
-| ----------- | -------------------------------------------------------------------------------------------------- |
-| `list_jobs` | Recent translation jobs (`projectId`, `sourcePath`, `status`, `limit` default 20 max 50, `offset`) |
-| `get_job`   | Job status by `jobId`. Poll after `run_workflow` until the job is terminal.                        |
+| Tool           | Description                                                                                                           |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `run_workflow` | Create and enqueue a string or file translation job                                                                   |
+| `list_jobs`    | Recent translation jobs (`projectId`, `sourcePath`, `status`, `limit` default 20 max 50, `offset`)                    |
+| `get_job`      | Job status by `jobId`. Poll after `run_workflow` until the job is terminal.                                           |
+
+`run_workflow` starts durable Cloud translation work and returns without waiting for translation to finish. Use `type: "string"` with `sourceText`, or `type: "file"` with exactly one of `sourceFileId` and `sourcePath` plus `fileFormat`. Both variants require `projectId`, the project's `sourceLocale`, and one or more configured `targetLocales`. String jobs also accept optional `context` and `maxLength`; both variants accept optional `metadata`.
+
+The response contains `jobId`, `type`, `status` (`queued` or `enqueued`), and `workflowRunIds` when the queue provides them. Poll `get_job` with the returned `jobId` for completion. For file jobs, use `list_files` to discover a source id or path first.
+
+Pass an optional `idempotencyKey` when a client may retry the same request. Reusing the key for the same organization and project returns the existing job instead of creating or enqueueing another one.
+
+Creating jobs requires the same job-creation permission and AI feature availability as Cloud Jobs. Project and file lookups are scoped to the authenticated organization and project. Locale mismatches return `invalid_job_payload`; missing files return `file_not_found`. Usage or organization budget failures retain their existing billing error codes. Queue failures return `job_queue_unavailable`.
 
 `list_jobs` finds recent translation jobs so you can call `get_job` without already knowing a job id. It defaults to `kind = translation`. Optional filters:
 
@@ -137,14 +146,6 @@ Each job is compact: `id`, `projectId`, `type`, `status`, `createdAt`, `complete
 `get_job` returns the public job envelope: `id`, `projectId`, `type`, `kind`, `status`, timestamps, and `lastError`. Status values include `queued`, `running`, `succeeded`, and `failed`. Completed file jobs also include `outputFiles` with `{ fileId, locale, filename }` so you can pass those ids to `download_translations` or file reads.
 
 Missing or inaccessible jobs, including jobs from another organization, return `job_not_found`.
-
-### Reserved (not implemented)
-
-These tools are advertised but return `not_implemented` today:
-
-- `run_workflow`
-
-Use the [public API](/platform/api) or [CLI](/platform/cli) for job orchestration until this tool is wired.
 
 ## Outbound MCP in automations
 
@@ -172,6 +173,11 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `issue_not_found`                              | Wrong `projectId`, issue id, or missing project access                                                                 |
 | `invalid_comment_cursor`                       | Stale or malformed `cursor` on `list_issue_comments`                                                                   |
 | `job_not_found`                                | Wrong `jobId`, missing project access, or a job from another organization                                              |
+| `invalid_job_payload`                          | Source or target locales do not match the project, or the translation job input is invalid                            |
+| `file_not_found`                               | The requested source file does not exist in the accessible project                                                     |
+| `job_queue_unavailable`                        | The translation job was created but could not be submitted to the workflow queue                                       |
+| `ai_features_required`                         | AI translation features are not available for the organization                                                        |
+| `ai_features_check_failed`                     | Hyperlocalise could not verify AI feature availability                                                                |
 | `project_not_found`                            | Wrong `projectId` or missing project access on `list_files`, `list_translations`, `get_project_status`, or `list_jobs` |
 | `glossary_not_found`                           | Wrong `glossaryId`, missing glossary access, or a provider glossary on `query_glossary`                                |
 | `translation_not_found`                        | Wrong or inaccessible project, translation key, target locale, or a hidden key                                         |


### PR DESCRIPTION
## What changed

- Replaced the reserved `run_workflow` MCP stub with a working translation job create-and-enqueue flow.
- Added bounded input validation for `string` and `file` translation jobs.
- Reused the existing Cloud job creation, billing reservation, and workflow queue paths.
- Added project isolation, permission, AI feature, locale, source-file, and file-format validation.
- Added optional `idempotencyKey` support to prevent duplicate jobs and queue submissions.
- Returned `jobId`, `type`, `status`, and `workflowRunIds`.
- Added tests covering advertisement, authorization, isolation, validation, successful enqueue, queue failure, and idempotent retries.
- Updated the hosted MCP documentation.

## How to test

From `apps/hyperlocalise-web`:

```sh
vp check --fix
vp test src/api/routes/mcp/mcp.route.test.ts
```

## Checklist
- I ran relevant checks locally (vp check --fix, focused MCP route tests)
- I updated docs, comments, or examples when needed
- This PR is scoped and ready for review