### PR TITLE
refactor(content-editor): one MobX store for header, files, and workspace

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-content-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-content-editor-page-content.tsx
@@ -23,13 +23,9 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
+import { ContentEditorPageRoot } from "@/components/content-editor/page/content-editor-page-root";
+import { createContentEditorLoadingWorkspaceState } from "@/components/content-editor/project-file/project-file-content-editor-mapper";
 import { ProjectFileContentEditorWorkspace } from "@/components/content-editor/project-file/project-file-content-editor-workspace";
-import {
-  ContentEditorFilesSidebar,
-  ContentEditorPageBody,
-} from "@/components/content-editor/files/content-editor-files-sidebar";
-import { ContentEditorActivityLogButton } from "@/components/content-editor/activity-log/content-editor-activity-log-dialog";
-import { ContentEditorQueueToolbarHost } from "@/components/content-editor/queue/content-editor-queue-toolbar-host";
 import {
   attemptCatPageNavigation,
   type ContentEditorPageNavigationGuardRef,
@@ -72,10 +68,6 @@ import {
   sortFilesByPath,
 } from "./project-files-tree-panel";
 import { projectFileCatPageContentMessages as messages } from "./project-file-content-editor-page-content.messages";
-import {
-  ContentEditorFileTreePicker,
-  ContentEditorLocaleSelect,
-} from "../../_components/content-editor-header-pickers";
 
 type ProjectFileContentEditorGithubRepository = {
   fullName: string;
@@ -583,122 +575,94 @@ export function ProjectFileContentEditorPageContent({
     attemptCatPageNavigation(pageNavigationGuardRef, navigate);
   };
 
-  return (
-    <main className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
-        <div className="flex min-w-0 shrink-0 items-center gap-2">
-          <Button
-            variant="outline"
-            size="icon-sm"
-            className="size-8 shrink-0"
-            render={<Link href={filesHref} />}
-          >
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-          </Button>
-
-          {contentEditorFiles.length > 0 || allFiles ? (
-            <div className="lg:hidden">
-              <ContentEditorFileTreePicker
-                files={contentEditorFiles}
-                selectedSourcePath={sourcePath ?? ""}
-                onSelectFile={handleFileChange}
-                allFilesSelected={allFiles}
-                onSelectAllFiles={canUseAllFiles ? handleSelectAllFiles : undefined}
-                repositoryFullNames={enabledRepositoryFullNames}
-                selectedRepositoryFullName={selectedRepositoryFullName}
-                onRepositoryChange={handleRepositoryChange}
-              />
-            </div>
-          ) : (
-            <TypographyP className="max-w-44 font-mono" lineClamp={1} size="xsmall" tone="subtle">
-              {sourcePath}
-            </TypographyP>
-          )}
-
-          {workspaceTargetLocales.length > 0 ? (
-            <ContentEditorLocaleSelect
-              targetLocales={workspaceTargetLocales}
-              selectedTargetLocale={targetLocale}
-              onTargetLocaleChange={handleLocaleChange}
-            />
-          ) : null}
-
-          <ContentEditorActivityLogButton
-            organizationSlug={organizationSlug}
-            projectId={projectId}
-            sourcePath={allFiles ? CONTENT_EDITOR_ALL_FILES_SOURCE_PATH : (sourcePath as string)}
-          />
-        </div>
-
-        <ContentEditorQueueToolbarHost />
-      </div>
-
-      {(repositoriesQuery.isError ||
-        (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName)) && (
-        <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
-          {repositoriesQuery.isError ? (
-            <TypographyP size="xsmall" tone="subtle">
-              <FormattedMessage {...messages.repositoriesLoadFailed} />
-            </TypographyP>
-          ) : (
-            <TypographyP size="xsmall" tone="subtle">
-              <FormattedMessage {...messages.selectRepositoryForContext} />
-            </TypographyP>
-          )}
-        </div>
-      )}
-
-      {localeFallbackMessage ? (
-        <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
+  const resolvedSourcePath = allFiles
+    ? CONTENT_EDITOR_ALL_FILES_SOURCE_PATH
+    : (sourcePath as string);
+  const pageActions = {
+    onSelectFile: handleFileChange,
+    onSelectAllFiles: canUseAllFiles ? handleSelectAllFiles : undefined,
+    onLocaleChange: handleLocaleChange,
+    onRepositoryChange: handleRepositoryChange,
+  };
+  const repositoryBanner =
+    repositoriesQuery.isError ||
+    (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName) ? (
+      <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
+        {repositoriesQuery.isError ? (
           <TypographyP size="xsmall" tone="subtle">
-            {localeFallbackMessage}
+            <FormattedMessage {...messages.repositoriesLoadFailed} />
           </TypographyP>
-        </div>
-      ) : null}
+        ) : (
+          <TypographyP size="xsmall" tone="subtle">
+            <FormattedMessage {...messages.selectRepositoryForContext} />
+          </TypographyP>
+        )}
+      </div>
+    ) : null;
 
-      <ContentEditorPageBody
-        sidebar={
-          contentEditorFiles.length > 0 || allFiles ? (
-            <ContentEditorFilesSidebar
-              className="hidden w-[17.5rem] shrink-0 lg:flex"
-              files={contentEditorFiles}
-              selectedSourcePath={sourcePath}
-              onSelectFile={handleFileChange}
-              allFilesSelected={allFiles}
-              onSelectAllFiles={canUseAllFiles ? handleSelectAllFiles : undefined}
-              repositoryFullNames={enabledRepositoryFullNames}
-              selectedRepositoryFullName={selectedRepositoryFullName}
-              onRepositoryChange={handleRepositoryChange}
-            />
-          ) : undefined
-        }
-      >
-        <ProjectFileContentEditorWorkspace
-          key={`${allFiles ? CONTENT_EDITOR_ALL_FILES_SOURCE_PATH : sourcePath}:${resolvedExternalResourceId ?? "source-path"}:${targetLocale}`}
-          organizationSlug={organizationSlug}
-          projectId={projectId}
-          sourceLocale={sourceLocale}
-          sourcePath={allFiles ? CONTENT_EDITOR_ALL_FILES_SOURCE_PATH : (sourcePath as string)}
-          externalResourceId={allFiles ? null : resolvedExternalResourceId}
-          resourceType={allFiles ? undefined : resolvedResourceType}
-          targetLocale={targetLocale}
-          targetLocales={workspaceTargetLocales}
-          highlightLocale={highlightLocale}
-          repositoryFullName={selectedRepositoryFullName}
-          canLookupFreshContext={canLookupFreshCatRepositoryContext(
-            enabledRepositoryFullNames,
-            selectedRepositoryFullName,
-          )}
-          initialSegmentKey={initialSegmentKey}
-          initialQueueFilter={initialQueueFilter}
-          initialQueueSort={initialQueueSort}
-          initialSearch={initialSearch}
-          sourcePathsFilter={sourcePaths}
-          layout="fullscreen"
-          className="min-h-0 flex-1"
-          pageNavigationGuardRef={pageNavigationGuardRef}
-        />
-      </ContentEditorPageBody>
-    </main>
+  return (
+    <ContentEditorPageRoot
+      initialState={createContentEditorLoadingWorkspaceState({
+        sourcePath: resolvedSourcePath,
+        sourceLocale,
+        targetLocale,
+      })}
+      initialQueueFilter={initialQueueFilter}
+      initialQueueSort={initialQueueSort}
+      initialSearch={initialSearch}
+      chrome={{
+        files: contentEditorFiles,
+        selectedSourcePath: sourcePath,
+        allFiles,
+        canUseAllFiles,
+        targetLocale,
+        targetLocales: workspaceTargetLocales,
+        repositoryFullNames: enabledRepositoryFullNames,
+        selectedRepositoryFullName,
+        activitySourcePath: resolvedSourcePath,
+        organizationSlug,
+        projectId,
+        showFileSidebar: contentEditorFiles.length > 0 || allFiles,
+      }}
+      backHref={filesHref}
+      actions={pageActions}
+      banners={
+        <>
+          {repositoryBanner}
+          {localeFallbackMessage ? (
+            <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
+              <TypographyP size="xsmall" tone="subtle">
+                {localeFallbackMessage}
+              </TypographyP>
+            </div>
+          ) : null}
+        </>
+      }
+    >
+      <ProjectFileContentEditorWorkspace
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        sourceLocale={sourceLocale}
+        sourcePath={resolvedSourcePath}
+        externalResourceId={allFiles ? null : resolvedExternalResourceId}
+        resourceType={allFiles ? undefined : resolvedResourceType}
+        targetLocale={targetLocale}
+        targetLocales={workspaceTargetLocales}
+        highlightLocale={highlightLocale}
+        repositoryFullName={selectedRepositoryFullName}
+        canLookupFreshContext={canLookupFreshCatRepositoryContext(
+          enabledRepositoryFullNames,
+          selectedRepositoryFullName,
+        )}
+        initialSegmentKey={initialSegmentKey}
+        initialQueueFilter={initialQueueFilter}
+        initialQueueSort={initialQueueSort}
+        initialSearch={initialSearch}
+        sourcePathsFilter={sourcePaths}
+        layout="fullscreen"
+        className="min-h-0 flex-1"
+        pageNavigationGuardRef={pageNavigationGuardRef}
+      />
+    </ContentEditorPageRoot>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-content-editor-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-content-editor-page-content.tsx
@@ -12,25 +12,17 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
 import { supportsProviderContentEditorFile } from "@/lib/providers/capabilities/provider-content-editor-capabilities";
 
-import {
-  ContentEditorFileTreePicker,
-  ContentEditorLocaleSelect,
-} from "../../../../_components/content-editor-header-pickers";
 import { ProjectPageShell, useProjectPageQuery } from "../../../../_components/project-page-shell";
 import {
   contentEditorFileRepositoryPreferenceKey,
@@ -51,13 +43,9 @@ import {
   sortJobContentEditorProviderFiles,
 } from "./select-job-content-editor-repository";
 import { jobCatPageContentMessages } from "./job-content-editor-page-content.messages";
+import { ContentEditorPageRoot } from "@/components/content-editor/page/content-editor-page-root";
+import { createContentEditorLoadingWorkspaceState } from "@/components/content-editor/project-file/project-file-content-editor-mapper";
 import { ProjectFileContentEditorWorkspace } from "@/components/content-editor/project-file/project-file-content-editor-workspace";
-import {
-  ContentEditorFilesSidebar,
-  ContentEditorPageBody,
-} from "@/components/content-editor/files/content-editor-files-sidebar";
-import { ContentEditorActivityLogButton } from "@/components/content-editor/activity-log/content-editor-activity-log-dialog";
-import { ContentEditorQueueToolbarHost } from "@/components/content-editor/queue/content-editor-queue-toolbar-host";
 import {
   attemptCatPageNavigation,
   type ContentEditorPageNavigationGuardRef,
@@ -645,90 +633,60 @@ export function JobContentEditorPageContent({
     };
 
     return (
-      <main className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
-        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
-          <div className="flex min-w-0 shrink-0 items-center gap-2">
-            <Button
-              variant="outline"
-              size="icon-sm"
-              className="size-8 shrink-0"
-              render={<Link href={taskHref} />}
-            >
-              <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-            </Button>
-
-            <div className="lg:hidden">
-              <ContentEditorFileTreePicker
-                files={jobFiles}
-                selectedSourcePath=""
-                onSelectFile={handleJobFileChange}
-                allFilesSelected
-                onSelectAllFiles={canUseAllFiles ? handleJobSelectAllFiles : undefined}
-                repositoryFullNames={enabledRepositoryFullNames}
-                selectedRepositoryFullName={selectedRepositoryFullName}
-                onRepositoryChange={handleRepositoryChange}
-              />
-            </div>
-
-            {jobTargetLocales.length > 0 ? (
-              <ContentEditorLocaleSelect
-                targetLocales={jobTargetLocales}
-                selectedTargetLocale={selectedTargetLocale}
-                onTargetLocaleChange={handleAllFilesLocaleChange}
-              />
-            ) : null}
-
-            <ContentEditorActivityLogButton
-              organizationSlug={organizationSlug}
-              projectId={projectId}
-              sourcePath={CONTENT_EDITOR_ALL_FILES_SOURCE_PATH}
-            />
-          </div>
-
-          <ContentEditorQueueToolbarHost />
-        </div>
-
-        {repositoryBanner}
-
-        <ContentEditorPageBody
-          sidebar={
-            <ContentEditorFilesSidebar
-              className="hidden w-[17.5rem] shrink-0 lg:flex"
-              files={jobFiles}
-              selectedSourcePath={null}
-              onSelectFile={handleJobFileChange}
-              allFilesSelected
-              onSelectAllFiles={canUseAllFiles ? handleJobSelectAllFiles : undefined}
-              repositoryFullNames={enabledRepositoryFullNames}
-              selectedRepositoryFullName={selectedRepositoryFullName}
-              onRepositoryChange={handleRepositoryChange}
-            />
-          }
-        >
-          <ProjectFileContentEditorWorkspace
-            key={`${CONTENT_EDITOR_ALL_FILES_SOURCE_PATH}:${selectedTargetLocale}`}
-            organizationSlug={organizationSlug}
-            projectId={projectId}
-            sourceLocale={sourceLocale}
-            sourcePath={CONTENT_EDITOR_ALL_FILES_SOURCE_PATH}
-            targetLocale={selectedTargetLocale}
-            highlightLocale={selectedTargetLocale}
-            repositoryFullName={selectedRepositoryFullName}
-            canLookupFreshContext={canLookupFreshCatRepositoryContext(
-              enabledRepositoryFullNames,
-              selectedRepositoryFullName,
-            )}
-            initialSegmentKey={initialSegmentKey}
-            initialQueueFilter={initialQueueFilter}
-            initialQueueSort={initialQueueSort}
-            initialSearch={initialSearch}
-            sourcePathsFilter={serializeCatSourcePathsFilter(jobSourcePaths)}
-            layout="fullscreen"
-            className="min-h-0 flex-1"
-            pageNavigationGuardRef={pageNavigationGuardRef}
-          />
-        </ContentEditorPageBody>
-      </main>
+      <ContentEditorPageRoot
+        initialState={createContentEditorLoadingWorkspaceState({
+          sourcePath: CONTENT_EDITOR_ALL_FILES_SOURCE_PATH,
+          sourceLocale,
+          targetLocale: selectedTargetLocale,
+        })}
+        initialQueueFilter={initialQueueFilter}
+        initialQueueSort={initialQueueSort}
+        initialSearch={initialSearch}
+        chrome={{
+          files: jobFiles,
+          selectedSourcePath: null,
+          allFiles: true,
+          canUseAllFiles,
+          targetLocale: selectedTargetLocale,
+          targetLocales: jobTargetLocales,
+          repositoryFullNames: enabledRepositoryFullNames,
+          selectedRepositoryFullName,
+          activitySourcePath: CONTENT_EDITOR_ALL_FILES_SOURCE_PATH,
+          organizationSlug,
+          projectId,
+          showFileSidebar: true,
+        }}
+        backHref={taskHref}
+        actions={{
+          onSelectFile: handleJobFileChange,
+          onSelectAllFiles: canUseAllFiles ? handleJobSelectAllFiles : undefined,
+          onLocaleChange: handleAllFilesLocaleChange,
+          onRepositoryChange: handleRepositoryChange,
+        }}
+        banners={repositoryBanner}
+      >
+        <ProjectFileContentEditorWorkspace
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          sourceLocale={sourceLocale}
+          sourcePath={CONTENT_EDITOR_ALL_FILES_SOURCE_PATH}
+          targetLocale={selectedTargetLocale}
+          highlightLocale={selectedTargetLocale}
+          repositoryFullName={selectedRepositoryFullName}
+          canLookupFreshContext={canLookupFreshCatRepositoryContext(
+            enabledRepositoryFullNames,
+            selectedRepositoryFullName,
+          )}
+          initialSegmentKey={initialSegmentKey}
+          initialQueueFilter={initialQueueFilter}
+          initialQueueSort={initialQueueSort}
+          initialSearch={initialSearch}
+          sourcePathsFilter={serializeCatSourcePathsFilter(jobSourcePaths)}
+          layout="fullscreen"
+          className="min-h-0 flex-1"
+          pageNavigationGuardRef={pageNavigationGuardRef}
+        />
+      </ContentEditorPageRoot>
     );
   }
 
@@ -847,85 +805,58 @@ export function JobContentEditorPageContent({
     }
 
     return (
-      <main className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
-        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
-          <div className="flex min-w-0 shrink-0 items-center gap-2">
-            <Button
-              variant="outline"
-              size="icon-sm"
-              className="size-8 shrink-0"
-              render={<Link href={taskHref} />}
-            >
-              <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-            </Button>
-
-            <div className="lg:hidden">
-              <ContentEditorFileTreePicker
-                files={[selectedFile]}
-                selectedSourcePath={selectedFile.sourcePath}
-                onSelectFile={() => undefined}
-                repositoryFullNames={enabledRepositoryFullNames}
-                selectedRepositoryFullName={selectedRepositoryFullName}
-                onRepositoryChange={handleRepositoryChange}
-              />
-            </div>
-
-            {jobTargetLocales.length > 0 ? (
-              <ContentEditorLocaleSelect
-                targetLocales={jobTargetLocales}
-                selectedTargetLocale={activeTargetLocale}
-                onTargetLocaleChange={handleLocaleChange}
-              />
-            ) : null}
-
-            <ContentEditorActivityLogButton
-              organizationSlug={organizationSlug}
-              projectId={projectId}
-              sourcePath={selectedFile.sourcePath}
-            />
-          </div>
-
-          <ContentEditorQueueToolbarHost />
-        </div>
-
-        {repositoryBanner}
-
-        <ContentEditorPageBody
-          sidebar={
-            <ContentEditorFilesSidebar
-              className="hidden w-[17.5rem] shrink-0 lg:flex"
-              files={[selectedFile]}
-              selectedSourcePath={selectedFile.sourcePath}
-              onSelectFile={() => undefined}
-              repositoryFullNames={enabledRepositoryFullNames}
-              selectedRepositoryFullName={selectedRepositoryFullName}
-              onRepositoryChange={handleRepositoryChange}
-            />
-          }
-        >
-          <ProjectFileContentEditorWorkspace
-            key={`${selectedFile.sourcePath}:${activeTargetLocale}`}
-            organizationSlug={organizationSlug}
-            projectId={projectId}
-            sourceLocale={sourceLocale}
-            sourcePath={selectedFile.sourcePath}
-            targetLocale={activeTargetLocale}
-            highlightLocale={activeTargetLocale}
-            repositoryFullName={selectedRepositoryFullName}
-            canLookupFreshContext={canLookupFreshCatRepositoryContext(
-              enabledRepositoryFullNames,
-              selectedRepositoryFullName,
-            )}
-            initialSegmentKey={initialSegmentKey}
-            initialQueueFilter={initialQueueFilter}
-            initialQueueSort={initialQueueSort}
-            initialSearch={initialSearch}
-            layout="fullscreen"
-            className="min-h-0 flex-1"
-            pageNavigationGuardRef={pageNavigationGuardRef}
-          />
-        </ContentEditorPageBody>
-      </main>
+      <ContentEditorPageRoot
+        initialState={createContentEditorLoadingWorkspaceState({
+          sourcePath: selectedFile.sourcePath,
+          sourceLocale,
+          targetLocale: activeTargetLocale,
+        })}
+        initialQueueFilter={initialQueueFilter}
+        initialQueueSort={initialQueueSort}
+        initialSearch={initialSearch}
+        chrome={{
+          files: [selectedFile],
+          selectedSourcePath: selectedFile.sourcePath,
+          allFiles: false,
+          canUseAllFiles: false,
+          targetLocale: activeTargetLocale,
+          targetLocales: jobTargetLocales,
+          repositoryFullNames: enabledRepositoryFullNames,
+          selectedRepositoryFullName,
+          activitySourcePath: selectedFile.sourcePath,
+          organizationSlug,
+          projectId,
+          showFileSidebar: true,
+        }}
+        backHref={taskHref}
+        actions={{
+          onSelectFile: () => undefined,
+          onLocaleChange: handleLocaleChange,
+          onRepositoryChange: handleRepositoryChange,
+        }}
+        banners={repositoryBanner}
+      >
+        <ProjectFileContentEditorWorkspace
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          sourceLocale={sourceLocale}
+          sourcePath={selectedFile.sourcePath}
+          targetLocale={activeTargetLocale}
+          highlightLocale={activeTargetLocale}
+          repositoryFullName={selectedRepositoryFullName}
+          canLookupFreshContext={canLookupFreshCatRepositoryContext(
+            enabledRepositoryFullNames,
+            selectedRepositoryFullName,
+          )}
+          initialSegmentKey={initialSegmentKey}
+          initialQueueFilter={initialQueueFilter}
+          initialQueueSort={initialQueueSort}
+          initialSearch={initialSearch}
+          layout="fullscreen"
+          className="min-h-0 flex-1"
+          pageNavigationGuardRef={pageNavigationGuardRef}
+        />
+      </ContentEditorPageRoot>
     );
   }
 
@@ -990,105 +921,65 @@ export function JobContentEditorPageContent({
   };
 
   return (
-    <main className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
-        <div className="flex min-w-0 shrink-0 items-center gap-2">
-          <Button
-            variant="outline"
-            size="icon-sm"
-            className="size-8 shrink-0"
-            render={<Link href={taskHref} />}
-          >
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-          </Button>
-
-          <div className="lg:hidden">
-            <ContentEditorFileTreePicker
-              files={providerFiles}
-              selectedSourcePath={selectedFile.sourcePath}
-              onSelectFile={handleFileChange}
-              allFilesSelected={false}
-              onSelectAllFiles={
-                canUseAllFiles
-                  ? () =>
-                      navigateToAllFiles(
-                        providerFiles.map((file) => file.sourcePath),
-                        selectedTargetLocale,
-                      )
-                  : undefined
-              }
-              repositoryFullNames={enabledRepositoryFullNames}
-              selectedRepositoryFullName={selectedRepositoryFullName}
-              onRepositoryChange={handleRepositoryChange}
-            />
-          </div>
-
-          {jobTargetLocales.length > 0 ? (
-            <ContentEditorLocaleSelect
-              targetLocales={jobTargetLocales}
-              selectedTargetLocale={selectedTargetLocale}
-              onTargetLocaleChange={handleLocaleChange}
-            />
-          ) : null}
-
-          <ContentEditorActivityLogButton
-            organizationSlug={organizationSlug}
-            projectId={projectId}
-            sourcePath={selectedFile.sourcePath}
-          />
-        </div>
-
-        <ContentEditorQueueToolbarHost />
-      </div>
-
-      {repositoryBanner}
-
-      <ContentEditorPageBody
-        sidebar={
-          <ContentEditorFilesSidebar
-            className="hidden w-[17.5rem] shrink-0 lg:flex"
-            files={providerFiles}
-            selectedSourcePath={selectedFile.sourcePath}
-            onSelectFile={handleFileChange}
-            allFilesSelected={false}
-            onSelectAllFiles={
-              canUseAllFiles
-                ? () =>
-                    navigateToAllFiles(
-                      providerFiles.map((file) => file.sourcePath),
-                      selectedTargetLocale,
-                    )
-                : undefined
-            }
-            repositoryFullNames={enabledRepositoryFullNames}
-            selectedRepositoryFullName={selectedRepositoryFullName}
-            onRepositoryChange={handleRepositoryChange}
-          />
-        }
-      >
-        <ProjectFileContentEditorWorkspace
-          key={`${selectedFile.sourcePath}:${selectedTargetLocale}`}
-          organizationSlug={organizationSlug}
-          projectId={projectId}
-          sourceLocale={sourceLocale}
-          sourcePath={selectedFile.sourcePath}
-          externalResourceId={selectedFile.provider.externalResourceId}
-          resourceType={selectedFile.provider.resourceType}
-          targetLocale={selectedTargetLocale}
-          repositoryFullName={selectedRepositoryFullName}
-          canLookupFreshContext={canLookupFreshCatRepositoryContext(
-            enabledRepositoryFullNames,
-            selectedRepositoryFullName,
-          )}
-          initialSegmentKey={initialSegmentKey}
-          initialQueueFilter={initialQueueFilter}
-          initialQueueSort={initialQueueSort}
-          initialSearch={initialSearch}
-          layout="fullscreen"
-          className="min-h-0 flex-1"
-          pageNavigationGuardRef={pageNavigationGuardRef}
-        />
-      </ContentEditorPageBody>
-    </main>
+    <ContentEditorPageRoot
+      initialState={createContentEditorLoadingWorkspaceState({
+        sourcePath: selectedFile.sourcePath,
+        sourceLocale,
+        targetLocale: selectedTargetLocale,
+      })}
+      initialQueueFilter={initialQueueFilter}
+      initialQueueSort={initialQueueSort}
+      initialSearch={initialSearch}
+      chrome={{
+        files: providerFiles,
+        selectedSourcePath: selectedFile.sourcePath,
+        allFiles: false,
+        canUseAllFiles,
+        targetLocale: selectedTargetLocale,
+        targetLocales: jobTargetLocales,
+        repositoryFullNames: enabledRepositoryFullNames,
+        selectedRepositoryFullName,
+        activitySourcePath: selectedFile.sourcePath,
+        organizationSlug,
+        projectId,
+        showFileSidebar: true,
+      }}
+      backHref={taskHref}
+      actions={{
+        onSelectFile: handleFileChange,
+        onSelectAllFiles: canUseAllFiles
+          ? () =>
+              navigateToAllFiles(
+                providerFiles.map((file) => file.sourcePath),
+                selectedTargetLocale,
+              )
+          : undefined,
+        onLocaleChange: handleLocaleChange,
+        onRepositoryChange: handleRepositoryChange,
+      }}
+      banners={repositoryBanner}
+    >
+      <ProjectFileContentEditorWorkspace
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        sourceLocale={sourceLocale}
+        sourcePath={selectedFile.sourcePath}
+        externalResourceId={selectedFile.provider.externalResourceId}
+        resourceType={selectedFile.provider.resourceType}
+        targetLocale={selectedTargetLocale}
+        repositoryFullName={selectedRepositoryFullName}
+        canLookupFreshContext={canLookupFreshCatRepositoryContext(
+          enabledRepositoryFullNames,
+          selectedRepositoryFullName,
+        )}
+        initialSegmentKey={initialSegmentKey}
+        initialQueueFilter={initialQueueFilter}
+        initialQueueSort={initialQueueSort}
+        initialSearch={initialSearch}
+        layout="fullscreen"
+        className="min-h-0 flex-1"
+        pageNavigationGuardRef={pageNavigationGuardRef}
+      />
+    </ContentEditorPageRoot>
   );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-chrome-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-chrome-sync.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useLayoutEffect } from "react";
+
+import { useContentEditorWorkspace } from "@/components/content-editor/workspace/content-editor-workspace-context";
+
+import type { ContentEditorPageChromeSnapshot } from "./content-editor-page-store";
+
+export function ContentEditorPageChromeSync(chrome: ContentEditorPageChromeSnapshot) {
+  const store = useContentEditorWorkspace();
+  const {
+    files,
+    selectedSourcePath,
+    allFiles,
+    canUseAllFiles,
+    targetLocale,
+    targetLocales,
+    repositoryFullNames,
+    selectedRepositoryFullName,
+    activitySourcePath,
+    organizationSlug,
+    projectId,
+    showFileSidebar,
+    showActivityLog,
+  } = chrome;
+
+  useLayoutEffect(() => {
+    store.page.applyChrome({
+      files,
+      selectedSourcePath,
+      allFiles,
+      canUseAllFiles,
+      targetLocale,
+      targetLocales,
+      repositoryFullNames,
+      selectedRepositoryFullName,
+      activitySourcePath,
+      organizationSlug,
+      projectId,
+      showFileSidebar,
+      showActivityLog,
+    });
+  }, [
+    activitySourcePath,
+    allFiles,
+    canUseAllFiles,
+    files,
+    organizationSlug,
+    projectId,
+    repositoryFullNames,
+    selectedRepositoryFullName,
+    selectedSourcePath,
+    showActivityLog,
+    showFileSidebar,
+    store,
+    targetLocale,
+    targetLocales,
+  ]);
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-header.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-header.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import Link from "next/link";
+import { observer } from "mobx-react-lite";
+import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import {
+  ContentEditorFileTreePicker,
+  ContentEditorLocaleSelect,
+} from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/content-editor-header-pickers";
+import { ContentEditorActivityLogButton } from "@/components/content-editor/activity-log/content-editor-activity-log-dialog";
+import { ContentEditorQueueToolbarHost } from "@/components/content-editor/queue/content-editor-queue-toolbar-host";
+import { useContentEditorWorkspace } from "@/components/content-editor/workspace/content-editor-workspace-context";
+import { Button } from "@/components/ui/button";
+import { TypographyP } from "@/components/ui/typography";
+
+import type { ContentEditorPageActions } from "./content-editor-page-shell";
+
+export const ContentEditorPageHeader = observer(function ContentEditorPageHeader({
+  backHref,
+  actions,
+}: {
+  backHref: string;
+  actions: ContentEditorPageActions;
+}) {
+  const page = useContentEditorWorkspace().page;
+  const showFilePicker = page.files.length > 0 || page.allFiles;
+
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
+      <div className="flex min-w-0 shrink-0 items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          className="size-8 shrink-0"
+          render={<Link href={backHref} />}
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        </Button>
+
+        {showFilePicker ? (
+          <div className="lg:hidden">
+            <ContentEditorFileTreePicker
+              files={page.files}
+              selectedSourcePath={page.selectedSourcePath ?? ""}
+              onSelectFile={actions.onSelectFile}
+              allFilesSelected={page.allFiles}
+              onSelectAllFiles={page.canUseAllFiles ? actions.onSelectAllFiles : undefined}
+              repositoryFullNames={page.repositoryFullNames}
+              selectedRepositoryFullName={page.selectedRepositoryFullName}
+              onRepositoryChange={actions.onRepositoryChange}
+            />
+          </div>
+        ) : page.selectedSourcePath ? (
+          <TypographyP className="max-w-44 font-mono" lineClamp={1} size="xsmall" tone="subtle">
+            {page.selectedSourcePath}
+          </TypographyP>
+        ) : null}
+
+        {page.targetLocales.length > 0 ? (
+          <ContentEditorLocaleSelect
+            targetLocales={page.targetLocales}
+            selectedTargetLocale={page.targetLocale}
+            onTargetLocaleChange={actions.onLocaleChange}
+          />
+        ) : null}
+
+        {page.showActivityLog &&
+        page.organizationSlug &&
+        page.projectId &&
+        page.activitySourcePath ? (
+          <ContentEditorActivityLogButton
+            organizationSlug={page.organizationSlug}
+            projectId={page.projectId}
+            sourcePath={page.activitySourcePath}
+          />
+        ) : null}
+      </div>
+
+      <ContentEditorQueueToolbarHost />
+    </div>
+  );
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-root.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-root.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+
+import type {
+  ContentEditorQueueFilter,
+  ContentEditorQueueSort,
+} from "@/components/content-editor/queue/content-editor-queue-filter";
+import type { ContentEditorWorkspaceState } from "@/components/content-editor/shared/types";
+import { ContentEditorWorkspaceProvider } from "@/components/content-editor/workspace/content-editor-workspace-context";
+
+import { ContentEditorPageChromeSync } from "./content-editor-page-chrome-sync";
+import { ContentEditorPageShell, type ContentEditorPageActions } from "./content-editor-page-shell";
+import type { ContentEditorPageChromeSnapshot } from "./content-editor-page-store";
+
+export function ContentEditorPageRoot({
+  initialState,
+  initialQueueFilter,
+  initialQueueSort,
+  initialSearch,
+  chrome,
+  backHref,
+  actions,
+  banners,
+  className,
+  children,
+}: {
+  initialState: ContentEditorWorkspaceState;
+  initialQueueFilter?: ContentEditorQueueFilter;
+  initialQueueSort?: ContentEditorQueueSort;
+  initialSearch?: string;
+  chrome: ContentEditorPageChromeSnapshot;
+  backHref: string;
+  actions: ContentEditorPageActions;
+  banners?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <ContentEditorWorkspaceProvider
+      initialState={initialState}
+      initialQueueFilter={initialQueueFilter}
+      initialQueueSort={initialQueueSort}
+      initialSearch={initialSearch}
+    >
+      <ContentEditorPageChromeSync {...chrome} />
+      <ContentEditorPageShell
+        backHref={backHref}
+        actions={actions}
+        banners={banners}
+        className={className}
+      >
+        {children}
+      </ContentEditorPageShell>
+    </ContentEditorWorkspaceProvider>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-shell.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { observer } from "mobx-react-lite";
+
+import {
+  ContentEditorFilesSidebar,
+  ContentEditorPageBody,
+} from "@/components/content-editor/files/content-editor-files-sidebar";
+import { useContentEditorWorkspace } from "@/components/content-editor/workspace/content-editor-workspace-context";
+import { cn } from "@/lib/primitives/cn";
+
+import { ContentEditorPageHeader } from "./content-editor-page-header";
+
+export type ContentEditorPageActions = {
+  onSelectFile: (sourcePath: string) => void;
+  onSelectAllFiles?: () => void;
+  onLocaleChange: (locale: string) => void;
+  onRepositoryChange?: (repositoryFullName: string, destinationSourcePath?: string) => void;
+};
+
+export const ContentEditorPageShell = observer(function ContentEditorPageShell({
+  backHref,
+  actions,
+  banners,
+  className,
+  children,
+}: {
+  backHref: string;
+  actions: ContentEditorPageActions;
+  banners?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}) {
+  const page = useContentEditorWorkspace().page;
+
+  return (
+    <main
+      className={cn(
+        "-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8",
+        className,
+      )}
+    >
+      <ContentEditorPageHeader backHref={backHref} actions={actions} />
+      {banners}
+
+      <ContentEditorPageBody
+        sidebar={
+          page.showFileSidebar ? (
+            <ContentEditorFilesSidebar
+              className="hidden w-[17.5rem] shrink-0 lg:flex"
+              files={page.files}
+              selectedSourcePath={page.selectedSourcePath}
+              onSelectFile={actions.onSelectFile}
+              allFilesSelected={page.allFiles}
+              onSelectAllFiles={page.canUseAllFiles ? actions.onSelectAllFiles : undefined}
+              repositoryFullNames={page.repositoryFullNames}
+              selectedRepositoryFullName={page.selectedRepositoryFullName}
+              onRepositoryChange={actions.onRepositoryChange}
+            />
+          ) : undefined
+        }
+      >
+        {children}
+      </ContentEditorPageBody>
+    </main>
+  );
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-store.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
+
+import { ContentEditorPageStore } from "./content-editor-page-store";
+
+describe("ContentEditorPageStore", () => {
+  it("applies chrome and keeps it when the open file changes", () => {
+    const store = new ContentEditorPageStore();
+    const files = [
+      createProjectFileRecord({ sourcePath: "en-US.json", filename: "en-US.json" }),
+      createProjectFileRecord({ sourcePath: "pricing.json", filename: "pricing.json" }),
+    ];
+
+    store.applyChrome({
+      files,
+      selectedSourcePath: "en-US.json",
+      allFiles: false,
+      canUseAllFiles: true,
+      targetLocale: "vi",
+      targetLocales: ["vi", "fr-FR"],
+      repositoryFullNames: ["acme/web"],
+      selectedRepositoryFullName: "acme/web",
+      activitySourcePath: "en-US.json",
+      organizationSlug: "acme",
+      projectId: "proj_1",
+      showFileSidebar: true,
+    });
+
+    store.beginFileScopeChange("pricing.json", "fr-FR");
+
+    expect(store.selectedSourcePath).toBe("pricing.json");
+    expect(store.targetLocale).toBe("fr-FR");
+    expect(store.activitySourcePath).toBe("pricing.json");
+    expect(store.files).toEqual(files);
+    expect(store.showFileSidebar).toBe(true);
+    expect(store.canUseAllFiles).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-store.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/page/content-editor-page-store.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { makeAutoObservable } from "mobx";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+
+export type ContentEditorPageChromeSnapshot = {
+  files: ProjectFileRecord[];
+  selectedSourcePath: string | null;
+  allFiles: boolean;
+  canUseAllFiles: boolean;
+  targetLocale: string;
+  targetLocales: string[];
+  repositoryFullNames: string[];
+  selectedRepositoryFullName: string | null;
+  activitySourcePath: string;
+  organizationSlug: string;
+  projectId: string;
+  showFileSidebar: boolean;
+  showActivityLog?: boolean;
+};
+
+export class ContentEditorPageStore {
+  files: ProjectFileRecord[] = [];
+  selectedSourcePath: string | null = null;
+  allFiles = false;
+  canUseAllFiles = false;
+  targetLocale = "";
+  targetLocales: string[] = [];
+  repositoryFullNames: string[] = [];
+  selectedRepositoryFullName: string | null = null;
+  activitySourcePath = "";
+  organizationSlug = "";
+  projectId = "";
+  showFileSidebar = false;
+  showActivityLog = true;
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  applyChrome(chrome: ContentEditorPageChromeSnapshot) {
+    this.files = chrome.files;
+    this.selectedSourcePath = chrome.selectedSourcePath;
+    this.allFiles = chrome.allFiles;
+    this.canUseAllFiles = chrome.canUseAllFiles;
+    this.targetLocale = chrome.targetLocale;
+    this.targetLocales = chrome.targetLocales;
+    this.repositoryFullNames = chrome.repositoryFullNames;
+    this.selectedRepositoryFullName = chrome.selectedRepositoryFullName;
+    this.activitySourcePath = chrome.activitySourcePath;
+    this.organizationSlug = chrome.organizationSlug;
+    this.projectId = chrome.projectId;
+    this.showFileSidebar = chrome.showFileSidebar;
+    this.showActivityLog = chrome.showActivityLog ?? true;
+  }
+
+  beginFileScopeChange(sourcePath: string, targetLocale: string) {
+    this.selectedSourcePath = sourcePath;
+    this.targetLocale = targetLocale;
+    this.activitySourcePath = sourcePath;
+  }
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-mapper.ts
@@ -327,3 +327,29 @@ export function resolveCatFileIdentity(input: {
     resourceType: input.resourceType ?? input.contentEditorFile?.provider?.resourceType,
   };
 }
+
+export function createContentEditorLoadingWorkspaceState(input: {
+  sourcePath: string;
+  sourceLocale: string;
+  targetLocale: string;
+}): ContentEditorWorkspaceState {
+  const filename = input.sourcePath.split("/").pop() ?? input.sourcePath;
+
+  return {
+    fileContext: {
+      sourcePath: input.sourcePath,
+      filename,
+      sourceLocale: input.sourceLocale,
+      targetLocale: input.targetLocale,
+      providerKind: null,
+      canEditTranslations: true,
+      canAddComments: true,
+    },
+    queueSegments: [],
+    selectedSegmentId: "",
+    formatChecks: [],
+    intelligence: {
+      glossaryTerms: [],
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.tsx
@@ -848,9 +848,9 @@ export function ProjectFileContentEditorWorkspace({
 
       <AiFeaturesUpgradeHrefProvider value={upgradePlanHref}>
         <ContentEditorWorkspaceContainer
-          key={`${sourcePath}:${externalResourceId ?? "source-path"}:${targetLocale}`}
           initialState={workspaceForRender}
           queueSnapshot={workspaceState}
+          fileScopeKey={`${sourcePath}:${externalResourceId ?? "source-path"}:${targetLocale}`}
           pageNavigationGuardRef={resolvedPageNavigationGuardRef}
           lazySegment={{
             organizationSlug,

--- a/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/project-file/project-file-content-editor-workspace.tsx
@@ -58,7 +58,6 @@ import {
   type ContentEditorPageNavigationGuard,
   type ContentEditorPageNavigationGuardRef,
 } from "@/components/content-editor/workspace/content-editor-page-navigation-guard";
-import { ContentEditorWorkspaceSkeleton } from "@/components/content-editor/workspace/content-editor-workspace-skeleton";
 import {
   contentEditorPageLimitForViewMode,
   readCatWorkspaceViewMode,
@@ -73,7 +72,10 @@ import {
   type ContentEditorLinkedIssueSegmentContext,
 } from "@/components/content-editor/issues/content-editor-linked-issues-dialog";
 
-import { projectFileCatToWorkspaceState } from "./project-file-content-editor-mapper";
+import {
+  createContentEditorLoadingWorkspaceState,
+  projectFileCatToWorkspaceState,
+} from "./project-file-content-editor-mapper";
 import { projectFileCatWorkspaceMessages } from "./project-file-content-editor-workspace.messages";
 import { fetchCatSegmentValidation } from "./project-file-content-editor-validation";
 import { useContentEditorMutations } from "./use-content-editor-mutations";
@@ -750,22 +752,12 @@ export function ProjectFileContentEditorWorkspace({
 
   const isFullscreen = layout === "fullscreen";
 
-  const isQueueLoading =
+  const isQueueDataPending =
     isSearchPending ||
     (contentEditorQuery.isLoading && !contentEditorFile) ||
     contentEditorQuery.isPlaceholderData;
-
-  if (contentEditorQuery.isLoading && !contentEditorFile) {
-    return (
-      <ContentEditorWorkspaceSkeleton
-        className={cn(
-          "min-h-0 flex-1",
-          isFullscreen && "rounded-lg border border-border",
-          className,
-        )}
-      />
-    );
-  }
+  const isQueueListLoading = isSearchPending;
+  const isTranslationViewLoading = contentEditorQuery.isLoading && !contentEditorFile;
 
   if (contentEditorQuery.isError) {
     return (
@@ -780,7 +772,15 @@ export function ProjectFileContentEditorWorkspace({
     );
   }
 
-  const workspaceForRender = workspaceState;
+  const workspaceForRender =
+    workspaceState ??
+    (isTranslationViewLoading
+      ? createContentEditorLoadingWorkspaceState({
+          sourcePath,
+          sourceLocale,
+          targetLocale,
+        })
+      : null);
   if (!workspaceForRender) {
     return null;
   }
@@ -937,7 +937,9 @@ export function ProjectFileContentEditorWorkspace({
           availableQueueSorts={availableQueueSorts}
           isQueueSearchPending={isSearchPending}
           isQueueFetchingPage={isFetchingNextPage}
-          isQueueLoading={isQueueLoading}
+          isQueueListLoading={isQueueListLoading}
+          isQueueDataPending={isQueueDataPending}
+          isTranslationViewLoading={isTranslationViewLoading}
           isImageBusy={isImageBusy}
           isMaxLengthSaving={isSavingMaxLength}
           queuePagination={pagination}

--- a/apps/hyperlocalise-web/src/components/content-editor/shared/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/shared/dependencies.ts
@@ -156,6 +156,12 @@ export interface ContentEditorWorkspaceViewProps {
   className?: string;
   queueSearch?: string;
   isQueueFetchingPage?: boolean;
+  /** Shows skeleton rows while search/filter results are pending. */
+  isQueueListLoading?: boolean;
+  /** Blocks bulk actions until the queue snapshot is ready. */
+  isQueueDataPending?: boolean;
+  isTranslationViewLoading?: boolean;
+  /** @deprecated Use isQueueListLoading or isQueueDataPending. */
   isQueueLoading?: boolean;
   queuePagination?: {
     offset: number;

--- a/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side-panel.tsx
@@ -41,6 +41,34 @@ import { ContentEditorSideBySideResizableLayout } from "@/components/content-edi
 import { ContentEditorSideBySideIntelligencePanel } from "./content-editor-side-by-side-intelligence-panel";
 import { ContentEditorSideBySideVirtualList } from "./content-editor-side-by-side-virtual-list";
 
+export function ContentEditorSideBySidePanelSkeleton({ className }: { className?: string }) {
+  return (
+    <ContentEditorSideBySideResizableLayout
+      className={cn("bg-background", className)}
+      editor={
+        <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+          <div className="shrink-0 border-b border-border px-4 py-3">
+            <div className="grid grid-cols-2 gap-0 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              <p className="border-r border-border pr-4">
+                <FormattedMessage {...contentEditorSideBySidePanelMessages.sourceColumn} />
+              </p>
+              <p className="pl-4">
+                <FormattedMessage {...contentEditorSideBySidePanelMessages.translationColumn} />
+              </p>
+            </div>
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col">
+            <ContentEditorQueueSkeletonList className="px-4 py-3" />
+          </div>
+        </div>
+      }
+      intelligence={
+        <div className="flex h-full min-h-0 flex-col bg-background lg:border-l lg:border-border" />
+      }
+    />
+  );
+}
+
 export const ContentEditorSideBySidePanel = observer(function ContentEditorSideBySidePanel({
   segments,
   focusedSegmentId,

--- a/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/side-by-side/content-editor-side-by-side-panel.tsx
@@ -76,7 +76,7 @@ export const ContentEditorSideBySidePanel = observer(function ContentEditorSideB
   search = "",
   queueFilter = "all",
   isFetchingPage = false,
-  isQueueLoading = false,
+  isTranslationViewLoading = false,
   pagination = null,
   hasMoreQueue = false,
   onLoadMoreQueue,
@@ -140,7 +140,7 @@ export const ContentEditorSideBySidePanel = observer(function ContentEditorSideB
   search?: string;
   queueFilter?: ContentEditorQueueFilter;
   isFetchingPage?: boolean;
-  isQueueLoading?: boolean;
+  isTranslationViewLoading?: boolean;
   pagination?: ContentEditorQueuePagination | null;
   hasMoreQueue?: boolean;
   onLoadMoreQueue?: () => void;
@@ -217,7 +217,7 @@ export const ContentEditorSideBySidePanel = observer(function ContentEditorSideB
           </div>
 
           <div className="flex min-h-0 flex-1 flex-col">
-            {isQueueLoading && segments.length === 0 ? (
+            {isTranslationViewLoading && segments.length === 0 ? (
               <ContentEditorQueueSkeletonList className="px-4 py-3" />
             ) : segments.length === 0 ? (
               <div className="flex flex-1 items-center justify-center px-4 py-8 text-sm text-muted-foreground">

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-page-shell.story-view.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-page-shell.story-view.tsx
@@ -13,25 +13,14 @@
  * Version 2.0 or later.
  */
 import { useEffect, useMemo, useState, type ComponentProps } from "react";
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
-import {
-  ContentEditorFileTreePicker,
-  ContentEditorLocaleSelect,
-} from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/content-editor-header-pickers";
-import {
-  ContentEditorFilesSidebar,
-  ContentEditorPageBody,
-} from "@/components/content-editor/files/content-editor-files-sidebar";
-import { ContentEditorQueueToolbarHost } from "@/components/content-editor/queue/content-editor-queue-toolbar-host";
+import { ContentEditorPageRoot } from "@/components/content-editor/page/content-editor-page-root";
 import type { ContentEditorWorkspaceState } from "@/components/content-editor/shared/types";
 import {
   writeCatWorkspaceViewMode,
   type ContentEditorWorkspaceViewMode,
 } from "@/components/content-editor/workspace/content-editor-workspace-view-mode";
-import { Button } from "@/components/ui/button";
 
 import { ContentEditorWorkspaceContainer } from "./content-editor-workspace-container";
 
@@ -90,49 +79,38 @@ export function ContentEditorPageShellStoryView({
   );
 
   return (
-    <main className="flex h-svh min-h-0 flex-col overflow-hidden bg-background text-foreground">
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4">
-        <div className="flex min-w-0 shrink-0 items-center gap-2">
-          <Button variant="outline" size="icon-sm" className="size-8 shrink-0" type="button">
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-          </Button>
-
-          <div className="lg:hidden">
-            <ContentEditorFileTreePicker
-              files={files}
-              selectedSourcePath={selectedSourcePath}
-              onSelectFile={setSelectedSourcePath}
-            />
-          </div>
-
-          <ContentEditorLocaleSelect
-            targetLocales={targetLocales}
-            selectedTargetLocale={targetLocale}
-            onTargetLocaleChange={setTargetLocale}
-          />
-        </div>
-
-        <ContentEditorQueueToolbarHost />
-      </div>
-
-      <ContentEditorPageBody
-        sidebar={
-          <ContentEditorFilesSidebar
-            className="hidden w-[17.5rem] shrink-0 lg:flex"
-            files={files}
-            selectedSourcePath={selectedSourcePath}
-            onSelectFile={setSelectedSourcePath}
-          />
-        }
-      >
-        <ContentEditorWorkspaceContainer
-          key={`${selectedSourcePath}:${targetLocale}:${activeEntry.initialViewMode}`}
-          initialState={workspaceState}
-          initialViewMode={activeEntry.initialViewMode}
-          className={className ?? "min-h-0 flex-1"}
-          {...workspaceProps}
-        />
-      </ContentEditorPageBody>
-    </main>
+    <ContentEditorPageRoot
+      initialState={workspaceState}
+      chrome={{
+        files,
+        selectedSourcePath,
+        allFiles: false,
+        canUseAllFiles: false,
+        targetLocale,
+        targetLocales,
+        repositoryFullNames: [],
+        selectedRepositoryFullName: null,
+        activitySourcePath: selectedSourcePath,
+        organizationSlug: "story",
+        projectId: "story",
+        showFileSidebar: true,
+        showActivityLog: false,
+      }}
+      backHref="#"
+      actions={{
+        onSelectFile: setSelectedSourcePath,
+        onLocaleChange: setTargetLocale,
+      }}
+      className="mx-0 my-0 h-svh sm:mx-0 lg:mx-0"
+    >
+      <ContentEditorWorkspaceContainer
+        initialState={workspaceState}
+        queueSnapshot={workspaceState}
+        fileScopeKey={`${selectedSourcePath}:${targetLocale}:${activeEntry.initialViewMode}`}
+        initialViewMode={activeEntry.initialViewMode}
+        className={className ?? "min-h-0 flex-1"}
+        {...workspaceProps}
+      />
+    </ContentEditorPageRoot>
   );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.test.tsx
@@ -29,6 +29,8 @@ import {
 } from "@/components/content-editor/shared/content-editor.fixture";
 import { renderWithContentEditorProviders } from "@/components/content-editor/shared/content-editor-test-utils";
 
+import { createContentEditorLoadingWorkspaceState } from "@/components/content-editor/project-file/project-file-content-editor-mapper";
+
 import { ContentEditorWorkspaceContainer } from "./content-editor-workspace-container";
 
 async function waitForTargetEditor() {
@@ -108,6 +110,25 @@ describe("ContentEditorWorkspaceContainer UI", () => {
       />,
     );
 
+    expect(screen.getByText("No segments in queue.")).toBeInTheDocument();
+  });
+
+  it("shows translation-view skeleton without queue skeleton while a file loads", () => {
+    renderCatWorkspace(
+      <ContentEditorWorkspaceContainer
+        initialState={createContentEditorLoadingWorkspaceState({
+          sourcePath: "app/dashboard/index.tsx",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+        })}
+        initialViewMode="comfortable"
+        isTranslationViewLoading
+      />,
+    );
+
+    expect(screen.getByLabelText("Loading editor")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Loading queue")).not.toBeInTheDocument();
+    expect(screen.getByText("Queue")).toBeInTheDocument();
     expect(screen.getByText("No segments in queue.")).toBeInTheDocument();
   });
 

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.test.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.test.tsx
@@ -132,6 +132,58 @@ describe("ContentEditorWorkspaceContainer UI", () => {
     expect(screen.getByText("No segments in queue.")).toBeInTheDocument();
   });
 
+  it("shows the compact editor skeleton while a file loads on a narrow viewport", () => {
+    const originalMatchMedia = window.matchMedia;
+    const matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("max-width"),
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    window.matchMedia = matchMedia;
+
+    try {
+      renderCatWorkspace(
+        <ContentEditorWorkspaceContainer
+          initialState={createContentEditorLoadingWorkspaceState({
+            sourcePath: "app/dashboard/index.tsx",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+          })}
+          initialViewMode="comfortable"
+          isTranslationViewLoading
+        />,
+      );
+
+      expect(screen.getByLabelText("Loading editor")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Loading queue")).not.toBeInTheDocument();
+      expect(screen.queryByText("No segments in queue.")).not.toBeInTheDocument();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it("shows the side-by-side translation skeleton while a file loads", () => {
+    renderCatWorkspace(
+      <ContentEditorWorkspaceContainer
+        initialState={createContentEditorLoadingWorkspaceState({
+          sourcePath: "app/dashboard/index.tsx",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+        })}
+        initialViewMode="side-by-side"
+        isTranslationViewLoading
+      />,
+    );
+
+    expect(screen.getByText("Source string")).toBeInTheDocument();
+    expect(screen.getByText("Translation")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading segments")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Loading queue")).not.toBeInTheDocument();
+    expect(screen.queryByText("No segments in queue.")).not.toBeInTheDocument();
+  });
+
   it("calls approve after editing the target translation", async () => {
     const user = userEvent.setup();
     const onApprove = vi.fn().mockResolvedValue("reviewed");

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import { observer } from "mobx-react-lite";
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { FormattedMessage } from "react-intl";
 
 import type { ProjectFileContentEditorQueueFile } from "@/api/routes/project/project.schema";
@@ -52,6 +52,7 @@ import { ContentEditorWorkspaceView } from "./content-editor-workspace";
 import {
   ContentEditorWorkspaceProvider,
   useContentEditorWorkspace,
+  useOptionalCatWorkspace,
 } from "./content-editor-workspace-context";
 import type { ContentEditorWorkspaceOrchestrator } from "./content-editor-workspace-orchestrator";
 import type { ContentEditorPageNavigationGuardRef } from "./content-editor-page-navigation-guard";
@@ -108,6 +109,8 @@ export interface ContentEditorWorkspaceContainerProps {
   nativeIssuesEnabled?: boolean;
   onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
   isDownloadingFilteredView?: boolean;
+  /** Stable identity for the open file/locale. Changing this resets workspace data only. */
+  fileScopeKey?: string;
 }
 
 const ContentEditorWorkspaceContainerObserver = observer(
@@ -147,6 +150,7 @@ const ContentEditorWorkspaceContainerObserver = observer(
     nativeIssuesEnabled = false,
     onDownloadFilteredView,
     isDownloadingFilteredView = false,
+    fileScopeKey,
   }: ContentEditorWorkspaceContainerProps & { store: ContentEditorWorkspaceOrchestrator }) {
     const controller = useContentEditorWorkspaceRuntime({
       store,
@@ -185,7 +189,7 @@ const ContentEditorWorkspaceContainerObserver = observer(
     const resolvedQueueDataPending =
       isQueueDataPending ?? legacyIsQueueLoading ?? resolvedQueueListLoading;
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       store.ui.setTranslationViewLoading(Boolean(isTranslationViewLoading));
     }, [isTranslationViewLoading, store]);
 
@@ -200,6 +204,13 @@ const ContentEditorWorkspaceContainerObserver = observer(
         {onPageLimitChange ? (
           <ContentEditorWorkspaceViewModeSync onPageLimitChange={onPageLimitChange} />
         ) : null}
+        <ContentEditorFileScopeSync
+          store={store}
+          fileScopeKey={fileScopeKey}
+          sourcePath={lazySegment?.sourcePath ?? store.fileContext.sourcePath}
+          sourceLocale={store.fileContext.sourceLocale}
+          targetLocale={lazySegment?.targetLocale ?? store.fileContext.targetLocale}
+        />
         <ContentEditorQueryBridge
           snapshot={queueSnapshot ?? null}
           initialSegmentKeyOrId={initialSegmentKeyOrId}
@@ -384,6 +395,42 @@ const ContentEditorWorkspaceContainerObserver = observer(
   },
 );
 
+function ContentEditorFileScopeSync({
+  store,
+  fileScopeKey,
+  sourcePath,
+  sourceLocale,
+  targetLocale,
+}: {
+  store: ContentEditorWorkspaceOrchestrator;
+  fileScopeKey?: string;
+  sourcePath: string;
+  sourceLocale: string;
+  targetLocale: string;
+}) {
+  const lastScopeKeyRef = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    if (!fileScopeKey) {
+      return;
+    }
+
+    if (lastScopeKeyRef.current === null) {
+      lastScopeKeyRef.current = fileScopeKey;
+      return;
+    }
+
+    if (lastScopeKeyRef.current === fileScopeKey) {
+      return;
+    }
+
+    lastScopeKeyRef.current = fileScopeKey;
+    store.prepareFileScopeChange({ sourcePath, sourceLocale, targetLocale });
+  }, [fileScopeKey, sourceLocale, sourcePath, store, targetLocale]);
+
+  return null;
+}
+
 export function ContentEditorWorkspaceContainer({
   initialState,
   initialSegmentKeyOrId,
@@ -393,6 +440,23 @@ export function ContentEditorWorkspaceContainer({
   queueSort,
   ...props
 }: ContentEditorWorkspaceContainerProps) {
+  const existingStore = useOptionalCatWorkspace();
+  const inner = (
+    <ContentEditorWorkspaceContainerInner
+      initialState={initialState}
+      initialSegmentKeyOrId={initialSegmentKeyOrId}
+      initialViewMode={initialViewMode}
+      queueFilter={queueFilter}
+      queueSearch={queueSearch}
+      queueSort={queueSort}
+      {...props}
+    />
+  );
+
+  if (existingStore) {
+    return inner;
+  }
+
   return (
     <ContentEditorWorkspaceProvider
       initialState={initialState}
@@ -402,15 +466,7 @@ export function ContentEditorWorkspaceContainer({
       initialQueueSort={queueSort}
       initialSearch={queueSearch}
     >
-      <ContentEditorWorkspaceContainerInner
-        initialState={initialState}
-        initialSegmentKeyOrId={initialSegmentKeyOrId}
-        initialViewMode={initialViewMode}
-        queueFilter={queueFilter}
-        queueSearch={queueSearch}
-        queueSort={queueSort}
-        {...props}
-      />
+      {inner}
     </ContentEditorWorkspaceProvider>
   );
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-container.tsx
@@ -90,6 +90,10 @@ export interface ContentEditorWorkspaceContainerProps {
   availableQueueSorts?: ContentEditorQueueSort[];
   isQueueSearchPending?: boolean;
   isQueueFetchingPage?: boolean;
+  isQueueListLoading?: boolean;
+  isQueueDataPending?: boolean;
+  isTranslationViewLoading?: boolean;
+  /** @deprecated Use isQueueListLoading or isQueueDataPending. */
   isQueueLoading?: boolean;
   isImageBusy?: boolean;
   isMaxLengthSaving?: boolean;
@@ -128,7 +132,10 @@ const ContentEditorWorkspaceContainerObserver = observer(
     availableQueueSorts,
     isQueueSearchPending,
     isQueueFetchingPage,
-    isQueueLoading,
+    isQueueListLoading,
+    isQueueDataPending,
+    isTranslationViewLoading,
+    isQueueLoading: legacyIsQueueLoading,
     isImageBusy,
     isMaxLengthSaving,
     queuePagination,
@@ -174,10 +181,18 @@ const ContentEditorWorkspaceContainerObserver = observer(
       }
     }, [queueSearch, store]);
 
+    const resolvedQueueListLoading = isQueueListLoading ?? legacyIsQueueLoading ?? false;
+    const resolvedQueueDataPending =
+      isQueueDataPending ?? legacyIsQueueLoading ?? resolvedQueueListLoading;
+
+    useEffect(() => {
+      store.ui.setTranslationViewLoading(Boolean(isTranslationViewLoading));
+    }, [isTranslationViewLoading, store]);
+
     // Cache hits make the query look ready before ContentEditorQueryBridge writes the
     // snapshot. Block bulk targets until both the query and the store agree.
     const isQueueBulkBlocked =
-      Boolean(isQueueLoading) || !store.hasIngestedQueueSnapshot(queueSnapshot ?? null);
+      Boolean(resolvedQueueDataPending) || !store.hasIngestedQueueSnapshot(queueSnapshot ?? null);
 
     return (
       <>
@@ -304,7 +319,8 @@ const ContentEditorWorkspaceContainerObserver = observer(
             className={className}
             queueSearch={queueSearch}
             isQueueFetchingPage={isQueueFetchingPage}
-            isQueueLoading={isQueueLoading}
+            isQueueListLoading={resolvedQueueListLoading}
+            isTranslationViewLoading={store.ui.translationViewLoading}
             isCommentsLoading={store.isCommentsLoading}
             isSegmentTargetLoading={store.isSegmentTargetLoading}
             isImageBusy={isImageBusy}

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-orchestrator.test.ts
@@ -1217,3 +1217,63 @@ describe("ContentEditorWorkspaceOrchestrator queue snapshot ingest", () => {
     expect(store.hasIngestedQueueSnapshot(sameIds)).toBe(true);
   });
 });
+
+describe("ContentEditorWorkspaceOrchestrator file scope", () => {
+  it("clears queue data and marks the translation view loading without dropping page chrome", () => {
+    const store = createCatWorkspace(
+      createContentEditorWorkspaceState({ selectedSegmentId: "seg-02" }),
+    );
+    store.page.applyChrome({
+      files: [],
+      selectedSourcePath: "app/dashboard/index.tsx",
+      allFiles: false,
+      canUseAllFiles: false,
+      targetLocale: "vi",
+      targetLocales: ["vi"],
+      repositoryFullNames: [],
+      selectedRepositoryFullName: null,
+      activitySourcePath: "app/dashboard/index.tsx",
+      organizationSlug: "acme",
+      projectId: "proj_1",
+      showFileSidebar: true,
+    });
+
+    expect(store.queueSegments.length).toBeGreaterThan(0);
+
+    store.prepareFileScopeChange({
+      sourcePath: "locales/messages.po",
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+    });
+
+    expect(store.queueSegments).toEqual([]);
+    expect(store.selectedSegmentId).toBe("");
+    expect(store.ui.translationViewLoading).toBe(true);
+    expect(store.page.selectedSourcePath).toBe("locales/messages.po");
+    expect(store.page.targetLocale).toBe("fr-FR");
+    expect(store.page.showFileSidebar).toBe(true);
+    expect(store.page.organizationSlug).toBe("acme");
+
+    const nextSnapshot = createContentEditorWorkspaceState({
+      selectedSegmentId: "seg-01",
+      segments: [
+        {
+          id: "seg-01",
+          index: 1,
+          key: "hello",
+          sourceText: "Hello",
+          targetText: "Bonjour",
+          sourceLocale: "en-US",
+          targetLocale: "fr-FR",
+          status: "pending",
+        },
+      ],
+      queueSegments: [{ id: "seg-01", index: 1, key: "hello", sourceText: "Hello" }],
+    });
+    store.ingestQueue(nextSnapshot);
+
+    expect(store.ui.translationViewLoading).toBe(false);
+    expect(store.queueSegments.map((segment) => segment.id)).toEqual(["seg-01"]);
+    expect(store.page.showFileSidebar).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-orchestrator.test.ts
@@ -1249,6 +1249,8 @@ describe("ContentEditorWorkspaceOrchestrator file scope", () => {
     expect(store.queueSegments).toEqual([]);
     expect(store.selectedSegmentId).toBe("");
     expect(store.ui.translationViewLoading).toBe(true);
+    expect(store.isFileScopeCurrent(0)).toBe(false);
+    expect(store.isFileScopeCurrent(store.fileScopeGeneration)).toBe(true);
     expect(store.page.selectedSourcePath).toBe("locales/messages.po");
     expect(store.page.targetLocale).toBe("fr-FR");
     expect(store.page.showFileSidebar).toBe(true);

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-orchestrator.ts
@@ -71,6 +71,7 @@ type UnsavedNavigationPrompt = {
 interface WorkspaceControllerLifecycle {
   start(): void;
   dispose(): void;
+  invalidateFileScope?(): void;
 }
 
 const defaultFileContext: ContentEditorFileContext = {
@@ -223,6 +224,7 @@ export class ContentEditorWorkspaceOrchestrator {
 
   validationSequence = 0;
   reviewSequence = 0;
+  fileScopeGeneration = 0;
   private controllers: WorkspaceControllerLifecycle[] = [];
   private dirtyStateDisposer?: IReactionDisposer;
   private beforeUnloadHandler?: (event: BeforeUnloadEvent) => void;
@@ -237,6 +239,7 @@ export class ContentEditorWorkspaceOrchestrator {
       {
         validationSequence: false,
         reviewSequence: false,
+        fileScopeGeneration: false,
         loadingSegmentIds: computed({ equals: loadingSegmentIdsEqual }),
       },
       { autoBind: true },
@@ -708,6 +711,20 @@ export class ContentEditorWorkspaceOrchestrator {
     targetLocale: string;
   }) {
     const filename = input.sourcePath.split("/").pop() ?? input.sourcePath;
+    this.fileScopeGeneration += 1;
+    this.reviewSequence += 1;
+    this.validationSequence += 1;
+    this.isApproving = false;
+    this.isSavingDraft = false;
+    this.isBulkActionPending = false;
+    this.isPostingComment = false;
+    this.isResolvingComment = false;
+    this.resolvingCommentId = null;
+    this.commentPostError = undefined;
+    this.isValidating = false;
+    this.isGeneratingAiRecommendation = false;
+    this.isRunningFormatChecks = false;
+    this.isLoadingVisualContext = false;
     this.lastHydratedSnapshot = null;
     this.lastHydratedQueueIdentity = "";
     this.initialSegmentJumpApplied = false;
@@ -730,6 +747,13 @@ export class ContentEditorWorkspaceOrchestrator {
     };
     this.page.beginFileScopeChange(input.sourcePath, input.targetLocale);
     this.ui.setTranslationViewLoading(true);
+    for (const controller of this.controllers) {
+      controller.invalidateFileScope?.();
+    }
+  }
+
+  isFileScopeCurrent(generation: number) {
+    return this.fileScopeGeneration === generation;
   }
 
   hasHydratedTarget(segmentId: string) {

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-orchestrator.ts
@@ -43,6 +43,8 @@ import {
 } from "@/components/content-editor/project-file/project-file-content-editor-mapper";
 
 import type { ContentEditorWorkspaceViewMode } from "./content-editor-workspace-view-mode";
+import { ContentEditorPageStore } from "@/components/content-editor/page/content-editor-page-store";
+
 import { ContentEditorIntelligenceStore } from "./store/content-editor-intelligence-store";
 import { ContentEditorQueueStore } from "./store/content-editor-queue-store";
 import { ContentEditorSegmentDraft } from "./store/content-editor-segment-draft";
@@ -182,6 +184,7 @@ export class ContentEditorWorkspaceOrchestrator {
   readonly queue = new ContentEditorQueueStore();
   readonly segments = new ContentEditorSegmentStore();
   readonly intelligenceState = new ContentEditorIntelligenceStore();
+  readonly page = new ContentEditorPageStore();
   readonly ui: ContentEditorWorkspaceUiStore;
 
   jobTitle?: string;
@@ -695,6 +698,40 @@ export class ContentEditorWorkspaceOrchestrator {
     this.ingestQueue(initialState, initialSegmentKeyOrId);
   }
 
+  /**
+   * File or locale changed while the page store stays mounted. Drop the previous
+   * file's queue so chrome can keep rendering, then wait for the next snapshot.
+   */
+  prepareFileScopeChange(input: {
+    sourcePath: string;
+    sourceLocale: string;
+    targetLocale: string;
+  }) {
+    const filename = input.sourcePath.split("/").pop() ?? input.sourcePath;
+    this.lastHydratedSnapshot = null;
+    this.lastHydratedQueueIdentity = "";
+    this.initialSegmentJumpApplied = false;
+    this.hydratedTargetSegmentIds = new Set();
+    this.locallyCommittedTargetTexts = new Map();
+    this.preSaveTargetTexts = new Map();
+    this.localStatusOverrides = new Map();
+    this.applySnapshotQueueMeta([], {});
+    this.selectedSegmentId = "";
+    this.formatChecks = [];
+    this.segmentFormatChecks = {};
+    this.fileContext = {
+      sourcePath: input.sourcePath,
+      filename,
+      sourceLocale: input.sourceLocale,
+      targetLocale: input.targetLocale,
+      providerKind: null,
+      canEditTranslations: true,
+      canAddComments: true,
+    };
+    this.page.beginFileScopeChange(input.sourcePath, input.targetLocale);
+    this.ui.setTranslationViewLoading(true);
+  }
+
   hasHydratedTarget(segmentId: string) {
     return this.hydratedTargetSegmentIds.has(segmentId);
   }
@@ -800,6 +837,7 @@ export class ContentEditorWorkspaceOrchestrator {
 
       this.lastHydratedSnapshot = normalizedNext;
       this.lastHydratedQueueIdentity = queueSnapshotIdentity(normalizedNext);
+      this.ui.setTranslationViewLoading(false);
     });
   }
 

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-skeleton.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-skeleton.tsx
@@ -149,7 +149,7 @@ function ContentEditorQueuePanelSkeleton() {
   );
 }
 
-function ContentEditorCompactWorkspaceSkeleton() {
+export function ContentEditorCompactWorkspaceSkeleton() {
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="shrink-0 border-b border-border px-4 py-3">

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-skeleton.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace-skeleton.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/primitives/cn";
 import { ContentEditorQueueSkeletonList } from "@/components/content-editor/queue/content-editor-queue-skeleton-list";
 import { contentEditorWorkspaceSkeletonMessages } from "./content-editor-workspace-skeleton.messages";
 
-function ContentEditorEditorPanelSkeleton() {
+export function ContentEditorEditorPanelSkeleton() {
   const intl = useIntl();
 
   return (

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
@@ -36,6 +36,7 @@ import { ContentEditorPanelErrorBoundary } from "./content-editor-panel-error-bo
 import { useContentEditorWorkspace } from "./content-editor-workspace-context";
 import { contentEditorWorkspaceViewMessages } from "./content-editor-workspace.messages";
 import { ContentEditorComfortableResizableLayout } from "./content-editor-workspace-resizable-layout";
+import { ContentEditorEditorPanelSkeleton } from "./content-editor-workspace-skeleton";
 import { resolveSegmentIntelligenceForDisplay } from "./store/content-editor-workspace-store-utils";
 
 const COMPACT_WORKSPACE_QUERY = "(max-width: 1023px)";
@@ -87,7 +88,8 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
   className,
   queueSearch,
   isQueueFetchingPage = false,
-  isQueueLoading = false,
+  isQueueListLoading = false,
+  isTranslationViewLoading = false,
   isCommentsLoading = false,
   isSegmentTargetLoading = false,
   isImageBusy = false,
@@ -147,34 +149,48 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
     selectedSegmentIdForIntelligence,
   ]);
 
-  if (!selectedSegment && isQueueLoading) {
-    return (
-      <div
-        className={cn(
-          "flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background",
-          className,
-        )}
-      >
-        <ContentEditorPanelErrorBoundary scope="queue" resetKeys={[queueSearch, queueFilter]}>
-          <ContentEditorQueuePanel
-            segments={[]}
-            selectedSegmentId=""
-            onSelectSegment={() => undefined}
-            search={queueSearch}
-            queueFilter={queueFilter}
-            showSelection={store.selectionMode}
-            isFetchingPage={isQueueFetchingPage}
-            isQueueLoading
-            pagination={queuePagination}
-            hasMoreQueue={hasMoreQueue}
-            onLoadMoreQueue={onLoadMoreQueue}
-          />
-        </ContentEditorPanelErrorBoundary>
-      </div>
-    );
-  }
+  const showTranslationViewSkeleton = isTranslationViewLoading || store.ui.translationViewLoading;
 
   if (!selectedSegment) {
+    const emptyQueuePanel = (
+      <ContentEditorPanelErrorBoundary scope="queue" resetKeys={[queueSearch, queueFilter]}>
+        <ContentEditorQueuePanel
+          segments={queueSegments}
+          selectedSegmentId=""
+          onSelectSegment={dependencies.navigation.onSelectSegment}
+          search={queueSearch}
+          queueFilter={queueFilter}
+          checkedSegmentIds={checkedSegmentIds}
+          onToggleSegmentChecked={onToggleSegmentChecked}
+          showSelection={store.selectionMode}
+          isFetchingPage={isQueueFetchingPage}
+          isQueueLoading={isQueueListLoading}
+          pagination={queuePagination}
+          hasMoreQueue={hasMoreQueue}
+          onLoadMoreQueue={onLoadMoreQueue}
+        />
+      </ContentEditorPanelErrorBoundary>
+    );
+
+    if (showTranslationViewSkeleton && !isCompact && !isFileView && !isSideBySideDesktop) {
+      return (
+        <div
+          className={cn(
+            "flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background",
+            className,
+          )}
+        >
+          <ContentEditorComfortableResizableLayout
+            queue={emptyQueuePanel}
+            editor={<ContentEditorEditorPanelSkeleton />}
+            intelligence={
+              <div className="flex h-full min-h-0 flex-col bg-background lg:border-l lg:border-border" />
+            }
+          />
+        </div>
+      );
+    }
+
     return (
       <div
         className={cn(
@@ -182,23 +198,7 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
           className,
         )}
       >
-        <ContentEditorPanelErrorBoundary scope="queue" resetKeys={[queueSearch, queueFilter]}>
-          <ContentEditorQueuePanel
-            segments={queueSegments}
-            selectedSegmentId=""
-            onSelectSegment={dependencies.navigation.onSelectSegment}
-            search={queueSearch}
-            queueFilter={queueFilter}
-            checkedSegmentIds={checkedSegmentIds}
-            onToggleSegmentChecked={onToggleSegmentChecked}
-            showSelection={store.selectionMode}
-            isFetchingPage={isQueueFetchingPage}
-            isQueueLoading={isQueueLoading}
-            pagination={queuePagination}
-            hasMoreQueue={hasMoreQueue}
-            onLoadMoreQueue={onLoadMoreQueue}
-          />
-        </ContentEditorPanelErrorBoundary>
+        {emptyQueuePanel}
       </div>
     );
   }
@@ -341,7 +341,7 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
           search={queueSearch}
           queueFilter={queueFilter}
           isFetchingPage={isQueueFetchingPage}
-          isQueueLoading={isQueueLoading}
+          isTranslationViewLoading={showTranslationViewSkeleton}
           pagination={queuePagination}
           hasMoreQueue={hasMoreQueue}
           onLoadMoreQueue={onLoadMoreQueue}
@@ -505,6 +505,10 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
   }
 
   function renderEditorPanel() {
+    if (showTranslationViewSkeleton) {
+      return <ContentEditorEditorPanelSkeleton />;
+    }
+
     if (isFileView) {
       return renderFileViewPanel();
     }
@@ -625,7 +629,7 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
           onToggleSegmentChecked={onToggleSegmentChecked}
           showSelection={store.selectionMode}
           isFetchingPage={isQueueFetchingPage}
-          isQueueLoading={isQueueLoading}
+          isQueueLoading={isQueueListLoading}
           pagination={queuePagination}
           hasMoreQueue={hasMoreQueue}
           onLoadMoreQueue={onLoadMoreQueue}

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/content-editor-workspace.tsx
@@ -26,7 +26,10 @@ import { resolveCatLinkedIssueTranslationKeyId } from "@/components/content-edit
 import { ContentEditorEditorIssuesSection } from "@/components/content-editor/issues/content-editor-editor-issues-section";
 import { ContentEditorQueuePanel } from "@/components/content-editor/queue/content-editor-queue-panel";
 import { ContentEditorSegmentKeyMeta } from "@/components/content-editor/segment/content-editor-segment-key-meta";
-import { ContentEditorSideBySidePanel } from "@/components/content-editor/side-by-side/content-editor-side-by-side-panel";
+import {
+  ContentEditorSideBySidePanel,
+  ContentEditorSideBySidePanelSkeleton,
+} from "@/components/content-editor/side-by-side/content-editor-side-by-side-panel";
 import type { ContentEditorWorkspaceViewProps } from "@/components/content-editor/shared/dependencies";
 import { contentEditorWorkspaceMessages } from "@/components/content-editor/shared/content-editor.messages";
 
@@ -36,7 +39,10 @@ import { ContentEditorPanelErrorBoundary } from "./content-editor-panel-error-bo
 import { useContentEditorWorkspace } from "./content-editor-workspace-context";
 import { contentEditorWorkspaceViewMessages } from "./content-editor-workspace.messages";
 import { ContentEditorComfortableResizableLayout } from "./content-editor-workspace-resizable-layout";
-import { ContentEditorEditorPanelSkeleton } from "./content-editor-workspace-skeleton";
+import {
+  ContentEditorCompactWorkspaceSkeleton,
+  ContentEditorEditorPanelSkeleton,
+} from "./content-editor-workspace-skeleton";
 import { resolveSegmentIntelligenceForDisplay } from "./store/content-editor-workspace-store-utils";
 
 const COMPACT_WORKSPACE_QUERY = "(max-width: 1023px)";
@@ -172,7 +178,46 @@ export const ContentEditorWorkspaceView = observer(function ContentEditorWorkspa
       </ContentEditorPanelErrorBoundary>
     );
 
-    if (showTranslationViewSkeleton && !isCompact && !isFileView && !isSideBySideDesktop) {
+    if (showTranslationViewSkeleton) {
+      if (isCompact) {
+        return (
+          <div
+            className={cn(
+              "flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background",
+              className,
+            )}
+          >
+            <ContentEditorCompactWorkspaceSkeleton />
+          </div>
+        );
+      }
+
+      if (isFileView) {
+        return (
+          <div
+            className={cn(
+              "flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background",
+              className,
+            )}
+          >
+            <ContentEditorEditorPanelSkeleton />
+          </div>
+        );
+      }
+
+      if (isSideBySideDesktop) {
+        return (
+          <div
+            className={cn(
+              "flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background",
+              className,
+            )}
+          >
+            <ContentEditorSideBySidePanelSkeleton className="min-h-0 flex-1" />
+          </div>
+        );
+      }
+
       return (
         <div
           className={cn(

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-intelligence-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-intelligence-controller.test.ts
@@ -450,6 +450,73 @@ describe("ContentEditorIntelligenceController", () => {
       expect(workspace.isLoadingVisualContext).toBe(false);
     });
 
+    it("does not merge visual context after a file scope change", async () => {
+      let resolveVisualContext: ((value: { screenshots: never[] }) => void) | undefined;
+      const lookupSegmentVisualContext = vi.fn(
+        () =>
+          new Promise<{ screenshots: never[] }>((resolve) => {
+            resolveVisualContext = resolve;
+          }),
+      );
+      const workspace = createTestWorkspace({
+        fileContext: {
+          sourcePath: "app/page.tsx",
+          filename: "page.tsx",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          providerKind: "crowdin",
+          canEditTranslations: true,
+          canAddComments: true,
+        },
+      });
+      const { controller } = createController(workspace, {
+        intl,
+        services: { lookupSegmentVisualContext },
+      });
+      workspace.attachControllers(controller);
+
+      controller.panelVisible("seg-02");
+      workspace.prepareFileScopeChange({
+        sourcePath: "locales/messages.po",
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+      });
+      workspace.ingestQueue(
+        createContentEditorWorkspaceState({
+          selectedSegmentId: "seg-02",
+          segments: [
+            {
+              id: "seg-02",
+              index: 1,
+              key: "hello",
+              sourceText: "Hello",
+              targetText: "Bonjour",
+              sourceLocale: "en-US",
+              targetLocale: "fr-FR",
+              status: "pending",
+            },
+          ],
+          queueSegments: [{ id: "seg-02", index: 1, key: "hello", sourceText: "Hello" }],
+          fileContext: {
+            sourcePath: "locales/messages.po",
+            filename: "messages.po",
+            sourceLocale: "en-US",
+            targetLocale: "fr-FR",
+            providerKind: "crowdin",
+            canEditTranslations: true,
+            canAddComments: true,
+          },
+        }),
+      );
+
+      resolveVisualContext?.({ screenshots: [] });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(workspace.segmentIntelligence["seg-02"]?.visualContext).toBeUndefined();
+      expect(workspace.isLoadingVisualContext).toBe(false);
+    });
+
     it("skips visual context lookup for native providers", async () => {
       const lookupSegmentVisualContext = vi.fn();
       const workspace = createTestWorkspace({

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-intelligence-controller.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-intelligence-controller.ts
@@ -79,6 +79,20 @@ export class ContentEditorIntelligenceController {
     this.inFlight.clear();
   }
 
+  invalidateFileScope() {
+    this.invalidateContextLookupGeneration();
+    this.concordanceAttempts.clear();
+    this.visualContextAttempts.clear();
+    this.loadedSegmentIds.clear();
+    for (const segmentId of this.inFlight.keys()) {
+      this.nextConcordanceGeneration(segmentId);
+      this.workspace.endConcordanceLoad(segmentId);
+    }
+    this.inFlight.clear();
+    this.workspace.isLoadingVisualContext = false;
+    this.visualContextLoadingSegmentId = null;
+  }
+
   async loadConcordance(
     segmentId: string,
   ): Promise<ContentEditorSegmentConcordanceResult | undefined> {
@@ -209,14 +223,15 @@ export class ContentEditorIntelligenceController {
     this.visualContextAttempts.add(segmentId);
     this.workspace.isLoadingVisualContext = true;
     this.visualContextLoadingSegmentId = segmentId;
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     void lookupSegmentVisualContext(segment)
       .then((visualContext) => {
-        if (!this.disposed) {
+        if (!this.disposed && this.workspace.isFileScopeCurrent(fileScopeGeneration)) {
           this.workspace.mergeSegmentIntelligence(segmentId, { visualContext });
         }
       })
       .catch(() => {
-        if (!this.disposed) {
+        if (!this.disposed && this.workspace.isFileScopeCurrent(fileScopeGeneration)) {
           this.workspace.upsertFormatCheck(segmentId, {
             id: `visual-context-failed-${segmentId}`,
             label: this.ports.intl.formatMessage(contentEditorIntelligencePanelMessages.panelTitle),
@@ -229,7 +244,10 @@ export class ContentEditorIntelligenceController {
         }
       })
       .finally(() => {
-        if (segmentId === this.visualContextLoadingSegmentId) {
+        if (
+          segmentId === this.visualContextLoadingSegmentId &&
+          this.workspace.isFileScopeCurrent(fileScopeGeneration)
+        ) {
           this.workspace.isLoadingVisualContext = false;
           this.visualContextLoadingSegmentId = null;
         }

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-review-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-review-controller.test.ts
@@ -344,6 +344,104 @@ describe("ContentEditorReviewController", () => {
       expect(workspace.selectedSegmentId).toBe("seg-01");
     });
 
+    it("does not write approve results after a file scope change", async () => {
+      let resolveApprove: ((status: string) => void) | undefined;
+      const onApprove = vi.fn(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveApprove = resolve;
+          }),
+      );
+      const { controller, workspace } = createController(undefined, {
+        review: { onApprove },
+      });
+      workspace.attachControllers(controller);
+
+      const approvePromise = controller.approve("seg-02", "Stale translation");
+      workspace.prepareFileScopeChange({
+        sourcePath: "locales/messages.po",
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+      });
+      workspace.ingestQueue(
+        createContentEditorWorkspaceState({
+          selectedSegmentId: "seg-02",
+          segments: [
+            {
+              id: "seg-02",
+              index: 1,
+              key: "hello",
+              sourceText: "Hello",
+              targetText: "Bonjour",
+              sourceLocale: "en-US",
+              targetLocale: "fr-FR",
+              status: "pending",
+            },
+          ],
+          queueSegments: [{ id: "seg-02", index: 1, key: "hello", sourceText: "Hello" }],
+        }),
+      );
+
+      resolveApprove?.("reviewed");
+      await approvePromise;
+
+      expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Bonjour");
+      expect(workspace.getSegmentView("seg-02")?.status).toBe("pending");
+      expect(workspace.selectedSegmentId).toBe("seg-02");
+      expect(workspace.isApproving).toBe(false);
+    });
+
+    it("does not clear a newer approve flag when a stale approve finishes", async () => {
+      let resolveStaleApprove: ((status: string) => void) | undefined;
+      const onApprove = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveStaleApprove = resolve;
+            }),
+        )
+        .mockImplementationOnce(() => new Promise<string>(() => undefined));
+      const { controller, workspace } = createController(undefined, {
+        review: { onApprove },
+      });
+      workspace.attachControllers(controller);
+
+      const staleApprove = controller.approve("seg-02", "Stale translation");
+      workspace.prepareFileScopeChange({
+        sourcePath: "locales/messages.po",
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+      });
+      workspace.ingestQueue(
+        createContentEditorWorkspaceState({
+          selectedSegmentId: "seg-02",
+          segments: [
+            {
+              id: "seg-02",
+              index: 1,
+              key: "hello",
+              sourceText: "Hello",
+              targetText: "Bonjour",
+              sourceLocale: "en-US",
+              targetLocale: "fr-FR",
+              status: "pending",
+            },
+          ],
+          queueSegments: [{ id: "seg-02", index: 1, key: "hello", sourceText: "Hello" }],
+        }),
+      );
+
+      void controller.approve("seg-02", "Bonjour");
+      expect(workspace.isApproving).toBe(true);
+
+      resolveStaleApprove?.("reviewed");
+      await staleApprove;
+
+      expect(workspace.isApproving).toBe(true);
+      expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Bonjour");
+    });
+
     it("adds save failure checks when approve fails", async () => {
       const { controller, workspace } = createController(undefined, {
         review: {
@@ -377,6 +475,52 @@ describe("ContentEditorReviewController", () => {
       expect(onSaveDraft).toHaveBeenCalledWith("seg-02", "Deuxième");
       expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Deuxième");
       expect(workspace.getSegmentView("seg-02")?.status).toBe("needs_review");
+      expect(workspace.isSavingDraft).toBe(false);
+    });
+
+    it("does not write draft results after a file scope change", async () => {
+      let resolveDraft: ((status: string) => void) | undefined;
+      const onSaveDraft = vi.fn(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveDraft = resolve;
+          }),
+      );
+      const { controller, workspace } = createController(undefined, {
+        review: { onSaveDraft },
+      });
+      workspace.attachControllers(controller);
+
+      const savePromise = controller.saveDraft("seg-02", "Stale draft");
+      workspace.prepareFileScopeChange({
+        sourcePath: "locales/messages.po",
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+      });
+      workspace.ingestQueue(
+        createContentEditorWorkspaceState({
+          selectedSegmentId: "seg-02",
+          segments: [
+            {
+              id: "seg-02",
+              index: 1,
+              key: "hello",
+              sourceText: "Hello",
+              targetText: "Bonjour",
+              sourceLocale: "en-US",
+              targetLocale: "fr-FR",
+              status: "pending",
+            },
+          ],
+          queueSegments: [{ id: "seg-02", index: 1, key: "hello", sourceText: "Hello" }],
+        }),
+      );
+
+      resolveDraft?.("needs_review");
+      await savePromise;
+
+      expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Bonjour");
+      expect(workspace.getSegmentView("seg-02")?.status).toBe("pending");
       expect(workspace.isSavingDraft).toBe(false);
     });
 

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-review-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-review-controller.test.ts
@@ -17,6 +17,7 @@ import { createContentEditorWorkspaceState } from "@/components/content-editor/s
 import type {
   ContentEditorFormatCheck,
   ContentEditorGlossaryTerm,
+  ContentEditorSegmentStatus,
 } from "@/components/content-editor/shared/types";
 
 import { createCatWorkspace } from "../content-editor-workspace-orchestrator";
@@ -345,10 +346,10 @@ describe("ContentEditorReviewController", () => {
     });
 
     it("does not write approve results after a file scope change", async () => {
-      let resolveApprove: ((status: string) => void) | undefined;
+      let resolveApprove: ((status: ContentEditorSegmentStatus) => void) | undefined;
       const onApprove = vi.fn(
-        () =>
-          new Promise<string>((resolve) => {
+        (_segmentId: string, _targetText: string) =>
+          new Promise<ContentEditorSegmentStatus>((resolve) => {
             resolveApprove = resolve;
           }),
       );
@@ -392,16 +393,19 @@ describe("ContentEditorReviewController", () => {
     });
 
     it("does not clear a newer approve flag when a stale approve finishes", async () => {
-      let resolveStaleApprove: ((status: string) => void) | undefined;
+      let resolveStaleApprove: ((status: ContentEditorSegmentStatus) => void) | undefined;
       const onApprove = vi
         .fn()
         .mockImplementationOnce(
-          () =>
-            new Promise<string>((resolve) => {
+          (_segmentId: string, _targetText: string) =>
+            new Promise<ContentEditorSegmentStatus>((resolve) => {
               resolveStaleApprove = resolve;
             }),
         )
-        .mockImplementationOnce(() => new Promise<string>(() => undefined));
+        .mockImplementationOnce(
+          (_segmentId: string, _targetText: string) =>
+            new Promise<ContentEditorSegmentStatus>(() => undefined),
+        );
       const { controller, workspace } = createController(undefined, {
         review: { onApprove },
       });
@@ -479,10 +483,10 @@ describe("ContentEditorReviewController", () => {
     });
 
     it("does not write draft results after a file scope change", async () => {
-      let resolveDraft: ((status: string) => void) | undefined;
+      let resolveDraft: ((status: ContentEditorSegmentStatus) => void) | undefined;
       const onSaveDraft = vi.fn(
-        () =>
-          new Promise<string>((resolve) => {
+        (_segmentId: string, _targetText: string) =>
+          new Promise<ContentEditorSegmentStatus>((resolve) => {
             resolveDraft = resolve;
           }),
       );

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-review-controller.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/controllers/content-editor-review-controller.ts
@@ -132,6 +132,22 @@ export class ContentEditorReviewController {
 
   dispose() {
     this.disposed = true;
+    this.abortPendingValidation();
+    this.lastVisibleCheckFingerprint.clear();
+    this.workspace.clearFormatCheckLoading();
+    this.selectedSegmentDisposer?.();
+    this.selectedSegmentDisposer = undefined;
+    this.visibleSegmentsDisposer?.();
+    this.visibleSegmentsDisposer = undefined;
+  }
+
+  invalidateFileScope() {
+    this.abortPendingValidation();
+    this.lastVisibleCheckFingerprint.clear();
+    this.workspace.clearFormatCheckLoading();
+  }
+
+  private abortPendingValidation() {
     if (this.validationTimeout) {
       clearTimeout(this.validationTimeout);
       this.validationTimeout = null;
@@ -142,16 +158,14 @@ export class ContentEditorReviewController {
       controller.abort();
     }
     this.segmentValidationControllers.clear();
-    this.lastVisibleCheckFingerprint.clear();
-    this.workspace.clearFormatCheckLoading();
-    this.selectedSegmentDisposer?.();
-    this.selectedSegmentDisposer = undefined;
-    this.visibleSegmentsDisposer?.();
-    this.visibleSegmentsDisposer = undefined;
   }
 
   get canRunChecks() {
     return Boolean(this.ports.services?.validateFormat || this.ports.services?.runQaChecks);
+  }
+
+  private isCurrentFileScope(generation: number) {
+    return !this.disposed && this.workspace.isFileScopeCurrent(generation);
   }
 
   async runChecks(
@@ -183,6 +197,7 @@ export class ContentEditorReviewController {
 
     const isSelected = this.workspace.selectedSegmentId === segment.id;
     const sequence = quiet || !isSelected ? null : this.workspace.beginValidation();
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.setFormatCheckLoading(segment.id, true);
     try {
       const glossaryTerms =
@@ -196,7 +211,8 @@ export class ContentEditorReviewController {
       if (
         this.disposed ||
         abortController.signal.aborted ||
-        (sequence !== null && !this.workspace.isValidationCurrent(sequence))
+        (sequence !== null && !this.workspace.isValidationCurrent(sequence)) ||
+        !this.isCurrentFileScope(fileScopeGeneration)
       ) {
         return;
       }
@@ -360,6 +376,7 @@ export class ContentEditorReviewController {
   }
 
   async approve(segmentId: string, targetText: string) {
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.isApproving = true;
     try {
       // Resolve the next row before the status change so Needs Review (and other
@@ -374,6 +391,9 @@ export class ContentEditorReviewController {
 
       const nextStatus =
         (await this.ports.review?.onApprove?.(segmentId, targetText)) ?? "reviewed";
+      if (!this.isCurrentFileScope(fileScopeGeneration)) {
+        return;
+      }
       this.workspace.markSegmentSaved(
         segmentId,
         targetText,
@@ -396,6 +416,9 @@ export class ContentEditorReviewController {
         );
       }
     } catch (error) {
+      if (!this.isCurrentFileScope(fileScopeGeneration)) {
+        return;
+      }
       this.workspace.addSaveFailureCheck(
         segmentId,
         error instanceof Error
@@ -406,7 +429,9 @@ export class ContentEditorReviewController {
         this.ports.intl.formatMessage(contentEditorWorkspaceContainerMessages.saveFailedLabel),
       );
     } finally {
-      this.workspace.isApproving = false;
+      if (this.isCurrentFileScope(fileScopeGeneration)) {
+        this.workspace.isApproving = false;
+      }
     }
   }
 
@@ -415,15 +440,22 @@ export class ContentEditorReviewController {
     if (!saveDraft) {
       return;
     }
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.isSavingDraft = true;
     try {
       const nextStatus = (await saveDraft(segmentId, targetText)) ?? "needs_review";
+      if (!this.isCurrentFileScope(fileScopeGeneration)) {
+        return;
+      }
       this.workspace.markSegmentSaved(
         segmentId,
         targetText,
         nextStatus as ContentEditorSegmentStatus,
       );
     } catch (error) {
+      if (!this.isCurrentFileScope(fileScopeGeneration)) {
+        return;
+      }
       this.workspace.addSaveFailureCheck(
         segmentId,
         error instanceof Error
@@ -434,7 +466,9 @@ export class ContentEditorReviewController {
         this.ports.intl.formatMessage(contentEditorWorkspaceContainerMessages.saveFailedLabel),
       );
     } finally {
-      this.workspace.isSavingDraft = false;
+      if (this.isCurrentFileScope(fileScopeGeneration)) {
+        this.workspace.isSavingDraft = false;
+      }
     }
   }
 
@@ -443,18 +477,24 @@ export class ContentEditorReviewController {
     if (!addComment) {
       return;
     }
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.commentPostError = undefined;
     this.workspace.isPostingComment = true;
     try {
       await addComment(segmentId, input);
     } catch (error) {
+      if (!this.isCurrentFileScope(fileScopeGeneration)) {
+        return;
+      }
       this.workspace.commentPostError =
         error instanceof Error
           ? error.message
           : this.ports.intl.formatMessage(contentEditorEditorPanelMessages.commentPostFailed);
       throw error;
     } finally {
-      this.workspace.isPostingComment = false;
+      if (this.isCurrentFileScope(fileScopeGeneration)) {
+        this.workspace.isPostingComment = false;
+      }
     }
   }
 
@@ -463,20 +503,26 @@ export class ContentEditorReviewController {
     if (!resolveComment) {
       return;
     }
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.commentPostError = undefined;
     this.workspace.resolvingCommentId = commentId;
     this.workspace.isResolvingComment = true;
     try {
       await resolveComment(segmentId, commentId);
     } catch (error) {
+      if (!this.isCurrentFileScope(fileScopeGeneration)) {
+        return;
+      }
       this.workspace.commentPostError =
         error instanceof Error
           ? error.message
           : this.ports.intl.formatMessage(contentEditorEditorPanelMessages.commentResolveFailed);
       throw error;
     } finally {
-      this.workspace.isResolvingComment = false;
-      this.workspace.resolvingCommentId = null;
+      if (this.isCurrentFileScope(fileScopeGeneration)) {
+        this.workspace.isResolvingComment = false;
+        this.workspace.resolvingCommentId = null;
+      }
     }
   }
 
@@ -510,12 +556,16 @@ export class ContentEditorReviewController {
     if (segmentIds.length === 0) {
       return;
     }
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.isBulkActionPending = true;
     try {
       if (this.ports.review?.onBulkApprove) {
         await this.ports.review.onBulkApprove(segmentIds);
       } else {
         for (const segmentId of segmentIds) {
+          if (!this.isCurrentFileScope(fileScopeGeneration)) {
+            return;
+          }
           const segment = this.workspace.getSegmentView(segmentId);
           if (segment) {
             await this.approve(segmentId, segment.targetText);
@@ -523,8 +573,10 @@ export class ContentEditorReviewController {
         }
       }
     } finally {
-      this.workspace.isBulkActionPending = false;
-      this.workspace.clearChecked();
+      if (this.isCurrentFileScope(fileScopeGeneration)) {
+        this.workspace.isBulkActionPending = false;
+        this.workspace.clearChecked();
+      }
     }
   }
 
@@ -533,6 +585,7 @@ export class ContentEditorReviewController {
     if (segmentIds.length === 0) {
       return;
     }
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.isBulkActionPending = true;
     try {
       if (this.ports.review?.onBulkSkip) {
@@ -543,8 +596,10 @@ export class ContentEditorReviewController {
         }
       }
     } finally {
-      this.workspace.isBulkActionPending = false;
-      this.workspace.clearChecked();
+      if (this.isCurrentFileScope(fileScopeGeneration)) {
+        this.workspace.isBulkActionPending = false;
+        this.workspace.clearChecked();
+      }
     }
   }
 
@@ -561,7 +616,11 @@ export class ContentEditorReviewController {
       return;
     }
 
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     await this.ports.review.onSetLocked(segmentIds, isLocked);
+    if (!this.isCurrentFileScope(fileScopeGeneration)) {
+      return;
+    }
     this.workspace.setSegmentsLocked(segmentIds, isLocked);
   }
 
@@ -584,13 +643,19 @@ export class ContentEditorReviewController {
       return;
     }
 
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.isBulkActionPending = true;
     try {
       await handler(segmentIds);
+      if (!this.isCurrentFileScope(fileScopeGeneration)) {
+        return;
+      }
       this.workspace.setSegmentsHidden(segmentIds, isHidden);
     } finally {
-      this.workspace.isBulkActionPending = false;
-      this.workspace.clearChecked();
+      if (this.isCurrentFileScope(fileScopeGeneration)) {
+        this.workspace.isBulkActionPending = false;
+        this.workspace.clearChecked();
+      }
     }
   }
 
@@ -605,13 +670,19 @@ export class ContentEditorReviewController {
       return;
     }
 
+    const fileScopeGeneration = this.workspace.fileScopeGeneration;
     this.workspace.isBulkActionPending = true;
     try {
       await handler(segmentIds);
+      if (!this.isCurrentFileScope(fileScopeGeneration)) {
+        return;
+      }
       this.workspace.setSegmentsLocked(segmentIds, isLocked);
     } finally {
-      this.workspace.isBulkActionPending = false;
-      this.workspace.clearChecked();
+      if (this.isCurrentFileScope(fileScopeGeneration)) {
+        this.workspace.isBulkActionPending = false;
+        this.workspace.clearChecked();
+      }
     }
   }
 }

--- a/apps/hyperlocalise-web/src/components/content-editor/workspace/store/content-editor-workspace-ui-store.ts
+++ b/apps/hyperlocalise-web/src/components/content-editor/workspace/store/content-editor-workspace-ui-store.ts
@@ -25,6 +25,8 @@ export class ContentEditorWorkspaceUiStore {
   previewLoadingSegmentId: string | null = null;
   previewTargetLoading = false;
   previewCommentsLoading = false;
+  /** True while the translation/editor pane is waiting for a new file snapshot. */
+  translationViewLoading = false;
   visibleSideBySideSegmentIds: string[] = [];
   // Explicit initial modes (e.g. marketing demos) must not overwrite the
   // visitor's real CAT workspace preference.
@@ -81,5 +83,9 @@ export class ContentEditorWorkspaceUiStore {
     this.previewLoadingSegmentId = segmentId;
     this.previewTargetLoading = state.isTargetLoading;
     this.previewCommentsLoading = state.isCommentsLoading;
+  }
+
+  setTranslationViewLoading(loading: boolean) {
+    this.translationViewLoading = loading;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The Content Editor is now three regions owned by one MobX store, so selecting a file no longer remounts (and skeletonizes) the whole page.

**Regions**
- **Header** — back, locale, filters/view toolbar, activity log
- **Files** — left sidebar / mobile file picker
- **Workspace** — translation view only

**MobX**
- `ContentEditorPageStore` holds chrome (files, selected path, locale, repository)
- `ContentEditorWorkspaceOrchestrator` owns `page` + existing queue/segment/intelligence/ui stores
- `prepareFileScopeChange()` clears workspace data and sets `translationViewLoading` without disposing the store
- Ingesting the next snapshot clears the translation-view skeleton
- File-scope generation invalidates in-flight approve, draft, comment, bulk, and visual-context writes so reused segment IDs cannot receive the previous file's results

**Composition**
- `ContentEditorPageRoot` wraps a page-level provider around header + sidebar + workspace
- File/job CAT pages and the editor Storybook shell use this root
- `ContentEditorWorkspaceContainer` reuses an existing store instead of creating a new one
- File/locale identity is a `fileScopeKey`, not a React remount `key`

Selecting a file keeps the header and sidebar interactive. Only the translation pane shows a skeleton while the new file loads, including compact, file, and side-by-side layouts.

## How to test

1. Open the content editor with multiple files in the sidebar.
2. Switch files: header and file tree stay mounted; queue does not flash a full-page skeleton.
3. Confirm only the center translation/editor pane shows loading during a cold fetch.
4. Switch locale and confirm the same chrome stays put.
5. On a narrow viewport and in side-by-side view, confirm the translation pane still shows a loading skeleton instead of the empty-queue fallback.
6. Start an approve or draft save, then switch file/locale before it finishes: the new file's segment with the same ID must not take the old status/text.
7. Automated: `vp test src/components/content-editor/page src/components/content-editor/workspace src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-content-editor-page-content.test.tsx`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a090ce-2b10-79e4-b6e0-6e2d0c1c66c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a090ce-2b10-79e4-b6e0-6e2d0c1c66c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

