### PR TITLE
feat(mcp): add query_translation_memory MCP tool

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp-query-translation-memory.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp-query-translation-memory.schema.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+import { localeInputSchema } from "@/lib/i18n/locales";
+import { projectIdSchema } from "@/lib/projects/identity/project-id";
+
+export const mcpQueryTranslationMemoryInputSchema = z.object({
+  sourceText: z
+    .string()
+    .trim()
+    .min(1)
+    .max(10_000)
+    .describe("Source text to find exact or similar translation-memory matches for."),
+
+  sourceLocale: localeInputSchema.describe("Locale of the source text."),
+
+  targetLocale: localeInputSchema.describe("Locale of the requested translations."),
+
+  projectId: projectIdSchema
+    .optional()
+    .describe("Optional project whose linked translation memories should be searched."),
+
+  memoryId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(128)
+    .optional()
+    .describe("Optional translation memory to search exclusively."),
+
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .default(10)
+    .describe("Maximum number of ranked matches to return."),
+});
+
+export type McpQueryTranslationMemoryInput = z.infer<typeof mcpQueryTranslationMemoryInputSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -6952,7 +6952,7 @@ describe("mcpRoutes", () => {
       throw new Error("expected test auth context");
     }
 
-    const sourceText = "a".repeat(4_500);
+    const sourceText = `${"a".repeat(3_998)}𐐷${"c".repeat(500)}`;
     const targetText = "b".repeat(4_500);
 
     const { memoryId } = await createAttachedMemoryEntry({
@@ -6991,8 +6991,9 @@ describe("mcpRoutes", () => {
       similarity: 1,
     });
 
-    expect(matches[0]?.sourceText).toHaveLength(4_000);
-    expect(matches[0]?.sourceText.endsWith("…")).toBe(true);
+    expect(Array.from(matches[0]?.sourceText ?? "")).toHaveLength(4_000);
+    expect(matches[0]?.sourceText.endsWith("𐐷…")).toBe(true);
+    expect(matches[0]?.sourceText).not.toContain("�");
 
     expect(matches[0]?.targetText).toHaveLength(4_000);
     expect(matches[0]?.targetText.endsWith("…")).toBe(true);

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -25,6 +25,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 import { IssueSheetCommentService } from "@/lib/projects/issue-sheet/issue-sheet-comment-service";
+import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
 import {
   createAuthorizationCode,
@@ -6309,6 +6310,805 @@ describe("mcpRoutes", () => {
       .limit(1);
 
     expect(saved).toBeUndefined();
+  });
+
+  it("advertises query_translation_memory with bounded inputs", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const response = await mcpClient.mcp.$post(
+      {},
+      {
+        headers: {
+          ...headers,
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        init: {
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list",
+            params: {},
+          }),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      result?: {
+        tools?: Array<{
+          name: string;
+          description?: string;
+          inputSchema?: {
+            required?: string[];
+            properties?: Record<string, unknown>;
+          };
+        }>;
+      };
+    };
+
+    const tool = body.result?.tools?.find(({ name }) => name === "query_translation_memory");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toContain("translation memory");
+
+    expect(tool?.inputSchema?.required).toEqual(
+      expect.arrayContaining(["sourceText", "sourceLocale", "targetLocale"]),
+    );
+
+    expect(tool?.inputSchema?.required).not.toEqual(
+      expect.arrayContaining(["projectId", "memoryId", "limit"]),
+    );
+
+    expect(tool?.inputSchema?.properties).toMatchObject({
+      sourceText: {
+        type: "string",
+        minLength: 1,
+      },
+      sourceLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 50,
+      },
+      targetLocale: {
+        type: "string",
+        minLength: 1,
+        maxLength: 50,
+      },
+      projectId: {
+        type: "string",
+      },
+      memoryId: {
+        type: "string",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 20,
+        default: 10,
+      },
+    });
+  });
+
+  it("returns empty matches when translation memory has no matching entry", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "This sentence has never been translated",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toEqual({
+      matches: [],
+    });
+  });
+
+  it("returns memory_not_found for an inaccessible translation memory", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "Save changes",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        memoryId: randomUUID(),
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "memory_not_found",
+    });
+  });
+
+  it("returns an exact translation memory match linked to the project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [memory] = await db
+      .insert(schema.memories)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Product translations",
+        description: "Approved product translations",
+        status: "active",
+        source: "native",
+      })
+      .returning({ id: schema.memories.id });
+
+    await db.insert(schema.projectMemories).values({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      memoryId: memory.id,
+    });
+
+    await db.insert(schema.memoryEntries).values({
+      memoryId: memory.id,
+      sourceLocale: "en-US",
+      targetLocale: "vi-VN",
+      sourceText: "Save changes",
+      normalizedSourceText: normalizeTranslationMemorySourceText("Save changes"),
+      targetText: "Lưu thay đổi",
+      matchScore: 100,
+      provenance: "manual",
+      reviewStatus: "approved",
+      createdByUserId: auth.user.localUserId,
+    });
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "  SAVE   changes ",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: stored.project.id,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toEqual({
+      matches: [
+        {
+          memoryId: memory.id,
+          sourceText: "Save changes",
+          targetText: "Lưu thay đổi",
+          locale: "vi-VN",
+          similarity: 1,
+        },
+      ],
+    });
+  });
+
+  it("does not return translation memories that are not linked to the project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [linkedMemory, unlinkedMemory] = await db
+      .insert(schema.memories)
+      .values([
+        {
+          organizationId: auth.organization.localOrganizationId,
+          createdByUserId: auth.user.localUserId,
+          name: "Linked memory",
+          description: "",
+          status: "active",
+          source: "native",
+        },
+        {
+          organizationId: auth.organization.localOrganizationId,
+          createdByUserId: auth.user.localUserId,
+          name: "Unlinked memory",
+          description: "",
+          status: "active",
+          source: "native",
+        },
+      ])
+      .returning({ id: schema.memories.id });
+
+    await db.insert(schema.projectMemories).values({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      memoryId: linkedMemory.id,
+    });
+
+    const sourceText = "Delete workspace";
+    const normalizedSourceText = normalizeTranslationMemorySourceText(sourceText);
+
+    await db.insert(schema.memoryEntries).values([
+      {
+        memoryId: linkedMemory.id,
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        sourceText,
+        normalizedSourceText,
+        targetText: "Xóa không gian làm việc",
+        matchScore: 100,
+        provenance: "manual",
+        reviewStatus: "approved",
+        createdByUserId: auth.user.localUserId,
+      },
+      {
+        memoryId: unlinkedMemory.id,
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        sourceText,
+        normalizedSourceText,
+        targetText: "Xóa workspace",
+        matchScore: 100,
+        provenance: "manual",
+        reviewStatus: "approved",
+        createdByUserId: auth.user.localUserId,
+      },
+    ]);
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText,
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: stored.project.id,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toEqual({
+      matches: [
+        {
+          memoryId: linkedMemory.id,
+          sourceText,
+          targetText: "Xóa không gian làm việc",
+          locale: "vi-VN",
+          similarity: 1,
+        },
+      ],
+    });
+  });
+
+  it("returns memory_not_found when the selected memory is not linked to the project", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [memory] = await db
+      .insert(schema.memories)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Unlinked memory",
+        description: "",
+        status: "active",
+        source: "native",
+      })
+      .returning({ id: schema.memories.id });
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "Save changes",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: stored.project.id,
+        memoryId: memory.id,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "memory_not_found",
+    });
+  });
+
+  it("returns project_not_found for an inaccessible project", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "Save changes",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: `project_${randomUUID()}`,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "project_not_found",
+    });
+  });
+
+  it("returns memory_not_found for a malformed memory ID", async () => {
+    const headers = await authenticatedMcpHeaders();
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "Save changes",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        memoryId: "missing_memory",
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "memory_not_found",
+    });
+  });
+
+  it("returns a ranked fuzzy translation memory match", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [memory] = await db
+      .insert(schema.memories)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Checkout translations",
+        description: "",
+        status: "active",
+        source: "native",
+      })
+      .returning({ id: schema.memories.id });
+
+    await db.insert(schema.projectMemories).values({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      memoryId: memory.id,
+    });
+
+    await db.insert(schema.memoryEntries).values({
+      memoryId: memory.id,
+      sourceLocale: "en-US",
+      targetLocale: "vi-VN",
+      sourceText: "Start checkout",
+      normalizedSourceText: normalizeTranslationMemorySourceText("Start checkout"),
+      targetText: "Bắt đầu thanh toán",
+      matchScore: 100,
+      provenance: "manual",
+      reviewStatus: "approved",
+      createdByUserId: auth.user.localUserId,
+    });
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "checkout",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: stored.project.id,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+
+    expect(result.output).toMatchObject({
+      matches: [
+        {
+          memoryId: memory.id,
+          sourceText: "Start checkout",
+          targetText: "Bắt đầu thanh toán",
+          locale: "vi-VN",
+          similarity: expect.any(Number),
+        },
+      ],
+    });
+
+    const matches = result.output.matches as Array<{
+      similarity: number;
+    }>;
+
+    expect(matches[0]?.similarity).toBeGreaterThan(0);
+    expect(matches[0]?.similarity).toBeLessThan(1);
+  });
+
+  it("returns only approved matches for the requested locale pair", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const memories = await db
+      .insert(schema.memories)
+      .values([
+        {
+          organizationId: auth.organization.localOrganizationId,
+          createdByUserId: auth.user.localUserId,
+          name: "Approved Vietnamese memory",
+          description: "",
+          status: "active",
+          source: "native",
+        },
+        {
+          organizationId: auth.organization.localOrganizationId,
+          createdByUserId: auth.user.localUserId,
+          name: "French memory",
+          description: "",
+          status: "active",
+          source: "native",
+        },
+        {
+          organizationId: auth.organization.localOrganizationId,
+          createdByUserId: auth.user.localUserId,
+          name: "Draft Vietnamese memory",
+          description: "",
+          status: "active",
+          source: "native",
+        },
+      ])
+      .returning({ id: schema.memories.id });
+
+    const [approvedMemory, wrongLocaleMemory, draftMemory] = memories;
+
+    await db.insert(schema.projectMemories).values(
+      memories.map(({ id }) => ({
+        organizationId: auth.organization.localOrganizationId,
+        projectId: stored.project.id,
+        memoryId: id,
+      })),
+    );
+
+    const sourceText = "Invite members";
+    const normalizedSourceText = normalizeTranslationMemorySourceText(sourceText);
+
+    await db.insert(schema.memoryEntries).values([
+      {
+        memoryId: approvedMemory.id,
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        sourceText,
+        normalizedSourceText,
+        targetText: "Mời thành viên",
+        matchScore: 100,
+        provenance: "manual",
+        reviewStatus: "approved",
+        createdByUserId: auth.user.localUserId,
+      },
+      {
+        memoryId: wrongLocaleMemory.id,
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+        sourceText,
+        normalizedSourceText,
+        targetText: "Inviter des membres",
+        matchScore: 100,
+        provenance: "manual",
+        reviewStatus: "approved",
+        createdByUserId: auth.user.localUserId,
+      },
+      {
+        memoryId: draftMemory.id,
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        sourceText,
+        normalizedSourceText,
+        targetText: "Mời các thành viên",
+        matchScore: 100,
+        provenance: "manual",
+        reviewStatus: "draft",
+        createdByUserId: auth.user.localUserId,
+      },
+    ]);
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText,
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: stored.project.id,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toEqual({
+      matches: [
+        {
+          memoryId: approvedMemory.id,
+          sourceText,
+          targetText: "Mời thành viên",
+          locale: "vi-VN",
+          similarity: 1,
+        },
+      ],
+    });
+  });
+
+  async function createAttachedMemoryEntry(input: {
+    organizationId: string;
+    userId: string;
+    projectId: string;
+    memoryName: string;
+    sourceText: string;
+    targetText: string;
+    sourceLocale?: string;
+    targetLocale?: string;
+    reviewStatus?: string;
+  }) {
+    const [memory] = await db
+      .insert(schema.memories)
+      .values({
+        organizationId: input.organizationId,
+        createdByUserId: input.userId,
+        name: input.memoryName,
+        description: "",
+        status: "active",
+        source: "native",
+      })
+      .returning({ id: schema.memories.id });
+
+    await db.insert(schema.projectMemories).values({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      memoryId: memory.id,
+    });
+
+    const [entry] = await db
+      .insert(schema.memoryEntries)
+      .values({
+        memoryId: memory.id,
+        sourceLocale: input.sourceLocale ?? "en-US",
+        targetLocale: input.targetLocale ?? "vi-VN",
+        sourceText: input.sourceText,
+        normalizedSourceText: normalizeTranslationMemorySourceText(input.sourceText),
+        targetText: input.targetText,
+        matchScore: 100,
+        provenance: "manual",
+        reviewStatus: input.reviewStatus ?? "approved",
+        createdByUserId: input.userId,
+      })
+      .returning({ id: schema.memoryEntries.id });
+
+    return {
+      memoryId: memory.id,
+      entryId: entry.id,
+    };
+  }
+
+  it("limits the number of translation memory matches", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const sourceText = "Save changes";
+
+    for (const index of [1, 2, 3]) {
+      await createAttachedMemoryEntry({
+        organizationId: auth.organization.localOrganizationId,
+        userId: auth.user.localUserId,
+        projectId: stored.project.id,
+        memoryName: `Product translations ${index}`,
+        sourceText,
+        targetText: `Lưu thay đổi ${index}`,
+      });
+    }
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText,
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: stored.project.id,
+        limit: 2,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+
+    const matches = result.output.matches as Array<{
+      targetText: string;
+    }>;
+
+    expect(matches).toHaveLength(2);
+
+    for (const match of matches) {
+      expect(["Lưu thay đổi 1", "Lưu thay đổi 2", "Lưu thay đổi 3"]).toContain(match.targetText);
+    }
+  });
+
+  it("truncates long translation memory segments", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const sourceText = "a".repeat(4_500);
+    const targetText = "b".repeat(4_500);
+
+    const { memoryId } = await createAttachedMemoryEntry({
+      organizationId: auth.organization.localOrganizationId,
+      userId: auth.user.localUserId,
+      projectId: stored.project.id,
+      memoryName: "Long segment translations",
+      sourceText,
+      targetText,
+    });
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText,
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: stored.project.id,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+
+    const matches = result.output.matches as Array<{
+      memoryId: string;
+      sourceText: string;
+      targetText: string;
+      locale: string;
+      similarity: number;
+    }>;
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      memoryId,
+      locale: "vi-VN",
+      similarity: 1,
+    });
+
+    expect(matches[0]?.sourceText).toHaveLength(4_000);
+    expect(matches[0]?.sourceText.endsWith("…")).toBe(true);
+
+    expect(matches[0]?.targetText).toHaveLength(4_000);
+    expect(matches[0]?.targetText.endsWith("…")).toBe(true);
+  });
+
+  it("returns memory_not_found for another organization's translation memory", async () => {
+    const accessible = await fixture.createStoredProjectFixture();
+    const inaccessible = await fixture.createStoredProjectFixture();
+
+    const headers = await authenticatedMcpHeaders(accessible.identity);
+
+    const [foreignMemory] = await db
+      .insert(schema.memories)
+      .values({
+        organizationId: inaccessible.organization.id,
+        createdByUserId: inaccessible.user.id,
+        name: "Foreign translation memory",
+        description: "",
+        status: "active",
+        source: "native",
+      })
+      .returning({ id: schema.memories.id });
+
+    if (!foreignMemory) {
+      throw new Error("expected foreign memory fixture");
+    }
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "Save changes",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        memoryId: foreignMemory.id,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toMatchObject({
+      error: "memory_not_found",
+    });
+  });
+
+  it("returns stored entries from a synced external translation memory", async () => {
+    const stored = await fixture.createStoredProjectFixture();
+    const headers = await authenticatedMcpHeaders(stored.identity);
+    const auth = globalThis.__testApiAuthContext;
+
+    if (!auth) {
+      throw new Error("expected test auth context");
+    }
+
+    const [memory] = await db
+      .insert(schema.memories)
+      .values({
+        organizationId: auth.organization.localOrganizationId,
+        createdByUserId: auth.user.localUserId,
+        name: "Synced Crowdin memory",
+        description: "",
+        status: "active",
+        source: "external_tms",
+        externalProviderKind: "crowdin",
+        externalProjectId: "crowdin-project-1",
+        externalMemoryId: "crowdin-memory-1",
+        capabilityMode: "synced_import",
+        syncState: "synced",
+        localeCoverage: ["en-US", "vi-VN"],
+      })
+      .returning({ id: schema.memories.id });
+
+    if (!memory) {
+      throw new Error("expected synced memory fixture");
+    }
+
+    await db.insert(schema.projectMemories).values({
+      organizationId: auth.organization.localOrganizationId,
+      projectId: stored.project.id,
+      memoryId: memory.id,
+    });
+
+    await db.insert(schema.memoryEntries).values({
+      memoryId: memory.id,
+      sourceLocale: "en-US",
+      targetLocale: "vi-VN",
+      sourceText: "Publish changes",
+      normalizedSourceText: normalizeTranslationMemorySourceText("Publish changes"),
+      targetText: "Xuất bản thay đổi",
+      matchScore: 100,
+      provenance: "crowdin_sync",
+      reviewStatus: "approved",
+      createdByUserId: auth.user.localUserId,
+    });
+
+    const result = await readMcpToolResult(
+      await callMcpTool(headers, "query_translation_memory", {
+        sourceText: "Publish changes",
+        sourceLocale: "en-US",
+        targetLocale: "vi-VN",
+        projectId: stored.project.id,
+        memoryId: memory.id,
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toEqual({
+      matches: [
+        {
+          memoryId: memory.id,
+          sourceText: "Publish changes",
+          targetText: "Xuất bản thay đổi",
+          locale: "vi-VN",
+          similarity: 1,
+        },
+      ],
+    });
   });
 
   it("returns provider_cat_unsupported for a provider-only translation update", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -822,11 +822,13 @@ function decodeMcpBase64(value: string): Uint8Array | null {
 const MAX_MCP_TRANSLATION_MEMORY_SEGMENT_LENGTH = 4_000;
 
 function truncateMcpTranslationMemorySegment(value: string) {
-  if (value.length <= MAX_MCP_TRANSLATION_MEMORY_SEGMENT_LENGTH) {
+  const codePoints = Array.from(value);
+
+  if (codePoints.length <= MAX_MCP_TRANSLATION_MEMORY_SEGMENT_LENGTH) {
     return value;
   }
 
-  return `${value.slice(0, MAX_MCP_TRANSLATION_MEMORY_SEGMENT_LENGTH - 1)}…`;
+  return `${codePoints.slice(0, MAX_MCP_TRANSLATION_MEMORY_SEGMENT_LENGTH - 1).join("")}…`;
 }
 
 function compactMcpTranslationMemoryMatch(match: {

--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.ts
@@ -109,6 +109,7 @@ import type { ApiAuthContext } from "@/api/auth/workos";
 import {
   isQueryableNativeGlossaryId,
   queryGlossaryTerms,
+  queryTranslationMemoryMatches,
   type QueryGlossaryHit,
 } from "@/lib/tools/asset-tools";
 import { loadMcpTranslation } from "@/api/routes/mcp/mcp-get-translation";
@@ -139,7 +140,9 @@ import { ensureAiFeaturesAllowed } from "@/lib/billing/ai-features";
 import { getOwnedGlossary, isGlossaryManageAllowed } from "@/api/routes/glossary/glossary.shared";
 import { getGlossaryProduct } from "@/lib/glossary/glossary-provider";
 import { GlossaryValidationError } from "@/lib/glossary/glossary";
+import { toolCanAccessMemory, toolCanAccessProject } from "@/lib/tools/tool-access";
 import { mcpCreateGlossaryConceptInputSchema } from "./mcp-create-glossary-concept.schema";
+import { mcpQueryTranslationMemoryInputSchema } from "./mcp-query-translation-memory.schema";
 
 const authorizationQuerySchema = z.object({
   response_type: z.literal("code"),
@@ -814,6 +817,40 @@ function decodeMcpBase64(value: string): Uint8Array | null {
   }
 
   return new Uint8Array(decoded);
+}
+
+const MAX_MCP_TRANSLATION_MEMORY_SEGMENT_LENGTH = 4_000;
+
+function truncateMcpTranslationMemorySegment(value: string) {
+  if (value.length <= MAX_MCP_TRANSLATION_MEMORY_SEGMENT_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, MAX_MCP_TRANSLATION_MEMORY_SEGMENT_LENGTH - 1)}…`;
+}
+
+function compactMcpTranslationMemoryMatch(match: {
+  memoryId: string;
+  sourceText: string;
+  targetText: string;
+  targetLocale: string;
+  rank?: number;
+}) {
+  return {
+    memoryId: match.memoryId,
+    sourceText: truncateMcpTranslationMemorySegment(match.sourceText),
+    targetText: truncateMcpTranslationMemorySegment(match.targetText),
+    locale: match.targetLocale,
+    ...(match.rank === undefined
+      ? {}
+      : {
+          similarity: match.rank,
+        }),
+  };
+}
+
+function isQueryableTranslationMemoryId(value: string) {
+  return z.uuid().safeParse(value).success;
 }
 
 function mcpToolContext(apiAuth: ApiAuthContext): ToolContext {
@@ -2512,6 +2549,68 @@ async function createMcpServerForRequest(auth: McpAuthVariables["mcpAuth"]) {
   );
 
   registerZernioMcpTools(server, apiAuth);
+
+  server.registerTool(
+    "query_translation_memory",
+    {
+      description: "Find exact and similar translation memory matches for a source segment.",
+      inputSchema: mcpQueryTranslationMemoryInputSchema,
+    },
+    async ({ sourceText, sourceLocale, targetLocale, projectId, memoryId, limit }) => {
+      const ctx = mcpToolContext(apiAuth);
+
+      if (projectId && !(await toolCanAccessProject(ctx, projectId))) {
+        return mcpToolError("project_not_found", "Project not found or inaccessible");
+      }
+
+      if (memoryId) {
+        if (
+          !isQueryableTranslationMemoryId(memoryId) ||
+          !(await toolCanAccessMemory(ctx, memoryId))
+        ) {
+          return mcpToolError("memory_not_found", "Translation memory not found or inaccessible");
+        }
+      }
+
+      if (projectId && memoryId) {
+        const [attachment] = await db
+          .select({ id: schema.projectMemories.id })
+          .from(schema.projectMemories)
+          .where(
+            and(
+              eq(schema.projectMemories.organizationId, apiAuth.organization.localOrganizationId),
+              eq(schema.projectMemories.projectId, projectId),
+              eq(schema.projectMemories.memoryId, memoryId),
+            ),
+          )
+          .limit(1);
+
+        if (!attachment) {
+          return mcpToolError("memory_not_found", "Translation memory not found or inaccessible");
+        }
+      }
+
+      const result = await queryTranslationMemoryMatches(ctx, {
+        sourceText,
+        sourceLocale,
+        targetLocale,
+        projectId,
+        memoryId,
+        limit,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              matches: result.matches.map(compactMcpTranslationMemoryMatch),
+            }),
+          },
+        ],
+      };
+    },
+  );
 
   return server;
 }

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.test.ts
@@ -141,6 +141,9 @@ async function createMemoryWithEntry(input: {
   name: string;
   sourceText: string;
   targetText: string;
+  status?: "draft" | "active" | "archived";
+  source?: "native" | "external_tms";
+  capabilityMode?: "live_search" | "synced_import" | "reference_only";
 }) {
   const [memory] = await db
     .insert(schema.memories)
@@ -148,7 +151,10 @@ async function createMemoryWithEntry(input: {
       organizationId: input.organizationId,
       name: input.name,
       description: "",
-      status: "active",
+      status: input.status ?? "active",
+      source: input.source ?? "native",
+      externalProviderKind: input.source === "external_tms" ? "crowdin" : undefined,
+      capabilityMode: input.capabilityMode,
     })
     .returning();
 
@@ -691,6 +697,66 @@ describe("createQueryTranslationMemoryTool", () => {
       sourceText: "Start checkout",
       targetText: "Commencer le paiement",
     });
+  });
+
+  it("returns fuzzy matches when the query contains an additional word", async () => {
+    const organization = await createOrganization();
+
+    await createMemoryWithEntry({
+      organizationId: organization.id,
+      name: "Edited Segment Memory",
+      sourceText: "Hello world",
+      targetText: "Bonjour le monde",
+    });
+
+    const result = await executeMemorySearch({
+      organizationId: organization.id,
+      sourceText: "Hello brave world",
+    });
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]).toMatchObject({
+      sourceText: "Hello world",
+      targetText: "Bonjour le monde",
+    });
+  });
+
+  it("excludes inactive and reference-only memories", async () => {
+    const organization = await createOrganization();
+
+    await createMemoryWithEntry({
+      organizationId: organization.id,
+      name: "Active Memory",
+      sourceText: "Start checkout",
+      targetText: "Commencer le paiement",
+    });
+    await createMemoryWithEntry({
+      organizationId: organization.id,
+      name: "Archived Memory",
+      sourceText: "Start checkout",
+      targetText: "Traduction archivée",
+      status: "archived",
+    });
+    await createMemoryWithEntry({
+      organizationId: organization.id,
+      name: "Reference-only Memory",
+      sourceText: "Start checkout",
+      targetText: "Traduction de référence",
+      source: "external_tms",
+      capabilityMode: "reference_only",
+    });
+
+    const exact = await executeMemorySearch({
+      organizationId: organization.id,
+      sourceText: "Start checkout",
+    });
+    const fuzzy = await executeMemorySearch({
+      organizationId: organization.id,
+      sourceText: "checkout",
+    });
+
+    expect(exact.matches.map(({ targetText }) => targetText)).toEqual(["Commencer le paiement"]);
+    expect(fuzzy.matches.map(({ targetText }) => targetText)).toEqual(["Commencer le paiement"]);
   });
 
   it("does not use a project ID from another organization to read attached memories", async () => {

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
@@ -341,6 +341,153 @@ export function createQueryGlossaryTool(ctx: ToolContext) {
  * If no exact match is found, falls back to the full-text search vector on
  * `memoryEntries.searchVector` for lexical similarity.
  */
+export type QueryTranslationMemoryInput = {
+  sourceText: string;
+  sourceLocale: string;
+  targetLocale: string;
+  projectId?: string;
+  memoryId?: string;
+  limit: number;
+};
+
+export async function queryTranslationMemoryMatches(
+  ctx: ToolContext,
+  {
+    sourceText,
+    sourceLocale,
+    targetLocale,
+    projectId,
+    memoryId,
+    limit,
+  }: QueryTranslationMemoryInput,
+) {
+  const db = ctx.db;
+  const normalized = normalizeTranslationMemorySourceText(sourceText);
+
+  let memoryIds: string[] | undefined;
+
+  if (projectId) {
+    const accessibleProject = await toolCanAccessProject(ctx, projectId);
+
+    if (!accessibleProject) {
+      return { matches: [] };
+    }
+
+    const attached = await db
+      .select({
+        memoryId: schema.projectMemories.memoryId,
+      })
+      .from(schema.projectMemories)
+      .where(
+        and(
+          eq(schema.projectMemories.projectId, projectId),
+          eq(schema.projectMemories.organizationId, ctx.organizationId),
+        ),
+      );
+
+    memoryIds = attached.map(({ memoryId }) => memoryId);
+
+    if (memoryIds.length === 0) {
+      return { matches: [] };
+    }
+  }
+
+  if (memoryId) {
+    if (memoryIds && !memoryIds.includes(memoryId)) {
+      return { matches: [] };
+    }
+
+    memoryIds = [memoryId];
+  }
+
+  const exactConditions = [
+    eq(schema.memoryEntries.normalizedSourceText, normalized),
+    eq(schema.memoryEntries.sourceLocale, sourceLocale),
+    eq(schema.memoryEntries.targetLocale, targetLocale),
+    eq(schema.memoryEntries.reviewStatus, "approved"),
+    await toolProjectLinkedMemoryWhere(ctx),
+  ];
+
+  if (memoryIds) {
+    exactConditions.push(inArray(schema.memoryEntries.memoryId, memoryIds));
+  }
+
+  const exactMatches = await db
+    .select({
+      id: schema.memoryEntries.id,
+      memoryId: schema.memoryEntries.memoryId,
+      sourceText: schema.memoryEntries.sourceText,
+      targetText: schema.memoryEntries.targetText,
+      sourceLocale: schema.memoryEntries.sourceLocale,
+      targetLocale: schema.memoryEntries.targetLocale,
+      matchScore: schema.memoryEntries.matchScore,
+      provenance: schema.memoryEntries.provenance,
+    })
+    .from(schema.memoryEntries)
+    .innerJoin(schema.memories, eq(schema.memoryEntries.memoryId, schema.memories.id))
+    .where(and(...exactConditions))
+    .limit(limit);
+
+  if (exactMatches.length > 0) {
+    return {
+      matches: exactMatches.map((match) => ({
+        ...match,
+        rank: 1,
+      })),
+    };
+  }
+
+  const tsQuery = buildTsQuery(sourceText);
+
+  if (!tsQuery) {
+    return { matches: [] };
+  }
+
+  const fuzzyConditions = [
+    sql`${schema.memoryEntries.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
+    eq(schema.memoryEntries.sourceLocale, sourceLocale),
+    eq(schema.memoryEntries.targetLocale, targetLocale),
+    eq(schema.memoryEntries.reviewStatus, "approved"),
+    await toolProjectLinkedMemoryWhere(ctx),
+  ];
+
+  if (memoryIds) {
+    fuzzyConditions.push(inArray(schema.memoryEntries.memoryId, memoryIds));
+  }
+
+  const fuzzyMatches = await db
+    .select({
+      id: schema.memoryEntries.id,
+      memoryId: schema.memoryEntries.memoryId,
+      sourceText: schema.memoryEntries.sourceText,
+      targetText: schema.memoryEntries.targetText,
+      sourceLocale: schema.memoryEntries.sourceLocale,
+      targetLocale: schema.memoryEntries.targetLocale,
+      matchScore: schema.memoryEntries.matchScore,
+      provenance: schema.memoryEntries.provenance,
+      rank: sql<number>`
+        ts_rank(
+          ${schema.memoryEntries.searchVector},
+          to_tsquery('simple', ${tsQuery})
+        )
+      `.as("rank"),
+    })
+    .from(schema.memoryEntries)
+    .innerJoin(schema.memories, eq(schema.memoryEntries.memoryId, schema.memories.id))
+    .where(and(...fuzzyConditions))
+    .orderBy(
+      sql`ts_rank(
+        ${schema.memoryEntries.searchVector},
+        to_tsquery('simple', ${tsQuery})
+      ) DESC`,
+    )
+    .limit(limit);
+
+  return {
+    matches: fuzzyMatches,
+  };
+}
+
 export function createQueryTranslationMemoryTool(ctx: ToolContext) {
   return tool({
     description: "Search translation memory for previous accepted translations of a source text.",
@@ -354,113 +501,6 @@ export function createQueryTranslationMemoryTool(ctx: ToolContext) {
         .describe("Optional project ID to restrict to attached memories."),
       limit: z.number().min(1).max(10).default(5).describe("Maximum results to return."),
     }),
-    execute: async ({ sourceText, sourceLocale, targetLocale, projectId, limit }) => {
-      const db = ctx.db;
-      const normalized = normalizeTranslationMemorySourceText(sourceText);
-
-      let memoryIds: string[] | undefined;
-      if (projectId) {
-        const accessibleProject = await toolCanAccessProject(ctx, projectId);
-        if (!accessibleProject) {
-          return { matches: [] };
-        }
-
-        const attached = await db
-          .select({ memoryId: schema.projectMemories.memoryId })
-          .from(schema.projectMemories)
-          .where(
-            and(
-              eq(schema.projectMemories.projectId, projectId),
-              eq(schema.projectMemories.organizationId, ctx.organizationId),
-            ),
-          );
-        memoryIds = attached.map((a) => a.memoryId);
-        if (memoryIds.length === 0) {
-          return { matches: [] };
-        }
-      }
-
-      // Exact match on normalized text first.
-      const exactConditions = [
-        eq(schema.memoryEntries.normalizedSourceText, normalized),
-        eq(schema.memoryEntries.sourceLocale, sourceLocale),
-        eq(schema.memoryEntries.targetLocale, targetLocale),
-        eq(schema.memoryEntries.reviewStatus, "approved"),
-        await toolProjectLinkedMemoryWhere(ctx),
-      ];
-      if (memoryIds) {
-        exactConditions.push(inArray(schema.memoryEntries.memoryId, memoryIds));
-      }
-
-      const exactMatches = await db
-        .select({
-          id: schema.memoryEntries.id,
-          sourceText: schema.memoryEntries.sourceText,
-          targetText: schema.memoryEntries.targetText,
-          sourceLocale: schema.memoryEntries.sourceLocale,
-          targetLocale: schema.memoryEntries.targetLocale,
-          matchScore: schema.memoryEntries.matchScore,
-          provenance: schema.memoryEntries.provenance,
-        })
-        .from(schema.memoryEntries)
-        .innerJoin(schema.memories, eq(schema.memoryEntries.memoryId, schema.memories.id))
-        .where(and(...exactConditions))
-        .limit(limit);
-
-      if (exactMatches.length > 0) {
-        return {
-          matches: exactMatches.map((m) => ({ ...m, rank: 1.0 })),
-        };
-      }
-
-      // Fallback to lexical full-text search.
-      const tsQuery = buildTsQuery(sourceText);
-      if (!tsQuery) {
-        return { matches: [] };
-      }
-
-      const fuzzyConditions = [
-        sql`${schema.memoryEntries.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
-        eq(schema.memoryEntries.sourceLocale, sourceLocale),
-        eq(schema.memoryEntries.targetLocale, targetLocale),
-        eq(schema.memoryEntries.reviewStatus, "approved"),
-        await toolProjectLinkedMemoryWhere(ctx),
-      ];
-      if (memoryIds) {
-        fuzzyConditions.push(inArray(schema.memoryEntries.memoryId, memoryIds));
-      }
-
-      const fuzzyMatches = await db
-        .select({
-          id: schema.memoryEntries.id,
-          sourceText: schema.memoryEntries.sourceText,
-          targetText: schema.memoryEntries.targetText,
-          sourceLocale: schema.memoryEntries.sourceLocale,
-          targetLocale: schema.memoryEntries.targetLocale,
-          matchScore: schema.memoryEntries.matchScore,
-          provenance: schema.memoryEntries.provenance,
-          rank: sql<number>`ts_rank(${schema.memoryEntries.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
-            "rank",
-          ),
-        })
-        .from(schema.memoryEntries)
-        .innerJoin(schema.memories, eq(schema.memoryEntries.memoryId, schema.memories.id))
-        .where(and(...fuzzyConditions))
-        .orderBy(desc(sql`rank`))
-        .limit(limit);
-
-      return {
-        matches: fuzzyMatches.map((m) => ({
-          id: m.id,
-          sourceText: m.sourceText,
-          targetText: m.targetText,
-          sourceLocale: m.sourceLocale,
-          targetLocale: m.targetLocale,
-          matchScore: m.matchScore,
-          provenance: m.provenance,
-          rank: m.rank,
-        })),
-      };
-    },
+    execute: async (input) => queryTranslationMemoryMatches(ctx, input),
   });
 }

--- a/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/asset-tools.ts
@@ -20,6 +20,7 @@ import { flattenNativeConceptTermsToPairs } from "@/lib/glossary/flatten-native-
 import { buildGlossaryTsQuery } from "@/lib/glossary/glossary";
 import { concordanceSourceContainsTerm } from "@/lib/glossary/native-glossary";
 import { groupConceptTerms } from "@/lib/glossary/query-glossary-terms";
+import { isMemorySearchableForExecution } from "@/lib/memory/memory-capabilities";
 import { parseLiveProviderGlossaryId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
@@ -37,14 +38,14 @@ import type { ToolContext } from "@/lib/tools/types";
  * Strips characters that have special meaning in Postgres tsquery syntax
  * so that untrusted input cannot break the query.
  */
-function buildTsQuery(input: string): string {
+function buildTsQuery(input: string, operator: " & " | " | " = " & "): string {
   const sanitized = input
     .replace(/[&|!():*<>]/g, " ")
     .trim()
     .split(/\s+/)
     .filter(Boolean)
     .map((w) => `${w}:*`)
-    .join(" & ");
+    .join(operator);
   return sanitized;
 }
 
@@ -400,17 +401,36 @@ export async function queryTranslationMemoryMatches(
     memoryIds = [memoryId];
   }
 
+  const searchableMemoryConditions = [await toolProjectLinkedMemoryWhere(ctx)];
+
+  if (memoryIds) {
+    searchableMemoryConditions.push(inArray(schema.memories.id, memoryIds));
+  }
+
+  const searchableMemories = await db
+    .select({
+      id: schema.memories.id,
+      source: schema.memories.source,
+      status: schema.memories.status,
+      capabilityMode: schema.memories.capabilityMode,
+      externalProviderKind: schema.memories.externalProviderKind,
+    })
+    .from(schema.memories)
+    .where(and(...searchableMemoryConditions));
+
+  memoryIds = searchableMemories.filter(isMemorySearchableForExecution).map(({ id }) => id);
+
+  if (memoryIds.length === 0) {
+    return { matches: [] };
+  }
+
   const exactConditions = [
     eq(schema.memoryEntries.normalizedSourceText, normalized),
     eq(schema.memoryEntries.sourceLocale, sourceLocale),
     eq(schema.memoryEntries.targetLocale, targetLocale),
     eq(schema.memoryEntries.reviewStatus, "approved"),
-    await toolProjectLinkedMemoryWhere(ctx),
+    inArray(schema.memoryEntries.memoryId, memoryIds),
   ];
-
-  if (memoryIds) {
-    exactConditions.push(inArray(schema.memoryEntries.memoryId, memoryIds));
-  }
 
   const exactMatches = await db
     .select({
@@ -437,7 +457,7 @@ export async function queryTranslationMemoryMatches(
     };
   }
 
-  const tsQuery = buildTsQuery(sourceText);
+  const tsQuery = buildTsQuery(sourceText, " | ");
 
   if (!tsQuery) {
     return { matches: [] };
@@ -448,12 +468,8 @@ export async function queryTranslationMemoryMatches(
     eq(schema.memoryEntries.sourceLocale, sourceLocale),
     eq(schema.memoryEntries.targetLocale, targetLocale),
     eq(schema.memoryEntries.reviewStatus, "approved"),
-    await toolProjectLinkedMemoryWhere(ctx),
+    inArray(schema.memoryEntries.memoryId, memoryIds),
   ];
-
-  if (memoryIds) {
-    fuzzyConditions.push(inArray(schema.memoryEntries.memoryId, memoryIds));
-  }
 
   const fuzzyMatches = await db
     .select({

--- a/docs/platform/mcp.mdx
+++ b/docs/platform/mcp.mdx
@@ -59,6 +59,7 @@ Tool responses are JSON text in MCP content blocks. Errors use `{ "error": "<cod
 | `create_glossary_concept` | Create concept-linked source and target terms in a native glossary                                                                                                   |
 | `upload_sources`       | Upload a source file to a project using UTF-8 `content` or binary `contentBase64`                                                                                       |
 | `download_translations` | Download a reconstructed UTF-8 target file (`projectId`, `sourcePath`, `locale`)                                                                                         |
+| `query_translation_memory` | Search approved translation-memory entries for exact and lexical matches, optionally scoped by project or memory |
 
 `list_files` returns metadata only: `id` (stored file or source-file id), `sourcePath`, `filename`, `contentType`, `byteSize`, `updatedAt`, and `sourceLocale` when known. Pagination includes `total`, `limit`, `offset`, `hasMore`, and `nextOffset`. The tool does not return file contents. Inaccessible projects return `project_not_found`. Use the listed `sourcePath` values for later upload, download, or `run_workflow` calls.
 
@@ -103,6 +104,28 @@ Native pairs come from concept-linked terms. Leftover `source_term` / `target_te
 `create_glossary_concept` adds one source term and one target term to a new concept in a native glossary. Provide `glossaryId`, `sourceLocale`, `sourceTerm`, `targetLocale`, and `targetTerm`; optional fields include `description`, `partOfSpeech`, and `forbidden`. The response contains `conceptId`, `sourceTermId`, and `targetTermId`. When `forbidden` is true, the target term is stored as not recommended so glossary searches and translation review can tell agents not to use it.
 
 Creating glossary concepts requires glossary-management permission. Missing or inaccessible glossaries return `glossary_not_found`, provider-synced glossaries return `glossary_read_only`, and a term already present for the same locale in the glossary returns `duplicate_glossary_concept_term`.
+
+### Translation memory search
+
+`query_translation_memory` searches previously approved translations for a source segment.
+
+Required input:
+
+- `sourceText`
+- `sourceLocale`
+- `targetLocale`
+
+Optional input:
+
+- `projectId` restricts the search to translation memories linked to an accessible project.
+- `memoryId` restricts the search to one accessible translation memory.
+- `limit` controls the number of results from 1 to 20 and defaults to 10.
+
+The tool first searches for an exact match using normalized source text. If no exact match exists, it falls back to lexical full-text search. Results are ranked and returned with `memoryId`, `sourceText`, `targetText`, `locale`, and `similarity` when available.
+
+Only approved memory entries are returned. When `projectId` is provided, unlinked memories are excluded. Missing or inaccessible projects return `project_not_found`. Missing, inaccessible, malformed, or project-unlinked memories return `memory_not_found`.
+
+Provider-backed translation memories use entries already stored or synchronized in Hyperlocalise. This tool does not initiate a live provider search.
 
 ### Board (issues)
 
@@ -203,7 +226,7 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `idempotency_conflict`                         | The supplied idempotency key is already associated with a different workflow payload                                  |
 | `ai_features_required`                         | AI translation features are not available for the organization                                                        |
 | `ai_features_check_failed`                     | Hyperlocalise could not verify AI feature availability                                                                |
-| `project_not_found`                            | Wrong `projectId` or missing project access on `list_files`, `list_translations`, `get_project_status`, or `list_jobs` |
+| `project_not_found`                            | Wrong `projectId` or missing project access on project-scoped tools, including `query_translation_memory`            |
 | `glossary_not_found`                           | Wrong `glossaryId`, missing glossary access, or a provider glossary on `query_glossary`                                |
 | `glossary_read_only`                           | `create_glossary_concept` targeted a provider-synced glossary                                                        |
 | `duplicate_glossary_concept_term`              | A source or target term already exists for the same locale in the native glossary                                    |
@@ -218,7 +241,8 @@ Token lifetime defaults to 60 minutes with a 30-day refresh window. Operators ca
 | `source_file_not_found`                        | The requested source path does not exist in the accessible project                                                     |
 | `translations_not_found`                       | The source file has no translation keys available to reconstruct                                                       |
 | `source_file_too_large`                        | The translation reconstruction exceeds the public API key limit                                                        |
-| `unsupported_binary_download`                  | The reconstructed file cannot be returned as UTF-8 text                                                                 |
+| `unsupported_binary_download`                  | The reconstructed file cannot be returned as UTF-8 text                                                                |
+| `memory_not_found`                             | `query_translation_memory` targeted a missing, inaccessible, malformed, or project-unlinked translation memory         |
 
 ## Next
 


### PR DESCRIPTION
## What changed

- Added the hosted MCP `query_translation_memory` tool for exact and fuzzy translation-memory concordance searches.
- Added a dedicated bounded input schema supporting source and target locales, optional project and memory scopes, and a result limit.
- Reused the existing translation-memory search path and source-text normalization.
- Added project, memory, organization, and project-memory attachment checks to prevent cross-scope data access.
- Returned stable `project_not_found` and `memory_not_found` errors for inaccessible or malformed resources.
- Returned compact ranked matches containing `memoryId`, source text, target text, target locale, and similarity when available.
- Truncated unusually long source and target segments in MCP responses.
- Kept provider-backed searches limited to entries already stored or synchronized locally.
- Preserved the existing agent-runtime translation-memory tool contract.
- Updated the MCP documentation.

## How to test

```bash
cd apps/hyperlocalise-web

vp check --fix
vp test src/lib/tools/asset-tools.test.ts
vp test src/api/routes/mcp/mcp.route.test.ts
```

Results:
- Asset tool tests: 16 passed
- MCP route tests: 174 passed
- Formatting, lint, and TypeScript checks passed
- git diff --check passed

## Checklist

- [X] I ran relevant checks locally (make fmt, make lint, make test)
- [X] I updated docs, comments, or examples when needed
- [X] This PR is scoped and ready for review
