### PR TITLE
feat(mcp): add create_glossary_concept MCP tool

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -901,6 +901,7 @@ export function createGlossaryConceptRoutes(
                       term.gender !== undefined ? (term.gender ?? undefined) : existing?.gender,
                     url: term.url !== undefined ? (term.url ?? undefined) : existing?.url,
                     lemma: term.lemma !== undefined ? (term.lemma ?? undefined) : existing?.lemma,
+                    forbidden: term.forbidden ?? existing?.forbidden ?? false,
                   };
                 }),
         } satisfies GlossaryConcept;
@@ -1032,6 +1033,7 @@ export function createGlossaryConceptRoutes(
             gender: payload.gender ?? existing.gender ?? "",
             url: payload.url ?? existing.url ?? "",
             lemma: payload.lemma ?? existing.lemma ?? "",
+            forbidden: payload.forbidden ?? existing.forbidden ?? false,
           });
         } catch (error) {
           const response = glossaryValidationErrorResponse(c, error);

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-create-glossary-concept.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-create-glossary-concept.schema.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+import {
+  createGlossaryConceptTermBodySchema,
+  glossaryIdParamsSchema,
+  glossaryPartOfSpeechSchema,
+} from "@/api/routes/glossary/glossary.schema";
+import { localeInputSchema } from "@/lib/i18n/locales";
+
+const glossaryTermShape = createGlossaryConceptTermBodySchema.shape;
+
+export const mcpCreateGlossaryConceptInputSchema = z.object({
+  glossaryId: glossaryIdParamsSchema.shape.glossaryId.describe(
+    "ID of the native glossary where the concept should be created.",
+  ),
+
+  sourceLocale: localeInputSchema.describe("Locale of the source terminology."),
+
+  sourceTerm: glossaryTermShape.term.describe("Source-language term for the concept."),
+
+  targetLocale: localeInputSchema.describe("Locale of the target terminology."),
+
+  targetTerm: glossaryTermShape.term.describe("Target-language term for the concept."),
+
+  description: glossaryTermShape.description.describe(
+    "Optional description of the concept and its intended meaning.",
+  ),
+
+  partOfSpeech: glossaryPartOfSpeechSchema
+    .optional()
+    .describe("Optional grammatical category shared by the terms."),
+
+  forbidden: z
+    .boolean()
+    .default(false)
+    .describe("Whether the target term must not be used in translations."),
+});
+
+export type McpCreateGlossaryConceptInput = z.infer<typeof mcpCreateGlossaryConceptInputSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -60,6 +60,7 @@ import { setCatSegmentLocks } from "@/lib/projects/content-editor/content-editor
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
 import { maxPublicUploadBytes } from "@/api/routes/public-files/public-files.schema";
+import { NativeGlossary } from "@/lib/glossary/native-glossary";
 import { err, ok } from "@/lib/primitives/result/results";
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
@@ -199,6 +200,75 @@ async function authenticatedMcpHeaders(identity = fixture.createWorkosIdentity()
   return {
     ...headers,
     authorization: `Bearer ${accessToken}`,
+  };
+}
+
+async function callMcpTool(
+  headers: Record<string, string>,
+  name: string,
+  arguments_: Record<string, unknown>,
+) {
+  return mcpClient.mcp.$post(
+    {},
+    {
+      headers: {
+        ...headers,
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      init: {
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name,
+            arguments: arguments_,
+          },
+        }),
+      },
+    },
+  );
+}
+
+async function callCreateGlossaryConcept(
+  headers: Record<string, string>,
+  arguments_: {
+    glossaryId: string;
+    sourceLocale?: string;
+    sourceTerm?: string;
+    targetLocale?: string;
+    targetTerm?: string;
+    description?: string;
+    partOfSpeech?: string;
+    forbidden?: boolean;
+  },
+) {
+  return callMcpTool(headers, "create_glossary_concept", {
+    sourceLocale: "en-US",
+    sourceTerm: "workspace",
+    targetLocale: "vi-VN",
+    targetTerm: "không gian làm việc",
+    ...arguments_,
+  });
+}
+
+async function readMcpToolResult(response: Response) {
+  expect(response.status).toBe(200);
+
+  const body = (await response.json()) as {
+    result?: {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+  };
+
+  const text = body.result?.content?.[0]?.text;
+  expect(text).toBeDefined();
+
+  return {
+    isError: body.result?.isError === true,
+    output: JSON.parse(text ?? "{}") as Record<string, unknown>,
   };
 }
 
@@ -8756,5 +8826,554 @@ describe("mcpRoutes", () => {
     expect(JSON.parse(body.result?.content?.[0]?.text ?? "{}")).toMatchObject({
       error: "unsupported_binary_download",
     });
+  });
+
+  it("advertises create_glossary_concept with bounded inputs", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list",
+            params: {},
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "create_glossary_concept");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("glossary");
+
+    expect(tool?.inputSchema?.required).toEqual(
+      expect.arrayContaining([
+        "glossaryId",
+        "sourceLocale",
+        "sourceTerm",
+        "targetLocale",
+        "targetTerm",
+      ]),
+    );
+
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      glossaryId: {
+        type: "string",
+        minLength: 1,
+        maxLength: 128,
+      },
+      sourceLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 50,
+      },
+      sourceTerm: {
+        type: "string",
+        minLength: 1,
+        maxLength: 1_000,
+      },
+      targetLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 50,
+      },
+      targetTerm: {
+        type: "string",
+        minLength: 1,
+        maxLength: 1_000,
+      },
+      description: {
+        type: "string",
+        maxLength: 10_000,
+      },
+      partOfSpeech: {
+        type: "string",
+        enum: expect.arrayContaining(["noun", "verb", "adjective", "other"]),
+      },
+      forbidden: {
+        type: "boolean",
+        default: false,
+      },
+    });
+  });
+
+  it("returns forbidden when a non-admin creates a glossary concept", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+
+    const memberIdentity = fixture.createWorkosIdentityForOrganization(
+      stored.identity.organization,
+      "member",
+    );
+
+    const headers = await authenticatedMcpHeaders(memberIdentity);
+    const createConceptSpy = vi.spyOn(NativeGlossary.prototype, "createConcept");
+
+    try {
+      const result = await readMcpToolResult(
+        await callCreateGlossaryConcept(headers, {
+          glossaryId: "glossary_inaccessible",
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toMatchObject({
+        error: "forbidden",
+      });
+
+      expect(createConceptSpy).not.toHaveBeenCalled();
+    } finally {
+      createConceptSpy.mockRestore();
+    }
+  });
+
+  it("returns glossary_not_found when creating a concept in a missing glossary", async () => {
+    const headers = await authenticatedMcpHeaders();
+    const createConceptSpy = vi.spyOn(NativeGlossary.prototype, "createConcept");
+
+    try {
+      const result = await readMcpToolResult(
+        await callCreateGlossaryConcept(headers, {
+          glossaryId: randomUUID(),
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toMatchObject({
+        error: "glossary_not_found",
+      });
+
+      expect(createConceptSpy).not.toHaveBeenCalled();
+    } finally {
+      createConceptSpy.mockRestore();
+    }
+  });
+
+  it("returns glossary_not_found for a malformed glossary ID", async () => {
+    const headers = await authenticatedMcpHeaders();
+    const createConceptSpy = vi.spyOn(NativeGlossary.prototype, "createConcept");
+
+    try {
+      const result = await readMcpToolResult(
+        await callCreateGlossaryConcept(headers, {
+          glossaryId: "missing_glossary",
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toMatchObject({
+        error: "glossary_not_found",
+      });
+      expect(createConceptSpy).not.toHaveBeenCalled();
+    } finally {
+      createConceptSpy.mockRestore();
+    }
+  });
+
+  it("does not create a concept in another organization's glossary", async () => {
+    const accessible = await fixture.createStoredProjectFixture();
+    const inaccessible = await fixture.createStoredProjectFixture();
+
+    const headers = await authenticatedMcpHeaders(accessible.identity);
+
+    const [foreignGlossary] = await db
+      .insert(schema.glossaries)
+      .values({
+        organizationId: inaccessible.organization.id,
+        createdByUserId: inaccessible.user.id,
+        name: "Foreign glossary",
+        sourceLocale: "en-US",
+        source: "native",
+      })
+      .returning({ id: schema.glossaries.id });
+
+    const createConceptSpy = vi.spyOn(NativeGlossary.prototype, "createConcept");
+
+    try {
+      const result = await readMcpToolResult(
+        await callCreateGlossaryConcept(headers, {
+          glossaryId: foreignGlossary.id,
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toMatchObject({
+        error: "glossary_not_found",
+      });
+
+      expect(createConceptSpy).not.toHaveBeenCalled();
+    } finally {
+      createConceptSpy.mockRestore();
+    }
+  });
+
+  it("returns glossary_read_only for a provider-synced glossary", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [providerGlossary] = await db
+      .insert(schema.glossaries)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Provider glossary",
+        sourceLocale: "en-US",
+        source: "external_tms",
+        externalProviderKind: "crowdin",
+        externalProjectId: "crowdin-project-1",
+        externalResourceType: "glossary",
+        externalGlossaryId: "crowdin-glossary-1",
+      })
+      .returning({ id: schema.glossaries.id });
+
+    const createConceptSpy = vi.spyOn(NativeGlossary.prototype, "createConcept");
+
+    try {
+      const result = await readMcpToolResult(
+        await callCreateGlossaryConcept(headers, {
+          glossaryId: providerGlossary.id,
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toMatchObject({
+        error: "glossary_read_only",
+      });
+
+      expect(createConceptSpy).not.toHaveBeenCalled();
+    } finally {
+      createConceptSpy.mockRestore();
+    }
+  });
+
+  it("rejects a source locale that differs from the glossary source locale", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [glossary] = await db
+      .insert(schema.glossaries)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Source locale validation",
+        sourceLocale: "en-US",
+        source: "native",
+      })
+      .returning({ id: schema.glossaries.id });
+
+    const createConceptSpy = vi.spyOn(NativeGlossary.prototype, "createConcept");
+
+    try {
+      const result = await readMcpToolResult(
+        await callCreateGlossaryConcept(headers, {
+          glossaryId: glossary.id,
+          sourceLocale: "fr-FR",
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toMatchObject({
+        error: "invalid_glossary_payload",
+        expectedSourceLocale: "en-US",
+      });
+      expect(createConceptSpy).not.toHaveBeenCalled();
+    } finally {
+      createConceptSpy.mockRestore();
+    }
+  });
+
+  it("creates concept-linked source and target terms in a native glossary", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [glossary] = await db
+      .insert(schema.glossaries)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Product terminology",
+        description: "Canonical product terminology",
+        sourceLocale: "en-US",
+        source: "native",
+      })
+      .returning({ id: schema.glossaries.id });
+
+    const result = await readMcpToolResult(
+      await callCreateGlossaryConcept(headers, {
+        glossaryId: glossary.id,
+        sourceLocale: "en-US",
+        sourceTerm: "workspace",
+        targetLocale: "vi-VN",
+        targetTerm: "khu vực làm việc",
+        description: "A shared area containing projects and members.",
+        partOfSpeech: "noun",
+        forbidden: true,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+
+    expect(result.output).toMatchObject({
+      conceptId: expect.any(String),
+      sourceTermId: expect.any(String),
+      targetTermId: expect.any(String),
+    });
+
+    const conceptId = String(result.output.conceptId);
+    const sourceTermId = String(result.output.sourceTermId);
+    const targetTermId = String(result.output.targetTermId);
+
+    expect(sourceTermId).not.toBe(targetTermId);
+
+    const [concept] = await db
+      .select({
+        id: schema.glossaryConcepts.id,
+        glossaryId: schema.glossaryConcepts.glossaryId,
+        primaryTerm: schema.glossaryConcepts.primaryTerm,
+        definition: schema.glossaryConcepts.definition,
+      })
+      .from(schema.glossaryConcepts)
+      .where(eq(schema.glossaryConcepts.id, conceptId))
+      .limit(1);
+
+    expect(concept).toEqual({
+      id: conceptId,
+      glossaryId: glossary.id,
+      primaryTerm: "workspace",
+      definition: "A shared area containing projects and members.",
+    });
+
+    const terms = await db
+      .select({
+        id: schema.glossaryTerms.id,
+        glossaryId: schema.glossaryTerms.glossaryId,
+        conceptId: schema.glossaryTerms.conceptId,
+        locale: schema.glossaryTerms.locale,
+        term: schema.glossaryTerms.term,
+        partOfSpeech: schema.glossaryTerms.partOfSpeech,
+        status: schema.glossaryTerms.status,
+        forbidden: schema.glossaryTerms.forbidden,
+      })
+      .from(schema.glossaryTerms)
+      .where(eq(schema.glossaryTerms.conceptId, conceptId));
+
+    expect(terms).toHaveLength(2);
+
+    const source = terms.find(({ id }) => id === sourceTermId);
+    const target = terms.find(({ id }) => id === targetTermId);
+
+    expect(source).toMatchObject({
+      glossaryId: glossary.id,
+      conceptId,
+      locale: "en-US",
+      term: "workspace",
+      partOfSpeech: "noun",
+      status: "preferred",
+      forbidden: false,
+    });
+
+    expect(target).toMatchObject({
+      glossaryId: glossary.id,
+      conceptId,
+      locale: "vi-VN",
+      term: "khu vực làm việc",
+      partOfSpeech: "noun",
+      status: "not_recommended",
+      forbidden: true,
+    });
+  });
+
+  it("rejects duplicate glossary concept terms without creating partial records", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [glossary] = await db
+      .insert(schema.glossaries)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Duplicate terminology test",
+        sourceLocale: "en-US",
+        source: "native",
+      })
+      .returning({ id: schema.glossaries.id });
+
+    const request = {
+      glossaryId: glossary.id,
+      sourceLocale: "en-US",
+      sourceTerm: "workspace",
+      targetLocale: "vi-VN",
+      targetTerm: "không gian làm việc",
+      partOfSpeech: "noun",
+    };
+
+    const first = await readMcpToolResult(await callCreateGlossaryConcept(headers, request));
+
+    expect(first.isError).toBe(false);
+
+    const duplicate = await readMcpToolResult(await callCreateGlossaryConcept(headers, request));
+
+    expect(duplicate.isError).toBe(true);
+    expect(duplicate.output).toMatchObject({
+      error: "duplicate_glossary_concept_term",
+    });
+
+    const concepts = await db
+      .select({ id: schema.glossaryConcepts.id })
+      .from(schema.glossaryConcepts)
+      .where(eq(schema.glossaryConcepts.glossaryId, glossary.id));
+
+    expect(concepts).toHaveLength(1);
+
+    const terms = await db
+      .select({
+        id: schema.glossaryTerms.id,
+        conceptId: schema.glossaryTerms.conceptId,
+        locale: schema.glossaryTerms.locale,
+        term: schema.glossaryTerms.term,
+      })
+      .from(schema.glossaryTerms)
+      .where(eq(schema.glossaryTerms.glossaryId, glossary.id));
+
+    expect(terms).toHaveLength(2);
+    expect(new Set(terms.map(({ conceptId }) => conceptId))).toEqual(new Set([concepts[0]?.id]));
+  });
+
+  it("exposes a created concept through glossary read tools", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [glossary] = await db
+      .insert(schema.glossaries)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Vietnamese product terminology",
+        sourceLocale: "en-US",
+        source: "native",
+      })
+      .returning({ id: schema.glossaries.id });
+
+    const created = await readMcpToolResult(
+      await callCreateGlossaryConcept(headers, {
+        glossaryId: glossary.id,
+        sourceLocale: "en-US",
+        sourceTerm: "workspace",
+        targetLocale: "vi-VN",
+        targetTerm: "không gian làm việc",
+        description: "A shared area containing projects and members.",
+        partOfSpeech: "noun",
+        forbidden: true,
+      }),
+    );
+
+    expect(created.isError).toBe(false);
+
+    const conceptId = String(created.output.conceptId);
+    const sourceTermId = String(created.output.sourceTermId);
+    const targetTermId = String(created.output.targetTermId);
+
+    const entries = await readMcpToolResult(
+      await callMcpTool(headers, "get_glossary_entries", {
+        glossaryId: glossary.id,
+        limit: 50,
+      }),
+    );
+
+    expect(entries.isError).toBe(false);
+    expect(entries.output.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: sourceTermId,
+          conceptId,
+          locale: "en-US",
+          term: "workspace",
+          partOfSpeech: "noun",
+          forbidden: false,
+        }),
+        expect.objectContaining({
+          id: targetTermId,
+          conceptId,
+          locale: "vi-VN",
+          term: "không gian làm việc",
+          partOfSpeech: "noun",
+          status: "not_recommended",
+          forbidden: true,
+        }),
+      ]),
+    );
+
+    const query = await readMcpToolResult(
+      await callMcpTool(headers, "query_glossary", {
+        glossaryId: glossary.id,
+        sourceText: "Create a new workspace",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        limit: 10,
+      }),
+    );
+
+    expect(query.isError).toBe(false);
+    expect(query.output.terms).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          glossaryId: glossary.id,
+          conceptId,
+          sourceTerm: "workspace",
+          targetTerm: "không gian làm việc",
+          forbidden: true,
+          status: "not_recommended",
+          partOfSpeech: "noun",
+        }),
+      ]),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -135,6 +135,10 @@ import {
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 import { createTranslationJob } from "@/lib/agent-runtime/tools/translation-tools";
 import { ensureAiFeaturesAllowed } from "@/lib/billing/ai-features";
+import { getOwnedGlossary, isGlossaryManageAllowed } from "@/api/routes/glossary/glossary.shared";
+import { getGlossaryProduct } from "@/lib/glossary/glossary-provider";
+import { GlossaryValidationError } from "@/lib/glossary/glossary";
+import { mcpCreateGlossaryConceptInputSchema } from "./mcp-create-glossary-concept.schema";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -1842,6 +1846,136 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
           },
         ],
       };
+    },
+  );
+
+  server.registerTool(
+    "create_glossary_concept",
+    {
+      description: "Create a source and target terminology concept in a native glossary.",
+      inputSchema: mcpCreateGlossaryConceptInputSchema,
+    },
+    async ({
+      glossaryId,
+      sourceLocale,
+      sourceTerm,
+      targetLocale,
+      targetTerm,
+      description,
+      partOfSpeech,
+      forbidden,
+    }) => {
+      if (!isGlossaryManageAllowed(apiAuth.membership.role)) {
+        return mcpToolError("forbidden", "Insufficient permissions to manage glossaries");
+      }
+
+      if (!isQueryableNativeGlossaryId(glossaryId)) {
+        return mcpToolError("glossary_not_found", "Glossary not found or inaccessible");
+      }
+
+      const glossary = await getOwnedGlossary(apiAuth, glossaryId);
+
+      if (!glossary) {
+        return mcpToolError("glossary_not_found", "Glossary not found or inaccessible");
+      }
+
+      if (glossary.source !== "native") {
+        return mcpToolError("glossary_read_only", "Provider-synced glossaries are read-only");
+      }
+
+      if (sourceLocale !== glossary.sourceLocale) {
+        return mcpToolError(
+          "invalid_glossary_payload",
+          "Source locale must match the glossary source locale",
+          {
+            expectedSourceLocale: glossary.sourceLocale,
+          },
+        );
+      }
+
+      const product = getGlossaryProduct({
+        auth: apiAuth,
+        glossary,
+        actorUserId: apiAuth.user.localUserId,
+      });
+
+      if (!product) {
+        return mcpToolError("glossary_read_only", "Provider-synced glossaries are read-only");
+      }
+
+      try {
+        const created = await product.createConcept({
+          primaryTerm: sourceTerm,
+          sourceLocale,
+          definition: description,
+          terms: [
+            {
+              locale: sourceLocale,
+              term: sourceTerm,
+              partOfSpeech,
+              status: "preferred",
+            },
+            {
+              locale: targetLocale,
+              term: targetTerm,
+              partOfSpeech,
+              status: forbidden ? "not_recommended" : "preferred",
+              forbidden,
+            },
+          ],
+        });
+
+        if (!created) {
+          return mcpToolError(
+            "duplicate_glossary_concept_term",
+            "A glossary concept with one of these terms already exists",
+          );
+        }
+
+        const conceptId = created.externalKey ?? String(created.conceptId ?? "");
+
+        const source = created.terms.find(
+          (term) =>
+            term.locale === sourceLocale &&
+            term.text.toLocaleLowerCase() === sourceTerm.toLocaleLowerCase(),
+        );
+
+        const target = created.terms.find(
+          (term) =>
+            term.locale === targetLocale &&
+            term.text.toLocaleLowerCase() === targetTerm.toLocaleLowerCase(),
+        );
+
+        if (!conceptId || source?.id == null || target?.id == null) {
+          throw new Error("Created glossary concept did not return its linked term IDs");
+        }
+
+        serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.glossaryTermCreated, {
+          status: "created",
+          source: "mcp_glossary_concept",
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                conceptId,
+                sourceTermId: String(source.id),
+                targetTermId: String(target.id),
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof GlossaryValidationError) {
+          return mcpToolError("invalid_glossary_payload", error.message, {
+            reason: error.code,
+          });
+        }
+
+        throw error;
+      }
     },
   );
 

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
@@ -141,6 +141,7 @@ export type NativeGlossaryTermInput = {
   note?: string;
   url?: string;
   lemma?: string;
+  forbidden?: boolean;
 };
 
 export type GlossaryConceptTerm = NativeGlossaryTermInput & {
@@ -217,6 +218,7 @@ export type GlossaryConceptRequestTerm = {
   gender?: string | null;
   url?: string | null;
   lemma?: string | null;
+  forbidden?: boolean;
 };
 
 export type GlossaryConceptInput = {

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -784,7 +784,7 @@ export class NativeGlossary extends Glossary {
           url: term.url ?? null,
           lemma: term.lemma ?? null,
           status: term.status ?? "draft",
-          forbidden: term.forbidden ?? false,
+          forbidden: term.forbidden ?? existing?.forbidden ?? false,
         };
         if (existing) {
           retainedIds.add(existing.id);
@@ -1157,7 +1157,9 @@ export class NativeGlossary extends Glossary {
         url: normalizedInput.url ?? null,
         lemma: normalizedInput.lemma ?? null,
         status: normalizedInput.status ?? "draft",
-        forbidden: normalizedInput.forbidden ?? false,
+        ...(normalizedInput.forbidden === undefined
+          ? {}
+          : { forbidden: normalizedInput.forbidden }),
       })
       .where(
         and(

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, asc, count, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import { buildAccessibleProjectsWhere } from "@/api/auth/team-access";
@@ -297,6 +297,7 @@ function toNativeConceptInput(input: GlossaryConceptInput, sourceLocale: string)
           gender: term.gender ?? undefined,
           url: term.url || undefined,
           lemma: term.lemma ?? undefined,
+          forbidden: term.forbidden,
         };
       }
       return { ...term };
@@ -589,6 +590,7 @@ export class NativeGlossary extends Glossary {
         note: term.note,
         url: term.url ?? undefined,
         lemma: term.lemma ?? undefined,
+        forbidden: term.forbidden,
         createdAt: term.createdAt.toISOString(),
         updatedAt: term.updatedAt.toISOString(),
       })),
@@ -608,6 +610,7 @@ export class NativeGlossary extends Glossary {
       note: term.note,
       url: term.url ?? undefined,
       lemma: term.lemma ?? undefined,
+      forbidden: term.forbidden,
       createdAt: term.createdAt.toISOString(),
       updatedAt: term.updatedAt.toISOString(),
     };
@@ -658,6 +661,38 @@ export class NativeGlossary extends Glossary {
         return null;
       }
 
+      const normalizedTermKeys = normalizedInput.terms.map(
+        (term) => `${term.locale}\0${term.text.toLocaleLowerCase()}`,
+      );
+
+      if (new Set(normalizedTermKeys).size !== normalizedTermKeys.length) {
+        return null;
+      }
+
+      if (normalizedInput.terms.length > 0) {
+        const [duplicateTerm] = await tx
+          .select({ id: schema.glossaryTerms.id })
+          .from(schema.glossaryTerms)
+          .where(
+            and(
+              eq(schema.glossaryTerms.glossaryId, this.input.glossary.id),
+              or(
+                ...normalizedInput.terms.map((term) =>
+                  and(
+                    eq(schema.glossaryTerms.locale, term.locale),
+                    sql`lower(${schema.glossaryTerms.term}) = lower(${term.text})`,
+                  ),
+                ),
+              ),
+            ),
+          )
+          .limit(1);
+
+        if (duplicateTerm) {
+          return null;
+        }
+      }
+
       const [concept] = await tx
         .insert(schema.glossaryConcepts)
         .values({
@@ -689,6 +724,7 @@ export class NativeGlossary extends Glossary {
             url: term.url ?? null,
             lemma: term.lemma ?? null,
             status: term.status ?? "draft",
+            forbidden: term.forbidden ?? false,
             provenance: "manual" as const,
           })),
         );
@@ -748,6 +784,7 @@ export class NativeGlossary extends Glossary {
           url: term.url ?? null,
           lemma: term.lemma ?? null,
           status: term.status ?? "draft",
+          forbidden: term.forbidden ?? false,
         };
         if (existing) {
           retainedIds.add(existing.id);
@@ -1094,6 +1131,7 @@ export class NativeGlossary extends Glossary {
           url: normalizedInput.url ?? null,
           lemma: normalizedInput.lemma ?? null,
           status: normalizedInput.status ?? "draft",
+          forbidden: normalizedInput.forbidden ?? false,
           provenance: "manual" as const,
         })
         .returning();
@@ -1119,6 +1157,7 @@ export class NativeGlossary extends Glossary {
         url: normalizedInput.url ?? null,
         lemma: normalizedInput.lemma ?? null,
         status: normalizedInput.status ?? "draft",
+        forbidden: normalizedInput.forbidden ?? false,
       })
       .where(
         and(

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -56,6 +56,7 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | `list_glossaries`      | List glossaries linked to accessible projects                                                                                                                           |
 | `get_glossary_entries` | Concept-linked terms for a `glossaryId` (`limit`, default 50, max 100)                                                                                                  |
 | `query_glossary`       | Ranked concept-linked hits for a source string and locale pair                                                                                                          |
+| `create_glossary_concept` | Create concept-linked source and target terms in a native glossary                                                                                                   |
 | `upload_sources`       | Upload a source file to a project using UTF-8 `content` or binary `contentBase64`                                                                                       |
 | `download_translations` | Download a reconstructed UTF-8 target file (`projectId`, `sourcePath`, `locale`)                                                                                         |
 
@@ -98,6 +99,10 @@ Each hit includes `glossaryId`, `conceptId`, `sourceTerm`, `targetTerm`, `forbid
 The search is the same native concordance path used in-app: an OR candidate query, then a source-text containment filter. A sentence such as `Proceed to checkout` still matches a `checkout` term.
 
 Native pairs come from concept-linked terms. Leftover `source_term` / `target_term` rows are ignored. Provider glossaries stay read-only; an inaccessible, non-UUID, or provider `glossaryId` returns `glossary_not_found`. An inaccessible `projectId` returns `{ "terms": [] }`.
+
+`create_glossary_concept` adds one source term and one target term to a new concept in a native glossary. Provide `glossaryId`, `sourceLocale`, `sourceTerm`, `targetLocale`, and `targetTerm`; optional fields include `description`, `partOfSpeech`, and `forbidden`. The response contains `conceptId`, `sourceTermId`, and `targetTermId`. When `forbidden` is true, the target term is stored as not recommended so glossary searches and translation review can tell agents not to use it.
+
+Creating glossary concepts requires glossary-management permission. Missing or inaccessible glossaries return `glossary_not_found`, provider-synced glossaries return `glossary_read_only`, and a term already present for the same locale in the glossary returns `duplicate_glossary_concept_term`.
 
 ### Board (issues)
 
@@ -181,6 +186,8 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `ai_features_check_failed`                     | Hyperlocalise could not verify AI feature availability                                                                |
 | `project_not_found`                            | Wrong `projectId` or missing project access on `list_files`, `list_translations`, `get_project_status`, or `list_jobs` |
 | `glossary_not_found`                           | Wrong `glossaryId`, missing glossary access, or a provider glossary on `query_glossary`                                |
+| `glossary_read_only`                           | `create_glossary_concept` targeted a provider-synced glossary                                                        |
+| `duplicate_glossary_concept_term`              | A source or target term already exists for the same locale in the native glossary                                    |
 | `translation_not_found`                        | Wrong or inaccessible project, translation key, target locale, or a hidden key                                         |
 | `translation_locked`                           | The requested translation segment is locked in the Content Editor                                                      |
 | `invalid_translation`                          | Target text has a blocking placeholder or ICU validation error                                                         |


### PR DESCRIPTION
## What changed

- Added the hosted MCP `create_glossary_concept` tool.
- Added bounded input validation for glossary IDs, locales, terms, descriptions, parts of speech, and forbidden target terms.
- Reused the native glossary concept creation path to create concept-linked source and target terms.
- Required glossary-management permission and preserved organization isolation.
- Rejected missing glossaries, provider-synced read-only glossaries, malformed IDs, locale mismatches, and duplicate terms with stable MCP errors.
- Persisted and exposed the target term's `forbidden` state without clearing it during unrelated glossary updates.
- Added coverage for tool advertisement, authorization, isolation, validation, duplicate prevention, persistence, and MCP glossary read-back.
- Updated the MCP documentation.

## How to test

```bash
vp test src/api/routes/mcp/mcp.route.test.ts
vp test src/api/routes/glossary/glossary.route.test.ts
```

## Checklist

- [X] I ran relevant checks locally (make fmt, make lint, make test)
- [X] I updated docs, comments, or examples when needed
- [X] This PR is scoped and ready for review
