### PR TITLE
feat(glossary): add terminology maintenance foundations

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept-page.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept-page.ts
@@ -145,6 +145,7 @@ function termExistsWhere(
     eq(schema.glossaryTerms.conceptId, conceptId),
     eq(schema.glossaryTerms.glossaryId, schema.glossaryConcepts.glossaryId),
   ];
+  if (!filters.includeArchived) conditions.push(sql`${schema.glossaryTerms.archivedAt} is null`);
   if (filters.locale) conditions.push(eq(schema.glossaryTerms.locale, filters.locale));
   if (filters.termReviewStatus)
     conditions.push(eq(schema.glossaryTerms.reviewStatus, filters.termReviewStatus));
@@ -202,8 +203,22 @@ function buildWhere(glossaryId: string, filters: FilterFields): SQL {
       ilike(schema.glossaryConcepts.definition, `%${search}%`),
       ilike(schema.glossaryConcepts.note, `%${search}%`),
     ];
-    if (UUID_PATTERN.test(search))
+    if (UUID_PATTERN.test(search)) {
       searchTerms.push(eq(schema.glossaryConcepts.id, search.toLowerCase()));
+      searchTerms.push(
+        exists(
+          db
+            .select({ id: schema.glossaryTerms.id })
+            .from(schema.glossaryTerms)
+            .where(
+              and(
+                eq(schema.glossaryTerms.conceptId, schema.glossaryConcepts.id),
+                eq(schema.glossaryTerms.id, search.toLowerCase()),
+              ),
+            ),
+        ),
+      );
+    }
     searchTerms.push(
       exists(
         db
@@ -212,8 +227,11 @@ function buildWhere(glossaryId: string, filters: FilterFields): SQL {
           .where(
             and(
               eq(schema.glossaryTerms.conceptId, schema.glossaryConcepts.id),
+              filters.includeArchived ? undefined : sql`${schema.glossaryTerms.archivedAt} is null`,
               or(
                 ilike(schema.glossaryTerms.term, `%${search}%`),
+                ilike(schema.glossaryTerms.sourceTerm, `%${search}%`),
+                ilike(schema.glossaryTerms.targetTerm, `%${search}%`),
                 ilike(schema.glossaryTerms.description, `%${search}%`),
                 ilike(schema.glossaryTerms.note, `%${search}%`),
                 sql`${schema.glossaryTerms.metadata}::text ilike ${`%${search}%`}`,
@@ -298,7 +316,12 @@ export async function listGlossaryConceptsPage(
           localeCount: sql<number>`count(distinct ${schema.glossaryTerms.locale})`,
         })
         .from(schema.glossaryTerms)
-        .where(inArray(schema.glossaryTerms.conceptId, ids))
+        .where(
+          and(
+            inArray(schema.glossaryTerms.conceptId, ids),
+            filters.includeArchived ? undefined : sql`${schema.glossaryTerms.archivedAt} is null`,
+          ),
+        )
         .groupBy(schema.glossaryTerms.conceptId)
     : [];
   const counts = new Map(termCounts.map((row) => [row.conceptId, row]));

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept-page.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept-page.ts
@@ -214,6 +214,9 @@ function buildWhere(glossaryId: string, filters: FilterFields): SQL {
               and(
                 eq(schema.glossaryTerms.conceptId, schema.glossaryConcepts.id),
                 eq(schema.glossaryTerms.id, search.toLowerCase()),
+                filters.includeArchived
+                  ? undefined
+                  : sql`${schema.glossaryTerms.archivedAt} is null`,
               ),
             ),
         ),

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -154,6 +154,7 @@ function toCrowdinTermRecord(
     userId?: number | null;
     createdAt?: string | null;
     updatedAt?: string | null;
+    version?: number;
   },
 ) {
   const createdAt = term.createdAt ?? new Date(0).toISOString();
@@ -182,6 +183,7 @@ function toCrowdinTermRecord(
     externalUserId: term.userId == null ? null : String(term.userId),
     externalCreatedAt: createdAt,
     externalUpdatedAt: updatedAt,
+    version: term.version,
     createdAt,
     updatedAt,
   };
@@ -210,6 +212,7 @@ function toCrowdinConceptRecord(
     }>;
     externalCreatedAt?: string | null;
     externalUpdatedAt?: string | null;
+    version?: number;
     reviewStatus?: string;
     reviewReason?: string | null;
     terms: Array<{
@@ -227,6 +230,7 @@ function toCrowdinConceptRecord(
       userId?: number | null;
       createdAt?: string | null;
       updatedAt?: string | null;
+      version?: number;
     }>;
   },
 ) {
@@ -258,6 +262,7 @@ function toCrowdinConceptRecord(
     externalUpdatedAt: updatedAt,
     reviewStatus: value.reviewStatus ?? "approved",
     reviewReason: value.reviewReason ?? null,
+    version: value.version,
     createdAt,
     updatedAt,
     terms: value.terms.map((term) => toCrowdinTermRecord(glossary, conceptId, term)),
@@ -1080,6 +1085,13 @@ export function createGlossaryConceptRoutes(
         });
         if (!result.ok) {
           if (result.code === "not_found") return glossaryNotFoundResponse(c);
+          if (result.code === "primary_term") {
+            return badRequestResponse(
+              c,
+              "glossary_primary_term_archived",
+              "The primary source term cannot be archived independently",
+            );
+          }
           return conflictResponse(
             c,
             "glossary_version_conflict",
@@ -1177,6 +1189,11 @@ export function createGlossaryConceptRoutes(
                     url: term.url !== undefined ? (term.url ?? undefined) : existing?.url,
                     lemma: term.lemma !== undefined ? (term.lemma ?? undefined) : existing?.lemma,
                     forbidden: term.forbidden ?? existing?.forbidden ?? false,
+                    reviewStatus: existing
+                      ? undefined
+                      : isGlossaryReviewAllowed(c.var.auth.membership.role)
+                        ? "approved"
+                        : "proposed",
                   };
                 }),
         } satisfies GlossaryConcept;

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -542,9 +542,15 @@ export function createGlossaryConceptRoutes(
         try {
           created = await product.createConcept({
             ...payload,
-            reviewStatus:
-              payload.reviewStatus ??
-              (isGlossaryReviewAllowed(c.var.auth.membership.role) ? "approved" : "proposed"),
+            terms: payload.terms?.map((term) => ({
+              ...term,
+              reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
+                ? term.reviewStatus
+                : "proposed",
+            })),
+            reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
+              ? (payload.reviewStatus ?? "approved")
+              : "proposed",
           });
         } catch (error) {
           const response = glossaryValidationErrorResponse(c, error);
@@ -1162,19 +1168,15 @@ export function createGlossaryConceptRoutes(
                     url: term.url !== undefined ? (term.url ?? undefined) : existing?.url,
                     lemma: term.lemma !== undefined ? (term.lemma ?? undefined) : existing?.lemma,
                     forbidden: term.forbidden ?? existing?.forbidden ?? false,
-                    reviewStatus:
-                      term.reviewStatus ??
-                      (isGlossaryReviewAllowed(c.var.auth.membership.role)
-                        ? existing?.reviewStatus
-                        : "proposed"),
+                    reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
+                      ? (term.reviewStatus ?? existing?.reviewStatus)
+                      : "proposed",
                     reviewReason: term.reviewReason ?? existing?.reviewReason,
                   };
                 }),
-          reviewStatus:
-            payload.reviewStatus ??
-            (isGlossaryReviewAllowed(c.var.auth.membership.role)
-              ? current.reviewStatus
-              : "proposed"),
+          reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
+            ? (payload.reviewStatus ?? current.reviewStatus)
+            : "proposed",
           reviewReason: payload.reviewReason ?? current.reviewReason,
         } satisfies GlossaryConcept;
         let updated;
@@ -1246,9 +1248,9 @@ export function createGlossaryConceptRoutes(
             gender: payload.gender ?? undefined,
             url: payload.url ?? undefined,
             lemma: payload.lemma ?? undefined,
-            reviewStatus:
-              payload.reviewStatus ??
-              (isGlossaryReviewAllowed(c.var.auth.membership.role) ? "approved" : "proposed"),
+            reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
+              ? (payload.reviewStatus ?? "approved")
+              : "proposed",
             reviewReason: payload.reviewReason,
           });
         } catch (error) {
@@ -1310,11 +1312,9 @@ export function createGlossaryConceptRoutes(
             url: payload.url ?? existing.url ?? "",
             lemma: payload.lemma ?? existing.lemma ?? "",
             forbidden: payload.forbidden ?? existing.forbidden ?? false,
-            reviewStatus:
-              payload.reviewStatus ??
-              (isGlossaryReviewAllowed(c.var.auth.membership.role)
-                ? existing.reviewStatus
-                : "proposed"),
+            reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
+              ? (payload.reviewStatus ?? existing.reviewStatus)
+              : "proposed",
             reviewReason: payload.reviewReason ?? existing.reviewReason,
           });
         } catch (error) {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -38,8 +38,15 @@ import { getFileStorageAdapter } from "@/lib/file-storage/get-file-storage-adapt
 import type { FileStorageAdapter } from "@/lib/file-storage/types";
 import { enqueueActivityLogEvent } from "@/lib/activity-log/activity-log-writer";
 import { getGlossaryProduct } from "@/lib/glossary/glossary-provider";
+import {
+  reviewGlossaryConcept,
+  reviewGlossaryTerm,
+  setGlossaryConceptArchived,
+  setGlossaryTermArchived,
+} from "@/lib/glossary/native-glossary-maintenance";
 import { listGlossaryConceptsPage } from "./glossary-concept-page";
 import { listGlossaryHistoryPage } from "./glossary-history-page";
+import { listGlossaryTermsPage } from "./glossary-term-page";
 import { canonicalizeLocale } from "@/lib/i18n/locales";
 import { toNativeGlossaryLocale } from "@/lib/providers/adapters/crowdin/crowdin-glossary-language";
 import {
@@ -54,6 +61,9 @@ import {
   createGlossaryConceptTermBodySchema,
   glossaryConceptPageQuerySchema,
   glossaryHistoryQuerySchema,
+  glossaryReviewBodySchema,
+  glossaryArchiveBodySchema,
+  glossaryTermPageQuerySchema,
   glossaryIdParamsSchema,
   glossaryConceptIdParamsSchema,
   glossaryConceptTermIdParamsSchema,
@@ -73,6 +83,7 @@ import {
   glossaryNotFoundResponse,
   invalidGlossaryPayloadResponse,
   isGlossaryManageAllowed,
+  isGlossaryReviewAllowed,
   nativeGlossaryConceptsOnlyResponse,
 } from "./glossary.shared";
 
@@ -135,6 +146,9 @@ function toCrowdinTermRecord(
     gender?: string | null;
     url?: string | null;
     lemma?: string | null;
+    provenance?: "manual" | "sync";
+    reviewStatus?: string;
+    reviewReason?: string | null;
     userId?: number | null;
     createdAt?: string | null;
     updatedAt?: string | null;
@@ -159,9 +173,10 @@ function toCrowdinTermRecord(
     status: localStatus(term.status),
     caseSensitive: false,
     forbidden: false,
-    provenance: "sync",
+    provenance: term.provenance ?? "sync",
     externalKey: String(term.id),
-    reviewStatus: "draft",
+    reviewStatus: term.reviewStatus ?? "approved",
+    reviewReason: term.reviewReason ?? null,
     externalUserId: term.userId == null ? null : String(term.userId),
     externalCreatedAt: createdAt,
     externalUpdatedAt: updatedAt,
@@ -193,6 +208,8 @@ function toCrowdinConceptRecord(
     }>;
     externalCreatedAt?: string | null;
     externalUpdatedAt?: string | null;
+    reviewStatus?: string;
+    reviewReason?: string | null;
     terms: Array<{
       id?: number | string;
       locale: string;
@@ -237,6 +254,8 @@ function toCrowdinConceptRecord(
     })),
     externalCreatedAt: createdAt,
     externalUpdatedAt: updatedAt,
+    reviewStatus: value.reviewStatus ?? "approved",
+    reviewReason: value.reviewReason ?? null,
     createdAt,
     updatedAt,
     terms: value.terms.map((term) => toCrowdinTermRecord(glossary, conceptId, term)),
@@ -521,7 +540,12 @@ export function createGlossaryConceptRoutes(
         if (!product) return externalTmsGlossaryImmutableResponse(c);
         let created;
         try {
-          created = await product.createConcept(payload);
+          created = await product.createConcept({
+            ...payload,
+            reviewStatus:
+              payload.reviewStatus ??
+              (isGlossaryReviewAllowed(c.var.auth.membership.role) ? "approved" : "proposed"),
+          });
         } catch (error) {
           const response = glossaryValidationErrorResponse(c, error);
           if (response) return response;
@@ -902,6 +926,168 @@ export function createGlossaryConceptRoutes(
         );
       },
     )
+    .post(
+      "/:conceptId/review",
+      validator("param", validateConceptParams),
+      validator("json", (value, c) => validateJson(glossaryReviewBodySchema, value, c)),
+      async (c) => {
+        const { glossaryId, conceptId } = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
+        if (!glossary) return glossaryNotFoundResponse(c);
+        if (glossary.source !== "native") return externalTmsGlossaryImmutableResponse(c);
+        if (!isGlossaryReviewAllowed(c.var.auth.membership.role)) return forbiddenResponse(c);
+        const product = getGlossaryProduct({ auth: c.var.auth, glossary });
+        if (!product) return externalTmsGlossaryImmutableResponse(c);
+        const result = await reviewGlossaryConcept({
+          glossaryId,
+          conceptId,
+          actorUserId: c.var.auth.user.localUserId,
+          ...payload,
+        });
+        if (!result.ok) {
+          if (result.code === "not_found") return glossaryNotFoundResponse(c);
+          if (result.code === "version_conflict") {
+            return conflictResponse(
+              c,
+              "glossary_version_conflict",
+              "The concept changed; reload and try again",
+              {
+                currentVersion: result.currentVersion,
+              },
+            );
+          }
+          return badRequestResponse(
+            c,
+            `glossary_${result.code}`,
+            "The review decision is not valid",
+          );
+        }
+        const concept = await product.getConcept(conceptId);
+        return concept
+          ? c.json({ concept: toGlossaryConceptRecord(glossary, concept) }, 200)
+          : glossaryNotFoundResponse(c);
+      },
+    )
+    .post(
+      "/:conceptId/archive",
+      validator("param", validateConceptParams),
+      validator("json", (value, c) => validateJson(glossaryArchiveBodySchema, value, c)),
+      async (c) => {
+        const { glossaryId, conceptId } = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
+        if (!glossary) return glossaryNotFoundResponse(c);
+        if (glossary.source !== "native") return externalTmsGlossaryImmutableResponse(c);
+        if (!isGlossaryReviewAllowed(c.var.auth.membership.role)) return forbiddenResponse(c);
+        const product = getGlossaryProduct({ auth: c.var.auth, glossary });
+        if (!product) return externalTmsGlossaryImmutableResponse(c);
+        const result = await setGlossaryConceptArchived({
+          glossaryId,
+          conceptId,
+          actorUserId: c.var.auth.user.localUserId,
+          ...payload,
+        });
+        if (!result.ok) {
+          if (result.code === "not_found") return glossaryNotFoundResponse(c);
+          return conflictResponse(
+            c,
+            "glossary_version_conflict",
+            "The concept changed; reload and try again",
+            {
+              currentVersion: result.currentVersion,
+            },
+          );
+        }
+        const concept = await product.getConcept(conceptId);
+        return concept
+          ? c.json({ concept: toGlossaryConceptRecord(glossary, concept) }, 200)
+          : glossaryNotFoundResponse(c);
+      },
+    )
+    .post(
+      "/:conceptId/terms/:termId/review",
+      validator("param", validateConceptTermParams),
+      validator("json", (value, c) => validateJson(glossaryReviewBodySchema, value, c)),
+      async (c) => {
+        const { glossaryId, conceptId, termId } = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
+        if (!glossary) return glossaryNotFoundResponse(c);
+        if (glossary.source !== "native") return externalTmsGlossaryImmutableResponse(c);
+        if (!isGlossaryReviewAllowed(c.var.auth.membership.role)) return forbiddenResponse(c);
+        const product = getGlossaryProduct({ auth: c.var.auth, glossary });
+        if (!product) return externalTmsGlossaryImmutableResponse(c);
+        const result = await reviewGlossaryTerm({
+          glossaryId,
+          conceptId,
+          termId,
+          actorUserId: c.var.auth.user.localUserId,
+          ...payload,
+        });
+        if (!result.ok) {
+          if (result.code === "not_found") return glossaryNotFoundResponse(c);
+          if (result.code === "version_conflict") {
+            return conflictResponse(
+              c,
+              "glossary_version_conflict",
+              "The term changed; reload and try again",
+              {
+                currentVersion: result.currentVersion,
+              },
+            );
+          }
+          return badRequestResponse(
+            c,
+            `glossary_${result.code}`,
+            "The review decision is not valid",
+          );
+        }
+        const concept = await product.getConcept(conceptId);
+        const term = concept?.terms.find((candidate) => String(candidate.id) === termId);
+        return term
+          ? c.json({ term: toGlossaryTermRecord(glossary, conceptId, term) }, 200)
+          : glossaryNotFoundResponse(c);
+      },
+    )
+    .post(
+      "/:conceptId/terms/:termId/archive",
+      validator("param", validateConceptTermParams),
+      validator("json", (value, c) => validateJson(glossaryArchiveBodySchema, value, c)),
+      async (c) => {
+        const { glossaryId, conceptId, termId } = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
+        if (!glossary) return glossaryNotFoundResponse(c);
+        if (glossary.source !== "native") return externalTmsGlossaryImmutableResponse(c);
+        if (!isGlossaryReviewAllowed(c.var.auth.membership.role)) return forbiddenResponse(c);
+        const product = getGlossaryProduct({ auth: c.var.auth, glossary });
+        if (!product) return externalTmsGlossaryImmutableResponse(c);
+        const result = await setGlossaryTermArchived({
+          glossaryId,
+          conceptId,
+          termId,
+          actorUserId: c.var.auth.user.localUserId,
+          ...payload,
+        });
+        if (!result.ok) {
+          if (result.code === "not_found") return glossaryNotFoundResponse(c);
+          return conflictResponse(
+            c,
+            "glossary_version_conflict",
+            "The term changed; reload and try again",
+            {
+              currentVersion: result.currentVersion,
+            },
+          );
+        }
+        const concept = await product.getConcept(conceptId);
+        const term = concept?.terms.find((candidate) => String(candidate.id) === termId);
+        return term
+          ? c.json({ term: toGlossaryTermRecord(glossary, conceptId, term) }, 200)
+          : glossaryNotFoundResponse(c);
+      },
+    )
     .get("/:conceptId", validator("param", validateConceptParams), async (c) => {
       const { glossaryId, conceptId } = c.req.valid("param");
       const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
@@ -912,6 +1098,28 @@ export function createGlossaryConceptRoutes(
       if (!concept) return glossaryNotFoundResponse(c);
       return c.json({ concept: toGlossaryConceptRecord(glossary, concept) }, 200);
     })
+    .get(
+      "/:conceptId/terms/page",
+      validator("param", validateConceptParams),
+      validator("query", (value, c) => {
+        const parsed = glossaryTermPageQuerySchema.safeParse(value);
+        return parsed.success ? parsed.data : invalidGlossaryPayloadResponse(c);
+      }),
+      async (c) => {
+        const { glossaryId, conceptId } = c.req.valid("param");
+        const query = c.req.valid("query");
+        const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
+        if (!glossary) return glossaryNotFoundResponse(c);
+        if (glossary.source !== "native") return nativeGlossaryConceptsOnlyResponse(c);
+        const concept = await getGlossaryProduct({ auth: c.var.auth, glossary })?.getConcept(
+          conceptId,
+        );
+        if (!concept) return glossaryNotFoundResponse(c);
+        const page = await listGlossaryTermsPage(glossaryId, query, conceptId);
+        if ("code" in page) return badRequestResponse(c, page.code, page.message);
+        return c.json(page, 200);
+      },
+    )
     .patch(
       "/:conceptId",
       validator("param", validateConceptParams),
@@ -954,8 +1162,20 @@ export function createGlossaryConceptRoutes(
                     url: term.url !== undefined ? (term.url ?? undefined) : existing?.url,
                     lemma: term.lemma !== undefined ? (term.lemma ?? undefined) : existing?.lemma,
                     forbidden: term.forbidden ?? existing?.forbidden ?? false,
+                    reviewStatus:
+                      term.reviewStatus ??
+                      (isGlossaryReviewAllowed(c.var.auth.membership.role)
+                        ? existing?.reviewStatus
+                        : "proposed"),
+                    reviewReason: term.reviewReason ?? existing?.reviewReason,
                   };
                 }),
+          reviewStatus:
+            payload.reviewStatus ??
+            (isGlossaryReviewAllowed(c.var.auth.membership.role)
+              ? current.reviewStatus
+              : "proposed"),
+          reviewReason: payload.reviewReason ?? current.reviewReason,
         } satisfies GlossaryConcept;
         let updated;
         try {
@@ -1026,6 +1246,10 @@ export function createGlossaryConceptRoutes(
             gender: payload.gender ?? undefined,
             url: payload.url ?? undefined,
             lemma: payload.lemma ?? undefined,
+            reviewStatus:
+              payload.reviewStatus ??
+              (isGlossaryReviewAllowed(c.var.auth.membership.role) ? "approved" : "proposed"),
+            reviewReason: payload.reviewReason,
           });
         } catch (error) {
           const response = glossaryValidationErrorResponse(c, error);
@@ -1086,6 +1310,12 @@ export function createGlossaryConceptRoutes(
             url: payload.url ?? existing.url ?? "",
             lemma: payload.lemma ?? existing.lemma ?? "",
             forbidden: payload.forbidden ?? existing.forbidden ?? false,
+            reviewStatus:
+              payload.reviewStatus ??
+              (isGlossaryReviewAllowed(c.var.auth.membership.role)
+                ? existing.reviewStatus
+                : "proposed"),
+            reviewReason: payload.reviewReason ?? existing.reviewReason,
           });
         } catch (error) {
           const response = glossaryValidationErrorResponse(c, error);

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -12,6 +12,7 @@
  */
 import { Hono } from "hono";
 import { validator } from "hono/validator";
+import { and, eq } from "drizzle-orm";
 
 import { conflictResponse, badRequestResponse } from "@/api/response.schema";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
@@ -37,6 +38,7 @@ import { createStoredFile, sha256Hex } from "@/lib/file-storage/records";
 import { getFileStorageAdapter } from "@/lib/file-storage/get-file-storage-adapter";
 import type { FileStorageAdapter } from "@/lib/file-storage/types";
 import { enqueueActivityLogEvent } from "@/lib/activity-log/activity-log-writer";
+import { db, schema } from "@/lib/database/client";
 import { getGlossaryProduct } from "@/lib/glossary/glossary-provider";
 import {
   reviewGlossaryConcept,
@@ -1117,9 +1119,16 @@ export function createGlossaryConceptRoutes(
         const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
         if (!glossary) return glossaryNotFoundResponse(c);
         if (glossary.source !== "native") return nativeGlossaryConceptsOnlyResponse(c);
-        const concept = await getGlossaryProduct({ auth: c.var.auth, glossary })?.getConcept(
-          conceptId,
-        );
+        const [concept] = await db
+          .select({ id: schema.glossaryConcepts.id })
+          .from(schema.glossaryConcepts)
+          .where(
+            and(
+              eq(schema.glossaryConcepts.id, conceptId),
+              eq(schema.glossaryConcepts.glossaryId, glossaryId),
+            ),
+          )
+          .limit(1);
         if (!concept) return glossaryNotFoundResponse(c);
         const page = await listGlossaryTermsPage(glossaryId, query, conceptId);
         if ("code" in page) return badRequestResponse(c, page.code, page.message);
@@ -1168,16 +1177,8 @@ export function createGlossaryConceptRoutes(
                     url: term.url !== undefined ? (term.url ?? undefined) : existing?.url,
                     lemma: term.lemma !== undefined ? (term.lemma ?? undefined) : existing?.lemma,
                     forbidden: term.forbidden ?? existing?.forbidden ?? false,
-                    reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
-                      ? (term.reviewStatus ?? existing?.reviewStatus)
-                      : "proposed",
-                    reviewReason: term.reviewReason ?? existing?.reviewReason,
                   };
                 }),
-          reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
-            ? (payload.reviewStatus ?? current.reviewStatus)
-            : "proposed",
-          reviewReason: payload.reviewReason ?? current.reviewReason,
         } satisfies GlossaryConcept;
         let updated;
         try {
@@ -1312,10 +1313,6 @@ export function createGlossaryConceptRoutes(
             url: payload.url ?? existing.url ?? "",
             lemma: payload.lemma ?? existing.lemma ?? "",
             forbidden: payload.forbidden ?? existing.forbidden ?? false,
-            reviewStatus: isGlossaryReviewAllowed(c.var.auth.membership.role)
-              ? (payload.reviewStatus ?? existing.reviewStatus)
-              : "proposed",
-            reviewReason: payload.reviewReason ?? existing.reviewReason,
           });
         } catch (error) {
           const response = glossaryValidationErrorResponse(c, error);

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-term-page.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-term-page.ts
@@ -22,6 +22,7 @@ type Filters = Omit<GlossaryTermPageQuery, "cursor" | "limit">;
 type Cursor = {
   v: 1;
   glossaryId: string;
+  conceptId: string | null;
   id: string;
   sortValue: string;
   issuedAt: string;
@@ -36,21 +37,27 @@ function secret() {
   );
 }
 
-function hash(glossaryId: string, filters: Filters) {
+function hash(glossaryId: string, conceptId: string | undefined, filters: Filters) {
   return createHash("sha256")
-    .update(JSON.stringify({ glossaryId, ...filters }))
+    .update(JSON.stringify({ glossaryId, conceptId: conceptId ?? null, ...filters }))
     .digest("hex")
     .slice(0, 16);
 }
 
-function encode(glossaryId: string, filters: Filters, term: { id: string; sortValue: string }) {
+function encode(
+  glossaryId: string,
+  conceptId: string | undefined,
+  filters: Filters,
+  term: { id: string; sortValue: string },
+) {
   const payload: Cursor = {
     v: 1,
     glossaryId,
+    conceptId: conceptId ?? null,
     id: term.id,
     sortValue: term.sortValue,
     issuedAt: new Date().toISOString(),
-    filterHash: hash(glossaryId, filters),
+    filterHash: hash(glossaryId, conceptId, filters),
   };
   const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
   const signature = createHmac("sha256", `${secret()}:glossary-term-page:v1`)
@@ -62,6 +69,7 @@ function encode(glossaryId: string, filters: Filters, term: { id: string; sortVa
 function decode(
   value: string,
   glossaryId: string,
+  conceptId: string | undefined,
   filters: Filters,
 ): Cursor | { code: "invalid_cursor"; message: string } {
   const [encoded, signature] = value.split(".");
@@ -79,7 +87,8 @@ function decode(
     if (
       cursor.v !== 1 ||
       cursor.glossaryId !== glossaryId ||
-      cursor.filterHash !== hash(glossaryId, filters) ||
+      cursor.conceptId !== (conceptId ?? null) ||
+      cursor.filterHash !== hash(glossaryId, conceptId, filters) ||
       Number.isNaN(issuedAt) ||
       issuedAt > Date.now() ||
       Date.now() - issuedAt > TTL
@@ -127,7 +136,7 @@ export async function listGlossaryTermsPage(
   conceptId?: string,
 ) {
   const { cursor, limit, ...filters } = query;
-  const decoded = cursor ? decode(cursor, glossaryId, filters) : undefined;
+  const decoded = cursor ? decode(cursor, glossaryId, conceptId, filters) : undefined;
   if (decoded && "code" in decoded) return decoded;
   const column = sortColumn(filters.sort);
   const baseWhere = whereFor(glossaryId, conceptId, filters);
@@ -171,7 +180,10 @@ export async function listGlossaryTermsPage(
   return {
     terms,
     nextCursor: hasMore
-      ? encode(glossaryId, filters, { id: last!.term.id, sortValue: last!.sortValue })
+      ? encode(glossaryId, conceptId, filters, {
+          id: last!.term.id,
+          sortValue: last!.sortValue,
+        })
       : null,
     total: Number(totalRows[0]?.value ?? 0),
     pagination: { limit, returned: terms.length, hasMore },

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-term-page.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-term-page.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+import { and, asc, count, desc, eq, ilike, or, sql, type SQL } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database/client";
+import { env } from "@/lib/env";
+import type { GlossaryTermPageQuery } from "./glossary.schema";
+
+type Filters = Omit<GlossaryTermPageQuery, "cursor" | "limit">;
+type Cursor = {
+  v: 1;
+  glossaryId: string;
+  id: string;
+  sortValue: string;
+  issuedAt: string;
+  filterHash: string;
+};
+
+const TTL = 24 * 60 * 60 * 1000;
+
+function secret() {
+  return (
+    env.WORKOS_COOKIE_PASSWORD ?? env.PROVIDER_CREDENTIALS_MASTER_KEY ?? "glossary-page-dev-secret"
+  );
+}
+
+function hash(glossaryId: string, filters: Filters) {
+  return createHash("sha256")
+    .update(JSON.stringify({ glossaryId, ...filters }))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function encode(glossaryId: string, filters: Filters, term: { id: string; sortValue: string }) {
+  const payload: Cursor = {
+    v: 1,
+    glossaryId,
+    id: term.id,
+    sortValue: term.sortValue,
+    issuedAt: new Date().toISOString(),
+    filterHash: hash(glossaryId, filters),
+  };
+  const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  const signature = createHmac("sha256", `${secret()}:glossary-term-page:v1`)
+    .update(encoded)
+    .digest("base64url");
+  return `${encoded}.${signature}`;
+}
+
+function decode(
+  value: string,
+  glossaryId: string,
+  filters: Filters,
+): Cursor | { code: "invalid_cursor"; message: string } {
+  const [encoded, signature] = value.split(".");
+  if (!encoded || !signature) return { code: "invalid_cursor", message: "Cursor is invalid" };
+  const expected = createHmac("sha256", `${secret()}:glossary-term-page:v1`)
+    .update(encoded)
+    .digest("base64url");
+  const left = Buffer.from(signature);
+  const right = Buffer.from(expected);
+  if (left.length !== right.length || !timingSafeEqual(left, right))
+    return { code: "invalid_cursor", message: "Cursor is invalid" };
+  try {
+    const cursor = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as Cursor;
+    const issuedAt = Date.parse(cursor.issuedAt);
+    if (
+      cursor.v !== 1 ||
+      cursor.glossaryId !== glossaryId ||
+      cursor.filterHash !== hash(glossaryId, filters) ||
+      Number.isNaN(issuedAt) ||
+      issuedAt > Date.now() ||
+      Date.now() - issuedAt > TTL
+    ) {
+      return { code: "invalid_cursor", message: "Cursor is invalid" };
+    }
+    return cursor;
+  } catch {
+    return { code: "invalid_cursor", message: "Cursor is invalid" };
+  }
+}
+
+function sortColumn(sort: Filters["sort"]) {
+  if (sort === "created_at") return schema.glossaryTerms.createdAt;
+  if (sort === "term") return schema.glossaryTerms.term;
+  return schema.glossaryTerms.updatedAt;
+}
+
+function whereFor(glossaryId: string, conceptId: string | undefined, filters: Filters): SQL {
+  const conditions: SQL[] = [eq(schema.glossaryTerms.glossaryId, glossaryId)];
+  if (conceptId) conditions.push(eq(schema.glossaryTerms.conceptId, conceptId));
+  if (!filters.includeArchived) conditions.push(sql`${schema.glossaryTerms.archivedAt} is null`);
+  if (filters.locale) conditions.push(eq(schema.glossaryTerms.locale, filters.locale));
+  if (filters.reviewStatus)
+    conditions.push(eq(schema.glossaryTerms.reviewStatus, filters.reviewStatus));
+  if (filters.search) {
+    const pattern = `%${filters.search}%`;
+    conditions.push(
+      or(
+        ilike(schema.glossaryTerms.term, pattern),
+        ilike(schema.glossaryTerms.sourceTerm, pattern),
+        ilike(schema.glossaryTerms.targetTerm, pattern),
+        ilike(schema.glossaryTerms.description, pattern),
+        ilike(schema.glossaryTerms.note, pattern),
+        sql`${schema.glossaryTerms.metadata}::text ilike ${pattern}`,
+      )!,
+    );
+  }
+  return and(...conditions)!;
+}
+
+export async function listGlossaryTermsPage(
+  glossaryId: string,
+  query: GlossaryTermPageQuery,
+  conceptId?: string,
+) {
+  const { cursor, limit, ...filters } = query;
+  const decoded = cursor ? decode(cursor, glossaryId, filters) : undefined;
+  if (decoded && "code" in decoded) return decoded;
+  const column = sortColumn(filters.sort);
+  const baseWhere = whereFor(glossaryId, conceptId, filters);
+  const cursorWhere = decoded
+    ? filters.sortDir === "asc"
+      ? sql`(${column} > ${decoded.sortValue} or (${column} = ${decoded.sortValue} and ${schema.glossaryTerms.id} > ${decoded.id}))`
+      : sql`(${column} < ${decoded.sortValue} or (${column} = ${decoded.sortValue} and ${schema.glossaryTerms.id} < ${decoded.id}))`
+    : undefined;
+  const where = cursorWhere ? and(baseWhere, cursorWhere)! : baseWhere;
+  const orderBy =
+    filters.sortDir === "asc"
+      ? [asc(column), asc(schema.glossaryTerms.id)]
+      : [desc(column), desc(schema.glossaryTerms.id)];
+  const [rows, totalRows] = await Promise.all([
+    db
+      .select({ term: schema.glossaryTerms, sortValue: sql<string>`${column}` })
+      .from(schema.glossaryTerms)
+      .where(where)
+      .orderBy(...orderBy)
+      .limit(limit + 1),
+    db.select({ value: count() }).from(schema.glossaryTerms).where(baseWhere),
+  ]);
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const terms = page.map(({ term }) => ({
+    id: term.id,
+    glossaryId: term.glossaryId,
+    conceptId: term.conceptId,
+    locale: term.locale,
+    term: term.term,
+    description: term.description,
+    note: term.note,
+    reviewStatus: term.reviewStatus as "proposed" | "approved" | "rejected" | "superseded",
+    provenance: term.provenance,
+    version: term.version,
+    archivedAt: term.archivedAt?.toISOString() ?? null,
+    createdAt: term.createdAt.toISOString(),
+    updatedAt: term.updatedAt.toISOString(),
+  }));
+  const last = page.at(-1);
+  return {
+    terms,
+    nextCursor: hasMore
+      ? encode(glossaryId, filters, { id: last!.term.id, sortValue: last!.sortValue })
+      : null,
+    total: Number(totalRows[0]?.value ?? 0),
+    pagination: { limit, returned: terms.length, hasMore },
+  };
+}

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-term-page.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-term-page.ts
@@ -12,7 +12,7 @@
  */
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 
-import { and, asc, count, desc, eq, ilike, or, sql, type SQL } from "drizzle-orm";
+import { and, asc, count, desc, eq, ilike, inArray, or, sql, type SQL } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database/client";
 import { env } from "@/lib/env";
@@ -112,6 +112,9 @@ function whereFor(glossaryId: string, conceptId: string | undefined, filters: Fi
   if (conceptId) conditions.push(eq(schema.glossaryTerms.conceptId, conceptId));
   if (!filters.includeArchived) conditions.push(sql`${schema.glossaryTerms.archivedAt} is null`);
   if (filters.locale) conditions.push(eq(schema.glossaryTerms.locale, filters.locale));
+  if (filters.locales?.length) {
+    conditions.push(inArray(schema.glossaryTerms.locale, filters.locales));
+  }
   if (filters.reviewStatus)
     conditions.push(eq(schema.glossaryTerms.reviewStatus, filters.reviewStatus));
   if (filters.search) {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -71,7 +71,7 @@ export const glossaryReviewDecisionSchema = z.enum([
 export const glossaryReviewBodySchema = z.object({
   decision: glossaryReviewDecisionSchema,
   reason: z.string().trim().max(10_000).nullable().optional(),
-  expectedVersion: z.number().int().positive().optional(),
+  expectedVersion: z.number().int().positive(),
 });
 
 export const glossaryArchiveBodySchema = z.object({
@@ -109,6 +109,7 @@ export const glossaryTermPageQuerySchema = z.object({
   cursor: z.string().trim().max(2_000).optional(),
   search: z.string().trim().max(200).optional(),
   locale: localeInputSchema.optional(),
+  locales: z.array(localeInputSchema).max(100).optional(),
   reviewStatus: glossaryReviewStatusSchema.optional(),
   includeArchived: queryBooleanSchema.default(false),
   sort: z.enum(["created_at", "updated_at", "term"]).default("updated_at"),
@@ -313,6 +314,7 @@ export const glossaryRecordSchema = z.object({
   lastSyncErrorMessage: z.string().nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  version: z.number().int().positive().optional(),
 });
 
 export const glossaryConceptTermRecordSchema = z.object({
@@ -371,6 +373,7 @@ export const glossaryConceptRecordSchema = z.object({
   externalUpdatedAt: z.string().datetime().nullable().optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  version: z.number().int().positive().optional(),
   terms: z.array(glossaryConceptTermRecordSchema),
   reviewStatus: glossaryReviewStatusSchema.optional(),
   reviewReason: z.string().nullable().optional(),

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -248,8 +248,6 @@ export const updateGlossaryConceptBodySchema = z
     note: z.string().max(10_000).optional(),
     figure: z.string().url().max(2_000).optional().or(z.literal("")),
     url: z.string().url().max(2_000).optional().or(z.literal("")),
-    reviewStatus: glossaryReviewStatusSchema.optional(),
-    reviewReason: z.string().max(10_000).nullable().optional(),
     terms: z.array(upsertGlossaryConceptTermBodySchema).max(1_000).optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
@@ -270,8 +268,6 @@ export const updateGlossaryConceptTermBodySchema = z
     description: z.string().max(10_000).optional(),
     caseSensitive: z.boolean().optional(),
     forbidden: z.boolean().optional(),
-    reviewStatus: glossaryReviewStatusSchema.optional(),
-    reviewReason: z.string().max(10_000).nullable().optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
     message: "at least one field must be provided",

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -61,6 +61,24 @@ export const glossaryReviewStatusSchema = z.enum([
   "superseded",
 ]);
 
+export const glossaryReviewDecisionSchema = z.enum([
+  "proposed",
+  "approved",
+  "rejected",
+  "superseded",
+]);
+
+export const glossaryReviewBodySchema = z.object({
+  decision: glossaryReviewDecisionSchema,
+  reason: z.string().trim().max(10_000).nullable().optional(),
+  expectedVersion: z.number().int().positive().optional(),
+});
+
+export const glossaryArchiveBodySchema = z.object({
+  archived: z.boolean(),
+  expectedVersion: z.number().int().positive().optional(),
+});
+
 const queryBooleanSchema = z
   .union([z.boolean(), z.enum(["true", "false"])])
   .transform((value) => value === true || value === "true");
@@ -83,6 +101,17 @@ export const glossaryConceptPageQuerySchema = z.object({
   modifiedTo: z.string().datetime().optional(),
   includeArchived: queryBooleanSchema.default(false),
   sort: z.enum(["created_at", "updated_at", "primary_term"]).default("updated_at"),
+  sortDir: z.enum(["asc", "desc"]).default("desc"),
+});
+
+export const glossaryTermPageQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  cursor: z.string().trim().max(2_000).optional(),
+  search: z.string().trim().max(200).optional(),
+  locale: localeInputSchema.optional(),
+  reviewStatus: glossaryReviewStatusSchema.optional(),
+  includeArchived: queryBooleanSchema.default(false),
+  sort: z.enum(["created_at", "updated_at", "term"]).default("updated_at"),
   sortDir: z.enum(["asc", "desc"]).default("desc"),
 });
 
@@ -175,6 +204,8 @@ export const createGlossaryConceptTermBodySchema = z.object({
   description: z.string().max(10_000).optional(),
   caseSensitive: z.boolean().optional().default(false),
   forbidden: z.boolean().optional().default(false),
+  reviewStatus: glossaryReviewStatusSchema.optional(),
+  reviewReason: z.string().max(10_000).nullable().optional(),
 });
 
 export const createGlossaryConceptBodySchema = z.object({
@@ -186,6 +217,8 @@ export const createGlossaryConceptBodySchema = z.object({
   figure: z.string().url().max(2_000).optional().or(z.literal("")),
   url: z.string().url().max(2_000).optional().or(z.literal("")),
   terms: z.array(createGlossaryConceptTermBodySchema).max(1_000).optional(),
+  reviewStatus: glossaryReviewStatusSchema.optional(),
+  reviewReason: z.string().max(10_000).nullable().optional(),
 });
 
 export const upsertGlossaryConceptTermBodySchema = z.object({
@@ -202,6 +235,8 @@ export const upsertGlossaryConceptTermBodySchema = z.object({
   description: z.string().max(10_000).optional(),
   caseSensitive: z.boolean().optional(),
   forbidden: z.boolean().optional(),
+  reviewStatus: glossaryReviewStatusSchema.optional(),
+  reviewReason: z.string().max(10_000).nullable().optional(),
 });
 
 export const updateGlossaryConceptBodySchema = z
@@ -213,6 +248,8 @@ export const updateGlossaryConceptBodySchema = z
     note: z.string().max(10_000).optional(),
     figure: z.string().url().max(2_000).optional().or(z.literal("")),
     url: z.string().url().max(2_000).optional().or(z.literal("")),
+    reviewStatus: glossaryReviewStatusSchema.optional(),
+    reviewReason: z.string().max(10_000).nullable().optional(),
     terms: z.array(upsertGlossaryConceptTermBodySchema).max(1_000).optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
@@ -233,6 +270,8 @@ export const updateGlossaryConceptTermBodySchema = z
     description: z.string().max(10_000).optional(),
     caseSensitive: z.boolean().optional(),
     forbidden: z.boolean().optional(),
+    reviewStatus: glossaryReviewStatusSchema.optional(),
+    reviewReason: z.string().max(10_000).nullable().optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
     message: "at least one field must be provided",
@@ -300,6 +339,7 @@ export const glossaryConceptTermRecordSchema = z.object({
   provenance: z.string(),
   externalKey: z.string().nullable().optional(),
   reviewStatus: z.string(),
+  reviewReason: z.string().nullable().optional(),
   externalUserId: z.string().nullable().optional(),
   externalCreatedAt: z.string().datetime().nullable().optional(),
   externalUpdatedAt: z.string().datetime().nullable().optional(),
@@ -336,6 +376,8 @@ export const glossaryConceptRecordSchema = z.object({
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   terms: z.array(glossaryConceptTermRecordSchema),
+  reviewStatus: glossaryReviewStatusSchema.optional(),
+  reviewReason: z.string().nullable().optional(),
 });
 
 export const glossaryProjectRecordSchema = z.object({
@@ -395,6 +437,33 @@ export const glossaryConceptPageResponseSchema = z.object({
   }),
 });
 
+export const glossaryTermSummarySchema = z.object({
+  id: z.string().uuid(),
+  glossaryId: z.string().uuid(),
+  conceptId: z.string().uuid().nullable(),
+  locale: z.string().nullable(),
+  term: z.string().nullable(),
+  description: z.string(),
+  note: z.string(),
+  reviewStatus: glossaryReviewStatusSchema,
+  provenance: z.string(),
+  version: z.number().int().positive(),
+  archivedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const glossaryTermPageResponseSchema = z.object({
+  terms: z.array(glossaryTermSummarySchema),
+  nextCursor: z.string().nullable(),
+  total: z.number().int().nonnegative(),
+  pagination: z.object({
+    limit: z.number().int().positive(),
+    returned: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
+  }),
+});
+
 export const glossaryHistoryChangeSchema = z.object({
   field: z.string(),
   before: z.unknown(),
@@ -443,6 +512,7 @@ export type GlossaryConceptTermIdParams = z.infer<typeof glossaryConceptTermIdPa
 export type GlossaryProjectParams = z.infer<typeof glossaryProjectParamsSchema>;
 export type ListGlossaryQuery = z.infer<typeof listGlossaryQuerySchema>;
 export type GlossaryConceptPageQuery = z.infer<typeof glossaryConceptPageQuerySchema>;
+export type GlossaryTermPageQuery = z.infer<typeof glossaryTermPageQuerySchema>;
 export type GlossaryHistoryQuery = z.infer<typeof glossaryHistoryQuerySchema>;
 export type CreateGlossaryBody = z.infer<typeof createGlossaryBodySchema>;
 export type UpdateGlossaryBody = z.infer<typeof updateGlossaryBodySchema>;

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.shared.ts
@@ -199,6 +199,10 @@ export function isGlossaryManageAllowed(role: ApiAuthContext["membership"]["role
   return hasCapability(role, "glossaries:write");
 }
 
+export function isGlossaryReviewAllowed(role: ApiAuthContext["membership"]["role"]) {
+  return hasCapability(role, "reviews:approve");
+}
+
 export function isGlossaryContributorRole(role: ApiAuthContext["membership"]["role"]) {
   return role === "translator" || isGlossaryManageAllowed(role);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-concept-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-concept-detail.tsx
@@ -305,6 +305,8 @@ export function GlossaryConceptDetail({
   const [expandedTermIds, setExpandedTermIds] = useState<Set<string>>(new Set());
   const [expandedCreatingTermIds, setExpandedCreatingTermIds] = useState<Set<string>>(new Set());
   const [termToDeleteId, setTermToDeleteId] = useState<string | null>(null);
+  const [termCursor, setTermCursor] = useState<string | undefined>();
+  const [, setTermCursorStack] = useState<string[]>([]);
   const [conceptDraft, setConceptDraft] = useState<ConceptDraft>(emptyConceptDraft);
   const { glossaryQuery, glossary, canContribute, isConceptGlossary, sourceLanguage } = useGlossary(
     {
@@ -330,6 +332,29 @@ export function GlossaryConceptDetail({
       return (await response.json()).concept as GlossaryConceptRecord;
     },
   });
+  const termPageQuery = useQuery({
+    queryKey: ["glossary-concept-terms-page", organizationSlug, glossaryId, conceptId, termCursor],
+    enabled: Boolean(isConceptGlossary) && !isCreatingConcept,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].concepts[":conceptId"].terms.page.$get({
+        param: { organizationSlug, glossaryId, conceptId },
+        query: {
+          limit: "100",
+          sort: "term",
+          sortDir: "asc",
+          includeArchived: "false",
+          ...(termCursor ? { cursor: termCursor } : {}),
+        },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, intl.formatMessage(messages.loadConceptsFailed));
+      }
+      return response.json();
+    },
+    placeholderData: (previous) => previous,
+  });
   const selectedConcept = conceptQuery.data ?? null;
   useEffect(() => {
     if (conceptId === "new") {
@@ -345,6 +370,8 @@ export function GlossaryConceptDetail({
       setNewTermDraft(emptyTermDraft);
       setExpandedTermIds(new Set());
       setExpandedCreatingTermIds(new Set());
+      setTermCursor(undefined);
+      setTermCursorStack([]);
     }
   }, [conceptId, sourceLanguage.locale]);
 
@@ -572,7 +599,13 @@ export function GlossaryConceptDetail({
 
   const normalizedLanguageFilter = languageFilter.trim().toLowerCase();
   const availableTermLocales = availableConceptTermLocales();
-  const unsortedTermGroups = (selectedConcept?.terms ?? [])
+  const pagedTermIds = new Set(
+    (termPageQuery.isSuccess ? termPageQuery.data.terms : (selectedConcept?.terms ?? [])).map(
+      (term) => term.id,
+    ),
+  );
+  const displayedTerms = selectedConcept?.terms.filter((term) => pagedTermIds.has(term.id)) ?? [];
+  const unsortedTermGroups = displayedTerms
     .filter((term) => !deletedTermIds.has(term.id))
     .filter(
       (term) =>
@@ -598,6 +631,19 @@ export function GlossaryConceptDetail({
     termGroupsWithPendingLocale,
     sourceLanguage.locale,
   );
+  const goToNextTermPage = () => {
+    const nextCursor = termPageQuery.data?.nextCursor;
+    if (!nextCursor) return;
+    setTermCursorStack((current) => [...current, termCursor ?? ""]);
+    setTermCursor(nextCursor);
+  };
+  const goToPreviousTermPage = () => {
+    setTermCursorStack((current) => {
+      const next = [...current];
+      setTermCursor(next.pop() || undefined);
+      return next;
+    });
+  };
   const creatingTermGroups = sortConceptDetailTermGroups(
     creatingTermDrafts
       .filter(
@@ -1674,6 +1720,33 @@ export function GlossaryConceptDetail({
             </div>
           </div>
         </div>
+        {!isCreatingConcept &&
+        termPageQuery.isSuccess &&
+        (termPageQuery.data.pagination.hasMore || termCursor) ? (
+          <div className="flex items-center justify-between gap-2 border-t border-border pt-3">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!termCursor || termPageQuery.isFetching}
+              onClick={goToPreviousTermPage}
+            >
+              Previous terms
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {termPageQuery.data.pagination.returned} of {termPageQuery.data.total} terms
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!termPageQuery.data.nextCursor || termPageQuery.isFetching}
+              onClick={goToNextTermPage}
+            >
+              Next terms
+            </Button>
+          </div>
+        ) : null}
         {canContribute ? (
           <div className="flex w-full flex-wrap items-center justify-between gap-2 border-t border-border pt-4">
             <Button

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-concept-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-concept-detail.tsx
@@ -296,6 +296,14 @@ export function GlossaryConceptDetail({
   const glossaryHref = `/org/${organizationSlug}/glossaries/${glossaryId}`;
   const conceptHref = (id: string) => `${glossaryHref}/concepts/${id}`;
   const [languageFilter, setLanguageFilter] = useState("");
+  const normalizedLanguageFilter = languageFilter.trim().toLowerCase();
+  const matchingTermLocales = normalizedLanguageFilter
+    ? availableConceptTermLocales().filter(
+        (locale) =>
+          getLocaleLabel(locale).toLowerCase().includes(normalizedLanguageFilter) ||
+          locale.toLowerCase().includes(normalizedLanguageFilter),
+      )
+    : undefined;
   const [localePickerOpen, setLocalePickerOpen] = useState(false);
   const [newTermLocale, setNewTermLocale] = useState<string | null>(null);
   const [newTermDraft, setNewTermDraft] = useState<TermDraft>(emptyTermDraft);
@@ -333,7 +341,14 @@ export function GlossaryConceptDetail({
     },
   });
   const termPageQuery = useQuery({
-    queryKey: ["glossary-concept-terms-page", organizationSlug, glossaryId, conceptId, termCursor],
+    queryKey: [
+      "glossary-concept-terms-page",
+      organizationSlug,
+      glossaryId,
+      conceptId,
+      termCursor,
+      matchingTermLocales,
+    ],
     enabled: Boolean(isConceptGlossary) && !isCreatingConcept,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
@@ -345,6 +360,7 @@ export function GlossaryConceptDetail({
           sort: "term",
           sortDir: "asc",
           includeArchived: "false",
+          ...(matchingTermLocales ? { locales: matchingTermLocales } : {}),
           ...(termCursor ? { cursor: termCursor } : {}),
         },
       });
@@ -459,9 +475,14 @@ export function GlossaryConceptDetail({
     ]);
 
   const invalidateConceptDetail = () =>
-    queryClient.invalidateQueries({
-      queryKey: ["glossary-concept", organizationSlug, glossaryId, conceptId],
-    });
+    Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ["glossary-concept", organizationSlug, glossaryId, conceptId],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ["glossary-concept-terms-page", organizationSlug, glossaryId, conceptId],
+      }),
+    ]);
   const saveConcept = useMutation({
     mutationFn: async (draft: ConceptDraft) => {
       let concept: GlossaryConceptRecord;
@@ -597,7 +618,6 @@ export function GlossaryConceptDetail({
     onError: (error) => toast.error(error.message),
   });
 
-  const normalizedLanguageFilter = languageFilter.trim().toLowerCase();
   const availableTermLocales = availableConceptTermLocales();
   const pagedTermIds = new Set(
     (termPageQuery.isSuccess ? termPageQuery.data.terms : (selectedConcept?.terms ?? [])).map(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-concept-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-concept-detail.tsx
@@ -392,6 +392,11 @@ export function GlossaryConceptDetail({
   }, [conceptId, sourceLanguage.locale]);
 
   useEffect(() => {
+    setTermCursor(undefined);
+    setTermCursorStack([]);
+  }, [normalizedLanguageFilter]);
+
+  useEffect(() => {
     if (selectedConcept) {
       setConceptDraft(conceptDraftFromRecord(selectedConcept));
       setTermDrafts(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/native-glossary-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/native-glossary-detail.tsx
@@ -825,6 +825,12 @@ export function NativeGlossaryDetail({
                     <td className="px-3 py-3">
                       <div className="flex flex-wrap items-center gap-2 font-medium">
                         {concept.primaryTerm}
+                        <Badge
+                          variant={concept.reviewStatus === "approved" ? "secondary" : "outline"}
+                          className="text-[10px] font-normal uppercase tracking-wide"
+                        >
+                          {concept.reviewStatus}
+                        </Badge>
                       </div>
                     </td>
                     <td className="max-w-xs truncate px-3 py-3 text-muted-foreground">

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
@@ -142,6 +142,9 @@ export type NativeGlossaryTermInput = {
   url?: string;
   lemma?: string;
   forbidden?: boolean;
+  reviewStatus?: "proposed" | "approved" | "rejected" | "superseded";
+  reviewReason?: string | null;
+  provenance?: "manual" | "sync";
 };
 
 export type GlossaryConceptTerm = NativeGlossaryTermInput & {
@@ -176,6 +179,8 @@ export type GlossaryConcept = {
   languageDetails?: NativeGlossaryLanguageDetails[];
   externalCreatedAt?: string | null;
   externalUpdatedAt?: string | null;
+  reviewStatus?: "proposed" | "approved" | "rejected" | "superseded";
+  reviewReason?: string | null;
   terms: GlossaryConceptTerm[];
 };
 
@@ -219,6 +224,8 @@ export type GlossaryConceptRequestTerm = {
   url?: string | null;
   lemma?: string | null;
   forbidden?: boolean;
+  reviewStatus?: "proposed" | "approved" | "rejected" | "superseded";
+  reviewReason?: string | null;
 };
 
 export type GlossaryConceptInput = {
@@ -230,6 +237,8 @@ export type GlossaryConceptInput = {
   note?: string;
   url?: string | null;
   figure?: string | null;
+  reviewStatus?: "proposed" | "approved" | "rejected" | "superseded";
+  reviewReason?: string | null;
   terms?: Array<GlossaryConceptRequestTerm | GlossaryConceptTerm>;
 };
 

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
@@ -153,6 +153,7 @@ export type GlossaryConceptTerm = NativeGlossaryTermInput & {
   userId?: number;
   createdAt?: string;
   updatedAt?: string;
+  version?: number;
 };
 
 export type NativeGlossaryLanguageDetails = {
@@ -181,6 +182,7 @@ export type GlossaryConcept = {
   externalUpdatedAt?: string | null;
   reviewStatus?: "proposed" | "approved" | "rejected" | "superseded";
   reviewReason?: string | null;
+  version?: number;
   terms: GlossaryConceptTerm[];
 };
 

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/native-glossary-import.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/native-glossary-import.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, eq, notInArray } from "drizzle-orm";
+import { and, eq, notInArray, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database/client";
 import type { GlossaryHistoryChange } from "@/lib/database/schema/glossary-history";
@@ -28,6 +28,23 @@ import {
 } from "./glossary-import-reports";
 
 const IMPORT_BATCH_SIZE = 250;
+
+function normalizeImportedReviewStatus(value: string | undefined, fallback = "approved") {
+  switch (value) {
+    case "proposed":
+    case "approved":
+    case "rejected":
+    case "superseded":
+      return value;
+    case "draft":
+    case "pending":
+    case "needs_review":
+    case "suggested":
+      return "proposed";
+    default:
+      return fallback;
+  }
+}
 type DatabaseTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type CreateGlossaryImportBackup = (input: {
   tx: DatabaseTransaction;
@@ -510,6 +527,7 @@ export async function applyNativeGlossaryImport(input: {
             : existing
               ? { updatedAt: existing.updatedAt }
               : {}),
+          ...(existing ? { version: sql`${schema.glossaryConcepts.version} + 1` } : {}),
           ...(actorUserId ? { modifiedByUserId: actorUserId } : {}),
         };
         let concept = existing;
@@ -659,7 +677,10 @@ export async function applyNativeGlossaryImport(input: {
             lemma:
               incomingTerm.lemma !== undefined ? incomingTerm.lemma : (existingTerm?.lemma ?? null),
             status: incomingTerm.status ?? existingTerm?.status ?? "draft",
-            reviewStatus: incomingTerm.reviewStatus ?? existingTerm?.reviewStatus ?? "approved",
+            reviewStatus: normalizeImportedReviewStatus(
+              incomingTerm.reviewStatus,
+              normalizeImportedReviewStatus(existingTerm?.reviewStatus),
+            ),
             caseSensitive: incomingTerm.caseSensitive ?? existingTerm?.caseSensitive ?? false,
             forbidden: incomingTerm.forbidden ?? existingTerm?.forbidden ?? false,
             provenance,
@@ -683,9 +704,7 @@ export async function applyNativeGlossaryImport(input: {
             ...(incomingTerm.url !== undefined ? { url: incomingTerm.url } : {}),
             ...(incomingTerm.lemma !== undefined ? { lemma: incomingTerm.lemma } : {}),
             ...(incomingTerm.status !== undefined ? { status: incomingTerm.status } : {}),
-            ...(incomingTerm.reviewStatus !== undefined
-              ? { reviewStatus: incomingTerm.reviewStatus }
-              : {}),
+            reviewStatus: values.reviewStatus,
             ...(incomingTerm.caseSensitive !== undefined
               ? { caseSensitive: incomingTerm.caseSensitive }
               : {}),
@@ -702,6 +721,7 @@ export async function applyNativeGlossaryImport(input: {
               : existingTerm
                 ? { updatedAt: existingTerm.updatedAt }
                 : {}),
+            ...(existingTerm ? { version: sql`${schema.glossaryTerms.version} + 1` } : {}),
             ...(actorUserId ? { modifiedByUserId: actorUserId } : {}),
           };
           if (existingTerm) {

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/native-glossary-import.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/native-glossary-import.ts
@@ -13,6 +13,7 @@
 import { and, eq, notInArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database/client";
+import type { GlossaryHistoryChange } from "@/lib/database/schema/glossary-history";
 import {
   diagnostic,
   emptyImportReportCounts,
@@ -296,6 +297,7 @@ export async function applyNativeGlossaryImport(input: {
   );
   const retainedConceptIds = new Set<string>();
   const retainedTermIds = new Set<string>();
+  const historyChanges: GlossaryHistoryChange[] = [];
   let mutated = false;
 
   let backupCleanup: (() => Promise<void>) | undefined;
@@ -307,6 +309,7 @@ export async function applyNativeGlossaryImport(input: {
       .limit(1)
       .for("update");
     if (!glossary) throw new Error("glossary_not_found");
+    const actorUserId = input.report?.createdByUserId ?? null;
     const existingConcepts = await tx
       .select()
       .from(schema.glossaryConcepts)
@@ -507,9 +510,23 @@ export async function applyNativeGlossaryImport(input: {
             : existing
               ? { updatedAt: existing.updatedAt }
               : {}),
+          ...(actorUserId ? { modifiedByUserId: actorUserId } : {}),
         };
         let concept = existing;
         if (concept) {
+          for (const field of [
+            "primaryTerm",
+            "subject",
+            "definition",
+            "translatable",
+            "note",
+          ] as const) {
+            const before = concept[field];
+            const after = conceptValues[field];
+            if (JSON.stringify(before) !== JSON.stringify(after)) {
+              historyChanges.push({ field: `concept.${field}`, before, after });
+            }
+          }
           await tx
             .update(schema.glossaryConcepts)
             .set(conceptUpdateValues)
@@ -525,6 +542,9 @@ export async function applyNativeGlossaryImport(input: {
               ...conceptValues,
               ...(conceptCreatedAt !== undefined ? { createdAt: conceptCreatedAt } : {}),
               ...(conceptUpdatedAt !== undefined ? { updatedAt: conceptUpdatedAt } : {}),
+              ...(actorUserId
+                ? { createdByUserId: actorUserId, modifiedByUserId: actorUserId }
+                : {}),
             })
             .returning();
           if (!created) throw new Error("glossary_concept_create_failed");
@@ -682,8 +702,23 @@ export async function applyNativeGlossaryImport(input: {
               : existingTerm
                 ? { updatedAt: existingTerm.updatedAt }
                 : {}),
+            ...(actorUserId ? { modifiedByUserId: actorUserId } : {}),
           };
           if (existingTerm) {
+            for (const field of [
+              "locale",
+              "term",
+              "description",
+              "note",
+              "reviewStatus",
+              "provenance",
+            ] as const) {
+              const before = existingTerm[field];
+              const after = values[field];
+              if (JSON.stringify(before) !== JSON.stringify(after)) {
+                historyChanges.push({ field: `term.${field}`, before, after });
+              }
+            }
             await tx
               .update(schema.glossaryTerms)
               .set(termUpdateValues)
@@ -693,6 +728,10 @@ export async function applyNativeGlossaryImport(input: {
             termByStableKey.set(incomingTerm.id, existingTerm);
             bump(counts, input.mode === "merge" ? "merged" : "updated", "term");
           } else {
+            historyChanges.push(
+              { field: "term.locale", before: null, after: values.locale },
+              { field: "term.term", before: null, after: values.term },
+            );
             const [created] = await tx
               .insert(schema.glossaryTerms)
               .values({
@@ -700,6 +739,9 @@ export async function applyNativeGlossaryImport(input: {
                 ...values,
                 ...(termCreatedAt !== undefined ? { createdAt: termCreatedAt } : {}),
                 ...(termUpdatedAt !== undefined ? { updatedAt: termUpdatedAt } : {}),
+                ...(actorUserId
+                  ? { createdByUserId: actorUserId, modifiedByUserId: actorUserId }
+                  : {}),
               })
               .returning();
             if (!created) throw new Error("glossary_term_create_failed");
@@ -762,7 +804,7 @@ export async function applyNativeGlossaryImport(input: {
         actorCredentialId: null,
         version: 1,
         changedFields: ["concepts", "terms"],
-        changes: [],
+        changes: historyChanges,
         attributes: {
           source: "native",
           importRunId: report.id,

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary-maintenance.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary-maintenance.ts
@@ -20,7 +20,12 @@ type MaintenanceResult<T> =
   | { ok: true; value: T }
   | {
       ok: false;
-      code: "not_found" | "version_conflict" | "invalid_transition" | "reason_required";
+      code:
+        | "not_found"
+        | "version_conflict"
+        | "invalid_transition"
+        | "reason_required"
+        | "primary_term";
       currentVersion?: number;
       currentStatus?: string;
     };
@@ -234,6 +239,13 @@ export async function setGlossaryTermArchived(input: {
       ),
     });
     if (!current) return { ok: false, code: "not_found" };
+    const glossary = await tx.query.glossaries.findFirst({
+      where: eq(schema.glossaries.id, input.glossaryId),
+      columns: { sourceLocale: true },
+    });
+    if (input.archived && glossary?.sourceLocale === current.locale) {
+      return { ok: false, code: "primary_term" };
+    }
     if (input.expectedVersion !== undefined && current.version !== input.expectedVersion) {
       return { ok: false, code: "version_conflict", currentVersion: current.version };
     }

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary-maintenance.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary-maintenance.ts
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database/client";
+
+export type GlossaryReviewDecision = "proposed" | "approved" | "rejected" | "superseded";
+
+type MaintenanceResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      code: "not_found" | "version_conflict" | "invalid_transition" | "reason_required";
+      currentVersion?: number;
+      currentStatus?: string;
+    };
+
+function canTransition(current: string, next: GlossaryReviewDecision) {
+  if (current === "proposed") return ["approved", "rejected", "superseded"].includes(next);
+  if (current === "rejected") return next === "proposed";
+  if (current === "approved") return next === "superseded";
+  return false;
+}
+
+function requireReason(decision: GlossaryReviewDecision) {
+  return decision === "rejected" || decision === "superseded";
+}
+
+export async function reviewGlossaryConcept(input: {
+  glossaryId: string;
+  conceptId: string;
+  actorUserId: string;
+  decision: GlossaryReviewDecision;
+  reason?: string | null;
+  expectedVersion?: number;
+}): Promise<MaintenanceResult<typeof schema.glossaryConcepts.$inferSelect>> {
+  return db.transaction(async (tx) => {
+    const current = await tx.query.glossaryConcepts.findFirst({
+      where: and(
+        eq(schema.glossaryConcepts.id, input.conceptId),
+        eq(schema.glossaryConcepts.glossaryId, input.glossaryId),
+      ),
+    });
+    if (!current) return { ok: false, code: "not_found" };
+    if (input.expectedVersion !== undefined && current.version !== input.expectedVersion) {
+      return { ok: false, code: "version_conflict", currentVersion: current.version };
+    }
+    if (!canTransition(current.reviewStatus, input.decision)) {
+      return { ok: false, code: "invalid_transition", currentStatus: current.reviewStatus };
+    }
+    if (requireReason(input.decision) && !input.reason?.trim()) {
+      return { ok: false, code: "reason_required" };
+    }
+    const [updated] = await tx
+      .update(schema.glossaryConcepts)
+      .set({
+        reviewStatus: input.decision,
+        reviewedByUserId: input.actorUserId,
+        reviewedAt: new Date(),
+        reviewReason: input.reason?.trim() || null,
+        modifiedByUserId: input.actorUserId,
+        version: current.version + 1,
+      })
+      .where(
+        and(
+          eq(schema.glossaryConcepts.id, input.conceptId),
+          eq(schema.glossaryConcepts.glossaryId, input.glossaryId),
+          eq(schema.glossaryConcepts.version, current.version),
+        ),
+      )
+      .returning();
+    if (!updated) return { ok: false, code: "version_conflict", currentVersion: current.version };
+    await tx.insert(schema.glossaryHistoryEvents).values({
+      organizationId: await organizationIdForGlossary(tx, input.glossaryId),
+      glossaryId: input.glossaryId,
+      conceptId: input.conceptId,
+      eventType: `concept_${input.decision}`,
+      actorKind: "user",
+      actorUserId: input.actorUserId,
+      version: updated.version,
+      reason: input.reason?.trim() || null,
+      changedFields: ["reviewStatus", "reviewedByUserId", "reviewedAt", "reviewReason"],
+      changes: [{ field: "reviewStatus", before: current.reviewStatus, after: input.decision }],
+    });
+    return { ok: true, value: updated };
+  });
+}
+
+export async function reviewGlossaryTerm(input: {
+  glossaryId: string;
+  conceptId: string;
+  termId: string;
+  actorUserId: string;
+  decision: GlossaryReviewDecision;
+  reason?: string | null;
+  expectedVersion?: number;
+}): Promise<MaintenanceResult<typeof schema.glossaryTerms.$inferSelect>> {
+  return db.transaction(async (tx) => {
+    const current = await tx.query.glossaryTerms.findFirst({
+      where: and(
+        eq(schema.glossaryTerms.id, input.termId),
+        eq(schema.glossaryTerms.conceptId, input.conceptId),
+        eq(schema.glossaryTerms.glossaryId, input.glossaryId),
+      ),
+    });
+    if (!current) return { ok: false, code: "not_found" };
+    if (input.expectedVersion !== undefined && current.version !== input.expectedVersion) {
+      return { ok: false, code: "version_conflict", currentVersion: current.version };
+    }
+    if (!canTransition(current.reviewStatus, input.decision)) {
+      return { ok: false, code: "invalid_transition", currentStatus: current.reviewStatus };
+    }
+    if (requireReason(input.decision) && !input.reason?.trim()) {
+      return { ok: false, code: "reason_required" };
+    }
+    const [updated] = await tx
+      .update(schema.glossaryTerms)
+      .set({
+        reviewStatus: input.decision,
+        reviewedByUserId: input.actorUserId,
+        reviewedAt: new Date(),
+        reviewReason: input.reason?.trim() || null,
+        modifiedByUserId: input.actorUserId,
+        version: current.version + 1,
+      })
+      .where(
+        and(
+          eq(schema.glossaryTerms.id, input.termId),
+          eq(schema.glossaryTerms.conceptId, input.conceptId),
+          eq(schema.glossaryTerms.glossaryId, input.glossaryId),
+          eq(schema.glossaryTerms.version, current.version),
+        ),
+      )
+      .returning();
+    if (!updated) return { ok: false, code: "version_conflict", currentVersion: current.version };
+    await tx.insert(schema.glossaryHistoryEvents).values({
+      organizationId: await organizationIdForGlossary(tx, input.glossaryId),
+      glossaryId: input.glossaryId,
+      conceptId: input.conceptId,
+      termId: input.termId,
+      eventType: `term_${input.decision}`,
+      actorKind: "user",
+      actorUserId: input.actorUserId,
+      version: updated.version,
+      reason: input.reason?.trim() || null,
+      changedFields: ["reviewStatus", "reviewedByUserId", "reviewedAt", "reviewReason"],
+      changes: [{ field: "reviewStatus", before: current.reviewStatus, after: input.decision }],
+    });
+    return { ok: true, value: updated };
+  });
+}
+
+export async function setGlossaryConceptArchived(input: {
+  glossaryId: string;
+  conceptId: string;
+  actorUserId: string;
+  archived: boolean;
+  expectedVersion?: number;
+}): Promise<MaintenanceResult<typeof schema.glossaryConcepts.$inferSelect>> {
+  return db.transaction(async (tx) => {
+    const current = await tx.query.glossaryConcepts.findFirst({
+      where: and(
+        eq(schema.glossaryConcepts.id, input.conceptId),
+        eq(schema.glossaryConcepts.glossaryId, input.glossaryId),
+      ),
+    });
+    if (!current) return { ok: false, code: "not_found" };
+    if (input.expectedVersion !== undefined && current.version !== input.expectedVersion) {
+      return { ok: false, code: "version_conflict", currentVersion: current.version };
+    }
+    const archivedAt = input.archived ? new Date() : null;
+    const [updated] = await tx
+      .update(schema.glossaryConcepts)
+      .set({
+        archivedAt,
+        archivedByUserId: input.archived ? input.actorUserId : null,
+        modifiedByUserId: input.actorUserId,
+        version: current.version + 1,
+      })
+      .where(
+        and(
+          eq(schema.glossaryConcepts.id, input.conceptId),
+          eq(schema.glossaryConcepts.glossaryId, input.glossaryId),
+          eq(schema.glossaryConcepts.version, current.version),
+        ),
+      )
+      .returning();
+    if (!updated) return { ok: false, code: "version_conflict", currentVersion: current.version };
+    await tx.insert(schema.glossaryHistoryEvents).values({
+      organizationId: await organizationIdForGlossary(tx, input.glossaryId),
+      glossaryId: input.glossaryId,
+      conceptId: input.conceptId,
+      eventType: input.archived ? "concept_archived" : "concept_restored",
+      actorKind: "user",
+      actorUserId: input.actorUserId,
+      version: updated.version,
+      changedFields: ["archivedAt", "archivedByUserId"],
+      changes: [
+        {
+          field: "archivedAt",
+          before: current.archivedAt?.toISOString() ?? null,
+          after: archivedAt?.toISOString() ?? null,
+        },
+      ],
+    });
+    return { ok: true, value: updated };
+  });
+}
+
+export async function setGlossaryTermArchived(input: {
+  glossaryId: string;
+  conceptId: string;
+  termId: string;
+  actorUserId: string;
+  archived: boolean;
+  expectedVersion?: number;
+}): Promise<MaintenanceResult<typeof schema.glossaryTerms.$inferSelect>> {
+  return db.transaction(async (tx) => {
+    const current = await tx.query.glossaryTerms.findFirst({
+      where: and(
+        eq(schema.glossaryTerms.id, input.termId),
+        eq(schema.glossaryTerms.conceptId, input.conceptId),
+        eq(schema.glossaryTerms.glossaryId, input.glossaryId),
+      ),
+    });
+    if (!current) return { ok: false, code: "not_found" };
+    if (input.expectedVersion !== undefined && current.version !== input.expectedVersion) {
+      return { ok: false, code: "version_conflict", currentVersion: current.version };
+    }
+    const archivedAt = input.archived ? new Date() : null;
+    const [updated] = await tx
+      .update(schema.glossaryTerms)
+      .set({
+        archivedAt,
+        archivedByUserId: input.archived ? input.actorUserId : null,
+        modifiedByUserId: input.actorUserId,
+        version: current.version + 1,
+      })
+      .where(
+        and(
+          eq(schema.glossaryTerms.id, input.termId),
+          eq(schema.glossaryTerms.conceptId, input.conceptId),
+          eq(schema.glossaryTerms.glossaryId, input.glossaryId),
+          eq(schema.glossaryTerms.version, current.version),
+        ),
+      )
+      .returning();
+    if (!updated) return { ok: false, code: "version_conflict", currentVersion: current.version };
+    await tx.insert(schema.glossaryHistoryEvents).values({
+      organizationId: await organizationIdForGlossary(tx, input.glossaryId),
+      glossaryId: input.glossaryId,
+      conceptId: input.conceptId,
+      termId: input.termId,
+      eventType: input.archived ? "term_archived" : "term_restored",
+      actorKind: "user",
+      actorUserId: input.actorUserId,
+      version: updated.version,
+      changedFields: ["archivedAt", "archivedByUserId"],
+      changes: [
+        {
+          field: "archivedAt",
+          before: current.archivedAt?.toISOString() ?? null,
+          after: archivedAt?.toISOString() ?? null,
+        },
+      ],
+    });
+    return { ok: true, value: updated };
+  });
+}
+
+async function organizationIdForGlossary(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  glossaryId: string,
+) {
+  const glossary = await tx.query.glossaries.findFirst({
+    where: eq(schema.glossaries.id, glossaryId),
+    columns: { organizationId: true },
+  });
+  if (!glossary) throw new Error("glossary_not_found");
+  return glossary.organizationId;
+}

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -868,7 +868,10 @@ export class NativeGlossary extends Glossary {
           retainedIds.add(existing.id);
           await tx
             .update(schema.glossaryTerms)
-            .set(values)
+            .set({
+              ...values,
+              version: sql`${schema.glossaryTerms.version} + 1`,
+            })
             .where(eq(schema.glossaryTerms.id, existing.id));
         } else {
           await tx.insert(schema.glossaryTerms).values({
@@ -1266,6 +1269,10 @@ export class NativeGlossary extends Glossary {
           status: normalizedInput.status ?? "draft",
           forbidden: normalizedInput.forbidden ?? false,
           provenance: "manual" as const,
+          createdByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+          modifiedByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+          reviewStatus: normalizedInput.reviewStatus ?? "approved",
+          reviewReason: normalizedInput.reviewReason ?? null,
         })
         .returning();
       if (created) {
@@ -1426,6 +1433,10 @@ export class NativeGlossary extends Glossary {
           externalGlossaryUrl: schema.glossaries.externalUrl,
         })
         .from(concordanceSourceTerms)
+        .innerJoin(
+          schema.glossaryConcepts,
+          eq(concordanceSourceTerms.conceptId, schema.glossaryConcepts.id),
+        )
         .innerJoin(schema.glossaries, eq(concordanceSourceTerms.glossaryId, schema.glossaries.id))
         .where(
           and(
@@ -1438,6 +1449,8 @@ export class NativeGlossary extends Glossary {
             // are intentionally excluded.
             isNotNull(concordanceSourceTerms.conceptId),
             isNotNull(concordanceSourceTerms.term),
+            sql`${concordanceSourceTerms.archivedAt} is null`,
+            sql`${schema.glossaryConcepts.archivedAt} is null`,
             eq(concordanceSourceTerms.reviewStatus, "approved"),
             sql`${concordanceSourceTerms.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
           ),
@@ -1509,6 +1522,7 @@ export class NativeGlossary extends Glossary {
         .where(
           and(
             inArray(schema.glossaryTerms.conceptId, conceptIds),
+            sql`${schema.glossaryTerms.archivedAt} is null`,
             eq(schema.glossaryTerms.reviewStatus, "approved"),
             inArray(schema.glossaryTerms.locale, [sourceLocale, ...query.targetLocales]),
           ),

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -601,6 +601,7 @@ export class NativeGlossary extends Glossary {
       externalUserId: null,
       externalCreatedAt: loaded.concept.createdAt.toISOString(),
       externalUpdatedAt: loaded.concept.updatedAt.toISOString(),
+      version: loaded.concept.version,
       languageDetails: loaded.concept.languageDetails?.map((detail) => ({
         locale: detail.locale,
         userId: detail.userId,
@@ -629,6 +630,7 @@ export class NativeGlossary extends Glossary {
         reviewReason: term.reviewReason,
         createdAt: term.createdAt.toISOString(),
         updatedAt: term.updatedAt.toISOString(),
+        version: term.version,
       })),
     };
   }
@@ -652,6 +654,7 @@ export class NativeGlossary extends Glossary {
       reviewReason: term.reviewReason,
       createdAt: term.createdAt.toISOString(),
       updatedAt: term.updatedAt.toISOString(),
+      version: term.version,
     };
   }
 

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -958,6 +958,16 @@ export class NativeGlossary extends Glossary {
           ),
         );
       if (!current) return false;
+      const terms = await tx
+        .select({
+          id: schema.glossaryTerms.id,
+          locale: schema.glossaryTerms.locale,
+          term: schema.glossaryTerms.term,
+          description: schema.glossaryTerms.description,
+          note: schema.glossaryTerms.note,
+        })
+        .from(schema.glossaryTerms)
+        .where(eq(schema.glossaryTerms.conceptId, conceptId));
       await this.recordHistoryEvent(tx, {
         conceptId,
         eventType: "concept_deleted",
@@ -967,6 +977,11 @@ export class NativeGlossary extends Glossary {
           { field: "primaryTerm", before: current.primaryTerm, after: null },
           { field: "subject", before: current.subject, after: null },
           { field: "definition", before: current.definition, after: null },
+          {
+            field: "terms",
+            before: terms,
+            after: null,
+          },
         ],
       });
       await tx.delete(schema.glossaryConcepts).where(eq(schema.glossaryConcepts.id, conceptId));
@@ -1346,30 +1361,28 @@ export class NativeGlossary extends Glossary {
         )
         .returning();
       if (term) {
+        const changes: GlossaryHistoryChange[] = [
+          { field: "locale", before: before.locale, after: term.locale },
+          { field: "term", before: before.term, after: term.term },
+          { field: "description", before: before.description, after: term.description },
+          { field: "note", before: before.note, after: term.note },
+          { field: "partOfSpeech", before: before.partOfSpeech, after: term.partOfSpeech },
+          { field: "gender", before: before.gender, after: term.gender },
+          { field: "termType", before: before.termType, after: term.termType },
+          { field: "url", before: before.url, after: term.url },
+          { field: "lemma", before: before.lemma, after: term.lemma },
+          { field: "status", before: before.status, after: term.status },
+          { field: "forbidden", before: before.forbidden, after: term.forbidden },
+          { field: "reviewStatus", before: before.reviewStatus, after: term.reviewStatus },
+          { field: "reviewReason", before: before.reviewReason, after: term.reviewReason },
+        ].filter((change) => change.before !== change.after);
         await this.recordHistoryEvent(tx, {
           conceptId,
           termId,
           eventType: "term_updated",
           version: term.version,
-          changedFields: [
-            "locale",
-            "term",
-            "description",
-            "note",
-            "partOfSpeech",
-            "gender",
-            "termType",
-            "url",
-            "lemma",
-            "status",
-            "forbidden",
-          ],
-          changes: [
-            { field: "term", before: before.term, after: term.term },
-            { field: "locale", before: before.locale, after: term.locale },
-            { field: "description", before: before.description, after: term.description },
-            { field: "reviewStatus", before: before.reviewStatus, after: term.reviewStatus },
-          ],
+          changedFields: changes.map((change) => change.field),
+          changes,
         });
       }
       return term ? this.toTermRecord(term) : null;
@@ -1458,6 +1471,7 @@ export class NativeGlossary extends Glossary {
             isNotNull(concordanceSourceTerms.term),
             sql`${concordanceSourceTerms.archivedAt} is null`,
             sql`${schema.glossaryConcepts.archivedAt} is null`,
+            eq(schema.glossaryConcepts.reviewStatus, "approved"),
             eq(concordanceSourceTerms.reviewStatus, "approved"),
             sql`${concordanceSourceTerms.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
           ),
@@ -1531,6 +1545,7 @@ export class NativeGlossary extends Glossary {
             inArray(schema.glossaryTerms.conceptId, conceptIds),
             sql`${schema.glossaryTerms.archivedAt} is null`,
             eq(schema.glossaryTerms.reviewStatus, "approved"),
+            eq(schema.glossaryConcepts.reviewStatus, "approved"),
             inArray(schema.glossaryTerms.locale, [sourceLocale, ...query.targetLocales]),
           ),
         ),

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -47,6 +47,7 @@ import type {
   NativeGlossaryTermInput,
   GlossaryProjectRecord,
 } from "./glossary";
+import type { GlossaryHistoryChange } from "@/lib/database/schema/glossary-history";
 
 const concordanceSourceTerms = alias(schema.glossaryTerms, "concordance_native_source_terms");
 const NATIVE_CONCORDANCE_CANDIDATE_PAGE_SIZE = 200;
@@ -283,6 +284,8 @@ function toNativeConceptInput(input: GlossaryConceptInput, sourceLocale: string)
     note: input.note,
     url: input.url,
     figure: input.figure,
+    reviewStatus: input.reviewStatus,
+    reviewReason: input.reviewReason,
     terms: (input.terms ?? []).map((term) => {
       if ("term" in term) {
         return {
@@ -298,6 +301,8 @@ function toNativeConceptInput(input: GlossaryConceptInput, sourceLocale: string)
           url: term.url || undefined,
           lemma: term.lemma ?? undefined,
           forbidden: term.forbidden,
+          reviewStatus: term.reviewStatus,
+          reviewReason: term.reviewReason,
         };
       }
       return { ...term };
@@ -525,6 +530,32 @@ export class NativeGlossary extends Glossary {
     return glossaryRow ?? null;
   }
 
+  private async recordHistoryEvent(
+    database: DatabaseClient,
+    input: {
+      conceptId?: string;
+      termId?: string;
+      eventType: string;
+      version: number;
+      changedFields: string[];
+      changes?: GlossaryHistoryChange[];
+    },
+  ) {
+    await database.insert(schema.glossaryHistoryEvents).values({
+      organizationId: this.input.auth.organization.localOrganizationId,
+      glossaryId: this.input.glossary.id,
+      conceptId: input.conceptId,
+      termId: input.termId,
+      eventType: input.eventType,
+      actorKind: "user",
+      actorUserId: this.input.auth.user.localUserId,
+      version: input.version,
+      changedFields: input.changedFields,
+      changes: input.changes ?? [],
+      attributes: { origin: "native_ui" },
+    });
+  }
+
   private async loadConcept(conceptId: string, database: DatabaseClient = db) {
     const [concept] = await database
       .select()
@@ -578,6 +609,8 @@ export class NativeGlossary extends Glossary {
         createdAt: detail.createdAt,
         updatedAt: detail.updatedAt,
       })),
+      reviewStatus: loaded.concept.reviewStatus as GlossaryConcept["reviewStatus"],
+      reviewReason: loaded.concept.reviewReason,
       terms: loaded.terms.map((term) => ({
         id: term.id,
         locale: term.locale ?? "",
@@ -591,6 +624,9 @@ export class NativeGlossary extends Glossary {
         url: term.url ?? undefined,
         lemma: term.lemma ?? undefined,
         forbidden: term.forbidden,
+        provenance: term.provenance,
+        reviewStatus: term.reviewStatus as NativeGlossaryTermInput["reviewStatus"],
+        reviewReason: term.reviewReason,
         createdAt: term.createdAt.toISOString(),
         updatedAt: term.updatedAt.toISOString(),
       })),
@@ -611,6 +647,9 @@ export class NativeGlossary extends Glossary {
       url: term.url ?? undefined,
       lemma: term.lemma ?? undefined,
       forbidden: term.forbidden,
+      provenance: term.provenance,
+      reviewStatus: term.reviewStatus as NativeGlossaryTermInput["reviewStatus"],
+      reviewReason: term.reviewReason,
       createdAt: term.createdAt.toISOString(),
       updatedAt: term.updatedAt.toISOString(),
     };
@@ -705,6 +744,10 @@ export class NativeGlossary extends Glossary {
           url: normalizedInput.url || null,
           figure: normalizedInput.figure || null,
           languageDetails: normalizedInput.languageDetails ?? [],
+          createdByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+          modifiedByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+          reviewStatus: normalizedInput.reviewStatus ?? "approved",
+          reviewReason: normalizedInput.reviewReason ?? null,
         })
         .returning();
       if (normalizedInput.terms.length > 0) {
@@ -726,9 +769,25 @@ export class NativeGlossary extends Glossary {
             status: term.status ?? "draft",
             forbidden: term.forbidden ?? false,
             provenance: "manual" as const,
+            createdByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+            modifiedByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+            reviewStatus: term.reviewStatus ?? "approved",
+            reviewReason: term.reviewReason ?? null,
           })),
         );
       }
+      await this.recordHistoryEvent(tx, {
+        conceptId: concept.id,
+        eventType: "concept_created",
+        version: concept.version,
+        changedFields: ["concept", "terms"],
+        changes: [
+          { field: "primaryTerm", before: null, after: concept.primaryTerm },
+          { field: "subject", before: null, after: concept.subject },
+          { field: "definition", before: null, after: concept.definition },
+          { field: "terms", before: 0, after: normalizedInput.terms.length },
+        ],
+      });
       return concept;
     });
     if (!created) {
@@ -760,6 +819,14 @@ export class NativeGlossary extends Glossary {
           url: normalizedInput.url || null,
           figure: normalizedInput.figure || null,
           languageDetails: normalizedInput.languageDetails ?? [],
+          version: sql`${schema.glossaryConcepts.version} + 1`,
+          modifiedByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+          ...(normalizedInput.reviewStatus !== undefined
+            ? { reviewStatus: normalizedInput.reviewStatus }
+            : {}),
+          ...(normalizedInput.reviewReason !== undefined
+            ? { reviewReason: normalizedInput.reviewReason }
+            : {}),
         })
         .where(eq(schema.glossaryConcepts.id, conceptId));
       // Match Crowdin concept PATCH reconcile: terms present in the payload are
@@ -785,6 +852,17 @@ export class NativeGlossary extends Glossary {
           lemma: term.lemma ?? null,
           status: term.status ?? "draft",
           forbidden: term.forbidden ?? existing?.forbidden ?? false,
+          modifiedByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+          ...(term.reviewStatus !== undefined
+            ? { reviewStatus: term.reviewStatus }
+            : existing
+              ? { reviewStatus: existing.reviewStatus }
+              : { reviewStatus: "approved" as const }),
+          ...(term.reviewReason !== undefined
+            ? { reviewReason: term.reviewReason }
+            : existing
+              ? { reviewReason: existing.reviewReason }
+              : { reviewReason: null }),
         };
         if (existing) {
           retainedIds.add(existing.id);
@@ -798,6 +876,7 @@ export class NativeGlossary extends Glossary {
             conceptId,
             ...values,
             provenance: "manual" as const,
+            createdByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
           });
         }
       }
@@ -816,6 +895,39 @@ export class NativeGlossary extends Glossary {
             ),
           );
       }
+      await this.recordHistoryEvent(tx, {
+        conceptId,
+        eventType: "concept_updated",
+        version: loaded.concept.version + 1,
+        changedFields: [
+          "primaryTerm",
+          "subject",
+          "definition",
+          "translatable",
+          "note",
+          "url",
+          "figure",
+          "terms",
+        ],
+        changes: [
+          {
+            field: "primaryTerm",
+            before: loaded.concept.primaryTerm,
+            after: normalizedInput.primaryTerm,
+          },
+          {
+            field: "subject",
+            before: loaded.concept.subject,
+            after: normalizedInput.subject ?? "",
+          },
+          {
+            field: "definition",
+            before: loaded.concept.definition,
+            after: normalizedInput.definition ?? "",
+          },
+          { field: "terms", before: loaded.terms.length, after: normalizedInput.terms.length },
+        ],
+      });
       return true;
     });
     if (!updated) return null;
@@ -823,16 +935,37 @@ export class NativeGlossary extends Glossary {
   }
 
   async deleteConcept(conceptId: string) {
-    const deleted = await db
-      .delete(schema.glossaryConcepts)
-      .where(
-        and(
-          eq(schema.glossaryConcepts.id, conceptId),
-          eq(schema.glossaryConcepts.glossaryId, this.input.glossary.id),
-        ),
-      )
-      .returning({ id: schema.glossaryConcepts.id });
-    return deleted.length > 0;
+    return db.transaction(async (tx) => {
+      const [current] = await tx
+        .select({
+          id: schema.glossaryConcepts.id,
+          version: schema.glossaryConcepts.version,
+          primaryTerm: schema.glossaryConcepts.primaryTerm,
+          subject: schema.glossaryConcepts.subject,
+          definition: schema.glossaryConcepts.definition,
+        })
+        .from(schema.glossaryConcepts)
+        .where(
+          and(
+            eq(schema.glossaryConcepts.id, conceptId),
+            eq(schema.glossaryConcepts.glossaryId, this.input.glossary.id),
+          ),
+        );
+      if (!current) return false;
+      await this.recordHistoryEvent(tx, {
+        conceptId,
+        eventType: "concept_deleted",
+        version: current.version + 1,
+        changedFields: ["concept", "terms"],
+        changes: [
+          { field: "primaryTerm", before: current.primaryTerm, after: null },
+          { field: "subject", before: current.subject, after: null },
+          { field: "definition", before: current.definition, after: null },
+        ],
+      });
+      await tx.delete(schema.glossaryConcepts).where(eq(schema.glossaryConcepts.id, conceptId));
+      return true;
+    });
   }
 
   async importConcepts(entries: GlossaryConceptImportEntry[]) {
@@ -1135,6 +1268,19 @@ export class NativeGlossary extends Glossary {
           provenance: "manual" as const,
         })
         .returning();
+      if (created) {
+        await this.recordHistoryEvent(tx, {
+          conceptId,
+          termId: created.id,
+          eventType: "term_created",
+          version: created.version,
+          changedFields: ["term"],
+          changes: [
+            { field: "locale", before: null, after: created.locale },
+            { field: "term", before: null, after: created.term },
+          ],
+        });
+      }
       return created ?? null;
     });
     return term ? this.toTermRecord(term) : null;
@@ -1142,48 +1288,108 @@ export class NativeGlossary extends Glossary {
 
   async updateTerm(conceptId: string, termId: string, input: NativeGlossaryTermInput) {
     const normalizedInput = normalizeNativeTerm(input);
-    const [term] = await db
-      .update(schema.glossaryTerms)
-      .set({
-        locale: normalizedInput.locale,
-        term: normalizedInput.text,
-        sourceTerm: normalizedInput.text,
-        targetTerm: normalizedInput.text,
-        description: normalizedInput.description ?? "",
-        note: normalizedInput.note ?? "",
-        partOfSpeech: normalizedInput.partOfSpeech ?? "",
-        gender: normalizedInput.gender ?? null,
-        termType: normalizedInput.type ?? null,
-        url: normalizedInput.url ?? null,
-        lemma: normalizedInput.lemma ?? null,
-        status: normalizedInput.status ?? "draft",
-        ...(normalizedInput.forbidden === undefined
-          ? {}
-          : { forbidden: normalizedInput.forbidden }),
-      })
-      .where(
-        and(
-          eq(schema.glossaryTerms.id, termId),
-          eq(schema.glossaryTerms.conceptId, conceptId),
-          eq(schema.glossaryTerms.glossaryId, this.input.glossary.id),
-        ),
-      )
-      .returning();
-    return term ? this.toTermRecord(term) : null;
+    return db.transaction(async (tx) => {
+      const [before] = await tx
+        .select()
+        .from(schema.glossaryTerms)
+        .where(
+          and(
+            eq(schema.glossaryTerms.id, termId),
+            eq(schema.glossaryTerms.conceptId, conceptId),
+            eq(schema.glossaryTerms.glossaryId, this.input.glossary.id),
+          ),
+        );
+      if (!before) return null;
+      const [term] = await tx
+        .update(schema.glossaryTerms)
+        .set({
+          locale: normalizedInput.locale,
+          term: normalizedInput.text,
+          sourceTerm: normalizedInput.text,
+          targetTerm: normalizedInput.text,
+          description: normalizedInput.description ?? "",
+          note: normalizedInput.note ?? "",
+          partOfSpeech: normalizedInput.partOfSpeech ?? "",
+          gender: normalizedInput.gender ?? null,
+          termType: normalizedInput.type ?? null,
+          url: normalizedInput.url ?? null,
+          lemma: normalizedInput.lemma ?? null,
+          status: normalizedInput.status ?? "draft",
+          ...(normalizedInput.forbidden === undefined
+            ? {}
+            : { forbidden: normalizedInput.forbidden }),
+          version: sql`${schema.glossaryTerms.version} + 1`,
+          modifiedByUserId: this.input.actorUserId ?? this.input.auth.user.localUserId,
+          ...(normalizedInput.reviewStatus !== undefined
+            ? { reviewStatus: normalizedInput.reviewStatus }
+            : {}),
+          ...(normalizedInput.reviewReason !== undefined
+            ? { reviewReason: normalizedInput.reviewReason }
+            : {}),
+        })
+        .where(
+          and(
+            eq(schema.glossaryTerms.id, termId),
+            eq(schema.glossaryTerms.conceptId, conceptId),
+            eq(schema.glossaryTerms.glossaryId, this.input.glossary.id),
+          ),
+        )
+        .returning();
+      if (term) {
+        await this.recordHistoryEvent(tx, {
+          conceptId,
+          termId,
+          eventType: "term_updated",
+          version: term.version,
+          changedFields: [
+            "locale",
+            "term",
+            "description",
+            "note",
+            "partOfSpeech",
+            "gender",
+            "termType",
+            "url",
+            "lemma",
+            "status",
+            "forbidden",
+          ],
+          changes: [
+            { field: "term", before: before.term, after: term.term },
+            { field: "locale", before: before.locale, after: term.locale },
+            { field: "description", before: before.description, after: term.description },
+            { field: "reviewStatus", before: before.reviewStatus, after: term.reviewStatus },
+          ],
+        });
+      }
+      return term ? this.toTermRecord(term) : null;
+    });
   }
 
   async deleteTerm(conceptId: string, termId: string) {
-    const deleted = await db
-      .delete(schema.glossaryTerms)
-      .where(
-        and(
-          eq(schema.glossaryTerms.id, termId),
-          eq(schema.glossaryTerms.conceptId, conceptId),
-          eq(schema.glossaryTerms.glossaryId, this.input.glossary.id),
-        ),
-      )
-      .returning({ id: schema.glossaryTerms.id });
-    return deleted.length > 0;
+    return db.transaction(async (tx) => {
+      const [current] = await tx
+        .select({ id: schema.glossaryTerms.id, version: schema.glossaryTerms.version })
+        .from(schema.glossaryTerms)
+        .where(
+          and(
+            eq(schema.glossaryTerms.id, termId),
+            eq(schema.glossaryTerms.conceptId, conceptId),
+            eq(schema.glossaryTerms.glossaryId, this.input.glossary.id),
+          ),
+        );
+      if (!current) return false;
+      await this.recordHistoryEvent(tx, {
+        conceptId,
+        termId,
+        eventType: "term_deleted",
+        version: current.version + 1,
+        changedFields: ["term"],
+        changes: [{ field: "term", before: current.id, after: null }],
+      });
+      await tx.delete(schema.glossaryTerms).where(eq(schema.glossaryTerms.id, termId));
+      return true;
+    });
   }
 
   async searchConcordance(

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -1376,7 +1376,11 @@ export class NativeGlossary extends Glossary {
   async deleteTerm(conceptId: string, termId: string) {
     return db.transaction(async (tx) => {
       const [current] = await tx
-        .select({ id: schema.glossaryTerms.id, version: schema.glossaryTerms.version })
+        .select({
+          id: schema.glossaryTerms.id,
+          version: schema.glossaryTerms.version,
+          term: schema.glossaryTerms.term,
+        })
         .from(schema.glossaryTerms)
         .where(
           and(
@@ -1392,7 +1396,7 @@ export class NativeGlossary extends Glossary {
         eventType: "term_deleted",
         version: current.version + 1,
         changedFields: ["term"],
-        changes: [{ field: "term", before: current.id, after: null }],
+        changes: [{ field: "term", before: current.term, after: null }],
       });
       await tx.delete(schema.glossaryTerms).where(eq(schema.glossaryTerms.id, termId));
       return true;

--- a/apps/hyperlocalise-web/src/lib/glossary/query-glossary-terms.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/query-glossary-terms.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, asc, eq, inArray, isNotNull, min, or } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, min, or, sql } from "drizzle-orm";
 
 import { db, schema, type DatabaseClient } from "@/lib/database/client";
 
@@ -230,6 +230,8 @@ async function listOrderedNativeConceptSummaries(
         eq(schema.glossaries.source, "native"),
         eq(schema.glossaries.sourceLocale, input.sourceLocale),
         eq(schema.glossaries.status, "active"),
+        sql`${schema.glossaryConcepts.archivedAt} is null`,
+        sql`${schema.glossaryTerms.archivedAt} is null`,
       ),
     )
     .groupBy(
@@ -300,6 +302,8 @@ async function fetchNativeConceptTermRows(
         eq(schema.glossaries.source, "native"),
         eq(schema.glossaries.sourceLocale, input.sourceLocale),
         eq(schema.glossaries.status, "active"),
+        sql`${schema.glossaryConcepts.archivedAt} is null`,
+        sql`${schema.glossaryTerms.archivedAt} is null`,
         isNotNull(schema.glossaryTerms.conceptId),
         isNotNull(schema.glossaryTerms.term),
         isNotNull(schema.glossaryTerms.locale),
@@ -429,6 +433,8 @@ export async function listNativeGlossaryTermPairs(
         eq(schema.glossaries.source, "native"),
         eq(schema.glossaries.sourceLocale, input.sourceLocale),
         eq(schema.glossaries.status, "active"),
+        sql`${schema.glossaryConcepts.archivedAt} is null`,
+        sql`${schema.glossaryTerms.archivedAt} is null`,
         isNotNull(schema.glossaryTerms.conceptId),
         isNotNull(schema.glossaryTerms.term),
         isNotNull(schema.glossaryTerms.locale),

--- a/apps/hyperlocalise-web/src/lib/glossary/query-glossary-terms.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/query-glossary-terms.ts
@@ -219,6 +219,7 @@ async function listOrderedNativeConceptSummaries(
       and(
         eq(schema.glossaryTerms.conceptId, schema.glossaryConcepts.id),
         eq(schema.glossaryTerms.locale, input.sourceLocale),
+        eq(schema.glossaryConcepts.reviewStatus, "approved"),
         eq(schema.glossaryTerms.reviewStatus, "approved"),
         isNotNull(schema.glossaryTerms.term),
       ),
@@ -231,6 +232,7 @@ async function listOrderedNativeConceptSummaries(
         eq(schema.glossaries.sourceLocale, input.sourceLocale),
         eq(schema.glossaries.status, "active"),
         sql`${schema.glossaryConcepts.archivedAt} is null`,
+        eq(schema.glossaryConcepts.reviewStatus, "approved"),
         sql`${schema.glossaryTerms.archivedAt} is null`,
       ),
     )
@@ -303,6 +305,7 @@ async function fetchNativeConceptTermRows(
         eq(schema.glossaries.sourceLocale, input.sourceLocale),
         eq(schema.glossaries.status, "active"),
         sql`${schema.glossaryConcepts.archivedAt} is null`,
+        eq(schema.glossaryConcepts.reviewStatus, "approved"),
         sql`${schema.glossaryTerms.archivedAt} is null`,
         isNotNull(schema.glossaryTerms.conceptId),
         isNotNull(schema.glossaryTerms.term),
@@ -434,6 +437,7 @@ export async function listNativeGlossaryTermPairs(
         eq(schema.glossaries.sourceLocale, input.sourceLocale),
         eq(schema.glossaries.status, "active"),
         sql`${schema.glossaryConcepts.archivedAt} is null`,
+        eq(schema.glossaryConcepts.reviewStatus, "approved"),
         sql`${schema.glossaryTerms.archivedAt} is null`,
         isNotNull(schema.glossaryTerms.conceptId),
         isNotNull(schema.glossaryTerms.term),


### PR DESCRIPTION
## Summary

Implements glossary terminology maintenance foundations:

- Adds native concept and term review transitions with reviewer authorization, reasons, and optimistic version checks.
- Adds atomic archive/restore workflows with immutable history events.
- Records native create/update/delete and import history with actor metadata and field changes.
- Populates creator/modifier metadata and round-trips review status, review reason, and provenance.
- Adds signed, filter-bound term pagination and updates the native concept detail view with term paging.
- Improves search and counts for term IDs, source/target fields, metadata, notes, and archived records.
- Keeps provider-backed glossaries read-only.

## Validation

- `vp check --fix`
- `vp test run src/api/routes/glossary/glossary.schema.test.ts src/api/routes/glossary/glossary.permissions.test.ts src/api/routes/glossary/glossary-history-actor.test.ts`

Both checks pass. Full database-backed glossary route tests were not runnable because local PostgreSQL was unavailable on `:5432`.

## Notes

The existing full concept payload remains available for edit/save compatibility; the detail view now renders and pages terms through the new term-page endpoint.
