### PR TITLE
fix(web): stop importing document story URLs from MSW handlers

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -9,11 +9,13 @@
 .storybook
 storybook-static
 
-# Tests, MSW handlers, and stories (not imported by production code)
+# Tests, fixtures, MSW handlers, and stories (not imported by production code)
 **/*.test.ts
 **/*.test.tsx
 **/*.test.js
 **/*.test.jsx
+**/*.fixture.ts
+**/*.fixture.js
 **/*-msw-handlers.ts
 **/*.stories.ts
 **/*.stories.tsx

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-msw-handlers.ts
@@ -12,11 +12,13 @@
  */
 import { http, HttpResponse } from "msw";
 
-export const CAT_STORY_DOCUMENT_SOURCE_URL = "/storybook/cat/content/intro.source.md";
-export const CAT_STORY_DOCUMENT_TARGET_URL = "/storybook/cat/content/intro.target.md";
-export const CAT_STORY_DOCUMENT_MDX_SOURCE_URL = "/storybook/cat/content/guide.source.mdx";
-export const CAT_STORY_DOCUMENT_MDX_TARGET_URL = "/storybook/cat/content/guide.target.mdx";
-export const CAT_STORY_DOCUMENT_ERROR_TARGET_URL = "/storybook/cat/content/missing.target.md";
+import {
+  CAT_STORY_DOCUMENT_ERROR_TARGET_URL,
+  CAT_STORY_DOCUMENT_MDX_SOURCE_URL,
+  CAT_STORY_DOCUMENT_MDX_TARGET_URL,
+  CAT_STORY_DOCUMENT_SOURCE_URL,
+  CAT_STORY_DOCUMENT_TARGET_URL,
+} from "./content-editor-document-story-assets";
 
 export const catStoryDocumentSourceMarkdown = `---
 title: Getting started

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-story-assets.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-story-assets.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  CAT_STORY_DOCUMENT_ERROR_TARGET_URL,
+  CAT_STORY_DOCUMENT_MDX_SOURCE_URL,
+  CAT_STORY_DOCUMENT_SOURCE_URL,
+  CAT_STORY_DOCUMENT_TARGET_URL,
+} from "./content-editor-document-story-assets";
+
+describe("content editor document story assets", () => {
+  it("uses Storybook CAT document asset URLs", () => {
+    expect(CAT_STORY_DOCUMENT_SOURCE_URL).toBe("/storybook/cat/content/intro.source.md");
+    expect(CAT_STORY_DOCUMENT_TARGET_URL).toBe("/storybook/cat/content/intro.target.md");
+    expect(CAT_STORY_DOCUMENT_MDX_SOURCE_URL).toBe("/storybook/cat/content/guide.source.mdx");
+    expect(CAT_STORY_DOCUMENT_ERROR_TARGET_URL).toBe("/storybook/cat/content/missing.target.md");
+  });
+
+  it("keeps fixtures off Vercel-ignored MSW handlers", () => {
+    const fixtureSource = readFileSync(
+      new URL("./content-editor-file-view.fixture.ts", import.meta.url),
+      "utf8",
+    );
+    expect(fixtureSource).not.toMatch(/content-editor-document-msw-handlers/);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-story-assets.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-document-story-assets.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const CAT_STORY_DOCUMENT_SOURCE_URL = "/storybook/cat/content/intro.source.md";
+export const CAT_STORY_DOCUMENT_TARGET_URL = "/storybook/cat/content/intro.target.md";
+export const CAT_STORY_DOCUMENT_MDX_SOURCE_URL = "/storybook/cat/content/guide.source.mdx";
+export const CAT_STORY_DOCUMENT_MDX_TARGET_URL = "/storybook/cat/content/guide.target.mdx";
+export const CAT_STORY_DOCUMENT_ERROR_TARGET_URL = "/storybook/cat/content/missing.target.md";

--- a/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/file-view/content-editor-file-view.fixture.ts
@@ -39,7 +39,7 @@ import {
   CAT_STORY_DOCUMENT_MDX_TARGET_URL,
   CAT_STORY_DOCUMENT_SOURCE_URL,
   CAT_STORY_DOCUMENT_TARGET_URL,
-} from "./content-editor-document-msw-handlers";
+} from "./content-editor-document-story-assets";
 import {
   CAT_STORY_OFFICE_DOCX_SOURCE_URL,
   CAT_STORY_OFFICE_DOCX_TARGET_URL,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Vercel ignores `*-msw-handlers.ts`, so typecheck failed when `content-editor-file-view.fixture.ts` imported Storybook document asset URLs from that module.

Move the CAT document asset URLs into `content-editor-document-story-assets.ts`, a module that ships with the app. MSW handlers and fixtures import the URLs from there instead.

Also add `**/*.fixture.ts` and `**/*.fixture.js` to the repo-root `.vercelignore` so it matches `apps/hyperlocalise-web/.vercelignore`.

## How to test

- `vp test` for `content-editor-document-story-assets.test.ts` and related file-view tests in `apps/hyperlocalise-web`
- `vp check --fix` in `apps/hyperlocalise-web`
- Confirm `content-editor-file-view.fixture.ts` imports `content-editor-document-story-assets`, not `*-msw-handlers.ts`

## Checklist

- [x] I ran relevant checks locally (`vp test` for document story-asset tests, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a509b20e-00d0-4911-bcee-0a70cb2dc176?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a509b20e-00d0-4911-bcee-0a70cb2dc176&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

