### PR TITLE
fix(web): run AuthKit on /mcp OAuth callback paths

### DIFF
--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -49,6 +49,9 @@ describe("isUnsupportedLocalePath", () => {
     expect(isUnsupportedLocalePath("/auth/sign-in")).toBe(false);
     expect(isUnsupportedLocalePath("/install")).toBe(false);
     expect(isUnsupportedLocalePath("/api/auth/callback")).toBe(false);
+    expect(isUnsupportedLocalePath("/mcp")).toBe(false);
+    expect(isUnsupportedLocalePath("/mcp/callback")).toBe(false);
+    expect(isUnsupportedLocalePath("/mcp/consent")).toBe(false);
     expect(isUnsupportedLocalePath("/crowdin-app/inbox")).toBe(false);
     expect(isUnsupportedLocalePath("/crowdin-app/manifest.json")).toBe(false);
   });
@@ -216,6 +219,18 @@ describe("proxy", () => {
     expect(response?.status).toBe(200);
   });
 
+  it("delegates /mcp OAuth callback and consent paths to AuthKit", async () => {
+    authkitProxyMock.mockReset();
+    authkitProxyMock.mockResolvedValue(NextResponse.next());
+
+    for (const pathname of ["/mcp/callback", "/mcp/consent", "/mcp"]) {
+      const response = await proxy(createRequest(pathname), {} as never);
+
+      expect(response?.status, pathname).toBe(200);
+      expect(authkitProxyMock).toHaveBeenCalled();
+    }
+  });
+
   it("does not 404 opaque UUID challenge paths as unsupported locale paths", async () => {
     authkitProxyMock.mockReset();
     authkitProxyMock.mockResolvedValueOnce(NextResponse.next());
@@ -275,5 +290,15 @@ describe("proxy matcher", () => {
     expect(regex.test("/auth.md")).toBe(false);
     expect(regex.test("/llms.txt")).toBe(false);
     expect(regex.test("/en/org/acme/dashboard")).toBe(true);
+  });
+
+  it("re-includes /mcp paths via a dedicated AuthKit matcher", () => {
+    const [localeMatcher] = config.matcher;
+    const regex = new RegExp(`^${localeMatcher}$`);
+
+    expect(regex.test("/mcp")).toBe(false);
+    expect(regex.test("/mcp/callback")).toBe(false);
+    expect(regex.test("/mcp/consent")).toBe(false);
+    expect(config.matcher).toContain("/mcp/:path*");
   });
 });

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -130,7 +130,7 @@ const PUBLIC_LOCALIZED_PATHS = new Set([
   "/localisation-audit",
 ]);
 const PROTECTED_LOCALIZED_PREFIXES = ["/dashboard", "/org", "/claim-domain"];
-const NON_LOCALE_ROOT_PREFIXES = ["/auth", "/install", "/api", "/crowdin-app"];
+const NON_LOCALE_ROOT_PREFIXES = ["/auth", "/install", "/api", "/crowdin-app", "/mcp"];
 // BotID (and similar) use opaque UUID first segments; locales never do.
 const UUID_PATH_SEGMENT_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -282,7 +282,10 @@ export const config = {
     // Exclude opaque UUID roots (BotID challenge scripts) so locale proxy does not 404 them.
     // Exclude /auth.md so the AuthKit agent skill is not wrapped in a session proxy.
     // Exclude /llms.txt so coding agents can read the public index without locale 404s.
+    // Exclude /api and /mcp from the locale matcher; re-include them below so AuthKit
+    // still runs. /mcp/callback and /mcp/consent call withAuth() and throw if skipped.
     "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|auth\\.md|llms\\.txt|\\.well-known|install|sitemap\\.xml|robots\\.txt|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}).*)",
     "/api/:path*",
+    "/mcp/:path*",
   ],
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`/mcp/callback` (and `/mcp/consent`) call `withAuth()` via `resolveApiAuthContextFromSession`, but the AuthKit proxy matcher excluded `mcp` and never re-included it. AuthKit then throws:

> You are calling 'withAuth' on a route that isn't covered by the AuthKit middleware.

This mirrors how `/api` is handled:

- Keep `/mcp` out of the locale matcher so it is not treated as a `/{lang}` path.
- Add `/mcp` to non-locale root prefixes so the proxy does not 404 it.
- Add `/mcp/:path*` so AuthKit still runs on MCP OAuth browser routes.

## How to test

- `vp test src/proxy.test.ts` in `apps/hyperlocalise-web` (24 passed)
- `vp check --fix` in `apps/hyperlocalise-web` (passed)
- Re-run MCP OAuth: authorize → sign-in → `/mcp/callback` should no longer throw the AuthKit middleware error

## Checklist

- [x] I ran relevant checks locally (`vp test src/proxy.test.ts`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4dc41f3-3f6b-4afc-868f-c061ef6d6cc6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4dc41f3-3f6b-4afc-868f-c061ef6d6cc6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

