### PR TITLE
chore(ci): disable xmllint install and RELAX NG test

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -117,8 +117,9 @@ jobs:
       - name: Install hyperlocalise-web dependencies
         run: vp install --frozen-lockfile
 
-      - name: Install xmllint
-        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      # TODO: Re-enable xmllint installation once RELAX NG validation test is stable in CI.
+      # - name: Install xmllint
+      #   run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
       - name: Migrate hyperlocalise-web database
         run: vp run db:migrate

--- a/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/interchange/tbx.test.ts
@@ -10,11 +10,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+// TODO: Re-enable xmllint RELAX NG validation once flaky CI failures are resolved.
+// import { execFileSync } from "node:child_process";
+// import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+// import { tmpdir } from "node:os";
+// import { dirname, join } from "node:path";
+// import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vite-plus/test";
 
@@ -147,20 +148,20 @@ function makeDocument(): GlossaryInterchangeDocument {
   };
 }
 
-const XMLLINT_CANDIDATES = ["/usr/bin/xmllint", "xmllint"] as const;
-
-function resolveXmllint(): string | null {
-  for (const candidate of XMLLINT_CANDIDATES) {
-    try {
-      execFileSync(candidate, ["--version"], { stdio: "pipe" });
-      return candidate;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-      return candidate;
-    }
-  }
-  return null;
-}
+// const XMLLINT_CANDIDATES = ["/usr/bin/xmllint", "xmllint"] as const;
+//
+// function resolveXmllint(): string | null {
+//   for (const candidate of XMLLINT_CANDIDATES) {
+//     try {
+//       execFileSync(candidate, ["--version"], { stdio: "pipe" });
+//       return candidate;
+//     } catch (error) {
+//       if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+//       return candidate;
+//     }
+//   }
+//   return null;
+// }
 
 function makeDocumentTerm(id: string, conceptId: string) {
   return {
@@ -237,27 +238,28 @@ describe("TBX-Basic DCA interchange", () => {
     expect(parsed.concepts[1]?.id).toBe("55555555-5555-4555-8555-555555555555");
   });
 
-  it.skipIf(!resolveXmllint())(
-    "validates generated output against the pinned RELAX NG schema",
-    () => {
-      const xmllint = resolveXmllint();
-      if (!xmllint) throw new Error("xmllint is required for this test");
-      const serialized = serializeTbx(makeDocument());
-      const directory = mkdtempSync(join(tmpdir(), "hyperlocalise-tbx-"));
-      const documentPath = join(directory, "export.tbx");
-      const schemaPath = join(
-        dirname(fileURLToPath(import.meta.url)),
-        "tbx-validation/TBXcoreStructV03_TBX-Basic_integrated.rng",
-      );
-      writeFileSync(documentPath, serialized.content);
-      expect(() =>
-        execFileSync(xmllint, ["--noout", "--relaxng", schemaPath, documentPath], {
-          stdio: "pipe",
-        }),
-      ).not.toThrow();
-      rmSync(directory, { recursive: true, force: true });
-    },
-  );
+  // TODO: Re-enable once xmllint RELAX NG validation is stable in CI.
+  // it.skipIf(!resolveXmllint())(
+  //   "validates generated output against the pinned RELAX NG schema",
+  //   () => {
+  //     const xmllint = resolveXmllint();
+  //     if (!xmllint) throw new Error("xmllint is required for this test");
+  //     const serialized = serializeTbx(makeDocument());
+  //     const directory = mkdtempSync(join(tmpdir(), "hyperlocalise-tbx-"));
+  //     const documentPath = join(directory, "export.tbx");
+  //     const schemaPath = join(
+  //       dirname(fileURLToPath(import.meta.url)),
+  //       "tbx-validation/TBXcoreStructV03_TBX-Basic_integrated.rng",
+  //     );
+  //     writeFileSync(documentPath, serialized.content);
+  //     expect(() =>
+  //       execFileSync(xmllint, ["--noout", "--relaxng", schemaPath, documentPath], {
+  //         stdio: "pipe",
+  //       }),
+  //     ).not.toThrow();
+  //     rmSync(directory, { recursive: true, force: true });
+  //   },
+  // );
 
   it("reports invalid XML characters and unsupported statuses", () => {
     const document = makeDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Temporarily disables xmllint in CI to unblock flaky web test failures.

## Changes

- Comment out `libxml2-utils` installation in `.github/workflows/web.yml`
- Comment out the TBX RELAX NG schema validation test and its xmllint helpers in `tbx.test.ts`

Both locations include `TODO` comments to re-enable once CI stability is restored.

## Testing

- `CI=true vp test src/lib/glossary/interchange/tbx.test.ts` — 10 tests passed (xmllint test excluded)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08ff7-0f28-752b-8702-0926aa74144d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08ff7-0f28-752b-8702-0926aa74144d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

