### PR TITLE
feat(glossary): add history API and UI

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -39,6 +39,7 @@ import type { FileStorageAdapter } from "@/lib/file-storage/types";
 import { enqueueActivityLogEvent } from "@/lib/activity-log/activity-log-writer";
 import { getGlossaryProduct } from "@/lib/glossary/glossary-provider";
 import { listGlossaryConceptsPage } from "./glossary-concept-page";
+import { listGlossaryHistoryPage } from "./glossary-history-page";
 import { canonicalizeLocale } from "@/lib/i18n/locales";
 import { toNativeGlossaryLocale } from "@/lib/providers/adapters/crowdin/crowdin-glossary-language";
 import {
@@ -52,6 +53,7 @@ import {
   createGlossaryConceptBodySchema,
   createGlossaryConceptTermBodySchema,
   glossaryConceptPageQuerySchema,
+  glossaryHistoryQuerySchema,
   glossaryIdParamsSchema,
   glossaryConceptIdParamsSchema,
   glossaryConceptTermIdParamsSchema,
@@ -458,6 +460,30 @@ export function createGlossaryConceptRoutes(
           );
         }
         const page = await listGlossaryConceptsPage(glossaryId, query);
+        if ("code" in page) return badRequestResponse(c, page.code, page.message);
+        return c.json(page, 200);
+      },
+    )
+    .get(
+      "/history",
+      validator("param", validateGlossaryParams),
+      validator("query", (value, c) => {
+        const parsed = glossaryHistoryQuerySchema.safeParse(value);
+        return parsed.success ? parsed.data : invalidGlossaryPayloadResponse(c);
+      }),
+      async (c) => {
+        const { glossaryId } = c.req.valid("param");
+        const query = c.req.valid("query");
+        const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
+        if (!glossary) return glossaryNotFoundResponse(c);
+        if (glossary.source !== "native") {
+          return badRequestResponse(
+            c,
+            "external_glossary_history_unsupported",
+            "Provider-backed glossaries do not expose local history",
+          );
+        }
+        const page = await listGlossaryHistoryPage(glossaryId, query);
         if ("code" in page) return badRequestResponse(c, page.code, page.message);
         return c.json(page, 200);
       },

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-actor.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-actor.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { actorDisplayName } from "./glossary-history-page";
+import { actorDisplayName } from "./glossary-history-actor";
 
 describe("glossary history actor display name", () => {
   it("uses the joined first and last name when present", () => {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-actor.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-actor.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export function actorDisplayName(
+  actorKind: string,
+  actorUserId: string | null,
+  firstName: string | null,
+  lastName: string | null,
+  email: string | null = null,
+) {
+  const name = [firstName, lastName].filter(Boolean).join(" ").trim();
+  if (name) return name;
+  // ON DELETE SET NULL clears actorUserId when the user row is removed.
+  if (actorKind === "user" && !actorUserId) return "Deleted user";
+  if (email) return email;
+  return actorKind;
+}

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-page.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-page.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { actorDisplayName } from "./glossary-history-page";
+
+describe("glossary history actor display name", () => {
+  it("uses the joined first and last name when present", () => {
+    expect(actorDisplayName("user", "user-1", "Ada", "Lovelace", "ada@example.com")).toBe(
+      "Ada Lovelace",
+    );
+  });
+
+  it("uses email for a living user without a name", () => {
+    expect(actorDisplayName("user", "user-1", null, null, "ada@example.com")).toBe(
+      "ada@example.com",
+    );
+  });
+
+  it("does not label a nameless living user as deleted", () => {
+    expect(actorDisplayName("user", "user-1", null, "", null)).toBe("user");
+  });
+
+  it("labels a user event as deleted after ON DELETE SET NULL", () => {
+    expect(actorDisplayName("user", null, null, null, null)).toBe("Deleted user");
+  });
+
+  it("keeps non-user actor kinds", () => {
+    expect(actorDisplayName("system", null, null, null, null)).toBe("system");
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-page.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-page.ts
@@ -143,15 +143,18 @@ function decodeCursor(
   return value;
 }
 
-function actorDisplayName(
+export function actorDisplayName(
   actorKind: string,
   actorUserId: string | null,
   firstName: string | null,
   lastName: string | null,
+  email: string | null = null,
 ) {
   const name = [firstName, lastName].filter(Boolean).join(" ").trim();
   if (name) return name;
-  if (actorKind === "user" && actorUserId) return "Deleted user";
+  // ON DELETE SET NULL clears actorUserId when the user row is removed.
+  if (actorKind === "user" && !actorUserId) return "Deleted user";
+  if (email) return email;
   return actorKind;
 }
 
@@ -203,6 +206,7 @@ export async function listGlossaryHistoryPage(glossaryId: string, query: Glossar
       event: schema.glossaryHistoryEvents,
       actorFirstName: schema.users.firstName,
       actorLastName: schema.users.lastName,
+      actorEmail: schema.users.email,
     })
     .from(schema.glossaryHistoryEvents)
     .leftJoin(schema.users, eq(schema.users.id, schema.glossaryHistoryEvents.actorUserId))
@@ -212,7 +216,7 @@ export async function listGlossaryHistoryPage(glossaryId: string, query: Glossar
 
   const hasMore = rows.length > limit;
   const page = hasMore ? rows.slice(0, limit) : rows;
-  const events = page.map(({ event, actorFirstName, actorLastName }) => ({
+  const events = page.map(({ event, actorFirstName, actorLastName, actorEmail }) => ({
     id: event.id,
     conceptId: event.conceptId,
     termId: event.termId,
@@ -225,6 +229,7 @@ export async function listGlossaryHistoryPage(glossaryId: string, query: Glossar
       event.actorUserId,
       actorFirstName,
       actorLastName,
+      actorEmail,
     ),
     version: event.version,
     reason: event.reason,

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-page.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-page.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+import { and, desc, eq, ilike, lt, or, sql } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database/client";
+import { env } from "@/lib/env";
+
+import type { GlossaryHistoryQuery } from "./glossary.schema";
+
+const CURSOR_TTL_MS = 24 * 60 * 60 * 1000;
+
+type HistoryFilters = Omit<GlossaryHistoryQuery, "cursor" | "limit">;
+
+type HistoryCursor = {
+  v: 1;
+  glossaryId: string;
+  occurredAt: string;
+  id: string;
+  filterHash: string;
+  issuedAt: string;
+};
+
+export type GlossaryHistoryPageError = {
+  code: "invalid_glossary_history_cursor";
+  reason: "malformed" | "tampered" | "expired" | "filter_mismatch";
+  message: string;
+};
+
+function cursorSecret() {
+  return (
+    env.WORKOS_COOKIE_PASSWORD ?? env.PROVIDER_CREDENTIALS_MASTER_KEY ?? "glossary-page-dev-secret"
+  );
+}
+
+function filterHash(glossaryId: string, filters: HistoryFilters) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        glossaryId,
+        conceptId: filters.conceptId ?? null,
+        termId: filters.termId ?? null,
+        search: filters.search ?? null,
+        eventType: filters.eventType ?? null,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function sign(encoded: string) {
+  return createHmac("sha256", `${cursorSecret()}:glossary-history-page:v1`)
+    .update(encoded)
+    .digest("base64url");
+}
+
+function encodeCursor(
+  glossaryId: string,
+  filters: HistoryFilters,
+  event: { id: string; occurredAt: Date },
+) {
+  const payload: HistoryCursor = {
+    v: 1,
+    glossaryId,
+    occurredAt: event.occurredAt.toISOString(),
+    id: event.id,
+    filterHash: filterHash(glossaryId, filters),
+    issuedAt: new Date().toISOString(),
+  };
+  const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return `${encoded}.${sign(encoded)}`;
+}
+
+function invalidCursor(reason: GlossaryHistoryPageError["reason"]): GlossaryHistoryPageError {
+  return {
+    code: "invalid_glossary_history_cursor",
+    reason,
+    message: "Glossary history cursor is invalid",
+  };
+}
+
+function decodeCursor(
+  cursor: string,
+  glossaryId: string,
+  filters: HistoryFilters,
+): HistoryCursor | GlossaryHistoryPageError {
+  const parts = cursor.split(".");
+  const [encoded, signature] = parts;
+  if (parts.length !== 2 || !encoded || !signature) return invalidCursor("malformed");
+
+  const expected = sign(encoded);
+  const left = Buffer.from(signature);
+  const right = Buffer.from(expected);
+  if (left.length !== right.length || !timingSafeEqual(left, right)) {
+    return invalidCursor("tampered");
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch {
+    return invalidCursor("malformed");
+  }
+
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    (payload as HistoryCursor).v !== 1 ||
+    typeof (payload as HistoryCursor).glossaryId !== "string" ||
+    typeof (payload as HistoryCursor).occurredAt !== "string" ||
+    typeof (payload as HistoryCursor).id !== "string" ||
+    typeof (payload as HistoryCursor).filterHash !== "string" ||
+    typeof (payload as HistoryCursor).issuedAt !== "string"
+  ) {
+    return invalidCursor("malformed");
+  }
+
+  const value = payload as HistoryCursor;
+  const occurredAt = Date.parse(value.occurredAt);
+  const issuedAt = Date.parse(value.issuedAt);
+  if (
+    Number.isNaN(occurredAt) ||
+    Number.isNaN(issuedAt) ||
+    issuedAt > Date.now() ||
+    Date.now() - issuedAt > CURSOR_TTL_MS
+  ) {
+    return invalidCursor("expired");
+  }
+  if (value.glossaryId !== glossaryId || value.filterHash !== filterHash(glossaryId, filters)) {
+    return invalidCursor("filter_mismatch");
+  }
+  return value;
+}
+
+function actorDisplayName(
+  actorKind: string,
+  actorUserId: string | null,
+  firstName: string | null,
+  lastName: string | null,
+) {
+  const name = [firstName, lastName].filter(Boolean).join(" ").trim();
+  if (name) return name;
+  if (actorKind === "user" && actorUserId) return "Deleted user";
+  return actorKind;
+}
+
+export async function listGlossaryHistoryPage(glossaryId: string, query: GlossaryHistoryQuery) {
+  const { cursor, limit, ...filters } = query;
+  const decoded = cursor ? decodeCursor(cursor, glossaryId, filters) : undefined;
+  if (decoded && "code" in decoded) return decoded;
+
+  const conditions = [eq(schema.glossaryHistoryEvents.glossaryId, glossaryId)];
+  if (filters.conceptId) {
+    conditions.push(eq(schema.glossaryHistoryEvents.conceptId, filters.conceptId));
+  }
+  if (filters.termId) {
+    conditions.push(eq(schema.glossaryHistoryEvents.termId, filters.termId));
+  }
+  if (filters.eventType) {
+    conditions.push(eq(schema.glossaryHistoryEvents.eventType, filters.eventType));
+  }
+  if (filters.search) {
+    const pattern = `%${filters.search}%`;
+    conditions.push(
+      or(
+        ilike(schema.glossaryHistoryEvents.eventType, pattern),
+        ilike(schema.glossaryHistoryEvents.actorKind, pattern),
+        ilike(schema.glossaryHistoryEvents.reason, pattern),
+        ilike(schema.users.firstName, pattern),
+        ilike(schema.users.lastName, pattern),
+        sql`${schema.glossaryHistoryEvents.changedFields}::text ILIKE ${pattern}`,
+        sql`${schema.glossaryHistoryEvents.changes}::text ILIKE ${pattern}`,
+        sql`${schema.glossaryHistoryEvents.attributes}::text ILIKE ${pattern}`,
+      )!,
+    );
+  }
+  if (decoded) {
+    const occurredAt = new Date(decoded.occurredAt);
+    conditions.push(
+      or(
+        lt(schema.glossaryHistoryEvents.occurredAt, occurredAt),
+        and(
+          eq(schema.glossaryHistoryEvents.occurredAt, occurredAt),
+          lt(schema.glossaryHistoryEvents.id, decoded.id),
+        ),
+      )!,
+    );
+  }
+
+  const rows = await db
+    .select({
+      event: schema.glossaryHistoryEvents,
+      actorFirstName: schema.users.firstName,
+      actorLastName: schema.users.lastName,
+    })
+    .from(schema.glossaryHistoryEvents)
+    .leftJoin(schema.users, eq(schema.users.id, schema.glossaryHistoryEvents.actorUserId))
+    .where(and(...conditions))
+    .orderBy(desc(schema.glossaryHistoryEvents.occurredAt), desc(schema.glossaryHistoryEvents.id))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const events = page.map(({ event, actorFirstName, actorLastName }) => ({
+    id: event.id,
+    conceptId: event.conceptId,
+    termId: event.termId,
+    eventType: event.eventType,
+    actorKind: event.actorKind,
+    actorUserId: event.actorUserId,
+    actorCredentialId: event.actorCredentialId,
+    actorDisplayName: actorDisplayName(
+      event.actorKind,
+      event.actorUserId,
+      actorFirstName,
+      actorLastName,
+    ),
+    version: event.version,
+    reason: event.reason,
+    changedFields: event.changedFields,
+    changes: event.changes,
+    attributes: event.attributes,
+    occurredAt: event.occurredAt.toISOString(),
+  }));
+
+  const last = page.at(-1)?.event;
+  return {
+    events,
+    nextCursor: hasMore && last ? encodeCursor(glossaryId, filters, last) : null,
+    pagination: { limit, returned: events.length, hasMore },
+  };
+}

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-page.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-history-page.ts
@@ -17,6 +17,7 @@ import { and, desc, eq, ilike, lt, or, sql } from "drizzle-orm";
 import { db, schema } from "@/lib/database/client";
 import { env } from "@/lib/env";
 
+import { actorDisplayName } from "./glossary-history-actor";
 import type { GlossaryHistoryQuery } from "./glossary.schema";
 
 const CURSOR_TTL_MS = 24 * 60 * 60 * 1000;
@@ -141,21 +142,6 @@ function decodeCursor(
     return invalidCursor("filter_mismatch");
   }
   return value;
-}
-
-export function actorDisplayName(
-  actorKind: string,
-  actorUserId: string | null,
-  firstName: string | null,
-  lastName: string | null,
-  email: string | null = null,
-) {
-  const name = [firstName, lastName].filter(Boolean).join(" ").trim();
-  if (name) return name;
-  // ON DELETE SET NULL clears actorUserId when the user row is removed.
-  if (actorKind === "user" && !actorUserId) return "Deleted user";
-  if (email) return email;
-  return actorKind;
 }
 
 export async function listGlossaryHistoryPage(glossaryId: string, query: GlossaryHistoryQuery) {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -89,6 +89,9 @@ export const glossaryConceptPageQuerySchema = z.object({
 export const glossaryHistoryQuerySchema = z.object({
   conceptId: z.string().uuid().optional(),
   termId: z.string().uuid().optional(),
+  cursor: z.string().trim().max(2_000).optional(),
+  search: z.string().trim().max(200).optional(),
+  eventType: z.string().trim().min(1).max(80).optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
 });
 
@@ -392,6 +395,39 @@ export const glossaryConceptPageResponseSchema = z.object({
   }),
 });
 
+export const glossaryHistoryChangeSchema = z.object({
+  field: z.string(),
+  before: z.unknown(),
+  after: z.unknown(),
+});
+
+export const glossaryHistoryEventSchema = z.object({
+  id: z.string().uuid(),
+  conceptId: z.string().uuid().nullable(),
+  termId: z.string().uuid().nullable(),
+  eventType: z.string(),
+  actorKind: z.string(),
+  actorUserId: z.string().uuid().nullable(),
+  actorCredentialId: z.string().nullable(),
+  actorDisplayName: z.string(),
+  version: z.number().int(),
+  reason: z.string().nullable(),
+  changedFields: z.array(z.string()),
+  changes: z.array(glossaryHistoryChangeSchema),
+  attributes: z.record(z.string(), z.unknown()),
+  occurredAt: z.string().datetime(),
+});
+
+export const glossaryHistoryPageResponseSchema = z.object({
+  events: z.array(glossaryHistoryEventSchema),
+  nextCursor: z.string().nullable(),
+  pagination: z.object({
+    limit: z.number().int().positive(),
+    returned: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
+  }),
+});
+
 export const glossaryConceptTermResponseSchema = z.object({
   term: glossaryConceptTermRecordSchema,
 });
@@ -429,5 +465,7 @@ export type GlossaryConceptResponse = z.infer<typeof glossaryConceptResponseSche
 export type GlossaryConceptsResponse = z.infer<typeof glossaryConceptsResponseSchema>;
 export type GlossaryConceptSummary = z.infer<typeof glossaryConceptSummarySchema>;
 export type GlossaryConceptPageResponse = z.infer<typeof glossaryConceptPageResponseSchema>;
+export type GlossaryHistoryEventRecord = z.infer<typeof glossaryHistoryEventSchema>;
+export type GlossaryHistoryPageResponse = z.infer<typeof glossaryHistoryPageResponseSchema>;
 export type GlossaryConceptTermResponse = z.infer<typeof glossaryConceptTermResponseSchema>;
 export type GlossaryConceptTermsResponse = z.infer<typeof glossaryConceptTermsResponseSchema>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
@@ -95,6 +95,11 @@ export const glossaryDetailPageContentMessages = defineMessages({
     id: "OU8ZFDP47O",
     description: "Accessible label for the glossary actions menu",
   },
+  glossaryHistory: {
+    defaultMessage: "View history",
+    id: "DzmZ+KrwIu",
+    description: "Link to the glossary history page",
+  },
   exportAsTbx: {
     defaultMessage: "Export as TBX",
     id: "Jh6eXznG+8",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.messages.ts
@@ -1,0 +1,149 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const glossaryHistoryPageMessages = defineMessages({
+  backToGlossary: {
+    defaultMessage: "Back to glossary",
+    id: "807Zi+p+pS",
+    description: "Link back to the glossary detail page",
+  },
+  title: {
+    defaultMessage: "Glossary history",
+    id: "UvANsyZrbI",
+    description: "Glossary history page heading",
+  },
+  description: {
+    defaultMessage: "Review imports and changes across this glossary.",
+    id: "owWio6fQLv",
+    description: "Glossary history page description",
+  },
+  searchLabel: {
+    defaultMessage: "Search history",
+    id: "XX0l5kWHfE",
+    description: "Glossary history search input label",
+  },
+  searchPlaceholder: {
+    defaultMessage: "Search event details",
+    id: "x9HI7zKaWm",
+    description: "Glossary history search input placeholder",
+  },
+  eventTypeLabel: {
+    defaultMessage: "Event type",
+    id: "9JeJOKsemV",
+    description: "Glossary history event type filter label",
+  },
+  allEvents: {
+    defaultMessage: "All events",
+    id: "7SltjgHpss",
+    description: "Option to show all glossary history event types",
+  },
+  imported: {
+    defaultMessage: "Imported",
+    id: "KREOm0BNYe",
+    description: "Glossary history imported event filter",
+  },
+  created: {
+    defaultMessage: "Created",
+    id: "dAoVLkrJwN",
+    description: "Glossary history created event filter",
+  },
+  updated: {
+    defaultMessage: "Updated",
+    id: "sEJSf7iVqH",
+    description: "Glossary history updated event filter",
+  },
+  deleted: {
+    defaultMessage: "Deleted",
+    id: "ZV4jhuXvh3",
+    description: "Glossary history deleted event filter",
+  },
+  loading: {
+    defaultMessage: "Loading glossary history",
+    id: "ed/4UsnyQZ",
+    description: "Accessible label for the glossary history loading state",
+  },
+  emptyTitle: {
+    defaultMessage: "No history yet",
+    id: "Smebv4yC+R",
+    description: "Glossary history empty state title",
+  },
+  emptyDescription: {
+    defaultMessage: "Glossary imports and changes will appear here.",
+    id: "DJ76ekFqdE",
+    description: "Glossary history empty state description",
+  },
+  errorTitle: {
+    defaultMessage: "Glossary history could not be loaded",
+    id: "CcfrzXT5ah",
+    description: "Glossary history error state title",
+  },
+  errorDescription: {
+    defaultMessage: "Try again to load the latest glossary history.",
+    id: "5ZQ992jk22",
+    description: "Glossary history error state description",
+  },
+  unavailableTitle: {
+    defaultMessage: "Glossary history is unavailable",
+    id: "4rC9Np88HF",
+    description: "Glossary history unavailable state title",
+  },
+  unavailableDescription: {
+    defaultMessage: "This glossary does not expose local history.",
+    id: "+kFbrUG7wz",
+    description: "Glossary history unavailable state description",
+  },
+  retry: {
+    defaultMessage: "Retry",
+    id: "pGj/L35EP+",
+    description: "Retry loading glossary history",
+  },
+  loadMore: {
+    defaultMessage: "Load more",
+    id: "w0sul/7gcV",
+    description: "Load another page of glossary history",
+  },
+  changedFields: {
+    defaultMessage: "Changed fields: {fields}",
+    id: "MMqdjTKoog",
+    description: "Glossary history changed fields summary",
+  },
+  eventMeta: {
+    defaultMessage: "{actor} · {date}",
+    id: "s3w5x5ZggY",
+    description: "Glossary history event actor and timestamp",
+  },
+  importMeta: {
+    defaultMessage: "{format} · {mode}",
+    id: "94NuGR6Dav",
+    description: "Glossary import history format and mode",
+  },
+  importCounts: {
+    defaultMessage:
+      "{created} created · {updated} updated · {merged} merged · {skipped} skipped · {failed} failed",
+    id: "RWAFusSGVX",
+    description: "Glossary import history result counts",
+  },
+  concept: {
+    defaultMessage: "Concept {id}",
+    id: "KQeC+CsXLT",
+    description: "Glossary history concept link label",
+  },
+  fieldChange: {
+    defaultMessage: "{before} → {after}",
+    id: "mE7391J8Q3",
+    description: "Glossary history before and after field values",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.messages.ts
@@ -112,7 +112,7 @@ export const glossaryHistoryPageMessages = defineMessages({
   },
   invalidCursor: {
     defaultMessage: "That page is no longer valid. Showing the first page.",
-    id: "k4nH8qL2wR",
+    id: "BxVa0XAhsz",
     description: "Status announced when a glossary history cursor can no longer be used",
   },
   loadMore: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.messages.ts
@@ -110,6 +110,11 @@ export const glossaryHistoryPageMessages = defineMessages({
     id: "pGj/L35EP+",
     description: "Retry loading glossary history",
   },
+  invalidCursor: {
+    defaultMessage: "That page is no longer valid. Showing the first page.",
+    id: "k4nH8qL2wR",
+    description: "Status announced when a glossary history cursor can no longer be used",
+  },
   loadMore: {
     defaultMessage: "Load more",
     id: "w0sul/7gcV",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.test.tsx
@@ -147,25 +147,23 @@ describe("GlossaryHistoryPage", () => {
 
   it("restarts from the first page when a cursor expires", async () => {
     const user = userEvent.setup();
-    apiMocks.getHistory.mockImplementation(
-      async (args: { query?: { cursor?: string } }) => {
-        if (args.query?.cursor) {
-          return jsonResponse(
-            {
-              error: "invalid_glossary_history_cursor",
-              message: "Glossary history cursor is invalid",
-            },
-            400,
-          );
-        }
+    apiMocks.getHistory.mockImplementation(async (args: { query?: { cursor?: string } }) => {
+      if (args.query?.cursor) {
         return jsonResponse(
-          historyPage(
-            [historyEvent("11111111-1111-4111-8111-111111111111")],
-            args.query?.cursor ? null : "cursor-1",
-          ),
+          {
+            error: "invalid_glossary_history_cursor",
+            message: "Glossary history cursor is invalid",
+          },
+          400,
         );
-      },
-    );
+      }
+      return jsonResponse(
+        historyPage(
+          [historyEvent("11111111-1111-4111-8111-111111111111")],
+          args.query?.cursor ? null : "cursor-1",
+        ),
+      );
+    });
 
     renderHistoryPage();
 
@@ -180,7 +178,9 @@ describe("GlossaryHistoryPage", () => {
         screen.getByText("That page is no longer valid. Showing the first page."),
       ).toBeInTheDocument();
     });
-    expect(screen.queryByText("This glossary does not expose local history.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("This glossary does not expose local history."),
+    ).not.toBeInTheDocument();
     expect(apiMocks.getHistory.mock.calls.some((call) => !call[0]?.query?.cursor)).toBe(true);
   });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.test.tsx
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { IntlProvider } from "react-intl";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { GlossaryHistoryPageResponse } from "@/api/routes/glossary/glossary.schema";
+
+import {
+  GlossaryHistoryPage,
+  GlossaryHistoryRequestError,
+  isInvalidGlossaryHistoryCursorError,
+  isUnavailableGlossaryHistoryError,
+} from "./glossary-history-page";
+
+const apiMocks = vi.hoisted(() => ({
+  getHistory: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/lib/api-client-instance", () => ({
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          glossaries: {
+            ":glossaryId": {
+              concepts: {
+                history: {
+                  $get: apiMocks.getHistory,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function historyPage(
+  events: GlossaryHistoryPageResponse["events"],
+  nextCursor: string | null = null,
+): GlossaryHistoryPageResponse {
+  return {
+    events,
+    nextCursor,
+    pagination: {
+      limit: 50,
+      returned: events.length,
+      hasMore: Boolean(nextCursor),
+    },
+  };
+}
+
+function historyEvent(id: string, actorDisplayName = "Ada Lovelace") {
+  return {
+    id,
+    conceptId: null,
+    termId: null,
+    eventType: "created",
+    actorKind: "user",
+    actorUserId: "11111111-1111-4111-8111-111111111111",
+    actorCredentialId: null,
+    actorDisplayName,
+    version: 1,
+    reason: null,
+    changedFields: [],
+    changes: [],
+    attributes: {},
+    occurredAt: "2026-09-10T00:00:00.000Z",
+  } satisfies GlossaryHistoryPageResponse["events"][number];
+}
+
+function renderHistoryPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      <QueryClientProvider client={queryClient}>
+        <GlossaryHistoryPage organizationSlug="acme" glossaryId="glossary-1" />
+      </QueryClientProvider>
+    </IntlProvider>,
+  );
+}
+
+describe("glossary history error classification", () => {
+  it("treats expired cursors as recoverable", () => {
+    const error = new GlossaryHistoryRequestError(
+      400,
+      "invalid_glossary_history_cursor",
+      "Glossary history cursor is invalid",
+    );
+    expect(isInvalidGlossaryHistoryCursorError(error)).toBe(true);
+    expect(isUnavailableGlossaryHistoryError(error)).toBe(false);
+  });
+
+  it("treats unsupported provider glossaries as unavailable", () => {
+    const error = new GlossaryHistoryRequestError(
+      400,
+      "external_glossary_history_unsupported",
+      "Provider-backed glossaries do not expose local history",
+    );
+    expect(isInvalidGlossaryHistoryCursorError(error)).toBe(false);
+    expect(isUnavailableGlossaryHistoryError(error)).toBe(true);
+  });
+
+  it("does not treat generic 400 errors as unavailable", () => {
+    const error = new GlossaryHistoryRequestError(400, "invalid_glossary_payload", "Bad request");
+    expect(isUnavailableGlossaryHistoryError(error)).toBe(false);
+  });
+});
+
+describe("GlossaryHistoryPage", () => {
+  beforeEach(() => {
+    apiMocks.getHistory.mockReset();
+  });
+
+  it("restarts from the first page when a cursor expires", async () => {
+    const user = userEvent.setup();
+    apiMocks.getHistory.mockImplementation(
+      async (args: { query?: { cursor?: string } }) => {
+        if (args.query?.cursor) {
+          return jsonResponse(
+            {
+              error: "invalid_glossary_history_cursor",
+              message: "Glossary history cursor is invalid",
+            },
+            400,
+          );
+        }
+        return jsonResponse(
+          historyPage(
+            [historyEvent("11111111-1111-4111-8111-111111111111")],
+            args.query?.cursor ? null : "cursor-1",
+          ),
+        );
+      },
+    );
+
+    renderHistoryPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ada Lovelace/)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("That page is no longer valid. Showing the first page."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("This glossary does not expose local history.")).not.toBeInTheDocument();
+    expect(apiMocks.getHistory.mock.calls.some((call) => !call[0]?.query?.cursor)).toBe(true);
+  });
+
+  it("keeps provider-backed glossaries unavailable without a retry", async () => {
+    apiMocks.getHistory.mockResolvedValue(
+      jsonResponse(
+        {
+          error: "external_glossary_history_unsupported",
+          message: "Provider-backed glossaries do not expose local history",
+        },
+        400,
+      ),
+    );
+
+    renderHistoryPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("This glossary does not expose local history.")).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useInfiniteQuery } from "@tanstack/react-query";
@@ -34,20 +34,39 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
-import { readApiError } from "@/lib/api-error";
+import { readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import { glossaryHistoryPageMessages as messages } from "./glossary-history-page.messages";
 
 const PAGE_SIZE = 50;
+const UNAVAILABLE_STATUSES = new Set([401, 403, 404]);
+const INVALID_GLOSSARY_HISTORY_CURSOR = "invalid_glossary_history_cursor";
+const EXTERNAL_GLOSSARY_HISTORY_UNSUPPORTED = "external_glossary_history_unsupported";
 
-class GlossaryHistoryRequestError extends Error {
+export class GlossaryHistoryRequestError extends Error {
   constructor(
     readonly status: number,
+    readonly code: string | null,
     message: string,
   ) {
     super(message);
+    this.name = "GlossaryHistoryRequestError";
   }
+}
+
+export function isInvalidGlossaryHistoryCursorError(error: unknown) {
+  return (
+    error instanceof GlossaryHistoryRequestError && error.code === INVALID_GLOSSARY_HISTORY_CURSOR
+  );
+}
+
+export function isUnavailableGlossaryHistoryError(error: unknown) {
+  if (!(error instanceof GlossaryHistoryRequestError)) return false;
+  if (isInvalidGlossaryHistoryCursorError(error)) return false;
+  return (
+    UNAVAILABLE_STATUSES.has(error.status) || error.code === EXTERNAL_GLOSSARY_HISTORY_UNSUPPORTED
+  );
 }
 
 function formatValue(value: unknown) {
@@ -173,10 +192,19 @@ export function GlossaryHistoryPage({
   const intl = useIntl();
   const [search, setSearch] = useState("");
   const [eventType, setEventType] = useState("");
+  const [paginationEpoch, setPaginationEpoch] = useState(0);
+  const [cursorNotice, setCursorNotice] = useState<string | null>(null);
   const glossaryHref = `/org/${organizationSlug}/glossaries/${glossaryId}`;
 
   const historyQuery = useInfiniteQuery({
-    queryKey: ["glossary-history", organizationSlug, glossaryId, search, eventType],
+    queryKey: [
+      "glossary-history",
+      organizationSlug,
+      glossaryId,
+      search,
+      eventType,
+      paginationEpoch,
+    ],
     initialPageParam: undefined as string | undefined,
     queryFn: async ({ pageParam, signal }) => {
       const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
@@ -194,23 +222,33 @@ export function GlossaryHistoryPage({
         { init: { signal } },
       );
       if (!response.ok) {
-        throw new GlossaryHistoryRequestError(
-          response.status,
-          await readApiError(response, intl.formatMessage(messages.errorTitle)),
+        const apiError = await readApiResponseError(
+          response,
+          intl.formatMessage(messages.errorTitle),
         );
+        throw new GlossaryHistoryRequestError(apiError.status, apiError.code, apiError.message);
       }
       return (await response.json()) as GlossaryHistoryPageResponse;
     },
     getNextPageParam: (page) => page.nextCursor ?? undefined,
   });
 
+  const invalidCursor = isInvalidGlossaryHistoryCursorError(historyQuery.error);
+  useEffect(() => {
+    if (!invalidCursor) return;
+    setCursorNotice(intl.formatMessage(messages.invalidCursor));
+    setPaginationEpoch((epoch) => epoch + 1);
+  }, [intl, invalidCursor]);
+
+  useEffect(() => {
+    setCursorNotice(null);
+  }, [search, eventType]);
+
   const events = useMemo(
     () => historyQuery.data?.pages.flatMap((page) => page.events) ?? [],
     [historyQuery.data?.pages],
   );
-  const unavailable =
-    historyQuery.error instanceof GlossaryHistoryRequestError &&
-    [400, 401, 403, 404].includes(historyQuery.error.status);
+  const unavailable = isUnavailableGlossaryHistoryError(historyQuery.error);
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-6">
@@ -272,9 +310,9 @@ export function GlossaryHistoryPage({
             </Select>
           </div>
         </div>
-        {historyQuery.isPending ? (
+        {(historyQuery.isPending || invalidCursor) && events.length === 0 ? (
           <HistorySkeleton />
-        ) : historyQuery.isError ? (
+        ) : historyQuery.isError && !invalidCursor ? (
           <div className="grid gap-3 rounded-md border border-destructive/30 p-4">
             <div>
               <TypographyP weight="medium">
@@ -293,7 +331,9 @@ export function GlossaryHistoryPage({
                 type="button"
                 variant="outline"
                 className="w-fit"
-                onClick={() => historyQuery.refetch()}
+                onClick={() => {
+                  void historyQuery.refetch();
+                }}
               >
                 <FormattedMessage {...messages.retry} />
               </Button>
@@ -310,6 +350,11 @@ export function GlossaryHistoryPage({
           </div>
         ) : (
           <div className="grid gap-3">
+            {cursorNotice ? (
+              <TypographyP size="small" tone="subtle">
+                {cursorNotice}
+              </TypographyP>
+            ) : null}
             {events.map((event) => (
               <HistoryEventCard key={event.id} event={event} glossaryHref={glossaryHref} />
             ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-history-page.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import type {
+  GlossaryHistoryEventRecord,
+  GlossaryHistoryPageResponse,
+} from "@/api/routes/glossary/glossary.schema";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+
+import { glossaryHistoryPageMessages as messages } from "./glossary-history-page.messages";
+
+const PAGE_SIZE = 50;
+
+class GlossaryHistoryRequestError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function formatValue(value: unknown) {
+  if (value === null || value === undefined || value === "") return "—";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+function importCount(attributes: Record<string, unknown>, key: string) {
+  const counts = attributes.counts;
+  if (!counts || typeof counts !== "object" || Array.isArray(counts)) return 0;
+  const value = (counts as Record<string, unknown>)[key];
+  return typeof value === "number" ? value : 0;
+}
+
+function HistoryEventCard({
+  event,
+  glossaryHref,
+}: {
+  event: GlossaryHistoryEventRecord;
+  glossaryHref: string;
+}) {
+  const intl = useIntl();
+  const format = event.attributes.format;
+  const mode = event.attributes.mode;
+  const isImport = event.eventType === "imported";
+
+  return (
+    <article className="grid gap-2 rounded-md border border-border p-4 text-sm">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <span className="font-medium capitalize">{event.eventType}</span>
+        <span className="text-xs text-muted-foreground">
+          <FormattedMessage
+            {...messages.eventMeta}
+            values={{
+              actor: event.actorDisplayName,
+              date: intl.formatDate(new Date(event.occurredAt), {
+                dateStyle: "medium",
+                timeStyle: "short",
+              }),
+            }}
+          />
+        </span>
+      </div>
+      {event.conceptId ? (
+        <Link
+          href={`${glossaryHref}/concepts/${event.conceptId}`}
+          className="text-xs text-primary hover:underline"
+        >
+          <FormattedMessage {...messages.concept} values={{ id: event.conceptId }} />
+        </Link>
+      ) : null}
+      {isImport && typeof format === "string" && typeof mode === "string" ? (
+        <TypographyP size="xsmall" tone="subtle">
+          <FormattedMessage {...messages.importMeta} values={{ format, mode }} />
+        </TypographyP>
+      ) : null}
+      {isImport ? (
+        <TypographyP size="xsmall" tone="subtle">
+          <FormattedMessage
+            {...messages.importCounts}
+            values={{
+              created: importCount(event.attributes, "created"),
+              updated: importCount(event.attributes, "updated"),
+              merged: importCount(event.attributes, "merged"),
+              skipped: importCount(event.attributes, "skipped"),
+              failed: importCount(event.attributes, "failed"),
+            }}
+          />
+        </TypographyP>
+      ) : null}
+      {event.changedFields.length ? (
+        <TypographyP size="xsmall" tone="subtle">
+          <FormattedMessage
+            {...messages.changedFields}
+            values={{ fields: event.changedFields.join(", ") }}
+          />
+        </TypographyP>
+      ) : null}
+      {event.changes.length ? (
+        <div className="grid gap-1 rounded-md bg-muted/40 p-2 font-mono text-xs">
+          {event.changes.map((change) => (
+            <div key={change.field} className="grid gap-1 sm:grid-cols-[8rem_1fr]">
+              <span className="font-semibold">{change.field}</span>
+              <span className="break-words text-muted-foreground">
+                <FormattedMessage
+                  {...messages.fieldChange}
+                  values={{
+                    before: formatValue(change.before),
+                    after: formatValue(change.after),
+                  }}
+                />
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function HistorySkeleton() {
+  return (
+    <div className="grid gap-3" aria-busy="true">
+      {Array.from({ length: 3 }, (_, index) => (
+        <Skeleton key={index} className="h-28 w-full" />
+      ))}
+    </div>
+  );
+}
+
+export function GlossaryHistoryPage({
+  organizationSlug,
+  glossaryId,
+}: {
+  organizationSlug: string;
+  glossaryId: string;
+}) {
+  const intl = useIntl();
+  const [search, setSearch] = useState("");
+  const [eventType, setEventType] = useState("");
+  const glossaryHref = `/org/${organizationSlug}/glossaries/${glossaryId}`;
+
+  const historyQuery = useInfiniteQuery({
+    queryKey: ["glossary-history", organizationSlug, glossaryId, search, eventType],
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam, signal }) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].concepts.history.$get(
+        {
+          param: { organizationSlug, glossaryId },
+          query: {
+            limit: String(PAGE_SIZE),
+            ...(pageParam ? { cursor: pageParam } : {}),
+            ...(search.trim() ? { search: search.trim() } : {}),
+            ...(eventType ? { eventType } : {}),
+          },
+        },
+        { init: { signal } },
+      );
+      if (!response.ok) {
+        throw new GlossaryHistoryRequestError(
+          response.status,
+          await readApiError(response, intl.formatMessage(messages.errorTitle)),
+        );
+      }
+      return (await response.json()) as GlossaryHistoryPageResponse;
+    },
+    getNextPageParam: (page) => page.nextCursor ?? undefined,
+  });
+
+  const events = useMemo(
+    () => historyQuery.data?.pages.flatMap((page) => page.events) ?? [],
+    [historyQuery.data?.pages],
+  );
+  const unavailable =
+    historyQuery.error instanceof GlossaryHistoryRequestError &&
+    [400, 401, 403, 404].includes(historyQuery.error.status);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <Link
+        href={glossaryHref}
+        className="inline-flex w-fit items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" strokeWidth={1.8} />
+        <FormattedMessage {...messages.backToGlossary} />
+      </Link>
+      <section className="grid gap-2">
+        <TypographyH1>{intl.formatMessage(messages.title)}</TypographyH1>
+        <TypographyP size="small" tone="subtle">
+          <FormattedMessage {...messages.description} />
+        </TypographyP>
+      </section>
+      <section className="grid gap-4 rounded-lg border border-border p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="grid flex-1 gap-1.5">
+            <label htmlFor="glossary-history-search" className="text-xs font-medium">
+              <FormattedMessage {...messages.searchLabel} />
+            </label>
+            <Input
+              id="glossary-history-search"
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.currentTarget.value)}
+              placeholder={intl.formatMessage(messages.searchPlaceholder)}
+            />
+          </div>
+          <div className="grid gap-1.5 sm:w-48">
+            <label htmlFor="glossary-history-event-type" className="text-xs font-medium">
+              <FormattedMessage {...messages.eventTypeLabel} />
+            </label>
+            <Select
+              value={eventType || "all"}
+              onValueChange={(value) => setEventType(value === "all" ? "" : (value ?? ""))}
+            >
+              <SelectTrigger id="glossary-history-event-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">
+                  <FormattedMessage {...messages.allEvents} />
+                </SelectItem>
+                <SelectItem value="imported">
+                  <FormattedMessage {...messages.imported} />
+                </SelectItem>
+                <SelectItem value="created">
+                  <FormattedMessage {...messages.created} />
+                </SelectItem>
+                <SelectItem value="updated">
+                  <FormattedMessage {...messages.updated} />
+                </SelectItem>
+                <SelectItem value="deleted">
+                  <FormattedMessage {...messages.deleted} />
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        {historyQuery.isPending ? (
+          <HistorySkeleton />
+        ) : historyQuery.isError ? (
+          <div className="grid gap-3 rounded-md border border-destructive/30 p-4">
+            <div>
+              <TypographyP weight="medium">
+                <FormattedMessage
+                  {...(unavailable ? messages.unavailableTitle : messages.errorTitle)}
+                />
+              </TypographyP>
+              <TypographyP size="small" tone="subtle">
+                <FormattedMessage
+                  {...(unavailable ? messages.unavailableDescription : messages.errorDescription)}
+                />
+              </TypographyP>
+            </div>
+            {!unavailable ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-fit"
+                onClick={() => historyQuery.refetch()}
+              >
+                <FormattedMessage {...messages.retry} />
+              </Button>
+            ) : null}
+          </div>
+        ) : events.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border px-5 py-10 text-center">
+            <TypographyP weight="medium">
+              <FormattedMessage {...messages.emptyTitle} />
+            </TypographyP>
+            <TypographyP size="small" tone="subtle">
+              <FormattedMessage {...messages.emptyDescription} />
+            </TypographyP>
+          </div>
+        ) : (
+          <div className="grid gap-3">
+            {events.map((event) => (
+              <HistoryEventCard key={event.id} event={event} glossaryHref={glossaryHref} />
+            ))}
+            {historyQuery.hasNextPage ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="mx-auto"
+                disabled={historyQuery.isFetchingNextPage}
+                onClick={() => historyQuery.fetchNextPage()}
+              >
+                <FormattedMessage {...messages.loadMore} />
+              </Button>
+            ) : null}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/native-glossary-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/native-glossary-detail.tsx
@@ -657,6 +657,9 @@ export function NativeGlossaryDetail({
                 <FormattedMessage {...messages.conceptsDescription} />
               </TypographyP>
             </div>
+            <Link href={`${glossaryHref}/history`} className="text-sm text-primary hover:underline">
+              <FormattedMessage {...messages.glossaryHistory} />
+            </Link>
             <div className="flex w-full flex-col gap-2 sm:w-auto sm:min-w-72">
               <label htmlFor="glossary-concept-search" className="sr-only">
                 Search concepts

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/history/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/history/page.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { GlossaryHistoryPage } from "../_components/glossary-history-page";
+import { OrgPageSuspense } from "../../../_components/org-page-suspense";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+export default function GlossaryHistoryRoute({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; glossaryId: string }>;
+}) {
+  return (
+    <OrgPageSuspense>
+      <GlossaryHistoryPageLoader params={params} />
+    </OrgPageSuspense>
+  );
+}
+
+async function GlossaryHistoryPageLoader({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; glossaryId: string }>;
+}) {
+  const { organizationSlug, glossaryId } = await params;
+  await requireAppAuthContext({ organizationSlug });
+  return <GlossaryHistoryPage organizationSlug={organizationSlug} glossaryId={glossaryId} />;
+}


### PR DESCRIPTION
## Summary

- Add stable cursor pagination and filters to the glossary history API.
- Add a dedicated glossary history page with import summaries, entity links, and load-more behavior.
- Link native glossary detail to history without changing PR2 import writes.

## Validation

- vp check --fix passed with no warnings, lint errors, or type errors.
- Glossary schema and permission tests passed.
- Glossary route integration tests were blocked because PostgreSQL was unavailable on localhost:5432 and the Docker daemon could not be started in the environment.

Base branch: feat/glossary-management-pr2-durable-history.
