### PR TITLE
chore(web): drop unused NEXT_PUBLIC_WAITLIST_URL

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -84,7 +84,6 @@ jobs:
     env:
       DATABASE_URL: postgres://hyperlocalise:hyperlocalise@127.0.0.1:5432/hyperlocalise?sslmode=disable
       OPENAI_API_KEY: test-openai-api-key
-      NEXT_PUBLIC_WAITLIST_URL: https://example.com/waitlist
       NEXT_PUBLIC_WORKOS_REDIRECT_URI: http://localhost:3000/auth/callback
       GITHUB_APP_WEBHOOK_SECRET: your-github-app-webhook-secret
       WORKOS_API_KEY: your-workos-api-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,6 @@ go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint
   ```
   DATABASE_URL=postgresql://hyperlocalise:hyperlocalise@localhost:5432/hyperlocalise
   PROVIDER_CREDENTIALS_MASTER_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
-  NEXT_PUBLIC_WAITLIST_URL=https://example.com/waitlist
   WORKOS_API_KEY=sk_test_placeholder
   WORKOS_CLIENT_ID=client_placeholder
   WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback

--- a/apps/hyperlocalise-web/.env.e2e.example
+++ b/apps/hyperlocalise-web/.env.e2e.example
@@ -3,7 +3,6 @@
 
 DATABASE_URL=postgresql://hyperlocalise:hyperlocalise@localhost:5432/hyperlocalise
 PROVIDER_CREDENTIALS_MASTER_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
-NEXT_PUBLIC_WAITLIST_URL=https://example.com/waitlist
 
 # Point AuthKit + the WorkOS Node SDK at the local emulator.
 WORKOS_API_KEY=sk_test_default

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -285,9 +285,6 @@ export const env = createEnv({
     GO_SVC_URL: z.url().optional(),
   },
   client: {
-    /** Public URL for the waitlist/sign-up page. Required for client-side redirects. */
-    NEXT_PUBLIC_WAITLIST_URL: z.url(),
-
     /** Public runtime environment exposed to the browser. Mirrors NODE_ENV. */
     NEXT_PUBLIC_APP_ENV: z.enum(["development", "test", "production"]).default("development"),
 
@@ -404,9 +401,6 @@ export const env = createEnv({
     CROWDIN_APP_FRAME_ANCESTORS: process.env.CROWDIN_APP_FRAME_ANCESTORS,
     E2E_BASE_URL: process.env.E2E_BASE_URL,
     GO_SVC_URL: process.env.GO_SVC_URL ?? (isTestEnv ? "http://127.0.0.1:8080" : undefined),
-    NEXT_PUBLIC_WAITLIST_URL:
-      process.env.NEXT_PUBLIC_WAITLIST_URL ??
-      (isTestEnv ? "https://example.com/waitlist" : undefined),
     NEXT_PUBLIC_WORKOS_REDIRECT_URI:
       process.env.NEXT_PUBLIC_WORKOS_REDIRECT_URI ??
       process.env.WORKOS_REDIRECT_URI ??

--- a/apps/hyperlocalise-web/src/lib/providers/organization-language-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-language-model.test.ts
@@ -34,7 +34,6 @@ vi.mock("@/lib/env", () => ({
   env: {
     DATABASE_URL: "postgresql://hyperlocalise:hyperlocalise@localhost:5432/hyperlocalise",
     PROVIDER_CREDENTIALS_MASTER_KEY: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
-    NEXT_PUBLIC_WAITLIST_URL: "https://example.com/waitlist",
   },
 }));
 


### PR DESCRIPTION
## What changed

Remove `NEXT_PUBLIC_WAITLIST_URL` from env validation, CI, tests, and docs. The waitlist URL is unused and no longer required.

## How to test

- Confirm the web app starts without `NEXT_PUBLIC_WAITLIST_URL` in `.env`
- Confirm CI env no longer needs this variable

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review