### PR TITLE
feat(web): expand keyword research screen

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keyword-analysis.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keyword-analysis.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useIntl } from "react-intl";
+import { Line, LineChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { Badge } from "@/components/ui/badge";
+import type { KeywordIdea, SerpResult } from "@/lib/domains/research-prototype";
+import { keywordScreenMessages as messages } from "./domain-keyword-screen.messages";
+import { domainKeywordsViewMessages as shared } from "./domain-keywords-view.messages";
+
+export function DomainKeywordAnalysis({
+  keyword,
+  results,
+}: {
+  keyword: KeywordIdea | null;
+  results: SerpResult[];
+}) {
+  const intl = useIntl();
+  const t = intl.formatMessage;
+  const history = keyword?.monthlySearches ?? [];
+  return (
+    <aside className="flex min-w-0 flex-col gap-4" aria-label={t(messages.serp)}>
+      <section className="rounded-lg border border-border p-4">
+        <h3 className="text-sm font-semibold">{t(messages.trends)}</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {keyword?.keyword ?? t(messages.chooseKeyword)}
+        </p>
+        {history.length ? (
+          <>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {history[0]?.month} – {history.at(-1)?.month}
+            </p>
+            <ChartContainer
+              className="mt-4 h-52 w-full"
+              config={{ volume: { label: t(shared.columnVolume), color: "var(--primary)" } }}
+            >
+              <LineChart
+                data={history}
+                accessibilityLayer
+                margin={{ left: 0, right: 12, top: 8, bottom: 0 }}
+              >
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey="month"
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={(month: string) =>
+                    intl.formatDate(new Date(`${month}-01T00:00:00Z`), {
+                      month: "short",
+                      timeZone: "UTC",
+                    })
+                  }
+                  minTickGap={24}
+                />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  width={42}
+                  tickFormatter={(value: number) =>
+                    intl.formatNumber(value, { notation: "compact" })
+                  }
+                />
+                <ChartTooltip content={<ChartTooltipContent />} />
+                <Line
+                  dataKey="volume"
+                  type="linear"
+                  stroke="var(--color-volume)"
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ChartContainer>
+          </>
+        ) : (
+          <p className="flex min-h-40 items-center text-sm text-muted-foreground">
+            {t(messages.noTrend)}
+          </p>
+        )}
+      </section>
+      <section className="rounded-lg border border-border">
+        <div className="border-b border-border p-4">
+          <h3 className="text-sm font-semibold">{t(messages.serp)}</h3>
+          <p className="mt-1 break-words text-sm text-muted-foreground">
+            {keyword?.keyword ?? t(messages.chooseKeyword)}
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            {t(messages.organicResults, { count: results.length })}
+          </p>
+        </div>
+        {results.length ? (
+          <ol className="divide-y divide-border px-4">
+            {results.map((result) => (
+              <li key={result.url} className="flex gap-3 py-4">
+                <span className="pt-0.5 text-xs tabular-nums text-muted-foreground">
+                  {result.position}
+                </span>
+                <div className="min-w-0">
+                  <a
+                    href={result.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+                  >
+                    {result.title}
+                  </a>
+                  <p className="mt-1 truncate text-xs text-muted-foreground">
+                    {new URL(result.url).hostname}
+                  </p>
+                  {result.isOwn ? (
+                    <Badge variant="outline" className="mt-2">
+                      {t(shared.ownResult)}
+                    </Badge>
+                  ) : null}
+                  <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                    {result.snippet}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="p-4 text-sm text-muted-foreground">{t(shared.serpEmpty)}</p>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keyword-screen.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keyword-screen.messages.ts
@@ -1,0 +1,179 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const keywordScreenMessages = defineMessages({
+  preview: {
+    defaultMessage:
+      "Sample research data. Search explores the available sample keywords; live discovery is not connected.",
+    id: "RNhpJbIBLD",
+    description: "Keyword research screen: preview",
+  },
+  search: {
+    defaultMessage: "Search keywords",
+    id: "Ns3Vzly6UD",
+    description: "Keyword research screen: search",
+  },
+  query: {
+    defaultMessage: "Keyword or phrase",
+    id: "fvon1YlGXk",
+    description: "Keyword research screen: query",
+  },
+  market: {
+    defaultMessage: "Market",
+    id: "JMzTiNnROZ",
+    description: "Keyword research screen: market",
+  },
+  filters: {
+    defaultMessage: "Filters",
+    id: "4T/AtweOC2",
+    description: "Keyword research screen: filters",
+  },
+  clear: {
+    defaultMessage: "Clear filters",
+    id: "fhcfvZHdGC",
+    description: "Keyword research screen: clear",
+  },
+  include: {
+    defaultMessage: "Include terms",
+    id: "4lGFVcdtnA",
+    description: "Keyword research screen: include",
+  },
+  exclude: {
+    defaultMessage: "Exclude terms",
+    id: "CnbGz8i/pk",
+    description: "Keyword research screen: exclude",
+  },
+  minVolume: {
+    defaultMessage: "Minimum volume",
+    id: "NXwxON9LCL",
+    description: "Keyword research screen: minVolume",
+  },
+  maxKd: {
+    defaultMessage: "Maximum difficulty",
+    id: "A7ZTePMTy2",
+    description: "Keyword research screen: maxKd",
+  },
+  allIntents: {
+    defaultMessage: "All intents",
+    id: "iLRYt1dvNP",
+    description: "Keyword research screen: allIntents",
+  },
+  competition: {
+    defaultMessage: "Competition",
+    id: "EXLDt167uQ",
+    description: "Keyword research screen: competition",
+  },
+  trends: {
+    defaultMessage: "Search trends",
+    id: "P39hls014a",
+    description: "Keyword research screen: trends",
+  },
+  noTrend: {
+    defaultMessage: "No monthly search history for this keyword yet.",
+    id: "7ockoYickt",
+    description: "Keyword research screen: noTrend",
+  },
+  results: {
+    defaultMessage: "{count, plural, one {# keyword} other {# keywords}}",
+    id: "d/j4DMj6XN",
+    description: "Keyword research screen: results",
+  },
+  export: {
+    defaultMessage: "Export CSV",
+    id: "0Kd+BaMKpW",
+    description: "Keyword research screen: export",
+  },
+  exportSelected: {
+    defaultMessage: "Export selected CSV",
+    id: "oH98RKdc2i",
+    description: "Keyword research screen: exportSelected",
+  },
+  selectAll: {
+    defaultMessage: "Select all visible keywords",
+    id: "HJz9Sf66Te",
+    description: "Keyword research screen: selectAll",
+  },
+  noMatches: {
+    defaultMessage: "No keywords match your search and filters.",
+    id: "VMtLP9ozqB",
+    description: "Keyword research screen: noMatches",
+  },
+  resetSearch: {
+    defaultMessage: "Reset search",
+    id: "gbgp71RdPY",
+    description: "Keyword research screen: resetSearch",
+  },
+  serp: {
+    defaultMessage: "SERP analysis",
+    id: "aKcI4nX5x6",
+    description: "Keyword research screen: serp",
+  },
+  organicResults: {
+    defaultMessage: "{count, plural, one {# organic result} other {# organic results}}",
+    id: "b2YL8gmkMg",
+    description: "Keyword research screen: organicResults",
+  },
+  chooseKeyword: {
+    defaultMessage: "Select a keyword to inspect its search demand and ranking results.",
+    id: "fWyfUTYZOq",
+    description: "Keyword research screen: chooseKeyword",
+  },
+  volumeHelp: {
+    defaultMessage: "Average monthly searches",
+    id: "6P1yaulLzF",
+    description: "Keyword research screen: volumeHelp",
+  },
+  kdHelp: {
+    defaultMessage: "Organic ranking difficulty, from 0 to 100. Higher is harder.",
+    id: "bOIgbrxaPd",
+    description: "Keyword research screen: kdHelp",
+  },
+  competitionHelp: {
+    defaultMessage: "Paid-search competition, from 0 to 1. Higher means more advertisers.",
+    id: "pFQUoH8pKh",
+    description: "Keyword research screen: competitionHelp",
+  },
+  cpcHelp: {
+    defaultMessage: "Cost per click in EUR for this sample dataset.",
+    id: "Z/LwXy5NwT",
+    description: "Keyword research screen: cpcHelp",
+  },
+  clearSelection: {
+    defaultMessage: "Clear selection",
+    id: "BXS2nvRpU+",
+    description: "Keyword research screen: clearSelection",
+  },
+  minCpc: {
+    defaultMessage: "Minimum CPC",
+    id: "8gMDutTCiw",
+    description: "Keyword research screen: minCpc",
+  },
+  maxCpc: {
+    defaultMessage: "Maximum CPC",
+    id: "5flm2IPpbq",
+    description: "Keyword research screen: maxCpc",
+  },
+  maxVolume: {
+    defaultMessage: "Maximum volume",
+    id: "BCgBQdXPnG",
+    description: "Keyword research screen: maxVolume",
+  },
+  minKd: {
+    defaultMessage: "Minimum difficulty",
+    id: "sLEdMYz0jq",
+    description: "Keyword research screen: minKd",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.tsx
@@ -41,6 +41,7 @@ import { DomainKeywordAnalysis } from "./domain-keyword-analysis";
 import {
   filterKeywordIdeas,
   keywordIdeasCsv,
+  resolveActiveKeyword,
   type KeywordFilters,
   type KeywordSort,
 } from "@/lib/domains/keyword-screen";
@@ -75,7 +76,7 @@ function KeywordScreen({ catalog }: { catalog: DomainResearchCatalog }) {
   const [activeId, setActiveId] = useState<string | null>(catalog.keywords[0]?.id ?? null);
   const keywords = market === catalog.domain.market.id ? catalog.keywords : [];
   const rows = filterKeywordIdeas(keywords, search, filters, sort);
-  const active = keywords.find((row) => row.id === activeId) ?? null;
+  const active = resolveActiveKeyword(rows, activeId);
   const selectedRows = rows.filter((row) => selected.includes(row.id));
   const allSelected = rows.length > 0 && selectedRows.length === rows.length;
   const activeFilterCount = Object.entries(filters).filter(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.tsx
@@ -12,236 +12,403 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useMemo, useState } from "react";
-import { Add01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { FormattedMessage, useIntl } from "react-intl";
-import { toast } from "sonner";
-
-import { Badge } from "@/components/ui/badge";
+import { useState } from "react";
+import { useIntl } from "react-intl";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Field, FieldLabel } from "@/components/ui/field";
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { TypographyP } from "@/components/ui/typography";
-import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  getResearchPrototypeCatalog,
+  DOMAIN_RESEARCH_MARKETS,
+  type DomainResearchCatalog,
+  type KeywordIdea,
+} from "@/lib/domains/research-prototype";
 import { cn } from "@/lib/primitives/cn";
-
-import { DomainResearchEmpty } from "./domain-research-empty";
 import { formatKeywordIntent } from "./domain-research-format";
-import { domainKeywordsViewMessages as messages } from "./domain-keywords-view.messages";
-import { DomainSeedKeywordsDialog } from "./domain-seed-keywords-dialog";
+import { domainKeywordsViewMessages as shared } from "./domain-keywords-view.messages";
+import { keywordScreenMessages as messages } from "./domain-keyword-screen.messages";
+import { DomainKeywordAnalysis } from "./domain-keyword-analysis";
+import {
+  filterKeywordIdeas,
+  keywordIdeasCsv,
+  type KeywordFilters,
+  type KeywordSort,
+} from "@/lib/domains/keyword-screen";
 
-const KEYWORD_GRID =
-  "grid grid-cols-[auto_minmax(12rem,1.4fr)_repeat(3,minmax(4.5rem,0.55fr))_minmax(6rem,0.7fr)_auto] items-center gap-3 px-3 py-2.5";
+const EMPTY_FILTERS: KeywordFilters = {
+  include: "",
+  exclude: "",
+  minVolume: "",
+  maxVolume: "",
+  minKd: "",
+  maxKd: "",
+  minCpc: "",
+  maxCpc: "",
+  intent: "all",
+};
 
 export function DomainKeywordsView({ linkedDomainId }: { linkedDomainId: string }) {
-  const intl = useIntl();
   const catalog = getResearchPrototypeCatalog(linkedDomainId);
-  const [seedOpen, setSeedOpen] = useState(false);
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [serpKeywordId, setSerpKeywordId] = useState<string | null>(null);
+  return catalog ? <KeywordScreen key={linkedDomainId} catalog={catalog} /> : null;
+}
 
-  const keywords = catalog?.keywords ?? [];
-  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
-  const serpKeyword = keywords.find((keyword) => keyword.id === serpKeywordId) ?? null;
-  const serpResults = serpKeyword ? (catalog?.serpByKeywordId[serpKeyword.id] ?? []) : [];
-
-  if (!catalog) {
-    return null;
+function KeywordScreen({ catalog }: { catalog: DomainResearchCatalog }) {
+  const intl = useIntl();
+  const t = intl.formatMessage;
+  const [query, setQuery] = useState("");
+  const [search, setSearch] = useState("");
+  const [market, setMarket] = useState(catalog.domain.market.id);
+  const [filters, setFilters] = useState(EMPTY_FILTERS);
+  const [showFilters, setShowFilters] = useState(false);
+  const [sort, setSort] = useState<KeywordSort>({ field: "volume", direction: "desc" });
+  const [selected, setSelected] = useState<string[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(catalog.keywords[0]?.id ?? null);
+  const keywords = market === catalog.domain.market.id ? catalog.keywords : [];
+  const rows = filterKeywordIdeas(keywords, search, filters, sort);
+  const active = keywords.find((row) => row.id === activeId) ?? null;
+  const selectedRows = rows.filter((row) => selected.includes(row.id));
+  const allSelected = rows.length > 0 && selectedRows.length === rows.length;
+  const activeFilterCount = Object.entries(filters).filter(
+    ([key, value]) => value !== "" && !(key === "intent" && value === "all"),
+  ).length;
+  const columns = [
+    { field: "keyword", label: shared.columnKeyword },
+    { field: "volume", label: shared.columnVolume, help: messages.volumeHelp },
+    { field: "kd", label: shared.columnKd, help: messages.kdHelp },
+    { field: "cpc", label: shared.columnCpc, help: messages.cpcHelp },
+    { field: "competition", label: messages.competition, help: messages.competitionHelp },
+  ] as const;
+  function exportCsv() {
+    const csv = keywordIdeasCsv(selectedRows.length ? selectedRows : rows);
+    const url = URL.createObjectURL(new Blob(["\uFEFF", csv], { type: "text/csv;charset=utf-8;" }));
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `keywords-${catalog.domain.domainKey}-${market}.csv`;
+    link.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
-
-  function toggleKeyword(id: string, checked: boolean) {
-    setSelectedIds((current) =>
-      checked
-        ? current.includes(id)
-          ? current
-          : [...current, id]
-        : current.filter((item) => item !== id),
-    );
+  function reset() {
+    setQuery("");
+    setSearch("");
+    setFilters(EMPTY_FILTERS);
+    setMarket(catalog.domain.market.id);
+    setSelected([]);
+    setActiveId(catalog.keywords[0]?.id ?? null);
   }
-
+  function metric(row: KeywordIdea, field: "volume" | "kd" | "cpc" | "competition") {
+    const value = row[field];
+    return value == null
+      ? "—"
+      : field === "cpc"
+        ? intl.formatNumber(value, { style: "currency", currency: "EUR" })
+        : intl.formatNumber(value, { maximumFractionDigits: 2 });
+  }
   return (
-    <div className="grid gap-4">
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <Button size="sm" variant="outline" onClick={() => setSeedOpen(true)}>
-          <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-          <FormattedMessage {...messages.seedCta} />
-        </Button>
-      </div>
-
-      {keywords.length === 0 ? (
-        <DomainResearchEmpty
-          title={<FormattedMessage {...messages.emptyTitle} />}
-          description={<FormattedMessage {...messages.emptyDescription} />}
-          action={
-            <Button size="sm" onClick={() => setSeedOpen(true)}>
-              <FormattedMessage {...messages.seedCta} />
-            </Button>
-          }
-        />
-      ) : (
-        <div className="overflow-x-auto rounded-lg border border-border">
-          <div
-            className={cn(
-              KEYWORD_GRID,
-              "border-b border-border bg-muted/40 text-xs font-medium text-muted-foreground",
-            )}
-          >
-            <span />
-            <span>
-              <FormattedMessage {...messages.columnKeyword} />
-            </span>
-            <span className="text-end">
-              <FormattedMessage {...messages.columnVolume} />
-            </span>
-            <span className="text-end">
-              <FormattedMessage {...messages.columnKd} />
-            </span>
-            <span className="text-end">
-              <FormattedMessage {...messages.columnCpc} />
-            </span>
-            <span>
-              <FormattedMessage {...messages.columnIntent} />
-            </span>
-            <span />
-          </div>
-          <div className="divide-y divide-border">
-            {keywords.map((keyword) => (
-              <div key={keyword.id} className={KEYWORD_GRID}>
-                <Checkbox
-                  checked={selectedSet.has(keyword.id)}
-                  onCheckedChange={(checked) => toggleKeyword(keyword.id, checked === true)}
-                  aria-label={intl.formatMessage(messages.selectKeyword, {
-                    keyword: keyword.keyword,
-                  })}
-                />
-                <button
-                  type="button"
-                  className="min-w-0 truncate text-start font-medium text-foreground underline-offset-4 hover:underline"
-                  onClick={() => setSerpKeywordId(keyword.id)}
-                >
-                  {keyword.keyword}
-                </button>
-                <span className="text-end tabular-nums text-sm text-muted-foreground">
-                  {intl.formatNumber(keyword.volume)}
-                </span>
-                <span className="text-end tabular-nums text-sm text-muted-foreground">
-                  {keyword.kd}
-                </span>
-                <span className="text-end tabular-nums text-sm text-muted-foreground">
-                  {intl.formatNumber(keyword.cpc, {
-                    style: "currency",
-                    currency: "EUR",
-                  })}
-                </span>
-                <Badge variant="outline">{formatKeywordIntent(intl, keyword.intent)}</Badge>
-                <Button size="sm" variant="ghost" onClick={() => setSerpKeywordId(keyword.id)}>
-                  <FormattedMessage {...messages.inspectSerp} />
-                </Button>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {selectedIds.length > 0 ? (
-        <div className="sticky bottom-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-popover px-4 py-3 shadow-lg">
-          <TypographyP size="small">
-            <FormattedMessage {...messages.selectedCount} values={{ count: selectedIds.length }} />
-          </TypographyP>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => {
-                toast.success(intl.formatMessage(messages.saved));
-                setSelectedIds([]);
-              }}
-            >
-              <FormattedMessage {...messages.save} />
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => {
-                toast.success(intl.formatMessage(messages.sentToRanks));
-                setSelectedIds([]);
-              }}
-            >
-              <FormattedMessage {...messages.sendToRanks} />
-            </Button>
-          </div>
-        </div>
-      ) : null}
-
-      <DomainSeedKeywordsDialog
-        open={seedOpen}
-        defaultKeyword={keywords[0]?.keyword ?? "traduction automatique"}
-        defaultMarketId={catalog.domain.market.id}
-        onOpenChange={setSeedOpen}
-      />
-
-      <Sheet
-        open={Boolean(serpKeyword)}
-        onOpenChange={(open) => {
-          if (!open) {
-            setSerpKeywordId(null);
-          }
+    <div className="flex min-w-0 flex-col gap-4">
+      <form
+        className="flex flex-wrap items-end gap-3 rounded-lg border border-border p-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          setSearch(query.trim());
+          setActiveId(filterKeywordIdeas(keywords, query, filters, sort)[0]?.id ?? null);
+          setSelected([]);
         }}
       >
-        <SheetContent side="right" className="sm:max-w-lg">
-          <SheetHeader>
-            <SheetTitle>
-              <FormattedMessage
-                {...messages.serpTitle}
-                values={{ keyword: serpKeyword?.keyword ?? "" }}
-              />
-            </SheetTitle>
-            <SheetDescription>
-              <FormattedMessage
-                {...messages.serpDescription}
-                values={{ market: catalog.domain.market.label }}
-              />
-            </SheetDescription>
-          </SheetHeader>
-          <div className="grid gap-3 overflow-y-auto px-6 pb-6">
-            {serpResults.length === 0 ? (
-              <TypographyP size="small" tone="subtle">
-                <FormattedMessage {...messages.serpEmpty} />
-              </TypographyP>
-            ) : (
-              serpResults.map((result) => (
-                <article
-                  key={`${result.position}-${result.url}`}
-                  className={cn(
-                    "rounded-xl border border-border p-3",
-                    result.isOwn && "border-primary/40 bg-muted/60",
-                  )}
+        <Field className="min-w-48 flex-1">
+          <FieldLabel htmlFor="keyword-query">{t(messages.query)}</FieldLabel>
+          <Input
+            id="keyword-query"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={catalog.keywords[0]?.keyword ?? t(messages.query)}
+          />
+        </Field>
+        <Field className="w-full sm:w-48">
+          <FieldLabel htmlFor="keyword-market">{t(messages.market)}</FieldLabel>
+          <Select
+            value={market}
+            items={DOMAIN_RESEARCH_MARKETS.map((item) => ({ value: item.id, label: item.label }))}
+            onValueChange={(value) => {
+              if (value) {
+                setMarket(value);
+                setSelected([]);
+                setActiveId(
+                  value === catalog.domain.market.id ? (catalog.keywords[0]?.id ?? null) : null,
+                );
+              }
+            }}
+          >
+            <SelectTrigger id="keyword-market" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {DOMAIN_RESEARCH_MARKETS.map((item) => (
+                  <SelectItem key={item.id} value={item.id} label={item.label}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Button type="submit">{t(messages.search)}</Button>
+      </form>
+      <p className="text-xs text-muted-foreground">{t(messages.preview)}</p>
+      <div className="grid min-w-0 items-start gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(18rem,2fr)]">
+        <div className="flex min-w-0 flex-col gap-4">
+          {active ? (
+            <section
+              className="flex flex-wrap items-center gap-x-6 gap-y-3 rounded-lg border border-border px-4 py-3"
+              aria-label={active.keyword}
+            >
+              <div className="min-w-0">
+                <h2 className="break-words text-base font-semibold">{active.keyword}</h2>
+                <Badge variant="outline" className="mt-1">
+                  {formatKeywordIntent(intl, active.intent)}
+                </Badge>
+              </div>
+              <dl className="flex flex-wrap gap-4">
+                {columns
+                  .filter((col) => col.field !== "keyword")
+                  .map((col) => (
+                    <div key={col.field}>
+                      <dt className="text-xs text-muted-foreground">{t(col.label)}</dt>
+                      <dd className="mt-1 text-sm font-medium tabular-nums">
+                        {metric(active, col.field as "volume" | "kd" | "cpc" | "competition")}
+                      </dd>
+                    </div>
+                  ))}
+              </dl>
+            </section>
+          ) : null}
+          <section className="min-w-0 overflow-hidden rounded-lg border border-border">
+            <div className="flex flex-wrap items-center gap-2 border-b border-border p-3">
+              <Button
+                size="sm"
+                variant="outline"
+                aria-expanded={showFilters}
+                aria-controls="keyword-filters"
+                onClick={() => setShowFilters(!showFilters)}
+              >
+                {t(messages.filters)}
+                {activeFilterCount ? ` (${activeFilterCount})` : ""}
+              </Button>
+              <span className="text-xs text-muted-foreground">
+                {t(messages.results, { count: rows.length })}
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="ms-auto"
+                disabled={!rows.length}
+                onClick={exportCsv}
+              >
+                {t(selectedRows.length ? messages.exportSelected : messages.export)}
+              </Button>
+            </div>
+            {showFilters ? (
+              <div
+                id="keyword-filters"
+                className="grid gap-3 border-b border-border bg-muted/20 p-4 sm:grid-cols-2"
+              >
+                {(
+                  [
+                    "include",
+                    "exclude",
+                    "minVolume",
+                    "maxVolume",
+                    "minKd",
+                    "maxKd",
+                    "minCpc",
+                    "maxCpc",
+                  ] as const
+                ).map((name) => (
+                  <Field key={name}>
+                    <FieldLabel htmlFor={`keyword-${name}`}>{t(messages[name])}</FieldLabel>
+                    <Input
+                      id={`keyword-${name}`}
+                      type={name === "include" || name === "exclude" ? "text" : "number"}
+                      min={0}
+                      step={name.endsWith("Cpc") ? "0.01" : "1"}
+                      value={filters[name]}
+                      onChange={(event) =>
+                        setFilters((current) => ({ ...current, [name]: event.target.value }))
+                      }
+                    />
+                  </Field>
+                ))}
+                <Field>
+                  <FieldLabel htmlFor="keyword-intent">{t(shared.columnIntent)}</FieldLabel>
+                  <Select
+                    value={filters.intent}
+                    items={[
+                      { value: "all", label: t(messages.allIntents) },
+                      ...(
+                        ["informational", "commercial", "transactional", "navigational"] as const
+                      ).map((intent) => ({
+                        value: intent,
+                        label: formatKeywordIntent(intl, intent),
+                      })),
+                    ]}
+                    onValueChange={(value) => {
+                      if (value) setFilters((current) => ({ ...current, intent: value }));
+                    }}
+                  >
+                    <SelectTrigger id="keyword-intent">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectItem value="all">{t(messages.allIntents)}</SelectItem>
+                        {(
+                          ["informational", "commercial", "transactional", "navigational"] as const
+                        ).map((intent) => (
+                          <SelectItem key={intent} value={intent}>
+                            {formatKeywordIntent(intl, intent)}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </Field>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="self-end"
+                  onClick={() => setFilters(EMPTY_FILTERS)}
                 >
-                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                    <span className="tabular-nums">#{result.position}</span>
-                    {result.isOwn ? (
-                      <Badge variant="success">
-                        <FormattedMessage {...messages.ownResult} />
-                      </Badge>
-                    ) : null}
-                  </div>
-                  <p className="mt-1 font-medium text-foreground">{result.title}</p>
-                  <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
-                    {result.url}
-                  </p>
-                  <p className="mt-2 text-sm text-muted-foreground">{result.snippet}</p>
-                </article>
-              ))
-            )}
-          </div>
-        </SheetContent>
-      </Sheet>
+                  {t(messages.clear)}
+                </Button>
+              </div>
+            ) : null}
+            {selectedRows.length ? (
+              <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/30 px-4 py-2">
+                <span className="text-xs">
+                  {t(shared.selectedCount, { count: selectedRows.length })}
+                </span>
+                <Button size="sm" variant="ghost" onClick={() => setSelected([])}>
+                  {t(messages.clearSelection)}
+                </Button>
+              </div>
+            ) : null}
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/30 text-xs text-muted-foreground">
+                  <tr>
+                    <th className="p-3">
+                      <Checkbox
+                        aria-label={t(messages.selectAll)}
+                        checked={allSelected ? true : selectedRows.length ? "indeterminate" : false}
+                        onCheckedChange={(checked) =>
+                          setSelected(checked === true ? rows.map((row) => row.id) : [])
+                        }
+                      />
+                    </th>
+                    {columns.map((col) => (
+                      <th
+                        key={col.field}
+                        className="whitespace-nowrap px-3 py-2 text-start"
+                        aria-sort={
+                          sort.field === col.field
+                            ? sort.direction === "asc"
+                              ? "ascending"
+                              : "descending"
+                            : "none"
+                        }
+                      >
+                        <button
+                          type="button"
+                          title={"help" in col ? t(col.help) : undefined}
+                          className="py-2"
+                          onClick={() =>
+                            setSort({
+                              field: col.field,
+                              direction:
+                                sort.field === col.field && sort.direction === "desc"
+                                  ? "asc"
+                                  : "desc",
+                            })
+                          }
+                        >
+                          {t(col.label)}{" "}
+                          {sort.field === col.field ? (sort.direction === "asc" ? "↑" : "↓") : ""}
+                        </button>
+                      </th>
+                    ))}
+                    <th className="px-3 py-2 text-start">{t(shared.columnIntent)}</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {rows.map((row) => (
+                    <tr
+                      key={row.id}
+                      className={cn("hover:bg-muted/30", active?.id === row.id && "bg-muted/50")}
+                    >
+                      <td className="p-3">
+                        <Checkbox
+                          checked={selected.includes(row.id)}
+                          aria-label={t(shared.selectKeyword, { keyword: row.keyword })}
+                          onCheckedChange={(checked) =>
+                            setSelected((current) =>
+                              checked === true
+                                ? [...new Set([...current, row.id])]
+                                : current.filter((id) => id !== row.id),
+                            )
+                          }
+                        />
+                      </td>
+                      <td className="min-w-48 px-3 py-3">
+                        <button
+                          type="button"
+                          aria-pressed={active?.id === row.id}
+                          onClick={() => setActiveId(row.id)}
+                          className="text-start font-medium underline-offset-4 hover:underline"
+                        >
+                          {row.keyword}
+                        </button>
+                      </td>
+                      {(["volume", "kd", "cpc", "competition"] as const).map((field) => (
+                        <td
+                          key={field}
+                          className="whitespace-nowrap px-3 py-3 text-end tabular-nums text-muted-foreground"
+                        >
+                          {metric(row, field)}
+                        </td>
+                      ))}
+                      <td className="px-3 py-3">
+                        <Badge variant="outline">{formatKeywordIntent(intl, row.intent)}</Badge>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {!rows.length ? (
+              <div className="flex flex-col items-center gap-3 px-4 py-12 text-center">
+                <p className="text-sm text-muted-foreground">{t(messages.noMatches)}</p>
+                <Button size="sm" variant="outline" onClick={reset}>
+                  {t(messages.resetSearch)}
+                </Button>
+              </div>
+            ) : null}
+          </section>
+        </div>
+        <DomainKeywordAnalysis
+          keyword={active}
+          results={active ? (catalog.serpByKeywordId[active.id] ?? []) : []}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/domains/keyword-screen.test.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/keyword-screen.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+import { filterKeywordIdeas, keywordIdeasCsv, type KeywordFilters } from "./keyword-screen";
+import type { KeywordIdea } from "./research-prototype";
+
+const filters: KeywordFilters = {
+  include: "",
+  exclude: "",
+  minVolume: "",
+  maxVolume: "",
+  minKd: "",
+  maxKd: "",
+  minCpc: "",
+  maxCpc: "",
+  intent: "all",
+};
+const rows: KeywordIdea[] = [
+  {
+    id: "a",
+    keyword: "Traduction API",
+    volume: 100,
+    kd: 20,
+    cpc: 1.5,
+    competition: 0,
+    intent: "commercial",
+  },
+  { id: "b", keyword: "Traduction gratuite", volume: 500, kd: 50, cpc: 0, intent: "informational" },
+  {
+    id: "c",
+    keyword: "Logiciel traduction API",
+    volume: 300,
+    kd: 30,
+    cpc: 3,
+    competition: 0.5,
+    intent: "commercial",
+  },
+];
+describe("keyword research table", () => {
+  it("combines query, include/exclude terms, intent and inclusive ranges", () => {
+    expect(
+      filterKeywordIdeas(
+        rows,
+        "TRADUCTION",
+        {
+          ...filters,
+          include: "traduction, api",
+          exclude: "logiciel, gratuite",
+          minVolume: "100",
+          maxVolume: "300",
+          maxKd: "20",
+          minCpc: "1.5",
+          intent: "commercial",
+        },
+        { field: "volume", direction: "desc" },
+      ).map((row) => row.id),
+    ).toEqual(["a"]);
+  });
+  it("keeps unavailable metrics last in either direction and preserves zero", () => {
+    expect(
+      filterKeywordIdeas(rows, "", filters, { field: "competition", direction: "asc" }).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["a", "c", "b"]);
+    expect(
+      filterKeywordIdeas(rows, "", filters, { field: "competition", direction: "desc" }).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["c", "a", "b"]);
+    expect(rows.map((row) => row.id)).toEqual(["a", "b", "c"]);
+  });
+  it("returns no matches for contradictory numeric bounds", () => {
+    expect(
+      filterKeywordIdeas(
+        rows,
+        "",
+        { ...filters, minVolume: "500", maxVolume: "100" },
+        { field: "volume", direction: "asc" },
+      ),
+    ).toEqual([]);
+  });
+  it("exports Unicode, quotes and missing metrics without spreadsheet formulas", () => {
+    const csv = keywordIdeasCsv([
+      { ...rows[0]!, keyword: '=HYPERLINK("https://example.com")' },
+      { ...rows[1]!, keyword: '翻訳, "API"' },
+    ]);
+    expect(csv).toContain('"\'=HYPERLINK(""https://example.com"")"');
+    expect(csv).toContain('"翻訳, ""API"""');
+    expect(csv).toContain('"0","","informational"');
+    expect(csv.split("\r\n")).toHaveLength(3);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/domains/keyword-screen.test.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/keyword-screen.test.ts
@@ -11,7 +11,12 @@
  * Version 2.0 or later.
  */
 import { describe, expect, it } from "vite-plus/test";
-import { filterKeywordIdeas, keywordIdeasCsv, type KeywordFilters } from "./keyword-screen";
+import {
+  filterKeywordIdeas,
+  keywordIdeasCsv,
+  resolveActiveKeyword,
+  type KeywordFilters,
+} from "./keyword-screen";
 import type { KeywordIdea } from "./research-prototype";
 
 const filters: KeywordFilters = {
@@ -88,6 +93,16 @@ describe("keyword research table", () => {
         { field: "volume", direction: "asc" },
       ),
     ).toEqual([]);
+  });
+  it("resolves the active keyword from visible rows only", () => {
+    expect(resolveActiveKeyword(rows, "c")?.id).toBe("c");
+    expect(
+      resolveActiveKeyword(
+        rows.filter((row) => row.id !== "a"),
+        "a",
+      )?.id,
+    ).toBe("b");
+    expect(resolveActiveKeyword([], "a")).toBeNull();
   });
   it("exports Unicode, quotes and missing metrics without spreadsheet formulas", () => {
     const csv = keywordIdeasCsv([

--- a/apps/hyperlocalise-web/src/lib/domains/keyword-screen.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/keyword-screen.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { KeywordIdea } from "./research-prototype";
+
+export type KeywordFilters = Record<
+  | "include"
+  | "exclude"
+  | "minVolume"
+  | "maxVolume"
+  | "minKd"
+  | "maxKd"
+  | "minCpc"
+  | "maxCpc"
+  | "intent",
+  string
+>;
+export type KeywordSort = {
+  field: "keyword" | "volume" | "kd" | "cpc" | "competition";
+  direction: "asc" | "desc";
+};
+
+export function filterKeywordIdeas(
+  rows: KeywordIdea[],
+  query: string,
+  filters: KeywordFilters,
+  sort: KeywordSort,
+) {
+  const terms = (text: string) =>
+    text
+      .toLocaleLowerCase()
+      .split(",")
+      .map((term) => term.trim())
+      .filter(Boolean);
+  const include = terms(filters.include);
+  const exclude = terms(filters.exclude);
+  return rows
+    .filter((row) => {
+      const keyword = row.keyword.toLocaleLowerCase();
+      if (
+        !keyword.includes(query.trim().toLocaleLowerCase()) ||
+        !include.every((term) => keyword.includes(term)) ||
+        exclude.some((term) => keyword.includes(term))
+      )
+        return false;
+      if (filters.intent !== "all" && row.intent !== filters.intent) return false;
+      return (
+        [
+          ["volume", "minVolume", "maxVolume"],
+          ["kd", "minKd", "maxKd"],
+          ["cpc", "minCpc", "maxCpc"],
+        ] as const
+      ).every(
+        ([field, min, max]) =>
+          (filters[min] === "" || row[field] >= Number(filters[min])) &&
+          (filters[max] === "" || row[field] <= Number(filters[max])),
+      );
+    })
+    .sort((a, b) => {
+      const left = a[sort.field],
+        right = b[sort.field];
+      if (left == null) return right == null ? 0 : 1;
+      if (right == null) return -1;
+      const order =
+        typeof left === "string" && typeof right === "string"
+          ? left.localeCompare(right)
+          : Number(left) - Number(right);
+      return sort.direction === "asc" ? order : -order;
+    });
+}
+
+export function keywordIdeasCsv(rows: KeywordIdea[]) {
+  const cell = (value: string | number | undefined) => {
+    let text = String(value ?? "");
+    if (/^[=+@\-\t\r]/.test(text)) text = "'" + text;
+    return '"' + text.replaceAll('"', '""') + '"';
+  };
+  return [
+    ["Keyword", "Volume", "KD", "CPC (EUR)", "Competition", "Intent"],
+    ...rows.map((row) => [row.keyword, row.volume, row.kd, row.cpc, row.competition, row.intent]),
+  ]
+    .map((row) => row.map(cell).join(","))
+    .join("\r\n");
+}

--- a/apps/hyperlocalise-web/src/lib/domains/keyword-screen.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/keyword-screen.ts
@@ -91,3 +91,7 @@ export function keywordIdeasCsv(rows: KeywordIdea[]) {
     .map((row) => row.map(cell).join(","))
     .join("\r\n");
 }
+
+export function resolveActiveKeyword(rows: KeywordIdea[], activeId: string | null) {
+  return rows.find((row) => row.id === activeId) ?? rows[0] ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/domains/research-prototype.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/research-prototype.ts
@@ -60,6 +60,8 @@ export type KeywordIdea = {
   kd: number;
   cpc: number;
   intent: KeywordIntent;
+  competition?: number;
+  monthlySearches?: { month: string; volume: number }[];
 };
 
 export type RankRow = {
@@ -134,6 +136,21 @@ const VIETNAM_VI = DOMAIN_RESEARCH_MARKETS[3]!;
 
 const HYPERLOCALISE_KEYWORDS: KeywordIdea[] = [
   {
+    competition: 0.28,
+    monthlySearches: [
+      { month: "2025-09", volume: 6600 },
+      { month: "2025-10", volume: 7200 },
+      { month: "2025-11", volume: 8100 },
+      { month: "2025-12", volume: 5900 },
+      { month: "2026-01", volume: 7400 },
+      { month: "2026-02", volume: 8100 },
+      { month: "2026-03", volume: 9900 },
+      { month: "2026-04", volume: 9100 },
+      { month: "2026-05", volume: 8800 },
+      { month: "2026-06", volume: 8100 },
+      { month: "2026-07", volume: 7600 },
+      { month: "2026-08", volume: 8100 },
+    ],
     id: "kw-traduction-automatique",
     keyword: "traduction automatique",
     volume: 8100,


### PR DESCRIPTION
## What changed

Expand keyword research with search and market controls, a selected-keyword summary, search trends, and inline SERP results. Add filters, sortable columns, paid competition, bulk selection, and CSV export.

The responsive screen explicitly labels sample data and handles unavailable metrics. Live keyword discovery remains outside this change.

## How to test

- Passed `vp check --fix`.
- Passed all four keyword filtering, sorting, and CSV tests.
- Verified desktop/mobile layouts, search, filter reset, and bulk selection in Storybook.
- Ran `vp test`: 6,776 passed; 12 failed across five unchanged suites. Those failures persisted on retry and block full validation.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`) — web checks ran; full test suite remains failing
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review — full validation remains blocked