### PR TITLE
test(web): stamp GitLab scheduled automations with the actor Pipes user

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -1624,6 +1624,7 @@ describe("workspace automations", () => {
       await createWorkspaceAutomation({
         ...base,
         name: "Scheduled GitLab review",
+        actorWorkosUserId: "user_workos",
         triggerConfig: {
           mode: "scheduled",
           schedule: { cadence: "daily", hourUtc: 9, timezone: "UTC" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

GitLab scheduled automations stamp the actor’s WorkOS Pipes user. The scheduled GitLab create in `workspace-automations.test.ts` omitted `actorWorkosUserId`, so the assertion expected `user_workos` and received the author’s fixture id.

## How to test

- `vp test src/lib/agents/workspace-automations.test.ts` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test` on the affected file)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c76e68e7-984d-4b74-84ff-9e4db7ac99d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c76e68e7-984d-4b74-84ff-9e4db7ac99d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

