### PR TITLE
feat(seo): add inLanguage to JSON-LD structured data

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/blog/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/blog/[slug]/page.tsx
@@ -16,6 +16,7 @@ import { notFound } from "next/navigation";
 
 import { BlogPostPage } from "@/components/marketing/blog/blog-post-page";
 import { JsonLd } from "@/components/seo/json-ld";
+import { jsonLdInLanguage } from "@/lib/seo/json-ld-in-language";
 import {
   DEFAULT_APP_LOCALE,
   normalizeAppLocale,
@@ -95,6 +96,7 @@ function buildArticleJsonLd(
   const articleSchema: WithContext<Article> = {
     "@context": "https://schema.org",
     "@type": "Article",
+    inLanguage: jsonLdInLanguage(locale),
     url: canonicalUrl,
     thumbnailUrl: imageUrl,
     mainEntityOfPage: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/layout.tsx
@@ -13,8 +13,9 @@
 import type { Metadata } from "next";
 
 import { JsonLd } from "@/components/seo/json-ld";
-import { organizationJsonLd } from "@/components/seo/organization-json-ld";
+import { buildOrganizationJsonLd } from "@/components/seo/organization-json-ld";
 import { BrandThemeProvider } from "@/components/ui/brand-theme";
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { INDEXABLE_ROBOTS } from "@/lib/seo/robots-metadata";
 
 import Navbar from "./_components/navbar";
@@ -23,7 +24,16 @@ export const metadata: Metadata = {
   robots: INDEXABLE_ROBOTS,
 };
 
-export default function MarketingLayout({ children }: { children: React.ReactNode }) {
+type MarketingLayoutProps = {
+  children: React.ReactNode;
+  params: Promise<{ lang: string }>;
+};
+
+export default async function MarketingLayout({ children, params }: MarketingLayoutProps) {
+  const { lang } = await params;
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const organizationJsonLd = buildOrganizationJsonLd(locale);
+
   return (
     <BrandThemeProvider theme="marketing">
       <JsonLd data={organizationJsonLd} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
@@ -22,6 +22,7 @@ import { HomepageFaqSection } from "@/components/marketing/homepage-faq-section"
 import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { JsonLd } from "@/components/seo/json-ld";
+import { jsonLdInLanguage } from "@/lib/seo/json-ld-in-language";
 import { RecentBlogPostsSection } from "@/components/marketing/recent-blog-posts-section";
 import { TourfinderTestimonialSection } from "@/components/marketing/tourfinder-testimonial-section";
 import {
@@ -34,7 +35,7 @@ import {
 } from "@/components/marketing/pricing/pricing-page-content";
 import { PricingPlansSection } from "@/components/marketing/pricing/pricing-plans-section";
 import { getIntlShape } from "@/lib/app-i18n/intl";
-import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
+import { DEFAULT_APP_LOCALE, normalizeAppLocale, type AppLocale } from "@/lib/app-i18n/locales";
 import { getAllPosts } from "@/lib/blog/blog-post";
 import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -95,12 +96,13 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
   };
 }
 
-function buildJsonLd(locale: string): WithContext<WebApplication> & object {
+function buildJsonLd(locale: AppLocale): WithContext<WebApplication> & object {
   const intl = getIntlShape(locale);
 
   return {
     "@context": "https://schema.org",
     "@type": "WebApplication",
+    inLanguage: jsonLdInLanguage(locale),
     name: "Hyperlocalise",
     applicationCategory: "DeveloperApplication",
     operatingSystem: "Cloud",
@@ -172,9 +174,10 @@ async function HomepagePricing({ params }: HomePageProps) {
 
 async function HomepageFaq({ params }: HomePageProps) {
   const { lang } = await params;
-  const jsonLd = buildJsonLd(lang);
-  const faqItems = getHomepageFaqItems(lang);
-  const faqJsonLd = buildHomepageFaqJsonLd(faqItems);
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const jsonLd = buildJsonLd(locale);
+  const faqItems = getHomepageFaqItems(locale);
+  const faqJsonLd = buildHomepageFaqJsonLd(locale, faqItems);
 
   return (
     <>

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/pricing/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/pricing/page.tsx
@@ -50,7 +50,7 @@ export default async function PricingRoutePage({ params }: PricingRouteProps) {
   const { lang } = await params;
   const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
   const faqItems = getPricingFaqItems(locale);
-  const faqJsonLd = buildPricingFaqJsonLd(faqItems);
+  const faqJsonLd = buildPricingFaqJsonLd(locale, faqItems);
 
   return (
     <>

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.test.ts
@@ -17,12 +17,13 @@ import { buildHomepageFaqJsonLd, getHomepageFaqItems } from "./homepage-faq-cont
 describe("homepage FAQ content", () => {
   it("builds matching visible content and FAQPage structured data", () => {
     const items = getHomepageFaqItems("en");
-    const jsonLd = buildHomepageFaqJsonLd(items);
+    const jsonLd = buildHomepageFaqJsonLd("en", items);
 
     expect(items).toHaveLength(12);
     expect(jsonLd).toMatchObject({
       "@context": "https://schema.org",
       "@type": "FAQPage",
+      inLanguage: "en",
     });
     expect(jsonLd.mainEntity).toEqual(
       items.map((item) => ({

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.ts
@@ -12,6 +12,9 @@
  */
 import type { FAQPage, WithContext } from "schema-dts";
 
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { jsonLdInLanguage } from "@/lib/seo/json-ld-in-language";
+
 import { getIntlShape } from "@/lib/app-i18n/intl";
 
 export type HomepageFaqItem = {
@@ -182,10 +185,14 @@ export function getHomepageFaqItems(locale: string): HomepageFaqItem[] {
   ];
 }
 
-export function buildHomepageFaqJsonLd(items: readonly HomepageFaqItem[]): WithContext<FAQPage> {
+export function buildHomepageFaqJsonLd(
+  locale: AppLocale,
+  items: readonly HomepageFaqItem[],
+): WithContext<FAQPage> {
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
+    inLanguage: jsonLdInLanguage(locale),
     mainEntity: items.map((item) => ({
       "@type": "Question",
       name: item.question,

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-page-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-page-content.test.ts
@@ -100,11 +100,12 @@ describe("pricing page content", () => {
 
   it("builds matching FAQ content and FAQPage structured data", () => {
     const items = getPricingFaqItems("en");
-    const jsonLd = buildPricingFaqJsonLd(items);
+    const jsonLd = buildPricingFaqJsonLd("en", items);
 
     expect(items.length).toBeGreaterThan(0);
     expect(jsonLd).toMatchObject({
       "@type": "FAQPage",
+      inLanguage: "en",
       mainEntity: items.map((item) => ({
         "@type": "Question",
         name: item.question,

--- a/apps/hyperlocalise-web/src/components/seo/organization-json-ld.test.ts
+++ b/apps/hyperlocalise-web/src/components/seo/organization-json-ld.test.ts
@@ -12,11 +12,11 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { organizationJsonLd } from "./organization-json-ld";
+import { buildOrganizationJsonLd } from "./organization-json-ld";
 
-describe("organizationJsonLd", () => {
+describe("buildOrganizationJsonLd", () => {
   it("describes Hyperlocalise and its public company profiles", () => {
-    expect(organizationJsonLd).toMatchObject({
+    expect(buildOrganizationJsonLd("en")).toMatchObject({
       "@context": "https://schema.org",
       "@type": "Organization",
       "@id": "https://www.hyperlocalise.com/#organization",
@@ -47,6 +47,11 @@ describe("organizationJsonLd", () => {
         contactType: "sales",
         email: "minh@hyperlocalise.com",
       },
+      inLanguage: "en",
     });
+  });
+
+  it("sets inLanguage from the page locale", () => {
+    expect(buildOrganizationJsonLd("fr-FR")).toMatchObject({ inLanguage: "fr-FR" });
   });
 });

--- a/apps/hyperlocalise-web/src/components/seo/organization-json-ld.ts
+++ b/apps/hyperlocalise-web/src/components/seo/organization-json-ld.ts
@@ -12,35 +12,43 @@
  */
 import type { Organization, WithContext } from "schema-dts";
 
-export const organizationJsonLd: WithContext<Organization> = {
-  "@context": "https://schema.org",
-  "@type": "Organization",
-  "@id": "https://www.hyperlocalise.com/#organization",
-  name: "Hyperlocalise",
-  url: "https://www.hyperlocalise.com",
-  logo: {
-    "@type": "ImageObject",
-    url: "https://www.hyperlocalise.com/images/logo.png",
-  },
-  description:
-    "Agentic localisation platform that connects product change signals, AI translation, human review, and release workflows.",
-  foundingDate: "2026",
-  founders: [
-    {
-      "@type": "Person",
-      name: "Minh Cung",
-      sameAs: "https://www.linkedin.com/in/minhcung/",
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { jsonLdInLanguage } from "@/lib/seo/json-ld-in-language";
+
+export function buildOrganizationJsonLd(locale: AppLocale): WithContext<Organization> & {
+  inLanguage: string;
+} {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": "https://www.hyperlocalise.com/#organization",
+    name: "Hyperlocalise",
+    url: "https://www.hyperlocalise.com",
+    logo: {
+      "@type": "ImageObject",
+      url: "https://www.hyperlocalise.com/images/logo.png",
     },
-    {
-      "@type": "Person",
-      name: "Hans Bui",
-      sameAs: "https://www.linkedin.com/in/hansbui/",
+    description:
+      "Agentic localisation platform that connects product change signals, AI translation, human review, and release workflows.",
+    foundingDate: "2026",
+    founders: [
+      {
+        "@type": "Person",
+        name: "Minh Cung",
+        sameAs: "https://www.linkedin.com/in/minhcung/",
+      },
+      {
+        "@type": "Person",
+        name: "Hans Bui",
+        sameAs: "https://www.linkedin.com/in/hansbui/",
+      },
+    ],
+    sameAs: ["https://www.linkedin.com/company/hyperlocalise/"],
+    contactPoint: {
+      "@type": "ContactPoint",
+      contactType: "sales",
+      email: "minh@hyperlocalise.com",
     },
-  ],
-  sameAs: ["https://www.linkedin.com/company/hyperlocalise/"],
-  contactPoint: {
-    "@type": "ContactPoint",
-    contactType: "sales",
-    email: "minh@hyperlocalise.com",
-  },
-};
+    inLanguage: jsonLdInLanguage(locale),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/seo/json-ld-in-language.test.ts
+++ b/apps/hyperlocalise-web/src/lib/seo/json-ld-in-language.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { jsonLdInLanguage } from "./json-ld-in-language";
+
+describe("jsonLdInLanguage", () => {
+  it("returns the app locale as a BCP 47 tag", () => {
+    expect(jsonLdInLanguage("en")).toBe("en");
+    expect(jsonLdInLanguage("zh-CN")).toBe("zh-CN");
+    expect(jsonLdInLanguage("fr-FR")).toBe("fr-FR");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/seo/json-ld-in-language.ts
+++ b/apps/hyperlocalise-web/src/lib/seo/json-ld-in-language.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { AppLocale } from "@/lib/app-i18n/locales";
+
+/** BCP 47 language tag for schema.org `inLanguage` on localized pages. */
+export function jsonLdInLanguage(locale: AppLocale): string {
+  return locale;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds schema.org `inLanguage` to all marketing JSON-LD blocks so structured data declares the page locale (BCP 47 tag).

## Changes

- Introduced `jsonLdInLanguage()` helper mapping `AppLocale` to a BCP 47 tag
- **Organization** JSON-LD (marketing layout): converted static export to `buildOrganizationJsonLd(locale)` with `inLanguage`
- **WebApplication** JSON-LD (homepage): added `inLanguage`
- **FAQPage** JSON-LD (homepage + pricing): added `inLanguage` via updated `buildHomepageFaqJsonLd(locale, items)`
- **Article** JSON-LD (blog posts): added `inLanguage`

## Testing

- `vp test` on JSON-LD-related unit tests (8 passed)
- `vp check --fix` (format, lint, typecheck — all clean)

## Motivation

Our localisation audit credits check that JSON-LD declares `inLanguage` matching the page locale. This aligns marketing structured data with that expectation and improves SEO clarity for localized pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09006-1a76-7d79-a088-f8d64a96f876?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09006-1a76-7d79-a088-f8d64a96f876&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

