### PR TITLE
feat(ai-engine): list TTS, transcribe, image, and video models

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-agent-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-agent-capabilities.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  hyperlocaliseImageModelId,
+  hyperlocaliseTtsModelId,
+  hyperlocaliseTranscribeModelId,
+  hyperlocaliseVideoModelId,
+} from "@/lib/providers/managed-model-ids";
+
+import {
+  getAgentCapabilityModelSource,
+  getIncludedAgentCapabilityModel,
+  isIncludedAgentCapabilityId,
+} from "./ai-engine-agent-capabilities";
+
+describe("ai engine agent capabilities", () => {
+  it("keeps ask, translation, and coding on the workspace default", () => {
+    expect(getAgentCapabilityModelSource("ask")).toBe("workspace-default");
+    expect(getAgentCapabilityModelSource("translation")).toBe("workspace-default");
+    expect(getAgentCapabilityModelSource("coding")).toBe("workspace-default");
+    expect(isIncludedAgentCapabilityId("ask")).toBe(false);
+  });
+
+  it("uses included models for speech, image, and video", () => {
+    expect(getAgentCapabilityModelSource("tts")).toBe("included");
+    expect(getIncludedAgentCapabilityModel("tts")).toBe(hyperlocaliseTtsModelId);
+    expect(getIncludedAgentCapabilityModel("transcribe")).toBe(hyperlocaliseTranscribeModelId);
+    expect(getIncludedAgentCapabilityModel("image")).toBe(hyperlocaliseImageModelId);
+    expect(getIncludedAgentCapabilityModel("video")).toBe(hyperlocaliseVideoModelId);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-agent-capabilities.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-agent-capabilities.ts
@@ -10,8 +10,46 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  hyperlocaliseImageModelId,
+  hyperlocaliseTtsModelId,
+  hyperlocaliseTranscribeModelId,
+  hyperlocaliseVideoModelId,
+} from "@/lib/providers/managed-model-ids";
 
 /** Hyperlocalise Agent capability slots (Phase 2 will persist per-capability models). */
-export const agentCapabilityIds = ["ask", "translation", "coding"] as const;
+export const workspaceDefaultAgentCapabilityIds = ["ask", "translation", "coding"] as const;
+
+export const includedAgentCapabilityIds = ["tts", "transcribe", "image", "video"] as const;
+
+export const agentCapabilityIds = [
+  ...workspaceDefaultAgentCapabilityIds,
+  ...includedAgentCapabilityIds,
+] as const;
 
 export type AgentCapabilityId = (typeof agentCapabilityIds)[number];
+export type IncludedAgentCapabilityId = (typeof includedAgentCapabilityIds)[number];
+export type AgentCapabilityModelSource = "workspace-default" | "included";
+
+const includedModelByCapabilityId = {
+  tts: hyperlocaliseTtsModelId,
+  transcribe: hyperlocaliseTranscribeModelId,
+  image: hyperlocaliseImageModelId,
+  video: hyperlocaliseVideoModelId,
+} as const satisfies Record<IncludedAgentCapabilityId, string>;
+
+export function isIncludedAgentCapabilityId(
+  capabilityId: AgentCapabilityId,
+): capabilityId is IncludedAgentCapabilityId {
+  return capabilityId in includedModelByCapabilityId;
+}
+
+export function getAgentCapabilityModelSource(
+  capabilityId: AgentCapabilityId,
+): AgentCapabilityModelSource {
+  return isIncludedAgentCapabilityId(capabilityId) ? "included" : "workspace-default";
+}
+
+export function getIncludedAgentCapabilityModel(capabilityId: IncludedAgentCapabilityId): string {
+  return includedModelByCapabilityId[capabilityId];
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-agent-capability-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-agent-capability-row.tsx
@@ -17,12 +17,14 @@ import { FormattedMessage } from "react-intl";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/primitives/cn";
 
+import type { AgentCapabilityModelSource } from "./ai-engine-agent-capabilities";
 import { aiEnginePageContentMessages } from "./ai-engine-page-content.messages";
 
 type AiEngineAgentCapabilityRowProps = {
   name: string;
   description: string;
   effectiveModel: string;
+  modelSource?: AgentCapabilityModelSource;
   isLast?: boolean;
 };
 
@@ -30,6 +32,7 @@ export function AiEngineAgentCapabilityRow({
   name,
   description,
   effectiveModel,
+  modelSource = "workspace-default",
   isLast = false,
 }: AiEngineAgentCapabilityRowProps) {
   return (
@@ -47,7 +50,11 @@ export function AiEngineAgentCapabilityRow({
       <div className="flex shrink-0 flex-col items-start gap-2 sm:min-w-[14rem] sm:items-end">
         <p className="font-mono text-sm text-foreground">{effectiveModel}</p>
         <Badge variant="outline" className="text-[10px]">
-          <FormattedMessage {...aiEnginePageContentMessages.workspaceDefaultBadge} />
+          <FormattedMessage
+            {...(modelSource === "included"
+              ? aiEnginePageContentMessages.includedBadge
+              : aiEnginePageContentMessages.workspaceDefaultBadge)}
+          />
         </Badge>
       </div>
     </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-page-content.messages.ts
@@ -38,8 +38,8 @@ export const aiEnginePageContentMessages = defineMessages({
   },
   agentSectionDescription: {
     defaultMessage:
-      "Ask, Translation, and Coding use the workspace default model today. Per-capability overrides are coming soon.",
-    id: "vSisR0WmWz",
+      "Ask, Translation, and Coding use the workspace default model today. Text to speech, Transcribe, Image generation, and Video generation use included models. Per-capability overrides are coming soon.",
+    id: "xHmiZAvHuU",
     description: "Description under the Hyperlocalise Agent section heading",
   },
   agentAutomationsNote: {
@@ -126,6 +126,47 @@ export const aiEnginePageContentMessages = defineMessages({
       "Repository agent, GitHub automations, patches, and sandboxed code changes for localization fixes.",
     id: "CIjzfipJPL",
     description: "Hyperlocalise Agent Coding capability description",
+  },
+  capabilityTtsName: {
+    defaultMessage: "Text to speech",
+    id: "mgiYpfU9jm",
+    description: "Hyperlocalise Agent text to speech capability name",
+  },
+  capabilityTtsDescription: {
+    defaultMessage: "Spoken audio for localized voiceovers, previews, and agent replies.",
+    id: "JWYwsX1bkl",
+    description: "Hyperlocalise Agent text to speech capability description",
+  },
+  capabilityTranscribeName: {
+    defaultMessage: "Transcribe",
+    id: "qjx6F4ATvy",
+    description: "Hyperlocalise Agent transcribe capability name",
+  },
+  capabilityTranscribeDescription: {
+    defaultMessage: "Speech-to-text for uploaded audio, meetings, and voice notes.",
+    id: "S8o/G+WkMb",
+    description: "Hyperlocalise Agent transcribe capability description",
+  },
+  capabilityImageName: {
+    defaultMessage: "Image generation",
+    id: "zNmLFPYZSE",
+    description: "Hyperlocalise Agent image generation capability name",
+  },
+  capabilityImageDescription: {
+    defaultMessage: "Localized image generation and regeneration for campaign assets.",
+    id: "SP5RujLemP",
+    description: "Hyperlocalise Agent image generation capability description",
+  },
+  capabilityVideoName: {
+    defaultMessage: "Video generation",
+    id: "9hH0faxMuJ",
+    description: "Hyperlocalise Agent video generation capability name",
+  },
+  capabilityVideoDescription: {
+    defaultMessage:
+      "Localized video generation and regeneration for on-screen text and spoken audio.",
+    id: "ia5z3O+Lwm",
+    description: "Hyperlocalise Agent video generation capability description",
   },
   noAccess: {
     defaultMessage: "You do not have permission to manage AI providers in this workspace.",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-page-content.stories.tsx
@@ -56,6 +56,14 @@ export const Default: Story = {
     await expect(canvas.getByText("Ask")).toBeInTheDocument();
     await expect(canvas.getByText("Translation")).toBeInTheDocument();
     await expect(canvas.getByText("Coding")).toBeInTheDocument();
+    await expect(canvas.getByText("Text to speech")).toBeInTheDocument();
+    await expect(canvas.getByText("Transcribe")).toBeInTheDocument();
+    await expect(canvas.getByText("Image generation")).toBeInTheDocument();
+    await expect(canvas.getByText("Video generation")).toBeInTheDocument();
+    await expect(canvas.getByText("fish-audio/s2.1-pro")).toBeInTheDocument();
+    await expect(canvas.getByText("google/gemini-3.5-transcribe")).toBeInTheDocument();
+    await expect(canvas.getByText("openai/gpt-image-2.5-flare")).toBeInTheDocument();
+    await expect(canvas.getByText("bytedance/seedance-2.5")).toBeInTheDocument();
     await expect(canvas.getAllByText("Workspace default").length).toBeGreaterThan(0);
     await expect(canvas.getByText("Open AI")).toBeInTheDocument();
     await expect(canvas.getByText("Included models")).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/ai-engine/_components/ai-engine-page-content.tsx
@@ -63,7 +63,12 @@ import {
   type ModelProviderCardConfig,
 } from "../../integrations/_components/model-provider-card";
 
-import { agentCapabilityIds } from "./ai-engine-agent-capabilities";
+import {
+  agentCapabilityIds,
+  getAgentCapabilityModelSource,
+  getIncludedAgentCapabilityModel,
+  isIncludedAgentCapabilityId,
+} from "./ai-engine-agent-capabilities";
 import { AiEngineAgentCapabilityRow } from "./ai-engine-agent-capability-row";
 import { AiEngineCurrentSetupPanel } from "./ai-engine-current-setup-panel";
 import { aiEnginePageContentMessages } from "./ai-engine-page-content.messages";
@@ -112,6 +117,37 @@ const byokProviderMeta = [
   logo: string;
   icon?: SimpleIcon;
 }[];
+
+const capabilityCopyById = {
+  ask: {
+    name: aiEnginePageContentMessages.capabilityAskName,
+    description: aiEnginePageContentMessages.capabilityAskDescription,
+  },
+  translation: {
+    name: aiEnginePageContentMessages.capabilityTranslationName,
+    description: aiEnginePageContentMessages.capabilityTranslationDescription,
+  },
+  coding: {
+    name: aiEnginePageContentMessages.capabilityCodingName,
+    description: aiEnginePageContentMessages.capabilityCodingDescription,
+  },
+  tts: {
+    name: aiEnginePageContentMessages.capabilityTtsName,
+    description: aiEnginePageContentMessages.capabilityTtsDescription,
+  },
+  transcribe: {
+    name: aiEnginePageContentMessages.capabilityTranscribeName,
+    description: aiEnginePageContentMessages.capabilityTranscribeDescription,
+  },
+  image: {
+    name: aiEnginePageContentMessages.capabilityImageName,
+    description: aiEnginePageContentMessages.capabilityImageDescription,
+  },
+  video: {
+    name: aiEnginePageContentMessages.capabilityVideoName,
+    description: aiEnginePageContentMessages.capabilityVideoDescription,
+  },
+} as const;
 
 function useProviderCredentials(organizationSlug: string) {
   return useQuery({
@@ -263,27 +299,17 @@ export function AiEnginePageContent({
   const agentCapabilities = useMemo(
     () =>
       agentCapabilityIds.map((capabilityId) => {
-        const copyById = {
-          ask: {
-            name: aiEnginePageContentMessages.capabilityAskName,
-            description: aiEnginePageContentMessages.capabilityAskDescription,
-          },
-          translation: {
-            name: aiEnginePageContentMessages.capabilityTranslationName,
-            description: aiEnginePageContentMessages.capabilityTranslationDescription,
-          },
-          coding: {
-            name: aiEnginePageContentMessages.capabilityCodingName,
-            description: aiEnginePageContentMessages.capabilityCodingDescription,
-          },
-        } as const;
-
-        const copy = copyById[capabilityId];
+        const copy = capabilityCopyById[capabilityId];
+        const modelSource = getAgentCapabilityModelSource(capabilityId);
 
         return {
           id: capabilityId,
           name: intl.formatMessage(copy.name),
           description: intl.formatMessage(copy.description),
+          modelSource,
+          includedModel: isIncludedAgentCapabilityId(capabilityId)
+            ? getIncludedAgentCapabilityModel(capabilityId)
+            : undefined,
         };
       }),
     [intl],
@@ -439,7 +465,8 @@ export function AiEnginePageContent({
                     key={capability.id}
                     name={capability.name}
                     description={capability.description}
-                    effectiveModel={workspaceDefaultModel}
+                    effectiveModel={capability.includedModel ?? workspaceDefaultModel}
+                    modelSource={capability.modelSource}
                     isLast={index === agentCapabilities.length - 1}
                   />
                 ))}

--- a/apps/hyperlocalise-web/src/lib/providers/language-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/language-model.test.ts
@@ -33,9 +33,13 @@ import {
   getAgentProviderOptions,
   getManagedImageModel,
   getManagedLanguageModel,
+  getManagedTranscribeModel,
+  getManagedTtsModel,
   getManagedVideoModel,
   hyperlocaliseImageModelId,
   hyperlocaliseManagedGatewayModelId,
+  hyperlocaliseTranscribeModelId,
+  hyperlocaliseTtsModelId,
   hyperlocaliseVideoModelId,
   resolveProviderLanguageModel,
 } from "./language-model";
@@ -45,9 +49,13 @@ describe("managed language model", () => {
     expect(getManagedLanguageModel()).toBe(hyperlocaliseManagedGatewayModelId);
     expect(getManagedImageModel()).toBe(hyperlocaliseImageModelId);
     expect(getManagedVideoModel()).toBe(hyperlocaliseVideoModelId);
+    expect(getManagedTtsModel()).toBe(hyperlocaliseTtsModelId);
+    expect(getManagedTranscribeModel()).toBe(hyperlocaliseTranscribeModelId);
     expect(hyperlocaliseManagedGatewayModelId).toBe("openai/gpt-5.6-luna");
     expect(hyperlocaliseImageModelId).toBe("openai/gpt-image-2.5-flare");
     expect(hyperlocaliseVideoModelId).toBe("bytedance/seedance-2.5");
+    expect(hyperlocaliseTtsModelId).toBe("fish-audio/s2.1-pro");
+    expect(hyperlocaliseTranscribeModelId).toBe("google/gemini-3.5-transcribe");
     expect(createOpenAIMock).not.toHaveBeenCalled();
     expect(createAnthropicMock).not.toHaveBeenCalled();
   });

--- a/apps/hyperlocalise-web/src/lib/providers/language-model.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/language-model.ts
@@ -16,10 +16,21 @@ import type { LanguageModel } from "ai";
 
 import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
 import type { LlmProvider } from "@/lib/database/types";
+import {
+  hyperlocaliseImageModelId,
+  hyperlocaliseTtsModelId,
+  hyperlocaliseTranscribeModelId,
+  hyperlocaliseVideoModelId,
+} from "@/lib/providers/managed-model-ids";
+
+export {
+  hyperlocaliseImageModelId,
+  hyperlocaliseTtsModelId,
+  hyperlocaliseTranscribeModelId,
+  hyperlocaliseVideoModelId,
+};
 
 export const hyperlocaliseManagedGatewayModelId = `openai/${hyperlocaliseAgentModelId}`;
-export const hyperlocaliseImageModelId = "openai/gpt-image-2.5-flare";
-export const hyperlocaliseVideoModelId = "bytedance/seedance-2.5";
 
 export type AgentLanguageModelSource = LlmProvider | "gateway";
 
@@ -45,6 +56,14 @@ export function getManagedImageModel() {
 
 export function getManagedVideoModel() {
   return hyperlocaliseVideoModelId;
+}
+
+export function getManagedTtsModel() {
+  return hyperlocaliseTtsModelId;
+}
+
+export function getManagedTranscribeModel() {
+  return hyperlocaliseTranscribeModelId;
 }
 
 export function resolveProviderLanguageModel(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/managed-model-ids.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/managed-model-ids.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+/** Lightweight managed model ids (no SDK / env imports). */
+export const hyperlocaliseImageModelId = "openai/gpt-image-2.5-flare";
+export const hyperlocaliseVideoModelId = "bytedance/seedance-2.5";
+export const hyperlocaliseTtsModelId = "fish-audio/s2.1-pro";
+export const hyperlocaliseTranscribeModelId = "google/gemini-3.5-transcribe";


### PR DESCRIPTION
## What changed

AI Engine now lists included models for text to speech (`fish-audio/s2.1-pro`), transcribe (`google/gemini-3.5-transcribe`), image generation (`openai/gpt-image-2.5-flare`), and video generation (`bytedance/seedance-2.5`). Ask, Translation, and Coding still inherit the workspace default.

## How to test

- Open AI Engine and confirm the four new capability rows show the included model ids and the Included badge.
- Confirm Ask, Translation, and Coding still show the workspace default model.
- `vp test` / `vp check --fix` in `apps/hyperlocalise-web` for the language-model and AI Engine capability tests.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)