### PR TITLE
feat(cli): add Lokalise locales list, files list, and upload poll (HL-744)

### DIFF
--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/locales"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/lokalise"
@@ -79,6 +80,8 @@ type lokaliseUploadSourcesOptions struct {
 	applyTM             bool
 	skipDetectLangISO   bool
 	dryRun              bool
+	poll                bool
+	pollTimeout         time.Duration
 }
 
 type lokaliseUploadTranslationsOptions struct {
@@ -97,6 +100,8 @@ type lokaliseUploadTranslationsOptions struct {
 	distinguishByFile   bool
 	applyTM             bool
 	dryRun              bool
+	poll                bool
+	pollTimeout         time.Duration
 }
 
 type lokaliseGlossaryCSVWriter interface {
@@ -113,10 +118,12 @@ type lokaliseSourceDownloader interface {
 
 type lokaliseSourceUploader interface {
 	UploadSourceFile(context.Context, lokalise.SourceUploadInput) (lokalise.SourceUploadResult, error)
+	WaitForQueuedProcess(context.Context, lokalise.QueuedProcessWaitInput) (lokalise.SourceUploadResult, error)
 }
 
 type lokaliseTranslationUploader interface {
 	UploadTranslationFile(context.Context, lokalise.TranslationUploadInput) (lokalise.TranslationUploadResult, error)
+	WaitForQueuedProcess(context.Context, lokalise.QueuedProcessWaitInput) (lokalise.SourceUploadResult, error)
 }
 
 var newLokaliseGlossaryCSVWriter = func(cfg lokalise.Config) (lokaliseGlossaryCSVWriter, error) {
@@ -145,7 +152,9 @@ func newLokaliseCmd() *cobra.Command {
 		Short: "Lokalise workflow commands",
 	}
 	cmd.AddCommand(newLokaliseDownloadCmd())
+	cmd.AddCommand(newLokaliseFilesCmd())
 	cmd.AddCommand(newLokaliseGlossaryCmd())
+	cmd.AddCommand(newLokaliseLocalesCmd())
 	cmd.AddCommand(newLokaliseUploadCmd())
 	return cmd
 }
@@ -633,6 +642,7 @@ func newLokaliseUploadSourcesCmd() *cobra.Command {
 	o := lokaliseUploadSourcesOptions{
 		tokenEnv:       defaultLokaliseAPITokenEnv,
 		timeoutSeconds: 30,
+		pollTimeout:    30 * time.Second,
 	}
 	cmd := &cobra.Command{
 		Use:          "sources",
@@ -658,6 +668,8 @@ func newLokaliseUploadSourcesCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.applyTM, "apply-tm", false, "apply 100% translation memory matches during import")
 	cmd.Flags().BoolVar(&o.skipDetectLangISO, "skip-detect-lang-iso", false, "skip automatic language detection by filename")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without uploading files")
+	cmd.Flags().BoolVar(&o.poll, "poll", false, "wait until the queued Lokalise import finishes")
+	cmd.Flags().DurationVar(&o.pollTimeout, "poll-timeout", o.pollTimeout, "maximum time to wait when --poll is set (lokalise2 default 30s; CI should pass a longer duration)")
 	return cmd
 }
 
@@ -665,6 +677,7 @@ func newLokaliseUploadTranslationsCmd() *cobra.Command {
 	o := lokaliseUploadTranslationsOptions{
 		tokenEnv:       defaultLokaliseAPITokenEnv,
 		timeoutSeconds: 30,
+		pollTimeout:    30 * time.Second,
 	}
 	cmd := &cobra.Command{
 		Use:          "translations",
@@ -689,6 +702,8 @@ func newLokaliseUploadTranslationsCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.distinguishByFile, "distinguish-by-file", false, "allow same key names in different filenames")
 	cmd.Flags().BoolVar(&o.applyTM, "apply-tm", false, "apply 100% translation memory matches during import")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without uploading files")
+	cmd.Flags().BoolVar(&o.poll, "poll", false, "wait until the queued Lokalise import finishes")
+	cmd.Flags().DurationVar(&o.pollTimeout, "poll-timeout", o.pollTimeout, "maximum time to wait when --poll is set (lokalise2 default 30s; CI should pass a longer duration)")
 	return cmd
 }
 
@@ -786,8 +801,9 @@ func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOpt
 		return err
 	}
 	processed := 0
+	ctx := lokaliseCommandContext(cmd)
 	for _, file := range files {
-		result, err := client.UploadSourceFile(backgroundContext(), lokalise.SourceUploadInput{
+		result, err := client.UploadSourceFile(ctx, lokalise.SourceUploadInput{
 			ProjectID:           cfg.ProjectID,
 			SourceLocale:        sourceLocale,
 			FilePath:            file,
@@ -806,6 +822,15 @@ func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOpt
 		processed++
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "uploaded file=%s process_id=%s status=%s type=%s\n", file, result.ProcessID, result.Status, result.Type); err != nil {
 			return err
+		}
+		result, err = waitForLokaliseUploadIfRequested(cmd, client, cfg.ProjectID, strings.TrimSpace(o.branch), result, o.poll, o.pollTimeout, o.dryRun, "lokalise upload sources")
+		if err != nil {
+			return err
+		}
+		if o.poll && !o.dryRun {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "uploaded file=%s process_id=%s status=%s type=%s\n", file, result.ProcessID, result.Status, result.Type); err != nil {
+				return err
+			}
 		}
 	}
 	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-sources processed=%d\n", processed)
@@ -836,8 +861,9 @@ func executeLokaliseUploadTranslations(cmd *cobra.Command, o lokaliseUploadTrans
 		return err
 	}
 	processed := 0
+	ctx := lokaliseCommandContext(cmd)
 	for _, file := range files {
-		result, err := client.UploadTranslationFile(cmd.Context(), lokalise.TranslationUploadInput{
+		result, err := client.UploadTranslationFile(ctx, lokalise.TranslationUploadInput{
 			ProjectID:           cfg.ProjectID,
 			TargetLocale:        targetLocale,
 			FilePath:            file,
@@ -856,9 +882,58 @@ func executeLokaliseUploadTranslations(cmd *cobra.Command, o lokaliseUploadTrans
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "uploaded file=%s process_id=%s status=%s type=%s modified_translations=%s\n", file, result.ProcessID, result.Status, result.Type, modified); err != nil {
 			return err
 		}
+		result, err = waitForLokaliseUploadIfRequested(cmd, client, cfg.ProjectID, strings.TrimSpace(o.branch), result, o.poll, o.pollTimeout, o.dryRun, "lokalise upload translations")
+		if err != nil {
+			return err
+		}
+		if o.poll && !o.dryRun {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "uploaded file=%s process_id=%s status=%s type=%s modified_translations=%s\n", file, result.ProcessID, result.Status, result.Type, modified); err != nil {
+				return err
+			}
+		}
 	}
 	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-translations processed=%d modified_translations=%s\n", processed, modified)
 	return err
+}
+
+func lokaliseCommandContext(cmd *cobra.Command) context.Context {
+	if cmd != nil && cmd.Context() != nil {
+		return cmd.Context()
+	}
+	return backgroundContext()
+}
+
+type lokaliseQueuedProcessWaiter interface {
+	WaitForQueuedProcess(context.Context, lokalise.QueuedProcessWaitInput) (lokalise.SourceUploadResult, error)
+}
+
+func waitForLokaliseUploadIfRequested(cmd *cobra.Command, client lokaliseQueuedProcessWaiter, projectID, branch string, result lokalise.SourceUploadResult, poll bool, pollTimeout time.Duration, dryRun bool, action string) (lokalise.SourceUploadResult, error) {
+	if !poll || dryRun {
+		return result, nil
+	}
+	if pollTimeout <= 0 {
+		return result, fmt.Errorf("%s: --poll-timeout must be greater than 0", action)
+	}
+	ctx, cancel := context.WithTimeout(lokaliseCommandContext(cmd), pollTimeout)
+	defer cancel()
+	waited, err := client.WaitForQueuedProcess(ctx, lokalise.QueuedProcessWaitInput{
+		ProjectID: projectID,
+		ProcessID: result.ProcessID,
+		Branch:    branch,
+	})
+	if strings.TrimSpace(waited.ProcessID) == "" {
+		waited.ProcessID = result.ProcessID
+		if waited.Status == "" {
+			waited.Status = result.Status
+		}
+		if waited.Type == "" {
+			waited.Type = result.Type
+		}
+	}
+	if err != nil {
+		return waited, fmt.Errorf("%s: %w", action, err)
+	}
+	return waited, nil
 }
 
 func lokaliseModifiedTranslationsLabel(replaceModified bool) string {

--- a/apps/cli/cmd/lokalise_discovery.go
+++ b/apps/cli/cmd/lokalise_discovery.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/lokalise"
+	"github.com/spf13/cobra"
+)
+
+type lokaliseLocalesListOptions struct {
+	configPath     string
+	projectID      string
+	branch         string
+	output         string
+	tokenEnv       string
+	apiBaseURL     string
+	timeoutSeconds int
+}
+
+type lokaliseFilesListOptions struct {
+	configPath     string
+	projectID      string
+	filterFilename string
+	branch         string
+	output         string
+	tokenEnv       string
+	apiBaseURL     string
+	timeoutSeconds int
+}
+
+type lokaliseDiscoveryClient interface {
+	ListProjectLanguages(context.Context, lokalise.LocaleListInput) ([]lokalise.LocaleListItem, error)
+	ListFiles(context.Context, lokalise.FileListInput) ([]lokalise.FileListItem, error)
+}
+
+var newLokaliseDiscoveryClient = func(cfg lokalise.Config) (lokaliseDiscoveryClient, error) {
+	return lokalise.NewHTTPClient(cfg)
+}
+
+func newLokaliseLocalesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "locales",
+		Short: "list locales in a Lokalise project",
+	}
+	cmd.AddCommand(newLokaliseLocalesListCmd())
+	return cmd
+}
+
+func newLokaliseLocalesListCmd() *cobra.Command {
+	o := lokaliseLocalesListOptions{output: "text"}
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "list locales in a Lokalise project",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeLokaliseLocalesList(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to i18n.yml with storage.adapter=lokalise")
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Lokalise project ID; overrides storage.config.projectID")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Lokalise branch name")
+	cmd.Flags().StringVar(&o.output, "output", o.output, "output format: text or json")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", "", "environment variable containing the Lokalise API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
+	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", 0, "HTTP timeout in seconds")
+	return cmd
+}
+
+func newLokaliseFilesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "files",
+		Short: "list files in a Lokalise project",
+	}
+	cmd.AddCommand(newLokaliseFilesListCmd())
+	return cmd
+}
+
+func newLokaliseFilesListCmd() *cobra.Command {
+	o := lokaliseFilesListOptions{output: "text"}
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "list files in a Lokalise project",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeLokaliseFilesList(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to i18n.yml with storage.adapter=lokalise")
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Lokalise project ID; overrides storage.config.projectID")
+	cmd.Flags().StringVar(&o.filterFilename, "filter-filename", "", "substring filter on filename (not a glob)")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Lokalise branch name")
+	cmd.Flags().StringVar(&o.output, "output", o.output, "output format: text or json")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", "", "environment variable containing the Lokalise API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
+	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", 0, "HTTP timeout in seconds")
+	return cmd
+}
+
+func executeLokaliseLocalesList(cmd *cobra.Command, o lokaliseLocalesListOptions) error {
+	cfg, err := resolveLokaliseListConfig(o.configPath, o.projectID, o.tokenEnv, o.apiBaseURL, o.timeoutSeconds, "lokalise locales list")
+	if err != nil {
+		return err
+	}
+	client, err := newLokaliseDiscoveryClient(cfg)
+	if err != nil {
+		return err
+	}
+	locales, err := client.ListProjectLanguages(lokaliseCommandContext(cmd), lokalise.LocaleListInput{
+		ProjectID: cfg.ProjectID,
+		Branch:    strings.TrimSpace(o.branch),
+	})
+	if err != nil {
+		return err
+	}
+	if locales == nil {
+		locales = []lokalise.LocaleListItem{}
+	}
+	return writeEncodedOutput(cmd.OutOrStdout(), o.output, func() error {
+		for _, locale := range locales {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "id=%d iso=%s name=%s\n", locale.LanguageID, locale.LanguageISO, locale.LanguageName); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, locales)
+}
+
+func executeLokaliseFilesList(cmd *cobra.Command, o lokaliseFilesListOptions) error {
+	cfg, err := resolveLokaliseListConfig(o.configPath, o.projectID, o.tokenEnv, o.apiBaseURL, o.timeoutSeconds, "lokalise files list")
+	if err != nil {
+		return err
+	}
+	client, err := newLokaliseDiscoveryClient(cfg)
+	if err != nil {
+		return err
+	}
+	files, err := client.ListFiles(lokaliseCommandContext(cmd), lokalise.FileListInput{
+		ProjectID:      cfg.ProjectID,
+		Branch:         strings.TrimSpace(o.branch),
+		FilterFilename: strings.TrimSpace(o.filterFilename),
+	})
+	if err != nil {
+		return err
+	}
+	if files == nil {
+		files = []lokalise.FileListItem{}
+	}
+	return writeEncodedOutput(cmd.OutOrStdout(), o.output, func() error {
+		for _, file := range files {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "id=%d filename=%s keys=%d\n", file.FileID, file.Filename, file.KeyCount); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, files)
+}
+
+func resolveLokaliseListConfig(configPath, projectID, tokenEnv, apiBaseURL string, timeoutSeconds int, action string) (lokalise.Config, error) {
+	cfg := lokalise.Config{
+		ProjectID:      strings.TrimSpace(projectID),
+		APITokenEnv:    strings.TrimSpace(tokenEnv),
+		APIBaseURL:     strings.TrimSpace(apiBaseURL),
+		TimeoutSeconds: timeoutSeconds,
+	}
+
+	if strings.TrimSpace(configPath) == "" && cfg.ProjectID == "" && !defaultI18NConfigExists() {
+		return lokalise.Config{}, fmt.Errorf("%s: --project-id is required unless --config points to a Lokalise storage config", action)
+	}
+
+	if strings.TrimSpace(configPath) != "" || cfg.ProjectID == "" {
+		loaded, err := loadLokaliseStorageConfigForAction(configPath, action)
+		if err != nil {
+			if cfg.ProjectID == "" || strings.TrimSpace(configPath) != "" {
+				return lokalise.Config{}, err
+			}
+		} else {
+			if cfg.ProjectID == "" {
+				cfg.ProjectID = loaded.ProjectID
+			}
+			if cfg.APITokenEnv == "" {
+				cfg.APITokenEnv = loaded.APITokenEnv
+			}
+			if cfg.APIBaseURL == "" {
+				cfg.APIBaseURL = loaded.APIBaseURL
+			}
+			if cfg.TimeoutSeconds <= 0 {
+				cfg.TimeoutSeconds = loaded.TimeoutSeconds
+			}
+			cfg.APIToken = loaded.APIToken
+		}
+	}
+	if strings.TrimSpace(cfg.ProjectID) == "" {
+		return lokalise.Config{}, fmt.Errorf("%s: --project-id is required unless --config points to a Lokalise storage config", action)
+	}
+	if cfg.APITokenEnv == "" {
+		cfg.APITokenEnv = lokalise.DefaultTokenEnvName
+	}
+	if strings.TrimSpace(cfg.APIToken) == "" {
+		token := strings.TrimSpace(os.Getenv(cfg.APITokenEnv))
+		if token == "" && cfg.APITokenEnv != lokalise.DefaultTokenEnvName {
+			token = strings.TrimSpace(os.Getenv(lokalise.DefaultTokenEnvName))
+		}
+		if token == "" {
+			if cfg.APITokenEnv != lokalise.DefaultTokenEnvName {
+				return lokalise.Config{}, fmt.Errorf("%s: API token is required (%s or %s)", action, cfg.APITokenEnv, lokalise.DefaultTokenEnvName)
+			}
+			return lokalise.Config{}, fmt.Errorf("%s: API token is required (%s)", action, cfg.APITokenEnv)
+		}
+		cfg.APIToken = token
+	}
+	if cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = 30
+	}
+	return cfg, nil
+}

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -1269,8 +1269,11 @@ func writeLokaliseDownloadConfig(t *testing.T) string {
 }
 
 type fakeLokaliseSourceUploader struct {
-	inputs []lokalise.SourceUploadInput
-	err    error
+	inputs     []lokalise.SourceUploadInput
+	waitInputs []lokalise.QueuedProcessWaitInput
+	waitResult lokalise.SourceUploadResult
+	waitErr    error
+	err        error
 }
 
 func (f *fakeLokaliseSourceUploader) UploadSourceFile(_ context.Context, input lokalise.SourceUploadInput) (lokalise.SourceUploadResult, error) {
@@ -1281,9 +1284,27 @@ func (f *fakeLokaliseSourceUploader) UploadSourceFile(_ context.Context, input l
 	return lokalise.SourceUploadResult{ProcessID: "proc-1", Type: "file-import", Status: "queued"}, nil
 }
 
+func (f *fakeLokaliseSourceUploader) WaitForQueuedProcess(_ context.Context, in lokalise.QueuedProcessWaitInput) (lokalise.SourceUploadResult, error) {
+	f.waitInputs = append(f.waitInputs, in)
+	if f.waitErr != nil {
+		result := f.waitResult
+		if result.ProcessID == "" {
+			result.ProcessID = in.ProcessID
+		}
+		return result, f.waitErr
+	}
+	if f.waitResult.ProcessID != "" {
+		return f.waitResult, nil
+	}
+	return lokalise.SourceUploadResult{ProcessID: in.ProcessID, Type: "file-import", Status: "finished"}, nil
+}
+
 type fakeLokaliseTranslationUploader struct {
-	inputs []lokalise.TranslationUploadInput
-	err    error
+	inputs     []lokalise.TranslationUploadInput
+	waitInputs []lokalise.QueuedProcessWaitInput
+	waitResult lokalise.SourceUploadResult
+	waitErr    error
+	err        error
 }
 
 func (f *fakeLokaliseTranslationUploader) UploadTranslationFile(_ context.Context, input lokalise.TranslationUploadInput) (lokalise.TranslationUploadResult, error) {
@@ -1292,4 +1313,318 @@ func (f *fakeLokaliseTranslationUploader) UploadTranslationFile(_ context.Contex
 		return lokalise.TranslationUploadResult{}, f.err
 	}
 	return lokalise.TranslationUploadResult{ProcessID: "proc-1", Type: "file-import", Status: "queued"}, nil
+}
+
+func (f *fakeLokaliseTranslationUploader) WaitForQueuedProcess(_ context.Context, in lokalise.QueuedProcessWaitInput) (lokalise.SourceUploadResult, error) {
+	f.waitInputs = append(f.waitInputs, in)
+	if f.waitErr != nil {
+		result := f.waitResult
+		if result.ProcessID == "" {
+			result.ProcessID = in.ProcessID
+		}
+		return result, f.waitErr
+	}
+	if f.waitResult.ProcessID != "" {
+		return f.waitResult, nil
+	}
+	return lokalise.SourceUploadResult{ProcessID: in.ProcessID, Type: "file-import", Status: "finished"}, nil
+}
+
+func TestLokaliseLocalesListPrintsOfficialFields(t *testing.T) {
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+	oldFactory := newLokaliseDiscoveryClient
+	defer func() { newLokaliseDiscoveryClient = oldFactory }()
+	newLokaliseDiscoveryClient = func(cfg lokalise.Config) (lokaliseDiscoveryClient, error) {
+		if cfg.ProjectID != "project-1" || cfg.APIToken != "secret" {
+			t.Fatalf("config = %#v", cfg)
+		}
+		return &fakeLokaliseDiscoveryClient{
+			locales: []lokalise.LocaleListItem{
+				{LanguageID: 640, LanguageISO: "en", LanguageName: "English"},
+			},
+		}, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "locales", "list", "--project-id", "project-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got, want := out.String(), "id=640 iso=en name=English\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+	if strings.Contains(out.String(), "default=") {
+		t.Fatalf("invented default field: %q", out.String())
+	}
+}
+
+func TestLokaliseLocalesListUsesConfigProjectID(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+	configPath := filepath.Join(dir, "i18n.yml")
+	if err := os.WriteFile(configPath, []byte(`
+locales:
+  source: en
+  targets:
+    - de
+buckets:
+  ui:
+    files:
+      - from: content/en.json
+        to: dist/{{target}}.json
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: test
+storage:
+  adapter: lokalise
+  config:
+    projectID: project-from-config
+    apiTokenEnv: LOKALISE_TEST_TOKEN
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldFactory := newLokaliseDiscoveryClient
+	defer func() { newLokaliseDiscoveryClient = oldFactory }()
+	var gotProject string
+	newLokaliseDiscoveryClient = func(cfg lokalise.Config) (lokaliseDiscoveryClient, error) {
+		gotProject = cfg.ProjectID
+		return &fakeLokaliseDiscoveryClient{locales: []lokalise.LocaleListItem{}}, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "locales", "list", "--config", configPath, "--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotProject != "project-from-config" {
+		t.Fatalf("project = %q", gotProject)
+	}
+	if strings.TrimSpace(out.String()) != "[]" {
+		t.Fatalf("json = %q, want []", out.String())
+	}
+}
+
+func TestLokaliseLocalesListRequiresProjectID(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "locales", "list"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "lokalise locales list") || !strings.Contains(err.Error(), "--project-id") {
+		t.Fatalf("error = %v, want lokalise locales list project id", err)
+	}
+}
+
+func TestLokaliseFilesListKeepsUnassignedAndEmpty(t *testing.T) {
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+	oldFactory := newLokaliseDiscoveryClient
+	defer func() { newLokaliseDiscoveryClient = oldFactory }()
+	fake := &fakeLokaliseDiscoveryClient{
+		files: []lokalise.FileListItem{
+			{FileID: -1, Filename: "__unassigned__", KeyCount: 11},
+		},
+	}
+	newLokaliseDiscoveryClient = func(lokalise.Config) (lokaliseDiscoveryClient, error) {
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "files", "list", "--project-id", "project-1", "--filter-filename", "en.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "id=-1 filename=__unassigned__ keys=11") {
+		t.Fatalf("output = %q", out.String())
+	}
+	if fake.fileIn.FilterFilename != "en.json" {
+		t.Fatalf("filter = %#v", fake.fileIn)
+	}
+
+	fake.files = nil
+	out.Reset()
+	cmd = newRootCmd("")
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "files", "list", "--project-id", "project-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("empty list: %v", err)
+	}
+	if out.String() != "" {
+		t.Fatalf("empty text output = %q, want empty", out.String())
+	}
+}
+
+func TestLokaliseUploadSourcesPollReprintsFinished(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseSourceUploader
+	defer func() { newLokaliseSourceUploader = oldFactory }()
+	fake := &fakeLokaliseSourceUploader{}
+	newLokaliseSourceUploader = func(lokalise.Config) (lokaliseSourceUploader, error) {
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath, "--branch", "main", "--poll"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "process_id=proc-1 status=queued") {
+		t.Fatalf("missing queued line: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "process_id=proc-1 status=finished") {
+		t.Fatalf("missing finished line: %q", out.String())
+	}
+	if len(fake.waitInputs) != 1 || fake.waitInputs[0].ProcessID != "proc-1" || fake.waitInputs[0].Branch != "main" {
+		t.Fatalf("wait inputs = %#v", fake.waitInputs)
+	}
+}
+
+func TestLokaliseUploadSourcesPollKeepsProcessIDOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseSourceUploader
+	defer func() { newLokaliseSourceUploader = oldFactory }()
+	fake := &fakeLokaliseSourceUploader{
+		waitErr:    errors.New("wait timed out: status=running"),
+		waitResult: lokalise.SourceUploadResult{ProcessID: "proc-1", Status: "running"},
+	}
+	newLokaliseSourceUploader = func(lokalise.Config) (lokaliseSourceUploader, error) {
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath, "--poll"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "wait timed out") {
+		t.Fatalf("error = %v, want timeout", err)
+	}
+	if !strings.Contains(out.String(), "process_id=proc-1") {
+		t.Fatalf("missing process_id after poll failure: %q", out.String())
+	}
+}
+
+func TestLokaliseUploadSourcesPollSkippedOnDryRun(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath, "--poll", "--dry-run"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry-run action=lokalise-upload-sources") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+func TestLokaliseUploadSourcesPollTimeoutWithoutPollDoesNotWait(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseSourceUploader
+	defer func() { newLokaliseSourceUploader = oldFactory }()
+	fake := &fakeLokaliseSourceUploader{}
+	newLokaliseSourceUploader = func(lokalise.Config) (lokaliseSourceUploader, error) {
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath, "--poll-timeout", "10m"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(fake.waitInputs) != 0 {
+		t.Fatalf("wait called without --poll: %#v", fake.waitInputs)
+	}
+	if strings.Contains(out.String(), "status=finished") {
+		t.Fatalf("unexpected finished status without poll: %q", out.String())
+	}
+}
+
+func TestLokaliseUploadTranslationsPollKeepsTargetLocaleLocks(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(filePath, []byte(`{"hello":"Xin chao"}`), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseTranslationUploader
+	defer func() { newLokaliseTranslationUploader = oldFactory }()
+	fake := &fakeLokaliseTranslationUploader{}
+	newLokaliseTranslationUploader = func(lokalise.Config) (lokaliseTranslationUploader, error) {
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "translations", "--project-id", "project-1", "--target-locale", "vi", "--file", filePath, "--poll"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(fake.inputs) != 1 || fake.inputs[0].TargetLocale != "vi" {
+		t.Fatalf("input = %#v", fake.inputs)
+	}
+	if len(fake.waitInputs) != 1 {
+		t.Fatalf("wait inputs = %#v", fake.waitInputs)
+	}
+	if !strings.Contains(out.String(), "status=finished") {
+		t.Fatalf("output = %q", out.String())
+	}
+}
+
+type fakeLokaliseDiscoveryClient struct {
+	locales []lokalise.LocaleListItem
+	files   []lokalise.FileListItem
+	fileIn  lokalise.FileListInput
+}
+
+func (f *fakeLokaliseDiscoveryClient) ListProjectLanguages(_ context.Context, _ lokalise.LocaleListInput) ([]lokalise.LocaleListItem, error) {
+	if f.locales == nil {
+		return []lokalise.LocaleListItem{}, nil
+	}
+	return f.locales, nil
+}
+
+func (f *fakeLokaliseDiscoveryClient) ListFiles(_ context.Context, in lokalise.FileListInput) ([]lokalise.FileListItem, error) {
+	f.fileIn = in
+	if f.files == nil {
+		return []lokalise.FileListItem{}, nil
+	}
+	return f.files, nil
 }

--- a/docs/cli/commands/lokalise.mdx
+++ b/docs/cli/commands/lokalise.mdx
@@ -6,8 +6,10 @@ description: "Lokalise file workflow commands using project flags and API creden
 ## Usage
 
 ```bash
-hyperlocalise lokalise upload sources --project-id <id> --source-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--skip-detect-lang-iso] [--dry-run]
-hyperlocalise lokalise upload translations [--config <path>] [--project-id <id>] --target-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--dry-run]
+hyperlocalise lokalise locales list [--config <path>] [--project-id <id>] [--branch <name>] [--output text|json]
+hyperlocalise lokalise files list [--config <path>] [--project-id <id>] [--filter-filename <substr>] [--branch <name>] [--output text|json]
+hyperlocalise lokalise upload sources --project-id <id> --source-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--skip-detect-lang-iso] [--poll] [--poll-timeout <duration>] [--dry-run]
+hyperlocalise lokalise upload translations [--config <path>] [--project-id <id>] --target-locale <locale> --file <path> [--format <format>] [--branch <name>] [--tag <tag>] [--token-env <name>] [--api-base-url <url>] [--convert-placeholders] [--replace-modified] [--distinguish-by-file] [--apply-tm] [--poll] [--poll-timeout <duration>] [--dry-run]
 hyperlocalise lokalise download sources --project-id <id> --source-locale <locale> [--format <format>] [--output <path>] [--all-platforms] [--force] [--dry-run]
 hyperlocalise lokalise download translations --project-id <id> --target-locale <locale> [--format <format>] [--output <path>] [--bundle-structure <pattern>] [--branch <name>] [--force] [--dry-run]
 hyperlocalise lokalise glossary download --project-id <id> [--language <locale>] [--output <path>] [--token-env <name>] [--api-base-url <url>]
@@ -17,12 +19,14 @@ These commands are flag-only. Hyperlocalise does not read a Lokalise YAML config
 
 ## What this command family does
 
-These commands talk to the Lokalise API v2 file and glossary endpoints.
+These commands talk to the Lokalise API v2 file, language, queued-process, and glossary endpoints.
 
 They are separate from Hyperlocalise native `i18n.yml` and `sync push` / `sync pull` workflows. Use native sync when you want Hyperlocalise-managed entry sync through the [Lokalise adapter](/cli/storage/lokalise). Use this surface when you want flag-driven file upload and download against a Lokalise project.
 
 Use them for:
 
+- listing project locales (`locales list`; lokalise2 `language list`)
+- listing project files (`files list`; lokalise2 `file list`)
 - source-file upload (`upload sources`)
 - import of a pre-translated locale file (`upload translations`)
 - source download (`download sources`)
@@ -39,21 +43,25 @@ Do not put the API token in `i18n.yml`. Point `apiTokenEnv` at an environment va
 
 ## Command notes
 
+`locales list` prints `id`, `iso`, and `name` from Lokalise project languages. `iso` is the value to pass as `--source-locale` or `--target-locale`. Lokalise has no default-locale field on this API. `--output` is `text` or `json`, not a file path. Empty projects print nothing in text mode and `[]` with `--output json`. Both exit 0.
+
+`files list` prints `id`, `filename`, and `keys`. Keys with no file association appear as `__unassigned__`. `--filter-filename` is Lokalise's substring filter, not a glob. `--output` is `text` or `json`.
+
 `upload sources` requires `--project-id` (or `projectID` in `--config`), `--source-locale` (or `sourceLanguage` in `--config`), and at least one `--file`. `--dry-run` checks files and flags and does not need a token.
 
 `upload translations` requires `--target-locale` on every run. It does not take the locale from `sourceLanguage` or `targetLanguages` in `--config`. Config may still supply the project id and token. The locale comes from the flag, not the filename: uploading `en.json` as French uses `--target-locale fr`.
 
 `--replace-modified` maps to Lokalise `replace_modified`. Off (the default) preserves translations Lokalise treats as modified. On replaces those modified translations from the uploaded file. It is not a guarantee that every existing key stays unchanged. Dry-run and the success line print `modified_translations=preserved` or `modified_translations=replaced`.
 
-Success means the import is queued, not that strings are already visible in Lokalise. The command prints a process id and stops. It does not wait for the background import to finish.
+Without `--poll`, success means the import is queued. The command prints a process id and stops. `--poll` waits until the queued process reaches `finished` (lokalise2 `--poll`). `--poll-timeout` defaults to 30s, matching lokalise2. CI should pass a longer duration such as `--poll-timeout 10m`. `--poll` does not mean translations were kept. `--dry-run` does not poll. `--poll-timeout` without `--poll` is ignored. This is not Phrase `--wait`.
 
 Lokalise matches files by name. Use the same filename as the source file when you can. Language codes in the name (`en.json` / `fr.json`) are usually treated as one file. A totally different name can create a second file.
 
-`--file` can repeat for several files in that one locale. Use a separate invocation for each target locale.
+`--file` can repeat for several files in that one locale. Use a separate invocation for each target locale. `--poll` waits for each file in order.
 
 `download translations` can take more than one `--target-locale`. Use `%locale%` in `--output` when you download more than one locale to files.
 
-`glossary download` writes CSV to stdout unless you pass `--output`.
+`glossary download` writes CSV to stdout unless you pass `--output`. That `--output` is a file path, unlike list `--output text|json`.
 
 ## Crowdin and lokalise2 gap inventory
 
@@ -62,32 +70,40 @@ Lokalise matches files by name. Use the same filename as the source file when yo
 | Crowdin `upload sources` / `upload translations` | `upload sources` / `upload translations` |
 | Crowdin `download sources` / `download translations` | `download sources` / `download translations` |
 | Crowdin `glossary download` | `glossary download` (Hyperlocalise CSV) |
+| lokalise2 `language list` | `locales list` |
+| lokalise2 `file list` | `files list` |
+| lokalise2 `file upload --poll` / `--poll-timeout` | `--poll` / `--poll-timeout` on `upload sources` and `upload translations` (default 30s; not `--wait`) |
 | Crowdin `init` / `crowdin.yml` / lokalise2 config file | Unsupported (flag-only) |
-| Crowdin `status`, branch, file list/delete, string list | Out of scope |
+| Crowdin `status`, branch, file delete, string list | Out of scope |
 | Crowdin `glossary upload` / `tm` list, download, upload | Out of scope (package has no TM export) |
-| Crowdin `auto-translate` / Lokalise tasks and jobs | Out of scope |
-| lokalise2 `file upload --lang-iso` | `upload sources` or `upload translations` (queued; no `--wait`) |
-| lokalise2 process wait / file list / key CRUD | Out of scope |
+| Crowdin `auto-translate` / Lokalise tasks and jobs / key CRUD | Out of scope |
 
 ## Examples
 
-Upload a source file, then a French translation that reuses the source filename:
+List locales, then upload a source file and wait for the import:
 
 ```bash
 export LOKALISE_API_TOKEN="your-lokalise-token"
+
+hyperlocalise lokalise locales list --project-id your-project-id
 
 hyperlocalise lokalise upload sources \
   --project-id your-project-id \
   --source-locale en \
   --file ./locales/en.json \
-  --dry-run
+  --poll \
+  --poll-timeout 10m
+```
 
+Upload a French translation that reuses the source filename:
+
+```bash
 hyperlocalise lokalise upload translations \
   --project-id your-project-id \
   --target-locale fr \
   --file ./locales/en.json \
   --replace-modified \
-  --dry-run
+  --poll
 ```
 
 Download French translations:

--- a/internal/i18n/storage/lokalise/discovery.go
+++ b/internal/i18n/storage/lokalise/discovery.go
@@ -1,0 +1,180 @@
+package lokalise
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var (
+	lokaliseListPageLimit = glossaryLanguagePageLimit
+	lokaliseListMaxPages  = lokaliseMaxLanguagePages
+)
+
+// LocaleListInput identifies a Lokalise project whose languages should be listed.
+type LocaleListInput struct {
+	ProjectID string
+	Branch    string
+}
+
+// LocaleListItem is one project language from GET /projects/{id}/languages.
+// Official fields only: lang_id, lang_iso, lang_name. There is no is_default.
+type LocaleListItem struct {
+	LanguageID   int64  `json:"lang_id"`
+	LanguageISO  string `json:"lang_iso"`
+	LanguageName string `json:"lang_name,omitempty"`
+}
+
+// FileListInput lists files in a Lokalise project.
+type FileListInput struct {
+	ProjectID      string
+	Branch         string
+	FilterFilename string
+}
+
+// FileListItem is one file from GET /projects/{id}/files.
+// Keys with no file association use filename __unassigned__ (file_id may be -1).
+type FileListItem struct {
+	FileID   int64  `json:"file_id"`
+	Filename string `json:"filename"`
+	KeyCount int    `json:"key_count"`
+}
+
+type projectFilesResponse struct {
+	Files []FileListItem `json:"files"`
+	Items []FileListItem `json:"items"`
+	Data  []FileListItem `json:"data"`
+}
+
+// ListProjectLanguages pages GET /projects/{id}/languages.
+func (c *HTTPClient) ListProjectLanguages(ctx context.Context, in LocaleListInput) ([]LocaleListItem, error) {
+	if c == nil || c.httpClient == nil {
+		return nil, fmt.Errorf("lokalise locales list: client is nil")
+	}
+	projectID := strings.TrimSpace(in.ProjectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("lokalise locales list: project id is required")
+	}
+	if strings.TrimSpace(c.apiToken) == "" {
+		return nil, fmt.Errorf("lokalise locales list: api token is required")
+	}
+
+	limit := lokaliseListPageLimit
+	if limit <= 0 {
+		limit = glossaryLanguagePageLimit
+	}
+	maxPages := lokaliseListMaxPages
+	if maxPages <= 0 {
+		maxPages = lokaliseMaxLanguagePages
+	}
+
+	out := make([]LocaleListItem, 0)
+	for page := 1; ; page++ {
+		if page > maxPages {
+			return nil, fmt.Errorf("lokalise locales list: pagination exceeded %d pages", maxPages)
+		}
+		endpoint, err := url.Parse(c.baseURL + "/projects/" + lokaliseProjectPathSegment(projectID, in.Branch) + "/languages")
+		if err != nil {
+			return nil, fmt.Errorf("lokalise locales list: build URL: %w", err)
+		}
+		q := endpoint.Query()
+		q.Set("limit", fmt.Sprintf("%d", limit))
+		q.Set("page", fmt.Sprintf("%d", page))
+		endpoint.RawQuery = q.Encode()
+
+		var resp projectLanguagesResponse
+		if _, err := c.doLokaliseJSON(ctx, http.MethodGet, endpoint.String(), &resp); err != nil {
+			return nil, fmt.Errorf("lokalise locales list: %w", err)
+		}
+		languages := resp.Languages
+		if len(languages) == 0 && len(resp.Items) > 0 {
+			languages = resp.Items
+		}
+		if len(languages) == 0 && len(resp.Data) > 0 {
+			languages = resp.Data
+		}
+		if len(languages) == 0 {
+			break
+		}
+		for _, lang := range languages {
+			out = append(out, LocaleListItem{
+				LanguageID:   lang.LanguageID,
+				LanguageISO:  strings.TrimSpace(lang.LanguageISO),
+				LanguageName: strings.TrimSpace(lang.LanguageName),
+			})
+		}
+		if len(languages) < limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+// ListFiles pages GET /projects/{id}/files.
+func (c *HTTPClient) ListFiles(ctx context.Context, in FileListInput) ([]FileListItem, error) {
+	if c == nil || c.httpClient == nil {
+		return nil, fmt.Errorf("lokalise files list: client is nil")
+	}
+	projectID := strings.TrimSpace(in.ProjectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("lokalise files list: project id is required")
+	}
+	if strings.TrimSpace(c.apiToken) == "" {
+		return nil, fmt.Errorf("lokalise files list: api token is required")
+	}
+
+	limit := lokaliseListPageLimit
+	if limit <= 0 {
+		limit = glossaryLanguagePageLimit
+	}
+	maxPages := lokaliseListMaxPages
+	if maxPages <= 0 {
+		maxPages = lokaliseMaxLanguagePages
+	}
+
+	out := make([]FileListItem, 0)
+	for page := 1; ; page++ {
+		if page > maxPages {
+			return nil, fmt.Errorf("lokalise files list: pagination exceeded %d pages", maxPages)
+		}
+		endpoint, err := url.Parse(c.baseURL + "/projects/" + lokaliseProjectPathSegment(projectID, in.Branch) + "/files")
+		if err != nil {
+			return nil, fmt.Errorf("lokalise files list: build URL: %w", err)
+		}
+		q := endpoint.Query()
+		q.Set("limit", fmt.Sprintf("%d", limit))
+		q.Set("page", fmt.Sprintf("%d", page))
+		if filter := strings.TrimSpace(in.FilterFilename); filter != "" {
+			q.Set("filter_filename", filter)
+		}
+		endpoint.RawQuery = q.Encode()
+
+		var resp projectFilesResponse
+		if _, err := c.doLokaliseJSON(ctx, http.MethodGet, endpoint.String(), &resp); err != nil {
+			return nil, fmt.Errorf("lokalise files list: %w", err)
+		}
+		files := resp.Files
+		if len(files) == 0 && len(resp.Items) > 0 {
+			files = resp.Items
+		}
+		if len(files) == 0 && len(resp.Data) > 0 {
+			files = resp.Data
+		}
+		if len(files) == 0 {
+			break
+		}
+		for _, file := range files {
+			out = append(out, FileListItem{
+				FileID:   file.FileID,
+				Filename: strings.TrimSpace(file.Filename),
+				KeyCount: file.KeyCount,
+			})
+		}
+		if len(files) < limit {
+			break
+		}
+	}
+	return out, nil
+}

--- a/internal/i18n/storage/lokalise/discovery_test.go
+++ b/internal/i18n/storage/lokalise/discovery_test.go
@@ -1,0 +1,121 @@
+package lokalise
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListProjectLanguagesPagesAndOmitsDefault(t *testing.T) {
+	oldLimit := lokaliseListPageLimit
+	lokaliseListPageLimit = 1
+	t.Cleanup(func() { lokaliseListPageLimit = oldLimit })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1:feature%2Fnew/languages", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if got := r.Header.Get("X-Api-Token"); got != "token" {
+			t.Fatalf("token = %q", got)
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			writeLokaliseJSON(t, w, map[string]any{
+				"languages": []any{
+					map[string]any{"lang_id": 640, "lang_iso": "en", "lang_name": "English", "is_default": true},
+				},
+			})
+		case "2":
+			writeLokaliseJSON(t, w, map[string]any{
+				"languages": []any{
+					map[string]any{"lang_id": 674, "lang_iso": "fr", "lang_name": "French"},
+				},
+			})
+		case "3":
+			writeLokaliseJSON(t, w, map[string]any{"languages": []any{}})
+		default:
+			t.Fatalf("unexpected page %s", r.URL.Query().Get("page"))
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{APIToken: "token"}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.ListProjectLanguages(context.Background(), LocaleListInput{ProjectID: "proj-1", Branch: "feature/new"})
+	if err != nil {
+		t.Fatalf("ListProjectLanguages: %v", err)
+	}
+	if len(got) != 2 || got[0].LanguageISO != "en" || got[1].LanguageISO != "fr" {
+		t.Fatalf("languages = %#v", got)
+	}
+	if got[0].LanguageName != "English" {
+		t.Fatalf("name = %q", got[0].LanguageName)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "is_default") || strings.Contains(string(encoded), `"default"`) {
+		t.Fatalf("json leaked invented default field: %s", encoded)
+	}
+}
+
+func TestListFilesKeepsUnassignedAndFilter(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1/files", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("filter_filename"); got != "en.json" {
+			t.Fatalf("filter_filename = %q, want en.json", got)
+		}
+		writeLokaliseJSON(t, w, map[string]any{
+			"files": []any{
+				map[string]any{"file_id": 24, "filename": "en.json", "key_count": 32},
+				map[string]any{"file_id": -1, "filename": "__unassigned__", "key_count": 11},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{APIToken: "token"}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.ListFiles(context.Background(), FileListInput{ProjectID: "proj-1", FilterFilename: "en.json"})
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("files = %#v", got)
+	}
+	if got[1].Filename != "__unassigned__" || got[1].FileID != -1 || got[1].KeyCount != 11 {
+		t.Fatalf("unassigned = %#v", got[1])
+	}
+}
+
+func TestListFilesEmptyProject(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1/files", func(w http.ResponseWriter, _ *http.Request) {
+		writeLokaliseJSON(t, w, map[string]any{"files": []any{}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{APIToken: "token"}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.ListFiles(context.Background(), FileListInput{ProjectID: "proj-1"})
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("files = %#v, want empty", got)
+	}
+}

--- a/internal/i18n/storage/lokalise/glossary.go
+++ b/internal/i18n/storage/lokalise/glossary.go
@@ -72,8 +72,9 @@ type glossaryTermTranslation struct {
 }
 
 type projectLanguage struct {
-	LanguageID  int64  `json:"lang_id"`
-	LanguageISO string `json:"lang_iso"`
+	LanguageID   int64  `json:"lang_id"`
+	LanguageISO  string `json:"lang_iso"`
+	LanguageName string `json:"lang_name"`
 }
 
 type glossaryTermsResponse struct {
@@ -194,41 +195,15 @@ func (c *HTTPClient) listGlossaryTerms(ctx context.Context, projectID string) ([
 func (c *HTTPClient) listProjectLanguageISOs(ctx context.Context, projectID string) (map[int64]string, error) {
 	// Some glossary translation payloads only contain lang_id. This lookup turns
 	// those IDs into stable locale strings for Lokalise's language columns.
+	languages, err := c.ListProjectLanguages(ctx, LocaleListInput{ProjectID: projectID})
+	if err != nil {
+		return nil, err
+	}
 	out := map[int64]string{}
-	page := 1
-	for {
-		if page > lokaliseMaxLanguagePages {
-			return nil, fmt.Errorf("lokalise project languages pagination exceeded %d pages", lokaliseMaxLanguagePages)
+	for _, lang := range languages {
+		if lang.LanguageID > 0 && strings.TrimSpace(lang.LanguageISO) != "" {
+			out[lang.LanguageID] = strings.TrimSpace(lang.LanguageISO)
 		}
-		endpoint, err := url.Parse(c.baseURL + "/projects/" + url.PathEscape(projectID) + "/languages")
-		if err != nil {
-			return nil, fmt.Errorf("build project languages URL: %w", err)
-		}
-		q := endpoint.Query()
-		q.Set("limit", fmt.Sprintf("%d", glossaryLanguagePageLimit))
-		q.Set("page", fmt.Sprintf("%d", page))
-		endpoint.RawQuery = q.Encode()
-
-		var resp projectLanguagesResponse
-		if _, err := c.doLokaliseJSON(ctx, http.MethodGet, endpoint.String(), &resp); err != nil {
-			return nil, fmt.Errorf("list lokalise project languages: %w", err)
-		}
-		languages := resp.Languages
-		if len(languages) == 0 && len(resp.Items) > 0 {
-			languages = resp.Items
-		}
-		if len(languages) == 0 && len(resp.Data) > 0 {
-			languages = resp.Data
-		}
-		for _, lang := range languages {
-			if lang.LanguageID > 0 && strings.TrimSpace(lang.LanguageISO) != "" {
-				out[lang.LanguageID] = strings.TrimSpace(lang.LanguageISO)
-			}
-		}
-		if len(languages) == 0 || len(languages) < glossaryLanguagePageLimit {
-			break
-		}
-		page++
 	}
 	return out, nil
 }

--- a/internal/i18n/storage/lokalise/queued_process.go
+++ b/internal/i18n/storage/lokalise/queued_process.go
@@ -1,0 +1,164 @@
+package lokalise
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+var lokaliseQueuedProcessPollInterval = time.Second
+
+// QueuedProcessWaitInput polls one Lokalise queued file-import process.
+type QueuedProcessWaitInput struct {
+	ProjectID string
+	ProcessID string
+	Branch    string
+	Interval  time.Duration
+}
+
+type queuedProcessResponse struct {
+	Process struct {
+		ID      string `json:"process_id"`
+		Type    string `json:"type"`
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	} `json:"process"`
+}
+
+func normalizeQueuedProcessStatus(status string) string {
+	return strings.ToLower(strings.TrimSpace(status))
+}
+
+func isQueuedProcessSuccessStatus(status string) bool {
+	return normalizeQueuedProcessStatus(status) == "finished"
+}
+
+func isQueuedProcessFailedStatus(status string) bool {
+	switch normalizeQueuedProcessStatus(status) {
+	case "failed", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+func isQueuedProcessInProgressStatus(status string) bool {
+	switch normalizeQueuedProcessStatus(status) {
+	case "queued", "pre_processing", "running", "post_processing":
+		return true
+	default:
+		return false
+	}
+}
+
+// GetQueuedProcess retrieves GET /projects/{id}/processes/{process_id}.
+func (c *HTTPClient) GetQueuedProcess(ctx context.Context, in QueuedProcessWaitInput) (SourceUploadResult, error) {
+	if c == nil || c.httpClient == nil {
+		return SourceUploadResult{}, fmt.Errorf("lokalise upload poll: client is nil")
+	}
+	projectID := strings.TrimSpace(in.ProjectID)
+	processID := strings.TrimSpace(in.ProcessID)
+	if projectID == "" {
+		return SourceUploadResult{}, fmt.Errorf("lokalise upload poll: project id is required")
+	}
+	if processID == "" {
+		return SourceUploadResult{}, fmt.Errorf("lokalise upload poll: process id is required")
+	}
+	if strings.TrimSpace(c.apiToken) == "" {
+		return SourceUploadResult{}, fmt.Errorf("lokalise upload poll: api token is required")
+	}
+
+	endpoint := c.baseURL + "/projects/" + lokaliseProjectPathSegment(projectID, in.Branch) + "/processes/" + url.PathEscape(processID)
+	var resp queuedProcessResponse
+	if _, err := c.doLokaliseJSON(ctx, http.MethodGet, endpoint, &resp); err != nil {
+		return SourceUploadResult{ProcessID: processID}, fmt.Errorf("lokalise upload poll: %w", err)
+	}
+	id := strings.TrimSpace(resp.Process.ID)
+	if id == "" {
+		id = processID
+	}
+	return SourceUploadResult{
+		ProcessID: id,
+		Type:      strings.TrimSpace(resp.Process.Type),
+		Status:    strings.TrimSpace(resp.Process.Status),
+		Message:   strings.TrimSpace(resp.Process.Message),
+	}, nil
+}
+
+// WaitForQueuedProcess polls until the process finishes, fails, or the context deadline is reached.
+// Empty details with status=finished is success. Unknown statuses fail closed.
+func (c *HTTPClient) WaitForQueuedProcess(ctx context.Context, in QueuedProcessWaitInput) (SourceUploadResult, error) {
+	interval := in.Interval
+	if interval <= 0 {
+		interval = lokaliseQueuedProcessPollInterval
+	}
+	if interval <= 0 {
+		interval = time.Second
+	}
+
+	result, err := c.GetQueuedProcess(ctx, in)
+	if err != nil {
+		return queuedProcessResultOnError(in.ProcessID, result, err, ctx)
+	}
+	if done, err := queuedProcessOutcome(result); done {
+		return result, err
+	}
+
+	for {
+		if err := sleepWithContext(ctx, interval); err != nil {
+			return result, queuedProcessTimeoutError(result, err)
+		}
+		next, err := c.GetQueuedProcess(ctx, in)
+		if err != nil {
+			return queuedProcessResultOnError(in.ProcessID, result, err, ctx)
+		}
+		result = next
+		if done, err := queuedProcessOutcome(result); done {
+			return result, err
+		}
+	}
+}
+
+func queuedProcessOutcome(result SourceUploadResult) (bool, error) {
+	if isQueuedProcessSuccessStatus(result.Status) {
+		return true, nil
+	}
+	if isQueuedProcessFailedStatus(result.Status) {
+		return true, fmt.Errorf("lokalise upload %s failed: status=%s", result.ProcessID, result.Status)
+	}
+	if isQueuedProcessInProgressStatus(result.Status) {
+		return false, nil
+	}
+	return true, fmt.Errorf("lokalise upload %s is in unknown status %q", result.ProcessID, result.Status)
+}
+
+func queuedProcessResultOnError(processID string, last SourceUploadResult, err error, ctx context.Context) (SourceUploadResult, error) {
+	if last.ProcessID == "" {
+		last.ProcessID = strings.TrimSpace(processID)
+	}
+	if ctx.Err() != nil {
+		if last.Status != "" {
+			return last, queuedProcessTimeoutError(last, ctx.Err())
+		}
+		return last, fmt.Errorf("lokalise upload %s wait timed out: %w", last.ProcessID, ctx.Err())
+	}
+	return last, err
+}
+
+func queuedProcessTimeoutError(result SourceUploadResult, err error) error {
+	return fmt.Errorf("lokalise upload %s wait timed out: status=%s: %w", result.ProcessID, result.Status, err)
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/i18n/storage/lokalise/queued_process.go
+++ b/internal/i18n/storage/lokalise/queued_process.go
@@ -127,6 +127,9 @@ func queuedProcessOutcome(result SourceUploadResult) (bool, error) {
 		return true, nil
 	}
 	if isQueuedProcessFailedStatus(result.Status) {
+		if message := strings.TrimSpace(result.Message); message != "" {
+			return true, fmt.Errorf("lokalise upload %s failed: status=%s: %s", result.ProcessID, result.Status, message)
+		}
 		return true, fmt.Errorf("lokalise upload %s failed: status=%s", result.ProcessID, result.Status)
 	}
 	if isQueuedProcessInProgressStatus(result.Status) {

--- a/internal/i18n/storage/lokalise/queued_process_test.go
+++ b/internal/i18n/storage/lokalise/queued_process_test.go
@@ -1,0 +1,199 @@
+package lokalise
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWaitForQueuedProcessSucceedsAfterPreProcessing(t *testing.T) {
+	oldInterval := lokaliseQueuedProcessPollInterval
+	lokaliseQueuedProcessPollInterval = time.Millisecond
+	t.Cleanup(func() { lokaliseQueuedProcessPollInterval = oldInterval })
+
+	var calls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1:main/processes/proc-1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s", r.Method)
+		}
+		n := calls.Add(1)
+		status := "pre_processing"
+		if n >= 2 {
+			status = "finished"
+		}
+		writeLokaliseJSON(t, w, map[string]any{
+			"process": map[string]any{
+				"process_id": "proc-1",
+				"type":       "file-import",
+				"status":     status,
+			},
+		})
+	})
+	client, teardown := newQueuedProcessClient(t, mux)
+	defer teardown()
+
+	result, err := client.WaitForQueuedProcess(context.Background(), QueuedProcessWaitInput{
+		ProjectID: "proj-1",
+		ProcessID: "proc-1",
+		Branch:    "main",
+	})
+	if err != nil {
+		t.Fatalf("WaitForQueuedProcess: %v", err)
+	}
+	if result.Status != "finished" || result.ProcessID != "proc-1" {
+		t.Fatalf("result = %#v", result)
+	}
+	if calls.Load() < 2 {
+		t.Fatalf("calls = %d, want at least 2", calls.Load())
+	}
+}
+
+func TestWaitForQueuedProcessFinishedWithEmptyDetails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1/processes/proc-1", func(w http.ResponseWriter, _ *http.Request) {
+		writeLokaliseJSON(t, w, map[string]any{
+			"process": map[string]any{
+				"process_id": "proc-1",
+				"type":       "file-import",
+				"status":     "finished",
+			},
+		})
+	})
+	client, teardown := newQueuedProcessClient(t, mux)
+	defer teardown()
+
+	result, err := client.WaitForQueuedProcess(context.Background(), QueuedProcessWaitInput{
+		ProjectID: "proj-1",
+		ProcessID: "proc-1",
+	})
+	if err != nil {
+		t.Fatalf("WaitForQueuedProcess: %v", err)
+	}
+	if result.Status != "finished" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestWaitForQueuedProcessFailsOnFailedStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1/processes/proc-1", func(w http.ResponseWriter, _ *http.Request) {
+		writeLokaliseJSON(t, w, map[string]any{
+			"process": map[string]any{
+				"process_id": "proc-1",
+				"status":     "failed",
+				"message":    "import failed",
+			},
+		})
+	})
+	client, teardown := newQueuedProcessClient(t, mux)
+	defer teardown()
+
+	result, err := client.WaitForQueuedProcess(context.Background(), QueuedProcessWaitInput{
+		ProjectID: "proj-1",
+		ProcessID: "proc-1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "status=failed") {
+		t.Fatalf("error = %v, want failed", err)
+	}
+	if result.ProcessID != "proc-1" {
+		t.Fatalf("result = %#v, want process id kept", result)
+	}
+}
+
+func TestWaitForQueuedProcessFailsClosedOnUnknownStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1/processes/proc-1", func(w http.ResponseWriter, _ *http.Request) {
+		writeLokaliseJSON(t, w, map[string]any{
+			"process": map[string]any{
+				"process_id": "proc-1",
+				"status":     "mystery",
+			},
+		})
+	})
+	client, teardown := newQueuedProcessClient(t, mux)
+	defer teardown()
+
+	_, err := client.WaitForQueuedProcess(context.Background(), QueuedProcessWaitInput{
+		ProjectID: "proj-1",
+		ProcessID: "proc-1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown status") {
+		t.Fatalf("error = %v, want unknown status", err)
+	}
+}
+
+func TestWaitForQueuedProcessTimeoutKeepsProcessID(t *testing.T) {
+	oldInterval := lokaliseQueuedProcessPollInterval
+	lokaliseQueuedProcessPollInterval = 20 * time.Millisecond
+	t.Cleanup(func() { lokaliseQueuedProcessPollInterval = oldInterval })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1/processes/proc-1", func(w http.ResponseWriter, _ *http.Request) {
+		writeLokaliseJSON(t, w, map[string]any{
+			"process": map[string]any{
+				"process_id": "proc-1",
+				"status":     "running",
+			},
+		})
+	})
+	client, teardown := newQueuedProcessClient(t, mux)
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+	result, err := client.WaitForQueuedProcess(ctx, QueuedProcessWaitInput{
+		ProjectID: "proj-1",
+		ProcessID: "proc-1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "wait timed out") || !strings.Contains(err.Error(), "proc-1") {
+		t.Fatalf("error = %v, want timeout with process id", err)
+	}
+	if result.ProcessID != "proc-1" {
+		t.Fatalf("result = %#v, want process id kept", result)
+	}
+}
+
+func TestWaitForQueuedProcessDoesNotRequireDetailsCounts(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1/processes/proc-1", func(w http.ResponseWriter, _ *http.Request) {
+		payload := map[string]any{
+			"process": map[string]any{
+				"process_id": "proc-1",
+				"status":     "finished",
+				"details": map[string]any{
+					"files": []any{
+						map[string]any{"status": "finished", "key_count_skipped": 1},
+					},
+				},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	})
+	client, teardown := newQueuedProcessClient(t, mux)
+	defer teardown()
+
+	if _, err := client.WaitForQueuedProcess(context.Background(), QueuedProcessWaitInput{
+		ProjectID: "proj-1",
+		ProcessID: "proc-1",
+	}); err != nil {
+		t.Fatalf("skipped keys must not fail: %v", err)
+	}
+}
+
+func newQueuedProcessClient(t *testing.T, mux *http.ServeMux) (*HTTPClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	client, err := NewHTTPClientWithBaseURL(Config{APIToken: "token"}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client, srv.Close
+}

--- a/internal/i18n/storage/lokalise/queued_process_test.go
+++ b/internal/i18n/storage/lokalise/queued_process_test.go
@@ -98,8 +98,8 @@ func TestWaitForQueuedProcessFailsOnFailedStatus(t *testing.T) {
 		ProjectID: "proj-1",
 		ProcessID: "proc-1",
 	})
-	if err == nil || !strings.Contains(err.Error(), "status=failed") {
-		t.Fatalf("error = %v, want failed", err)
+	if err == nil || !strings.Contains(err.Error(), "status=failed") || !strings.Contains(err.Error(), "import failed") {
+		t.Fatalf("error = %v, want failed status and Lokalise message", err)
 	}
 	if result.ProcessID != "proc-1" {
 		t.Fatalf("result = %#v, want process id kept", result)


### PR DESCRIPTION
## Summary
- Closes [HL-744](https://linear.app/hyperlocalise/issue/HL-744/add-lokalise-locales-list-files-list-and-upload-poll). Follow-on after HL-663.
- Add `hyperlocalise lokalise locales list` (lokalise2 `language list`) and `files list` (including `__unassigned__` and `--filter-filename`).
- Add `--poll` / `--poll-timeout` (default 30s) on `upload sources` and `upload translations`; wait on GET `/processes/{id}` until `finished`.
- English docs gap table updated. No glossary CRUD, TM, Phrase `--wait`, or file delete.

## Test plan
- [x] `go test ./internal/i18n/storage/lokalise`
- [x] `go test ./apps/cli/cmd -run Lokalise`
- [ ] `locales list` / `files list` with `--config` and empty project
- [ ] `--poll` reprints `status=finished`; timeout still prints `process_id`; dry-run does not poll
- [ ] Translation upload still requires `--target-locale` and sends `skip_detect_lang_iso=true`

Made with [Cursor](https://cursor.com)