### PR TITLE
fix(web): match locale progress skeleton rows to target locale count

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.stories.tsx
@@ -68,6 +68,7 @@ export const Empty: Story = {
 export const Loading: Story = {
   args: {
     locales: [],
+    expectedLocaleCount: projectOverviewLocaleProgressFixture.length,
     isLoading: true,
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ProjectLocaleProgressList } from "./project-locale-progress-list";
+
+function renderList(props: ComponentProps<typeof ProjectLocaleProgressList>) {
+  return render(
+    <IntlProvider locale="en" messages={{}} onError={() => undefined}>
+      <ProjectLocaleProgressList {...props} />
+    </IntlProvider>,
+  );
+}
+
+describe("ProjectLocaleProgressList", () => {
+  it("renders one skeleton row per expected locale while loading", () => {
+    const { container } = renderList({
+      locales: [],
+      expectedLocaleCount: 3,
+      isLoading: true,
+      settingsHref: "/org/acme/projects/p1/settings",
+    });
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(3);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-locale-progress-list.tsx
@@ -49,6 +49,8 @@ import {
 
 export type ProjectLocaleProgressListProps = {
   locales: readonly ProjectLocaleProgressRow[];
+  /** Target locale count from project metadata, used for skeleton rows while progress loads. */
+  expectedLocaleCount?: number;
   isLoading?: boolean;
   isError?: boolean;
   settingsHref: string;
@@ -329,6 +331,7 @@ function LocaleProgressItem({
 
 export function ProjectLocaleProgressList({
   locales,
+  expectedLocaleCount,
   isLoading = false,
   isError = false,
   settingsHref,
@@ -337,6 +340,8 @@ export function ProjectLocaleProgressList({
   const intl = useIntl();
   const [query, setQuery] = useState("");
   const [sort, setSort] = useState<LocaleProgressSort>("az");
+  const localeCount =
+    isLoading && expectedLocaleCount !== undefined ? expectedLocaleCount : locales.length;
 
   const visibleLocales = useMemo(
     () =>
@@ -355,15 +360,16 @@ export function ProjectLocaleProgressList({
           <FormattedMessage {...messages.title} />
         </span>
         <span className="text-xs font-medium tracking-wider text-muted-foreground uppercase tabular-nums">
-          {locales.length}
+          {localeCount}
         </span>
       </Row>
       <Separator className="bg-foreground" />
 
       {isLoading ? (
         <Rows spacing="1u">
-          <Skeleton className="h-12 w-full" />
-          <Skeleton className="h-12 w-full" />
+          {Array.from({ length: localeCount }, (_, index) => (
+            <Skeleton key={index} className="h-12 w-full" />
+          ))}
         </Rows>
       ) : isError ? (
         <Box paddingTop="1u">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -448,6 +448,7 @@ export function ProjectOverviewPageContentView({
             <Rows spacing="4u">
               <ProjectLocaleProgressList
                 locales={locales}
+                expectedLocaleCount={project.targetLocales.length}
                 isLoading={isLocaleProgressLoading}
                 isError={isLocaleProgressError}
                 settingsHref={settingsHref}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes layout shift on the project detail overview when locale progress is loading. The Languages section now renders one skeleton row per target locale (from project metadata) instead of a fixed count of two, and the header count matches during loading.

## Changes

- Add `expectedLocaleCount` prop to `ProjectLocaleProgressList`, sourced from `project.targetLocales.length`
- Drive skeleton row count and header locale count from `expectedLocaleCount` while progress is loading
- Update Storybook loading story and add a component test

## Testing

- `vp check --fix` — pass
- `vp test project-locale-progress-list.test.tsx` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a090cf-abdf-7c32-bfb7-0cf0675421cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a090cf-abdf-7c32-bfb7-0cf0675421cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

