### PR TITLE
fix(web): keep Storybook helpers out of Vercel typecheck

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -9,7 +9,7 @@
 .storybook
 storybook-static
 
-# Tests, fixtures, MSW handlers, and stories (not imported by production code)
+# Tests, fixtures, MSW handlers, stories, and story views (not imported by production code)
 **/*.test.ts
 **/*.test.tsx
 **/*.test.js
@@ -21,6 +21,8 @@ storybook-static
 **/*.stories.tsx
 **/*.stories.js
 **/*.stories.jsx
+**/*.story-view.ts
+**/*.story-view.tsx
 
 # Test output
 coverage

--- a/apps/hyperlocalise-web/.vercelignore
+++ b/apps/hyperlocalise-web/.vercelignore
@@ -7,7 +7,7 @@
 .storybook
 storybook-static
 
-# Tests, fixtures, MSW handlers, and stories (not imported by production code)
+# Tests, fixtures, MSW handlers, stories, and story views (not imported by production code)
 **/*.test.ts
 **/*.test.tsx
 **/*.test.js
@@ -19,6 +19,8 @@ storybook-static
 **/*.stories.tsx
 **/*.stories.js
 **/*.stories.jsx
+**/*.story-view.ts
+**/*.story-view.tsx
 
 # Test output
 coverage

--- a/apps/hyperlocalise-web/AGENTS.md
+++ b/apps/hyperlocalise-web/AGENTS.md
@@ -337,3 +337,4 @@ For GitHub Actions, consider using [`voidzero-dev/setup-vp`](https://github.com/
 - Base UI `DropdownMenuItem` handlers use `onClick`, not Radix-style `onSelect`; menu actions silently no-op if `onSelect` is used.
 - Browser E2E loads `.env` then overrides with `.env.e2e` (WorkOS emulator). Placeholder `AUTUMN_API_KEY` from `.env.e2e.example` causes project creation to fail with 503; seed test data via DB in E2E fixtures instead of UI project create when billing is not configured.
 - When `vp` is unavailable in agent shells, run E2E with `vp run test:e2e` after fixing PATH, or invoke vitest through the project's `vite-plus` dependency with `--config vite.e2e.config.ts`.
+- `next build` / Vercel type-check omit `*.test.*`, `*.fixture.ts`, `*.stories.*`, `*-msw-handlers.ts`, and `*.story-view.*` (see `.vercelignore` and `tsconfig.build.json`). Never import a fixture from a file that is not one of those suffixes.

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-page-shell.story-view.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-page-shell.story-view.tsx
@@ -26,11 +26,19 @@ import {
   ContentEditorPageBody,
 } from "@/components/content-editor/files/content-editor-files-sidebar";
 import { ContentEditorQueueToolbarHost } from "@/components/content-editor/queue/content-editor-queue-toolbar-host";
-import { writeCatWorkspaceViewMode } from "@/components/content-editor/workspace/content-editor-workspace-view-mode";
+import type { ContentEditorWorkspaceState } from "@/components/content-editor/shared/types";
+import {
+  writeCatWorkspaceViewMode,
+  type ContentEditorWorkspaceViewMode,
+} from "@/components/content-editor/workspace/content-editor-workspace-view-mode";
 import { Button } from "@/components/ui/button";
 
-import type { ContentEditorPageShellWorkspaceEntry } from "./content-editor-page-shell.fixture";
 import { ContentEditorWorkspaceContainer } from "./content-editor-workspace-container";
+
+type ContentEditorPageShellWorkspaceEntry = {
+  state: ContentEditorWorkspaceState;
+  initialViewMode: ContentEditorWorkspaceViewMode;
+};
 
 type ContentEditorPageShellStoryViewProps = {
   files: ProjectFileRecord[];

--- a/apps/hyperlocalise-web/tsconfig.build.json
+++ b/apps/hyperlocalise-web/tsconfig.build.json
@@ -1,4 +1,16 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "src/e2e", "src/api/typed-app.ts", "**/*.test.ts", "**/*.fixture.ts"]
+  "exclude": [
+    "node_modules",
+    "src/e2e",
+    "src/api/typed-app.ts",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.fixture.ts",
+    "**/*-msw-handlers.ts",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.story-view.ts",
+    "**/*.story-view.tsx"
+  ]
 }


### PR DESCRIPTION
## What changed

Vercel omits `*.fixture.ts` from the deploy, but `*.story-view.tsx` still ships. The CAT page-shell story helper imported a fixture type, so `next build` failed with TS2307.

This change:

- Stops `content-editor-page-shell.story-view.tsx` from importing a fixture
- Excludes `*.story-view.*` from both `.vercelignore` files
- Aligns `tsconfig.build.json` with the same Storybook/test ignores so local `next build` matches Vercel

## How to test

- [ ] `cd apps/hyperlocalise-web && vp exec tsc --project tsconfig.build.json --noEmit`
- [ ] `cd apps/hyperlocalise-web && vp check --fix`
- [ ] Confirm a Vercel preview build type-checks (no TS2307 for `content-editor-page-shell.story-view.tsx`)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; `tsc --project tsconfig.build.json --noEmit`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)