### PR TITLE
feat(web): add GitLab Pipes integration and sandbox clone

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -23,6 +23,7 @@ import {
 } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
 import {
   buildFileTranslationInstructions,
+  getOrCreateConversationGitlabRepositorySandbox,
   getOrCreateConversationRepositorySandbox,
   resolveConversationRepositoryContext,
   stopStaleRepositorySandbox,
@@ -308,6 +309,7 @@ async function processSlackMessage(
       return [{ role: chatMessage.role, content: chatMessage.content }];
     });
     const storedRepositoryContext = threadState?.repositoryGitHubContext ?? null;
+    const storedGitLabContext = threadState?.repositoryGitLabContext ?? null;
     const languageModel = await resolveHyperlocaliseAgentLanguageModel({
       organizationId,
     });
@@ -315,7 +317,7 @@ async function processSlackMessage(
       currentMessage: message.text,
       conversationText,
       hasFileAttachments: hasTranslationAttachments,
-      hasStoredRepositoryContext: Boolean(storedRepositoryContext),
+      hasStoredRepositoryContext: Boolean(storedRepositoryContext ?? storedGitLabContext),
       surface: "slack",
       model: languageModel.model,
     });
@@ -323,7 +325,7 @@ async function processSlackMessage(
       {
         needsRepositoryTools: classification.needsRepositoryTools,
         continuesRepositoryThread: classification.continuesRepositoryThread,
-        hasStoredRepositoryContext: Boolean(storedRepositoryContext),
+        hasStoredRepositoryContext: Boolean(storedRepositoryContext ?? storedGitLabContext),
         hasConnectorConfig: Boolean(connectorConfig),
       },
       "slack agent conversation classified",
@@ -332,6 +334,7 @@ async function processSlackMessage(
     const repositoryResolution = await resolveConversationRepositoryContext({
       surface: "slack",
       organizationId,
+      localUserId: membership.localUserId,
       projectId,
       conversationText,
       classification,
@@ -348,13 +351,18 @@ async function processSlackMessage(
     }
 
     const resolvedRepositoryContext = repositoryResolution.context;
+    const resolvedGitlabContext = repositoryResolution.gitlabContext;
     const repositoryContextInstructions = repositoryResolution.instructions;
     let updatedThreadState = repositoryResolution.updatedSession;
 
-    if (updatedThreadState?.repositoryGitHubContext) {
+    if (
+      updatedThreadState?.repositoryGitHubContext ||
+      updatedThreadState?.repositoryGitLabContext
+    ) {
       await thread.setState({
         ...threadState,
         repositoryGitHubContext: updatedThreadState.repositoryGitHubContext,
+        repositoryGitLabContext: updatedThreadState.repositoryGitLabContext,
       });
     }
 
@@ -423,6 +431,34 @@ async function processSlackMessage(
         }
         throw error;
       }
+    } else if (resolvedGitlabContext) {
+      const sandboxResult = await getOrCreateConversationGitlabRepositorySandbox({
+        conversationId: interactionId,
+        surface: "slack",
+        gitlabContext: resolvedGitlabContext,
+        repositorySession: updatedThreadState ?? latestThreadState,
+        organizationId,
+        localUserId: membership.localUserId,
+      });
+      sandboxId = sandboxResult.sandboxId;
+      updatedThreadState = sandboxResult.updatedSession;
+      try {
+        await thread.setState({
+          ...latestThreadState,
+          ...updatedThreadState,
+        });
+        await stopStaleRepositorySandbox(sandboxResult.staleSandboxId, log);
+      } catch (error) {
+        if (sandboxResult.sandboxCreated) {
+          await stopRepositorySandbox(sandboxResult.sandboxId).catch((cleanupError: unknown) => {
+            log.warn(
+              { err: serializeErrorForLog(cleanupError), sandboxId: sandboxResult.sandboxId },
+              "gitlab repository sandbox cleanup failed after slack state write failure",
+            );
+          });
+        }
+        throw error;
+      }
     }
 
     const [hasTmsIntegration, hasVisualMockSkill] = await Promise.all([
@@ -446,7 +482,11 @@ async function processSlackMessage(
           ? {
               sandboxId,
               githubContext: resolvedRepositoryContext,
-              workMode: hasVisualMockSkill ? ("write" as const) : ("read_only" as const),
+              gitlabContext: resolvedGitlabContext,
+              workMode:
+                hasVisualMockSkill && resolvedRepositoryContext
+                  ? ("write" as const)
+                  : ("read_only" as const),
               repositorySource: "slack" as const,
               actor: {
                 sourceUserId: message.author.userId,
@@ -466,7 +506,7 @@ async function processSlackMessage(
     });
     log.info(
       {
-        hasRepositoryContext: Boolean(resolvedRepositoryContext),
+        hasRepositoryContext: Boolean(resolvedRepositoryContext ?? resolvedGitlabContext),
         hasSandbox: Boolean(sandboxId),
         hasFileAttachments: hasTranslationAttachments,
       },

--- a/apps/hyperlocalise-web/src/api/route-groups.ts
+++ b/apps/hyperlocalise-web/src/api/route-groups.ts
@@ -47,6 +47,7 @@ import { createMentionSuggestionsRoutes } from "./routes/mentions/mention-sugges
 import { createIssueNotificationsRoutes } from "./routes/notifications/notifications.route";
 import { createNotificationPreferencesRoutes } from "./routes/notification-preferences/notification-preferences.route";
 import { createGithubInstallationRoutes } from "./routes/github-installation/github-installation.route";
+import { createGitlabRoutes } from "./routes/gitlab/gitlab.route";
 import { createWorkspaceJobRoutes } from "./routes/project/job.route";
 import { createProjectRoutes } from "./routes/project/project.route";
 import { createProviderCredentialRoutes } from "./routes/provider-credential/provider-credential.route";
@@ -180,7 +181,8 @@ export function createOrgAgentsRoutes() {
     .route("/agent-email", createAgentEmailRoutes())
     .route("/agent-slack", createAgentSlackRoutes())
     .route("/slack-connect", createSlackConnectRoutes())
-    .route("/github-installation", createGithubInstallationRoutes());
+    .route("/github-installation", createGithubInstallationRoutes())
+    .route("/gitlab", createGitlabRoutes());
 }
 
 export function createOrgWorkspaceRoutes() {

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -43,6 +43,9 @@ const { createInteractionMock } = vi.hoisted(() => ({
 const { createWebChatAgentUIStreamResponseMock } = vi.hoisted(() => ({
   createWebChatAgentUIStreamResponseMock: vi.fn(() => new Response("stream-ok", { status: 200 })),
 }));
+const { resolveGitLabProjectContextMock } = vi.hoisted(() => ({
+  resolveGitLabProjectContextMock: vi.fn(),
+}));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
@@ -71,6 +74,10 @@ vi.mock("@/lib/billing/ai-features", async (importOriginal) => {
 
 vi.mock("@/agents/hyperlocalise/agent/channels/web", () => ({
   createWebChatAgentUIStreamResponse: createWebChatAgentUIStreamResponseMock,
+}));
+
+vi.mock("@/lib/gitlab/repository-context", () => ({
+  resolveGitLabProjectContext: resolveGitLabProjectContextMock,
 }));
 
 const app = createApp({ fileStorageAdapter: createMemoryFileStorageAdapter() });
@@ -124,6 +131,7 @@ afterEach(async () => {
   createWebChatAgentUIStreamResponseMock.mockReturnValue(
     new Response("stream-ok", { status: 200 }),
   );
+  resolveGitLabProjectContextMock.mockResolvedValue(null);
   await cleanup();
 });
 
@@ -353,6 +361,42 @@ describe("conversation creation", () => {
       resolved: true,
       installationId: Number(repository.githubInstallationId),
       repositoryFullName: repository.fullName,
+      branch: "main",
+    });
+  });
+
+  it("seeds selected GitLab project context when creating a chat UI conversation", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    resolveGitLabProjectContextMock.mockResolvedValue({
+      resolved: true,
+      provider: "gitlab",
+      projectId: 11,
+      repositoryFullName: "acme/platform/web",
+      httpUrlToRepo: "https://gitlab.com/acme/platform/web.git",
+      branch: "main",
+    });
+    const formData = new FormData();
+    formData.set("text", "Review the GitLab localization setup");
+    formData.set("repositoryFullName", "acme/platform/web");
+    formData.set("repositoryProvider", "gitlab");
+
+    const response = await app.request(`/api/orgs/${identity.organization.slug}/conversations`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      conversation: { id: string };
+    };
+    const session = await getWebConversationRepositorySession(body.conversation.id);
+    expect(session?.session.repositoryGitLabContext).toMatchObject({
+      resolved: true,
+      provider: "gitlab",
+      projectId: 11,
+      repositoryFullName: "acme/platform/web",
       branch: "main",
     });
   });

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -31,13 +31,16 @@ import {
   toStoredTranslationFileRef,
 } from "@/lib/conversations/stored-file-context";
 import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats";
+import type { RepositoryAgentGitLabContext } from "@/lib/agent-contracts/gitlab-repository-task";
 import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
 import {
+  getGitlabRepositoryContextKey,
   getRepositoryContextKey,
   getWebConversationRepositorySession,
   setWebConversationRepositorySession,
 } from "@/lib/agent-runtime/loops/conversation-repository-session";
 import { resolveWebProjectRepositoryGitHubContext } from "@/lib/agents/repository-context";
+import { resolveGitLabProjectContext } from "@/lib/gitlab/repository-context";
 import { isEncodedProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import { createChatStreamRoutes } from "./chat-stream.route";
@@ -172,13 +175,19 @@ function normalizeRepositoryFullName(value: string | undefined): string | undefi
 async function seedConversationRepositorySession(input: {
   conversationId: string;
   organizationId: string;
-  repositoryGitHubContext: RepositoryAgentGitHubContext;
+  repositoryGitHubContext?: RepositoryAgentGitHubContext;
+  repositoryGitLabContext?: RepositoryAgentGitLabContext;
 }) {
-  const repositoryContextKey = getRepositoryContextKey(input.repositoryGitHubContext);
+  const repositoryContextKey = input.repositoryGitHubContext
+    ? getRepositoryContextKey(input.repositoryGitHubContext)
+    : input.repositoryGitLabContext
+      ? getGitlabRepositoryContextKey(input.repositoryGitLabContext)
+      : null;
 
   for (let attempt = 0; attempt < 3; attempt++) {
     const current = await getWebConversationRepositorySession(input.conversationId);
     const repositorySandboxSession =
+      repositoryContextKey &&
       current?.session.repositorySandboxSession?.repositoryContextKey === repositoryContextKey
         ? current.session.repositorySandboxSession
         : undefined;
@@ -189,6 +198,7 @@ async function seedConversationRepositorySession(input: {
       session: {
         ...current?.session,
         repositoryGitHubContext: input.repositoryGitHubContext,
+        repositoryGitLabContext: input.repositoryGitLabContext,
         ...(repositorySandboxSession ? { repositorySandboxSession } : {}),
       },
     });
@@ -215,6 +225,74 @@ async function resolveSelectedRepositoryGitHubContext(input: {
   });
 
   return resolution.status === "resolved" ? resolution.context : null;
+}
+
+async function resolveSelectedChatRepositoryContext(input: {
+  organizationId: string;
+  workosUserId: string;
+  repositoryFullName?: string;
+  repositoryProvider?: "github" | "gitlab";
+}): Promise<
+  | { status: "none" }
+  | { status: "github"; context: RepositoryAgentGitHubContext }
+  | { status: "gitlab"; context: RepositoryAgentGitLabContext }
+  | {
+      status: "unavailable";
+      error: "github_repository_not_available" | "gitlab_project_not_available";
+    }
+> {
+  if (!input.repositoryFullName) {
+    return { status: "none" };
+  }
+
+  if (input.repositoryProvider !== "gitlab") {
+    const githubContext = await resolveSelectedRepositoryGitHubContext({
+      organizationId: input.organizationId,
+      repositoryFullName: input.repositoryFullName,
+    });
+    if (githubContext) {
+      return { status: "github", context: githubContext };
+    }
+    if (input.repositoryProvider === "github") {
+      return { status: "unavailable", error: "github_repository_not_available" };
+    }
+  }
+
+  const gitlabContext = await resolveGitLabProjectContext({
+    localOrganizationId: input.organizationId,
+    workosUserId: input.workosUserId,
+    pathWithNamespace: input.repositoryFullName,
+  });
+  if (gitlabContext) {
+    return { status: "gitlab", context: gitlabContext };
+  }
+
+  return {
+    status: "unavailable",
+    error:
+      input.repositoryProvider === "gitlab"
+        ? "gitlab_project_not_available"
+        : "github_repository_not_available",
+  };
+}
+
+function selectedRepositoryUnavailableResponse(
+  c: Parameters<typeof badRequestResponse>[0],
+  error: "github_repository_not_available" | "gitlab_project_not_available",
+) {
+  if (error === "gitlab_project_not_available") {
+    return badRequestResponse(
+      c,
+      "gitlab_project_not_available",
+      "Selected GitLab project is not available with the connected GitLab account.",
+    );
+  }
+
+  return badRequestResponse(
+    c,
+    "github_repository_not_available",
+    "Selected GitHub repository is not enabled for this workspace.",
+  );
 }
 
 const validateConversationParams = validator("param", (value, c) => {
@@ -367,6 +445,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         text: asString(body.text),
         projectId: asString(body.projectId),
         repositoryFullName: asString(body.repositoryFullName),
+        repositoryProvider: asString(body.repositoryProvider),
       });
 
       if (!parsed.success) {
@@ -412,16 +491,14 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
       }
 
       const orgId = c.var.auth.activeOrganization.localOrganizationId;
-      const repositoryGitHubContext = await resolveSelectedRepositoryGitHubContext({
+      const selectedRepository = await resolveSelectedChatRepositoryContext({
         organizationId: orgId,
+        workosUserId: c.var.auth.user.workosUserId,
         repositoryFullName: parsed.data.repositoryFullName,
+        repositoryProvider: parsed.data.repositoryProvider,
       });
-      if (parsed.data.repositoryFullName && !repositoryGitHubContext) {
-        return badRequestResponse(
-          c,
-          "github_repository_not_available",
-          "Selected GitHub repository is not enabled for this workspace.",
-        );
+      if (selectedRepository.status === "unavailable") {
+        return selectedRepositoryUnavailableResponse(c, selectedRepository.error);
       }
 
       const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
@@ -477,11 +554,17 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         });
         conversation = createdConversation;
 
-        if (repositoryGitHubContext) {
+        if (selectedRepository.status === "github") {
           await seedConversationRepositorySession({
             conversationId: createdConversation.id,
             organizationId: orgId,
-            repositoryGitHubContext,
+            repositoryGitHubContext: selectedRepository.context,
+          });
+        } else if (selectedRepository.status === "gitlab") {
+          await seedConversationRepositorySession({
+            conversationId: createdConversation.id,
+            organizationId: orgId,
+            repositoryGitLabContext: selectedRepository.context,
           });
         }
 
@@ -590,6 +673,12 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         const requestedProjectId =
           typeof normalizedProjectId === "string" ? normalizedProjectId : undefined;
         const repositoryFullName = normalizeRepositoryFullName(asString(body.repositoryFullName));
+        const repositoryProviderParse = createConversationRequestSchema
+          .pick({ repositoryProvider: true })
+          .safeParse({ repositoryProvider: asString(body.repositoryProvider) });
+        const repositoryProvider = repositoryProviderParse.success
+          ? repositoryProviderParse.data.repositoryProvider
+          : undefined;
 
         if (!text.trim() && files.length === 0) {
           return invalidMessagePayloadResponse(c);
@@ -611,16 +700,14 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
           return c.json({ error: "conversation_not_replyable" }, 400);
         }
 
-        const repositoryGitHubContext = await resolveSelectedRepositoryGitHubContext({
+        const selectedRepository = await resolveSelectedChatRepositoryContext({
           organizationId: orgId,
+          workosUserId: c.var.auth.user.workosUserId,
           repositoryFullName,
+          repositoryProvider,
         });
-        if (repositoryFullName && !repositoryGitHubContext) {
-          return badRequestResponse(
-            c,
-            "github_repository_not_available",
-            "Selected GitHub repository is not enabled for this workspace.",
-          );
+        if (selectedRepository.status === "unavailable") {
+          return selectedRepositoryUnavailableResponse(c, selectedRepository.error);
         }
 
         if (requestedProjectId && requestedProjectId !== conversation.projectId) {
@@ -688,11 +775,17 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
           translationFileRefs,
         );
 
-        if (repositoryGitHubContext) {
+        if (selectedRepository.status === "github") {
           await seedConversationRepositorySession({
             conversationId,
             organizationId: orgId,
-            repositoryGitHubContext,
+            repositoryGitHubContext: selectedRepository.context,
+          });
+        } else if (selectedRepository.status === "gitlab") {
+          await seedConversationRepositorySession({
+            conversationId,
+            organizationId: orgId,
+            repositoryGitLabContext: selectedRepository.context,
           });
         }
 

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.schema.ts
@@ -18,10 +18,13 @@ export const conversationIdParamsSchema = z.object({
   conversationId: z.uuid(),
 });
 
+export const repositoryProviderSchema = z.enum(["github", "gitlab"]);
+
 export const createConversationRequestSchema = z.object({
   text: z.string().trim().max(10000).default(""),
   projectId: optionalProjectIdSchema,
   repositoryFullName: z.string().trim().min(1).max(255).optional(),
+  repositoryProvider: repositoryProviderSchema.optional(),
 });
 
 export const listConversationsQuerySchema = z.object({

--- a/apps/hyperlocalise-web/src/api/routes/gitlab/gitlab.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/gitlab/gitlab.route.test.ts
@@ -106,7 +106,7 @@ describe("gitlabRoutes", () => {
       projects: [],
       error: { code: "gitlab_not_connected", message: "Connect GitLab" },
     });
-    const identity = fixture.createWorkosIdentityWithRole("member");
+    const identity = fixture.createWorkosIdentityWithRole("developer");
     const headers = await fixture.authHeadersFor(identity);
 
     const response = await client.api.orgs[":organizationSlug"].gitlab.projects.$get(

--- a/apps/hyperlocalise-web/src/api/routes/gitlab/gitlab.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/gitlab/gitlab.route.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+  listAccessibleGitLabProjects: vi.fn(),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: mocks.resolveApiAuthContextFromSessionMock,
+  };
+});
+
+vi.mock("@/lib/gitlab/repository-context", () => ({
+  listAccessibleGitLabProjects: (...args: unknown[]) => mocks.listAccessibleGitLabProjects(...args),
+}));
+
+import { createApp } from "@/api/app";
+import type { AppType } from "@/api/typed-app";
+import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { db } from "@/lib/database/client";
+
+const client = testClient<AppType>(createApp());
+const fixture = createAuthTestFixture();
+
+describe("gitlabRoutes", () => {
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  beforeEach(() => {
+    mocks.listAccessibleGitLabProjects.mockReset();
+    mocks.listAccessibleGitLabProjects.mockResolvedValue({
+      projects: [
+        {
+          id: 11,
+          name: "web",
+          pathWithNamespace: "acme/platform/web",
+          defaultBranch: "main",
+          httpUrlToRepo: "https://gitlab.com/acme/platform/web.git",
+          archived: false,
+        },
+      ],
+      error: null,
+    });
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  it("lists membership projects for the connected GitLab account", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"].gitlab.projects.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      projects: [
+        {
+          id: 11,
+          name: "web",
+          pathWithNamespace: "acme/platform/web",
+          defaultBranch: "main",
+          httpUrlToRepo: "https://gitlab.com/acme/platform/web.git",
+          archived: false,
+        },
+      ],
+    });
+    expect(mocks.listAccessibleGitLabProjects).toHaveBeenCalledWith({
+      localOrganizationId: expect.any(String),
+      workosUserId: identity.user.workosUserId,
+    });
+  });
+
+  it("returns an empty list when GitLab is not connected", async () => {
+    mocks.listAccessibleGitLabProjects.mockResolvedValue({
+      projects: [],
+      error: { code: "gitlab_not_connected", message: "Connect GitLab" },
+    });
+    const identity = fixture.createWorkosIdentityWithRole("member");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"].gitlab.projects.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ projects: [] });
+  });
+
+  it("returns 503 when WorkOS Pipes is unavailable", async () => {
+    mocks.listAccessibleGitLabProjects.mockResolvedValue({
+      projects: [],
+      error: {
+        code: "gitlab_pipes_unavailable",
+        message: "WorkOS is not configured, so GitLab cannot connect through Pipes.",
+      },
+    });
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"].gitlab.projects.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "gitlab_pipes_unavailable",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/gitlab/gitlab.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/gitlab/gitlab.route.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Hono } from "hono";
+
+import { isIntegrationsReadAllowed } from "@/api/auth/capability-guards";
+import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { forbiddenResponse, serviceUnavailableResponse } from "@/api/response.schema";
+import { listAccessibleGitLabProjects } from "@/lib/gitlab/repository-context";
+
+export function createGitlabRoutes() {
+  return new Hono<{ Variables: AuthVariables }>()
+    .use("*", workosAuthMiddleware)
+    .get("/projects", async (c) => {
+      if (!isIntegrationsReadAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const result = await listAccessibleGitLabProjects({
+        localOrganizationId: c.var.auth.organization.localOrganizationId,
+        workosUserId: c.var.auth.user.workosUserId,
+      });
+
+      if (result.error?.code === "gitlab_pipes_unavailable") {
+        return serviceUnavailableResponse(c, result.error.code, result.error.message);
+      }
+
+      if (
+        result.error &&
+        result.error.code !== "gitlab_not_connected" &&
+        result.error.code !== "gitlab_pipes_needs_reauthorization"
+      ) {
+        return serviceUnavailableResponse(c, result.error.code, result.error.message);
+      }
+
+      return c.json({ projects: result.projects }, 200);
+    });
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/chat-repository.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/chat-repository.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { GithubRepository } from "./github-repository";
+
+export type ChatRepositoryProvider = "github" | "gitlab";
+
+export type ChatRepository = {
+  archived: boolean;
+  defaultBranch: string | null;
+  enabled: boolean;
+  fullName: string;
+  name: string;
+  provider: ChatRepositoryProvider;
+  selectionKey: string;
+};
+
+export function chatRepositorySelectionKey(
+  provider: ChatRepositoryProvider,
+  fullName: string,
+): string {
+  return `${provider}:${fullName}`;
+}
+
+export function parseChatRepositorySelectionKey(
+  key: string,
+): { provider: ChatRepositoryProvider; fullName: string } | null {
+  if (key.startsWith("github:")) {
+    const fullName = key.slice("github:".length);
+    return fullName ? { provider: "github", fullName } : null;
+  }
+  if (key.startsWith("gitlab:")) {
+    const fullName = key.slice("gitlab:".length);
+    return fullName ? { provider: "gitlab", fullName } : null;
+  }
+  return null;
+}
+
+export function toChatRepositoryFromGithub(repository: GithubRepository): ChatRepository {
+  return {
+    archived: repository.archived,
+    defaultBranch: repository.defaultBranch,
+    enabled: repository.enabled,
+    fullName: repository.fullName,
+    name: repository.name,
+    provider: "github",
+    selectionKey: chatRepositorySelectionKey("github", repository.fullName),
+  };
+}
+
+export function toChatRepositoryFromGitlab(project: {
+  archived: boolean;
+  defaultBranch: string | null;
+  name: string;
+  pathWithNamespace: string;
+}): ChatRepository {
+  return {
+    archived: project.archived,
+    defaultBranch: project.defaultBranch,
+    enabled: !project.archived,
+    fullName: project.pathWithNamespace,
+    name: project.name,
+    provider: "gitlab",
+    selectionKey: chatRepositorySelectionKey("gitlab", project.pathWithNamespace),
+  };
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.messages.ts
@@ -17,17 +17,17 @@ import { defineMessages } from "react-intl";
 export const repositorySelectorMessages = defineMessages({
   reposUnavailable: {
     defaultMessage: "Repos unavailable",
-    id: "Ped2s5KX7Z",
+    id: "JekhZbjY8c",
     description: "Repository selector label when repositories failed to load",
   },
   noRepos: {
     defaultMessage: "No repos",
-    id: "fuMDhQC4xa",
+    id: "iFmiFrAfXR",
     description: "Repository selector label when the account has no GitHub or GitLab repositories",
   },
   repoPlaceholder: {
     defaultMessage: "Repository",
-    id: "g1Tiy1/MKw",
+    id: "3nJQ/U/1eb",
     description: "Repository selector placeholder when no repository is selected yet",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.messages.ts
@@ -18,15 +18,15 @@ export const repositorySelectorMessages = defineMessages({
   reposUnavailable: {
     defaultMessage: "Repos unavailable",
     id: "Ped2s5KX7Z",
-    description: "Repository selector label when GitHub repositories failed to load",
+    description: "Repository selector label when repositories failed to load",
   },
-  noGithubRepos: {
-    defaultMessage: "No GitHub repos",
+  noRepos: {
+    defaultMessage: "No repos",
     id: "fuMDhQC4xa",
-    description: "Repository selector label when the account has no GitHub repositories",
+    description: "Repository selector label when the account has no GitHub or GitLab repositories",
   },
-  githubRepoPlaceholder: {
-    defaultMessage: "GitHub repo",
+  repoPlaceholder: {
+    defaultMessage: "Repository",
     id: "g1Tiy1/MKw",
     description: "Repository selector placeholder when no repository is selected yet",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.test.tsx
@@ -59,10 +59,7 @@ describe("RepositorySelector", () => {
 
     renderWithIntl(
       <RepositorySelector
-        repositories={[
-          createRepository({ name: "web", fullName: "acme/web" }),
-          gitlabRepository,
-        ]}
+        repositories={[createRepository({ name: "web", fullName: "acme/web" }), gitlabRepository]}
         repositoriesIsError={false}
         repositoriesIsLoading={false}
         selectedRepositoryKey=""

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.test.tsx
@@ -18,7 +18,8 @@ import userEvent from "@testing-library/user-event";
 import { IntlProvider } from "react-intl";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import type { GithubRepository } from "./github-repository";
+import type { ChatRepository } from "./chat-repository";
+import { chatRepositorySelectionKey } from "./chat-repository";
 import { RepositorySelector } from "./repository-selector";
 
 function renderWithIntl(ui: ReactElement) {
@@ -29,45 +30,50 @@ function renderWithIntl(ui: ReactElement) {
   );
 }
 
-function createRepository(overrides: Partial<GithubRepository> = {}): GithubRepository {
+function createRepository(overrides: Partial<ChatRepository> = {}): ChatRepository {
   const name = overrides.name ?? "web";
-  const owner = overrides.owner ?? "acme";
+  const fullName = overrides.fullName ?? `acme/${name}`;
+  const provider = overrides.provider ?? "github";
 
   return {
     archived: false,
     defaultBranch: "main",
     enabled: true,
-    fullName: `${owner}/${name}`,
-    githubRepositoryId: `repo_${owner}_${name}`,
-    id: `installation_repo_${owner}_${name}`,
+    fullName,
     name,
-    owner,
+    provider,
+    selectionKey: chatRepositorySelectionKey(provider, fullName),
     ...overrides,
   };
 }
 
 describe("RepositorySelector", () => {
-  it("opens the repository menu and selects a repository", async () => {
+  it("opens the repository menu and selects a GitLab project", async () => {
     const user = userEvent.setup();
     const onSelectRepository = vi.fn();
+    const gitlabRepository = createRepository({
+      provider: "gitlab",
+      name: "docs",
+      fullName: "acme/platform/docs",
+    });
 
     renderWithIntl(
       <RepositorySelector
         repositories={[
           createRepository({ name: "web", fullName: "acme/web" }),
-          createRepository({ name: "docs", fullName: "acme/docs" }),
+          gitlabRepository,
         ]}
         repositoriesIsError={false}
         repositoriesIsLoading={false}
-        selectedRepositoryFullName=""
+        selectedRepositoryKey=""
         onSelectRepository={onSelectRepository}
         triggerStyle="button"
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /github repo/i }));
-    await user.click(await screen.findByText("acme/docs"));
+    await user.click(screen.getByRole("button", { name: /repository/i }));
+    await user.click(await screen.findByText("acme/platform/docs"));
 
-    expect(onSelectRepository).toHaveBeenCalledWith("acme/docs");
+    expect(onSelectRepository).toHaveBeenCalledWith(gitlabRepository);
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.tsx
@@ -16,7 +16,7 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { siGithub } from "simple-icons";
+import { siGithub, siGitlab } from "simple-icons";
 
 import { PromptInputButton } from "@/components/ai-elements/prompt-input";
 import { Button } from "@/components/ui/button";
@@ -30,7 +30,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { SimpleBrandIcon } from "../integrations/_components/simple-brand-icon";
-import type { GithubRepository } from "./github-repository";
+import type { ChatRepository, ChatRepositoryProvider } from "./chat-repository";
 import { repositorySelectorMessages as messages } from "./repository-selector.messages";
 
 type RepositorySelectorTriggerStyle = "button" | "prompt-input";
@@ -74,22 +74,41 @@ function RepositorySelectorTrigger({
   );
 }
 
+function ProviderIcon({
+  provider,
+  className,
+}: {
+  provider: ChatRepositoryProvider;
+  className?: string;
+}) {
+  return (
+    <SimpleBrandIcon
+      icon={provider === "gitlab" ? siGitlab : siGithub}
+      colored
+      className={className}
+    />
+  );
+}
+
 export function RepositorySelector({
   onSelectRepository,
   repositories,
   repositoriesIsError,
   repositoriesIsLoading,
-  selectedRepositoryFullName,
+  selectedRepositoryKey,
   triggerStyle,
 }: {
-  onSelectRepository: (fullName: string) => void;
-  repositories: GithubRepository[];
+  onSelectRepository: (repository: ChatRepository) => void;
+  repositories: ChatRepository[];
   repositoriesIsError: boolean;
   repositoriesIsLoading: boolean;
-  selectedRepositoryFullName: string;
+  selectedRepositoryKey: string;
   triggerStyle: RepositorySelectorTriggerStyle;
 }) {
   const intl = useIntl();
+  const selectedRepository =
+    repositories.find((repository) => repository.selectionKey === selectedRepositoryKey) ?? null;
+  const triggerProvider = selectedRepository?.provider ?? repositories[0]?.provider ?? "github";
   const disabledTriggerClassName =
     triggerStyle === "prompt-input"
       ? "inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
@@ -110,7 +129,7 @@ export function RepositorySelector({
         className={disabledTriggerClassName}
         disabled
       >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        <ProviderIcon provider={triggerProvider} className="size-4" />
         <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
       </RepositorySelectorTrigger>
     );
@@ -123,7 +142,7 @@ export function RepositorySelector({
         className={disabledTriggerClassName}
         disabled
       >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        <ProviderIcon provider={triggerProvider} className="size-4" />
         <FormattedMessage {...messages.reposUnavailable} />
       </RepositorySelectorTrigger>
     );
@@ -136,8 +155,8 @@ export function RepositorySelector({
         className={disabledTriggerClassName}
         disabled
       >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-        <FormattedMessage {...messages.noGithubRepos} />
+        <ProviderIcon provider={triggerProvider} className="size-4" />
+        <FormattedMessage {...messages.noRepos} />
       </RepositorySelectorTrigger>
     );
   }
@@ -149,7 +168,7 @@ export function RepositorySelector({
         className={singleRepositoryTriggerClassName}
         disabled
       >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
+        <ProviderIcon provider={triggerProvider} className="size-4 shrink-0" />
         <span className="truncate">{repositories[0]?.fullName}</span>
       </RepositorySelectorTrigger>
     );
@@ -163,9 +182,9 @@ export function RepositorySelector({
             triggerStyle={triggerStyle}
             className={interactiveTriggerClassName}
           >
-            <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
+            <ProviderIcon provider={triggerProvider} className="size-4 shrink-0" />
             <span className="max-w-44 truncate">
-              {selectedRepositoryFullName || intl.formatMessage(messages.githubRepoPlaceholder)}
+              {selectedRepository?.fullName || intl.formatMessage(messages.repoPlaceholder)}
             </span>
             <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5 shrink-0" />
           </RepositorySelectorTrigger>
@@ -175,10 +194,10 @@ export function RepositorySelector({
         <DropdownMenuGroup>
           {repositories.map((repository) => (
             <DropdownMenuItem
-              key={repository.id}
-              onClick={() => onSelectRepository(repository.fullName)}
+              key={repository.selectionKey}
+              onClick={() => onSelectRepository(repository)}
             >
-              <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+              <ProviderIcon provider={repository.provider} className="size-4" />
               <span className="min-w-0 flex-1 truncate">{repository.fullName}</span>
             </DropdownMenuItem>
           ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -29,6 +29,7 @@ import { useAiFeaturesAccess } from "@/lib/billing/use-ai-features-access";
 
 import { ConversationMessageList } from "./conversation-message-list";
 import { conversationPanelMessages } from "./conversation-panel.messages";
+import type { ChatComposerSendOptions } from "./inbox-api";
 import { InboxPanelErrorBoundary } from "./inbox-panel-error-boundary";
 import {
   formatRelativeTime,
@@ -99,7 +100,7 @@ export function ConversationPanel({
   onSendMessage: (
     text: string,
     files: File[],
-    options?: { projectId?: string; repositoryFullName?: string },
+    options?: ChatComposerSendOptions,
   ) => void | Promise<void>;
   organizationSlug: string;
   streamedAssistant: StreamedAssistantMessage | null;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.test.ts
@@ -37,6 +37,9 @@ function stubInboxApiClient() {
             "github-installation": {
               repositories: { $get: vi.fn() },
             },
+            gitlab: {
+              projects: { $get: vi.fn() },
+            },
           },
         },
       },
@@ -118,5 +121,86 @@ describe("createInboxApi FormData", () => {
         text: "   ",
       },
     });
+  });
+
+  it("sends repositoryProvider with GitLab selections", async () => {
+    const { client, createConversationPost } = stubInboxApiClient();
+    createConversationPost.mockResolvedValue(jsonResponse({ conversation: { id: "conv_3" } }, 201));
+
+    const api = createInboxApi(client);
+    await api.createConversation("acme", {
+      text: "Review this GitLab project",
+      files: [],
+      repositoryFullName: "acme/platform/web",
+      repositoryProvider: "gitlab",
+    });
+
+    expect(createConversationPost).toHaveBeenCalledWith({
+      param: { organizationSlug: "acme" },
+      form: {
+        text: "Review this GitLab project",
+        repositoryFullName: "acme/platform/web",
+        repositoryProvider: "gitlab",
+      },
+    });
+  });
+
+  it("merges GitHub repositories and GitLab projects into chat repository options", async () => {
+    const { client } = stubInboxApiClient();
+    const githubGet = client.api.orgs[":organizationSlug"]["github-installation"].repositories.$get;
+    const gitlabGet = client.api.orgs[":organizationSlug"].gitlab.projects.$get;
+    githubGet.mockResolvedValue(
+      jsonResponse(
+        {
+          repositories: [
+            {
+              archived: false,
+              defaultBranch: "main",
+              enabled: true,
+              fullName: "acme/web",
+              name: "web",
+            },
+          ],
+        },
+        200,
+      ),
+    );
+    gitlabGet.mockResolvedValue(
+      jsonResponse(
+        {
+          projects: [
+            {
+              archived: false,
+              defaultBranch: "main",
+              name: "docs",
+              pathWithNamespace: "acme/platform/docs",
+            },
+          ],
+        },
+        200,
+      ),
+    );
+
+    const api = createInboxApi(client);
+    await expect(api.listChatRepositories("acme")).resolves.toEqual([
+      {
+        archived: false,
+        defaultBranch: "main",
+        enabled: true,
+        fullName: "acme/web",
+        name: "web",
+        provider: "github",
+        selectionKey: "github:acme/web",
+      },
+      {
+        archived: false,
+        defaultBranch: "main",
+        enabled: true,
+        fullName: "acme/platform/docs",
+        name: "docs",
+        provider: "gitlab",
+        selectionKey: "gitlab:acme/platform/docs",
+      },
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.test.ts
@@ -19,9 +19,13 @@ const FILE_ONLY_CONVERSATION_TEXT = "Please translate the attached source file."
 function stubInboxApiClient() {
   const createConversationPost = vi.fn();
   const sendMessagePost = vi.fn();
+  const listGithubRepositoriesGet = vi.fn();
+  const listGitlabProjectsGet = vi.fn();
   return {
     createConversationPost,
     sendMessagePost,
+    listGithubRepositoriesGet,
+    listGitlabProjectsGet,
     client: {
       api: {
         orgs: {
@@ -35,10 +39,10 @@ function stubInboxApiClient() {
               },
             },
             "github-installation": {
-              repositories: { $get: vi.fn() },
+              repositories: { $get: listGithubRepositoriesGet },
             },
             gitlab: {
-              projects: { $get: vi.fn() },
+              projects: { $get: listGitlabProjectsGet },
             },
           },
         },
@@ -146,10 +150,8 @@ describe("createInboxApi FormData", () => {
   });
 
   it("merges GitHub repositories and GitLab projects into chat repository options", async () => {
-    const { client } = stubInboxApiClient();
-    const githubGet = client.api.orgs[":organizationSlug"]["github-installation"].repositories.$get;
-    const gitlabGet = client.api.orgs[":organizationSlug"].gitlab.projects.$get;
-    githubGet.mockResolvedValue(
+    const { client, listGithubRepositoriesGet, listGitlabProjectsGet } = stubInboxApiClient();
+    listGithubRepositoriesGet.mockResolvedValue(
       jsonResponse(
         {
           repositories: [
@@ -165,7 +167,7 @@ describe("createInboxApi FormData", () => {
         200,
       ),
     );
-    gitlabGet.mockResolvedValue(
+    listGitlabProjectsGet.mockResolvedValue(
       jsonResponse(
         {
           projects: [

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -13,23 +13,31 @@
 import type { createApiClient } from "@/lib/api-client";
 import { readApiResponseError } from "@/lib/api-error";
 
-import type { GithubRepository } from "../../_components/github-repository";
+import type { ChatRepository, ChatRepositoryProvider } from "../../_components/chat-repository";
+import {
+  toChatRepositoryFromGithub,
+  toChatRepositoryFromGitlab,
+} from "../../_components/chat-repository";
 import type { Conversation, ConversationMessage, LinkedJob } from "./inbox-types";
 
-export type InboxGithubRepository = GithubRepository;
+export type InboxChatRepository = ChatRepository;
+
+export type ChatComposerSendOptions = {
+  projectId?: string;
+  repositoryFullName?: string;
+  repositoryProvider?: ChatRepositoryProvider;
+};
 
 export type SendConversationMessageInput = {
   text: string;
   files: File[];
-  projectId?: string;
-  repositoryFullName?: string;
-};
+} & ChatComposerSendOptions;
 
 export type InboxApi = {
   listConversations(organizationSlug: string, limit?: number): Promise<Conversation[]>;
   listMessages(organizationSlug: string, conversationId: string): Promise<ConversationMessage[]>;
   listLinkedJobs(organizationSlug: string, conversationId: string): Promise<LinkedJob[]>;
-  listGithubRepositories(organizationSlug: string): Promise<InboxGithubRepository[]>;
+  listChatRepositories(organizationSlug: string): Promise<InboxChatRepository[]>;
   createConversation(
     organizationSlug: string,
     input: SendConversationMessageInput,
@@ -114,18 +122,41 @@ export function createInboxApi(client: ApiClient): InboxApi {
       return body.jobs;
     },
 
-    async listGithubRepositories(organizationSlug) {
-      const response = await client.api.orgs[":organizationSlug"]["github-installation"][
+    async listChatRepositories(organizationSlug) {
+      const githubRequest = client.api.orgs[":organizationSlug"]["github-installation"][
         "repositories"
       ].$get({
         param: { organizationSlug },
         query: {},
       });
-      if (response.status !== 200) {
-        throw await readApiResponseError(response, "Failed to load GitHub repositories");
+      const gitlabRequest = client.api.orgs[":organizationSlug"].gitlab.projects.$get({
+        param: { organizationSlug },
+      });
+      const [githubResponse, gitlabResponse] = await Promise.all([githubRequest, gitlabRequest]);
+
+      if (githubResponse.status !== 200 && gitlabResponse.status !== 200) {
+        throw await readApiResponseError(githubResponse, "Failed to load repositories");
       }
-      const body = await response.json();
-      return body.repositories.filter((repository) => repository.enabled && !repository.archived);
+
+      const repositories: InboxChatRepository[] = [];
+      if (githubResponse.status === 200) {
+        const body = await githubResponse.json();
+        repositories.push(
+          ...body.repositories
+            .filter((repository) => repository.enabled && !repository.archived)
+            .map(toChatRepositoryFromGithub),
+        );
+      }
+      if (gitlabResponse.status === 200) {
+        const body = await gitlabResponse.json();
+        repositories.push(
+          ...body.projects
+            .filter((project) => !project.archived)
+            .map(toChatRepositoryFromGitlab),
+        );
+      }
+
+      return repositories;
     },
 
     async createConversation(organizationSlug, input) {
@@ -135,6 +166,7 @@ export function createInboxApi(client: ApiClient): InboxApi {
           text: input.text.trim() || FILE_ONLY_CONVERSATION_TEXT,
           ...(input.projectId ? { projectId: input.projectId } : {}),
           ...(input.repositoryFullName ? { repositoryFullName: input.repositoryFullName } : {}),
+          ...(input.repositoryProvider ? { repositoryProvider: input.repositoryProvider } : {}),
           ...(input.files.length > 0 ? { files: input.files } : {}),
         },
       } as never);
@@ -155,6 +187,7 @@ export function createInboxApi(client: ApiClient): InboxApi {
           text: input.text,
           ...(input.projectId ? { projectId: input.projectId } : {}),
           ...(input.repositoryFullName ? { repositoryFullName: input.repositoryFullName } : {}),
+          ...(input.repositoryProvider ? { repositoryProvider: input.repositoryProvider } : {}),
           ...(input.files.length > 0 ? { files: input.files } : {}),
         },
       } as never);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -150,9 +150,7 @@ export function createInboxApi(client: ApiClient): InboxApi {
       if (gitlabResponse.status === 200) {
         const body = await gitlabResponse.json();
         repositories.push(
-          ...body.projects
-            .filter((project) => !project.archived)
-            .map(toChatRepositoryFromGitlab),
+          ...body.projects.filter((project) => !project.archived).map(toChatRepositoryFromGitlab),
         );
       }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -24,7 +24,7 @@ import { getChatStreamManager } from "@/components/app-shell/chat-dock/chat-stre
 import { isInboxNewRequestPath } from "@/components/app-shell/navigation-config";
 import { apiClient } from "@/lib/api-client-instance";
 
-import { createInboxApi, type InboxApi } from "./inbox-api";
+import { createInboxApi, type ChatComposerSendOptions, type InboxApi } from "./inbox-api";
 import { conversationPanelMessages } from "./conversation-panel.messages";
 import { resolveInboxSelection, type InboxSelection } from "./inbox-list";
 import {
@@ -181,9 +181,8 @@ export const InboxPageContent = observer(function InboxPageContent({
     mutationFn: (input: {
       text: string;
       files: File[];
-      projectId?: string;
-      repositoryFullName?: string;
-    }) => injectedInboxApi.sendMessage(organizationSlug, selectedConversationId, input),
+    } & ChatComposerSendOptions) =>
+      injectedInboxApi.sendMessage(organizationSlug, selectedConversationId, input),
     onSuccess: () => {
       void messagesQuery.refetch();
       void conversationsQuery.refetch();
@@ -194,9 +193,7 @@ export const InboxPageContent = observer(function InboxPageContent({
     mutationFn: (input: {
       text: string;
       files: File[];
-      projectId?: string;
-      repositoryFullName?: string;
-    }) => injectedInboxApi.createConversation(organizationSlug, input),
+    } & ChatComposerSendOptions) => injectedInboxApi.createConversation(organizationSlug, input),
   });
 
   const markReadMutation = useMutation({
@@ -236,7 +233,7 @@ export const InboxPageContent = observer(function InboxPageContent({
     async (
       text: string,
       files: File[],
-      options?: { projectId?: string; repositoryFullName?: string },
+      options?: ChatComposerSendOptions,
     ) => {
       if (composeNew) {
         try {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -178,11 +178,12 @@ export const InboxPageContent = observer(function InboxPageContent({
     : null;
 
   const sendMessageMutation = useMutation({
-    mutationFn: (input: {
-      text: string;
-      files: File[];
-    } & ChatComposerSendOptions) =>
-      injectedInboxApi.sendMessage(organizationSlug, selectedConversationId, input),
+    mutationFn: (
+      input: {
+        text: string;
+        files: File[];
+      } & ChatComposerSendOptions,
+    ) => injectedInboxApi.sendMessage(organizationSlug, selectedConversationId, input),
     onSuccess: () => {
       void messagesQuery.refetch();
       void conversationsQuery.refetch();
@@ -190,10 +191,12 @@ export const InboxPageContent = observer(function InboxPageContent({
   });
 
   const createConversationMutation = useMutation({
-    mutationFn: (input: {
-      text: string;
-      files: File[];
-    } & ChatComposerSendOptions) => injectedInboxApi.createConversation(organizationSlug, input),
+    mutationFn: (
+      input: {
+        text: string;
+        files: File[];
+      } & ChatComposerSendOptions,
+    ) => injectedInboxApi.createConversation(organizationSlug, input),
   });
 
   const markReadMutation = useMutation({
@@ -230,11 +233,7 @@ export const InboxPageContent = observer(function InboxPageContent({
   const mutateAsync = sendMessageMutation.mutateAsync;
   const createConversationAsync = createConversationMutation.mutateAsync;
   const onSendMessage = useCallback(
-    async (
-      text: string,
-      files: File[],
-      options?: ChatComposerSendOptions,
-    ) => {
+    async (text: string, files: File[], options?: ChatComposerSendOptions) => {
       if (composeNew) {
         try {
           const result = await createConversationAsync({ text, files, ...options });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
@@ -18,6 +18,7 @@ import { Box } from "@/components/ui/layout/box";
 
 import { ConversationPanel } from "./conversation-panel";
 import { inboxChatSplitPaneClassName } from "./inbox-chat-split-pane";
+import type { ChatComposerSendOptions } from "./inbox-api";
 import { InboxIssuePanel } from "./inbox-issue-panel";
 import { InboxList, type InboxSelection } from "./inbox-list";
 import { InboxPanelErrorBoundary } from "./inbox-panel-error-boundary";
@@ -88,7 +89,7 @@ export function InboxPageView({
   onSendMessage: (
     text: string,
     files: File[],
-    options?: { projectId?: string; repositoryFullName?: string },
+    options?: ChatComposerSendOptions,
   ) => void | Promise<void>;
   organizationSlug: string;
   selectedConversation: Conversation | undefined;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox.fixture.ts
@@ -12,7 +12,8 @@
  */
 import type { UIMessage } from "ai";
 
-import type { InboxGithubRepository } from "./inbox-api";
+import { chatRepositorySelectionKey } from "../../_components/chat-repository";
+import type { InboxChatRepository } from "./inbox-api";
 import type { InboxIssueNotification } from "./inbox-notifications-api";
 import type {
   Conversation,
@@ -85,18 +86,21 @@ export function createLinkedJob(overrides: Partial<LinkedJob> = {}): LinkedJob {
   };
 }
 
-export function createGithubRepository(
-  overrides: Partial<InboxGithubRepository> = {},
-): InboxGithubRepository {
+export function createChatRepository(
+  overrides: Partial<InboxChatRepository> = {},
+): InboxChatRepository {
+  const fullName = overrides.fullName ?? "hyperlocalise/hyperlocalise-web";
+  const provider = overrides.provider ?? "github";
+  const name = overrides.name ?? "hyperlocalise-web";
+
   return {
-    id: "repo_website",
-    githubRepositoryId: "101",
-    owner: "hyperlocalise",
-    name: "hyperlocalise-web",
-    fullName: "hyperlocalise/hyperlocalise-web",
     archived: false,
     defaultBranch: "main",
     enabled: true,
+    fullName,
+    name,
+    provider,
+    selectionKey: chatRepositorySelectionKey(provider, fullName),
     ...overrides,
   };
 }
@@ -195,13 +199,16 @@ export const linkedJobsFixture: LinkedJob[] = [
   }),
 ];
 
-export const repositoriesFixture: InboxGithubRepository[] = [
-  createGithubRepository(),
-  createGithubRepository({
-    id: "repo_mobile",
-    githubRepositoryId: "102",
+export const repositoriesFixture: InboxChatRepository[] = [
+  createChatRepository(),
+  createChatRepository({
     name: "mobile-app",
     fullName: "hyperlocalise/mobile-app",
+  }),
+  createChatRepository({
+    provider: "gitlab",
+    name: "docs",
+    fullName: "hyperlocalise/platform/docs",
   }),
 ];
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
@@ -53,7 +53,7 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByPlaceholderText("Ask Hyperlocalise…")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
-    await expect(canvas.getByText("GitHub repo")).toBeInTheDocument();
+    await expect(canvas.getByText("Repository")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.test.tsx
@@ -92,7 +92,7 @@ describe("ReplyComposerView toolbar", () => {
     expect(screen.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send reply" })).toHaveTextContent("Send");
     expect(screen.getByRole("button", { name: "Add photos and files" })).toBeInTheDocument();
-    expect(screen.getByText("GitHub repo")).toBeInTheDocument();
+    expect(screen.getByText("Repository")).toBeInTheDocument();
     expect(screen.getByText("Hyperlocalise Website Localisation")).toBeInTheDocument();
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -83,11 +83,7 @@ type ReplyComposerViewProps = {
   lockedProjectId?: string | null;
   lockedProjectName?: string | null;
   onDraftChange?: (draft: string) => void;
-  onSend: (
-    text: string,
-    files: File[],
-    options?: ChatComposerSendOptions,
-  ) => void | Promise<void>;
+  onSend: (text: string, files: File[], options?: ChatComposerSendOptions) => void | Promise<void>;
   placeholder?: string;
   projects: ChatProjectOption[];
   projectsIsError: boolean;
@@ -253,7 +249,9 @@ export function ReplyComposerView({
                 repositoriesIsError={repositoriesIsError}
                 repositoriesIsLoading={repositoriesIsLoading}
                 selectedRepositoryKey={resolvedRepository?.selectionKey ?? ""}
-                onSelectRepository={(repository) => setSelectedRepositoryKey(repository.selectionKey)}
+                onSelectRepository={(repository) =>
+                  setSelectedRepositoryKey(repository.selectionKey)
+                }
                 triggerStyle="prompt-input"
               />
               <PromptInputSubmit

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -41,6 +41,7 @@ import {
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
+import type { ChatRepository } from "../../_components/chat-repository";
 import { RepositorySelector } from "../../_components/repository-selector";
 import { ProjectSelector } from "../../_components/project-selector";
 import {
@@ -49,7 +50,12 @@ import {
   type ChatProjectOption,
 } from "../../_components/project-selector-model";
 import { useTmsLiveProjects } from "../../_hooks/use-tms-live-projects";
-import { createInboxApi, type InboxApi, type InboxGithubRepository } from "./inbox-api";
+import {
+  createInboxApi,
+  type ChatComposerSendOptions,
+  type InboxApi,
+  type InboxChatRepository,
+} from "./inbox-api";
 import { replyComposerMessages } from "./reply-composer.messages";
 
 const inboxApi = createInboxApi(apiClient);
@@ -80,13 +86,13 @@ type ReplyComposerViewProps = {
   onSend: (
     text: string,
     files: File[],
-    options?: { projectId?: string; repositoryFullName?: string },
+    options?: ChatComposerSendOptions,
   ) => void | Promise<void>;
   placeholder?: string;
   projects: ChatProjectOption[];
   projectsIsError: boolean;
   projectsIsLoading: boolean;
-  repositories: InboxGithubRepository[];
+  repositories: InboxChatRepository[];
   repositoriesIsError: boolean;
   repositoriesIsLoading: boolean;
 };
@@ -110,7 +116,7 @@ export function ReplyComposerView({
 }: ReplyComposerViewProps) {
   const intl = useIntl();
   const [replyText, setReplyText] = useState(draft);
-  const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState("");
+  const [selectedRepositoryKey, setSelectedRepositoryKey] = useState("");
   const [selectedProjectId, setSelectedProjectId] = useState("");
   const promptInputController = usePromptInputController();
   // Stable across keystrokes; the controller object itself is recreated whenever
@@ -129,12 +135,12 @@ export function ReplyComposerView({
 
   useEffect(() => {
     if (
-      selectedRepositoryFullName &&
-      !repositories.some((repository) => repository.fullName === selectedRepositoryFullName)
+      selectedRepositoryKey &&
+      !repositories.some((repository) => repository.selectionKey === selectedRepositoryKey)
     ) {
-      setSelectedRepositoryFullName("");
+      setSelectedRepositoryKey("");
     }
-  }, [repositories, selectedRepositoryFullName]);
+  }, [repositories, selectedRepositoryKey]);
 
   useEffect(() => {
     if (selectedProjectId && !projects.some((project) => project.id === selectedProjectId)) {
@@ -142,8 +148,9 @@ export function ReplyComposerView({
     }
   }, [projects, selectedProjectId]);
 
-  const resolvedRepositoryFullName =
-    selectedRepositoryFullName || (repositories.length === 1 ? repositories[0]?.fullName : "");
+  const resolvedRepository: ChatRepository | undefined =
+    repositories.find((repository) => repository.selectionKey === selectedRepositoryKey) ??
+    (repositories.length === 1 ? repositories[0] : undefined);
   const resolvedProjectId = resolveChatProjectSelection({
     projects,
     selectedProjectId,
@@ -168,7 +175,8 @@ export function ReplyComposerView({
 
     await onSend(trimmedText, fileObjects, {
       projectId: resolvedProjectId || undefined,
-      repositoryFullName: resolvedRepositoryFullName || undefined,
+      repositoryFullName: resolvedRepository?.fullName,
+      repositoryProvider: resolvedRepository?.provider,
     });
     setReplyText("");
     onDraftChange?.("");
@@ -244,8 +252,8 @@ export function ReplyComposerView({
                 repositories={repositories}
                 repositoriesIsError={repositoriesIsError}
                 repositoriesIsLoading={repositoriesIsLoading}
-                selectedRepositoryFullName={resolvedRepositoryFullName}
-                onSelectRepository={setSelectedRepositoryFullName}
+                selectedRepositoryKey={resolvedRepository?.selectionKey ?? ""}
+                onSelectRepository={(repository) => setSelectedRepositoryKey(repository.selectionKey)}
                 triggerStyle="prompt-input"
               />
               <PromptInputSubmit
@@ -289,8 +297,8 @@ export const ReplyComposer = memo(function ReplyComposer({
   ...viewProps
 }: ReplyComposerProps) {
   const repositoriesQuery = useQuery({
-    queryKey: ["github-repositories", organizationSlug],
-    queryFn: () => injectedInboxApi.listGithubRepositories(organizationSlug),
+    queryKey: ["chat-repositories", organizationSlug],
+    queryFn: () => injectedInboxApi.listChatRepositories(organizationSlug),
   });
   const nativeProjectsQuery = useQuery({
     queryKey: ["chat-composer-projects", organizationSlug, "native"],

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.tsx
@@ -30,6 +30,7 @@ import {
   workspacePipesCollaborationSlugs,
   workspacePipesCustomerEngagementSlugs,
   workspacePipesGuidelineSlugs,
+  workspacePipesSourceControlSlugs,
   type WorkspaceIntegrationSummary,
 } from "@/lib/integrations/workspace-integrations";
 import type { PipesProviderSlug } from "@/lib/pipes/providers";
@@ -99,13 +100,17 @@ function useWorkspaceIntegrations(slugs: readonly string[]) {
 export function SourceControlIntegrationsSection({
   organizationSlug,
   userCanManage,
-}: AgentIntegrationsSectionProps) {
-  const comingSoonGitLab = useWorkspaceIntegrations(["gitlab"])[0];
-
+  userIsAdmin,
+}: AgentIntegrationsSectionProps & { userIsAdmin: boolean }) {
   return (
     <>
       <GitHubIntegrationRow organizationSlug={organizationSlug} userCanManage={userCanManage} />
-      {comingSoonGitLab ? <ComingSoonIntegrationRow integration={comingSoonGitLab} isLast /> : null}
+      <PipesIntegrationList
+        organizationSlug={organizationSlug}
+        slugs={workspacePipesSourceControlSlugs}
+        disabled={!userIsAdmin}
+        isLast
+      />
     </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -841,6 +841,7 @@ export function IntegrationsPageContent({
               <SourceControlIntegrationsSection
                 organizationSlug={organizationSlug}
                 userCanManage={userCanManageAgents}
+                userIsAdmin={userIsAdmin}
               />
             </IntegrationCategorySection>
           ) : null}

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-repository-task.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-repository-task.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+/**
+ * Resolved GitLab project context for repository sandbox clone.
+ */
+export const repositoryAgentGitLabContextSchema = z.object({
+  resolved: z.literal(true),
+  provider: z.literal("gitlab"),
+  projectId: z.number(),
+  repositoryFullName: z.string(),
+  httpUrlToRepo: z.string(),
+  mergeRequestIid: z.number().optional(),
+  branch: z.string().optional(),
+  commitSha: z.string().optional(),
+});
+
+export type RepositoryAgentGitLabContext = z.infer<typeof repositoryAgentGitLabContextSchema>;

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.test.ts
@@ -27,6 +27,31 @@ describe("gitlab text patterns", () => {
     ).toEqual(["acme/platform/web"]);
   });
 
+  it("stops project URL capture at the GitLab /-/ boundary", () => {
+    expect(
+      extractGitLabProjectPathReferences(
+        [
+          "https://gitlab.com/acme/web/-/tree/main",
+          "https://gitlab.com/acme/web/-/blob/main/README.md",
+          "https://gitlab.com/acme/web/-/issues/12",
+          "https://gitlab.com/acme/web/-/commits/main",
+        ].join(" "),
+      ),
+    ).toEqual(["acme/web"]);
+  });
+
+  it("extracts nested group project paths from tree URLs", () => {
+    expect(
+      extractGitLabProjectPathReferences("See https://gitlab.com/acme/platform/web/-/tree/main"),
+    ).toEqual(["acme/platform/web"]);
+  });
+
+  it("keeps hyphenated project names while stopping at /-/", () => {
+    expect(
+      extractGitLabProjectPathReferences("https://gitlab.com/acme/my-web/-/tree/feature-login"),
+    ).toEqual(["acme/my-web"]);
+  });
+
   it("extracts merge request URLs including nested groups", () => {
     expect(
       extractGitLabMergeRequestReferences(

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  extractGitLabMergeRequestReferences,
+  extractGitLabProjectPathReferences,
+  normalizeGitLabPathWithNamespace,
+} from "./gitlab-text-patterns";
+
+describe("gitlab text patterns", () => {
+  it("extracts nested GitLab project paths from URLs", () => {
+    expect(
+      extractGitLabProjectPathReferences(
+        "Clone https://gitlab.com/acme/platform/web and ignore github.com/acme/web",
+      ),
+    ).toEqual(["acme/platform/web"]);
+  });
+
+  it("extracts merge request URLs including nested groups", () => {
+    expect(
+      extractGitLabMergeRequestReferences(
+        "Review https://gitlab.com/acme/platform/web/-/merge_requests/42 please",
+      ),
+    ).toEqual([
+      {
+        pathWithNamespace: "acme/platform/web",
+        mergeRequestIid: 42,
+        sourceUrl: "https://gitlab.com/acme/platform/web/-/merge_requests/42",
+      },
+    ]);
+  });
+
+  it("normalizes GitLab path_with_namespace values", () => {
+    expect(normalizeGitLabPathWithNamespace("acme/web.git")).toBe("acme/web");
+    expect(normalizeGitLabPathWithNamespace("acme")).toBeNull();
+    expect(normalizeGitLabPathWithNamespace("acme/sub/web")).toBe("acme/sub/web");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export type GitLabProjectReference = {
+  pathWithNamespace: string;
+  sourceUrl: string;
+};
+
+export type GitLabMergeRequestReference = GitLabProjectReference & {
+  mergeRequestIid: number;
+};
+
+export const gitlabMergeRequestUrlPatternSource =
+  String.raw`https?:\/\/(?:www\.)?gitlab\.com\/((?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+)\/-\/merge_requests\/(\d+)(?=[/?#\s>|)\].,;:!?]|$)`;
+
+const gitlabMergeRequestUrlPattern = new RegExp(gitlabMergeRequestUrlPatternSource, "gi");
+const gitlabProjectUrlPattern =
+  /https?:\/\/(?:www\.)?gitlab\.com\/((?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+)(?=\/-\/|[/?#\s>|)\].,;:!?]|$)/gi;
+
+function trimTrailingPunctuation(value: string) {
+  return value.replace(/[.,;:!?]+$/g, "");
+}
+
+function normalizeGitLabPath(value: string): string | null {
+  const trimmed = trimTrailingPunctuation(value.trim()).replace(/\.git$/i, "");
+  const parts = trimmed.split("/").filter(Boolean);
+  if (parts.length < 2) {
+    return null;
+  }
+
+  if (parts.some((part) => /\s/.test(part))) {
+    return null;
+  }
+
+  return parts.join("/");
+}
+
+export function extractGitLabMergeRequestReferences(text: string): GitLabMergeRequestReference[] {
+  const references = new Map<string, GitLabMergeRequestReference>();
+
+  for (const match of text.matchAll(gitlabMergeRequestUrlPattern)) {
+    const pathWithNamespace = normalizeGitLabPath(match[1] ?? "");
+    const mergeRequestIid = Number.parseInt(match[2] ?? "", 10);
+    if (!pathWithNamespace || !Number.isSafeInteger(mergeRequestIid)) {
+      continue;
+    }
+
+    references.set(`${pathWithNamespace.toLowerCase()}!${mergeRequestIid}`, {
+      pathWithNamespace,
+      mergeRequestIid,
+      sourceUrl: match[0],
+    });
+  }
+
+  return [...references.values()];
+}
+
+export function extractGitLabProjectPathReferences(text: string): string[] {
+  const references = new Map<string, string>();
+
+  for (const match of text.matchAll(gitlabProjectUrlPattern)) {
+    const pathWithNamespace = normalizeGitLabPath(match[1] ?? "");
+    if (!pathWithNamespace) {
+      continue;
+    }
+    references.set(pathWithNamespace.toLowerCase(), pathWithNamespace);
+  }
+
+  return [...references.values()];
+}
+
+export function normalizeGitLabPathWithNamespace(value: string): string | null {
+  return normalizeGitLabPath(value);
+}

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.ts
@@ -20,8 +20,7 @@ export type GitLabMergeRequestReference = GitLabProjectReference & {
   mergeRequestIid: number;
 };
 
-export const gitlabMergeRequestUrlPatternSource =
-  String.raw`https?:\/\/(?:www\.)?gitlab\.com\/((?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+)\/-\/merge_requests\/(\d+)(?=[/?#\s>|)\].,;:!?]|$)`;
+export const gitlabMergeRequestUrlPatternSource = String.raw`https?:\/\/(?:www\.)?gitlab\.com\/((?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+)\/-\/merge_requests\/(\d+)(?=[/?#\s>|)\].,;:!?]|$)`;
 
 const gitlabMergeRequestUrlPattern = new RegExp(gitlabMergeRequestUrlPatternSource, "gi");
 const gitlabProjectUrlPattern =

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/gitlab-text-patterns.ts
@@ -20,11 +20,15 @@ export type GitLabMergeRequestReference = GitLabProjectReference & {
   mergeRequestIid: number;
 };
 
-export const gitlabMergeRequestUrlPatternSource = String.raw`https?:\/\/(?:www\.)?gitlab\.com\/((?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+)\/-\/merge_requests\/(\d+)(?=[/?#\s>|)\].,;:!?]|$)`;
+const gitlabPathWithNamespacePatternSource = String.raw`(?:(?!-\/)[A-Za-z0-9_.-]+\/)+(?!-\/)[A-Za-z0-9_.-]+`;
+
+export const gitlabMergeRequestUrlPatternSource = String.raw`https?:\/\/(?:www\.)?gitlab\.com\/(${gitlabPathWithNamespacePatternSource})\/-\/merge_requests\/(\d+)(?=[/?#\s>|)\].,;:!?]|$)`;
 
 const gitlabMergeRequestUrlPattern = new RegExp(gitlabMergeRequestUrlPatternSource, "gi");
-const gitlabProjectUrlPattern =
-  /https?:\/\/(?:www\.)?gitlab\.com\/((?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+)(?=\/-\/|[/?#\s>|)\].,;:!?]|$)/gi;
+const gitlabProjectUrlPattern = new RegExp(
+  String.raw`https?:\/\/(?:www\.)?gitlab\.com\/(${gitlabPathWithNamespacePatternSource})(?=\/-\/|[/?#\s>|)\].,;:!?]|$)`,
+  "gi",
+);
 
 function trimTrailingPunctuation(value: string) {
   return value.replace(/[.,;:!?]+$/g, "");

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/tool-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/tool-context.ts
@@ -12,6 +12,7 @@
  */
 import type { db } from "@/lib/database/client";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
+import type { RepositoryAgentGitLabContext } from "@/lib/agent-contracts/gitlab-repository-task";
 import type {
   RepositoryAgentActor,
   RepositoryAgentGitHubContext,
@@ -68,6 +69,7 @@ export type ToolContext = {
   actor?: RepositoryAgentActor;
   sandboxId?: string | null;
   githubContext?: RepositoryAgentGitHubContext | null;
+  gitlabContext?: RepositoryAgentGitLabContext | null;
   /** Mutable per-run session state (todos, etc.). */
   agentSession?: AgentSessionState;
   /** Request-scoped live progress for web chat tools. Other channels omit it. */

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
@@ -180,7 +180,7 @@ describe("conversation classifier", () => {
     expect(generateTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         prompt: expect.stringContaining(
-          "they usually mean context in the connected GitHub repository",
+          "they usually mean context in the connected GitHub or GitLab repository",
         ),
       }),
     );

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
@@ -69,12 +69,12 @@ function buildConversationClassificationPrompt(input: ClassifyConversationInput)
       : [];
 
   return [
-    "Classify this Hyperlocalise agent conversation for GitHub repository tooling setup.",
+    "Classify this Hyperlocalise agent conversation for GitHub or GitLab repository tooling setup.",
     "",
     "Repository tooling flags:",
-    "- needsRepositoryTools: true when the assistant should connect to GitHub and use read-only repo search tools for this turn.",
+    "- needsRepositoryTools: true when the assistant should connect to GitHub or GitLab and use read-only repo search tools for this turn.",
     "- continuesRepositoryThread: true when the latest message continues an in-thread repo lookup (for example nearby words, surrounding copy, which file, show more) even if the latest message is short.",
-    "- currentMessageSpecifiesRepository: true only when the latest user message explicitly names a repo (owner/name), GitHub URL, or pull request.",
+    "- currentMessageSpecifiesRepository: true only when the latest user message explicitly names a repo (owner/name), GitHub URL, GitLab URL, pull request, or merge request.",
     "- requiresPullRequest: true only when the user is asking for PR-scoped work such as fixing, reviewing, or checking a specific pull request.",
     "- shouldAskForRepositoryClarification: true when the user clearly wants repo-based localization context but the conversation does not yet identify which repository or PR to use.",
     ...knowledgeMemoryRouting,
@@ -88,7 +88,7 @@ function buildConversationClassificationPrompt(input: ClassifyConversationInput)
     "  Classification: needsRepositoryTools false.",
     "",
     "Use the full recent conversation, not only the latest message.",
-    "If the user asks for the context of a string, key, label, word, or copy, they usually mean context in the connected GitHub repository.",
+    "If the user asks for the context of a string, key, label, word, or copy, they usually mean context in the connected GitHub or GitLab repository.",
     "If a repository was already established earlier in the thread, treat short follow-ups as continuesRepositoryThread and keep needsRepositoryTools true when repository lookup still applies.",
     "",
     `Surface: ${input.surface}`,
@@ -125,7 +125,7 @@ export function createConversationClassifier({ model }: CreateConversationClassi
         schema: conversationClassificationSchema,
       }),
       instructions:
-        "You are a precise conversation classifier for a localization agent. Return only structured classification data for GitHub repository tooling.",
+        "You are a precise conversation classifier for a localization agent. Return only structured classification data for GitHub or GitLab repository tooling.",
       prompt: buildConversationClassificationPrompt(input),
       temperature: 0,
     });
@@ -185,7 +185,7 @@ export function getRecentUserConversationText(
 
 export function shouldAttemptRepositoryContextResolution(input: {
   classification: ConversationClassification;
-  storedRepositoryContext?: RepositoryAgentGitHubContext | null;
+  storedRepositoryContext?: unknown;
 }): boolean {
   if (input.classification.needsRepositoryTools) {
     return true;

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
@@ -13,8 +13,6 @@
 import { generateText, Output, type LanguageModel, type ModelMessage } from "ai";
 import { z } from "zod";
 
-import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
-
 import type { RepositoryGitHubContextResolution } from "@/lib/agents/repository-context";
 
 export const conversationClassificationSchema = z.object({

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
@@ -25,6 +25,7 @@ export type ConversationRepositorySandboxSession = {
   repositoryContextKey: string;
   createdAt: string;
   lastUsedAt: string;
+  credentialOwnerWorkosUserId?: string;
 };
 
 export type ConversationRepositorySession = {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
@@ -12,6 +12,7 @@
  */
 import { and, eq, lte } from "drizzle-orm";
 
+import type { RepositoryAgentGitLabContext } from "@/lib/agent-contracts/gitlab-repository-task";
 import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
 import { stopRepositorySandbox } from "@/lib/agent-runtime/workspaces/repository-sandbox";
 import { db, schema } from "@/lib/database/client";
@@ -28,6 +29,7 @@ export type ConversationRepositorySandboxSession = {
 
 export type ConversationRepositorySession = {
   repositoryGitHubContext?: RepositoryAgentGitHubContext;
+  repositoryGitLabContext?: RepositoryAgentGitLabContext;
   repositorySandboxSession?: ConversationRepositorySandboxSession;
 };
 
@@ -39,6 +41,17 @@ export function getRepositoryContextKey(context: RepositoryAgentGitHubContext): 
     branch: context.branch ?? null,
     commitSha: context.commitSha ?? null,
     commentId: context.commentId ?? null,
+  });
+}
+
+export function getGitlabRepositoryContextKey(context: RepositoryAgentGitLabContext): string {
+  return JSON.stringify({
+    provider: "gitlab",
+    projectId: context.projectId,
+    repositoryFullName: context.repositoryFullName,
+    mergeRequestIid: context.mergeRequestIid ?? null,
+    branch: context.branch ?? null,
+    commitSha: context.commitSha ?? null,
   });
 }
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -17,18 +17,23 @@ const {
   createConversationToolLoopAgentMock,
   loadInteractionModelMessagesMock,
   resolveConversationRepositoryGitHubContextMock,
+  resolveConversationRepositoryGitLabContextMock,
   createRepositorySandboxMock,
+  createGitlabRepositorySandboxMock,
   isRepositorySandboxAvailableMock,
   resolveOrganizationHasTmsIntegrationMock,
   resolveWorkspaceVisualMockFlagMock,
   getOrganizationRepositoryConnectorConfigMock,
   resolveHyperlocaliseAgentLanguageModelMock,
+  resolveGitLabPipesWorkosUserIdMock,
 } = vi.hoisted(() => ({
   classifyConversationMock: vi.fn(),
   createConversationToolLoopAgentMock: vi.fn(() => ({ stream: vi.fn() })),
   loadInteractionModelMessagesMock: vi.fn(),
   resolveConversationRepositoryGitHubContextMock: vi.fn(),
+  resolveConversationRepositoryGitLabContextMock: vi.fn(),
   createRepositorySandboxMock: vi.fn(),
+  createGitlabRepositorySandboxMock: vi.fn(),
   isRepositorySandboxAvailableMock: vi.fn(async () => true),
   resolveOrganizationHasTmsIntegrationMock: vi.fn(),
   resolveWorkspaceVisualMockFlagMock: vi.fn(),
@@ -40,6 +45,7 @@ const {
     source: "gateway" as const,
     modelId: "openai/gpt-5.6-luna",
   })),
+  resolveGitLabPipesWorkosUserIdMock: vi.fn(async () => "user_workos"),
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -86,6 +92,19 @@ vi.mock("@/lib/agents/repository-context", () => ({
   resolveConversationRepositoryGitHubContext: resolveConversationRepositoryGitHubContextMock,
 }));
 
+vi.mock("@/lib/gitlab/repository-context", () => ({
+  buildRepositoryGitLabContextInstructions: vi.fn(() => "resolved-gitlab-context"),
+  resolveConversationRepositoryGitLabContext: resolveConversationRepositoryGitLabContextMock,
+}));
+
+vi.mock("@/lib/gitlab/gitlab-repository-sandbox", () => ({
+  createGitlabRepositorySandbox: createGitlabRepositorySandboxMock,
+}));
+
+vi.mock("@/lib/gitlab/pipes", () => ({
+  resolveGitLabPipesWorkosUserId: resolveGitLabPipesWorkosUserIdMock,
+}));
+
 vi.mock("@/lib/agent-runtime/workspaces/repository-sandbox", () => ({
   createRepositorySandbox: createRepositorySandboxMock,
   isRepositorySandboxAvailable: isRepositorySandboxAvailableMock,
@@ -113,6 +132,7 @@ vi.mock("@/lib/log", () => ({
 
 import {
   buildFileTranslationInstructions,
+  getOrCreateConversationGitlabRepositorySandbox,
   getOrCreateConversationRepositorySandbox,
   prepareConversationAgentTurn,
   REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP,
@@ -213,6 +233,83 @@ describe("conversation repository sandbox reuse", () => {
   });
 });
 
+describe("conversation gitlab repository sandbox reuse", () => {
+  const gitlabContext = {
+    resolved: true as const,
+    provider: "gitlab" as const,
+    projectId: 11,
+    repositoryFullName: "acme/web",
+    httpUrlToRepo: "https://gitlab.com/acme/web.git",
+  };
+  const repositoryContextKey = JSON.stringify({
+    provider: "gitlab",
+    projectId: gitlabContext.projectId,
+    repositoryFullName: gitlabContext.repositoryFullName,
+    mergeRequestIid: null,
+    branch: null,
+    commitSha: null,
+  });
+  const repositorySession = {
+    repositoryGitLabContext: gitlabContext,
+    repositorySandboxSession: {
+      sandboxId: "sandbox_gitlab_stored",
+      repositoryContextKey,
+      createdAt: "2026-07-01T12:00:00.000Z",
+      lastUsedAt: "2026-07-01T12:00:00.000Z",
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isRepositorySandboxAvailableMock.mockResolvedValue(true);
+    resolveGitLabPipesWorkosUserIdMock.mockResolvedValue("user_workos");
+  });
+
+  it("reuses a matching stored gitlab sandbox after the availability probe", async () => {
+    const result = await getOrCreateConversationGitlabRepositorySandbox({
+      conversationId: "conv_123",
+      surface: "web",
+      gitlabContext,
+      repositorySession,
+      organizationId: "org_123",
+      localUserId: "user_123",
+    });
+
+    expect(isRepositorySandboxAvailableMock).toHaveBeenCalledWith("sandbox_gitlab_stored");
+    expect(createGitlabRepositorySandboxMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      sandboxId: "sandbox_gitlab_stored",
+      sandboxCreated: false,
+      staleSandboxId: null,
+    });
+  });
+
+  it("creates a gitlab sandbox when the stored sandbox is missing", async () => {
+    isRepositorySandboxAvailableMock.mockResolvedValueOnce(false);
+    createGitlabRepositorySandboxMock.mockResolvedValueOnce("sandbox_gitlab_new");
+
+    const result = await getOrCreateConversationGitlabRepositorySandbox({
+      conversationId: "conv_123",
+      surface: "web",
+      gitlabContext,
+      repositorySession,
+      organizationId: "org_123",
+      localUserId: "user_123",
+    });
+
+    expect(createGitlabRepositorySandboxMock).toHaveBeenCalledWith({
+      localOrganizationId: "org_123",
+      workosUserId: "user_workos",
+      gitlabContext,
+    });
+    expect(result).toMatchObject({
+      sandboxId: "sandbox_gitlab_new",
+      sandboxCreated: true,
+      staleSandboxId: "sandbox_gitlab_stored",
+    });
+  });
+});
+
 describe("resolveVirtualAttachedProjectContext", () => {
   it("recovers Crowdin provider metadata from live encoded project ids", () => {
     expect(resolveVirtualAttachedProjectContext("ext:crowdin:42")).toEqual({
@@ -239,6 +336,9 @@ describe("conversation turn preparation", () => {
     resolveOrganizationHasTmsIntegrationMock.mockResolvedValue(true);
     resolveWorkspaceVisualMockFlagMock.mockResolvedValue(false);
     resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "not_applicable",
+    });
+    resolveConversationRepositoryGitLabContextMock.mockResolvedValue({
       status: "not_applicable",
     });
   });
@@ -596,5 +696,54 @@ describe("conversation turn preparation", () => {
     expect(result.updatedRepositorySession?.repositorySandboxSession?.sandboxId).toBe(
       "sandbox_committed",
     );
+  });
+
+  it("creates a gitlab sandbox when gitlab repository context resolves", async () => {
+    const gitlabContext = {
+      resolved: true as const,
+      provider: "gitlab" as const,
+      projectId: 11,
+      repositoryFullName: "acme/platform/web",
+      httpUrlToRepo: "https://gitlab.com/acme/platform/web.git",
+      branch: "main",
+    };
+    classifyConversationMock.mockResolvedValue({
+      ...baseClassification,
+      needsRepositoryTools: true,
+    });
+    resolveConversationRepositoryGitLabContextMock.mockResolvedValue({
+      status: "resolved",
+      context: gitlabContext,
+    });
+    createGitlabRepositorySandboxMock.mockResolvedValue("sandbox_gitlab");
+
+    const result = await prepareConversationAgentTurn({
+      surface: "web",
+      conversationId: "conv_123",
+      organizationId: "org_123",
+      localUserId: "user_123",
+      membershipRole: "admin",
+      projectId: null,
+      messageText: "where is the login copy in https://gitlab.com/acme/platform/web?",
+      hasTranslationAttachments: false,
+      db: {} as never,
+    });
+
+    expect(createGitlabRepositorySandboxMock).toHaveBeenCalledWith({
+      localOrganizationId: "org_123",
+      workosUserId: "user_workos",
+      gitlabContext,
+    });
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolContext: expect.objectContaining({
+          sandboxId: "sandbox_gitlab",
+          gitlabContext,
+          githubContext: null,
+          workMode: "read_only",
+        }),
+      }),
+    );
+    expect(result.updatedRepositorySession?.repositoryGitLabContext).toEqual(gitlabContext);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -254,6 +254,7 @@ describe("conversation gitlab repository sandbox reuse", () => {
     repositorySandboxSession: {
       sandboxId: "sandbox_gitlab_stored",
       repositoryContextKey,
+      credentialOwnerWorkosUserId: "user_workos",
       createdAt: "2026-07-01T12:00:00.000Z",
       lastUsedAt: "2026-07-01T12:00:00.000Z",
     },
@@ -275,6 +276,10 @@ describe("conversation gitlab repository sandbox reuse", () => {
       localUserId: "user_123",
     });
 
+    expect(resolveGitLabPipesWorkosUserIdMock).toHaveBeenCalledWith({
+      workosUserId: undefined,
+      localUserId: "user_123",
+    });
     expect(isRepositorySandboxAvailableMock).toHaveBeenCalledWith("sandbox_gitlab_stored");
     expect(createGitlabRepositorySandboxMock).not.toHaveBeenCalled();
     expect(result).toMatchObject({
@@ -304,6 +309,77 @@ describe("conversation gitlab repository sandbox reuse", () => {
     });
     expect(result).toMatchObject({
       sandboxId: "sandbox_gitlab_new",
+      sandboxCreated: true,
+      staleSandboxId: "sandbox_gitlab_stored",
+      updatedSession: {
+        repositorySandboxSession: {
+          sandboxId: "sandbox_gitlab_new",
+          repositoryContextKey,
+          credentialOwnerWorkosUserId: "user_workos",
+        },
+      },
+    });
+  });
+
+  it("creates a gitlab sandbox when the stored credential owner differs", async () => {
+    createGitlabRepositorySandboxMock.mockResolvedValueOnce("sandbox_gitlab_other_owner");
+
+    const result = await getOrCreateConversationGitlabRepositorySandbox({
+      conversationId: "conv_123",
+      surface: "web",
+      gitlabContext,
+      repositorySession: {
+        ...repositorySession,
+        repositorySandboxSession: {
+          ...repositorySession.repositorySandboxSession,
+          credentialOwnerWorkosUserId: "user_other",
+        },
+      },
+      organizationId: "org_123",
+      localUserId: "user_123",
+    });
+
+    expect(isRepositorySandboxAvailableMock).not.toHaveBeenCalled();
+    expect(createGitlabRepositorySandboxMock).toHaveBeenCalledWith({
+      localOrganizationId: "org_123",
+      workosUserId: "user_workos",
+      gitlabContext,
+    });
+    expect(result).toMatchObject({
+      sandboxId: "sandbox_gitlab_other_owner",
+      sandboxCreated: true,
+      staleSandboxId: "sandbox_gitlab_stored",
+    });
+  });
+
+  it("creates a gitlab sandbox when the stored credential owner is missing", async () => {
+    createGitlabRepositorySandboxMock.mockResolvedValueOnce("sandbox_gitlab_legacy");
+
+    const result = await getOrCreateConversationGitlabRepositorySandbox({
+      conversationId: "conv_123",
+      surface: "web",
+      gitlabContext,
+      repositorySession: {
+        ...repositorySession,
+        repositorySandboxSession: {
+          sandboxId: "sandbox_gitlab_stored",
+          repositoryContextKey,
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
+      },
+      organizationId: "org_123",
+      localUserId: "user_123",
+    });
+
+    expect(isRepositorySandboxAvailableMock).not.toHaveBeenCalled();
+    expect(createGitlabRepositorySandboxMock).toHaveBeenCalledWith({
+      localOrganizationId: "org_123",
+      workosUserId: "user_workos",
+      gitlabContext,
+    });
+    expect(result).toMatchObject({
+      sandboxId: "sandbox_gitlab_legacy",
       sandboxCreated: true,
       staleSandboxId: "sandbox_gitlab_stored",
     });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -16,6 +16,7 @@ import type {
   HyperlocaliseAgentSurface,
   HyperlocaliseAttachedProjectContext,
 } from "@/agents/hyperlocalise/agent/agent";
+import type { RepositoryAgentGitLabContext } from "@/lib/agent-contracts/gitlab-repository-task";
 import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
 import type { RepositoryAgentTaskSource } from "@/lib/agent-contracts/repository-task";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
@@ -27,6 +28,12 @@ import {
   getOrganizationRepositoryConnectorConfig,
   resolveConversationRepositoryGitHubContext,
 } from "@/lib/agents/repository-context";
+import { createGitlabRepositorySandbox } from "@/lib/gitlab/gitlab-repository-sandbox";
+import { resolveGitLabPipesWorkosUserId } from "@/lib/gitlab/pipes";
+import {
+  buildRepositoryGitLabContextInstructions,
+  resolveConversationRepositoryGitLabContext,
+} from "@/lib/gitlab/repository-context";
 import {
   createRepositorySandbox,
   isRepositorySandboxAvailable,
@@ -52,6 +59,7 @@ import {
 } from "./hyperlocalise-agent";
 import { resolveOrganizationHasTmsIntegration } from "../skills/conversation-tms-integration";
 import {
+  getGitlabRepositoryContextKey,
   getRepositoryContextKey,
   type ConversationRepositorySession,
 } from "./conversation-repository-session";
@@ -133,7 +141,7 @@ export function buildMissingRepositoryContextInstructions(followUp: string) {
   return [
     "Repository context is not available for this request.",
     `If the user asks where a string, message, copy, or localized text appears in code, ask this follow-up exactly: ${followUp}`,
-    "Do not invent a GitHub repository, pull request, branch, installation ID, path, or file contents.",
+    "Do not invent a GitHub or GitLab repository, pull request, merge request, branch, installation ID, path, or file contents.",
   ].join("\n");
 }
 
@@ -147,9 +155,23 @@ export function buildResolvedRepositoryContextInstructions(context: RepositoryAg
   ].join("\n");
 }
 
+export function buildResolvedGitLabRepositoryContextInstructions(
+  context: RepositoryAgentGitLabContext,
+) {
+  return [
+    buildRepositoryGitLabContextInstructions(context),
+    "Repository read tools are available for this request.",
+    "Use grep with the user's literal string or copy, then read for surrounding lines when needed.",
+    "Only explain where strings, messages, or copy appear and what nearby code implies.",
+    "Do not modify files, upload sources, commit, push, or create jobs from repository context alone.",
+  ].join("\n");
+}
+
 type ResolveRepositoryContextInput = {
   surface: HyperlocaliseAgentSurface;
   organizationId: string;
+  localUserId?: string | null;
+  workosUserId?: string | null;
   projectId: string | null;
   conversationText: string;
   classification: ConversationClassification;
@@ -160,27 +182,36 @@ type ResolveRepositoryContextInput = {
 
 export type ResolvedRepositoryContext = {
   context: RepositoryAgentGitHubContext | null;
+  gitlabContext: RepositoryAgentGitLabContext | null;
   instructions: string | null;
   clarificationFollowUp: string | null;
   updatedSession: ConversationRepositorySession | null;
 };
 
+function emptyRepositoryResolution(
+  repositorySession: ConversationRepositorySession | null,
+): ResolvedRepositoryContext {
+  return {
+    context: null,
+    gitlabContext: null,
+    instructions: null,
+    clarificationFollowUp: null,
+    updatedSession: repositorySession,
+  };
+}
+
 export async function resolveConversationRepositoryContext(
   input: ResolveRepositoryContextInput,
 ): Promise<ResolvedRepositoryContext> {
   const storedRepositoryContext = input.repositorySession?.repositoryGitHubContext ?? null;
+  const storedGitLabContext = input.repositorySession?.repositoryGitLabContext ?? null;
   const shouldResolve = shouldAttemptRepositoryContextResolution({
     classification: input.classification,
-    storedRepositoryContext,
+    storedRepositoryContext: storedRepositoryContext ?? storedGitLabContext,
   });
 
   if (!shouldResolve) {
-    return {
-      context: null,
-      instructions: null,
-      clarificationFollowUp: null,
-      updatedSession: input.repositorySession,
-    };
+    return emptyRepositoryResolution(input.repositorySession);
   }
 
   const connectorConfig =
@@ -189,13 +220,23 @@ export async function resolveConversationRepositoryContext(
       ? await getOrganizationRepositoryConnectorConfig(input.organizationId)
       : null);
 
-  const canReuseStoredRepositoryContext =
-    storedRepositoryContext !== null && !input.classification.currentMessageSpecifiesRepository;
+  const canReuseStoredRepositoryContext = !input.classification.currentMessageSpecifiesRepository;
 
-  if (canReuseStoredRepositoryContext) {
+  if (canReuseStoredRepositoryContext && storedRepositoryContext) {
     return {
       context: storedRepositoryContext,
+      gitlabContext: null,
       instructions: buildResolvedRepositoryContextInstructions(storedRepositoryContext),
+      clarificationFollowUp: null,
+      updatedSession: input.repositorySession,
+    };
+  }
+
+  if (canReuseStoredRepositoryContext && storedGitLabContext) {
+    return {
+      context: null,
+      gitlabContext: storedGitLabContext,
+      instructions: buildResolvedGitLabRepositoryContextInstructions(storedGitLabContext),
       clarificationFollowUp: null,
       updatedSession: input.repositorySession,
     };
@@ -214,11 +255,36 @@ export async function resolveConversationRepositoryContext(
     const context = githubContextResolution.context;
     return {
       context,
+      gitlabContext: null,
       instructions: buildResolvedRepositoryContextInstructions(context),
       clarificationFollowUp: null,
       updatedSession: {
         ...input.repositorySession,
         repositoryGitHubContext: context,
+        repositoryGitLabContext: undefined,
+      },
+    };
+  }
+
+  const gitlabContextResolution = await resolveConversationRepositoryGitLabContext({
+    organizationId: input.organizationId,
+    localUserId: input.localUserId,
+    workosUserId: input.workosUserId,
+    text: input.conversationText,
+  });
+
+  if (gitlabContextResolution.status === "resolved") {
+    return {
+      context: null,
+      gitlabContext: gitlabContextResolution.context,
+      instructions: buildResolvedGitLabRepositoryContextInstructions(
+        gitlabContextResolution.context,
+      ),
+      clarificationFollowUp: null,
+      updatedSession: {
+        ...input.repositorySession,
+        repositoryGitHubContext: undefined,
+        repositoryGitLabContext: gitlabContextResolution.context,
       },
     };
   }
@@ -227,6 +293,7 @@ export async function resolveConversationRepositoryContext(
     if (storedRepositoryContext && !input.classification.currentMessageSpecifiesRepository) {
       return {
         context: storedRepositoryContext,
+        gitlabContext: null,
         instructions: buildResolvedRepositoryContextInstructions(storedRepositoryContext),
         clarificationFollowUp: null,
         updatedSession: input.repositorySession,
@@ -245,18 +312,44 @@ export async function resolveConversationRepositoryContext(
 
     return {
       context: null,
+      gitlabContext: null,
       instructions,
       clarificationFollowUp,
       updatedSession: input.repositorySession,
     };
   }
 
-  return {
-    context: null,
-    instructions: null,
-    clarificationFollowUp: null,
-    updatedSession: input.repositorySession,
-  };
+  if (gitlabContextResolution.status === "unresolved") {
+    const instructions = buildMissingRepositoryContextInstructions(
+      gitlabContextResolution.followUp,
+    );
+    const clarificationFollowUp = shouldRequireRepositoryContextClarification(
+      input.classification,
+      { repositoryContextStatus: "unresolved" },
+    )
+      ? gitlabContextResolution.followUp
+      : null;
+
+    return {
+      context: null,
+      gitlabContext: null,
+      instructions,
+      clarificationFollowUp,
+      updatedSession: input.repositorySession,
+    };
+  }
+
+  if (storedGitLabContext && !input.classification.currentMessageSpecifiesRepository) {
+    return {
+      context: null,
+      gitlabContext: storedGitLabContext,
+      instructions: buildResolvedGitLabRepositoryContextInstructions(storedGitLabContext),
+      clarificationFollowUp: null,
+      updatedSession: input.repositorySession,
+    };
+  }
+
+  return emptyRepositoryResolution(input.repositorySession);
 }
 
 export async function getOrCreateConversationRepositorySandbox(input: {
@@ -291,6 +384,7 @@ export async function getOrCreateConversationRepositorySandbox(input: {
       updatedSession: {
         ...input.repositorySession,
         repositoryGitHubContext: input.githubContext,
+        repositoryGitLabContext: undefined,
         repositorySandboxSession: {
           ...sandboxSession,
           lastUsedAt: now,
@@ -315,6 +409,93 @@ export async function getOrCreateConversationRepositorySandbox(input: {
   const updatedSession: ConversationRepositorySession = {
     ...input.repositorySession,
     repositoryGitHubContext: input.githubContext,
+    repositoryGitLabContext: undefined,
+    repositorySandboxSession: {
+      sandboxId,
+      repositoryContextKey,
+      createdAt: now,
+      lastUsedAt: now,
+    },
+  };
+
+  const staleSandboxId = sandboxSession?.sandboxId ?? null;
+
+  return { sandboxId, updatedSession, sandboxCreated: true, staleSandboxId };
+}
+
+export async function getOrCreateConversationGitlabRepositorySandbox(input: {
+  conversationId: string;
+  surface: HyperlocaliseAgentSurface;
+  gitlabContext: RepositoryAgentGitLabContext;
+  repositorySession: ConversationRepositorySession | null;
+  organizationId: string;
+  workosUserId?: string | null;
+  localUserId?: string | null;
+}): Promise<{
+  sandboxId: string;
+  updatedSession: ConversationRepositorySession;
+  sandboxCreated: boolean;
+  staleSandboxId: string | null;
+}> {
+  const log = logger.child({
+    conversationId: input.conversationId,
+    surface: input.surface,
+  });
+  const repositoryContextKey = getGitlabRepositoryContextKey(input.gitlabContext);
+  const sandboxSession = input.repositorySession?.repositorySandboxSession;
+  const now = new Date().toISOString();
+
+  if (
+    sandboxSession?.repositoryContextKey === repositoryContextKey &&
+    (await isRepositorySandboxAvailable(sandboxSession.sandboxId))
+  ) {
+    log.info(
+      { sandboxId: sandboxSession.sandboxId },
+      "reusing stored gitlab repository sandbox for conversation agent",
+    );
+    return {
+      sandboxId: sandboxSession.sandboxId,
+      updatedSession: {
+        ...input.repositorySession,
+        repositoryGitHubContext: undefined,
+        repositoryGitLabContext: input.gitlabContext,
+        repositorySandboxSession: {
+          ...sandboxSession,
+          lastUsedAt: now,
+        },
+      },
+      sandboxCreated: false,
+      staleSandboxId: null,
+    };
+  }
+
+  const workosUserId = await resolveGitLabPipesWorkosUserId({
+    workosUserId: input.workosUserId,
+    localUserId: input.localUserId,
+  });
+  if (!workosUserId) {
+    throw new Error("gitlab_not_connected");
+  }
+
+  log.info(
+    {
+      projectId: input.gitlabContext.projectId,
+      branch: input.gitlabContext.branch ?? null,
+      commitSha: input.gitlabContext.commitSha ?? null,
+    },
+    "creating gitlab repository sandbox for conversation agent",
+  );
+  const sandboxId = await createGitlabRepositorySandbox({
+    localOrganizationId: input.organizationId,
+    workosUserId,
+    gitlabContext: input.gitlabContext,
+  });
+  log.info({ sandboxId }, "gitlab repository sandbox created for conversation agent");
+
+  const updatedSession: ConversationRepositorySession = {
+    ...input.repositorySession,
+    repositoryGitHubContext: undefined,
+    repositoryGitLabContext: input.gitlabContext,
     repositorySandboxSession: {
       sandboxId,
       repositoryContextKey,
@@ -349,6 +530,7 @@ export type PrepareConversationAgentTurnInput = {
   conversationId: string;
   organizationId: string;
   localUserId: string;
+  workosUserId?: string | null;
   membershipRole: OrganizationMembershipRole;
   projectId: string | null;
   messageText: string;
@@ -391,6 +573,7 @@ export async function prepareConversationAgentTurn(
   const chatMessages = await loadInteractionModelMessages(input.conversationId);
   const conversationText = getRecentUserConversationText(chatMessages, input.messageText);
   const storedRepositoryContext = input.repositorySession?.repositoryGitHubContext ?? null;
+  const storedGitLabContext = input.repositorySession?.repositoryGitLabContext ?? null;
   const languageModel = await resolveHyperlocaliseAgentLanguageModel({
     organizationId: input.organizationId,
   });
@@ -399,7 +582,7 @@ export async function prepareConversationAgentTurn(
     currentMessage: input.messageText,
     conversationText,
     hasFileAttachments: input.hasTranslationAttachments,
-    hasStoredRepositoryContext: Boolean(storedRepositoryContext),
+    hasStoredRepositoryContext: Boolean(storedRepositoryContext ?? storedGitLabContext),
     knowledgeMemoryEnabled: input.knowledgeMemoryEnabled === true,
     surface: input.surface,
     model: languageModel.model,
@@ -408,6 +591,8 @@ export async function prepareConversationAgentTurn(
   const repositoryResolution = await resolveConversationRepositoryContext({
     surface: input.surface,
     organizationId: input.organizationId,
+    localUserId: input.localUserId,
+    workosUserId: input.workosUserId,
     projectId: input.projectId,
     conversationText,
     classification,
@@ -420,6 +605,7 @@ export async function prepareConversationAgentTurn(
   let sandboxId: string | null = null;
   let staleSandboxId: string | null = null;
   let activeRepositoryContext = repositoryResolution.context;
+  let activeGitlabContext = repositoryResolution.gitlabContext;
   let repositoryInstructions = repositoryResolution.instructions;
   let clarificationFollowUp = repositoryResolution.clarificationFollowUp;
 
@@ -432,6 +618,7 @@ export async function prepareConversationAgentTurn(
     if (input.reuseCommittedRepositorySandboxOnly && !canReuseStoredSandbox) {
       updatedRepositorySession = input.repositorySession ?? null;
       activeRepositoryContext = null;
+      activeGitlabContext = null;
       repositoryInstructions = null;
       clarificationFollowUp = REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP;
     } else {
@@ -440,6 +627,31 @@ export async function prepareConversationAgentTurn(
         surface: input.surface,
         githubContext: repositoryResolution.context,
         repositorySession: updatedRepositorySession,
+      });
+      sandboxId = sandboxResult.sandboxId;
+      updatedRepositorySession = sandboxResult.updatedSession;
+      staleSandboxId = sandboxResult.staleSandboxId;
+    }
+  } else if (repositoryResolution.gitlabContext) {
+    const repositoryContextKey = getGitlabRepositoryContextKey(repositoryResolution.gitlabContext);
+    const storedSandboxSession = updatedRepositorySession?.repositorySandboxSession;
+    const canReuseStoredSandbox =
+      storedSandboxSession?.repositoryContextKey === repositoryContextKey;
+
+    if (input.reuseCommittedRepositorySandboxOnly && !canReuseStoredSandbox) {
+      updatedRepositorySession = input.repositorySession ?? null;
+      activeGitlabContext = null;
+      repositoryInstructions = null;
+      clarificationFollowUp = REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP;
+    } else {
+      const sandboxResult = await getOrCreateConversationGitlabRepositorySandbox({
+        conversationId: input.conversationId,
+        surface: input.surface,
+        gitlabContext: repositoryResolution.gitlabContext,
+        repositorySession: updatedRepositorySession,
+        organizationId: input.organizationId,
+        workosUserId: input.workosUserId,
+        localUserId: input.localUserId,
       });
       sandboxId = sandboxResult.sandboxId;
       updatedRepositorySession = sandboxResult.updatedSession;
@@ -479,7 +691,11 @@ export async function prepareConversationAgentTurn(
         ? {
             sandboxId,
             githubContext: activeRepositoryContext,
-            workMode: hasVisualMockSkill ? ("write" as const) : ("read_only" as const),
+            gitlabContext: activeGitlabContext,
+            workMode:
+              hasVisualMockSkill && activeRepositoryContext
+                ? ("write" as const)
+                : ("read_only" as const),
             repositorySource: input.repositorySource ?? "chat_ui",
             actor: resolveConversationActor(input),
           }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -441,14 +441,23 @@ export async function getOrCreateConversationGitlabRepositorySandbox(input: {
     conversationId: input.conversationId,
     surface: input.surface,
   });
+  const workosUserId = await resolveGitLabPipesWorkosUserId({
+    workosUserId: input.workosUserId,
+    localUserId: input.localUserId,
+  });
+  if (!workosUserId) {
+    throw new Error("gitlab_not_connected");
+  }
+
   const repositoryContextKey = getGitlabRepositoryContextKey(input.gitlabContext);
   const sandboxSession = input.repositorySession?.repositorySandboxSession;
   const now = new Date().toISOString();
+  const canReuseStoredSandbox =
+    sandboxSession != null &&
+    sandboxSession.repositoryContextKey === repositoryContextKey &&
+    sandboxSession.credentialOwnerWorkosUserId === workosUserId;
 
-  if (
-    sandboxSession?.repositoryContextKey === repositoryContextKey &&
-    (await isRepositorySandboxAvailable(sandboxSession.sandboxId))
-  ) {
+  if (canReuseStoredSandbox && (await isRepositorySandboxAvailable(sandboxSession.sandboxId))) {
     log.info(
       { sandboxId: sandboxSession.sandboxId },
       "reusing stored gitlab repository sandbox for conversation agent",
@@ -469,19 +478,14 @@ export async function getOrCreateConversationGitlabRepositorySandbox(input: {
     };
   }
 
-  const workosUserId = await resolveGitLabPipesWorkosUserId({
-    workosUserId: input.workosUserId,
-    localUserId: input.localUserId,
-  });
-  if (!workosUserId) {
-    throw new Error("gitlab_not_connected");
-  }
-
   log.info(
     {
       projectId: input.gitlabContext.projectId,
-      branch: input.gitlabContext.branch ?? null,
-      commitSha: input.gitlabContext.commitSha ?? null,
+      revisionKind: input.gitlabContext.commitSha
+        ? "commit"
+        : input.gitlabContext.branch
+          ? "branch"
+          : "head",
     },
     "creating gitlab repository sandbox for conversation agent",
   );
@@ -499,6 +503,7 @@ export async function getOrCreateConversationGitlabRepositorySandbox(input: {
     repositorySandboxSession: {
       sandboxId,
       repositoryContextKey,
+      credentialOwnerWorkosUserId: workosUserId,
       createdAt: now,
       lastUsedAt: now,
     },

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/audit.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/audit.ts
@@ -43,7 +43,7 @@ export async function auditRepositoryMutation(
     },
     action: input.action,
     source: ctx.repositorySource ?? (ctx.actor ? "repository_agent" : "unknown"),
-    provider: ctx.githubContext ? "github" : "repository",
+    provider: ctx.githubContext ? "github" : ctx.gitlabContext ? "gitlab" : "repository",
     status: input.status,
     details: input.details ?? {},
   });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-logging.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-logging.ts
@@ -187,6 +187,7 @@ function summarizeValue(value: unknown, key?: string, depth = 0): unknown {
 
 function summarizeToolContext(ctx: ToolContext): SafeRecord {
   const githubContext = ctx.githubContext;
+  const gitlabContext = ctx.gitlabContext;
   return {
     conversationId: ctx.conversationId,
     workflowRunId: ctx.workflowRunId ?? null,
@@ -197,6 +198,7 @@ function summarizeToolContext(ctx: ToolContext): SafeRecord {
     repositorySource: ctx.repositorySource ?? null,
     sandboxId: ctx.sandboxId ?? null,
     hasGithubContext: Boolean(githubContext),
+    hasGitlabContext: Boolean(gitlabContext),
     githubContext: githubContext
       ? {
           installationId: githubContext.installationId,
@@ -207,6 +209,17 @@ function summarizeToolContext(ctx: ToolContext): SafeRecord {
               : null,
           commitSha: githubContext.commitSha ? githubContext.commitSha.slice(0, 12) : null,
           commentId: githubContext.commentId ?? null,
+        }
+      : null,
+    gitlabContext: gitlabContext
+      ? {
+          projectId: gitlabContext.projectId,
+          mergeRequestIid: gitlabContext.mergeRequestIid ?? null,
+          branch:
+            typeof gitlabContext.branch === "string"
+              ? summarizeString(gitlabContext.branch, "branch")
+              : null,
+          commitSha: gitlabContext.commitSha ? gitlabContext.commitSha.slice(0, 12) : null,
         }
       : null,
   };

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -46,6 +46,7 @@ const {
   loadMessagesMock,
   resolveOrganizationHasTmsIntegrationMock,
   resolveSlackRepositoryGitHubContextMock,
+  resolveSlackRepositoryGitLabContextMock,
   resolveHyperlocaliseAgentLanguageModelMock,
 } = vi.hoisted(() => ({
   agentGenerateMock: vi.fn(),
@@ -56,6 +57,7 @@ const {
   loadMessagesMock: vi.fn(async () => []),
   resolveOrganizationHasTmsIntegrationMock: vi.fn(async () => false),
   resolveSlackRepositoryGitHubContextMock: vi.fn(),
+  resolveSlackRepositoryGitLabContextMock: vi.fn(async () => ({ status: "not_applicable" })),
   resolveHyperlocaliseAgentLanguageModelMock: vi.fn(async () => ({
     model: "org-model",
     source: "gateway" as const,
@@ -136,6 +138,11 @@ vi.mock("@/lib/agents/repository-context", async (importOriginal) => {
     getOrganizationRepositoryConnectorConfig: vi.fn(async () => null),
   };
 });
+
+vi.mock("@/lib/gitlab/repository-context", () => ({
+  buildRepositoryGitLabContextInstructions: vi.fn(() => "resolved-gitlab-context"),
+  resolveConversationRepositoryGitLabContext: resolveSlackRepositoryGitLabContextMock,
+}));
 
 vi.mock("@ai-sdk/openai", () => ({
   openai: vi.fn(() => "mock-model"),
@@ -484,6 +491,7 @@ describe("handleNewConversation", () => {
     interactionHasTranslationAttachmentsMock.mockResolvedValue(false);
     loggerChildMock.info.mockClear();
     resolveSlackRepositoryGitHubContextMock.mockResolvedValue({ status: "not_applicable" });
+    resolveSlackRepositoryGitLabContextMock.mockResolvedValue({ status: "not_applicable" });
     classifyConversationMock.mockImplementation(async () => createMockClassification());
   });
 
@@ -1485,6 +1493,7 @@ describe("handleSubscribedMessage", () => {
     loadMessagesMock.mockResolvedValue([]);
     interactionHasTranslationAttachmentsMock.mockResolvedValue(false);
     resolveSlackRepositoryGitHubContextMock.mockResolvedValue({ status: "not_applicable" });
+    resolveSlackRepositoryGitLabContextMock.mockResolvedValue({ status: "not_applicable" });
     classifyConversationMock.mockImplementation(async () => createMockClassification());
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/repository-session.ts
@@ -31,6 +31,7 @@ export type SlackRepositorySandboxSession = {
   repositoryContextKey: string;
   createdAt: string;
   lastUsedAt: string;
+  credentialOwnerWorkosUserId?: string;
 };
 
 export type SlackImageLocalizationOutput = {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/repository-session.ts
@@ -10,9 +10,10 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import type { RepositoryAgentGitLabContext } from "@/lib/agent-contracts/gitlab-repository-task";
 import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
 
-export type { RepositoryAgentGitHubContext };
+export type { RepositoryAgentGitHubContext, RepositoryAgentGitLabContext };
 
 export function getSlackRepositoryContextKey(context: RepositoryAgentGitHubContext): string {
   return JSON.stringify({
@@ -59,6 +60,7 @@ export type PendingSlackImageTask = {
 export type SlackBotThreadState = {
   warnedNonMemberUsers?: string[];
   repositoryGitHubContext?: RepositoryAgentGitHubContext;
+  repositoryGitLabContext?: RepositoryAgentGitLabContext;
   repositorySandboxSession?: SlackRepositorySandboxSession;
   pendingSlackImageTask?: PendingSlackImageTask;
   imageSourceAssets?: SlackImageSourceAsset[];

--- a/apps/hyperlocalise-web/src/lib/api-client.test.ts
+++ b/apps/hyperlocalise-web/src/lib/api-client.test.ts
@@ -51,6 +51,7 @@ describe("createApiClient", () => {
     expect(typeof org["agent-slack"].$get).toBe("function");
     expect(typeof org["slack-connect"].$get).toBe("function");
     expect(typeof org["github-installation"].$get).toBe("function");
+    expect(typeof org.gitlab.projects.$get).toBe("function");
     expect(typeof org.teams.$get).toBe("function");
     expect(typeof org.members.$get).toBe("function");
     expect(typeof org.workspace.$get).toBe("function");
@@ -69,6 +70,7 @@ describe("createApiClient", () => {
     expectTypeOf(org.glossaries.$get).toBeFunction();
     expectTypeOf(org["tms-provider"].connection.$get).toBeFunction();
     expectTypeOf(org["github-installation"].$get).toBeFunction();
+    expectTypeOf(org.gitlab.projects.$get).toBeFunction();
     expectTypeOf(org.teams.$get).toBeFunction();
     expectTypeOf(org.files.$post).toBeFunction();
     expectTypeOf(client.api.v1.files.$post).toBeFunction();

--- a/apps/hyperlocalise-web/src/lib/api-client.ts
+++ b/apps/hyperlocalise-web/src/lib/api-client.ts
@@ -85,6 +85,7 @@ function createOrgSlugClient(origin: string) {
       "agent-slack",
       "slack-connect",
       "github-installation",
+      "gitlab",
     ]),
     ...pickClientPaths(workspace, [
       "teams",

--- a/apps/hyperlocalise-web/src/lib/gitlab/client.test.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/client.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { isErr, isOk } from "@/lib/primitives/result/results";
+
+import { getGitLabMergeRequest, getGitLabProject, listGitLabMembershipProjects } from "./client";
+
+describe("gitlab client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("lists membership projects and skips archived rows", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify([
+          {
+            id: 11,
+            name: "web",
+            path_with_namespace: "acme/web",
+            http_url_to_repo: "https://gitlab.com/acme/web.git",
+            default_branch: "main",
+            archived: false,
+          },
+          {
+            id: 12,
+            name: "old",
+            path_with_namespace: "acme/old",
+            http_url_to_repo: "https://gitlab.com/acme/old.git",
+            default_branch: "main",
+            archived: true,
+          },
+        ]),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await listGitLabMembershipProjects({ accessToken: "token" });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected ok");
+    }
+    expect(result.value).toEqual([
+      {
+        id: 11,
+        name: "web",
+        pathWithNamespace: "acme/web",
+        httpUrlToRepo: "https://gitlab.com/acme/web.git",
+        defaultBranch: "main",
+        archived: false,
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+      }),
+    );
+  });
+
+  it("loads a project by path_with_namespace", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          id: 99,
+          name: "web",
+          path_with_namespace: "acme/platform/web",
+          http_url_to_repo: "https://gitlab.com/acme/platform/web.git",
+          default_branch: "develop",
+          archived: false,
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getGitLabProject({
+      accessToken: "token",
+      pathWithNamespace: "acme/platform/web",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected ok");
+    }
+    expect(result.value.pathWithNamespace).toBe("acme/platform/web");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "/api/v4/projects/acme%2Fplatform%2Fweb",
+    );
+  });
+
+  it("maps 401 responses to gitlab_unauthorized", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => "",
+      }),
+    );
+
+    const result = await getGitLabMergeRequest({
+      accessToken: "token",
+      pathWithNamespace: "acme/web",
+      mergeRequestIid: 7,
+    });
+
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) {
+      throw new Error("expected err");
+    }
+    expect(result.error.code).toBe("gitlab_unauthorized");
+  });
+
+  it("maps merge request source branch and commit sha", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            iid: 42,
+            source_branch: "fix-copy",
+            sha: "abc123",
+            diff_refs: { head_sha: "def456" },
+          }),
+      }),
+    );
+
+    const result = await getGitLabMergeRequest({
+      accessToken: "token",
+      pathWithNamespace: "acme/web",
+      mergeRequestIid: 42,
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected ok");
+    }
+    expect(result.value).toEqual({
+      iid: 42,
+      sourceBranch: "fix-copy",
+      commitSha: "abc123",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/gitlab/client.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/client.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import { safeJsonParse } from "@/lib/primitives/safeJsonParse/safeJsonParse";
+
+import {
+  GITLAB_API_ORIGIN,
+  GITLAB_CLONE_MIN_ACCESS_LEVEL,
+  GITLAB_PROJECT_MAX_PAGES,
+  GITLAB_PROJECT_PAGE_SIZE,
+} from "./constants";
+import type { GitLabApiError, GitLabMergeRequestDetails, GitLabProject } from "./types";
+
+const UNAUTHORIZED: GitLabApiError = {
+  code: "gitlab_unauthorized",
+  message: "GitLab rejected the connected account token.",
+};
+
+const NOT_FOUND: GitLabApiError = {
+  code: "gitlab_not_found",
+  message: "GitLab could not find that project.",
+};
+
+function requestFailed(status: number): GitLabApiError {
+  return {
+    code: "gitlab_request_failed",
+    message: "GitLab request failed.",
+    status,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseProject(value: unknown): GitLabProject | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const id = asNumber(record.id);
+  const pathWithNamespace = asString(record.path_with_namespace);
+  const httpUrlToRepo = asString(record.http_url_to_repo);
+  const name = asString(record.name);
+  if (!id || !pathWithNamespace || !httpUrlToRepo || !name) {
+    return null;
+  }
+
+  return {
+    id,
+    name,
+    pathWithNamespace,
+    httpUrlToRepo,
+    defaultBranch: asString(record.default_branch),
+    archived: record.archived === true,
+  };
+}
+
+async function gitlabJson(input: {
+  accessToken: string;
+  path: string;
+  query?: URLSearchParams;
+  signal?: AbortSignal;
+}): Promise<Result<unknown, GitLabApiError>> {
+  const url = new URL(input.path, `${GITLAB_API_ORIGIN}/`);
+  if (input.query) {
+    url.search = input.query.toString();
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${input.accessToken}`,
+        Accept: "application/json",
+      },
+      signal: input.signal,
+    });
+  } catch {
+    return err(requestFailed(0));
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return err(UNAUTHORIZED);
+  }
+  if (response.status === 404) {
+    return err(NOT_FOUND);
+  }
+  if (!response.ok) {
+    return err(requestFailed(response.status));
+  }
+
+  const body = await response.text();
+  const parsed = safeJsonParse(body);
+  if (isErr(parsed)) {
+    return err(requestFailed(response.status));
+  }
+
+  return ok(parsed.value);
+}
+
+export async function listGitLabMembershipProjects(input: {
+  accessToken: string;
+  signal?: AbortSignal;
+}): Promise<Result<GitLabProject[], GitLabApiError>> {
+  const projects: GitLabProject[] = [];
+
+  for (let page = 1; page <= GITLAB_PROJECT_MAX_PAGES; page += 1) {
+    const query = new URLSearchParams({
+      membership: "true",
+      min_access_level: String(GITLAB_CLONE_MIN_ACCESS_LEVEL),
+      simple: "true",
+      order_by: "last_activity_at",
+      per_page: String(GITLAB_PROJECT_PAGE_SIZE),
+      page: String(page),
+    });
+
+    const result = await gitlabJson({
+      accessToken: input.accessToken,
+      path: "/api/v4/projects",
+      query,
+      signal: input.signal,
+    });
+    if (isErr(result)) {
+      return result;
+    }
+
+    if (!Array.isArray(result.value)) {
+      return err(requestFailed(200));
+    }
+
+    for (const item of result.value) {
+      const project = parseProject(item);
+      if (project && !project.archived) {
+        projects.push(project);
+      }
+    }
+
+    if (result.value.length < GITLAB_PROJECT_PAGE_SIZE) {
+      break;
+    }
+  }
+
+  return ok(projects);
+}
+
+export async function getGitLabProject(input: {
+  accessToken: string;
+  pathWithNamespace: string;
+  signal?: AbortSignal;
+}): Promise<Result<GitLabProject, GitLabApiError>> {
+  const encodedPath = encodeURIComponent(input.pathWithNamespace);
+  const result = await gitlabJson({
+    accessToken: input.accessToken,
+    path: `/api/v4/projects/${encodedPath}`,
+    signal: input.signal,
+  });
+  if (isErr(result)) {
+    return result;
+  }
+
+  const project = parseProject(result.value);
+  if (!project) {
+    return err(NOT_FOUND);
+  }
+
+  return ok(project);
+}
+
+export async function getGitLabMergeRequest(input: {
+  accessToken: string;
+  pathWithNamespace: string;
+  mergeRequestIid: number;
+  signal?: AbortSignal;
+}): Promise<Result<GitLabMergeRequestDetails, GitLabApiError>> {
+  const encodedPath = encodeURIComponent(input.pathWithNamespace);
+  const result = await gitlabJson({
+    accessToken: input.accessToken,
+    path: `/api/v4/projects/${encodedPath}/merge_requests/${input.mergeRequestIid}`,
+    signal: input.signal,
+  });
+  if (isErr(result)) {
+    return result;
+  }
+
+  const record = asRecord(result.value);
+  const iid = asNumber(record?.iid);
+  if (!record || iid === null) {
+    return err(NOT_FOUND);
+  }
+
+  const shaRecord = asRecord(record.diff_refs) ?? asRecord(record.sha);
+  return ok({
+    iid,
+    sourceBranch: asString(record.source_branch),
+    commitSha: asString(record.sha) ?? asString(shaRecord?.head_sha),
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/gitlab/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/constants.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { PipesProviderSlug } from "@/lib/pipes/providers";
+
+/** WorkOS Pipes slug for the GitLab OAuth provider. */
+export const GITLAB_PIPES_SLUG = "gitlab" satisfies PipesProviderSlug;
+
+/** GitLab.com REST API origin used for project listing and clone metadata. */
+export const GITLAB_API_ORIGIN = "https://gitlab.com";
+
+/** HTTP basic-auth username GitLab expects for OAuth access tokens. */
+export const GITLAB_GIT_OAUTH_USERNAME = "oauth2";
+
+/** Reporter and above can clone project source. */
+export const GITLAB_CLONE_MIN_ACCESS_LEVEL = 20;
+
+export const GITLAB_PROJECT_PAGE_SIZE = 100;
+
+export const GITLAB_PROJECT_MAX_PAGES = 3;

--- a/apps/hyperlocalise-web/src/lib/gitlab/gitlab-repository-sandbox.test.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/gitlab-repository-sandbox.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { createVercelSandboxWorkspaceMock, loadGitLabPipesAccessTokenMock } = vi.hoisted(() => ({
+  createVercelSandboxWorkspaceMock: vi.fn(),
+  loadGitLabPipesAccessTokenMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-runtime/workspaces/vercel-sandbox-runtime", () => ({
+  createVercelSandboxWorkspace: createVercelSandboxWorkspaceMock,
+  stopWorkspace: vi.fn(),
+}));
+
+vi.mock("./pipes", () => ({
+  loadGitLabPipesAccessToken: loadGitLabPipesAccessTokenMock,
+}));
+
+import { err, ok } from "@/lib/primitives/result/results";
+
+import { createGitlabRepositorySandbox } from "./gitlab-repository-sandbox";
+
+describe("createGitlabRepositorySandbox", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clones with oauth2 credentials and the Pipes access token", async () => {
+    loadGitLabPipesAccessTokenMock.mockResolvedValue(ok("oauth-token"));
+    createVercelSandboxWorkspaceMock.mockResolvedValue({ id: "sbx_gitlab" });
+
+    await expect(
+      createGitlabRepositorySandbox({
+        localOrganizationId: "org-local",
+        workosUserId: "user_workos",
+        gitlabContext: {
+          resolved: true,
+          provider: "gitlab",
+          projectId: 11,
+          repositoryFullName: "acme/web",
+          httpUrlToRepo: "https://gitlab.com/acme/web.git",
+          branch: "main",
+        },
+      }),
+    ).resolves.toBe("sbx_gitlab");
+
+    expect(createVercelSandboxWorkspaceMock).toHaveBeenCalledWith({
+      source: {
+        type: "git",
+        url: "https://gitlab.com/acme/web.git",
+        revision: "main",
+        depth: 1,
+        username: "oauth2",
+        password: "oauth-token",
+      },
+    });
+  });
+
+  it("throws a stable error code when GitLab is not connected", async () => {
+    loadGitLabPipesAccessTokenMock.mockResolvedValue(
+      err({ code: "gitlab_not_connected", message: "Connect GitLab" }),
+    );
+
+    await expect(
+      createGitlabRepositorySandbox({
+        localOrganizationId: "org-local",
+        workosUserId: "user_workos",
+        gitlabContext: {
+          resolved: true,
+          provider: "gitlab",
+          projectId: 11,
+          repositoryFullName: "acme/web",
+          httpUrlToRepo: "https://gitlab.com/acme/web.git",
+        },
+      }),
+    ).rejects.toThrow("gitlab_not_connected");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/gitlab/gitlab-repository-sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/gitlab-repository-sandbox.ts
@@ -23,6 +23,18 @@ import { loadGitLabPipesAccessToken } from "./pipes";
 
 const logger = createLogger("gitlab-repository-sandbox");
 
+function gitlabRepositorySandboxRevisionKind(
+  context: RepositoryAgentGitLabContext,
+): "commit" | "branch" | "head" {
+  if (context.commitSha) {
+    return "commit";
+  }
+  if (context.branch) {
+    return "branch";
+  }
+  return "head";
+}
+
 export async function createGitlabRepositorySandbox(input: {
   localOrganizationId: string;
   workosUserId: string;
@@ -31,8 +43,7 @@ export async function createGitlabRepositorySandbox(input: {
 }): Promise<string> {
   const log = logger.child({
     projectId: input.gitlabContext.projectId,
-    branch: input.gitlabContext.branch ?? null,
-    commitSha: input.gitlabContext.commitSha ?? null,
+    revisionKind: gitlabRepositorySandboxRevisionKind(input.gitlabContext),
   });
   log.info("vending gitlab pipes access token for repository sandbox");
 
@@ -46,7 +57,7 @@ export async function createGitlabRepositorySandbox(input: {
   }
 
   const revision = input.gitlabContext.commitSha ?? input.gitlabContext.branch ?? "HEAD";
-  log.info({ revision }, "creating vercel repository sandbox from gitlab git source");
+  log.info("creating vercel repository sandbox from gitlab git source");
 
   try {
     const workspace = await createVercelSandboxWorkspace({

--- a/apps/hyperlocalise-web/src/lib/gitlab/gitlab-repository-sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/gitlab-repository-sandbox.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { RepositoryAgentGitLabContext } from "@/lib/agent-contracts/gitlab-repository-task";
+import {
+  createVercelSandboxWorkspace,
+  stopWorkspace,
+} from "@/lib/agent-runtime/workspaces/vercel-sandbox-runtime";
+import { createLogger, serializeErrorForLog } from "@/lib/log";
+import { isErr } from "@/lib/primitives/result/results";
+
+import { GITLAB_GIT_OAUTH_USERNAME } from "./constants";
+import { loadGitLabPipesAccessToken } from "./pipes";
+
+const logger = createLogger("gitlab-repository-sandbox");
+
+export async function createGitlabRepositorySandbox(input: {
+  localOrganizationId: string;
+  workosUserId: string;
+  gitlabContext: RepositoryAgentGitLabContext;
+  cloneDepth?: number;
+}): Promise<string> {
+  const log = logger.child({
+    projectId: input.gitlabContext.projectId,
+    branch: input.gitlabContext.branch ?? null,
+    commitSha: input.gitlabContext.commitSha ?? null,
+  });
+  log.info("vending gitlab pipes access token for repository sandbox");
+
+  const tokenResult = await loadGitLabPipesAccessToken({
+    localOrganizationId: input.localOrganizationId,
+    workosUserId: input.workosUserId,
+  });
+  if (isErr(tokenResult)) {
+    log.error({ err: tokenResult.error.code }, "gitlab pipes token unavailable for sandbox clone");
+    throw new Error(tokenResult.error.code);
+  }
+
+  const revision = input.gitlabContext.commitSha ?? input.gitlabContext.branch ?? "HEAD";
+  log.info({ revision }, "creating vercel repository sandbox from gitlab git source");
+
+  try {
+    const workspace = await createVercelSandboxWorkspace({
+      source: {
+        type: "git",
+        url: input.gitlabContext.httpUrlToRepo,
+        revision,
+        depth: input.cloneDepth ?? 1,
+        username: GITLAB_GIT_OAUTH_USERNAME,
+        password: tokenResult.value,
+      },
+    });
+    log.info({ sandboxId: workspace.id }, "vercel gitlab repository sandbox created");
+    return workspace.id;
+  } catch (error) {
+    log.error(
+      { err: serializeErrorForLog(error) },
+      "vercel gitlab repository sandbox creation failed",
+    );
+    throw error;
+  }
+}
+
+export async function stopGitlabRepositorySandbox(sandboxId: string): Promise<void> {
+  await stopWorkspace(sandboxId);
+}

--- a/apps/hyperlocalise-web/src/lib/gitlab/pipes.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/pipes.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database/client";
+import { getPipesAccountStatus, loadPipesAccessToken } from "@/lib/pipes/accounts";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { GITLAB_PIPES_SLUG } from "./constants";
+import type { GitLabPipesError } from "./types";
+
+const PIPES_UNAVAILABLE: GitLabPipesError = {
+  code: "gitlab_pipes_unavailable",
+  message: "WorkOS is not configured, so GitLab cannot connect through Pipes.",
+};
+
+const GITLAB_NOT_CONNECTED: GitLabPipesError = {
+  code: "gitlab_not_connected",
+  message: "Connect GitLab in Integrations before using it.",
+};
+
+const GITLAB_NEEDS_REAUTHORIZATION: GitLabPipesError = {
+  code: "gitlab_pipes_needs_reauthorization",
+  message: "Reconnect GitLab in Integrations, then try again.",
+};
+
+function mapPipesError(code: string): GitLabPipesError {
+  if (code === "pipes_not_connected") {
+    return GITLAB_NOT_CONNECTED;
+  }
+  if (code === "pipes_needs_reauthorization") {
+    return GITLAB_NEEDS_REAUTHORIZATION;
+  }
+  return PIPES_UNAVAILABLE;
+}
+
+export async function resolveGitLabPipesWorkosUserId(input: {
+  workosUserId?: string | null;
+  localUserId?: string | null;
+}): Promise<string | null> {
+  const explicit = input.workosUserId?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  if (!input.localUserId) {
+    return null;
+  }
+
+  const [user] = await db
+    .select({ workosUserId: schema.users.workosUserId })
+    .from(schema.users)
+    .where(eq(schema.users.id, input.localUserId))
+    .limit(1);
+
+  return user?.workosUserId ?? null;
+}
+
+export async function loadGitLabPipesAccessToken(input: {
+  localOrganizationId: string;
+  workosUserId: string;
+}): Promise<Result<string, GitLabPipesError>> {
+  const result = await loadPipesAccessToken({
+    provider: GITLAB_PIPES_SLUG,
+    localOrganizationId: input.localOrganizationId,
+    workosUserId: input.workosUserId,
+  });
+  if (isErr(result)) {
+    return err(mapPipesError(result.error.code));
+  }
+  return ok(result.value);
+}
+
+export async function getGitLabPipesConnectionStatus(input: {
+  localOrganizationId: string;
+  workosUserId: string;
+}) {
+  return getPipesAccountStatus({
+    provider: GITLAB_PIPES_SLUG,
+    localOrganizationId: input.localOrganizationId,
+    workosUserId: input.workosUserId,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/gitlab/repository-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/repository-context.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { loadGitLabPipesAccessTokenMock, getGitLabProjectMock, getGitLabMergeRequestMock } =
+  vi.hoisted(() => ({
+    loadGitLabPipesAccessTokenMock: vi.fn(),
+    getGitLabProjectMock: vi.fn(),
+    getGitLabMergeRequestMock: vi.fn(),
+  }));
+
+vi.mock("./pipes", () => ({
+  loadGitLabPipesAccessToken: loadGitLabPipesAccessTokenMock,
+  resolveGitLabPipesWorkosUserId: vi.fn(async (input: { workosUserId?: string | null }) =>
+    input.workosUserId ? input.workosUserId : null,
+  ),
+}));
+
+vi.mock("./client", () => ({
+  getGitLabProject: getGitLabProjectMock,
+  getGitLabMergeRequest: getGitLabMergeRequestMock,
+  listGitLabMembershipProjects: vi.fn(),
+}));
+
+import { err, ok } from "@/lib/primitives/result/results";
+
+import {
+  resolveConversationRepositoryGitLabContext,
+  resolveGitLabProjectContext,
+} from "./repository-context";
+
+describe("resolveGitLabProjectContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns sandbox clone context for a membership project", async () => {
+    loadGitLabPipesAccessTokenMock.mockResolvedValue(ok("oauth-token"));
+    getGitLabProjectMock.mockResolvedValue(
+      ok({
+        id: 11,
+        name: "web",
+        pathWithNamespace: "acme/platform/web",
+        defaultBranch: "main",
+        httpUrlToRepo: "https://gitlab.com/acme/platform/web.git",
+        archived: false,
+      }),
+    );
+
+    await expect(
+      resolveGitLabProjectContext({
+        localOrganizationId: "org-local",
+        workosUserId: "user_workos",
+        pathWithNamespace: "acme/platform/web",
+      }),
+    ).resolves.toEqual({
+      resolved: true,
+      provider: "gitlab",
+      projectId: 11,
+      repositoryFullName: "acme/platform/web",
+      httpUrlToRepo: "https://gitlab.com/acme/platform/web.git",
+      branch: "main",
+    });
+  });
+
+  it("returns null when GitLab is not connected", async () => {
+    loadGitLabPipesAccessTokenMock.mockResolvedValue(
+      err({ code: "gitlab_not_connected", message: "Connect GitLab" }),
+    );
+
+    await expect(
+      resolveGitLabProjectContext({
+        localOrganizationId: "org-local",
+        workosUserId: "user_workos",
+        pathWithNamespace: "acme/web",
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("resolveConversationRepositoryGitLabContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves a merge request URL to clone context", async () => {
+    loadGitLabPipesAccessTokenMock.mockResolvedValue(ok("oauth-token"));
+    getGitLabProjectMock.mockResolvedValue(
+      ok({
+        id: 11,
+        name: "web",
+        pathWithNamespace: "acme/platform/web",
+        defaultBranch: "main",
+        httpUrlToRepo: "https://gitlab.com/acme/platform/web.git",
+        archived: false,
+      }),
+    );
+    getGitLabMergeRequestMock.mockResolvedValue(
+      ok({
+        iid: 42,
+        sourceBranch: "fix-copy",
+        commitSha: "abc123",
+      }),
+    );
+
+    await expect(
+      resolveConversationRepositoryGitLabContext({
+        organizationId: "org-local",
+        workosUserId: "user_workos",
+        text: "Review https://gitlab.com/acme/platform/web/-/merge_requests/42",
+      }),
+    ).resolves.toEqual({
+      status: "resolved",
+      context: {
+        resolved: true,
+        provider: "gitlab",
+        projectId: 11,
+        repositoryFullName: "acme/platform/web",
+        httpUrlToRepo: "https://gitlab.com/acme/platform/web.git",
+        mergeRequestIid: 42,
+        branch: "fix-copy",
+        commitSha: "abc123",
+      },
+    });
+  });
+
+  it("is not applicable without a GitLab URL or connected user", async () => {
+    await expect(
+      resolveConversationRepositoryGitLabContext({
+        organizationId: "org-local",
+        text: "where is the login copy?",
+      }),
+    ).resolves.toEqual({ status: "not_applicable" });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/gitlab/repository-context.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/repository-context.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  extractGitLabMergeRequestReferences,
+  extractGitLabProjectPathReferences,
+  normalizeGitLabPathWithNamespace,
+} from "@/lib/agent-contracts/gitlab-text-patterns";
+import type { RepositoryAgentGitLabContext } from "@/lib/agent-contracts/gitlab-repository-task";
+import { isErr } from "@/lib/primitives/result/results";
+
+import { getGitLabMergeRequest, getGitLabProject, listGitLabMembershipProjects } from "./client";
+import { loadGitLabPipesAccessToken, resolveGitLabPipesWorkosUserId } from "./pipes";
+import type { GitLabApiError, GitLabProject } from "./types";
+
+export type GitLabContextResolution =
+  | { status: "not_applicable" }
+  | { status: "resolved"; context: RepositoryAgentGitLabContext }
+  | { status: "unresolved"; followUp: string };
+
+export async function listAccessibleGitLabProjects(input: {
+  localOrganizationId: string;
+  workosUserId: string;
+  signal?: AbortSignal;
+}): Promise<{ projects: GitLabProject[]; error: GitLabApiError | null }> {
+  const tokenResult = await loadGitLabPipesAccessToken({
+    localOrganizationId: input.localOrganizationId,
+    workosUserId: input.workosUserId,
+  });
+  if (isErr(tokenResult)) {
+    if (tokenResult.error.code === "gitlab_not_connected") {
+      return { projects: [], error: null };
+    }
+    return { projects: [], error: tokenResult.error };
+  }
+
+  const projectsResult = await listGitLabMembershipProjects({
+    accessToken: tokenResult.value,
+    signal: input.signal,
+  });
+  if (isErr(projectsResult)) {
+    return { projects: [], error: projectsResult.error };
+  }
+
+  return { projects: projectsResult.value, error: null };
+}
+
+export async function resolveGitLabProjectContext(input: {
+  localOrganizationId: string;
+  workosUserId: string;
+  pathWithNamespace: string;
+  mergeRequestIid?: number;
+  signal?: AbortSignal;
+}): Promise<RepositoryAgentGitLabContext | null> {
+  const pathWithNamespace = normalizeGitLabPathWithNamespace(input.pathWithNamespace);
+  if (!pathWithNamespace) {
+    return null;
+  }
+
+  const tokenResult = await loadGitLabPipesAccessToken({
+    localOrganizationId: input.localOrganizationId,
+    workosUserId: input.workosUserId,
+  });
+  if (isErr(tokenResult)) {
+    return null;
+  }
+
+  const projectResult = await getGitLabProject({
+    accessToken: tokenResult.value,
+    pathWithNamespace,
+    signal: input.signal,
+  });
+  if (isErr(projectResult)) {
+    return null;
+  }
+
+  const project = projectResult.value;
+  if (input.mergeRequestIid === undefined) {
+    return {
+      resolved: true,
+      provider: "gitlab",
+      projectId: project.id,
+      repositoryFullName: project.pathWithNamespace,
+      httpUrlToRepo: project.httpUrlToRepo,
+      branch: project.defaultBranch ?? undefined,
+    };
+  }
+
+  const mergeRequestResult = await getGitLabMergeRequest({
+    accessToken: tokenResult.value,
+    pathWithNamespace: project.pathWithNamespace,
+    mergeRequestIid: input.mergeRequestIid,
+    signal: input.signal,
+  });
+  if (isErr(mergeRequestResult)) {
+    return null;
+  }
+
+  return {
+    resolved: true,
+    provider: "gitlab",
+    projectId: project.id,
+    repositoryFullName: project.pathWithNamespace,
+    httpUrlToRepo: project.httpUrlToRepo,
+    mergeRequestIid: input.mergeRequestIid,
+    branch: mergeRequestResult.value.sourceBranch ?? project.defaultBranch ?? undefined,
+    commitSha: mergeRequestResult.value.commitSha ?? undefined,
+  };
+}
+
+export async function resolveConversationRepositoryGitLabContext(input: {
+  organizationId: string;
+  localUserId?: string | null;
+  workosUserId?: string | null;
+  text: string;
+}): Promise<GitLabContextResolution> {
+  const workosUserId = await resolveGitLabPipesWorkosUserId({
+    workosUserId: input.workosUserId,
+    localUserId: input.localUserId,
+  });
+  if (!workosUserId) {
+    return { status: "not_applicable" };
+  }
+
+  const mergeRequests = extractGitLabMergeRequestReferences(input.text);
+  if (mergeRequests.length > 1) {
+    return {
+      status: "unresolved",
+      followUp:
+        "I found more than one GitLab merge request link. Please send one MR URL so I know which project to clone.",
+    };
+  }
+
+  if (mergeRequests.length === 1) {
+    const reference = mergeRequests[0]!;
+    const context = await resolveGitLabProjectContext({
+      localOrganizationId: input.organizationId,
+      workosUserId,
+      pathWithNamespace: reference.pathWithNamespace,
+      mergeRequestIid: reference.mergeRequestIid,
+    });
+    if (!context) {
+      return {
+        status: "unresolved",
+        followUp:
+          "I found a GitLab merge request, but I can't access that project with the connected GitLab account. Connect GitLab in Integrations and try again.",
+      };
+    }
+    return { status: "resolved", context };
+  }
+
+  const projectPaths = extractGitLabProjectPathReferences(input.text);
+  if (projectPaths.length > 1) {
+    return {
+      status: "unresolved",
+      followUp:
+        "I found more than one GitLab project. Please send one GitLab URL so I know which repository to clone.",
+    };
+  }
+
+  if (projectPaths.length === 1) {
+    const context = await resolveGitLabProjectContext({
+      localOrganizationId: input.organizationId,
+      workosUserId,
+      pathWithNamespace: projectPaths[0]!,
+    });
+    if (!context) {
+      return {
+        status: "unresolved",
+        followUp:
+          "I found a GitLab project URL, but I can't access that project with the connected GitLab account. Connect GitLab in Integrations and try again.",
+      };
+    }
+    return { status: "resolved", context };
+  }
+
+  return { status: "not_applicable" };
+}
+
+export function buildRepositoryGitLabContextInstructions(
+  context: RepositoryAgentGitLabContext,
+): string {
+  return [
+    "Resolved GitLab repository context:",
+    `- provider: gitlab`,
+    `- repository: ${context.repositoryFullName}`,
+    context.mergeRequestIid === undefined
+      ? null
+      : `- mergeRequestIid: ${context.mergeRequestIid}`,
+    context.branch ? `- branch: ${context.branch}` : null,
+    context.commitSha ? `- commitSha: ${context.commitSha}` : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}

--- a/apps/hyperlocalise-web/src/lib/gitlab/repository-context.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/repository-context.ts
@@ -193,9 +193,7 @@ export function buildRepositoryGitLabContextInstructions(
     "Resolved GitLab repository context:",
     `- provider: gitlab`,
     `- repository: ${context.repositoryFullName}`,
-    context.mergeRequestIid === undefined
-      ? null
-      : `- mergeRequestIid: ${context.mergeRequestIid}`,
+    context.mergeRequestIid === undefined ? null : `- mergeRequestIid: ${context.mergeRequestIid}`,
     context.branch ? `- branch: ${context.branch}` : null,
     context.commitSha ? `- commitSha: ${context.commitSha}` : null,
   ]

--- a/apps/hyperlocalise-web/src/lib/gitlab/types.ts
+++ b/apps/hyperlocalise-web/src/lib/gitlab/types.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export type GitLabPipesError =
+  | { code: "gitlab_pipes_unavailable"; message: string }
+  | { code: "gitlab_not_connected"; message: string }
+  | { code: "gitlab_pipes_needs_reauthorization"; message: string };
+
+export type GitLabApiError =
+  | GitLabPipesError
+  | { code: "gitlab_unauthorized"; message: string }
+  | { code: "gitlab_not_found"; message: string }
+  | { code: "gitlab_request_failed"; message: string; status: number };
+
+export type GitLabProject = {
+  id: number;
+  name: string;
+  pathWithNamespace: string;
+  defaultBranch: string | null;
+  httpUrlToRepo: string;
+  archived: boolean;
+};
+
+export type GitLabMergeRequestDetails = {
+  iid: number;
+  sourceBranch: string | null;
+  commitSha: string | null;
+};

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.copy.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.copy.ts
@@ -70,20 +70,20 @@ export const integrationCatalogCopy = {
     },
     tagline: {
       defaultMessage:
-        "Connect GitLab so Hyperlocalise can inspect localized strings, review merge requests, and open localization fixes.",
+        "Connect GitLab so Hyperlocalise can list your projects and clone them into the chat sandbox.",
       id: "ezhaX1jR0b",
       description: "GitLab integration description on the integrations page",
     },
     overview: [
       {
         defaultMessage:
-          "GitLab support lets Hyperlocalise inspect localized strings, review merge requests, and open localization fixes from GitLab repositories.",
+          "GitLab support lets Hyperlocalise inspect localized strings from GitLab.com projects in the conversation sandbox.",
         id: "intGitLabOverview0",
         description: "GitLab integration marketing overview paragraph",
       },
       {
         defaultMessage:
-          "This connector is on the roadmap for teams that run localization workflows on GitLab instead of GitHub.",
+          "Connect GitLab through WorkOS Pipes so Hyperlocalise can list membership projects and clone them into the chat sandbox.",
         id: "intGitLabOverview1",
         description: "GitLab integration marketing overview paragraph",
       },

--- a/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/integration-catalog.ts
@@ -30,7 +30,7 @@ export const integrationCatalogEntries: IntegrationCatalogEntry[] = [
   {
     slug: "gitlab",
     category: "source-control",
-    status: "coming-soon",
+    status: "available",
     type: "partner",
     marketing: true,
     workspace: true,

--- a/apps/hyperlocalise-web/src/lib/integrations/workspace-integrations.ts
+++ b/apps/hyperlocalise-web/src/lib/integrations/workspace-integrations.ts
@@ -38,6 +38,10 @@ export const workspaceComingSoonCustomerEngagementSlugs = [
   "loops",
 ] as const;
 
+export const workspacePipesSourceControlSlugs = [
+  "gitlab",
+] as const satisfies readonly PipesProviderSlug[];
+
 export const workspacePipesCollaborationSlugs = [
   "atlassian",
 ] as const satisfies readonly PipesProviderSlug[];

--- a/apps/hyperlocalise-web/src/lib/pipes/accounts.test.ts
+++ b/apps/hyperlocalise-web/src/lib/pipes/accounts.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   getWorkosServerClient: vi.fn(),
   getUserConnectedAccount: vi.fn(),
   createDataIntegrationCredential: vi.fn(),
+  getAccessToken: vi.fn(),
   organizationSelect: vi.fn(),
 }));
 
@@ -42,7 +43,7 @@ vi.mock("@/lib/database/client", () => ({
   },
 }));
 
-import { getPipesAccountStatus, loadPipesApiKey } from "./accounts";
+import { getPipesAccountStatus, loadPipesAccessToken, loadPipesApiKey } from "./accounts";
 
 describe("pipes accounts", () => {
   beforeEach(() => {
@@ -52,6 +53,7 @@ describe("pipes accounts", () => {
       pipes: {
         getUserConnectedAccount: mocks.getUserConnectedAccount,
         createDataIntegrationCredential: mocks.createDataIntegrationCredential,
+        getAccessToken: mocks.getAccessToken,
       },
     });
   });
@@ -174,5 +176,48 @@ describe("pipes accounts", () => {
       throw new Error("expected err result");
     }
     expect(result.error.code).toBe("pipes_not_connected");
+  });
+
+  it("vends an OAuth access token from Pipes", async () => {
+    mocks.getAccessToken.mockResolvedValue({
+      active: true,
+      accessToken: { accessToken: " glpat-oauth-token " },
+    });
+
+    const result = await loadPipesAccessToken({
+      provider: "gitlab",
+      localOrganizationId: "org-local",
+      workosUserId: "user_workos",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected ok result");
+    }
+    expect(result.value).toBe("glpat-oauth-token");
+    expect(mocks.getAccessToken).toHaveBeenCalledWith({
+      provider: "gitlab",
+      userId: "user_workos",
+      organizationId: "org_workos",
+    });
+  });
+
+  it("maps a stale OAuth installation to pipes_needs_reauthorization", async () => {
+    mocks.getAccessToken.mockResolvedValue({
+      active: false,
+      error: "needs_reauthorization",
+    });
+
+    const result = await loadPipesAccessToken({
+      provider: "gitlab",
+      localOrganizationId: "org-local",
+      workosUserId: "user_workos",
+    });
+
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) {
+      throw new Error("expected err result");
+    }
+    expect(result.error.code).toBe("pipes_needs_reauthorization");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/pipes/accounts.ts
+++ b/apps/hyperlocalise-web/src/lib/pipes/accounts.ts
@@ -150,3 +150,59 @@ export async function loadPipesApiKey(input: {
     return err(PIPES_UNAVAILABLE);
   }
 }
+
+function pipesCredentialErrorFromVendError(error: unknown): PipesCredentialError {
+  const code =
+    typeof error === "string"
+      ? error
+      : error && typeof error === "object" && "code" in error && typeof error.code === "string"
+        ? error.code
+        : null;
+
+  if (code === "needs_reauthorization" || code === "reauthorization_needed") {
+    return PIPES_NEEDS_REAUTHORIZATION;
+  }
+
+  return PIPES_NOT_CONNECTED;
+}
+
+export async function loadPipesAccessToken(input: {
+  provider: PipesProviderSlug;
+  localOrganizationId: string;
+  workosUserId: string;
+}): Promise<Result<string, PipesCredentialError>> {
+  const workos = getWorkosServerClient();
+  if (!workos) {
+    return err(PIPES_UNAVAILABLE);
+  }
+
+  const organizationIdResult = await loadWorkosOrganizationId(input.localOrganizationId);
+  if (isErr(organizationIdResult)) {
+    return organizationIdResult;
+  }
+
+  try {
+    const result = await workos.pipes.getAccessToken({
+      provider: input.provider,
+      userId: input.workosUserId,
+      organizationId: organizationIdResult.value,
+    });
+
+    if (!result.active) {
+      return err(pipesCredentialErrorFromVendError(result.error));
+    }
+
+    const accessToken = result.accessToken.accessToken.trim();
+    if (!accessToken) {
+      return err(PIPES_NOT_CONNECTED);
+    }
+
+    return ok(accessToken);
+  } catch (error) {
+    if (isNotFound(error)) {
+      return err(PIPES_NOT_CONNECTED);
+    }
+
+    return err(PIPES_UNAVAILABLE);
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/pipes/providers.test.ts
+++ b/apps/hyperlocalise-web/src/lib/pipes/providers.test.ts
@@ -29,10 +29,12 @@ describe("pipes providers", () => {
     expect(pipesProvidersForCategory("cms")).toEqual(expect.arrayContaining(["sanity", "webflow"]));
     expect(pipesProvidersForCategory("guidelines")).toEqual(["notion"]);
     expect(pipesProvidersForCategory("collaboration")).toEqual(["atlassian"]);
+    expect(pipesProvidersForCategory("source-control")).toEqual(["gitlab"]);
   });
 
   it("keeps the exposed slug list stable", () => {
     expect(PIPES_PROVIDER_SLUGS).toContain("atlassian");
+    expect(PIPES_PROVIDER_SLUGS).toContain("gitlab");
     expect(PIPES_PROVIDER_SLUGS).toContain("sanity");
     expect(PIPES_PROVIDER_SLUGS).toContain("webflow");
   });

--- a/apps/hyperlocalise-web/src/lib/pipes/providers.ts
+++ b/apps/hyperlocalise-web/src/lib/pipes/providers.ts
@@ -17,6 +17,7 @@ import type { IntegrationCategory } from "@/lib/integrations/integration-catalog
 export const PIPES_PROVIDER_SLUGS = [
   "ahrefs",
   "atlassian",
+  "gitlab",
   "hubspot",
   "intercom",
   "mailchimp",
@@ -33,6 +34,7 @@ export type PipesProviderSlug = (typeof PIPES_PROVIDER_SLUGS)[number];
 export const PIPES_PROVIDER_CATEGORIES = {
   ahrefs: "seo-tools",
   similarweb: "seo-tools",
+  gitlab: "source-control",
   intercom: "customer-engagement",
   hubspot: "customer-engagement",
   mailchimp: "customer-engagement",

--- a/docs/adr/2026-09-10-gitlab-workos-pipes-sandbox-clone-design.md
+++ b/docs/adr/2026-09-10-gitlab-workos-pipes-sandbox-clone-design.md
@@ -1,0 +1,27 @@
+# GitLab WorkOS Pipes Sandbox Clone Design
+
+## Date
+
+2026-09-10
+
+## Context
+
+GitHub repository context for chat and Slack clones through a GitHub App installation token. GitLab is already a WorkOS Pipes OAuth provider. Teams that keep source on GitLab.com need the same sandbox clone path without GitHub-parity features such as webhooks or merge-request automations.
+
+Pipes credentials belong to the connected user. `workos.pipes.getAccessToken` vends a short-lived OAuth token. Git clone over HTTPS uses username `oauth2` and that token as the password.
+
+## Decision
+
+Connect GitLab on Integrations with the existing Pipes widget (`slugs: ['gitlab']`), admin-only like other Pipes rows. Flip the catalog entry from coming-soon to available.
+
+List cloneable membership projects with `GET /api/v4/projects?membership=true&min_access_level=20` and expose them as `GET /api/orgs/:slug/gitlab/projects`. Chat's repository picker merges GitHub and GitLab with composite keys (`github:owner/repo`, `gitlab:group/project`). Conversation create and reply accept `repositoryProvider` plus `repositoryFullName`.
+
+Resolve GitLab from a selected project or from `gitlab.com` project and merge-request URLs in the message. Persist `repositoryGitLabContext` on the conversation session. Clone into the Vercel sandbox with `createGitlabRepositorySandbox`. Reuse the stored sandbox when the GitLab context key matches.
+
+Do not persist GitLab installation tables. Do not add GitLab webhooks, MR review automations, or a `use_gitlab_repository` workspace tool. Do not support self-hosted GitLab.
+
+## Consequences
+
+- Only the connected user can list and clone GitLab projects.
+- GitLab sandbox turns stay read-only for repository write tools that still require GitHub App context.
+- Nested GitLab paths (`group/subgroup/project`) are first-class; GitHub `owner/repo` stays two segments.

--- a/docs/platform/integrations.mdx
+++ b/docs/platform/integrations.mdx
@@ -46,27 +46,42 @@ Use those enabled repos in automation **GitHub push** triggers. See [Automations
 
 Click **Disconnect** to unlink the installation from this organization.
 
+## GitLab
+
+Open **Integrations**, find **GitLab**, then connect it through the WorkOS Pipes widget. GitLab uses OAuth, not an API key. Only workspace admins can connect Pipes providers.
+
+After you connect GitLab:
+
+1. Chat lists GitLab.com projects you can clone (Reporter access or higher).
+2. Selecting a project, or pasting a `gitlab.com` project or merge request URL, clones that project into the conversation sandbox.
+3. Clone uses the connected user's OAuth token (`oauth2` over HTTPS). Reconnect GitLab if Pipes asks.
+
+Self-hosted GitLab, merge-request automations, and a dedicated GitLab workspace tool are not included.
+
 ## TMS and CLI sync
 
 Cloud can work with an existing TMS. For repository-first native projects, the CLI [pushes](/cli/commands/sync-push) and [pulls](/cli/commands/sync-pull) against Hyperlocalise. See [Connect the CLI](/platform/cli).
 
-## WorkOS Pipes API keys
+## WorkOS Pipes
 
-Open **Integrations** and connect these providers through the WorkOS Pipes widget. Enable each provider in the WorkOS Dashboard and allow the widget origin for this app. Users paste an API key; WorkOS stores the secret.
+Open **Integrations** and connect these providers through the WorkOS Pipes widget. Enable each provider in the WorkOS Dashboard and allow the widget origin for this app.
 
-| Provider | WorkOS slug | Integrations category |
-| --- | --- | --- |
-| Ahrefs | `ahrefs` (custom) | SEO tools |
-| Similarweb | `similarweb` | SEO tools |
-| Intercom | `intercom` | Customer engagement |
-| HubSpot | `hubspot` | Customer engagement |
-| Mailchimp | `mailchimp` | Customer engagement |
-| SendGrid | `sendgrid` | Customer engagement |
-| Resend | `resend` | Customer engagement |
-| Webflow | `webflow` | Content & publishing |
-| Sanity | `sanity` | Content & publishing |
-| Notion | `notion` | Guidelines |
-| Atlassian | `atlassian` | Collaboration |
+Most Pipes providers store an API key. GitLab is OAuth: WorkOS vends an access token with `getAccessToken`.
+
+| Provider | WorkOS slug | Integrations category | Credential |
+| --- | --- | --- | --- |
+| GitLab | `gitlab` | Source control | OAuth access token |
+| Ahrefs | `ahrefs` (custom) | SEO tools | API key |
+| Similarweb | `similarweb` | SEO tools | API key |
+| Intercom | `intercom` | Customer engagement | API key |
+| HubSpot | `hubspot` | Customer engagement | API key |
+| Mailchimp | `mailchimp` | Customer engagement | API key |
+| SendGrid | `sendgrid` | Customer engagement | API key |
+| Resend | `resend` | Customer engagement | API key |
+| Webflow | `webflow` | Content & publishing | API key |
+| Sanity | `sanity` | Content & publishing | API key |
+| Notion | `notion` | Guidelines | API key |
+| Atlassian | `atlassian` | Collaboration | API key |
 
 Ahrefs is not in the default WorkOS catalog. Enable a custom API-key provider with slug `ahrefs`. The other providers are catalog API-key integrations.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

GitLab is now a first-class source-control integration through WorkOS Pipes, with the same chat/Slack sandbox clone path GitHub already has.

- Connect GitLab on Integrations with the existing Pipes widget (admin-only). Catalog status is available.
- List cloneable GitLab.com membership projects (`Reporter` and above) at `GET /api/orgs/:slug/gitlab/projects`.
- Chat repository picker merges GitHub and GitLab with composite keys (`github:owner/repo`, `gitlab:group/project`).
- Conversation create/reply and Slack turns resolve GitLab from the picker or from `gitlab.com` project/MR URLs, then clone into the Vercel sandbox using `oauth2` + the Pipes access token.

Out of scope: GitLab webhooks, MR review automations, a `use_gitlab_repository` workspace tool, and self-hosted GitLab. GitLab sandbox turns stay read-only for write tools that still require GitHub App context.

### Codex review follow-up

- Reuse a stored GitLab sandbox only when `credentialOwnerWorkosUserId` matches the current member's WorkOS user. Missing owner (legacy sessions) and a different owner both create a new sandbox and mark the old one stale.
- Sandbox logs emit opaque `projectId` plus `revisionKind` (`commit` | `branch` | `head`). Raw branch names and SHAs are not logged.
- Project and merge-request URL parsers stop at GitLab's `/-/` boundary, so tree/blob/issue/commit URLs resolve to the project path.

## How to test

1. Connect GitLab on Integrations (workspace admin) through the Pipes widget.
2. Open Inbox chat. The repository picker should list GitLab.com projects alongside GitHub repos.
3. Start a conversation with a GitLab project selected, or paste a `gitlab.com` project/MR URL. The agent turn should clone that project into the sandbox.
4. Automated: from `apps/hyperlocalise-web`, run `vp check --fix` and `vp test`.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

## Test evidence

- `vp check --fix`: pass (3462 files, no lint or type errors)
- GitLab-related tests after the Codex follow-up: 8 files / 93 passing, including new owner-mismatch, missing-owner, and `/-/` URL cases
- Earlier full `vp test`: 6849 passing. One remaining failure is an unrelated MCP idempotency flake in `mcp.route.test.ts` (`run_workflow` enqueue called twice under concurrent identical keys). That file is unchanged in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fefac73f-715f-4e90-9ce8-080cdd46e8c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fefac73f-715f-4e90-9ce8-080cdd46e8c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

