### PR TITLE
feat(web): add mocked domain research screens

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/brand/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/brand/page.tsx
@@ -10,35 +10,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { isResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+import { DomainBrandView } from "../../_components/domain-brand-view";
+import { DomainResearchShell } from "../../_components/domain-research-shell";
 
-import { DomainHomeView } from "../_components/domain-home-view";
-import { DomainResearchShell } from "../_components/domain-research-shell";
-import { DomainDetailPageContent } from "./_components/domain-detail-page-content";
-
-export default async function DomainDetailPage({
+export default async function DomainBrandPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
 }) {
   const { organizationSlug, linkedDomainId } = await params;
 
-  if (!isResearchPrototypeDomain(linkedDomainId)) {
-    return (
-      <DomainDetailPageContent
-        organizationSlug={organizationSlug}
-        linkedDomainId={linkedDomainId}
-      />
-    );
-  }
-
   return (
     <DomainResearchShell
       organizationSlug={organizationSlug}
       linkedDomainId={linkedDomainId}
-      surface="home"
+      surface="brand"
     >
-      <DomainHomeView organizationSlug={organizationSlug} linkedDomainId={linkedDomainId} />
+      <DomainBrandView linkedDomainId={linkedDomainId} />
     </DomainResearchShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/keywords/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/keywords/page.tsx
@@ -10,35 +10,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { isResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+import { DomainKeywordsView } from "../../_components/domain-keywords-view";
+import { DomainResearchShell } from "../../_components/domain-research-shell";
 
-import { DomainHomeView } from "../_components/domain-home-view";
-import { DomainResearchShell } from "../_components/domain-research-shell";
-import { DomainDetailPageContent } from "./_components/domain-detail-page-content";
-
-export default async function DomainDetailPage({
+export default async function DomainKeywordsPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
 }) {
   const { organizationSlug, linkedDomainId } = await params;
 
-  if (!isResearchPrototypeDomain(linkedDomainId)) {
-    return (
-      <DomainDetailPageContent
-        organizationSlug={organizationSlug}
-        linkedDomainId={linkedDomainId}
-      />
-    );
-  }
-
   return (
     <DomainResearchShell
       organizationSlug={organizationSlug}
       linkedDomainId={linkedDomainId}
-      surface="home"
+      surface="keywords"
     >
-      <DomainHomeView organizationSlug={organizationSlug} linkedDomainId={linkedDomainId} />
+      <DomainKeywordsView linkedDomainId={linkedDomainId} />
     </DomainResearchShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/layout.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+
+import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
+import { getWorkspaceFeatureFlagEnabled, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
+import { requireAppCapability } from "@/lib/workos/app-auth";
+
+import { OrgPageSuspense } from "../../_components/org-page-suspense";
+
+export default function DomainDetailLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <DomainDetailLayoutLoader params={params}>{children}</DomainDetailLayoutLoader>
+    </OrgPageSuspense>
+  );
+}
+
+async function DomainDetailLayoutLoader({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
+}) {
+  const { organizationSlug } = await params;
+  const auth = await requireAppCapability("projects:read", { organizationSlug });
+  const domainsEnabled = await getWorkspaceFeatureFlagEnabled(workspaceDomainsFlag, auth);
+
+  if (!domainsEnabled) {
+    return <FeatureTeaserPage feature="domains" scope="workspace" />;
+  }
+
+  return children;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/overview/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/overview/page.tsx
@@ -10,35 +10,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { isResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+import { DomainOverviewView } from "../../_components/domain-overview-view";
+import { DomainResearchShell } from "../../_components/domain-research-shell";
 
-import { DomainHomeView } from "../_components/domain-home-view";
-import { DomainResearchShell } from "../_components/domain-research-shell";
-import { DomainDetailPageContent } from "./_components/domain-detail-page-content";
-
-export default async function DomainDetailPage({
+export default async function DomainOverviewPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
 }) {
   const { organizationSlug, linkedDomainId } = await params;
 
-  if (!isResearchPrototypeDomain(linkedDomainId)) {
-    return (
-      <DomainDetailPageContent
-        organizationSlug={organizationSlug}
-        linkedDomainId={linkedDomainId}
-      />
-    );
-  }
-
   return (
     <DomainResearchShell
       organizationSlug={organizationSlug}
       linkedDomainId={linkedDomainId}
-      surface="home"
+      surface="overview"
     >
-      <DomainHomeView organizationSlug={organizationSlug} linkedDomainId={linkedDomainId} />
+      <DomainOverviewView linkedDomainId={linkedDomainId} />
     </DomainResearchShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/prompts/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/prompts/page.tsx
@@ -10,35 +10,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { isResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+import { DomainPromptsView } from "../../_components/domain-prompts-view";
+import { DomainResearchShell } from "../../_components/domain-research-shell";
 
-import { DomainHomeView } from "../_components/domain-home-view";
-import { DomainResearchShell } from "../_components/domain-research-shell";
-import { DomainDetailPageContent } from "./_components/domain-detail-page-content";
-
-export default async function DomainDetailPage({
+export default async function DomainPromptsPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
 }) {
   const { organizationSlug, linkedDomainId } = await params;
 
-  if (!isResearchPrototypeDomain(linkedDomainId)) {
-    return (
-      <DomainDetailPageContent
-        organizationSlug={organizationSlug}
-        linkedDomainId={linkedDomainId}
-      />
-    );
-  }
-
   return (
     <DomainResearchShell
       organizationSlug={organizationSlug}
       linkedDomainId={linkedDomainId}
-      surface="home"
+      surface="prompts"
     >
-      <DomainHomeView organizationSlug={organizationSlug} linkedDomainId={linkedDomainId} />
+      <DomainPromptsView linkedDomainId={linkedDomainId} />
     </DomainResearchShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/ranks/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/ranks/page.tsx
@@ -10,35 +10,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { isResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+import { DomainRanksView } from "../../_components/domain-ranks-view";
+import { DomainResearchShell } from "../../_components/domain-research-shell";
 
-import { DomainHomeView } from "../_components/domain-home-view";
-import { DomainResearchShell } from "../_components/domain-research-shell";
-import { DomainDetailPageContent } from "./_components/domain-detail-page-content";
-
-export default async function DomainDetailPage({
+export default async function DomainRanksPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
 }) {
   const { organizationSlug, linkedDomainId } = await params;
 
-  if (!isResearchPrototypeDomain(linkedDomainId)) {
-    return (
-      <DomainDetailPageContent
-        organizationSlug={organizationSlug}
-        linkedDomainId={linkedDomainId}
-      />
-    );
-  }
-
   return (
     <DomainResearchShell
       organizationSlug={organizationSlug}
       linkedDomainId={linkedDomainId}
-      surface="home"
+      surface="ranks"
     >
-      <DomainHomeView organizationSlug={organizationSlug} linkedDomainId={linkedDomainId} />
+      <DomainRanksView linkedDomainId={linkedDomainId} />
     </DomainResearchShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-brand-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-brand-view.messages.ts
@@ -1,0 +1,98 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainBrandViewMessages = defineMessages({
+  addCta: {
+    defaultMessage: "Add competitors",
+    id: "ehiNyfW7wC",
+    description: "Open add competitors dialog",
+  },
+  addTitle: {
+    defaultMessage: "Add competitors",
+    id: "dOPqWy+7LT",
+    description: "Add competitors dialog title",
+  },
+  addDescription: {
+    defaultMessage: "One brand name per line. We’ll look them up next to this domain.",
+    id: "YKrlBkbjMO",
+    description: "Add competitors dialog description",
+  },
+  addLabel: {
+    defaultMessage: "Competitors",
+    id: "ZVZIaOT6mh",
+    description: "Add competitors textarea label",
+  },
+  addPlaceholder: {
+    defaultMessage: "Phrase",
+    id: "CbWoJgQftn",
+    description: "Add competitors textarea placeholder",
+  },
+  addSubmit: {
+    defaultMessage: "Add competitors",
+    id: "QnEWqTaPq3",
+    description: "Submit add competitors dialog",
+  },
+  addSuccess: {
+    defaultMessage: "Competitors added to this lookup.",
+    id: "tw8Dxn5ajk",
+    description: "Toast after adding competitors",
+  },
+  enginesHeading: {
+    defaultMessage: "Mentions by engine",
+    id: "/MSF8xAJVo",
+    description: "Heading above AI engine mention scores",
+  },
+  columnCompetitor: {
+    defaultMessage: "Competitor",
+    id: "y+opIciqLH",
+    description: "Brand lookup competitor column",
+  },
+  columnMentions: {
+    defaultMessage: "Mentions",
+    id: "ctCnTU7Kh5",
+    description: "Brand lookup mentions column",
+  },
+  columnSentiment: {
+    defaultMessage: "Sentiment",
+    id: "EcNwGUZY/j",
+    description: "Brand lookup sentiment column",
+  },
+  sentimentPositive: {
+    defaultMessage: "Positive",
+    id: "wyFyFdRxOh",
+    description: "Positive competitor sentiment",
+  },
+  sentimentMixed: {
+    defaultMessage: "Mixed",
+    id: "CeI2Q523KF",
+    description: "Mixed competitor sentiment",
+  },
+  sentimentNegative: {
+    defaultMessage: "Negative",
+    id: "rRmPYSuRjD",
+    description: "Negative competitor sentiment",
+  },
+  emptyTitle: {
+    defaultMessage: "No competitor set yet",
+    id: "xCK+zfPmQl",
+    description: "Empty brand lookup title",
+  },
+  emptyDescription: {
+    defaultMessage: "Add the brands you compete with in this market.",
+    id: "GKE7xJDkbr",
+    description: "Empty brand lookup description",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-brand-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-brand-view.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useState } from "react";
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { TypographyH2, TypographyP } from "@/components/ui/typography";
+import type { BrandEngine, BrandSentiment } from "@/lib/domains/research-prototype";
+import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+import { cn } from "@/lib/primitives/cn";
+
+import { DomainResearchEmpty } from "./domain-research-empty";
+import { formatBrandEngine } from "./domain-research-format";
+import { DomainResearchTextareaDialog } from "./domain-research-textarea-dialog";
+import { domainBrandViewMessages as messages } from "./domain-brand-view.messages";
+
+const ENGINES: BrandEngine[] = ["chatgpt", "claude", "gemini", "perplexity"];
+const COMPETITOR_GRID =
+  "grid grid-cols-[minmax(10rem,1.2fr)_minmax(5rem,0.4fr)_minmax(6rem,0.5fr)] items-center gap-3 px-3 py-2.5";
+
+function sentimentMessage(sentiment: BrandSentiment) {
+  switch (sentiment) {
+    case "positive":
+      return messages.sentimentPositive;
+    case "mixed":
+      return messages.sentimentMixed;
+    case "negative":
+      return messages.sentimentNegative;
+  }
+}
+
+export function DomainBrandView({ linkedDomainId }: { linkedDomainId: string }) {
+  const intl = useIntl();
+  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const [addOpen, setAddOpen] = useState(false);
+
+  if (!catalog) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-6">
+      <div className="flex justify-end">
+        <Button size="sm" variant="outline" onClick={() => setAddOpen(true)}>
+          <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+          <FormattedMessage {...messages.addCta} />
+        </Button>
+      </div>
+
+      <section className="grid gap-3">
+        <TypographyH2 className="pb-0" size="xlarge">
+          <FormattedMessage {...messages.enginesHeading} />
+        </TypographyH2>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {ENGINES.map((engine) => (
+            <Card
+              key={engine}
+              size="sm"
+              className="rounded-lg border border-border bg-muted py-0 ring-0"
+            >
+              <CardContent className="px-4 py-4">
+                <TypographyP size="small" tone="subtle">
+                  {formatBrandEngine(intl, engine)}
+                </TypographyP>
+                <TypographyP className="mt-2 font-heading text-3xl" weight="medium">
+                  {intl.formatNumber(catalog.engineMentions[engine] / 100, {
+                    style: "percent",
+                  })}
+                </TypographyP>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {catalog.competitors.length === 0 ? (
+        <DomainResearchEmpty
+          title={<FormattedMessage {...messages.emptyTitle} />}
+          description={<FormattedMessage {...messages.emptyDescription} />}
+          action={
+            <Button size="sm" onClick={() => setAddOpen(true)}>
+              <FormattedMessage {...messages.addCta} />
+            </Button>
+          }
+        />
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <div
+            className={cn(
+              COMPETITOR_GRID,
+              "border-b border-border bg-muted/40 text-xs font-medium text-muted-foreground",
+            )}
+          >
+            <span>
+              <FormattedMessage {...messages.columnCompetitor} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnMentions} />
+            </span>
+            <span>
+              <FormattedMessage {...messages.columnSentiment} />
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {catalog.competitors.map((row) => (
+              <div key={row.id} className={COMPETITOR_GRID}>
+                <span className="font-medium">{row.name}</span>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {intl.formatNumber(row.mentions)}
+                </span>
+                <Badge
+                  variant={
+                    row.sentiment === "positive"
+                      ? "success"
+                      : row.sentiment === "negative"
+                        ? "destructive"
+                        : "outline"
+                  }
+                >
+                  <FormattedMessage {...sentimentMessage(row.sentiment)} />
+                </Badge>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <DomainResearchTextareaDialog
+        open={addOpen}
+        title={intl.formatMessage(messages.addTitle)}
+        description={intl.formatMessage(messages.addDescription)}
+        label={intl.formatMessage(messages.addLabel)}
+        placeholder={intl.formatMessage(messages.addPlaceholder)}
+        submitLabel={intl.formatMessage(messages.addSubmit)}
+        onOpenChange={setAddOpen}
+        onSubmit={() => toast.success(intl.formatMessage(messages.addSuccess))}
+      />
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-home-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-home-view.messages.ts
@@ -1,0 +1,93 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainHomeViewMessages = defineMessages({
+  traffic: {
+    defaultMessage: "Traffic",
+    id: "dmqqydjhME",
+    description: "Domain home metric for organic traffic",
+  },
+  keywords: {
+    defaultMessage: "Keywords",
+    id: "5BAUGLu7hM",
+    description: "Domain home metric for ranking keywords",
+  },
+  tracked: {
+    defaultMessage: "Tracked",
+    id: "0y3PD4KoPE",
+    description: "Domain home metric for tracked keywords",
+  },
+  aiMentions: {
+    defaultMessage: "AI mentions",
+    id: "y3ph5cleq+",
+    description: "Domain home metric for AI brand mentions",
+  },
+  keywordsCardTitle: {
+    defaultMessage: "Keyword research",
+    id: "JtXMB6h9JR",
+    description: "Home card title for keyword research",
+  },
+  keywordsCardBody: {
+    defaultMessage: "Seed a query in this market and expand ideas you can save or track.",
+    id: "lmUseo3Jj5",
+    description: "Home card body for keyword research",
+  },
+  overviewCardTitle: {
+    defaultMessage: "Domain overview",
+    id: "IjguADi3/V",
+    description: "Home card title for domain overview",
+  },
+  overviewCardBody: {
+    defaultMessage: "See which keywords and pages already send traffic in this market.",
+    id: "IieTiCG3YI",
+    description: "Home card body for domain overview",
+  },
+  ranksCardTitle: {
+    defaultMessage: "Rank tracking",
+    id: "K90e7oYXRQ",
+    description: "Home card title for rank tracking",
+  },
+  ranksCardBody: {
+    defaultMessage: "Watch positions for the queries you care about on this hostname.",
+    id: "OmuTDA1qQw",
+    description: "Home card body for rank tracking",
+  },
+  brandCardTitle: {
+    defaultMessage: "AI brand lookup",
+    id: "rt89U2wxDo",
+    description: "Home card title for AI brand lookup",
+  },
+  brandCardBody: {
+    defaultMessage: "Check whether assistants mention this brand next to competitors.",
+    id: "3pnD0Y5+NC",
+    description: "Home card body for AI brand lookup",
+  },
+  promptsCardTitle: {
+    defaultMessage: "Prompt explorer",
+    id: "SJWVK43s3U",
+    description: "Home card title for prompt explorer",
+  },
+  promptsCardBody: {
+    defaultMessage: "Run a prompt across ChatGPT, Claude, Gemini, and Perplexity.",
+    id: "Xz4MIe+QQE",
+    description: "Home card body for prompt explorer",
+  },
+  openSurface: {
+    defaultMessage: "Open",
+    id: "FczzwMnvUu",
+    description: "Open a research surface from domain home",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-home-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-home-view.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  ArrowUp01Icon,
+  Chat01Icon,
+  DashboardSquare01Icon,
+  Search01Icon,
+  SparklesIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
+import { buildDomainPath } from "@/components/app-shell/navigation-config";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { TypographyP } from "@/components/ui/typography";
+import type { DomainResearchSurface } from "@/lib/domains/research-prototype";
+import { getResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+
+import { domainHomeViewMessages as messages } from "./domain-home-view.messages";
+
+const SURFACES: {
+  id: DomainResearchSurface;
+  icon: typeof Search01Icon;
+  title: typeof messages.keywordsCardTitle;
+  body: typeof messages.keywordsCardBody;
+}[] = [
+  {
+    id: "keywords",
+    icon: Search01Icon,
+    title: messages.keywordsCardTitle,
+    body: messages.keywordsCardBody,
+  },
+  {
+    id: "overview",
+    icon: DashboardSquare01Icon,
+    title: messages.overviewCardTitle,
+    body: messages.overviewCardBody,
+  },
+  {
+    id: "ranks",
+    icon: ArrowUp01Icon,
+    title: messages.ranksCardTitle,
+    body: messages.ranksCardBody,
+  },
+  {
+    id: "brand",
+    icon: SparklesIcon,
+    title: messages.brandCardTitle,
+    body: messages.brandCardBody,
+  },
+  {
+    id: "prompts",
+    icon: Chat01Icon,
+    title: messages.promptsCardTitle,
+    body: messages.promptsCardBody,
+  },
+];
+
+export function DomainHomeView({
+  organizationSlug,
+  linkedDomainId,
+}: {
+  organizationSlug: string;
+  linkedDomainId: string;
+}) {
+  const intl = useIntl();
+  const domain = getResearchPrototypeDomain(linkedDomainId);
+  if (!domain) {
+    return null;
+  }
+
+  const metrics = [
+    {
+      label: intl.formatMessage(messages.traffic),
+      value: domain.trafficLabel,
+    },
+    {
+      label: intl.formatMessage(messages.keywords),
+      value: domain.keywordCountLabel,
+    },
+    {
+      label: intl.formatMessage(messages.tracked),
+      value: intl.formatNumber(domain.trackedCount),
+    },
+    {
+      label: intl.formatMessage(messages.aiMentions),
+      value: intl.formatNumber(domain.aiMentions),
+    },
+  ];
+
+  return (
+    <div className="grid gap-6">
+      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => (
+          <Card
+            key={metric.label}
+            size="sm"
+            className="rounded-lg border border-border bg-muted py-0 ring-0"
+          >
+            <CardContent className="px-4 py-4">
+              <TypographyP size="small" tone="subtle">
+                {metric.label}
+              </TypographyP>
+              <TypographyP className="mt-2 font-heading text-3xl" weight="medium">
+                {metric.value}
+              </TypographyP>
+              <TypographyP className="mt-1" size="small" tone="subtle">
+                {domain.market.label}
+              </TypographyP>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {SURFACES.map((surface) => (
+          <Card key={surface.id} className="rounded-lg border border-border bg-muted py-0 ring-0">
+            <CardHeader className="px-5 py-5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <CardTitle className="text-lg">
+                    <FormattedMessage {...surface.title} />
+                  </CardTitle>
+                  <CardDescription className="mt-1">
+                    <FormattedMessage {...surface.body} />
+                  </CardDescription>
+                </div>
+                <HugeiconsIcon
+                  icon={surface.icon}
+                  strokeWidth={1.8}
+                  className="size-5 shrink-0 text-muted-foreground"
+                />
+              </div>
+            </CardHeader>
+            <CardContent className="px-5 pb-5">
+              <Button
+                size="sm"
+                variant="outline"
+                render={
+                  <OrgNavLink
+                    href={buildDomainPath(organizationSlug, linkedDomainId, surface.id)}
+                  />
+                }
+              >
+                <FormattedMessage {...messages.openSurface} />
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.messages.ts
@@ -1,0 +1,148 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainKeywordsViewMessages = defineMessages({
+  seedCta: {
+    defaultMessage: "Seed keywords",
+    id: "wq110jUHyr",
+    description: "Open the seed keywords dialog",
+  },
+  seedTitle: {
+    defaultMessage: "Seed keywords",
+    id: "aJQZvwdXzn",
+    description: "Seed keywords dialog title",
+  },
+  seedDescription: {
+    defaultMessage: "Expand ideas from a query in this domain’s market.",
+    id: "ciwH2j2J/2",
+    description: "Seed keywords dialog description",
+  },
+  seedKeywordLabel: {
+    defaultMessage: "Seed",
+    id: "ehALlAgOmB",
+    description: "Seed keyword field label",
+  },
+  seedKeywordPlaceholder: {
+    defaultMessage: "traduction automatique",
+    id: "PmPfVWTjmU",
+    description: "Seed keyword placeholder",
+  },
+  seedMarketLabel: {
+    defaultMessage: "Market",
+    id: "LEmGTbo93A",
+    description: "Market field on the seed keywords dialog",
+  },
+  seedSubmit: {
+    defaultMessage: "Expand ideas",
+    id: "3NyprC4I6O",
+    description: "Submit seed keywords",
+  },
+  seedSuccess: {
+    defaultMessage: "Ideas expanded for this market.",
+    id: "Uq2h47XEsH",
+    description: "Toast after seeding keywords",
+  },
+  columnKeyword: {
+    defaultMessage: "Keyword",
+    id: "rvznxHqIs8",
+    description: "Keyword research column for the query",
+  },
+  columnVolume: {
+    defaultMessage: "Volume",
+    id: "RXclhblLSq",
+    description: "Keyword research column for search volume",
+  },
+  columnKd: {
+    defaultMessage: "KD",
+    id: "0zbYiE/2Rj",
+    description: "Keyword research column for keyword difficulty",
+  },
+  columnCpc: {
+    defaultMessage: "CPC",
+    id: "e8hZSFrKgI",
+    description: "Keyword research column for cost per click",
+  },
+  columnIntent: {
+    defaultMessage: "Intent",
+    id: "UmJEDvN4kE",
+    description: "Keyword research column for intent",
+  },
+  inspectSerp: {
+    defaultMessage: "Inspect SERP",
+    id: "lnpu+nisbE",
+    description: "Open the SERP sheet for a keyword",
+  },
+  selectedCount: {
+    defaultMessage: "{count, plural, one {# selected} other {# selected}}",
+    id: "DukW+nZE9G",
+    description: "Count of selected keyword ideas",
+  },
+  save: {
+    defaultMessage: "Save",
+    id: "RvIRC+2k01",
+    description: "Save selected keyword ideas",
+  },
+  sendToRanks: {
+    defaultMessage: "Send to rank tracking",
+    id: "NlEBPcL/uy",
+    description: "Send selected keywords to rank tracking",
+  },
+  saved: {
+    defaultMessage: "Keywords saved to this domain.",
+    id: "v2T0Wek8yI",
+    description: "Toast after saving keywords",
+  },
+  sentToRanks: {
+    defaultMessage: "Keywords sent to rank tracking.",
+    id: "Y/+xOQi7sH",
+    description: "Toast after sending keywords to ranks",
+  },
+  emptyTitle: {
+    defaultMessage: "Seed a query to expand ideas",
+    id: "G052FcCXn0",
+    description: "Empty keyword research title",
+  },
+  emptyDescription: {
+    defaultMessage: "Start from a phrase this market actually searches for.",
+    id: "dDYz0HQlRX",
+    description: "Empty keyword research description",
+  },
+  serpTitle: {
+    defaultMessage: "SERP · {keyword}",
+    id: "+FX267AAXq",
+    description: "SERP sheet title",
+  },
+  serpDescription: {
+    defaultMessage: "Live Google results in {market}. Your domain is highlighted when it appears.",
+    id: "LSs2GWeMba",
+    description: "SERP sheet description",
+  },
+  ownResult: {
+    defaultMessage: "Your domain",
+    id: "qBA6a2d2LM",
+    description: "Badge on the workspace domain’s SERP row",
+  },
+  serpEmpty: {
+    defaultMessage: "No SERP snapshot for this keyword yet.",
+    id: "NMo/Dkl5Sm",
+    description: "Empty SERP sheet body",
+  },
+  selectKeyword: {
+    defaultMessage: "Select {keyword}",
+    id: "WUx/Brx1Q5",
+    description: "Accessible label for selecting a keyword idea",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useMemo, useState } from "react";
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { TypographyP } from "@/components/ui/typography";
+import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+import { cn } from "@/lib/primitives/cn";
+
+import { DomainResearchEmpty } from "./domain-research-empty";
+import { formatKeywordIntent } from "./domain-research-format";
+import { domainKeywordsViewMessages as messages } from "./domain-keywords-view.messages";
+import { DomainSeedKeywordsDialog } from "./domain-seed-keywords-dialog";
+
+const KEYWORD_GRID =
+  "grid grid-cols-[auto_minmax(12rem,1.4fr)_repeat(3,minmax(4.5rem,0.55fr))_minmax(6rem,0.7fr)_auto] items-center gap-3 px-3 py-2.5";
+
+export function DomainKeywordsView({ linkedDomainId }: { linkedDomainId: string }) {
+  const intl = useIntl();
+  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const [seedOpen, setSeedOpen] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [serpKeywordId, setSerpKeywordId] = useState<string | null>(null);
+
+  const keywords = catalog?.keywords ?? [];
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const serpKeyword = keywords.find((keyword) => keyword.id === serpKeywordId) ?? null;
+  const serpResults = serpKeyword ? (catalog?.serpByKeywordId[serpKeyword.id] ?? []) : [];
+
+  if (!catalog) {
+    return null;
+  }
+
+  function toggleKeyword(id: string, checked: boolean) {
+    setSelectedIds((current) =>
+      checked
+        ? current.includes(id)
+          ? current
+          : [...current, id]
+        : current.filter((item) => item !== id),
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button size="sm" variant="outline" onClick={() => setSeedOpen(true)}>
+          <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+          <FormattedMessage {...messages.seedCta} />
+        </Button>
+      </div>
+
+      {keywords.length === 0 ? (
+        <DomainResearchEmpty
+          title={<FormattedMessage {...messages.emptyTitle} />}
+          description={<FormattedMessage {...messages.emptyDescription} />}
+          action={
+            <Button size="sm" onClick={() => setSeedOpen(true)}>
+              <FormattedMessage {...messages.seedCta} />
+            </Button>
+          }
+        />
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <div
+            className={cn(
+              KEYWORD_GRID,
+              "border-b border-border bg-muted/40 text-xs font-medium text-muted-foreground",
+            )}
+          >
+            <span />
+            <span>
+              <FormattedMessage {...messages.columnKeyword} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnVolume} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnKd} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnCpc} />
+            </span>
+            <span>
+              <FormattedMessage {...messages.columnIntent} />
+            </span>
+            <span />
+          </div>
+          <div className="divide-y divide-border">
+            {keywords.map((keyword) => (
+              <div key={keyword.id} className={KEYWORD_GRID}>
+                <Checkbox
+                  checked={selectedSet.has(keyword.id)}
+                  onCheckedChange={(checked) => toggleKeyword(keyword.id, checked === true)}
+                  aria-label={intl.formatMessage(messages.selectKeyword, {
+                    keyword: keyword.keyword,
+                  })}
+                />
+                <button
+                  type="button"
+                  className="min-w-0 truncate text-start font-medium text-foreground underline-offset-4 hover:underline"
+                  onClick={() => setSerpKeywordId(keyword.id)}
+                >
+                  {keyword.keyword}
+                </button>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {intl.formatNumber(keyword.volume)}
+                </span>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {keyword.kd}
+                </span>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {intl.formatNumber(keyword.cpc, {
+                    style: "currency",
+                    currency: "EUR",
+                  })}
+                </span>
+                <Badge variant="outline">{formatKeywordIntent(intl, keyword.intent)}</Badge>
+                <Button size="sm" variant="ghost" onClick={() => setSerpKeywordId(keyword.id)}>
+                  <FormattedMessage {...messages.inspectSerp} />
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {selectedIds.length > 0 ? (
+        <div className="sticky bottom-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-popover px-4 py-3 shadow-lg">
+          <TypographyP size="small">
+            <FormattedMessage {...messages.selectedCount} values={{ count: selectedIds.length }} />
+          </TypographyP>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                toast.success(intl.formatMessage(messages.saved));
+                setSelectedIds([]);
+              }}
+            >
+              <FormattedMessage {...messages.save} />
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => {
+                toast.success(intl.formatMessage(messages.sentToRanks));
+                setSelectedIds([]);
+              }}
+            >
+              <FormattedMessage {...messages.sendToRanks} />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <DomainSeedKeywordsDialog
+        open={seedOpen}
+        defaultKeyword={keywords[0]?.keyword ?? "traduction automatique"}
+        defaultMarketId={catalog.domain.market.id}
+        onOpenChange={setSeedOpen}
+      />
+
+      <Sheet
+        open={Boolean(serpKeyword)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSerpKeywordId(null);
+          }
+        }}
+      >
+        <SheetContent side="right" className="sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle>
+              <FormattedMessage
+                {...messages.serpTitle}
+                values={{ keyword: serpKeyword?.keyword ?? "" }}
+              />
+            </SheetTitle>
+            <SheetDescription>
+              <FormattedMessage
+                {...messages.serpDescription}
+                values={{ market: catalog.domain.market.label }}
+              />
+            </SheetDescription>
+          </SheetHeader>
+          <div className="grid gap-3 overflow-y-auto px-6 pb-6">
+            {serpResults.length === 0 ? (
+              <TypographyP size="small" tone="subtle">
+                <FormattedMessage {...messages.serpEmpty} />
+              </TypographyP>
+            ) : (
+              serpResults.map((result) => (
+                <article
+                  key={`${result.position}-${result.url}`}
+                  className={cn(
+                    "rounded-xl border border-border p-3",
+                    result.isOwn && "border-primary/40 bg-muted/60",
+                  )}
+                >
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span className="tabular-nums">#{result.position}</span>
+                    {result.isOwn ? (
+                      <Badge variant="success">
+                        <FormattedMessage {...messages.ownResult} />
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 font-medium text-foreground">{result.title}</p>
+                  <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                    {result.url}
+                  </p>
+                  <p className="mt-2 text-sm text-muted-foreground">{result.snippet}</p>
+                </article>
+              ))
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.messages.ts
@@ -1,0 +1,59 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainLinkDialogMessages = defineMessages({
+  title: {
+    defaultMessage: "Link domain",
+    id: "2+oKbAvHmj",
+    description: "Link domain dialog title",
+  },
+  description: {
+    defaultMessage:
+      "Attach a hostname and pick the market research should run in. Verification comes next.",
+    id: "hJh6vnt3pF",
+    description: "Link domain dialog description",
+  },
+  hostnameLabel: {
+    defaultMessage: "Hostname",
+    id: "QzCT9StKW7",
+    description: "Hostname field on the link domain dialog",
+  },
+  hostnamePlaceholder: {
+    defaultMessage: "shop.example.com",
+    id: "oV4/G//JgO",
+    description: "Hostname placeholder on the link domain dialog",
+  },
+  marketLabel: {
+    defaultMessage: "Market",
+    id: "SJ1G8g/3h7",
+    description: "Market field on the link domain dialog",
+  },
+  submit: {
+    defaultMessage: "Continue to verification",
+    id: "lt5CygG2lb",
+    description: "Submit the link domain dialog",
+  },
+  hostnameRequired: {
+    defaultMessage: "Enter a hostname.",
+    id: "tyAE2cKpjv",
+    description: "Validation when the hostname is missing",
+  },
+  success: {
+    defaultMessage: "Domain queued. Add the DNS record to finish linking.",
+    id: "UF5RFmfnwB",
+    description: "Toast after linking a domain in the prototype",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { type FormEvent, useEffect, useId, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DOMAIN_RESEARCH_MARKETS } from "@/lib/domains/research-prototype";
+
+import { domainLinkDialogMessages as messages } from "./domain-link-dialog.messages";
+import { domainResearchSharedMessages as sharedMessages } from "./domain-research-shared.messages";
+
+export function DomainLinkDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const intl = useIntl();
+  const hostnameId = useId();
+  const marketId = useId();
+  const [hostname, setHostname] = useState("");
+  const [marketIdValue, setMarketIdValue] = useState(DOMAIN_RESEARCH_MARKETS[0]?.id ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setHostname("");
+      setMarketIdValue(DOMAIN_RESEARCH_MARKETS[0]?.id ?? "");
+      setError(null);
+    }
+  }, [open]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const nextHostname = hostname.trim().toLowerCase();
+    if (!nextHostname) {
+      setError(intl.formatMessage(messages.hostnameRequired));
+      return;
+    }
+
+    toast.success(intl.formatMessage(messages.success));
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form className="grid gap-4" onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...messages.title} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage {...messages.description} />
+            </DialogDescription>
+          </DialogHeader>
+
+          <Field>
+            <FieldLabel htmlFor={hostnameId}>
+              <FormattedMessage {...messages.hostnameLabel} />
+            </FieldLabel>
+            <Input
+              id={hostnameId}
+              value={hostname}
+              onChange={(event) => {
+                setHostname(event.target.value);
+                setError(null);
+              }}
+              placeholder={intl.formatMessage(messages.hostnamePlaceholder)}
+              aria-invalid={Boolean(error)}
+              autoComplete="off"
+            />
+            <FieldError errors={error ? [{ message: error }] : undefined} />
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor={marketId}>
+              <FormattedMessage {...messages.marketLabel} />
+            </FieldLabel>
+            <Select
+              value={marketIdValue || null}
+              onValueChange={(value) => {
+                if (value) {
+                  setMarketIdValue(value);
+                }
+              }}
+            >
+              <SelectTrigger id={marketId} className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DOMAIN_RESEARCH_MARKETS.map((market) => (
+                  <SelectItem key={market.id} value={market.id} label={market.label}>
+                    {market.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              <FormattedMessage {...sharedMessages.cancel} />
+            </Button>
+            <Button type="submit">
+              <FormattedMessage {...messages.submit} />
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-overview-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-overview-view.messages.ts
@@ -1,0 +1,68 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainOverviewViewMessages = defineMessages({
+  keywordsTab: {
+    defaultMessage: "Keywords",
+    id: "b04WpJPIZh",
+    description: "Domain overview tab for ranking keywords",
+  },
+  pagesTab: {
+    defaultMessage: "Pages",
+    id: "48liY3M4is",
+    description: "Domain overview tab for ranking pages",
+  },
+  columnKeyword: {
+    defaultMessage: "Keyword",
+    id: "zDKQV1vdb3",
+    description: "Overview keyword column",
+  },
+  columnPosition: {
+    defaultMessage: "Pos",
+    id: "bOWosORc57",
+    description: "Overview position column",
+  },
+  columnVolume: {
+    defaultMessage: "Volume",
+    id: "giuftZHtFk",
+    description: "Overview volume column",
+  },
+  columnTraffic: {
+    defaultMessage: "Traffic",
+    id: "bH4OJBTlRQ",
+    description: "Overview traffic column",
+  },
+  columnPage: {
+    defaultMessage: "Page",
+    id: "GzdUfM35EF",
+    description: "Overview page path column",
+  },
+  columnKeywords: {
+    defaultMessage: "Keywords",
+    id: "JNN3VfD4RF",
+    description: "Overview page keyword count column",
+  },
+  emptyKeywords: {
+    defaultMessage: "No ranking keywords in this market yet.",
+    id: "f8Qa8QmhOi",
+    description: "Empty overview keywords",
+  },
+  emptyPages: {
+    defaultMessage: "No ranking pages in this market yet.",
+    id: "lL3u/hCPNt",
+    description: "Empty overview pages",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-overview-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-overview-view.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+import { cn } from "@/lib/primitives/cn";
+
+import { DomainResearchEmpty } from "./domain-research-empty";
+import { domainOverviewViewMessages as messages } from "./domain-overview-view.messages";
+
+const KEYWORD_GRID =
+  "grid grid-cols-[minmax(12rem,1.4fr)_repeat(3,minmax(4.5rem,0.55fr))] items-center gap-3 px-3 py-2.5";
+const PAGE_GRID =
+  "grid grid-cols-[minmax(12rem,1.4fr)_repeat(2,minmax(4.5rem,0.55fr))] items-center gap-3 px-3 py-2.5";
+
+export function DomainOverviewView({ linkedDomainId }: { linkedDomainId: string }) {
+  const intl = useIntl();
+  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const [tab, setTab] = useState<"keywords" | "pages">("keywords");
+
+  if (!catalog) {
+    return null;
+  }
+
+  const rows = tab === "keywords" ? catalog.overviewKeywords : catalog.overviewPages;
+
+  return (
+    <div className="grid gap-4">
+      <Tabs
+        value={tab}
+        onValueChange={(value) => {
+          if (value === "keywords" || value === "pages") {
+            setTab(value);
+          }
+        }}
+      >
+        <TabsList>
+          <TabsTrigger value="keywords">
+            <FormattedMessage {...messages.keywordsTab} />
+          </TabsTrigger>
+          <TabsTrigger value="pages">
+            <FormattedMessage {...messages.pagesTab} />
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {rows.length === 0 ? (
+        <DomainResearchEmpty
+          title={
+            tab === "pages" ? (
+              <FormattedMessage {...messages.emptyPages} />
+            ) : (
+              <FormattedMessage {...messages.emptyKeywords} />
+            )
+          }
+        />
+      ) : tab === "keywords" ? (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <div
+            className={cn(
+              KEYWORD_GRID,
+              "border-b border-border bg-muted/40 text-xs font-medium text-muted-foreground",
+            )}
+          >
+            <span>
+              <FormattedMessage {...messages.columnKeyword} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnPosition} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnVolume} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnTraffic} />
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {catalog.overviewKeywords.map((row) => (
+              <div key={row.id} className={KEYWORD_GRID}>
+                <span className="truncate font-medium">{row.keyword}</span>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {row.position}
+                </span>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {intl.formatNumber(row.volume)}
+                </span>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {intl.formatNumber(row.traffic)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <div
+            className={cn(
+              PAGE_GRID,
+              "border-b border-border bg-muted/40 text-xs font-medium text-muted-foreground",
+            )}
+          >
+            <span>
+              <FormattedMessage {...messages.columnPage} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnKeywords} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnTraffic} />
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {catalog.overviewPages.map((row) => (
+              <div key={row.id} className={PAGE_GRID}>
+                <span className="truncate font-mono text-sm">{row.path}</span>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {intl.formatNumber(row.keywords)}
+                </span>
+                <span className="text-end tabular-nums text-sm text-muted-foreground">
+                  {intl.formatNumber(row.traffic)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-prompts-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-prompts-view.messages.ts
@@ -1,0 +1,43 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainPromptsViewMessages = defineMessages({
+  promptLabel: {
+    defaultMessage: "Prompt",
+    id: "KzpahbggTa",
+    description: "Prompt explorer input label",
+  },
+  run: {
+    defaultMessage: "Run prompt",
+    id: "7mHM45p5Gr",
+    description: "Run the prompt across engines",
+  },
+  ran: {
+    defaultMessage: "Answers refreshed for this market.",
+    id: "uJhgTrf87d",
+    description: "Toast after running a prompt",
+  },
+  emptyTitle: {
+    defaultMessage: "No prompt sampled yet",
+    id: "4w/GI31xOr",
+    description: "Empty prompt explorer title",
+  },
+  emptyDescription: {
+    defaultMessage: "Ask how buyers describe this category, then compare engine answers.",
+    id: "88S+ZbXuL7",
+    description: "Empty prompt explorer description",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-prompts-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-prompts-view.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useId, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Textarea } from "@/components/ui/textarea";
+import { TypographyP } from "@/components/ui/typography";
+import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+
+import { DomainResearchEmpty } from "./domain-research-empty";
+import { formatBrandEngine } from "./domain-research-format";
+import { domainResearchSharedMessages as sharedMessages } from "./domain-research-shared.messages";
+import { domainPromptsViewMessages as messages } from "./domain-prompts-view.messages";
+
+export function DomainPromptsView({ linkedDomainId }: { linkedDomainId: string }) {
+  const intl = useIntl();
+  const promptId = useId();
+  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const [prompt, setPrompt] = useState(catalog?.prompt ?? "");
+
+  if (!catalog) {
+    return null;
+  }
+
+  if (catalog.promptResults.length === 0) {
+    return (
+      <DomainResearchEmpty
+        title={<FormattedMessage {...messages.emptyTitle} />}
+        description={<FormattedMessage {...messages.emptyDescription} />}
+      />
+    );
+  }
+
+  return (
+    <div className="grid gap-6">
+      <form
+        className="grid gap-3 rounded-lg border border-border p-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          toast.success(intl.formatMessage(messages.ran));
+        }}
+      >
+        <Field>
+          <FieldLabel htmlFor={promptId}>
+            <FormattedMessage {...messages.promptLabel} />
+          </FieldLabel>
+          <Textarea
+            id={promptId}
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            className="min-h-20"
+          />
+        </Field>
+        <div className="flex justify-end">
+          <Button type="submit" size="sm">
+            <FormattedMessage {...messages.run} />
+          </Button>
+        </div>
+      </form>
+
+      <section className="grid gap-3 md:grid-cols-2">
+        {catalog.promptResults.map((result) => (
+          <Card
+            key={result.engine}
+            className="rounded-lg border border-border bg-muted py-0 ring-0"
+          >
+            <CardHeader className="px-5 py-4">
+              <div className="flex items-center justify-between gap-3">
+                <CardTitle className="text-base">
+                  {formatBrandEngine(intl, result.engine)}
+                </CardTitle>
+                <Badge variant={result.mentioned ? "success" : "outline"}>
+                  <FormattedMessage
+                    {...(result.mentioned ? sharedMessages.mentioned : sharedMessages.notMentioned)}
+                  />
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="px-5 pb-5">
+              <TypographyP size="small" tone="subtle">
+                {result.excerpt}
+              </TypographyP>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-ranks-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-ranks-view.messages.ts
@@ -1,0 +1,93 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainRanksViewMessages = defineMessages({
+  addCta: {
+    defaultMessage: "Add keywords",
+    id: "MPyZMdy3Mn",
+    description: "Open add keywords dialog on rank tracking",
+  },
+  addTitle: {
+    defaultMessage: "Add keywords",
+    id: "Pl1QYYtwq2",
+    description: "Add keywords dialog title",
+  },
+  addDescription: {
+    defaultMessage: "Track one query per line for this hostname and market.",
+    id: "4TdFgYKUpH",
+    description: "Add keywords dialog description",
+  },
+  addLabel: {
+    defaultMessage: "Keywords",
+    id: "9CS7SXDP/E",
+    description: "Add keywords textarea label",
+  },
+  addPlaceholder: {
+    defaultMessage: "traduction automatique",
+    id: "MbFisZdAiR",
+    description: "Add keywords textarea placeholder",
+  },
+  addSubmit: {
+    defaultMessage: "Track keywords",
+    id: "Cjmm2y/kv2",
+    description: "Submit add keywords dialog",
+  },
+  addSuccess: {
+    defaultMessage: "Keywords added to rank tracking.",
+    id: "M/bA5ZKYrc",
+    description: "Toast after adding rank-tracking keywords",
+  },
+  columnKeyword: {
+    defaultMessage: "Keyword",
+    id: "u0dyjBiqWo",
+    description: "Rank tracking keyword column",
+  },
+  columnPosition: {
+    defaultMessage: "Pos",
+    id: "i9JekvPu3c",
+    description: "Rank tracking position column",
+  },
+  columnChange: {
+    defaultMessage: "Change",
+    id: "EfvdjZ/lNf",
+    description: "Rank tracking position change column",
+  },
+  columnUrl: {
+    defaultMessage: "URL",
+    id: "Sx94aDUTBX",
+    description: "Rank tracking URL column",
+  },
+  columnVolume: {
+    defaultMessage: "Volume",
+    id: "MJXPKuSba6",
+    description: "Rank tracking volume column",
+  },
+  emptyTitle: {
+    defaultMessage: "No keywords tracked yet",
+    id: "bbfynfwu7y",
+    description: "Empty rank tracking title",
+  },
+  emptyDescription: {
+    defaultMessage: "Add queries from keyword research, or paste them here.",
+    id: "OETHn/tWgc",
+    description: "Empty rank tracking description",
+  },
+  unranked: {
+    defaultMessage: "—",
+    id: "bnmPX9ah2A",
+    description: "Shown when a tracked keyword has no position",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-ranks-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-ranks-view.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useState } from "react";
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+import { cn } from "@/lib/primitives/cn";
+
+import { DomainResearchEmpty } from "./domain-research-empty";
+import { formatSignedDelta } from "./domain-research-format";
+import { DomainResearchTextareaDialog } from "./domain-research-textarea-dialog";
+import { domainRanksViewMessages as messages } from "./domain-ranks-view.messages";
+
+const RANK_GRID =
+  "grid grid-cols-[minmax(12rem,1.2fr)_repeat(2,minmax(4rem,0.4fr))_minmax(10rem,1fr)_minmax(4.5rem,0.45fr)] items-center gap-3 px-3 py-2.5";
+
+export function DomainRanksView({ linkedDomainId }: { linkedDomainId: string }) {
+  const intl = useIntl();
+  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const [addOpen, setAddOpen] = useState(false);
+
+  if (!catalog) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-4">
+      <div className="flex justify-end">
+        <Button size="sm" variant="outline" onClick={() => setAddOpen(true)}>
+          <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+          <FormattedMessage {...messages.addCta} />
+        </Button>
+      </div>
+
+      {catalog.ranks.length === 0 ? (
+        <DomainResearchEmpty
+          title={<FormattedMessage {...messages.emptyTitle} />}
+          description={<FormattedMessage {...messages.emptyDescription} />}
+          action={
+            <Button size="sm" onClick={() => setAddOpen(true)}>
+              <FormattedMessage {...messages.addCta} />
+            </Button>
+          }
+        />
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <div
+            className={cn(
+              RANK_GRID,
+              "border-b border-border bg-muted/40 text-xs font-medium text-muted-foreground",
+            )}
+          >
+            <span>
+              <FormattedMessage {...messages.columnKeyword} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnPosition} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnChange} />
+            </span>
+            <span>
+              <FormattedMessage {...messages.columnUrl} />
+            </span>
+            <span className="text-end">
+              <FormattedMessage {...messages.columnVolume} />
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {catalog.ranks.map((row) => {
+              const delta =
+                row.position != null && row.previousPosition != null
+                  ? row.previousPosition - row.position
+                  : 0;
+              return (
+                <div key={row.id} className={RANK_GRID}>
+                  <span className="truncate font-medium">{row.keyword}</span>
+                  <span className="text-end tabular-nums text-sm text-muted-foreground">
+                    {row.position ?? intl.formatMessage(messages.unranked)}
+                  </span>
+                  <span
+                    className={cn(
+                      "text-end tabular-nums text-sm",
+                      delta > 0 && "text-grove-900",
+                      delta < 0 && "text-destructive",
+                      delta === 0 && "text-muted-foreground",
+                    )}
+                  >
+                    {formatSignedDelta(delta)}
+                  </span>
+                  <span className="truncate font-mono text-xs text-muted-foreground">
+                    {row.url}
+                  </span>
+                  <span className="text-end tabular-nums text-sm text-muted-foreground">
+                    {intl.formatNumber(row.volume)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <DomainResearchTextareaDialog
+        open={addOpen}
+        title={intl.formatMessage(messages.addTitle)}
+        description={intl.formatMessage(messages.addDescription)}
+        label={intl.formatMessage(messages.addLabel)}
+        placeholder={intl.formatMessage(messages.addPlaceholder)}
+        submitLabel={intl.formatMessage(messages.addSubmit)}
+        onOpenChange={setAddOpen}
+        onSubmit={() => toast.success(intl.formatMessage(messages.addSuccess))}
+      />
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-empty.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-empty.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { Globe02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage } from "react-intl";
+
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+import { domainResearchSharedMessages as messages } from "./domain-research-shared.messages";
+
+export function DomainResearchEmpty({
+  title,
+  description,
+  action,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <Empty className="border border-dashed border-border">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <HugeiconsIcon icon={Globe02Icon} strokeWidth={1.8} />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        {description ? <EmptyDescription>{description}</EmptyDescription> : null}
+      </EmptyHeader>
+      {action ? <EmptyContent>{action}</EmptyContent> : null}
+    </Empty>
+  );
+}
+
+export function DomainResearchMissingDomain({ organizationSlug }: { organizationSlug: string }) {
+  return (
+    <DomainResearchEmpty
+      title={<FormattedMessage {...messages.missingTitle} />}
+      description={<FormattedMessage {...messages.missingDescription} />}
+      action={
+        <Button
+          size="sm"
+          variant="outline"
+          render={<OrgNavLink href={`/org/${organizationSlug}/domains`} />}
+        >
+          <FormattedMessage {...messages.backToDomains} />
+        </Button>
+      }
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-format.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-format.ts
@@ -1,0 +1,62 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { IntlShape } from "react-intl";
+
+import type {
+  BrandEngine,
+  DomainResearchStatus,
+  KeywordIntent,
+} from "@/lib/domains/research-prototype";
+
+import { domainResearchSharedMessages as messages } from "./domain-research-shared.messages";
+
+export function formatDomainStatus(intl: IntlShape, status: DomainResearchStatus) {
+  return intl.formatMessage(
+    status === "verified" ? messages.statusVerified : messages.statusPending,
+  );
+}
+
+export function formatKeywordIntent(intl: IntlShape, intent: KeywordIntent) {
+  switch (intent) {
+    case "commercial":
+      return intl.formatMessage(messages.intentCommercial);
+    case "informational":
+      return intl.formatMessage(messages.intentInformational);
+    case "transactional":
+      return intl.formatMessage(messages.intentTransactional);
+    case "navigational":
+      return intl.formatMessage(messages.intentNavigational);
+  }
+}
+
+export function formatBrandEngine(intl: IntlShape, engine: BrandEngine) {
+  switch (engine) {
+    case "chatgpt":
+      return intl.formatMessage(messages.engineChatgpt);
+    case "claude":
+      return intl.formatMessage(messages.engineClaude);
+    case "gemini":
+      return intl.formatMessage(messages.engineGemini);
+    case "perplexity":
+      return intl.formatMessage(messages.enginePerplexity);
+  }
+}
+
+export function formatSignedDelta(value: number) {
+  if (value === 0) {
+    return "0";
+  }
+  return value > 0 ? `+${value}` : String(value);
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shared.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shared.messages.ts
@@ -1,0 +1,124 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainResearchSharedMessages = defineMessages({
+  statusVerified: {
+    defaultMessage: "Verified",
+    id: "Ldg/nc2ZNW",
+    description: "Verified linked domain status",
+  },
+  statusPending: {
+    defaultMessage: "Pending verification",
+    id: "4Gs0swvUKr",
+    description: "Pending linked domain status",
+  },
+  intentCommercial: {
+    defaultMessage: "Commercial",
+    id: "1MUKxSsh+U",
+    description: "Commercial keyword intent",
+  },
+  intentInformational: {
+    defaultMessage: "Informational",
+    id: "Cfwqtf2yZL",
+    description: "Informational keyword intent",
+  },
+  intentTransactional: {
+    defaultMessage: "Transactional",
+    id: "Ecdn8DbQSv",
+    description: "Transactional keyword intent",
+  },
+  intentNavigational: {
+    defaultMessage: "Navigational",
+    id: "jtZQ7+L9OR",
+    description: "Navigational keyword intent",
+  },
+  engineChatgpt: {
+    defaultMessage: "ChatGPT",
+    id: "2DTehBHI2r",
+    description: "ChatGPT engine label",
+  },
+  engineClaude: {
+    defaultMessage: "Claude",
+    id: "BWMSk9WXT+",
+    description: "Claude engine label",
+  },
+  engineGemini: {
+    defaultMessage: "Gemini",
+    id: "qMZ6NrKEO8",
+    description: "Gemini engine label",
+  },
+  enginePerplexity: {
+    defaultMessage: "Perplexity",
+    id: "iRxIH6lG2y",
+    description: "Perplexity engine label",
+  },
+  mentioned: {
+    defaultMessage: "Mentioned",
+    id: "xaW1VYfh1p",
+    description: "Brand mentioned in an AI answer",
+  },
+  notMentioned: {
+    defaultMessage: "Not mentioned",
+    id: "23RDpfUwz6",
+    description: "Brand missing from an AI answer",
+  },
+  verifyCta: {
+    defaultMessage: "Verify DNS",
+    id: "jLf4FX4frG",
+    description: "Open the DNS verification dialog",
+  },
+  pendingTitle: {
+    defaultMessage: "Verify this domain to unlock research",
+    id: "pWbRWFseNX",
+    description: "Empty title when a domain is still pending verification",
+  },
+  pendingDescription: {
+    defaultMessage:
+      "Research is scoped to a linked domain and a market. Add the TXT record, then come back to keywords, ranks, and AI mentions.",
+    id: "bNgyxWyYAV",
+    description: "Empty description when a domain is still pending verification",
+  },
+  missingTitle: {
+    defaultMessage: "Domain not found",
+    id: "tbvTBs/44L",
+    description: "Title when a linked domain id is unknown",
+  },
+  missingDescription: {
+    defaultMessage: "This domain is not in the workspace catalog.",
+    id: "wuTr/wBWSH",
+    description: "Description when a linked domain id is unknown",
+  },
+  backToDomains: {
+    defaultMessage: "Back to domains",
+    id: "myq8pvTAj1",
+    description: "Link back to the domains list from a missing domain",
+  },
+  emptyTitle: {
+    defaultMessage: "Nothing here yet",
+    id: "vmnQBcZ7YW",
+    description: "Generic empty research title",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "KagGSv+37S",
+    description: "Cancel a domains research dialog",
+  },
+  copied: {
+    defaultMessage: "Copied",
+    id: "GX2g34x0MG",
+    description: "Clipboard copy confirmation",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.messages.ts
@@ -1,0 +1,58 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainResearchShellMessages = defineMessages({
+  navHome: {
+    defaultMessage: "Home",
+    id: "wpfeiFkA9G",
+    description: "Domain research tab for the domain home",
+  },
+  navKeywords: {
+    defaultMessage: "Keywords",
+    id: "Wll3W4intY",
+    description: "Domain research tab for keyword research",
+  },
+  navOverview: {
+    defaultMessage: "Overview",
+    id: "oG1OMIsUb2",
+    description: "Domain research tab for domain overview",
+  },
+  navRanks: {
+    defaultMessage: "Ranks",
+    id: "C5ZmaDbx8N",
+    description: "Domain research tab for rank tracking",
+  },
+  navBrand: {
+    defaultMessage: "Brand",
+    id: "Uy/topjaXg",
+    description: "Domain research tab for AI brand lookup",
+  },
+  navPrompts: {
+    defaultMessage: "Prompts",
+    id: "kRCx0FuBBM",
+    description: "Domain research tab for prompt explorer",
+  },
+  shellDescription: {
+    defaultMessage: "Research this domain in {market}.",
+    id: "xzG6mihfhR",
+    description: "Domain research header description",
+  },
+  sectionLabel: {
+    defaultMessage: "Domains",
+    id: "szhXuo8hoK",
+    description: "Section label above a domain research heading",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { type ReactNode, useState } from "react";
+import { Globe02Icon } from "@hugeicons/core-free-icons";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { DomainResearchNavId, DomainResearchSurface } from "@/lib/domains/research-prototype";
+import {
+  getResearchPrototypeDomain,
+  isDomainResearchSurface,
+} from "@/lib/domains/research-prototype";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
+
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { buildDomainPath } from "@/components/app-shell/navigation-config";
+
+import { DomainResearchEmpty, DomainResearchMissingDomain } from "./domain-research-empty";
+import { formatDomainStatus } from "./domain-research-format";
+import { domainResearchSharedMessages as sharedMessages } from "./domain-research-shared.messages";
+import { domainResearchShellMessages as messages } from "./domain-research-shell.messages";
+import { DomainVerifyDialog } from "./domain-verify-dialog";
+
+const NAV_ITEMS: { id: DomainResearchNavId; message: typeof messages.navHome }[] = [
+  { id: "home", message: messages.navHome },
+  { id: "keywords", message: messages.navKeywords },
+  { id: "overview", message: messages.navOverview },
+  { id: "ranks", message: messages.navRanks },
+  { id: "brand", message: messages.navBrand },
+  { id: "prompts", message: messages.navPrompts },
+];
+
+export function DomainResearchShell({
+  organizationSlug,
+  linkedDomainId,
+  surface,
+  children,
+}: {
+  organizationSlug: string;
+  linkedDomainId: string;
+  surface: DomainResearchNavId;
+  children: ReactNode;
+}) {
+  const intl = useIntl();
+  const router = useOrgRouter();
+  const domain = getResearchPrototypeDomain(linkedDomainId);
+  const [verifyOpen, setVerifyOpen] = useState(false);
+
+  if (!domain) {
+    return (
+      <WorkspacePageShell>
+        <DomainResearchMissingDomain organizationSlug={organizationSlug} />
+      </WorkspacePageShell>
+    );
+  }
+
+  function handleSurfaceChange(next: string) {
+    const nextSurface: DomainResearchSurface | undefined = isDomainResearchSurface(next)
+      ? next
+      : undefined;
+    router.push(buildDomainPath(organizationSlug, linkedDomainId, nextSurface));
+  }
+
+  const isPending = domain.status !== "verified";
+
+  return (
+    <WorkspacePageShell className="gap-5">
+      <PageHeader
+        icon={Globe02Icon}
+        label={intl.formatMessage(messages.sectionLabel)}
+        title={domain.domainKey}
+        description={intl.formatMessage(messages.shellDescription, {
+          market: domain.market.label,
+        })}
+        statusLabel={formatDomainStatus(intl, domain.status)}
+        actions={
+          isPending ? (
+            <Button size="sm" onClick={() => setVerifyOpen(true)}>
+              <FormattedMessage {...sharedMessages.verifyCta} />
+            </Button>
+          ) : null
+        }
+      />
+
+      <Tabs value={surface} onValueChange={handleSurfaceChange}>
+        <TabsList variant="line" className="w-full max-w-full justify-start overflow-x-auto">
+          {NAV_ITEMS.map((item) => (
+            <TabsTrigger key={item.id} value={item.id}>
+              <FormattedMessage {...item.message} />
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {isPending && surface !== "home" ? (
+        <DomainResearchEmpty
+          title={<FormattedMessage {...sharedMessages.pendingTitle} />}
+          description={<FormattedMessage {...sharedMessages.pendingDescription} />}
+          action={
+            <Button size="sm" onClick={() => setVerifyOpen(true)}>
+              <FormattedMessage {...sharedMessages.verifyCta} />
+            </Button>
+          }
+        />
+      ) : (
+        children
+      )}
+
+      <DomainVerifyDialog
+        open={verifyOpen}
+        domainKey={domain.domainKey}
+        onOpenChange={setVerifyOpen}
+      />
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-textarea-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-textarea-dialog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { type FormEvent, useEffect, useId, useState } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Textarea } from "@/components/ui/textarea";
+
+import { domainResearchSharedMessages as sharedMessages } from "./domain-research-shared.messages";
+
+export function DomainResearchTextareaDialog({
+  open,
+  title,
+  description,
+  label,
+  placeholder,
+  submitLabel,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean;
+  title: string;
+  description: string;
+  label: string;
+  placeholder: string;
+  submitLabel: string;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (value: string) => void;
+}) {
+  const fieldId = useId();
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setValue("");
+    }
+  }, [open]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onSubmit(value);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form className="grid gap-4" onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+            <Textarea
+              id={fieldId}
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              placeholder={placeholder}
+              className="min-h-28"
+            />
+          </Field>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              <FormattedMessage {...sharedMessages.cancel} />
+            </Button>
+            <Button type="submit">{submitLabel}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-seed-keywords-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-seed-keywords-dialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { type FormEvent, useEffect, useId, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DOMAIN_RESEARCH_MARKETS } from "@/lib/domains/research-prototype";
+
+import { domainKeywordsViewMessages as messages } from "./domain-keywords-view.messages";
+import { domainResearchSharedMessages as sharedMessages } from "./domain-research-shared.messages";
+
+export function DomainSeedKeywordsDialog({
+  open,
+  defaultKeyword,
+  defaultMarketId,
+  onOpenChange,
+}: {
+  open: boolean;
+  defaultKeyword: string;
+  defaultMarketId: string;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const intl = useIntl();
+  const keywordId = useId();
+  const marketId = useId();
+  const [keyword, setKeyword] = useState(defaultKeyword);
+  const [market, setMarket] = useState(defaultMarketId);
+
+  useEffect(() => {
+    if (open) {
+      setKeyword(defaultKeyword);
+      setMarket(defaultMarketId);
+    }
+  }, [defaultKeyword, defaultMarketId, open]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    toast.success(intl.formatMessage(messages.seedSuccess));
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form className="grid gap-4" onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>
+              <FormattedMessage {...messages.seedTitle} />
+            </DialogTitle>
+            <DialogDescription>
+              <FormattedMessage {...messages.seedDescription} />
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel htmlFor={keywordId}>
+              <FormattedMessage {...messages.seedKeywordLabel} />
+            </FieldLabel>
+            <Input
+              id={keywordId}
+              value={keyword}
+              onChange={(event) => setKeyword(event.target.value)}
+              placeholder={intl.formatMessage(messages.seedKeywordPlaceholder)}
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={marketId}>
+              <FormattedMessage {...messages.seedMarketLabel} />
+            </FieldLabel>
+            <Select
+              value={market || null}
+              onValueChange={(value) => {
+                if (value) {
+                  setMarket(value);
+                }
+              }}
+            >
+              <SelectTrigger id={marketId} className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DOMAIN_RESEARCH_MARKETS.map((item) => (
+                  <SelectItem key={item.id} value={item.id} label={item.label}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              <FormattedMessage {...sharedMessages.cancel} />
+            </Button>
+            <Button type="submit">
+              <FormattedMessage {...messages.seedSubmit} />
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-status-badge.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-status-badge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useIntl } from "react-intl";
+
+import { Badge } from "@/components/ui/badge";
+import type { DomainResearchStatus } from "@/lib/domains/research-prototype";
+
+import { formatDomainStatus } from "./domain-research-format";
+
+export function DomainStatusBadge({ status }: { status: DomainResearchStatus }) {
+  const intl = useIntl();
+  return (
+    <Badge variant={status === "verified" ? "success" : "warning"}>
+      {formatDomainStatus(intl, status)}
+    </Badge>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-verify-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-verify-dialog.messages.ts
@@ -1,0 +1,59 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const domainVerifyDialogMessages = defineMessages({
+  title: {
+    defaultMessage: "Verify DNS",
+    id: "FbWiUTt6DX",
+    description: "Verify DNS dialog title",
+  },
+  description: {
+    defaultMessage:
+      "Add this TXT record at the DNS host for {domain}. Checking is mocked in this prototype.",
+    id: "iCk2jFziPA",
+    description: "Verify DNS dialog description",
+  },
+  hostLabel: {
+    defaultMessage: "Host",
+    id: "1NNWYQidJ2",
+    description: "DNS host label",
+  },
+  typeLabel: {
+    defaultMessage: "Type",
+    id: "2UOyOVIi0T",
+    description: "DNS record type label",
+  },
+  valueLabel: {
+    defaultMessage: "Value",
+    id: "9MIwXNtVoL",
+    description: "DNS record value label",
+  },
+  copyValue: {
+    defaultMessage: "Copy value",
+    id: "ojrPiYWxu8",
+    description: "Copy DNS TXT value",
+  },
+  check: {
+    defaultMessage: "Check now",
+    id: "UsyjaZLxwE",
+    description: "Run the mocked DNS check",
+  },
+  success: {
+    defaultMessage: "Record found. Research unlocks after verification finishes.",
+    id: "OsEkNLI6gz",
+    description: "Toast after a mocked DNS check",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-verify-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-verify-dialog.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Copy01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { DOMAIN_RESEARCH_VERIFY_RECORD } from "@/lib/domains/research-prototype";
+
+import { domainResearchSharedMessages as sharedMessages } from "./domain-research-shared.messages";
+import { domainVerifyDialogMessages as messages } from "./domain-verify-dialog.messages";
+
+export function DomainVerifyDialog({
+  open,
+  domainKey,
+  onOpenChange,
+}: {
+  open: boolean;
+  domainKey: string;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const intl = useIntl();
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(DOMAIN_RESEARCH_VERIFY_RECORD.value);
+      toast.success(intl.formatMessage(sharedMessages.copied));
+    } catch {
+      toast.success(intl.formatMessage(messages.success));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            <FormattedMessage {...messages.title} />
+          </DialogTitle>
+          <DialogDescription>
+            <FormattedMessage {...messages.description} values={{ domain: domainKey }} />
+          </DialogDescription>
+        </DialogHeader>
+
+        <dl className="grid gap-3 rounded-xl border border-border bg-muted/40 p-4 text-sm">
+          <div className="grid gap-1 sm:grid-cols-[6rem_1fr] sm:items-center">
+            <dt className="text-muted-foreground">
+              <FormattedMessage {...messages.hostLabel} />
+            </dt>
+            <dd className="font-mono text-foreground">{DOMAIN_RESEARCH_VERIFY_RECORD.host}</dd>
+          </div>
+          <div className="grid gap-1 sm:grid-cols-[6rem_1fr] sm:items-center">
+            <dt className="text-muted-foreground">
+              <FormattedMessage {...messages.typeLabel} />
+            </dt>
+            <dd className="font-mono text-foreground">{DOMAIN_RESEARCH_VERIFY_RECORD.type}</dd>
+          </div>
+          <div className="grid gap-1 sm:grid-cols-[6rem_1fr] sm:items-center">
+            <dt className="text-muted-foreground">
+              <FormattedMessage {...messages.valueLabel} />
+            </dt>
+            <dd className="flex min-w-0 items-center gap-2">
+              <code className="min-w-0 truncate font-mono text-foreground">
+                {DOMAIN_RESEARCH_VERIFY_RECORD.value}
+              </code>
+              <Button
+                type="button"
+                size="icon-sm"
+                variant="outline"
+                onClick={() => {
+                  void handleCopy();
+                }}
+              >
+                <HugeiconsIcon icon={Copy01Icon} strokeWidth={1.8} />
+                <span className="sr-only">
+                  <FormattedMessage {...messages.copyValue} />
+                </span>
+              </Button>
+            </dd>
+          </div>
+        </dl>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <FormattedMessage {...sharedMessages.cancel} />
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              toast.success(intl.formatMessage(messages.success));
+              onOpenChange(false);
+            }}
+          >
+            <FormattedMessage {...messages.check} />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.messages.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /*
  * Copyright (c) 2026 Hyperlocalise Pty Ltd
  *
@@ -15,8 +17,8 @@ import { defineMessages } from "react-intl";
 export const domainsPageContentMessages = defineMessages({
   pageDescription: {
     defaultMessage:
-      "Domains verified for this workspace, with linked projects and localisation audit reports.",
-    id: "lZrVrk7oZs",
+      "Linked domains and the markets you research them in. Open a site to run keywords, ranks, and AI brand lookup.",
+    id: "qmpjf3XZ1L",
     description: "Domains workspace page description",
   },
   loadError: {
@@ -24,60 +26,49 @@ export const domainsPageContentMessages = defineMessages({
     id: "BBrh+7z4Oj",
     description: "Error when the domains list fails to load",
   },
-  loading: {
-    defaultMessage: "Loading domains…",
-    id: "0cJX5jLe/m",
-    description: "Loading state for the domains list",
+  linkDomain: {
+    defaultMessage: "Link domain",
+    id: "RjCKAD/IFR",
+    description: "Open the link domain dialog",
   },
-  empty: {
-    defaultMessage:
-      "No linked domains yet. Claim a domain from a localisation audit to get started.",
-    id: "blgD4379yD",
-    description: "Empty state for the domains list",
+  columnDomain: {
+    defaultMessage: "Domain",
+    id: "//lV7u3bI3",
+    description: "Domains list column for hostname",
   },
-  statusPending: {
-    defaultMessage: "Pending verification",
-    id: "M9l7nT/Rpj",
-    description: "Linked domain status label for pending verification",
+  columnMarket: {
+    defaultMessage: "Market",
+    id: "q4dfro4K/5",
+    description: "Domains list column for market",
   },
-  statusVerified: {
-    defaultMessage: "Verified",
-    id: "3GLhqP/R2l",
-    description: "Linked domain status label for verified",
+  columnKeywords: {
+    defaultMessage: "Keywords",
+    id: "y0Em+Wp3gc",
+    description: "Domains list column for keyword count",
   },
-  statusFailed: {
-    defaultMessage: "Failed",
-    id: "LRZ3vQhI80",
-    description: "Linked domain status label for failed",
+  columnTraffic: {
+    defaultMessage: "Traffic",
+    id: "uH1X4fN7MB",
+    description: "Domains list column for traffic",
   },
-  statusRevoked: {
-    defaultMessage: "Revoked",
-    id: "i9wq9AC2+9",
-    description: "Linked domain status label for revoked",
+  columnScore: {
+    defaultMessage: "Score",
+    id: "hBm/PWp/+S",
+    description: "Domains list column for audit score",
   },
-  scoreLabel: {
-    defaultMessage: "Score {score}",
-    id: "Xg01khiunA",
-    description: "Audit score label on a domain list row",
-  },
-  scoreUnavailable: {
-    defaultMessage: "No score yet",
-    id: "8UNQ0H4OW1",
-    description: "Shown when a linked domain has no audit score",
-  },
-  viewReport: {
-    defaultMessage: "View report",
-    id: "KRbtCrnBZw",
-    description: "Link to open a linked domain audit report",
+  openDomain: {
+    defaultMessage: "Open",
+    id: "NBDQ/KtIXb",
+    description: "Open a linked domain home",
   },
   continueVerification: {
-    defaultMessage: "Continue verification",
-    id: "k3MhPbqttd",
+    defaultMessage: "Verify",
+    id: "ANFQka6p0Z",
     description: "Link to continue verifying a pending linked domain",
   },
-  openProject: {
-    defaultMessage: "Open project",
-    id: "greERnCNu1",
-    description: "Link to open the project attached to a linked domain",
+  scoreUnavailable: {
+    defaultMessage: "—",
+    id: "giZZw2GSFO",
+    description: "Shown when a linked domain has no audit score",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
@@ -12,59 +12,32 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { OrgNavLink } from "@/components/app-shell/org-nav-link";
-import { Globe02Icon } from "@hugeicons/core-free-icons";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { Add01Icon, Globe02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { Badge } from "@/components/ui/badge";
+import { OrgNavLink } from "@/components/app-shell/org-nav-link";
+import { buildDomainPath } from "@/components/app-shell/navigation-config";
 import { Button } from "@/components/ui/button";
-import { TypographyP } from "@/components/ui/typography";
-import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
+import { listResearchPrototypeDomains } from "@/lib/domains/research-prototype";
+import { cn } from "@/lib/primitives/cn";
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 
+import { DomainLinkDialog } from "./domain-link-dialog";
+import { DomainStatusBadge } from "./domain-status-badge";
+import { DomainVerifyDialog } from "./domain-verify-dialog";
 import { domainsPageContentMessages as messages } from "./domains-page-content.messages";
 
-function statusLabel(
-  status: LinkedDomainPublic["status"],
-  intl: ReturnType<typeof useIntl>,
-): string {
-  switch (status) {
-    case "pending_verification":
-      return intl.formatMessage(messages.statusPending);
-    case "verified":
-      return intl.formatMessage(messages.statusVerified);
-    case "failed":
-      return intl.formatMessage(messages.statusFailed);
-    case "revoked":
-      return intl.formatMessage(messages.statusRevoked);
-    default:
-      return status;
-  }
-}
+const LIST_GRID_CLASS =
+  "grid grid-cols-1 items-center gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.3fr)_minmax(7rem,0.8fr)_repeat(3,minmax(4rem,0.45fr))_auto_auto]";
 
 export function DomainsPageContent({ organizationSlug }: { organizationSlug: string }) {
   const intl = useIntl();
-  const domainsQuery = useQuery({
-    queryKey: ["linked-domains", organizationSlug],
-    queryFn: async () => {
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(organizationSlug)}/linked-domains`,
-      );
-      const body = (await response.json().catch(() => ({}))) as {
-        linkedDomains?: LinkedDomainPublic[];
-        message?: string;
-        error?: string;
-      };
-      if (!response.ok) {
-        throw new Error(body.message || body.error || intl.formatMessage(messages.loadError));
-      }
-      return body.linkedDomains ?? [];
-    },
-  });
-
-  const linkedDomains = domainsQuery.data ?? [];
+  const domains = useMemo(() => listResearchPrototypeDomains(), []);
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [verifyDomainKey, setVerifyDomainKey] = useState<string | null>(null);
 
   return (
     <WorkspacePageShell>
@@ -73,91 +46,97 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
         label="Workspace"
         title="Domains"
         description={intl.formatMessage(messages.pageDescription)}
+        actions={
+          <Button size="sm" onClick={() => setLinkOpen(true)}>
+            <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+            <FormattedMessage {...messages.linkDomain} />
+          </Button>
+        }
       />
 
-      {domainsQuery.isError ? (
-        <TypographyP size="small" tone="critical">
-          {domainsQuery.error instanceof Error
-            ? domainsQuery.error.message
-            : intl.formatMessage(messages.loadError)}
-        </TypographyP>
-      ) : null}
-
-      {domainsQuery.isLoading ? (
-        <TypographyP size="small" tone="subtle">
-          <FormattedMessage {...messages.loading} />
-        </TypographyP>
-      ) : null}
-
-      {!domainsQuery.isLoading && !domainsQuery.isError && linkedDomains.length === 0 ? (
-        <TypographyP size="small" tone="subtle">
-          <FormattedMessage {...messages.empty} />
-        </TypographyP>
-      ) : null}
-
-      {linkedDomains.length > 0 ? (
-        <ul className="divide-y divide-border rounded-lg border border-border">
-          {linkedDomains.map((domain) => (
-            <li
-              key={domain.id}
-              className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
-            >
-              <div className="min-w-0 space-y-1">
-                <OrgNavLink
-                  href={`/org/${organizationSlug}/domains/${domain.id}`}
-                  className="font-medium text-foreground underline-offset-4 hover:underline"
-                >
-                  {domain.domainKey}
-                </OrgNavLink>
-                <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                  <Badge variant="outline">{statusLabel(domain.status, intl)}</Badge>
-                  <span>
-                    {domain.auditScore != null
-                      ? intl.formatMessage(messages.scoreLabel, { score: domain.auditScore })
-                      : intl.formatMessage(messages.scoreUnavailable)}
-                  </span>
-                  {domain.verifiedMethod ? <span>· {domain.verifiedMethod}</span> : null}
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  nativeButton={false}
-                  render={<OrgNavLink href={`/org/${organizationSlug}/domains/${domain.id}`} />}
-                >
-                  <FormattedMessage {...messages.viewReport} />
-                </Button>
-                {domain.status !== "verified" ? (
-                  <Button
-                    size="sm"
-                    nativeButton={false}
-                    render={
-                      <OrgNavLink
-                        href={`/org/${organizationSlug}/link-domain/${domain.domainSlug}`}
-                      />
-                    }
+      <div className="overflow-hidden rounded-lg border border-border">
+        <div
+          className={cn(
+            LIST_GRID_CLASS,
+            "hidden border-b border-border bg-muted/40 text-xs font-medium text-muted-foreground md:grid",
+          )}
+        >
+          <span>
+            <FormattedMessage {...messages.columnDomain} />
+          </span>
+          <span>
+            <FormattedMessage {...messages.columnMarket} />
+          </span>
+          <span className="text-end">
+            <FormattedMessage {...messages.columnKeywords} />
+          </span>
+          <span className="text-end">
+            <FormattedMessage {...messages.columnTraffic} />
+          </span>
+          <span className="text-end">
+            <FormattedMessage {...messages.columnScore} />
+          </span>
+          <span />
+          <span />
+        </div>
+        <ul className="divide-y divide-border">
+          {domains.map((domain) => (
+            <li key={domain.id}>
+              <div className={LIST_GRID_CLASS}>
+                <div className="min-w-0">
+                  <OrgNavLink
+                    href={buildDomainPath(organizationSlug, domain.id)}
+                    className="font-medium text-foreground underline-offset-4 hover:underline"
                   >
-                    <FormattedMessage {...messages.continueVerification} />
-                  </Button>
-                ) : null}
-                {domain.projectId ? (
+                    {domain.domainKey}
+                  </OrgNavLink>
+                  <p className="mt-1 text-sm text-muted-foreground md:hidden">
+                    {domain.market.label}
+                  </p>
+                </div>
+                <span className="hidden text-sm text-muted-foreground md:block">
+                  {domain.market.label}
+                </span>
+                <span className="hidden text-end tabular-nums text-sm text-muted-foreground md:block">
+                  {domain.keywordCountLabel}
+                </span>
+                <span className="hidden text-end tabular-nums text-sm text-muted-foreground md:block">
+                  {domain.trafficLabel}
+                </span>
+                <span className="hidden text-end tabular-nums text-sm text-muted-foreground md:block">
+                  {domain.score ?? intl.formatMessage(messages.scoreUnavailable)}
+                </span>
+                <DomainStatusBadge status={domain.status} />
+                <div className="flex flex-wrap justify-end gap-2">
                   <Button
                     size="sm"
                     variant="outline"
-                    nativeButton={false}
-                    render={
-                      <OrgNavLink href={`/org/${organizationSlug}/projects/${domain.projectId}`} />
-                    }
+                    render={<OrgNavLink href={buildDomainPath(organizationSlug, domain.id)} />}
                   >
-                    <FormattedMessage {...messages.openProject} />
+                    <FormattedMessage {...messages.openDomain} />
                   </Button>
-                ) : null}
+                  {domain.status !== "verified" ? (
+                    <Button size="sm" onClick={() => setVerifyDomainKey(domain.domainKey)}>
+                      <FormattedMessage {...messages.continueVerification} />
+                    </Button>
+                  ) : null}
+                </div>
               </div>
             </li>
           ))}
         </ul>
-      ) : null}
+      </div>
+
+      <DomainLinkDialog open={linkOpen} onOpenChange={setLinkOpen} />
+      <DomainVerifyDialog
+        open={Boolean(verifyDomainKey)}
+        domainKey={verifyDomainKey ?? ""}
+        onOpenChange={(open) => {
+          if (!open) {
+            setVerifyDomainKey(null);
+          }
+        }}
+      />
     </WorkspacePageShell>
   );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
@@ -29,6 +29,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
 import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
+import { getResearchPrototypeDomain } from "@/lib/domains/research-prototype";
 import { cn } from "@/lib/primitives/cn";
 
 import {
@@ -88,11 +89,19 @@ function isDomainBreadcrumbCrumb(
   breadcrumbs: readonly AppShellBreadcrumbItem[],
   organizationSlug: string,
 ) {
-  if (index !== 1 || breadcrumbs.length !== 2 || crumb.href) {
+  if (index !== 1 || breadcrumbs.length < 2 || breadcrumbs.length > 3) {
     return false;
   }
 
-  return breadcrumbs[0]?.href === buildOrganizationPath(organizationSlug, "domains");
+  if (breadcrumbs[0]?.href !== buildOrganizationPath(organizationSlug, "domains")) {
+    return false;
+  }
+
+  if (breadcrumbs.length === 2) {
+    return !crumb.href;
+  }
+
+  return Boolean(crumb.href);
 }
 
 function resolveSelectorCrumbKind(
@@ -227,6 +236,7 @@ function SelectorBreadcrumbCrumbContent({
         organizationSlug={organizationSlug}
         linkedDomainId={domainRoute.linkedDomainId}
         domainName={domainName?.trim() || crumb.label || domainRoute.linkedDomainId}
+        surface={domainRoute.surface}
         isLast={isLast}
       />
     );
@@ -286,9 +296,13 @@ export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
     },
   });
 
+  const mockDomain = domainRoute?.linkedDomainId
+    ? getResearchPrototypeDomain(domainRoute.linkedDomainId)
+    : null;
+
   const domainQuery = useQuery({
     queryKey: ["linked-domain", resolvedOrganizationSlug, domainRoute?.linkedDomainId],
-    enabled: Boolean(domainRoute?.linkedDomainId),
+    enabled: Boolean(domainRoute?.linkedDomainId) && !mockDomain,
     queryFn: async () => {
       const response = await fetch(
         `/api/orgs/${encodeURIComponent(resolvedOrganizationSlug)}/linked-domains/${encodeURIComponent(domainRoute!.linkedDomainId)}`,
@@ -314,8 +328,8 @@ export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
       projectNameLoading: projectQuery.isPending,
       teamName: teamQuery.data?.name,
       teamNameLoading: teamQuery.isPending,
-      domainName: domainQuery.data?.domainKey,
-      domainNameLoading: domainQuery.isPending,
+      domainName: mockDomain?.domainKey ?? domainQuery.data?.domainKey,
+      domainNameLoading: !mockDomain && domainQuery.isPending,
     }),
   );
 
@@ -374,7 +388,7 @@ export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
                     domainRoute={domainRoute}
                     projectName={projectQuery.data?.name}
                     teamName={teamQuery.data?.name}
-                    domainName={domainQuery.data?.domainKey}
+                    domainName={mockDomain?.domainKey ?? domainQuery.data?.domainKey}
                   />
                 ) : (
                   <BreadcrumbCrumbContent crumb={crumb} isLast={isLast} />

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -46,6 +46,7 @@ describe("getAppShellTitle", () => {
     ["/org/acme/ai-engine", "AI Engine"],
     ["/org/acme/domains", "Domains"],
     ["/org/acme/domains/ld_1", "ld_1"],
+    ["/org/acme/domains/hyperlocalise-com/keywords", "Keywords"],
     ["/org/acme/glossaries", "Glossaries"],
     ["/org/acme/translation-memories", "Translation Memories"],
     ["/org/acme/integrations", "Integrations"],
@@ -148,6 +149,15 @@ describe("getAppShellBreadcrumbs", () => {
     ).toEqual([
       { label: "Domains", href: "/org/acme/domains" },
       { label: "", isLoading: true },
+    ]);
+    expect(
+      getAppShellBreadcrumbs("/org/acme/domains/hyperlocalise-com/keywords", intl, {
+        domainName: "hyperlocalise.com",
+      }),
+    ).toEqual([
+      { label: "Domains", href: "/org/acme/domains" },
+      { label: "hyperlocalise.com", href: "/org/acme/domains/hyperlocalise-com" },
+      { label: "Keywords" },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -13,6 +13,10 @@
 import type { ReactNode } from "react";
 import type { IntlShape } from "react-intl";
 
+import { isDomainResearchSurface } from "@/lib/domains/research-prototype";
+
+import { buildDomainPath } from "./navigation-config";
+
 export type AppShellBreadcrumb = {
   label: string;
   href?: string;
@@ -39,14 +43,19 @@ type RouteTitleKey =
   | "issues"
   | "issue-sheet"
   | "jobs"
+  | "keywords"
   | "knowledge"
   | "linked-domains"
   | "locales"
   | "members"
   | "my-jobs"
   | "my-work"
+  | "overview"
   | "permissions"
+  | "prompts"
   | "projects"
+  | "ranks"
+  | "brand"
   | "qa"
   | "reviews"
   | "settings"
@@ -91,15 +100,19 @@ function isRouteTitleKey(value: string): value is RouteTitleKey {
     value === "issues" ||
     value === "issue-sheet" ||
     value === "jobs" ||
-    value === "automations" ||
+    value === "keywords" ||
     value === "knowledge" ||
     value === "linked-domains" ||
     value === "locales" ||
     value === "members" ||
     value === "my-jobs" ||
     value === "my-work" ||
+    value === "overview" ||
     value === "permissions" ||
+    value === "prompts" ||
     value === "projects" ||
+    value === "ranks" ||
+    value === "brand" ||
     value === "qa" ||
     value === "reviews" ||
     value === "settings" ||
@@ -248,6 +261,36 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
         defaultMessage: "Jobs",
         id: "WzPTL0QId6",
         description: "App shell breadcrumb title for the jobs page",
+      });
+    case "keywords":
+      return intl.formatMessage({
+        defaultMessage: "Keywords",
+        id: "m6sWTuk4o8",
+        description: "App shell breadcrumb title for domain keyword research",
+      });
+    case "overview":
+      return intl.formatMessage({
+        defaultMessage: "Overview",
+        id: "vum/tkTswv",
+        description: "App shell breadcrumb title for domain overview research",
+      });
+    case "ranks":
+      return intl.formatMessage({
+        defaultMessage: "Ranks",
+        id: "v8HmqsxSuZ",
+        description: "App shell breadcrumb title for domain rank tracking",
+      });
+    case "brand":
+      return intl.formatMessage({
+        defaultMessage: "Brand",
+        id: "QqEr64QiAA",
+        description: "App shell breadcrumb title for domain AI brand lookup",
+      });
+    case "prompts":
+      return intl.formatMessage({
+        defaultMessage: "Prompts",
+        id: "Cx/AirNdqn",
+        description: "App shell breadcrumb title for domain prompt explorer",
       });
     case "automations":
       return intl.formatMessage({
@@ -427,17 +470,26 @@ export function getAppShellBreadcrumbs(
     const resolvedDomainName = options?.domainName?.trim();
     const domainNameLoading = options?.domainNameLoading && !resolvedDomainName;
     const domainLabel = resolvedDomainName || (domainNameLoading ? "" : linkedDomainId);
+    const surface =
+      projectSection && isDomainResearchSurface(projectSection) ? projectSection : undefined;
 
-    return [
+    const crumbs: AppShellBreadcrumb[] = [
       {
         label: formatRouteTitle(intl, "domains"),
         href: buildOrgPath(organizationSlug, "domains"),
       },
       {
         label: domainLabel,
+        ...(surface ? { href: buildDomainPath(organizationSlug, linkedDomainId) } : {}),
         ...(domainNameLoading ? { isLoading: true } : {}),
       },
     ];
+
+    if (surface) {
+      crumbs.push({ label: formatRouteTitle(intl, surface) });
+    }
+
+    return crumbs;
   }
 
   if (section === "members") {

--- a/apps/hyperlocalise-web/src/components/app-shell/domain-breadcrumb-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/domain-breadcrumb-selector.tsx
@@ -12,9 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 
+import type { DomainResearchSurface } from "@/lib/domains/research-prototype";
+import { listResearchPrototypeDomains } from "@/lib/domains/research-prototype";
 import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
 import { useOrgRouter } from "@/lib/navigation/use-org-router";
 
@@ -29,6 +32,7 @@ type DomainBreadcrumbSelectorProps = {
   organizationSlug: string;
   linkedDomainId: string;
   domainName: string;
+  surface?: DomainResearchSurface;
   isLast?: boolean;
 };
 
@@ -36,10 +40,19 @@ export function DomainBreadcrumbSelector({
   organizationSlug,
   linkedDomainId,
   domainName,
+  surface,
   isLast = false,
 }: DomainBreadcrumbSelectorProps) {
   const intl = useIntl();
   const router = useOrgRouter();
+  const mockOptions = useMemo(
+    () =>
+      listResearchPrototypeDomains().map((domain) => ({
+        value: domain.id,
+        label: domain.domainKey,
+      })),
+    [],
+  );
   const domainsQuery = useQuery({
     queryKey: organizationDomainsQueryKey(organizationSlug),
     queryFn: async () => {
@@ -65,22 +78,34 @@ export function DomainBreadcrumbSelector({
     },
   });
 
+  const options = useMemo(() => {
+    const seen = new Set(mockOptions.map((option) => option.value));
+    const merged = [...mockOptions];
+    for (const option of domainsQuery.data ?? []) {
+      if (!seen.has(option.value)) {
+        seen.add(option.value);
+        merged.push(option);
+      }
+    }
+    return merged;
+  }, [domainsQuery.data, mockOptions]);
+
   function handleSelect(nextLinkedDomainId: string) {
     if (nextLinkedDomainId === linkedDomainId) {
       return;
     }
 
-    router.push(buildDomainPath(organizationSlug, nextLinkedDomainId));
+    router.push(buildDomainPath(organizationSlug, nextLinkedDomainId, surface));
   }
 
   return (
     <BreadcrumbCrumbSelector
       value={linkedDomainId}
       label={domainName}
-      options={domainsQuery.data ?? []}
+      options={options}
       onSelect={handleSelect}
-      isLoading={domainsQuery.isPending}
-      isError={domainsQuery.isError}
+      isLoading={mockOptions.length === 0 && domainsQuery.isPending}
+      isError={mockOptions.length === 0 && domainsQuery.isError}
       menuLabel={intl.formatMessage(messages.switchDomain)}
       isLast={isLast}
     />

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -339,6 +339,15 @@ describe("parseDomainRoute", () => {
       organizationSlug: "acme",
       linkedDomainId: "ld_1",
     });
+    expect(parseDomainRoute("/org/acme/domains/hyperlocalise-com/keywords")).toEqual({
+      organizationSlug: "acme",
+      linkedDomainId: "hyperlocalise-com",
+      surface: "keywords",
+    });
+    expect(parseDomainRoute("/org/acme/domains/ld_1/unknown")).toEqual({
+      organizationSlug: "acme",
+      linkedDomainId: "ld_1",
+    });
   });
 });
 
@@ -351,6 +360,7 @@ describe("buildTeamPath", () => {
 describe("buildDomainPath", () => {
   it("encodes linked domain ids in the path", () => {
     expect(buildDomainPath("acme", "ld_1")).toBe("/org/acme/domains/ld_1");
+    expect(buildDomainPath("acme", "ld_1", "prompts")).toBe("/org/acme/domains/ld_1/prompts");
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -14,6 +14,10 @@ import type { ComponentProps } from "react";
 import type { IntlShape } from "react-intl";
 
 import { normalizeAppLocale } from "@/lib/app-i18n/locales";
+import {
+  isDomainResearchSurface,
+  type DomainResearchSurface,
+} from "@/lib/domains/research-prototype";
 import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
@@ -86,8 +90,13 @@ export function buildTeamPath(organizationSlug: string, teamId: string) {
   return `/org/${organizationSlug}/teams/${encodeURIComponent(teamId)}`;
 }
 
-export function buildDomainPath(organizationSlug: string, linkedDomainId: string) {
-  return `/org/${organizationSlug}/domains/${encodeURIComponent(linkedDomainId)}`;
+export function buildDomainPath(
+  organizationSlug: string,
+  linkedDomainId: string,
+  surface?: DomainResearchSurface,
+) {
+  const base = `/org/${organizationSlug}/domains/${encodeURIComponent(linkedDomainId)}`;
+  return surface ? `${base}/${surface}` : base;
 }
 
 export function buildAutomationsPath(
@@ -506,14 +515,19 @@ export function parseTeamRoute(pathname: string | null) {
 export function parseDomainRoute(pathname: string | null) {
   if (!pathname) return null;
 
-  const match = stripAppLocalePrefix(pathname).match(/^\/org\/([^/]+)\/domains\/([^/]+)$/);
+  const match = stripAppLocalePrefix(pathname).match(
+    /^\/org\/([^/]+)\/domains\/([^/]+)(?:\/([^/]+))?\/?$/,
+  );
   if (!match) return null;
 
-  const [, organizationSlug, linkedDomainIdSegment] = match;
+  const [, organizationSlug, linkedDomainIdSegment, surfaceSegment] = match;
+  const surface =
+    surfaceSegment && isDomainResearchSurface(surfaceSegment) ? surfaceSegment : undefined;
 
   return {
     organizationSlug,
     linkedDomainId: decodePathSegment(linkedDomainIdSegment),
+    ...(surface ? { surface } : {}),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/domains/research-prototype.test.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/research-prototype.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  DOMAIN_RESEARCH_SURFACES,
+  getResearchPrototypeCatalog,
+  getResearchPrototypeDomain,
+  isDomainResearchSurface,
+  isResearchPrototypeDomain,
+  listResearchPrototypeDomains,
+} from "./research-prototype";
+
+describe("research prototype catalog", () => {
+  it("lists the Paper domain set", () => {
+    expect(listResearchPrototypeDomains().map((domain) => domain.domainKey)).toEqual([
+      "hyperlocalise.com",
+      "acme.fr",
+      "help.acme.com",
+      "acme.jp",
+      "docs.acme.com",
+      "shop.acme.de",
+    ]);
+  });
+
+  it("loads keyword research for the primary French domain", () => {
+    const catalog = getResearchPrototypeCatalog("hyperlocalise-com");
+    expect(catalog?.keywords).toHaveLength(10);
+    expect(catalog?.keywords[0]?.keyword).toBe("traduction automatique");
+    expect(catalog?.promptResults.find((result) => result.engine === "perplexity")?.mentioned).toBe(
+      true,
+    );
+    expect(catalog?.promptResults.find((result) => result.engine === "gemini")?.mentioned).toBe(
+      false,
+    );
+  });
+
+  it("keeps pending domains empty until verification", () => {
+    expect(getResearchPrototypeDomain("help-acme-com")?.status).toBe("pending_verification");
+    expect(getResearchPrototypeCatalog("shop-acme-de")?.keywords).toEqual([]);
+    expect(isResearchPrototypeDomain("missing")).toBe(false);
+  });
+
+  it("recognises research surfaces", () => {
+    expect(DOMAIN_RESEARCH_SURFACES).toContain("prompts");
+    expect(isDomainResearchSurface("keywords")).toBe(true);
+    expect(isDomainResearchSurface("audit")).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/domains/research-prototype.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/research-prototype.ts
@@ -1,0 +1,739 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const DOMAIN_RESEARCH_SURFACES = [
+  "keywords",
+  "overview",
+  "ranks",
+  "brand",
+  "prompts",
+] as const;
+
+export type DomainResearchSurface = (typeof DOMAIN_RESEARCH_SURFACES)[number];
+
+export type DomainResearchNavId = "home" | DomainResearchSurface;
+
+export type DomainResearchStatus = "verified" | "pending_verification";
+
+export type KeywordIntent = "informational" | "commercial" | "transactional" | "navigational";
+
+export type BrandEngine = "chatgpt" | "claude" | "gemini" | "perplexity";
+
+export type BrandSentiment = "positive" | "mixed" | "negative";
+
+export type DomainResearchMarket = {
+  id: string;
+  location: string;
+  language: string;
+  label: string;
+};
+
+export type DomainResearchDomain = {
+  id: string;
+  domainKey: string;
+  sourceUrl: string;
+  market: DomainResearchMarket;
+  status: DomainResearchStatus;
+  keywordCount: number;
+  keywordCountLabel: string;
+  traffic: number;
+  trafficLabel: string;
+  score: number | null;
+  trackedCount: number;
+  aiMentions: number;
+};
+
+export type KeywordIdea = {
+  id: string;
+  keyword: string;
+  volume: number;
+  kd: number;
+  cpc: number;
+  intent: KeywordIntent;
+};
+
+export type RankRow = {
+  id: string;
+  keyword: string;
+  position: number | null;
+  previousPosition: number | null;
+  url: string;
+  volume: number;
+};
+
+export type OverviewKeywordRow = {
+  id: string;
+  keyword: string;
+  position: number;
+  volume: number;
+  traffic: number;
+};
+
+export type OverviewPageRow = {
+  id: string;
+  path: string;
+  keywords: number;
+  traffic: number;
+};
+
+export type BrandCompetitor = {
+  id: string;
+  name: string;
+  mentions: number;
+  sentiment: BrandSentiment;
+};
+
+export type PromptEngineResult = {
+  engine: BrandEngine;
+  mentioned: boolean;
+  excerpt: string;
+};
+
+export type SerpResult = {
+  position: number;
+  title: string;
+  url: string;
+  snippet: string;
+  isOwn?: boolean;
+};
+
+export type DomainResearchCatalog = {
+  domain: DomainResearchDomain;
+  keywords: KeywordIdea[];
+  ranks: RankRow[];
+  overviewKeywords: OverviewKeywordRow[];
+  overviewPages: OverviewPageRow[];
+  competitors: BrandCompetitor[];
+  engineMentions: Record<BrandEngine, number>;
+  prompt: string;
+  promptResults: PromptEngineResult[];
+  serpByKeywordId: Record<string, SerpResult[]>;
+};
+
+export const DOMAIN_RESEARCH_MARKETS: DomainResearchMarket[] = [
+  { id: "france-fr", location: "France", language: "fr", label: "France · fr" },
+  { id: "germany-de", location: "Germany", language: "de", label: "Germany · de" },
+  { id: "japan-ja", location: "Japan", language: "ja", label: "Japan · ja" },
+  { id: "vietnam-vi", location: "Vietnam", language: "vi", label: "Vietnam · vi" },
+];
+
+const FRANCE_FR = DOMAIN_RESEARCH_MARKETS[0]!;
+const GERMANY_DE = DOMAIN_RESEARCH_MARKETS[1]!;
+const JAPAN_JA = DOMAIN_RESEARCH_MARKETS[2]!;
+const VIETNAM_VI = DOMAIN_RESEARCH_MARKETS[3]!;
+
+const HYPERLOCALISE_KEYWORDS: KeywordIdea[] = [
+  {
+    id: "kw-traduction-automatique",
+    keyword: "traduction automatique",
+    volume: 8100,
+    kd: 41,
+    cpc: 1.2,
+    intent: "commercial",
+  },
+  {
+    id: "kw-logiciel-de-traduction",
+    keyword: "logiciel de traduction",
+    volume: 5400,
+    kd: 48,
+    cpc: 2.1,
+    intent: "commercial",
+  },
+  {
+    id: "kw-traduire-un-site-web",
+    keyword: "traduire un site web",
+    volume: 3600,
+    kd: 35,
+    cpc: 1.8,
+    intent: "commercial",
+  },
+  {
+    id: "kw-localisation-de-logiciel",
+    keyword: "localisation de logiciel",
+    volume: 2900,
+    kd: 39,
+    cpc: 3.4,
+    intent: "commercial",
+  },
+  {
+    id: "kw-traduction-ia",
+    keyword: "traduction IA",
+    volume: 4400,
+    kd: 44,
+    cpc: 1.65,
+    intent: "commercial",
+  },
+  {
+    id: "kw-gestion-terminologique",
+    keyword: "gestion terminologique",
+    volume: 880,
+    kd: 28,
+    cpc: 4.2,
+    intent: "informational",
+  },
+  {
+    id: "kw-api-de-traduction",
+    keyword: "API de traduction",
+    volume: 1600,
+    kd: 52,
+    cpc: 5.1,
+    intent: "transactional",
+  },
+  {
+    id: "kw-memoire-de-traduction",
+    keyword: "mémoire de traduction",
+    volume: 2100,
+    kd: 33,
+    cpc: 2.8,
+    intent: "informational",
+  },
+  {
+    id: "kw-tms-traduction",
+    keyword: "TMS traduction",
+    volume: 720,
+    kd: 31,
+    cpc: 6.4,
+    intent: "commercial",
+  },
+  {
+    id: "kw-localisation-de-site-web",
+    keyword: "localisation de site web",
+    volume: 1900,
+    kd: 37,
+    cpc: 2.45,
+    intent: "commercial",
+  },
+];
+
+const ACME_FR_KEYWORDS: KeywordIdea[] = [
+  {
+    id: "kw-acme-catalogue",
+    keyword: "catalogue produits France",
+    volume: 2900,
+    kd: 29,
+    cpc: 1.1,
+    intent: "commercial",
+  },
+  {
+    id: "kw-acme-livraison",
+    keyword: "livraison France",
+    volume: 6600,
+    kd: 46,
+    cpc: 0.9,
+    intent: "transactional",
+  },
+  {
+    id: "kw-acme-support",
+    keyword: "support client français",
+    volume: 1200,
+    kd: 22,
+    cpc: 1.4,
+    intent: "informational",
+  },
+];
+
+const ACME_JP_KEYWORDS: KeywordIdea[] = [
+  {
+    id: "kw-jp-localization",
+    keyword: "ソフトウェアローカライズ",
+    volume: 2400,
+    kd: 36,
+    cpc: 3.1,
+    intent: "commercial",
+  },
+  {
+    id: "kw-jp-translation",
+    keyword: "翻訳管理システム",
+    volume: 1800,
+    kd: 41,
+    cpc: 4.6,
+    intent: "commercial",
+  },
+  {
+    id: "kw-jp-help",
+    keyword: "日本語ヘルプセンター",
+    volume: 980,
+    kd: 24,
+    cpc: 1.2,
+    intent: "informational",
+  },
+];
+
+const DOCS_KEYWORDS: KeywordIdea[] = [
+  {
+    id: "kw-vi-docs",
+    keyword: "tài liệu sản phẩm tiếng Việt",
+    volume: 720,
+    kd: 18,
+    cpc: 0.7,
+    intent: "informational",
+  },
+  {
+    id: "kw-vi-api",
+    keyword: "tài liệu API",
+    volume: 1600,
+    kd: 27,
+    cpc: 1.3,
+    intent: "informational",
+  },
+];
+
+const HYPERLOCALISE_SERP: SerpResult[] = [
+  {
+    position: 1,
+    title: "Traduction automatique — Wikipédia",
+    url: "https://fr.wikipedia.org/wiki/Traduction_automatique",
+    snippet: "La traduction automatique est un domaine de la linguistique et de l’informatique…",
+  },
+  {
+    position: 2,
+    title: "DeepL Traduction : le meilleur traducteur au monde",
+    url: "https://www.deepl.com/fr/translator",
+    snippet: "Traduisez des textes et documents entiers en un instant. Qualité proche de l’humain.",
+  },
+  {
+    position: 3,
+    title: "Google Traduction",
+    url: "https://translate.google.com/?hl=fr",
+    snippet: "Service de traduction automatique de Google pour sites, documents et conversations.",
+  },
+  {
+    position: 4,
+    title: "SYSTRAN : solutions de traduction automatique",
+    url: "https://www.systran.fr/",
+    snippet: "Moteurs de traduction pour entreprises, API et workflows de localisation.",
+  },
+  {
+    position: 22,
+    title: "Hyperlocalise — localisation produit pour les équipes",
+    url: "https://hyperlocalise.com/fr",
+    snippet: "Recherche, traduction et publication sur le marché français, dans le même workspace.",
+    isOwn: true,
+  },
+];
+
+function catalogFor(
+  domain: DomainResearchDomain,
+  extras?: Partial<Omit<DomainResearchCatalog, "domain">>,
+): DomainResearchCatalog {
+  return {
+    domain,
+    keywords: [],
+    ranks: [],
+    overviewKeywords: [],
+    overviewPages: [],
+    competitors: [],
+    engineMentions: {
+      chatgpt: 0,
+      claude: 0,
+      gemini: 0,
+      perplexity: 0,
+    },
+    prompt: "",
+    promptResults: [],
+    serpByKeywordId: {},
+    ...extras,
+  };
+}
+
+const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
+  catalogFor(
+    {
+      id: "hyperlocalise-com",
+      domainKey: "hyperlocalise.com",
+      sourceUrl: "https://hyperlocalise.com",
+      market: FRANCE_FR,
+      status: "verified",
+      keywordCount: 12400,
+      keywordCountLabel: "12.4k",
+      traffic: 84000,
+      trafficLabel: "84k",
+      score: 82,
+      trackedCount: 48,
+      aiMentions: 36,
+    },
+    {
+      keywords: HYPERLOCALISE_KEYWORDS,
+      ranks: [
+        {
+          id: "rank-traduction-automatique",
+          keyword: "traduction automatique",
+          position: 22,
+          previousPosition: 25,
+          url: "https://hyperlocalise.com/fr",
+          volume: 8100,
+        },
+        {
+          id: "rank-logiciel-de-traduction",
+          keyword: "logiciel de traduction",
+          position: 8,
+          previousPosition: 9,
+          url: "https://hyperlocalise.com/fr/product",
+          volume: 5400,
+        },
+        {
+          id: "rank-traduction-ia",
+          keyword: "traduction IA",
+          position: 14,
+          previousPosition: 11,
+          url: "https://hyperlocalise.com/fr/blog/traduction-ia",
+          volume: 4400,
+        },
+        {
+          id: "rank-tms-traduction",
+          keyword: "TMS traduction",
+          position: 6,
+          previousPosition: 6,
+          url: "https://hyperlocalise.com/fr/product",
+          volume: 720,
+        },
+      ],
+      overviewKeywords: [
+        {
+          id: "ov-kw-1",
+          keyword: "traduction automatique",
+          position: 22,
+          volume: 8100,
+          traffic: 420,
+        },
+        {
+          id: "ov-kw-2",
+          keyword: "logiciel de traduction",
+          position: 8,
+          volume: 5400,
+          traffic: 980,
+        },
+        {
+          id: "ov-kw-3",
+          keyword: "traduction IA",
+          position: 14,
+          volume: 4400,
+          traffic: 610,
+        },
+        {
+          id: "ov-kw-4",
+          keyword: "TMS traduction",
+          position: 6,
+          volume: 720,
+          traffic: 210,
+        },
+      ],
+      overviewPages: [
+        { id: "ov-pg-1", path: "/fr", keywords: 86, traffic: 12400 },
+        { id: "ov-pg-2", path: "/fr/product", keywords: 41, traffic: 8600 },
+        { id: "ov-pg-3", path: "/fr/pricing", keywords: 18, traffic: 2100 },
+        { id: "ov-pg-4", path: "/fr/blog/traduction-ia", keywords: 12, traffic: 940 },
+      ],
+      competitors: [
+        { id: "comp-phrase", name: "Phrase", mentions: 18, sentiment: "mixed" },
+        { id: "comp-crowdin", name: "Crowdin", mentions: 14, sentiment: "positive" },
+        { id: "comp-lokalise", name: "Lokalise", mentions: 11, sentiment: "mixed" },
+        { id: "comp-smartling", name: "Smartling", mentions: 9, sentiment: "positive" },
+        { id: "comp-deepl", name: "DeepL", mentions: 22, sentiment: "positive" },
+      ],
+      engineMentions: {
+        chatgpt: 42,
+        claude: 38,
+        gemini: 12,
+        perplexity: 29,
+      },
+      prompt: "meilleur outil de localisation pour une équipe produit",
+      promptResults: [
+        {
+          engine: "chatgpt",
+          mentioned: true,
+          excerpt:
+            "Hyperlocalise appears among tools for product teams that need research and translation in one workspace.",
+        },
+        {
+          engine: "claude",
+          mentioned: true,
+          excerpt:
+            "For French-market localisation, Hyperlocalise is listed next to Crowdin and Phrase for product orgs.",
+        },
+        {
+          engine: "gemini",
+          mentioned: false,
+          excerpt: "Answers focus on Phrase, Crowdin, and Smartling. Hyperlocalise is not named.",
+        },
+        {
+          engine: "perplexity",
+          mentioned: true,
+          excerpt:
+            "Cites Hyperlocalise for domain-scoped keyword research tied to a market and language.",
+        },
+      ],
+      serpByKeywordId: {
+        "kw-traduction-automatique": HYPERLOCALISE_SERP,
+      },
+    },
+  ),
+  catalogFor(
+    {
+      id: "acme-fr",
+      domainKey: "acme.fr",
+      sourceUrl: "https://acme.fr",
+      market: FRANCE_FR,
+      status: "verified",
+      keywordCount: 6100,
+      keywordCountLabel: "6.1k",
+      traffic: 29000,
+      trafficLabel: "29k",
+      score: 71,
+      trackedCount: 22,
+      aiMentions: 11,
+    },
+    {
+      keywords: ACME_FR_KEYWORDS,
+      ranks: [
+        {
+          id: "rank-acme-livraison",
+          keyword: "livraison France",
+          position: 4,
+          previousPosition: 7,
+          url: "https://acme.fr/livraison",
+          volume: 6600,
+        },
+      ],
+      overviewKeywords: [
+        {
+          id: "ov-acme-1",
+          keyword: "livraison France",
+          position: 4,
+          volume: 6600,
+          traffic: 1800,
+        },
+      ],
+      overviewPages: [{ id: "ov-acme-home", path: "/", keywords: 54, traffic: 9100 }],
+      competitors: [
+        { id: "comp-fnac", name: "Fnac", mentions: 8, sentiment: "mixed" },
+        { id: "comp-cdiscount", name: "Cdiscount", mentions: 6, sentiment: "negative" },
+      ],
+      engineMentions: {
+        chatgpt: 18,
+        claude: 9,
+        gemini: 4,
+        perplexity: 7,
+      },
+      prompt: "meilleure boutique acme en France",
+      promptResults: [
+        {
+          engine: "chatgpt",
+          mentioned: true,
+          excerpt: "acme.fr is named as the French storefront.",
+        },
+        {
+          engine: "claude",
+          mentioned: false,
+          excerpt: "Recommends marketplaces instead of the branded domain.",
+        },
+        {
+          engine: "gemini",
+          mentioned: false,
+          excerpt: "No branded mention in the sampled answer.",
+        },
+        {
+          engine: "perplexity",
+          mentioned: true,
+          excerpt: "Links to acme.fr for shipping and support in French.",
+        },
+      ],
+    },
+  ),
+  catalogFor({
+    id: "help-acme-com",
+    domainKey: "help.acme.com",
+    sourceUrl: "https://help.acme.com",
+    market: GERMANY_DE,
+    status: "pending_verification",
+    keywordCount: 0,
+    keywordCountLabel: "—",
+    traffic: 0,
+    trafficLabel: "—",
+    score: null,
+    trackedCount: 0,
+    aiMentions: 0,
+  }),
+  catalogFor(
+    {
+      id: "acme-jp",
+      domainKey: "acme.jp",
+      sourceUrl: "https://acme.jp",
+      market: JAPAN_JA,
+      status: "verified",
+      keywordCount: 8600,
+      keywordCountLabel: "8.6k",
+      traffic: 41000,
+      trafficLabel: "41k",
+      score: 77,
+      trackedCount: 31,
+      aiMentions: 19,
+    },
+    {
+      keywords: ACME_JP_KEYWORDS,
+      ranks: [
+        {
+          id: "rank-jp-tms",
+          keyword: "翻訳管理システム",
+          position: 11,
+          previousPosition: 13,
+          url: "https://acme.jp/product",
+          volume: 1800,
+        },
+      ],
+      overviewKeywords: [
+        {
+          id: "ov-jp-1",
+          keyword: "翻訳管理システム",
+          position: 11,
+          volume: 1800,
+          traffic: 340,
+        },
+      ],
+      overviewPages: [{ id: "ov-jp-home", path: "/", keywords: 63, traffic: 15200 }],
+      competitors: [{ id: "comp-phrase-jp", name: "Phrase", mentions: 12, sentiment: "positive" }],
+      engineMentions: {
+        chatgpt: 24,
+        claude: 21,
+        gemini: 16,
+        perplexity: 14,
+      },
+      prompt: "日本向けのローカライズツール",
+      promptResults: [
+        {
+          engine: "chatgpt",
+          mentioned: true,
+          excerpt: "acme.jp is listed for Japanese product localisation.",
+        },
+        {
+          engine: "claude",
+          mentioned: true,
+          excerpt: "Names acme.jp among Japan-market localisation stacks.",
+        },
+        {
+          engine: "gemini",
+          mentioned: true,
+          excerpt: "Includes acme.jp in a shortlist of JP help centers.",
+        },
+        {
+          engine: "perplexity",
+          mentioned: false,
+          excerpt: "Cites Phrase and Crowdin only.",
+        },
+      ],
+    },
+  ),
+  catalogFor(
+    {
+      id: "docs-acme-com",
+      domainKey: "docs.acme.com",
+      sourceUrl: "https://docs.acme.com",
+      market: VIETNAM_VI,
+      status: "verified",
+      keywordCount: 2400,
+      keywordCountLabel: "2.4k",
+      traffic: 11000,
+      trafficLabel: "11k",
+      score: 64,
+      trackedCount: 0,
+      aiMentions: 4,
+    },
+    {
+      keywords: DOCS_KEYWORDS,
+      overviewKeywords: [
+        {
+          id: "ov-docs-1",
+          keyword: "tài liệu API",
+          position: 9,
+          volume: 1600,
+          traffic: 280,
+        },
+      ],
+      overviewPages: [{ id: "ov-docs-home", path: "/vi", keywords: 19, traffic: 2400 }],
+      competitors: [{ id: "comp-readme", name: "ReadMe", mentions: 5, sentiment: "mixed" }],
+      engineMentions: {
+        chatgpt: 8,
+        claude: 6,
+        gemini: 3,
+        perplexity: 5,
+      },
+      prompt: "tài liệu sản phẩm tiếng Việt tốt nhất",
+      promptResults: [
+        {
+          engine: "chatgpt",
+          mentioned: false,
+          excerpt: "Points to generic documentation hosts.",
+        },
+        {
+          engine: "claude",
+          mentioned: true,
+          excerpt: "Mentions docs.acme.com for Vietnamese product docs.",
+        },
+        {
+          engine: "gemini",
+          mentioned: false,
+          excerpt: "No branded mention.",
+        },
+        {
+          engine: "perplexity",
+          mentioned: false,
+          excerpt: "No branded mention.",
+        },
+      ],
+    },
+  ),
+  catalogFor({
+    id: "shop-acme-de",
+    domainKey: "shop.acme.de",
+    sourceUrl: "https://shop.acme.de",
+    market: GERMANY_DE,
+    status: "pending_verification",
+    keywordCount: 0,
+    keywordCountLabel: "—",
+    traffic: 0,
+    trafficLabel: "—",
+    score: null,
+    trackedCount: 0,
+    aiMentions: 0,
+  }),
+];
+
+const RESEARCH_PROTOTYPE_BY_ID = new Map(
+  RESEARCH_PROTOTYPE_CATALOG.map((entry) => [entry.domain.id, entry]),
+);
+
+export function isDomainResearchSurface(value: string): value is DomainResearchSurface {
+  return (DOMAIN_RESEARCH_SURFACES as readonly string[]).includes(value);
+}
+
+export function listResearchPrototypeDomains(): DomainResearchDomain[] {
+  return RESEARCH_PROTOTYPE_CATALOG.map((entry) => entry.domain);
+}
+
+export function getResearchPrototypeDomain(linkedDomainId: string): DomainResearchDomain | null {
+  return RESEARCH_PROTOTYPE_BY_ID.get(linkedDomainId)?.domain ?? null;
+}
+
+export function getResearchPrototypeCatalog(linkedDomainId: string): DomainResearchCatalog | null {
+  return RESEARCH_PROTOTYPE_BY_ID.get(linkedDomainId) ?? null;
+}
+
+export function isResearchPrototypeDomain(linkedDomainId: string): boolean {
+  return RESEARCH_PROTOTYPE_BY_ID.has(linkedDomainId);
+}
+
+export const DOMAIN_RESEARCH_VERIFY_RECORD = {
+  host: "_hyperlocalise-verify",
+  type: "TXT",
+  value: "hl-verify=demo",
+} as const;


### PR DESCRIPTION
## What changed

Implements the Paper Domains research flow in the web app using existing UI components and mocked catalog data (no backend). Linked domains now have Home, Keywords, Overview, Ranks, Brand, and Prompts surfaces, plus link/verify dialogs. Existing audit detail still renders for real linked-domain IDs.

## How to test

- Enable the workspace domains flag, then open `/org/<slug>/domains`.
- Walk the list → home → keywords (select two, inspect SERP) → overview → ranks → brand → prompts.
- Confirm pending domains show the verify empty state, and that breadcrumbs keep the domain selector on nested surfaces.
- `vp test src/lib/domains/research-prototype.test.ts src/components/app-shell/navigation-config.test.ts src/components/app-shell/app-shell-title.test.ts`

## Checklist

- [x] I ran relevant checks locally (`vp test` on domain/nav/breadcrumb tests)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)