### PR TITLE
fix(web): stop importing office story URLs from MSW handlers

### DIFF
--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.fixture.ts
@@ -47,7 +47,7 @@ import {
   CAT_STORY_OFFICE_PPTX_TARGET_URL,
   CAT_STORY_OFFICE_XLSX_SOURCE_URL,
   CAT_STORY_OFFICE_XLSX_TARGET_URL,
-} from "./content-editor-office-msw-handlers";
+} from "./content-editor-office-story-assets";
 
 export const contentEditorImageFileIntelligenceFixture: ContentEditorSegmentIntelligence = {
   ...contentEditorIntelligenceFixture,

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-office-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-office-file-viewer.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/content-editor/file-view/content-editor-office-convert";
 import { contentEditorFileViewMessages } from "@/components/content-editor/file-view/content-editor-file-view.messages";
 import { ContentEditorOfficeFilePreview } from "@/components/content-editor/file-view/content-editor-office-file-preview";
-import { isCatStoryOfficeAssetUrl } from "@/components/content-editor/file-view/content-editor-office-msw-handlers";
+import { isCatStoryOfficeAssetUrl } from "@/components/content-editor/file-view/content-editor-office-story-assets";
 import {
   isCatOfficeKind,
   mountCatUniverHost,

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-office-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-office-msw-handlers.ts
@@ -15,18 +15,14 @@ import { http, HttpResponse } from "msw";
 import PptxGenJS from "pptxgenjs";
 import * as XLSX from "xlsx";
 
-export const CAT_STORY_OFFICE_DOCX_SOURCE_URL = "/storybook/cat/docs/product-brief.source.docx";
-export const CAT_STORY_OFFICE_DOCX_TARGET_URL = "/storybook/cat/docs/product-brief.target.docx";
-export const CAT_STORY_OFFICE_XLSX_SOURCE_URL =
-  "/storybook/cat/sheets/localization-metrics.source.xlsx";
-export const CAT_STORY_OFFICE_XLSX_TARGET_URL =
-  "/storybook/cat/sheets/localization-metrics.target.xlsx";
-export const CAT_STORY_OFFICE_PPTX_SOURCE_URL = "/storybook/cat/decks/quarterly-review.source.pptx";
-export const CAT_STORY_OFFICE_PPTX_TARGET_URL = "/storybook/cat/decks/quarterly-review.target.pptx";
-
-export function isCatStoryOfficeAssetUrl(src: string | null | undefined) {
-  return Boolean(src?.startsWith("/storybook/cat/"));
-}
+import {
+  CAT_STORY_OFFICE_DOCX_SOURCE_URL,
+  CAT_STORY_OFFICE_DOCX_TARGET_URL,
+  CAT_STORY_OFFICE_PPTX_SOURCE_URL,
+  CAT_STORY_OFFICE_PPTX_TARGET_URL,
+  CAT_STORY_OFFICE_XLSX_SOURCE_URL,
+  CAT_STORY_OFFICE_XLSX_TARGET_URL,
+} from "./content-editor-office-story-assets";
 
 async function buildStoryDocx(paragraphs: string[]) {
   const document = new Document({

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-office-story-assets.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-office-story-assets.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  CAT_STORY_OFFICE_DOCX_SOURCE_URL,
+  CAT_STORY_OFFICE_PPTX_TARGET_URL,
+  CAT_STORY_OFFICE_XLSX_SOURCE_URL,
+  isCatStoryOfficeAssetUrl,
+} from "./content-editor-office-story-assets";
+
+describe("isCatStoryOfficeAssetUrl", () => {
+  it("matches Storybook CAT office asset URLs", () => {
+    expect(isCatStoryOfficeAssetUrl(CAT_STORY_OFFICE_DOCX_SOURCE_URL)).toBe(true);
+    expect(isCatStoryOfficeAssetUrl(CAT_STORY_OFFICE_XLSX_SOURCE_URL)).toBe(true);
+    expect(isCatStoryOfficeAssetUrl(CAT_STORY_OFFICE_PPTX_TARGET_URL)).toBe(true);
+  });
+
+  it("rejects missing and production asset URLs", () => {
+    expect(isCatStoryOfficeAssetUrl(undefined)).toBe(false);
+    expect(isCatStoryOfficeAssetUrl(null)).toBe(false);
+    expect(isCatStoryOfficeAssetUrl("")).toBe(false);
+    expect(isCatStoryOfficeAssetUrl("/files/brief.docx")).toBe(false);
+    expect(isCatStoryOfficeAssetUrl("https://cdn.example/storybook/cat/brief.docx")).toBe(false);
+  });
+
+  it("keeps the production office viewer off Vercel-ignored MSW handlers", () => {
+    const viewerSource = readFileSync(
+      new URL("./content-editor-office-file-viewer.tsx", import.meta.url),
+      "utf8",
+    );
+    expect(viewerSource).not.toMatch(/content-editor-office-msw-handlers/);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-office-story-assets.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-office-story-assets.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const CAT_STORY_OFFICE_ASSET_PREFIX = "/storybook/cat/";
+
+export const CAT_STORY_OFFICE_DOCX_SOURCE_URL = "/storybook/cat/docs/product-brief.source.docx";
+export const CAT_STORY_OFFICE_DOCX_TARGET_URL = "/storybook/cat/docs/product-brief.target.docx";
+export const CAT_STORY_OFFICE_XLSX_SOURCE_URL =
+  "/storybook/cat/sheets/localization-metrics.source.xlsx";
+export const CAT_STORY_OFFICE_XLSX_TARGET_URL =
+  "/storybook/cat/sheets/localization-metrics.target.xlsx";
+export const CAT_STORY_OFFICE_PPTX_SOURCE_URL = "/storybook/cat/decks/quarterly-review.source.pptx";
+export const CAT_STORY_OFFICE_PPTX_TARGET_URL = "/storybook/cat/decks/quarterly-review.target.pptx";
+
+export function isCatStoryOfficeAssetUrl(src: string | null | undefined) {
+  return Boolean(src?.startsWith(CAT_STORY_OFFICE_ASSET_PREFIX));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The production office file viewer imported `isCatStoryOfficeAssetUrl` from `content-editor-office-msw-handlers.ts`. Vercel ignores `*-msw-handlers.ts`, so Turbopack failed with `Module not found` during the production build.

Move the Storybook office asset URLs and URL helper into `content-editor-office-story-assets.ts`, a module that ships with the app. MSW handlers and fixtures import the URLs from there instead.

## How to test

- `vp test` for the office file-view tests in `apps/hyperlocalise-web` (15 passed, including the new story-assets tests)
- `vp check --fix` in `apps/hyperlocalise-web` (no lint or type errors)
- Confirm `content-editor-office-file-viewer.tsx` imports `content-editor-office-story-assets`, not `*-msw-handlers.ts`

## Checklist

- [x] I ran relevant checks locally (`vp test` for office file-view tests, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6130a871-c174-405a-9981-3a8e3d13989e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6130a871-c174-405a-9981-3a8e3d13989e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

