### PR TITLE
fix(go-svc): copy dataforseo into the Vercel image

### DIFF
--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -16,7 +16,10 @@ RUN apt-get update \
 
 COPY go.mod go.sum ./
 COPY third_party ./third_party
+# Shared packages imported by apps/go-svc. Add a COPY for each new
+# internal/... import, or `go build ./apps/go-svc` fails in this image.
 COPY internal/i18n ./internal/i18n
+COPY internal/dataforseo ./internal/dataforseo
 COPY apps/go-svc ./apps/go-svc
 
 RUN go mod download


### PR DESCRIPTION
## What changed

`Dockerfile.vercel` now copies `internal/dataforseo` into the go-svc image. The previous context only included `internal/i18n`, so `go build ./apps/go-svc` failed after Domains research started importing that package.

## How to test

- Confirm `Dockerfile.vercel` copies `internal/dataforseo` next to `internal/i18n`.
- Redeploy the `go_svc` Vercel container and confirm the image builds past `go build ./apps/go-svc`.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)