### PR TITLE
feat(web): replace Hyperlab tabs with a dedicated sidebar

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audience-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audience-detail.tsx
@@ -124,8 +124,6 @@ export function HyperlabAudienceDetail({
 
   return (
     <HyperlabPageShell
-      organizationSlug={organizationSlug}
-      section="audiences"
       title={audience?.name ?? intl.formatMessage(messages.audiencesTitle)}
       description={intl.formatMessage(messages.audiencesDescription)}
       backHref={`/org/${organizationSlug}/hyperlab/audiences`}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audiences-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audiences-page.tsx
@@ -65,8 +65,6 @@ export function HyperlabAudiencesPage({
 
   return (
     <HyperlabPageShell
-      organizationSlug={organizationSlug}
-      section="audiences"
       title={intl.formatMessage(messages.audiencesTitle)}
       description={intl.formatMessage(messages.audiencesDescription)}
       actions={createAction}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiment-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiment-detail.tsx
@@ -396,8 +396,6 @@ export function HyperlabExperimentDetail({
 
   return (
     <HyperlabPageShell
-      organizationSlug={organizationSlug}
-      section="experiments"
       title={experiment?.name ?? intl.formatMessage(messages.experimentsTitle)}
       description={intl.formatMessage(messages.experimentsDescription)}
       backHref={`/org/${organizationSlug}/hyperlab/experiments`}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiments-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiments-page.tsx
@@ -66,8 +66,6 @@ export function HyperlabExperimentsPage({
 
   return (
     <HyperlabPageShell
-      organizationSlug={organizationSlug}
-      section="experiments"
       title={intl.formatMessage(messages.experimentsTitle)}
       description={intl.formatMessage(messages.experimentsDescription)}
       actions={createAction}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flag-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flag-detail.tsx
@@ -170,8 +170,6 @@ export function HyperlabFlagDetail({
 
   return (
     <HyperlabPageShell
-      organizationSlug={organizationSlug}
-      section="flags"
       title={flag?.key ?? intl.formatMessage(messages.flagsTitle)}
       description={intl.formatMessage(messages.flagsDescription)}
       backHref={`/org/${organizationSlug}/hyperlab/flags`}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flags-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flags-page.tsx
@@ -64,8 +64,6 @@ export function HyperlabFlagsPage({
 
   return (
     <HyperlabPageShell
-      organizationSlug={organizationSlug}
-      section="flags"
       title={intl.formatMessage(messages.flagsTitle)}
       description={intl.formatMessage(messages.flagsDescription)}
       actions={createAction}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-keys-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-keys-page.tsx
@@ -87,8 +87,6 @@ export function HyperlabKeysPage({
 
   return (
     <HyperlabPageShell
-      organizationSlug={organizationSlug}
-      section="keys"
       title={intl.formatMessage(messages.keysTitle)}
       description={intl.formatMessage(messages.keysDescription)}
       actions={createAction}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-overview.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-overview.stories.tsx
@@ -47,7 +47,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(await canvas.findByRole("heading", { name: "Hyperlab" })).toBeInTheDocument();
-    await expect(canvas.getByRole("link", { name: "Home", current: "page" })).toBeInTheDocument();
     await expect(await canvas.findAllByText("2 set up")).toHaveLength(3);
     await expect(canvas.getByText("Experiments", { selector: "a" })).toBeInTheDocument();
     await expect(canvas.getByText("How a test usually goes")).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-overview.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-overview.tsx
@@ -132,8 +132,6 @@ OpenFeature.setProvider(
 
   return (
     <HyperlabPageShell
-      organizationSlug={organizationSlug}
-      section="overview"
       title={intl.formatMessage(messages.overviewTitle)}
       description={intl.formatMessage(messages.overviewDescription)}
     >

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-page-shell.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-page-shell.tsx
@@ -19,34 +19,18 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
-import { Row } from "@/components/ui/layout/row";
 import { Rows } from "@/components/ui/layout/rows";
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
-import { cn } from "@/lib/primitives/cn";
 
 import { hyperlabMessages as messages } from "./hyperlab.messages";
 
-type HyperlabSection = "overview" | "experiments" | "audiences" | "flags" | "keys";
-
-const SECTIONS: Array<{ id: HyperlabSection; href: string; message: typeof messages.navHome }> = [
-  { id: "overview", href: "", message: messages.navHome },
-  { id: "experiments", href: "/experiments", message: messages.navExperiments },
-  { id: "audiences", href: "/audiences", message: messages.navAudiences },
-  { id: "flags", href: "/flags", message: messages.navFlags },
-  { id: "keys", href: "/keys", message: messages.navKeys },
-];
-
 export function HyperlabPageShell({
-  organizationSlug,
-  section,
   title,
   description,
   actions,
   backHref,
   children,
 }: {
-  organizationSlug: string;
-  section: HyperlabSection;
   title: string;
   description: string;
   actions?: ReactNode;
@@ -54,7 +38,6 @@ export function HyperlabPageShell({
   children: ReactNode;
 }) {
   const intl = useIntl();
-  const base = `/org/${organizationSlug}/hyperlab`;
 
   return (
     <WorkspacePageShell>
@@ -78,29 +61,6 @@ export function HyperlabPageShell({
           description={description}
           actions={actions}
         />
-        <nav aria-label="Hyperlab" className="border-b border-border">
-          <Row spacing="0.5u" alignY="center">
-            {SECTIONS.map((item) => {
-              const href = `${base}${item.href}`;
-              const active = section === item.id;
-              return (
-                <Link
-                  key={item.id}
-                  href={href}
-                  className={cn(
-                    "relative px-3 py-2 text-sm",
-                    active
-                      ? "font-medium text-foreground after:absolute after:inset-x-3 after:bottom-0 after:h-0.5 after:bg-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                  aria-current={active ? "page" : undefined}
-                >
-                  <FormattedMessage {...item.message} />
-                </Link>
-              );
-            })}
-          </Row>
-        </nav>
         {children}
       </Rows>
     </WorkspacePageShell>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab.messages.ts
@@ -16,8 +16,8 @@ import { defineMessages } from "react-intl";
 
 export const hyperlabMessages = defineMessages({
   workspaceLabel: {
-    defaultMessage: "Workspace",
-    id: "vttVPlqAsl",
+    defaultMessage: "Hyperlab",
+    id: "YY/pZV3cX9",
     description: "Page label above Hyperlab titles",
   },
   overviewTitle: {
@@ -30,31 +30,6 @@ export const hyperlabMessages = defineMessages({
       "Try a different headline, checkout, or offer in one market. Keep the version people like.",
     id: "M7Q//ePO1O",
     description: "Hyperlab overview page description",
-  },
-  navHome: {
-    defaultMessage: "Home",
-    id: "lrOpO6sjSs",
-    description: "Hyperlab sub-navigation item for the home page",
-  },
-  navFlags: {
-    defaultMessage: "Flags",
-    id: "IpQ4vzh2L9",
-    description: "Hyperlab sub-navigation item for flags",
-  },
-  navExperiments: {
-    defaultMessage: "Experiments",
-    id: "A6hxrVxwgZ",
-    description: "Hyperlab sub-navigation item for experiments",
-  },
-  navAudiences: {
-    defaultMessage: "Audiences",
-    id: "ZJI5SD947D",
-    description: "Hyperlab sub-navigation item for audiences",
-  },
-  navKeys: {
-    defaultMessage: "API keys",
-    id: "AyY17qkMp3",
-    description: "Hyperlab sub-navigation item for API keys",
   },
   backToList: {
     defaultMessage: "Back",

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.messages.ts
@@ -45,4 +45,14 @@ export const appShellNavigationMessages = defineMessages({
     id: "cCjEeqCM8J",
     description: "Sidebar group label for gated features that are not yet enabled",
   },
+  workspace: {
+    defaultMessage: "Workspace",
+    id: "eycmrBubUR",
+    description: "Sidebar link to return from Hyperlab to the workspace overview",
+  },
+  hyperlabSection: {
+    defaultMessage: "Hyperlab",
+    id: "pJnog+S4bX",
+    description: "Sidebar section label above Hyperlab navigation items",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -47,9 +47,11 @@ import {
 import { formatInboxUnreadBadgeLabel, inboxUnreadBadgeClassName } from "./inbox-unread-badge";
 
 import {
+  buildHyperlabNavigationItems,
   buildOrganizationPath,
   buildProjectNavigationItems,
   isNavigationItemActive,
+  parseHyperlabRoute,
   parseProjectRoute,
   type NavigationGroup,
   type NavigationItem,
@@ -68,6 +70,7 @@ export const AppShellNavigation = observer(function AppShellNavigation({
   const store = useAppShellStore();
   const pathname = usePathname();
   const projectRoute = parseProjectRoute(pathname);
+  const hyperlabRoute = parseHyperlabRoute(pathname);
 
   if (store.navigation.mode === "custom" && store.navigation.customState) {
     const customState = store.navigation.customState;
@@ -101,6 +104,13 @@ export const AppShellNavigation = observer(function AppShellNavigation({
         pathname={pathname}
       />
     );
+  }
+
+  if (
+    hyperlabRoute?.organizationSlug === organizationSlug &&
+    store.workspaceFeatureFlags.hyperlab
+  ) {
+    return <HyperlabNavigation organizationSlug={organizationSlug} pathname={pathname} />;
   }
 
   return (
@@ -253,6 +263,53 @@ function ProjectNavigation({
           />
         </LabeledNavigationSection>
       ) : null}
+    </div>
+  );
+}
+
+function HyperlabNavigation({
+  organizationSlug,
+  pathname,
+}: {
+  organizationSlug: string;
+  pathname: string;
+}) {
+  const intl = useIntl();
+  const items = buildHyperlabNavigationItems(organizationSlug, intl);
+  const workspaceHref = buildOrganizationPath(organizationSlug, "dashboard");
+  const workspaceLabel = intl.formatMessage(appShellNavigationMessages.workspace);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SidebarGroup className="p-0">
+        <SidebarGroupContent>
+          <SidebarMenu className="gap-1">
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                render={<OrgNavLink href={workspaceHref} />}
+                tooltip={workspaceLabel}
+                className="h-8 rounded-md px-2.5 text-sm font-medium text-muted-foreground hover:text-sidebar-foreground group-data-[collapsible=icon]:size-8!"
+              >
+                <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={2} className="size-4" />
+                <span>
+                  <FormattedMessage {...appShellNavigationMessages.workspace} />
+                </span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+
+      <SidebarGroup className="gap-1 p-0">
+        <SidebarGroupLabel className="h-auto px-3 py-1 text-xs font-medium tracking-wide text-muted-foreground uppercase group-data-[collapsible=icon]:hidden">
+          <FormattedMessage {...appShellNavigationMessages.hyperlabSection} />
+        </SidebarGroupLabel>
+        <NavigationGroupItems
+          group={{ items }}
+          pathname={pathname}
+          organizationSlug={organizationSlug}
+        />
+      </SidebarGroup>
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-sidebar.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-sidebar.stories.tsx
@@ -78,6 +78,27 @@ export const ProjectNavigation: Story = {
   },
 };
 
+export const HyperlabNavigation: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: `/org/${APP_SHELL_STORY_ORGANIZATION_SLUG}/hyperlab/experiments`,
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("link", { name: "Workspace" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Home" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Experiments" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Audiences" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Flags" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "API keys" })).toBeInTheDocument();
+    const experimentsLink = canvas.getByRole("link", { name: "Experiments" });
+    await expect(experimentsLink.querySelector("[data-active]")).toBeTruthy();
+  },
+};
+
 export const Collapsed: Story = {
   render: () => <AppShellSidebarStoryFrame collapsed />,
   play: async () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -48,6 +48,11 @@ describe("getAppShellTitle", () => {
     ["/org/acme/domains/ld_1", "ld_1"],
     ["/org/acme/domains/hyperlocalise-com/keywords", "Keywords"],
     ["/org/acme/glossaries", "Glossaries"],
+    ["/org/acme/hyperlab", "Hyperlab"],
+    ["/org/acme/hyperlab/experiments", "Experiments"],
+    ["/org/acme/hyperlab/audiences", "Audiences"],
+    ["/org/acme/hyperlab/flags", "Flags"],
+    ["/org/acme/hyperlab/keys", "API keys"],
     ["/org/acme/translation-memories", "Translation Memories"],
     ["/org/acme/integrations", "Integrations"],
     ["/org/acme/teams", "Teams"],
@@ -166,6 +171,31 @@ describe("getAppShellBreadcrumbs", () => {
     expect(getAppShellBreadcrumbs("/org/acme/members/permissions", intl)).toEqual([
       { label: "Members", href: "/org/acme/members" },
       { label: "Role permissions" },
+    ]);
+  });
+
+  it("returns Hyperlab breadcrumbs for Hyperlab sections", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/hyperlab", intl)).toEqual([{ label: "Hyperlab" }]);
+    expect(getAppShellBreadcrumbs("/en/org/acme/hyperlab", intl)).toEqual([{ label: "Hyperlab" }]);
+    expect(getAppShellBreadcrumbs("/org/acme/hyperlab/experiments", intl)).toEqual([
+      { label: "Hyperlab", href: "/org/acme/hyperlab" },
+      { label: "Experiments" },
+    ]);
+    expect(getAppShellBreadcrumbs("/org/acme/hyperlab/experiments/exp_1", intl)).toEqual([
+      { label: "Hyperlab", href: "/org/acme/hyperlab" },
+      { label: "Experiments" },
+    ]);
+    expect(getAppShellBreadcrumbs("/org/acme/hyperlab/audiences", intl)).toEqual([
+      { label: "Hyperlab", href: "/org/acme/hyperlab" },
+      { label: "Audiences" },
+    ]);
+    expect(getAppShellBreadcrumbs("/org/acme/hyperlab/flags", intl)).toEqual([
+      { label: "Hyperlab", href: "/org/acme/hyperlab" },
+      { label: "Flags" },
+    ]);
+    expect(getAppShellBreadcrumbs("/org/acme/hyperlab/keys", intl)).toEqual([
+      { label: "Hyperlab", href: "/org/acme/hyperlab" },
+      { label: "API keys" },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -33,17 +33,22 @@ type RouteTitleKey =
   | "ai-engine"
   | "api-keys"
   | "automations"
+  | "audiences"
   | "billing"
   | "dashboard"
   | "domains"
+  | "experiments"
   | "files"
+  | "flags"
   | "glossaries"
+  | "hyperlab"
   | "inbox"
   | "integrations"
   | "issues"
   | "issue-sheet"
   | "jobs"
   | "keywords"
+  | "keys"
   | "knowledge"
   | "linked-domains"
   | "locales"
@@ -79,7 +84,15 @@ const PROJECT_SECTION_KEYS = {
   strings: true,
 } as const;
 
+const HYPERLAB_SECTION_KEYS = {
+  audiences: true,
+  experiments: true,
+  flags: true,
+  keys: true,
+} as const;
+
 type ProjectSectionKey = keyof typeof PROJECT_SECTION_KEYS;
+type HyperlabSectionKey = keyof typeof HYPERLAB_SECTION_KEYS;
 
 function isRouteTitleKey(value: string): value is RouteTitleKey {
   return (
@@ -90,17 +103,22 @@ function isRouteTitleKey(value: string): value is RouteTitleKey {
     value === "ai-engine" ||
     value === "api-keys" ||
     value === "automations" ||
+    value === "audiences" ||
     value === "billing" ||
     value === "dashboard" ||
     value === "domains" ||
+    value === "experiments" ||
     value === "files" ||
+    value === "flags" ||
     value === "glossaries" ||
+    value === "hyperlab" ||
     value === "inbox" ||
     value === "integrations" ||
     value === "issues" ||
     value === "issue-sheet" ||
     value === "jobs" ||
     value === "keywords" ||
+    value === "keys" ||
     value === "knowledge" ||
     value === "linked-domains" ||
     value === "locales" ||
@@ -124,6 +142,10 @@ function isRouteTitleKey(value: string): value is RouteTitleKey {
 
 function isProjectSectionKey(value: string): value is ProjectSectionKey {
   return value in PROJECT_SECTION_KEYS;
+}
+
+function isHyperlabSectionKey(value: string): value is HyperlabSectionKey {
+  return value in HYPERLAB_SECTION_KEYS;
 }
 
 function parseOrgRoute(pathname: string | null) {
@@ -202,6 +224,12 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
         id: "XRHW9DFjAT",
         description: "App shell breadcrumb title for the API keys settings page",
       });
+    case "audiences":
+      return intl.formatMessage({
+        defaultMessage: "Audiences",
+        id: "pMWGh46Ptt",
+        description: "App shell breadcrumb title for the Hyperlab audiences page",
+      });
     case "billing":
       return intl.formatMessage({
         defaultMessage: "Billing",
@@ -220,6 +248,12 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
         id: "GuSsVpTTay",
         description: "App shell breadcrumb title for the domains page",
       });
+    case "experiments":
+      return intl.formatMessage({
+        defaultMessage: "Experiments",
+        id: "6acz11Hecl",
+        description: "App shell breadcrumb title for the Hyperlab experiments page",
+      });
     case "files":
       return intl.formatMessage({
         defaultMessage: "Files",
@@ -237,6 +271,24 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
         defaultMessage: "Inbox",
         id: "2f2Oa8dJQI",
         description: "App shell breadcrumb title for the inbox page",
+      });
+    case "hyperlab":
+      return intl.formatMessage({
+        defaultMessage: "Hyperlab",
+        id: "xeqCGSaHwJ",
+        description: "App shell breadcrumb title for Hyperlab",
+      });
+    case "flags":
+      return intl.formatMessage({
+        defaultMessage: "Flags",
+        id: "rgJk0uxb7q",
+        description: "App shell breadcrumb title for the Hyperlab flags page",
+      });
+    case "keys":
+      return intl.formatMessage({
+        defaultMessage: "API keys",
+        id: "NxYY7eU7aJ",
+        description: "App shell breadcrumb title for the Hyperlab API keys page",
       });
     case "integrations":
       return intl.formatMessage({
@@ -544,6 +596,27 @@ export function getAppShellBreadcrumbs(
 
   if (section === "projects") {
     return [{ label: formatRouteTitle(intl, "projects") }];
+  }
+
+  if (section === "hyperlab") {
+    if (!subsection) {
+      return [{ label: formatRouteTitle(intl, "hyperlab") }];
+    }
+
+    const crumbs: AppShellBreadcrumb[] = [
+      {
+        label: formatRouteTitle(intl, "hyperlab"),
+        href: buildOrgPath(organizationSlug, "hyperlab"),
+      },
+    ];
+
+    if (isHyperlabSectionKey(subsection)) {
+      crumbs.push({
+        label: formatRouteTitle(intl, subsection),
+      });
+    }
+
+    return crumbs;
   }
 
   if (section && isRouteTitleKey(section)) {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.fixture.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.stories.fixture.tsx
@@ -257,7 +257,10 @@ export function AppShellSidebarStoryFrame({
   const intl = useIntl();
 
   return (
-    <AppShellStoreProvider defaultNavigationGroups={buildAppShellStoryNavigationGroups()}>
+    <AppShellStoreProvider
+      defaultNavigationGroups={buildAppShellStoryNavigationGroups()}
+      workspaceFeatureFlags={ALL_WORKSPACE_FEATURE_FLAGS}
+    >
       <SidebarProvider
         defaultOpen={!collapsed}
         style={appShellStoryLayoutStyle}

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -28,6 +28,8 @@ import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resou
 import {
   buildAutomationsPath,
   buildGlobalNavigationGroups,
+  buildHyperlabNavigationItems,
+  buildHyperlabPath,
   buildOrganizationPath,
   buildProjectNavigationItems,
   buildProjectPath,
@@ -37,6 +39,7 @@ import {
   isNavigationItemActive,
   isOrganizationSettingsPath,
   parseDomainRoute,
+  parseHyperlabRoute,
   parseProjectRoute,
   parseTeamRoute,
   stripAppLocalePrefix,
@@ -168,6 +171,11 @@ describe("path builders", () => {
     expect(buildProjectPath("acme", "proj_1", "files")).toBe("/org/acme/projects/proj_1/files");
   });
 
+  it("builds Hyperlab paths with and without a section", () => {
+    expect(buildHyperlabPath("acme")).toBe("/org/acme/hyperlab");
+    expect(buildHyperlabPath("acme", "experiments")).toBe("/org/acme/hyperlab/experiments");
+  });
+
   it("builds workspace and project automations paths", () => {
     expect(buildAutomationsPath("acme")).toBe("/org/acme/automations");
     expect(buildAutomationsPath("acme", { section: "new" })).toBe("/org/acme/automations/new");
@@ -251,6 +259,18 @@ describe("path builders", () => {
     expect(items.find((item) => item.label === "Reports")?.featureFlagKey).toBe(
       WORKSPACE_REPORTS_FLAG,
     );
+  });
+
+  it("builds Hyperlab navigation items scoped to the organization", () => {
+    const items = buildHyperlabNavigationItems("acme", intl);
+
+    expect(items.map((item) => [item.label, item.href, item.exact ?? false])).toEqual([
+      ["Home", "/org/acme/hyperlab", true],
+      ["Experiments", "/org/acme/hyperlab/experiments", false],
+      ["Audiences", "/org/acme/hyperlab/audiences", false],
+      ["Flags", "/org/acme/hyperlab/flags", false],
+      ["API keys", "/org/acme/hyperlab/keys", false],
+    ]);
   });
 });
 
@@ -351,6 +371,41 @@ describe("parseDomainRoute", () => {
   });
 });
 
+describe("parseHyperlabRoute", () => {
+  it("returns null for empty and non-hyperlab routes", () => {
+    expect(parseHyperlabRoute(null)).toBeNull();
+    expect(parseHyperlabRoute("")).toBeNull();
+    expect(parseHyperlabRoute("/org/acme/inbox")).toBeNull();
+    expect(parseHyperlabRoute("/org/acme/projects/proj_1")).toBeNull();
+  });
+
+  it("returns a null section for the Hyperlab home route", () => {
+    expect(parseHyperlabRoute("/org/acme/hyperlab")).toEqual({
+      organizationSlug: "acme",
+      section: null,
+    });
+    expect(parseHyperlabRoute("/en/org/acme/hyperlab")).toEqual({
+      organizationSlug: "acme",
+      section: null,
+    });
+  });
+
+  it("only reports the first section segment for nested routes", () => {
+    expect(parseHyperlabRoute("/org/acme/hyperlab/experiments")).toEqual({
+      organizationSlug: "acme",
+      section: "experiments",
+    });
+    expect(parseHyperlabRoute("/org/acme/hyperlab/experiments/exp_1")).toEqual({
+      organizationSlug: "acme",
+      section: "experiments",
+    });
+    expect(parseHyperlabRoute("/org/acme/hyperlab/flags/flag_1")).toEqual({
+      organizationSlug: "acme",
+      section: "flags",
+    });
+  });
+});
+
 describe("buildTeamPath", () => {
   it("encodes team ids in the path", () => {
     expect(buildTeamPath("acme", "team_1")).toBe("/org/acme/teams/team_1");
@@ -443,6 +498,21 @@ describe("isNavigationItemActive", () => {
     expect(isNavigationItemActive("/org/acme/my-jobs/job_1", myWorkHref)).toBe(true);
     expect(isNavigationItemActive("/en/org/acme/my-jobs", myWorkHref)).toBe(true);
     expect(isNavigationItemActive("/org/acme/inbox", myWorkHref)).toBe(false);
+  });
+
+  it("keeps Hyperlab home exact and nested sections distinct", () => {
+    const homeHref = buildHyperlabPath("acme");
+    const experimentsHref = buildHyperlabPath("acme", "experiments");
+    const flagsHref = buildHyperlabPath("acme", "flags");
+
+    expect(isNavigationItemActive(homeHref, homeHref, { exact: true })).toBe(true);
+    expect(
+      isNavigationItemActive("/org/acme/hyperlab/experiments", homeHref, { exact: true }),
+    ).toBe(false);
+    expect(isNavigationItemActive("/org/acme/hyperlab/experiments/exp_1", experimentsHref)).toBe(
+      true,
+    );
+    expect(isNavigationItemActive("/org/acme/hyperlab/experiments", flagsHref)).toBe(false);
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -38,10 +38,12 @@ import {
   DashboardSquare01Icon,
   Database01Icon,
   File01Icon,
+  Flag01Icon,
   FlashIcon,
   FlaskConicalIcon,
   Globe02Icon,
   InboxIcon,
+  Key01Icon,
   LanguageCircleIcon,
   PuzzleIcon,
   SentIcon,
@@ -83,6 +85,11 @@ export function buildOrganizationPath(organizationSlug: string, section: string)
 
 export function buildProjectPath(organizationSlug: string, projectId: string, section?: string) {
   const base = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}`;
+  return section ? `${base}/${section}` : base;
+}
+
+export function buildHyperlabPath(organizationSlug: string, section?: string) {
+  const base = `/org/${organizationSlug}/hyperlab`;
   return section ? `${base}/${section}` : base;
 }
 
@@ -461,6 +468,62 @@ export function buildProjectNavigationItems(
   return items;
 }
 
+export function buildHyperlabNavigationItems(
+  organizationSlug: string,
+  intl: IntlShape,
+): readonly NavigationItem[] {
+  const hyperlab = (section?: string) => buildHyperlabPath(organizationSlug, section);
+
+  return [
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Home",
+        id: "lrOpO6sjSs",
+        description: "Hyperlab sub-navigation item for the home page",
+      }),
+      href: hyperlab(),
+      icon: DashboardSquare01Icon,
+      exact: true,
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Experiments",
+        id: "A6hxrVxwgZ",
+        description: "Hyperlab sub-navigation item for experiments",
+      }),
+      href: hyperlab("experiments"),
+      icon: FlaskConicalIcon,
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Audiences",
+        id: "ZJI5SD947D",
+        description: "Hyperlab sub-navigation item for audiences",
+      }),
+      href: hyperlab("audiences"),
+      icon: UserMultiple02Icon,
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Flags",
+        id: "IpQ4vzh2L9",
+        description: "Hyperlab sub-navigation item for flags",
+      }),
+      href: hyperlab("flags"),
+      icon: Flag01Icon,
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "API keys",
+        id: "AyY17qkMp3",
+        description: "Hyperlab sub-navigation item for API keys",
+      }),
+      href: hyperlab("keys"),
+      icon: Key01Icon,
+    },
+  ];
+}
+
 export function stripAppLocalePrefix(pathname: string | null | undefined) {
   if (!pathname) {
     return "/";
@@ -528,6 +591,21 @@ export function parseDomainRoute(pathname: string | null) {
     organizationSlug,
     linkedDomainId: decodePathSegment(linkedDomainIdSegment),
     ...(surface ? { surface } : {}),
+  };
+}
+
+export function parseHyperlabRoute(pathname: string | null) {
+  if (!pathname) return null;
+
+  const match = stripAppLocalePrefix(pathname).match(/^\/org\/([^/]+)\/hyperlab(?:\/(.*))?$/);
+  if (!match) return null;
+
+  const [, organizationSlug, remainder] = match;
+  const section = remainder?.split("/").filter(Boolean)[0] ?? null;
+
+  return {
+    organizationSlug,
+    section,
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Hyperlab used in-page tabs for Home, Experiments, Audiences, Flags, and API keys. Each tab was a separate route, so switching tabs remounted the page shell and showed a loading skeleton.

Hyperlab now uses a dedicated app-shell sidebar, matching Project:

- Workspace back link to the workspace overview
- Home, Experiments, Audiences, Flags, and API keys as sidebar items
- In-page tab bar removed; page headers stay on each section
- Breadcrumbs show Hyperlab and the active section

The app-shell sidebar stays mounted across Hyperlab routes, so navigation no longer flashes the tab bar.

## How to test

- `vp check --fix` in `apps/hyperlocalise-web`
- `vp test src/components/app-shell/navigation-config.test.ts src/components/app-shell/app-shell-title.test.ts`
- Open a workspace with Hyperlab enabled, go to `/org/{slug}/hyperlab`, and switch among Home, Experiments, Audiences, Flags, and API keys
- Confirm the sidebar stays put and only page content loads
- Confirm Workspace returns to the workspace overview
- Confirm the global Hyperlab item still appears in workspace nav outside Hyperlab routes

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-707a54ca-2278-4923-93bc-9488ba63c2e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-707a54ca-2278-4923-93bc-9488ba63c2e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

