### PR TITLE
feat(web): attach multiple locales to each research domain

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-brand-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-brand-view.tsx
@@ -23,7 +23,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { TypographyH2, TypographyP } from "@/components/ui/typography";
 import type { BrandEngine, BrandSentiment } from "@/lib/domains/research-prototype";
-import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+import { useDomainResearchCatalog } from "./domain-research-context";
 import { cn } from "@/lib/primitives/cn";
 
 import { DomainResearchEmpty } from "./domain-research-empty";
@@ -48,7 +48,7 @@ function sentimentMessage(sentiment: BrandSentiment) {
 
 export function DomainBrandView({ linkedDomainId }: { linkedDomainId: string }) {
   const intl = useIntl();
-  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const catalog = useDomainResearchCatalog(linkedDomainId);
   const [addOpen, setAddOpen] = useState(false);
 
   if (!catalog) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-keywords-view.tsx
@@ -12,6 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { useDomainResearchCatalog } from "./domain-research-context";
 import { useState } from "react";
 import { useIntl } from "react-intl";
 import { Button } from "@/components/ui/button";
@@ -27,12 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  getResearchPrototypeCatalog,
-  DOMAIN_RESEARCH_MARKETS,
-  type DomainResearchCatalog,
-  type KeywordIdea,
-} from "@/lib/domains/research-prototype";
+import { type DomainResearchCatalog, type KeywordIdea } from "@/lib/domains/research-prototype";
 import { cn } from "@/lib/primitives/cn";
 import { formatKeywordIntent } from "./domain-research-format";
 import { domainKeywordsViewMessages as shared } from "./domain-keywords-view.messages";
@@ -59,8 +55,10 @@ const EMPTY_FILTERS: KeywordFilters = {
 };
 
 export function DomainKeywordsView({ linkedDomainId }: { linkedDomainId: string }) {
-  const catalog = getResearchPrototypeCatalog(linkedDomainId);
-  return catalog ? <KeywordScreen key={linkedDomainId} catalog={catalog} /> : null;
+  const catalog = useDomainResearchCatalog(linkedDomainId);
+  return catalog ? (
+    <KeywordScreen key={`${linkedDomainId}-${catalog.market.id}`} catalog={catalog} />
+  ) : null;
 }
 
 function KeywordScreen({ catalog }: { catalog: DomainResearchCatalog }) {
@@ -68,13 +66,13 @@ function KeywordScreen({ catalog }: { catalog: DomainResearchCatalog }) {
   const t = intl.formatMessage;
   const [query, setQuery] = useState("");
   const [search, setSearch] = useState("");
-  const [market, setMarket] = useState(catalog.domain.market.id);
+
   const [filters, setFilters] = useState(EMPTY_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
   const [sort, setSort] = useState<KeywordSort>({ field: "volume", direction: "desc" });
   const [selected, setSelected] = useState<string[]>([]);
   const [activeId, setActiveId] = useState<string | null>(catalog.keywords[0]?.id ?? null);
-  const keywords = market === catalog.domain.market.id ? catalog.keywords : [];
+  const keywords = catalog.keywords;
   const rows = filterKeywordIdeas(keywords, search, filters, sort);
   const active = resolveActiveKeyword(rows, activeId);
   const selectedRows = rows.filter((row) => selected.includes(row.id));
@@ -94,7 +92,7 @@ function KeywordScreen({ catalog }: { catalog: DomainResearchCatalog }) {
     const url = URL.createObjectURL(new Blob(["\uFEFF", csv], { type: "text/csv;charset=utf-8;" }));
     const link = document.createElement("a");
     link.href = url;
-    link.download = `keywords-${catalog.domain.domainKey}-${market}.csv`;
+    link.download = `keywords-${catalog.domain.domainKey}-${catalog.market.id}.csv`;
     link.click();
     setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
@@ -102,7 +100,6 @@ function KeywordScreen({ catalog }: { catalog: DomainResearchCatalog }) {
     setQuery("");
     setSearch("");
     setFilters(EMPTY_FILTERS);
-    setMarket(catalog.domain.market.id);
     setSelected([]);
     setActiveId(catalog.keywords[0]?.id ?? null);
   }
@@ -133,35 +130,6 @@ function KeywordScreen({ catalog }: { catalog: DomainResearchCatalog }) {
             onChange={(event) => setQuery(event.target.value)}
             placeholder={catalog.keywords[0]?.keyword ?? t(messages.query)}
           />
-        </Field>
-        <Field className="w-full sm:w-48">
-          <FieldLabel htmlFor="keyword-market">{t(messages.market)}</FieldLabel>
-          <Select
-            value={market}
-            items={DOMAIN_RESEARCH_MARKETS.map((item) => ({ value: item.id, label: item.label }))}
-            onValueChange={(value) => {
-              if (value) {
-                setMarket(value);
-                setSelected([]);
-                setActiveId(
-                  value === catalog.domain.market.id ? (catalog.keywords[0]?.id ?? null) : null,
-                );
-              }
-            }}
-          >
-            <SelectTrigger id="keyword-market" className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                {DOMAIN_RESEARCH_MARKETS.map((item) => (
-                  <SelectItem key={item.id} value={item.id} label={item.label}>
-                    {item.label}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
         </Field>
         <Button type="submit">{t(messages.search)}</Button>
       </form>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.messages.ts
@@ -15,15 +15,55 @@
 import { defineMessages } from "react-intl";
 
 export const domainLinkDialogMessages = defineMessages({
+  editTitle: {
+    defaultMessage: "Edit locales",
+    id: "K6HKJyJvL1",
+    description: "Domain locale dialog title",
+  },
+  editDescription: {
+    defaultMessage: "Choose the locales to research for this domain.",
+    id: "NVI4PGUZDH",
+    description: "Domain locale dialog description",
+  },
+  save: {
+    defaultMessage: "Save locales",
+    id: "L1dn3JIeHU",
+    description: "Save supported domain locales",
+  },
+  saved: {
+    defaultMessage: "Locales updated for this preview.",
+    id: "BGjPXD5fgV",
+    description: "Prototype locale save toast",
+  },
+  localesRequired: {
+    defaultMessage: "Select at least one locale.",
+    id: "wYyC/XZMmS",
+    description: "Domain locale validation",
+  },
+  hostnameInvalid: {
+    defaultMessage: "Enter a hostname such as shop.example.com, without a URL path.",
+    id: "PYIsQFA2Np",
+    description: "Invalid domain hostname",
+  },
+  hostnameDuplicate: {
+    defaultMessage: "This domain is already linked. Edit its locales instead.",
+    id: "Ck9MOHJiWV",
+    description: "Duplicate domain validation",
+  },
+  prototypeNotice: {
+    defaultMessage:
+      "Preview only. Changes last until you reload and are not saved to your workspace.",
+    id: "4HQ7im6sof",
+    description: "Prototype domain persistence disclosure",
+  },
   title: {
     defaultMessage: "Link domain",
     id: "2+oKbAvHmj",
     description: "Link domain dialog title",
   },
   description: {
-    defaultMessage:
-      "Attach a hostname and pick the market research should run in. Verification comes next.",
-    id: "hJh6vnt3pF",
+    defaultMessage: "Choose the locales for this hostname. Verify the domain once for all locales.",
+    id: "ed78rqC5km",
     description: "Link domain dialog description",
   },
   hostnameLabel: {
@@ -37,8 +77,8 @@ export const domainLinkDialogMessages = defineMessages({
     description: "Hostname placeholder on the link domain dialog",
   },
   marketLabel: {
-    defaultMessage: "Market",
-    id: "SJ1G8g/3h7",
+    defaultMessage: "Locales",
+    id: "vOplG6AhcP",
     description: "Market field on the link domain dialog",
   },
   submit: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.stories.tsx
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { getResearchPrototypeDomain } from "@/lib/domains/research-prototype";
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { Button } from "@/components/ui/button";
@@ -31,3 +32,5 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
+
+export const EditMultipleLocales: Story = { args: { domain: getResearchPrototypeDomain("hyperlocalise-com")! } };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.stories.tsx
@@ -33,4 +33,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
-export const EditMultipleLocales: Story = { args: { domain: getResearchPrototypeDomain("hyperlocalise-com")! } };
+export const EditMultipleLocales: Story = {
+  args: { domain: getResearchPrototypeDomain("hyperlocalise-com")! },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.test.tsx
@@ -21,37 +21,60 @@ import { DomainLinkDialog } from "./domain-link-dialog";
 vi.mock("sonner", () => ({ toast: { success: vi.fn() } }));
 
 describe("domain locale editing", () => {
-    it("requires a locale and links one hostname with multiple locales", () => {
-        const onSave = vi.fn();
-        render(<IntlProvider locale="en"><DomainLinkDialog open onOpenChange={() => {}} onSave={onSave} /></IntlProvider>);
-        fireEvent.change(screen.getByLabelText("Hostname"), { target: { value: "EXAMPLE.COM" } });
-        fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
-        expect(screen.getByText("Select at least one locale.")).toBeInTheDocument();
-        expect(onSave).not.toHaveBeenCalled();
-        fireEvent.click(screen.getByRole("checkbox", { name: "French (France)" }));
-        fireEvent.click(screen.getByRole("checkbox", { name: "German (Germany)" }));
-        fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
-        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ domainKey: "example.com", status: "pending_verification", locales: [expect.objectContaining({ id: "france-fr" }), expect.objectContaining({ id: "germany-de" })] }));
-    });
+  it("requires a locale and links one hostname with multiple locales", () => {
+    const onSave = vi.fn();
+    render(
+      <IntlProvider locale="en">
+        <DomainLinkDialog open onOpenChange={() => {}} onSave={onSave} />
+      </IntlProvider>,
+    );
+    fireEvent.change(screen.getByLabelText("Hostname"), { target: { value: "EXAMPLE.COM" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
+    expect(screen.getByText("Select at least one locale.")).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("checkbox", { name: "French (France)" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "German (Germany)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domainKey: "example.com",
+        status: "pending_verification",
+        locales: [
+          expect.objectContaining({ id: "france-fr" }),
+          expect.objectContaining({ id: "germany-de" }),
+        ],
+      }),
+    );
+  });
 
-    it("edits locales without changing domain identity or verification", () => {
-        const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
-        const onSave = vi.fn();
-        render(<IntlProvider locale="en"><DomainLinkDialog open domain={domain} onOpenChange={() => {}} onSave={onSave} /></IntlProvider>);
-        expect(screen.getByRole("checkbox", { name: "German (Germany)" })).toBeChecked();
-        expect(screen.getByLabelText("Hostname")).toHaveAttribute("readonly");
-        fireEvent.click(screen.getByRole("checkbox", { name: "French (France)" }));
-        fireEvent.click(screen.getByRole("button", { name: "Save locales" }));
-        expect(onSave).toHaveBeenCalledWith({ ...domain, locales: domain.locales.slice(1) });
-    });
+  it("edits locales without changing domain identity or verification", () => {
+    const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+    const onSave = vi.fn();
+    render(
+      <IntlProvider locale="en">
+        <DomainLinkDialog open domain={domain} onOpenChange={() => {}} onSave={onSave} />
+      </IntlProvider>,
+    );
+    expect(screen.getByRole("checkbox", { name: "German (Germany)" })).toBeChecked();
+    expect(screen.getByLabelText("Hostname")).toHaveAttribute("readonly");
+    fireEvent.click(screen.getByRole("checkbox", { name: "French (France)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save locales" }));
+    expect(onSave).toHaveBeenCalledWith({ ...domain, locales: domain.locales.slice(1) });
+  });
 
-    it("rejects duplicate hostnames instead of adding another domain row", () => {
-        const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
-        const onSave = vi.fn();
-        render(<IntlProvider locale="en"><DomainLinkDialog open existingDomains={[domain]} onOpenChange={() => {}} onSave={onSave} /></IntlProvider>);
-        fireEvent.change(screen.getByLabelText("Hostname"), { target: { value: domain.domainKey } });
-        fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
-        expect(screen.getByText("This domain is already linked. Edit its locales instead.")).toBeInTheDocument();
-        expect(onSave).not.toHaveBeenCalled();
-    });
+  it("rejects duplicate hostnames instead of adding another domain row", () => {
+    const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+    const onSave = vi.fn();
+    render(
+      <IntlProvider locale="en">
+        <DomainLinkDialog open existingDomains={[domain]} onOpenChange={() => {}} onSave={onSave} />
+      </IntlProvider>,
+    );
+    fireEvent.change(screen.getByLabelText("Hostname"), { target: { value: domain.domainKey } });
+    fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
+    expect(
+      screen.getByText("This domain is already linked. Edit its locales instead."),
+    ).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { getResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+import { DomainLinkDialog } from "./domain-link-dialog";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn() } }));
+
+describe("domain locale editing", () => {
+    it("requires a locale and links one hostname with multiple locales", () => {
+        const onSave = vi.fn();
+        render(<IntlProvider locale="en"><DomainLinkDialog open onOpenChange={() => {}} onSave={onSave} /></IntlProvider>);
+        fireEvent.change(screen.getByLabelText("Hostname"), { target: { value: "EXAMPLE.COM" } });
+        fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
+        expect(screen.getByText("Select at least one locale.")).toBeInTheDocument();
+        expect(onSave).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByRole("checkbox", { name: "French (France)" }));
+        fireEvent.click(screen.getByRole("checkbox", { name: "German (Germany)" }));
+        fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
+        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ domainKey: "example.com", status: "pending_verification", locales: [expect.objectContaining({ id: "france-fr" }), expect.objectContaining({ id: "germany-de" })] }));
+    });
+
+    it("edits locales without changing domain identity or verification", () => {
+        const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+        const onSave = vi.fn();
+        render(<IntlProvider locale="en"><DomainLinkDialog open domain={domain} onOpenChange={() => {}} onSave={onSave} /></IntlProvider>);
+        expect(screen.getByRole("checkbox", { name: "German (Germany)" })).toBeChecked();
+        expect(screen.getByLabelText("Hostname")).toHaveAttribute("readonly");
+        fireEvent.click(screen.getByRole("checkbox", { name: "French (France)" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save locales" }));
+        expect(onSave).toHaveBeenCalledWith({ ...domain, locales: domain.locales.slice(1) });
+    });
+
+    it("rejects duplicate hostnames instead of adding another domain row", () => {
+        const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+        const onSave = vi.fn();
+        render(<IntlProvider locale="en"><DomainLinkDialog open existingDomains={[domain]} onOpenChange={() => {}} onSave={onSave} /></IntlProvider>);
+        fireEvent.change(screen.getByLabelText("Hostname"), { target: { value: domain.domainKey } });
+        fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
+        expect(screen.getByText("This domain is already linked. Edit its locales instead.")).toBeInTheDocument();
+        expect(onSave).not.toHaveBeenCalled();
+    });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.tsx
@@ -25,7 +25,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Field, FieldError, FieldLabel, FieldSet, FieldLegend, FieldGroup } from "@/components/ui/field";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  FieldSet,
+  FieldLegend,
+  FieldGroup,
+} from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -151,22 +158,24 @@ export function DomainLinkDialog({
               <FormattedMessage {...messages.marketLabel} />
             </FieldLegend>
             <FieldGroup className="gap-3">
-            {DOMAIN_RESEARCH_MARKETS.map((locale) => (
-              <Field key={locale.id} orientation="horizontal" data-invalid={Boolean(localeError)}>
-                <Checkbox
-                  id={`${marketId}-${locale.id}`}
-                  checked={localeIds.includes(locale.id)}
-                  aria-invalid={Boolean(localeError)}
-                  onCheckedChange={(checked) => {
-                    setLocaleIds((current) =>
-                      checked ? [...current, locale.id] : current.filter((id) => id !== locale.id),
-                    );
-                    setLocaleError(null);
-                  }}
-                />
-                <FieldLabel htmlFor={`${marketId}-${locale.id}`}>{locale.label}</FieldLabel>
-              </Field>
-            ))}
+              {DOMAIN_RESEARCH_MARKETS.map((locale) => (
+                <Field key={locale.id} orientation="horizontal" data-invalid={Boolean(localeError)}>
+                  <Checkbox
+                    id={`${marketId}-${locale.id}`}
+                    checked={localeIds.includes(locale.id)}
+                    aria-invalid={Boolean(localeError)}
+                    onCheckedChange={(checked) => {
+                      setLocaleIds((current) =>
+                        checked
+                          ? [...current, locale.id]
+                          : current.filter((id) => id !== locale.id),
+                      );
+                      setLocaleError(null);
+                    }}
+                  />
+                  <FieldLabel htmlFor={`${marketId}-${locale.id}`}>{locale.label}</FieldLabel>
+                </Field>
+              ))}
             </FieldGroup>
             <FieldError
               id={`${marketId}-error`}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.tsx
@@ -25,16 +25,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Field, FieldError, FieldLabel, FieldSet, FieldLegend, FieldGroup } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { DOMAIN_RESEARCH_MARKETS } from "@/lib/domains/research-prototype";
+  DOMAIN_RESEARCH_MARKETS,
+  type DomainResearchDomain,
+} from "@/lib/domains/research-prototype";
 
 import { domainLinkDialogMessages as messages } from "./domain-link-dialog.messages";
 import { domainResearchSharedMessages as sharedMessages } from "./domain-research-shared.messages";
@@ -42,7 +39,13 @@ import { domainResearchSharedMessages as sharedMessages } from "./domain-researc
 export function DomainLinkDialog({
   open,
   onOpenChange,
+  domain,
+  existingDomains = [],
+  onSave,
 }: {
+  domain?: DomainResearchDomain;
+  existingDomains?: DomainResearchDomain[];
+  onSave?: (domain: DomainResearchDomain) => void;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -50,16 +53,18 @@ export function DomainLinkDialog({
   const hostnameId = useId();
   const marketId = useId();
   const [hostname, setHostname] = useState("");
-  const [marketIdValue, setMarketIdValue] = useState(DOMAIN_RESEARCH_MARKETS[0]?.id ?? "");
+  const [localeIds, setLocaleIds] = useState<string[]>([]);
+  const [localeError, setLocaleError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
-      setHostname("");
-      setMarketIdValue(DOMAIN_RESEARCH_MARKETS[0]?.id ?? "");
+      setHostname(domain?.domainKey ?? "");
+      setLocaleIds(domain?.locales.map((locale) => locale.id) ?? []);
+      setLocaleError(null);
       setError(null);
     }
-  }, [open]);
+  }, [open, domain]);
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -69,7 +74,40 @@ export function DomainLinkDialog({
       return;
     }
 
-    toast.success(intl.formatMessage(messages.success));
+    if (
+      !/^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(nextHostname)
+    ) {
+      setError(intl.formatMessage(messages.hostnameInvalid));
+      return;
+    }
+    if (existingDomains.some((item) => item.id !== domain?.id && item.domainKey === nextHostname)) {
+      setError(intl.formatMessage(messages.hostnameDuplicate));
+      return;
+    }
+    const locales = DOMAIN_RESEARCH_MARKETS.filter((locale) => localeIds.includes(locale.id));
+    if (!locales.length) {
+      setLocaleError(intl.formatMessage(messages.localesRequired));
+      return;
+    }
+    onSave?.(
+      domain
+        ? { ...domain, locales }
+        : {
+            id: `preview-${crypto.randomUUID()}`,
+            domainKey: nextHostname,
+            sourceUrl: `https://${nextHostname}`,
+            locales,
+            status: "pending_verification",
+            keywordCount: 0,
+            keywordCountLabel: "—",
+            traffic: 0,
+            trafficLabel: "—",
+            score: null,
+            trackedCount: 0,
+            aiMentions: 0,
+          },
+    );
+    toast.success(intl.formatMessage(domain ? messages.saved : messages.success));
     onOpenChange(false);
   }
 
@@ -79,18 +117,19 @@ export function DomainLinkDialog({
         <form className="grid gap-4" onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>
-              <FormattedMessage {...messages.title} />
+              <FormattedMessage {...(domain ? messages.editTitle : messages.title)} />
             </DialogTitle>
             <DialogDescription>
-              <FormattedMessage {...messages.description} />
+              <FormattedMessage {...(domain ? messages.editDescription : messages.description)} />
             </DialogDescription>
           </DialogHeader>
 
-          <Field>
+          <Field data-invalid={Boolean(error)}>
             <FieldLabel htmlFor={hostnameId}>
               <FormattedMessage {...messages.hostnameLabel} />
             </FieldLabel>
             <Input
+              readOnly={Boolean(domain)}
               id={hostnameId}
               value={hostname}
               onChange={(event) => {
@@ -104,37 +143,46 @@ export function DomainLinkDialog({
             <FieldError errors={error ? [{ message: error }] : undefined} />
           </Field>
 
-          <Field>
-            <FieldLabel htmlFor={marketId}>
+          <FieldSet
+            className="grid gap-3"
+            aria-describedby={localeError ? `${marketId}-error` : undefined}
+          >
+            <FieldLegend variant="label">
               <FormattedMessage {...messages.marketLabel} />
-            </FieldLabel>
-            <Select
-              value={marketIdValue || null}
-              onValueChange={(value) => {
-                if (value) {
-                  setMarketIdValue(value);
-                }
-              }}
-            >
-              <SelectTrigger id={marketId} className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {DOMAIN_RESEARCH_MARKETS.map((market) => (
-                  <SelectItem key={market.id} value={market.id} label={market.label}>
-                    {market.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
+            </FieldLegend>
+            <FieldGroup className="gap-3">
+            {DOMAIN_RESEARCH_MARKETS.map((locale) => (
+              <Field key={locale.id} orientation="horizontal" data-invalid={Boolean(localeError)}>
+                <Checkbox
+                  id={`${marketId}-${locale.id}`}
+                  checked={localeIds.includes(locale.id)}
+                  aria-invalid={Boolean(localeError)}
+                  onCheckedChange={(checked) => {
+                    setLocaleIds((current) =>
+                      checked ? [...current, locale.id] : current.filter((id) => id !== locale.id),
+                    );
+                    setLocaleError(null);
+                  }}
+                />
+                <FieldLabel htmlFor={`${marketId}-${locale.id}`}>{locale.label}</FieldLabel>
+              </Field>
+            ))}
+            </FieldGroup>
+            <FieldError
+              id={`${marketId}-error`}
+              errors={localeError ? [{ message: localeError }] : undefined}
+            />
+          </FieldSet>
+          <p className="text-sm text-muted-foreground">
+            <FormattedMessage {...messages.prototypeNotice} />
+          </p>
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               <FormattedMessage {...sharedMessages.cancel} />
             </Button>
             <Button type="submit">
-              <FormattedMessage {...messages.submit} />
+              <FormattedMessage {...(domain ? messages.save : messages.submit)} />
             </Button>
           </DialogFooter>
         </form>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-overview-tables.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-overview-tables.tsx
@@ -16,7 +16,7 @@ import { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+import { useDomainResearchCatalog } from "./domain-research-context";
 import { cn } from "@/lib/primitives/cn";
 
 import { DomainResearchEmpty } from "./domain-research-empty";
@@ -29,7 +29,7 @@ const PAGE_GRID =
 
 export function DomainOverviewTables({ linkedDomainId }: { linkedDomainId: string }) {
   const intl = useIntl();
-  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const catalog = useDomainResearchCatalog(linkedDomainId);
   const [tab, setTab] = useState<"keywords" | "pages">("keywords");
 
   if (!catalog) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-overview-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-overview-view.tsx
@@ -12,7 +12,7 @@
  * Version 2.0 or later.
  */
 import { FormattedMessage, useIntl } from "react-intl";
-import { getResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+import { useDomainResearchCatalog } from "./domain-research-context";
 import { getDomainMetricHistory } from "@/lib/domains/research-metric-history";
 import { DomainMetricCard } from "./domain-metric-card";
 import { DomainOverviewTables } from "./domain-overview-tables";
@@ -20,7 +20,7 @@ import { domainMetricMessages as messages } from "./domain-metric.messages";
 
 export function DomainOverviewView({ linkedDomainId }: { linkedDomainId: string }) {
   const intl = useIntl();
-  const domain = getResearchPrototypeDomain(linkedDomainId);
+  const domain = useDomainResearchCatalog(linkedDomainId)?.domain;
   if (!domain) return null;
   const history = getDomainMetricHistory(linkedDomainId);
   const metrics = [

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-prompts-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-prompts-view.tsx
@@ -22,7 +22,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
-import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+import { useDomainResearchCatalog } from "./domain-research-context";
 
 import { DomainResearchEmpty } from "./domain-research-empty";
 import { formatBrandEngine } from "./domain-research-format";
@@ -32,7 +32,7 @@ import { domainPromptsViewMessages as messages } from "./domain-prompts-view.mes
 export function DomainPromptsView({ linkedDomainId }: { linkedDomainId: string }) {
   const intl = useIntl();
   const promptId = useId();
-  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const catalog = useDomainResearchCatalog(linkedDomainId);
   const [prompt, setPrompt] = useState(catalog?.prompt ?? "");
 
   if (!catalog) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-ranks-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-ranks-view.tsx
@@ -19,7 +19,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+import { useDomainResearchCatalog } from "./domain-research-context";
 import { cn } from "@/lib/primitives/cn";
 
 import { DomainResearchEmpty } from "./domain-research-empty";
@@ -32,7 +32,7 @@ const RANK_GRID =
 
 export function DomainRanksView({ linkedDomainId }: { linkedDomainId: string }) {
   const intl = useIntl();
-  const catalog = getResearchPrototypeCatalog(linkedDomainId);
+  const catalog = useDomainResearchCatalog(linkedDomainId);
   const [addOpen, setAddOpen] = useState(false);
 
   if (!catalog) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-context.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-context.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+import { createContext, useContext } from "react";
+import {
+  getResearchPrototypeCatalog,
+  type DomainResearchCatalog,
+} from "@/lib/domains/research-prototype";
+
+export const DomainResearchContext = createContext<DomainResearchCatalog | null | undefined>(
+  undefined,
+);
+
+export function useDomainResearchCatalog(linkedDomainId: string) {
+  const catalog = useContext(DomainResearchContext);
+  return catalog === undefined ? getResearchPrototypeCatalog(linkedDomainId) : catalog;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-page.stories.tsx
@@ -84,5 +84,12 @@ export const MissingHistory: Story = {
 };
 
 export const LocaleWithoutResearch: Story = {
-    parameters: { nextjs: { navigation: { pathname: "/en/org/domains-preview/domains/hyperlocalise-com/overview", query: { locale: "germany-de" } } } },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/en/org/domains-preview/domains/hyperlocalise-com/overview",
+        query: { locale: "germany-de" },
+      },
+    },
+  },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-page.stories.tsx
@@ -82,3 +82,7 @@ export const JapaneseMarket: Story = { args: { surface: "keywords", linkedDomain
 export const MissingHistory: Story = {
   args: { surface: "overview", linkedDomainId: "docs-acme-com" },
 };
+
+export const LocaleWithoutResearch: Story = {
+    parameters: { nextjs: { navigation: { pathname: "/en/org/domains-preview/domains/hyperlocalise-com/overview", query: { locale: "germany-de" } } } },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.messages.ts
@@ -15,6 +15,32 @@
 import { defineMessages } from "react-intl";
 
 export const domainResearchShellMessages = defineMessages({
+  localeLabel: {
+    defaultMessage: "Research locale",
+    id: "M7q1LgOgRx",
+    description: "Shared locale selector label",
+  },
+  editLocales: {
+    defaultMessage: "Edit locales",
+    id: "D6IBUTnPaw",
+    description: "Manage domain locales from research",
+  },
+  localeScope: {
+    defaultMessage: "Applies to every research tab.",
+    id: "yWOL2/uNay",
+    description: "Research locale scope help",
+  },
+  localeEmptyTitle: {
+    defaultMessage: "No research for this locale yet",
+    id: "HaSJjDRAg0",
+    description: "Missing locale research title",
+  },
+  localeEmptyDescription: {
+    defaultMessage:
+      "There is no preview research for {locale}. Choose another locale to explore available data.",
+    id: "Zln5rf1e7d",
+    description: "Missing locale research explanation",
+  },
   navKeywords: {
     defaultMessage: "Keyword research",
     id: "8Gk5dEdlLz",
@@ -41,8 +67,9 @@ export const domainResearchShellMessages = defineMessages({
     description: "Domain research navigation label",
   },
   shellDescription: {
-    defaultMessage: "Research this domain in {market}.",
-    id: "xzG6mihfhR",
+    defaultMessage:
+      "{count, plural, one {# locale configured} other {# locales configured}}. Verification applies to the whole domain.",
+    id: "4+P6YOB0GC",
     description: "Domain research header description",
   },
   sectionLabel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+// @vitest-environment happy-dom
+import { render } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  getResearchPrototypeDomain,
+  type DomainResearchDomain,
+} from "@/lib/domains/research-prototype";
+import { DomainResearchShell } from "./domain-research-shell";
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  search: "locale=france-fr",
+  domains: [] as DomainResearchDomain[],
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+vi.mock("@/lib/navigation/use-org-router", () => ({
+  useOrgRouter: () => ({
+    push: vi.fn(),
+    replace: mocks.replace,
+  }),
+}));
+
+vi.mock("./use-domain-prototype", () => ({
+  useDomainPrototype: () => ({
+    domains: mocks.domains,
+    saveDomain: vi.fn(),
+  }),
+}));
+
+describe("domain research locale URL", () => {
+  beforeEach(() => {
+    mocks.replace.mockReset();
+    mocks.search = "locale=france-fr";
+    mocks.domains = [getResearchPrototypeDomain("hyperlocalise-com")!];
+  });
+
+  it("replaces a removed locale in the URL with the fallback locale", () => {
+    const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+    mocks.domains = [{ ...domain, locales: domain.locales.slice(1) }];
+    render(
+      <IntlProvider locale="en">
+        <DomainResearchShell
+          organizationSlug="acme"
+          linkedDomainId="hyperlocalise-com"
+          surface="overview"
+        >
+          research
+        </DomainResearchShell>
+      </IntlProvider>,
+    );
+    expect(mocks.replace).toHaveBeenCalledWith(
+      "/org/acme/domains/hyperlocalise-com?locale=germany-de",
+      { scroll: false },
+    );
+  });
+
+  it("keeps a supported locale in the URL", () => {
+    render(
+      <IntlProvider locale="en">
+        <DomainResearchShell
+          organizationSlug="acme"
+          linkedDomainId="hyperlocalise-com"
+          surface="overview"
+        >
+          research
+        </DomainResearchShell>
+      </IntlProvider>,
+    );
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { type ReactNode, useId, useState } from "react";
+import { type ReactNode, useEffect, useId, useState } from "react";
 import { Globe02Icon } from "@hugeicons/core-free-icons";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -58,6 +58,24 @@ const NAV_ITEMS: { id: DomainResearchNavId; message: typeof messages.navOverview
   { id: "prompts", message: messages.navPrompts },
 ];
 
+function hrefForLocale({
+  organizationSlug,
+  linkedDomainId,
+  surface,
+  search,
+  localeId,
+}: {
+  organizationSlug: string;
+  linkedDomainId: string;
+  surface?: DomainResearchNavId;
+  search: string;
+  localeId: string;
+}) {
+  const params = new URLSearchParams(search);
+  params.set("locale", localeId);
+  return `${buildDomainPath(organizationSlug, linkedDomainId, surface)}?${params}`;
+}
+
 export function DomainResearchShell({
   organizationSlug,
   linkedDomainId,
@@ -74,11 +92,24 @@ export function DomainResearchShell({
   const { domains, saveDomain } = useDomainPrototype(organizationSlug);
   const domain = domains.find((item) => item.id === linkedDomainId);
   const searchParams = useSearchParams();
+  const search = searchParams.toString();
+  const requestedLocaleId = searchParams.get("locale");
+  const locale = domain ? resolveDomainLocale(domain, requestedLocaleId) : null;
+  const localeId = locale?.id;
   const localeSelectId = useId();
   const [editOpen, setEditOpen] = useState(false);
   const [verifyOpen, setVerifyOpen] = useState(false);
 
-  if (!domain) {
+  useEffect(() => {
+    if (!localeId || requestedLocaleId === localeId) return;
+    router.replace(hrefForLocale({ organizationSlug, linkedDomainId, surface, search, localeId }), {
+      scroll: false,
+    });
+    // useOrgRouter() returns a new object each render; depending on it recanonicalizes forever
+    // while the URL is still stale.
+  }, [linkedDomainId, localeId, organizationSlug, requestedLocaleId, search, surface]);
+
+  if (!domain || !locale) {
     return (
       <WorkspacePageShell>
         <DomainResearchMissingDomain organizationSlug={organizationSlug} />
@@ -86,24 +117,28 @@ export function DomainResearchShell({
     );
   }
 
-  const locale = resolveDomainLocale(domain, searchParams.get("locale"));
   const catalog = getResearchPrototypeCatalog(linkedDomainId, locale.id);
+  const activeLocaleId = locale.id;
 
-  function changeLocale(localeId: string) {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("locale", localeId);
-    router.replace(`${buildDomainPath(organizationSlug, linkedDomainId, surface)}?${params}`, {
-      scroll: false,
+  function researchHref(nextLocaleId: string, nextSurface = surface) {
+    return hrefForLocale({
+      organizationSlug,
+      linkedDomainId,
+      surface: nextSurface,
+      search,
+      localeId: nextLocaleId,
     });
+  }
+
+  function changeLocale(nextLocaleId: string) {
+    router.replace(researchHref(nextLocaleId), { scroll: false });
   }
 
   function handleSurfaceChange(next: string) {
     const nextSurface: DomainResearchSurface | undefined = isDomainResearchSurface(next)
       ? next
       : undefined;
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("locale", locale.id);
-    router.push(`${buildDomainPath(organizationSlug, linkedDomainId, nextSurface)}?${params}`);
+    router.push(researchHref(activeLocaleId, nextSurface));
   }
 
   const isPending = domain.status !== "verified";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.tsx
@@ -12,15 +12,29 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useId, useState } from "react";
 import { Globe02Icon } from "@hugeicons/core-free-icons";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { useSearchParams } from "next/navigation";
+import { DomainResearchContext } from "./domain-research-context";
+import { useDomainPrototype } from "./use-domain-prototype";
+import { DomainLinkDialog } from "./domain-link-dialog";
+import { Field, FieldLabel } from "@/components/ui/field";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { DomainResearchNavId, DomainResearchSurface } from "@/lib/domains/research-prototype";
 import {
-  getResearchPrototypeDomain,
+  getResearchPrototypeCatalog,
+  resolveDomainLocale,
   isDomainResearchSurface,
 } from "@/lib/domains/research-prototype";
 import { useOrgRouter } from "@/lib/navigation/use-org-router";
@@ -57,7 +71,11 @@ export function DomainResearchShell({
 }) {
   const intl = useIntl();
   const router = useOrgRouter();
-  const domain = getResearchPrototypeDomain(linkedDomainId);
+  const { domains, saveDomain } = useDomainPrototype(organizationSlug);
+  const domain = domains.find((item) => item.id === linkedDomainId);
+  const searchParams = useSearchParams();
+  const localeSelectId = useId();
+  const [editOpen, setEditOpen] = useState(false);
   const [verifyOpen, setVerifyOpen] = useState(false);
 
   if (!domain) {
@@ -68,11 +86,24 @@ export function DomainResearchShell({
     );
   }
 
+  const locale = resolveDomainLocale(domain, searchParams.get("locale"));
+  const catalog = getResearchPrototypeCatalog(linkedDomainId, locale.id);
+
+  function changeLocale(localeId: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("locale", localeId);
+    router.replace(`${buildDomainPath(organizationSlug, linkedDomainId, surface)}?${params}`, {
+      scroll: false,
+    });
+  }
+
   function handleSurfaceChange(next: string) {
     const nextSurface: DomainResearchSurface | undefined = isDomainResearchSurface(next)
       ? next
       : undefined;
-    router.push(buildDomainPath(organizationSlug, linkedDomainId, nextSurface));
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("locale", locale.id);
+    router.push(`${buildDomainPath(organizationSlug, linkedDomainId, nextSurface)}?${params}`);
   }
 
   const isPending = domain.status !== "verified";
@@ -85,7 +116,7 @@ export function DomainResearchShell({
           label={intl.formatMessage(messages.sectionLabel)}
           title={domain.domainKey}
           description={intl.formatMessage(messages.shellDescription, {
-            market: domain.market.label,
+            count: domain.locales.length,
           })}
           actions={
             <>
@@ -98,6 +129,40 @@ export function DomainResearchShell({
             </>
           }
         />
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <Field className="w-full sm:w-72">
+          <FieldLabel htmlFor={localeSelectId}>
+            <FormattedMessage {...messages.localeLabel} />
+          </FieldLabel>
+          <Select
+            value={locale.id}
+            items={domain.locales.map((item) => ({ value: item.id, label: item.label }))}
+            onValueChange={(value) => {
+              if (value) changeLocale(value);
+            }}
+          >
+            <SelectTrigger id={localeSelectId} className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {domain.locales.map((item) => (
+                  <SelectItem key={item.id} value={item.id} label={item.label}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Button size="sm" variant="outline" onClick={() => setEditOpen(true)}>
+          <FormattedMessage {...messages.editLocales} />
+        </Button>
+        <p className="text-sm text-muted-foreground">
+          <FormattedMessage {...messages.localeScope} />
+        </p>
       </div>
 
       <Tabs value={surface} onValueChange={handleSurfaceChange}>
@@ -120,9 +185,32 @@ export function DomainResearchShell({
             </Button>
           }
         />
+      ) : catalog ? (
+        <DomainResearchContext value={catalog} key={`${linkedDomainId}-${locale.id}`}>
+          {children}
+        </DomainResearchContext>
       ) : (
-        children
+        <DomainResearchEmpty
+          title={<FormattedMessage {...messages.localeEmptyTitle} />}
+          description={
+            <FormattedMessage
+              {...messages.localeEmptyDescription}
+              values={{ locale: locale.label }}
+            />
+          }
+          action={
+            <Button size="sm" variant="outline" onClick={() => setEditOpen(true)}>
+              <FormattedMessage {...messages.editLocales} />
+            </Button>
+          }
+        />
       )}
+      <DomainLinkDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        domain={domain}
+        onSave={saveDomain}
+      />
 
       <DomainVerifyDialog
         open={verifyOpen}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.messages.ts
@@ -15,10 +15,15 @@
 import { defineMessages } from "react-intl";
 
 export const domainsPageContentMessages = defineMessages({
+  editLocales: {
+    defaultMessage: "Edit locales",
+    id: "icuWnstCMG",
+    description: "Edit locales for a domain in the list",
+  },
   pageDescription: {
     defaultMessage:
-      "Linked domains and the markets you research them in. Open a site to run keywords, ranks, and AI brand lookup.",
-    id: "qmpjf3XZ1L",
+      "Manage each domain and its locales. Open a domain to explore research by locale.",
+    id: "2NdI8ju66r",
     description: "Domains workspace page description",
   },
   loadError: {
@@ -36,9 +41,9 @@ export const domainsPageContentMessages = defineMessages({
     id: "//lV7u3bI3",
     description: "Domains list column for hostname",
   },
-  columnMarket: {
-    defaultMessage: "Market",
-    id: "q4dfro4K/5",
+  columnLocales: {
+    defaultMessage: "Locales",
+    id: "pUz7QP2QGI",
     description: "Domains list column for market",
   },
   columnKeywords: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Add01Icon, Globe02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -20,7 +20,9 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { OrgNavLink } from "@/components/app-shell/org-nav-link";
 import { buildDomainPath } from "@/components/app-shell/navigation-config";
 import { Button } from "@/components/ui/button";
-import { listResearchPrototypeDomains } from "@/lib/domains/research-prototype";
+import { type DomainResearchDomain } from "@/lib/domains/research-prototype";
+import { useDomainPrototype } from "./use-domain-prototype";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/primitives/cn";
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
@@ -33,11 +35,12 @@ import { domainsPageContentMessages as messages } from "./domains-page-content.m
 import styles from "./domain-header.module.css";
 
 const LIST_GRID_CLASS =
-  "grid grid-cols-1 items-center gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.3fr)_minmax(7rem,0.8fr)_repeat(3,minmax(4rem,0.45fr))_auto_auto]";
+  "grid grid-cols-1 items-center gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_4rem_auto_auto]";
 
 export function DomainsPageContent({ organizationSlug }: { organizationSlug: string }) {
   const intl = useIntl();
-  const domains = useMemo(() => listResearchPrototypeDomains(), []);
+  const { domains, saveDomain } = useDomainPrototype(organizationSlug);
+  const [editingDomain, setEditingDomain] = useState<DomainResearchDomain | undefined>();
   const [linkOpen, setLinkOpen] = useState(false);
   const [verifyDomainKey, setVerifyDomainKey] = useState<string | null>(null);
 
@@ -69,13 +72,7 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
             <FormattedMessage {...messages.columnDomain} />
           </span>
           <span>
-            <FormattedMessage {...messages.columnMarket} />
-          </span>
-          <span className="text-end">
-            <FormattedMessage {...messages.columnKeywords} />
-          </span>
-          <span className="text-end">
-            <FormattedMessage {...messages.columnTraffic} />
+            <FormattedMessage {...messages.columnLocales} />
           </span>
           <span className="text-end">
             <FormattedMessage {...messages.columnScore} />
@@ -91,33 +88,33 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
               >
                 <div className="min-w-0">
                   <OrgNavLink
-                    href={buildDomainPath(organizationSlug, domain.id)}
+                    href={buildDomainPath(organizationSlug, domain.id, "overview")}
                     className="font-medium text-foreground underline-offset-4 hover:underline"
                   >
                     {domain.domainKey}
                   </OrgNavLink>
-                  <p className="mt-1 text-sm text-muted-foreground md:hidden">
-                    {domain.market.label}
-                  </p>
                 </div>
-                <span className="hidden text-sm text-muted-foreground md:block">
-                  {domain.market.label}
-                </span>
-                <span className="hidden text-end tabular-nums text-sm text-muted-foreground md:block">
-                  {domain.keywordCountLabel}
-                </span>
-                <span className="hidden text-end tabular-nums text-sm text-muted-foreground md:block">
-                  {domain.trafficLabel}
-                </span>
+                <div className="flex flex-wrap gap-1.5">
+                  {domain.locales.map((locale) => (
+                    <Badge key={locale.id} variant="secondary">
+                      {locale.label}
+                    </Badge>
+                  ))}
+                </div>
                 <span className="hidden text-end tabular-nums text-sm text-muted-foreground md:block">
                   {domain.score ?? intl.formatMessage(messages.scoreUnavailable)}
                 </span>
                 <DomainStatusBadge status={domain.status} />
                 <div className="flex flex-wrap justify-end gap-2">
+                  <Button size="sm" variant="ghost" onClick={() => setEditingDomain(domain)}>
+                    <FormattedMessage {...messages.editLocales} />
+                  </Button>
                   <Button
                     size="sm"
                     variant="outline"
-                    render={<OrgNavLink href={buildDomainPath(organizationSlug, domain.id)} />}
+                    render={
+                      <OrgNavLink href={buildDomainPath(organizationSlug, domain.id, "overview")} />
+                    }
                   >
                     <FormattedMessage {...messages.openDomain} />
                   </Button>
@@ -133,7 +130,23 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
         </ul>
       </div>
 
-      <DomainLinkDialog open={linkOpen} onOpenChange={setLinkOpen} />
+      <DomainLinkDialog
+        open={linkOpen}
+        onOpenChange={setLinkOpen}
+        existingDomains={domains}
+        onSave={(domain) => {
+          saveDomain(domain);
+          setVerifyDomainKey(domain.domainKey);
+        }}
+      />
+      <DomainLinkDialog
+        open={Boolean(editingDomain)}
+        domain={editingDomain}
+        onOpenChange={(open) => {
+          if (!open) setEditingDomain(undefined);
+        }}
+        onSave={saveDomain}
+      />
       <DomainVerifyDialog
         open={Boolean(verifyDomainKey)}
         domainKey={verifyDomainKey ?? ""}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/use-domain-prototype.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/use-domain-prototype.ts
@@ -1,0 +1,41 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  listResearchPrototypeDomains,
+  type DomainResearchDomain,
+} from "@/lib/domains/research-prototype";
+
+// Prototype edits live in the client cache, scoped to the workspace.
+export function useDomainPrototype(organizationSlug: string) {
+  const queryClient = useQueryClient();
+  const queryKey = ["domain-research-prototype", organizationSlug];
+  const { data: domains } = useQuery({
+    queryKey,
+    queryFn: listResearchPrototypeDomains,
+    initialData: listResearchPrototypeDomains,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+  function saveDomain(domain: DomainResearchDomain) {
+    queryClient.setQueryData<DomainResearchDomain[]>(queryKey, (current = []) =>
+      current.some((item) => item.id === domain.id)
+        ? current.map((item) => (item.id === domain.id ? domain : item))
+        : [...current, domain],
+    );
+  }
+  return { domains, saveDomain };
+}

--- a/apps/hyperlocalise-web/src/lib/domains/research-prototype.test.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/research-prototype.test.ts
@@ -60,15 +60,19 @@ describe("research prototype catalog", () => {
 });
 
 describe("domain research locales", () => {
-    it("does not substitute another locale's research when data is missing", () => {
-        expect(getResearchPrototypeCatalog("hyperlocalise-com", "france-fr")?.keywords.length).toBeGreaterThan(0);
-        expect(getResearchPrototypeCatalog("hyperlocalise-com", "germany-de")).toBeNull();
-        expect(getResearchPrototypeCatalog("missing", "france-fr")).toBeNull();
-    });
-    it("resolves only supported locales, including after removing the active locale", () => {
-        const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
-        expect(resolveDomainLocale(domain, "germany-de").id).toBe("germany-de");
-        expect(resolveDomainLocale(domain, "japan-ja").id).toBe("france-fr");
-        expect(resolveDomainLocale({ ...domain, locales: domain.locales.slice(1) }, "france-fr").id).toBe("germany-de");
-    });
+  it("does not substitute another locale's research when data is missing", () => {
+    expect(
+      getResearchPrototypeCatalog("hyperlocalise-com", "france-fr")?.keywords.length,
+    ).toBeGreaterThan(0);
+    expect(getResearchPrototypeCatalog("hyperlocalise-com", "germany-de")).toBeNull();
+    expect(getResearchPrototypeCatalog("missing", "france-fr")).toBeNull();
+  });
+  it("resolves only supported locales, including after removing the active locale", () => {
+    const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+    expect(resolveDomainLocale(domain, "germany-de").id).toBe("germany-de");
+    expect(resolveDomainLocale(domain, "japan-ja").id).toBe("france-fr");
+    expect(
+      resolveDomainLocale({ ...domain, locales: domain.locales.slice(1) }, "france-fr").id,
+    ).toBe("germany-de");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/domains/research-prototype.test.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/research-prototype.test.ts
@@ -19,6 +19,7 @@ import {
   isDomainResearchSurface,
   isResearchPrototypeDomain,
   listResearchPrototypeDomains,
+  resolveDomainLocale,
 } from "./research-prototype";
 
 describe("research prototype catalog", () => {
@@ -56,4 +57,18 @@ describe("research prototype catalog", () => {
     expect(isDomainResearchSurface("keywords")).toBe(true);
     expect(isDomainResearchSurface("audit")).toBe(false);
   });
+});
+
+describe("domain research locales", () => {
+    it("does not substitute another locale's research when data is missing", () => {
+        expect(getResearchPrototypeCatalog("hyperlocalise-com", "france-fr")?.keywords.length).toBeGreaterThan(0);
+        expect(getResearchPrototypeCatalog("hyperlocalise-com", "germany-de")).toBeNull();
+        expect(getResearchPrototypeCatalog("missing", "france-fr")).toBeNull();
+    });
+    it("resolves only supported locales, including after removing the active locale", () => {
+        const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+        expect(resolveDomainLocale(domain, "germany-de").id).toBe("germany-de");
+        expect(resolveDomainLocale(domain, "japan-ja").id).toBe("france-fr");
+        expect(resolveDomainLocale({ ...domain, locales: domain.locales.slice(1) }, "france-fr").id).toBe("germany-de");
+    });
 });

--- a/apps/hyperlocalise-web/src/lib/domains/research-prototype.test.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/research-prototype.test.ts
@@ -67,6 +67,15 @@ describe("domain research locales", () => {
     expect(getResearchPrototypeCatalog("hyperlocalise-com", "germany-de")).toBeNull();
     expect(getResearchPrototypeCatalog("missing", "france-fr")).toBeNull();
   });
+  it("keeps a second locale's catalog without replacing the first", () => {
+    const french = getResearchPrototypeCatalog("hyperlocalise-com", "france-fr");
+    const vietnamese = getResearchPrototypeCatalog("hyperlocalise-com", "vietnam-vi");
+    expect(french?.keywords[0]?.keyword).toBe("traduction automatique");
+    expect(vietnamese?.keywords[0]?.keyword).toBe("dịch tự động");
+    expect(
+      listResearchPrototypeDomains().filter((domain) => domain.id === "hyperlocalise-com"),
+    ).toHaveLength(1);
+  });
   it("resolves only supported locales, including after removing the active locale", () => {
     const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
     expect(resolveDomainLocale(domain, "germany-de").id).toBe("germany-de");

--- a/apps/hyperlocalise-web/src/lib/domains/research-prototype.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/research-prototype.ts
@@ -346,7 +346,7 @@ function catalogFor(
 ): DomainResearchCatalog {
   return {
     domain,
-    market: domain.locales[0]!,
+    market: extras?.market ?? domain.locales[0]!,
     keywords: [],
     ranks: [],
     overviewKeywords: [],
@@ -365,138 +365,170 @@ function catalogFor(
   };
 }
 
+const HYPERLOCALISE_DOMAIN: DomainResearchDomain = {
+  id: "hyperlocalise-com",
+  domainKey: "hyperlocalise.com",
+  sourceUrl: "https://hyperlocalise.com",
+  locales: [FRANCE_FR, GERMANY_DE, VIETNAM_VI],
+  status: "verified",
+  keywordCount: 12400,
+  keywordCountLabel: "12.4k",
+  traffic: 84000,
+  trafficLabel: "84k",
+  score: 82,
+  trackedCount: 48,
+  aiMentions: 36,
+};
+
 const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
-  catalogFor(
-    {
-      id: "hyperlocalise-com",
-      domainKey: "hyperlocalise.com",
-      sourceUrl: "https://hyperlocalise.com",
-      locales: [FRANCE_FR, GERMANY_DE, VIETNAM_VI],
-      status: "verified",
-      keywordCount: 12400,
-      keywordCountLabel: "12.4k",
-      traffic: 84000,
-      trafficLabel: "84k",
-      score: 82,
-      trackedCount: 48,
-      aiMentions: 36,
-    },
-    {
-      keywords: HYPERLOCALISE_KEYWORDS,
-      ranks: [
-        {
-          id: "rank-traduction-automatique",
-          keyword: "traduction automatique",
-          position: 22,
-          previousPosition: 25,
-          url: "https://hyperlocalise.com/fr",
-          volume: 8100,
-        },
-        {
-          id: "rank-logiciel-de-traduction",
-          keyword: "logiciel de traduction",
-          position: 8,
-          previousPosition: 9,
-          url: "https://hyperlocalise.com/fr/product",
-          volume: 5400,
-        },
-        {
-          id: "rank-traduction-ia",
-          keyword: "traduction IA",
-          position: 14,
-          previousPosition: 11,
-          url: "https://hyperlocalise.com/fr/blog/traduction-ia",
-          volume: 4400,
-        },
-        {
-          id: "rank-tms-traduction",
-          keyword: "TMS traduction",
-          position: 6,
-          previousPosition: 6,
-          url: "https://hyperlocalise.com/fr/product",
-          volume: 720,
-        },
-      ],
-      overviewKeywords: [
-        {
-          id: "ov-kw-1",
-          keyword: "traduction automatique",
-          position: 22,
-          volume: 8100,
-          traffic: 420,
-        },
-        {
-          id: "ov-kw-2",
-          keyword: "logiciel de traduction",
-          position: 8,
-          volume: 5400,
-          traffic: 980,
-        },
-        {
-          id: "ov-kw-3",
-          keyword: "traduction IA",
-          position: 14,
-          volume: 4400,
-          traffic: 610,
-        },
-        {
-          id: "ov-kw-4",
-          keyword: "TMS traduction",
-          position: 6,
-          volume: 720,
-          traffic: 210,
-        },
-      ],
-      overviewPages: [
-        { id: "ov-pg-1", path: "/fr", keywords: 86, traffic: 12400 },
-        { id: "ov-pg-2", path: "/fr/product", keywords: 41, traffic: 8600 },
-        { id: "ov-pg-3", path: "/fr/pricing", keywords: 18, traffic: 2100 },
-        { id: "ov-pg-4", path: "/fr/blog/traduction-ia", keywords: 12, traffic: 940 },
-      ],
-      competitors: [
-        { id: "comp-phrase", name: "Phrase", mentions: 18, sentiment: "mixed" },
-        { id: "comp-crowdin", name: "Crowdin", mentions: 14, sentiment: "positive" },
-        { id: "comp-lokalise", name: "Lokalise", mentions: 11, sentiment: "mixed" },
-        { id: "comp-smartling", name: "Smartling", mentions: 9, sentiment: "positive" },
-        { id: "comp-deepl", name: "DeepL", mentions: 22, sentiment: "positive" },
-      ],
-      engineMentions: {
-        chatgpt: 42,
-        claude: 38,
-        gemini: 12,
-        perplexity: 29,
+  catalogFor(HYPERLOCALISE_DOMAIN, {
+    keywords: HYPERLOCALISE_KEYWORDS,
+    ranks: [
+      {
+        id: "rank-traduction-automatique",
+        keyword: "traduction automatique",
+        position: 22,
+        previousPosition: 25,
+        url: "https://hyperlocalise.com/fr",
+        volume: 8100,
       },
-      prompt: "meilleur outil de localisation pour une équipe produit",
-      promptResults: [
-        {
-          engine: "chatgpt",
-          mentioned: true,
-          excerpt:
-            "Hyperlocalise appears among tools for product teams that need research and translation in one workspace.",
-        },
-        {
-          engine: "claude",
-          mentioned: true,
-          excerpt:
-            "For French-market localisation, Hyperlocalise is listed next to Crowdin and Phrase for product orgs.",
-        },
-        {
-          engine: "gemini",
-          mentioned: false,
-          excerpt: "Answers focus on Phrase, Crowdin, and Smartling. Hyperlocalise is not named.",
-        },
-        {
-          engine: "perplexity",
-          mentioned: true,
-          excerpt:
-            "Cites Hyperlocalise for domain-scoped keyword research tied to a market and language.",
-        },
-      ],
-      serpByKeywordId: {
-        "kw-traduction-automatique": HYPERLOCALISE_SERP,
+      {
+        id: "rank-logiciel-de-traduction",
+        keyword: "logiciel de traduction",
+        position: 8,
+        previousPosition: 9,
+        url: "https://hyperlocalise.com/fr/product",
+        volume: 5400,
       },
+      {
+        id: "rank-traduction-ia",
+        keyword: "traduction IA",
+        position: 14,
+        previousPosition: 11,
+        url: "https://hyperlocalise.com/fr/blog/traduction-ia",
+        volume: 4400,
+      },
+      {
+        id: "rank-tms-traduction",
+        keyword: "TMS traduction",
+        position: 6,
+        previousPosition: 6,
+        url: "https://hyperlocalise.com/fr/product",
+        volume: 720,
+      },
+    ],
+    overviewKeywords: [
+      {
+        id: "ov-kw-1",
+        keyword: "traduction automatique",
+        position: 22,
+        volume: 8100,
+        traffic: 420,
+      },
+      {
+        id: "ov-kw-2",
+        keyword: "logiciel de traduction",
+        position: 8,
+        volume: 5400,
+        traffic: 980,
+      },
+      {
+        id: "ov-kw-3",
+        keyword: "traduction IA",
+        position: 14,
+        volume: 4400,
+        traffic: 610,
+      },
+      {
+        id: "ov-kw-4",
+        keyword: "TMS traduction",
+        position: 6,
+        volume: 720,
+        traffic: 210,
+      },
+    ],
+    overviewPages: [
+      { id: "ov-pg-1", path: "/fr", keywords: 86, traffic: 12400 },
+      { id: "ov-pg-2", path: "/fr/product", keywords: 41, traffic: 8600 },
+      { id: "ov-pg-3", path: "/fr/pricing", keywords: 18, traffic: 2100 },
+      { id: "ov-pg-4", path: "/fr/blog/traduction-ia", keywords: 12, traffic: 940 },
+    ],
+    competitors: [
+      { id: "comp-phrase", name: "Phrase", mentions: 18, sentiment: "mixed" },
+      { id: "comp-crowdin", name: "Crowdin", mentions: 14, sentiment: "positive" },
+      { id: "comp-lokalise", name: "Lokalise", mentions: 11, sentiment: "mixed" },
+      { id: "comp-smartling", name: "Smartling", mentions: 9, sentiment: "positive" },
+      { id: "comp-deepl", name: "DeepL", mentions: 22, sentiment: "positive" },
+    ],
+    engineMentions: {
+      chatgpt: 42,
+      claude: 38,
+      gemini: 12,
+      perplexity: 29,
     },
-  ),
+    prompt: "meilleur outil de localisation pour une équipe produit",
+    promptResults: [
+      {
+        engine: "chatgpt",
+        mentioned: true,
+        excerpt:
+          "Hyperlocalise appears among tools for product teams that need research and translation in one workspace.",
+      },
+      {
+        engine: "claude",
+        mentioned: true,
+        excerpt:
+          "For French-market localisation, Hyperlocalise is listed next to Crowdin and Phrase for product orgs.",
+      },
+      {
+        engine: "gemini",
+        mentioned: false,
+        excerpt: "Answers focus on Phrase, Crowdin, and Smartling. Hyperlocalise is not named.",
+      },
+      {
+        engine: "perplexity",
+        mentioned: true,
+        excerpt:
+          "Cites Hyperlocalise for domain-scoped keyword research tied to a market and language.",
+      },
+    ],
+    serpByKeywordId: {
+      "kw-traduction-automatique": HYPERLOCALISE_SERP,
+    },
+  }),
+  catalogFor(HYPERLOCALISE_DOMAIN, {
+    market: VIETNAM_VI,
+    keywords: [
+      {
+        id: "kw-dich-tu-dong",
+        keyword: "dịch tự động",
+        volume: 2400,
+        kd: 28,
+        cpc: 0.6,
+        intent: "commercial",
+      },
+    ],
+    ranks: [
+      {
+        id: "rank-dich-tu-dong",
+        keyword: "dịch tự động",
+        position: 11,
+        previousPosition: 14,
+        url: "https://hyperlocalise.com/vi",
+        volume: 2400,
+      },
+    ],
+    overviewKeywords: [
+      {
+        id: "ov-vi-1",
+        keyword: "dịch tự động",
+        position: 11,
+        volume: 2400,
+        traffic: 180,
+      },
+    ],
+    overviewPages: [{ id: "ov-vi-home", path: "/vi", keywords: 22, traffic: 1600 }],
+  }),
   catalogFor(
     {
       id: "acme-fr",
@@ -727,28 +759,40 @@ const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
   }),
 ];
 
-const RESEARCH_PROTOTYPE_BY_ID = new Map(
-  RESEARCH_PROTOTYPE_CATALOG.map((entry) => [entry.domain.id, entry]),
-);
+const RESEARCH_PROTOTYPE_DOMAINS = new Map<string, DomainResearchDomain>();
+const RESEARCH_PROTOTYPE_CATALOGS = new Map<string, Map<string, DomainResearchCatalog>>();
+
+for (const catalog of RESEARCH_PROTOTYPE_CATALOG) {
+  if (!RESEARCH_PROTOTYPE_DOMAINS.has(catalog.domain.id)) {
+    RESEARCH_PROTOTYPE_DOMAINS.set(catalog.domain.id, catalog.domain);
+  }
+  const catalogsByLocale =
+    RESEARCH_PROTOTYPE_CATALOGS.get(catalog.domain.id) ?? new Map<string, DomainResearchCatalog>();
+  catalogsByLocale.set(catalog.market.id, catalog);
+  RESEARCH_PROTOTYPE_CATALOGS.set(catalog.domain.id, catalogsByLocale);
+}
 
 export function isDomainResearchSurface(value: string): value is DomainResearchSurface {
   return (DOMAIN_RESEARCH_SURFACES as readonly string[]).includes(value);
 }
 
 export function listResearchPrototypeDomains(): DomainResearchDomain[] {
-  return RESEARCH_PROTOTYPE_CATALOG.map((entry) => entry.domain);
+  return [...RESEARCH_PROTOTYPE_DOMAINS.values()];
 }
 
 export function getResearchPrototypeDomain(linkedDomainId: string): DomainResearchDomain | null {
-  return RESEARCH_PROTOTYPE_BY_ID.get(linkedDomainId)?.domain ?? null;
+  return RESEARCH_PROTOTYPE_DOMAINS.get(linkedDomainId) ?? null;
 }
 
 export function getResearchPrototypeCatalog(
   linkedDomainId: string,
   localeId?: string,
 ): DomainResearchCatalog | null {
-  const catalog = RESEARCH_PROTOTYPE_BY_ID.get(linkedDomainId);
-  return catalog && (!localeId || catalog.market.id === localeId) ? catalog : null;
+  const catalogsByLocale = RESEARCH_PROTOTYPE_CATALOGS.get(linkedDomainId);
+  if (!catalogsByLocale) return null;
+  if (localeId) return catalogsByLocale.get(localeId) ?? null;
+  const domain = RESEARCH_PROTOTYPE_DOMAINS.get(linkedDomainId);
+  return domain ? (catalogsByLocale.get(domain.locales[0]!.id) ?? null) : null;
 }
 
 export function resolveDomainLocale(domain: DomainResearchDomain, localeId: string | null) {
@@ -756,7 +800,7 @@ export function resolveDomainLocale(domain: DomainResearchDomain, localeId: stri
 }
 
 export function isResearchPrototypeDomain(linkedDomainId: string): boolean {
-  return RESEARCH_PROTOTYPE_BY_ID.has(linkedDomainId);
+  return RESEARCH_PROTOTYPE_DOMAINS.has(linkedDomainId);
 }
 
 export const DOMAIN_RESEARCH_VERIFY_RECORD = {

--- a/apps/hyperlocalise-web/src/lib/domains/research-prototype.ts
+++ b/apps/hyperlocalise-web/src/lib/domains/research-prototype.ts
@@ -42,7 +42,7 @@ export type DomainResearchDomain = {
   id: string;
   domainKey: string;
   sourceUrl: string;
-  market: DomainResearchMarket;
+  locales: DomainResearchMarket[];
   status: DomainResearchStatus;
   keywordCount: number;
   keywordCountLabel: string;
@@ -111,6 +111,7 @@ export type SerpResult = {
 
 export type DomainResearchCatalog = {
   domain: DomainResearchDomain;
+  market: DomainResearchMarket;
   keywords: KeywordIdea[];
   ranks: RankRow[];
   overviewKeywords: OverviewKeywordRow[];
@@ -123,10 +124,10 @@ export type DomainResearchCatalog = {
 };
 
 export const DOMAIN_RESEARCH_MARKETS: DomainResearchMarket[] = [
-  { id: "france-fr", location: "France", language: "fr", label: "France · fr" },
-  { id: "germany-de", location: "Germany", language: "de", label: "Germany · de" },
-  { id: "japan-ja", location: "Japan", language: "ja", label: "Japan · ja" },
-  { id: "vietnam-vi", location: "Vietnam", language: "vi", label: "Vietnam · vi" },
+  { id: "france-fr", location: "France", language: "fr", label: "French (France)" },
+  { id: "germany-de", location: "Germany", language: "de", label: "German (Germany)" },
+  { id: "japan-ja", location: "Japan", language: "ja", label: "Japanese (Japan)" },
+  { id: "vietnam-vi", location: "Vietnam", language: "vi", label: "Vietnamese (Vietnam)" },
 ];
 
 const FRANCE_FR = DOMAIN_RESEARCH_MARKETS[0]!;
@@ -345,6 +346,7 @@ function catalogFor(
 ): DomainResearchCatalog {
   return {
     domain,
+    market: domain.locales[0]!,
     keywords: [],
     ranks: [],
     overviewKeywords: [],
@@ -369,7 +371,7 @@ const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
       id: "hyperlocalise-com",
       domainKey: "hyperlocalise.com",
       sourceUrl: "https://hyperlocalise.com",
-      market: FRANCE_FR,
+      locales: [FRANCE_FR, GERMANY_DE, VIETNAM_VI],
       status: "verified",
       keywordCount: 12400,
       keywordCountLabel: "12.4k",
@@ -500,7 +502,7 @@ const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
       id: "acme-fr",
       domainKey: "acme.fr",
       sourceUrl: "https://acme.fr",
-      market: FRANCE_FR,
+      locales: [FRANCE_FR],
       status: "verified",
       keywordCount: 6100,
       keywordCountLabel: "6.1k",
@@ -571,7 +573,7 @@ const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
     id: "help-acme-com",
     domainKey: "help.acme.com",
     sourceUrl: "https://help.acme.com",
-    market: GERMANY_DE,
+    locales: [GERMANY_DE],
     status: "pending_verification",
     keywordCount: 0,
     keywordCountLabel: "—",
@@ -586,7 +588,7 @@ const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
       id: "acme-jp",
       domainKey: "acme.jp",
       sourceUrl: "https://acme.jp",
-      market: JAPAN_JA,
+      locales: [JAPAN_JA],
       status: "verified",
       keywordCount: 8600,
       keywordCountLabel: "8.6k",
@@ -655,7 +657,7 @@ const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
       id: "docs-acme-com",
       domainKey: "docs.acme.com",
       sourceUrl: "https://docs.acme.com",
-      market: VIETNAM_VI,
+      locales: [VIETNAM_VI],
       status: "verified",
       keywordCount: 2400,
       keywordCountLabel: "2.4k",
@@ -713,7 +715,7 @@ const RESEARCH_PROTOTYPE_CATALOG: DomainResearchCatalog[] = [
     id: "shop-acme-de",
     domainKey: "shop.acme.de",
     sourceUrl: "https://shop.acme.de",
-    market: GERMANY_DE,
+    locales: [GERMANY_DE],
     status: "pending_verification",
     keywordCount: 0,
     keywordCountLabel: "—",
@@ -741,8 +743,16 @@ export function getResearchPrototypeDomain(linkedDomainId: string): DomainResear
   return RESEARCH_PROTOTYPE_BY_ID.get(linkedDomainId)?.domain ?? null;
 }
 
-export function getResearchPrototypeCatalog(linkedDomainId: string): DomainResearchCatalog | null {
-  return RESEARCH_PROTOTYPE_BY_ID.get(linkedDomainId) ?? null;
+export function getResearchPrototypeCatalog(
+  linkedDomainId: string,
+  localeId?: string,
+): DomainResearchCatalog | null {
+  const catalog = RESEARCH_PROTOTYPE_BY_ID.get(linkedDomainId);
+  return catalog && (!localeId || catalog.market.id === localeId) ? catalog : null;
+}
+
+export function resolveDomainLocale(domain: DomainResearchDomain, localeId: string | null) {
+  return domain.locales.find((locale) => locale.id === localeId) ?? domain.locales[0]!;
 }
 
 export function isResearchPrototypeDomain(linkedDomainId: string): boolean {

--- a/docs/adr/2026-09-10-domain-locales-design.md
+++ b/docs/adr/2026-09-10-domain-locales-design.md
@@ -1,0 +1,7 @@
+# Multiple locales per domain
+
+Approved design: show each hostname once with its supported locales. Link and edit dialogs allow multiple locale selections. A shared research locale selector applies to overview, keywords, ranks, AI visibility, and prompts, and persists in the URL across tabs. DNS verification remains attached to the hostname.
+
+The existing research UI uses prototype fixtures. Keep locale edits and newly linked domains in an organization-scoped client cache for the current session. Clearly disclose this limitation in the dialogs. Store supported locales on the domain and associate each research catalog with one locale. Do not display another locale’s metrics when research is unavailable. Use an explicit empty state instead.
+
+Show locales, audit score, and verification in the domain list. Keep market-specific keyword and traffic metrics inside research. Validate at least one locale and prevent duplicate hostnames when linking. Test multi-locale selection, navigation, data isolation, and pending domain verification. Run `vp test` and `vp check --fix`.


### PR DESCRIPTION
## What changed

The domain research prototype now stores locales on each hostname instead of treating market as a single field. Link and edit dialogs accept multiple locales, the list shows locale badges, and a shared locale selector in the research shell persists across tabs via the URL.

When a locale has no catalog, research shows an empty state rather than another locale's metrics. Linked and edited domains stay in an organization-scoped session cache, with that limitation disclosed in the dialogs. DNS verification remains attached to the hostname.

## How to test

- [ ] Open Domains, link a hostname with more than one locale, and confirm the list shows badges instead of a single market column
- [ ] Edit locales on an existing domain and confirm keyword/traffic columns no longer appear on the list
- [ ] Open a domain and switch locales; the URL `locale` param should persist when changing research tabs
- [ ] Choose a locale with no catalog (e.g. Germany on hyperlocalise.com) and confirm the empty state, not another market's data
- [ ] Confirm duplicate hostname linking is rejected and at least one locale is required
- [ ] From `apps/hyperlocalise-web`, run `vp test` and `vp check --fix`

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review