### PR TITLE
feat(web): show project logos in the projects list

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx
@@ -12,14 +12,36 @@
  */
 // @vitest-environment happy-dom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vite-plus/test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   PROJECT_AVATAR_KEY_MAX_LENGTH,
   ProjectAvatar,
   projectAvatarLabelFromName,
 } from "./project-avatar";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function stubLoadedImages() {
+  vi.stubGlobal(
+    "Image",
+    class {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      complete = true;
+      naturalWidth = 16;
+      referrerPolicy = "";
+      crossOrigin: string | null = null;
+      set src(_value: string) {
+        this.onload?.();
+      }
+    },
+  );
+}
 
 describe("projectAvatarLabelFromName", () => {
   it("uses word initials for multi-word names", () => {
@@ -72,6 +94,7 @@ describe("ProjectAvatar", () => {
   });
 
   it("renders the project image when a logo URL is present", () => {
+    stubLoadedImages();
     render(
       <ProjectAvatar
         project={{

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx
@@ -70,4 +70,37 @@ describe("ProjectAvatar", () => {
 
     expect(screen.getByText("DOC")).toBeInTheDocument();
   });
+
+  it("renders the project image when a logo URL is present", () => {
+    render(
+      <ProjectAvatar
+        project={{
+          name: "Mobile App",
+          logoUrl: "https://crowdin.example/project.png",
+          externalProviderKind: "crowdin",
+          source: "external_tms",
+        }}
+      />,
+    );
+
+    expect(document.querySelector('img[src="https://crowdin.example/project.png"]')).not.toBeNull();
+    expect(screen.getByTitle("Mobile App")).toBeInTheDocument();
+  });
+
+  it("uses two letters in compact chips", () => {
+    render(
+      <ProjectAvatar
+        compact
+        project={{
+          name: "Tourmatic",
+          logoUrl: null,
+          externalProviderKind: null,
+          source: "native",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("TO")).toBeInTheDocument();
+    expect(screen.queryByText("TOU")).not.toBeInTheDocument();
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
@@ -58,20 +58,35 @@ export function ProjectAvatar({
   className?: string;
   compact?: boolean;
 }) {
-  const sizeClass = compact ? "size-9 rounded-lg" : "size-10 rounded-lg";
+  const sizeClass = compact ? "size-5 rounded-md" : "size-8 rounded-lg";
   const avatarLabel = projectAvatarLabelFromName(project.name);
+  const showProviderMark =
+    !compact && project.source === "external_tms" && Boolean(project.externalProviderKind);
 
   return (
     <span className={cn("relative shrink-0", className)}>
-      <Avatar className={cn(sizeClass, "after:rounded-lg")} title={project.name}>
+      <Avatar
+        className={cn(sizeClass, compact ? "after:rounded-md" : "after:rounded-lg")}
+        title={project.name}
+      >
         {project.logoUrl ? (
-          <AvatarImage src={project.logoUrl} alt="" className="rounded-lg object-cover" />
+          <AvatarImage
+            src={project.logoUrl}
+            alt=""
+            referrerPolicy="no-referrer"
+            className={cn("object-contain", compact ? "rounded-md" : "rounded-lg")}
+          />
         ) : null}
-        <AvatarFallback className="overflow-hidden rounded-lg bg-background text-xs font-medium text-foreground">
-          {avatarLabel}
+        <AvatarFallback
+          className={cn(
+            "overflow-hidden bg-muted font-medium text-foreground",
+            compact ? "rounded-md text-[9px]" : "rounded-lg text-xs",
+          )}
+        >
+          {compact ? avatarLabel.slice(0, 2) : avatarLabel}
         </AvatarFallback>
       </Avatar>
-      {project.source === "external_tms" && project.externalProviderKind ? (
+      {showProviderMark ? (
         <span className="absolute -right-1 -bottom-1 rounded-md border border-border bg-background p-0.5 shadow-sm">
           <TmsProviderBrandMark
             providerKind={project.externalProviderKind}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.stories.tsx
@@ -18,6 +18,11 @@ import { recordRecentProjectVisit } from "./recent-projects";
 
 const ORGANIZATION_SLUG = "projects-design-preview";
 const HOURS = 3_600_000;
+const CROWDIN_PROJECT_LOGO =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="12" fill="#2B5CFF"/><text x="32" y="42" text-anchor="middle" fill="white" font-size="28" font-family="system-ui">M</text></svg>',
+  );
 const projects = [
   {
     id: "marketing",
@@ -45,6 +50,7 @@ const projects = [
     description: "iOS & Android strings",
     source: "external_tms",
     externalProviderKind: "crowdin",
+    logoUrl: CROWDIN_PROJECT_LOGO,
     sourceLocale: "en",
     targetLocales: ["fr", "de", "vi", "zh", "ja", "es", "ko", "pt", "it", "nl", "ar", "th"],
     openJobCount: 3,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -42,11 +42,11 @@ import {
 } from "./project-form";
 import { ProjectDialog } from "./project-dialog";
 import { mapProjectToListRow, type ProjectListRow } from "./project-list";
+import { ProjectAvatar } from "./project-avatar";
 import {
   PROJECTS_PAGE_SIZE,
   ProjectsTable,
   ProjectsTableHeader,
-  ProjectSourceMark,
 } from "./projects-table";
 import { projectsPageContentMessages } from "./projects-page-content.messages";
 import { recordRecentProjectVisit, resolveRecentProjects } from "./recent-projects";
@@ -133,10 +133,12 @@ function RecentProjectsStrip({
             size="sm"
             className="max-w-full gap-2 rounded-lg bg-background"
           >
-            <ProjectSourceMark
+            <ProjectAvatar
               compact
               project={
                 allProjects.find((row) => row.id === project.id) ?? {
+                  name: project.name,
+                  logoUrl: null,
                   source: "native",
                   externalProviderKind: null,
                 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -34,20 +34,16 @@ import { PageHeader, WorkspacePageShell } from "../../_components/workspace-reso
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
 import { fetchTmsLiveProjects, tmsLiveProjectsQueryKey } from "../../_hooks/use-tms-live-projects";
 import { DeleteProjectDialog } from "./delete-project-dialog";
+import { ProjectAvatar } from "./project-avatar";
+import { ProjectDialog } from "./project-dialog";
 import {
   createEmptyProjectForm,
   createProjectFormFromRow,
   toProjectPayload,
   type ProjectFormValues,
 } from "./project-form";
-import { ProjectDialog } from "./project-dialog";
 import { mapProjectToListRow, type ProjectListRow } from "./project-list";
-import { ProjectAvatar } from "./project-avatar";
-import {
-  PROJECTS_PAGE_SIZE,
-  ProjectsTable,
-  ProjectsTableHeader,
-} from "./projects-table";
+import { PROJECTS_PAGE_SIZE, ProjectsTable, ProjectsTableHeader } from "./projects-table";
 import { projectsPageContentMessages } from "./projects-page-content.messages";
 import { recordRecentProjectVisit, resolveRecentProjects } from "./recent-projects";
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
@@ -112,6 +112,10 @@ describe("ProjectsTable", () => {
 
     expect(screen.getByText("Native")).toBeInTheDocument();
     expect(screen.getByText("Crowdin")).toBeInTheDocument();
+    expect(screen.getByTitle("Hyperlocalise Web")).toHaveTextContent("HW");
+    expect(screen.getByTitle("Crowdin Site")).toHaveTextContent("CS");
+    expect(screen.queryByText("H")).not.toBeInTheDocument();
+    expect(screen.queryByText("C")).not.toBeInTheDocument();
     expect(screen.getAllByText("en → vi")).toHaveLength(2);
   });
 
@@ -172,5 +176,29 @@ describe("ProjectsTable", () => {
     expect(onLoadMore).toHaveBeenCalledOnce();
     await user.click(screen.getByRole("link", { name: "Hyperlocalise Web" }));
     expect(onOpenProject).toHaveBeenCalledWith("project_native");
+  });
+
+  it("renders a project image when the TMS project has a logo", () => {
+    renderWithIntl(
+      <ProjectsTable
+        projects={[
+          createProject({
+            id: "project_crowdin",
+            name: "Crowdin Site",
+            source: "external_tms",
+            externalProviderKind: "crowdin",
+            logoUrl: "https://crowdin.example/site.png",
+          }),
+        ]}
+        projectsQuery={successQuery()}
+        isSavingProject={false}
+        isDeletingProject={false}
+        organizationSlug="acme"
+        variant="tms"
+      />,
+    );
+
+    expect(document.querySelector('img[src="https://crowdin.example/site.png"]')).not.toBeNull();
+    expect(screen.getByTitle("Crowdin Site")).toBeInTheDocument();
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
@@ -28,7 +28,25 @@ vi.mock("next/navigation", () => ({
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
+
+function stubLoadedImages() {
+  vi.stubGlobal(
+    "Image",
+    class {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      complete = true;
+      naturalWidth = 16;
+      referrerPolicy = "";
+      crossOrigin: string | null = null;
+      set src(_value: string) {
+        this.onload?.();
+      }
+    },
+  );
+}
 
 function renderWithIntl(ui: ReactElement) {
   return render(
@@ -179,6 +197,7 @@ describe("ProjectsTable", () => {
   });
 
   it("renders a project image when the TMS project has a logo", () => {
+    stubLoadedImages();
     renderWithIntl(
       <ProjectsTable
         projects={[

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -42,6 +42,7 @@ import { getTmsProviderBranding } from "@/lib/providers/shared/tms-provider-bran
 import { isTmsUserConnectionRequiredError } from "@/lib/providers/credentials/tms-user-connection-shared";
 
 import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
+import { ProjectAvatar } from "./project-avatar";
 import { formatProjectLocaleRoute, type ProjectListRow } from "./project-list";
 import { projectsTableMessages } from "./projects-table.messages";
 
@@ -123,7 +124,7 @@ function ProjectRow({
     <tr className="group border-b border-border last:border-b-0 hover:bg-muted/50">
       <td className="px-4 py-3">
         <div className="flex min-w-0 items-center gap-2.5">
-          <ProjectSourceMark project={project} />
+          <ProjectAvatar project={project} />
           <div className="min-w-0">
             <OrgNavLink
               href={projectHref}
@@ -263,33 +264,6 @@ function ProjectRow({
         </div>
       </td>
     </tr>
-  );
-}
-
-export function ProjectSourceMark({
-  project,
-  compact = false,
-}: {
-  project: Pick<ProjectListRow, "source" | "externalProviderKind">;
-  compact?: boolean;
-}) {
-  const isNative = project.source === "native";
-  const label = isNative
-    ? "H"
-    : getTmsProviderBranding(project.externalProviderKind).name.slice(0, 1);
-  return (
-    <span
-      aria-hidden="true"
-      className={cn(
-        "inline-flex shrink-0 items-center justify-center font-medium",
-        compact ? "size-5 rounded-sm text-[9px]" : "size-8 rounded-md text-[11px]",
-        isNative
-          ? "bg-[#F0F4FF] text-[#4F6BED] dark:bg-blue-100 dark:text-blue-900"
-          : "bg-[#E8F4F8] text-primary dark:bg-muted",
-      )}
-    >
-      {label}
-    </span>
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The projects list used a platform letter (`H` / `C`) next to each row. It now uses `ProjectAvatar`: Crowdin (and other TMS) project images when the provider supplies one, and project-name initials when it does not.

Recent-project chips use the same mark, scaled down.

## How to test

- Open an org with Crowdin connected and confirm projects that have a Crowdin logo show that image.
- Confirm projects without a logo (native or TMS) show initials from the project name, not the platform letter.
- Confirm the Crowdin badge still appears on TMS rows that have a logo.

```
cd apps/hyperlocalise-web
vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.test.tsx src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp test` on the touched files, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ceddd6d-97c3-424c-81c1-55a172361655?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ceddd6d-97c3-424c-81c1-55a172361655&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

