### PR TITLE
feat(cli): add native SRX segmentation for run

### DIFF
--- a/apps/cli/cmd/run.go
+++ b/apps/cli/cmd/run.go
@@ -47,6 +47,7 @@ type runOptions struct {
 	contextMemoryScope        string
 	contextMemoryMaxChars     int
 	outputDetail              string
+	srx                       string
 }
 
 var runFunc = runsvc.Run
@@ -96,6 +97,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.contextMemoryScope, "context-memory-scope", runsvc.ContextMemoryScopeFile, "scope for experimental context memory: file|bucket|group")
 	cmd.Flags().IntVar(&o.contextMemoryMaxChars, "context-memory-max-chars", 1200, "maximum context memory characters injected into each translation request")
 	cmd.Flags().StringVar(&o.outputDetail, "output-detail", runsvc.ReportJSONDetailSummary, "for --output JSON: summary (default; counts, tokens, failures, warnings only—no task or prune lists) or full (complete report including tasks and batches)")
+	cmd.Flags().StringVar(&o.srx, "srx", "", "override buckets.*.files[].srx for this run (default, html, markdown, or a project-relative SRX 2.0 file)")
 
 	return cmd
 }
@@ -330,6 +332,7 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		PrefilledEntries:          prefilled.Flat,
 		PrefilledByLocale:         prefilled.ByLocale,
 		PrefilledTargetPath:       prefilledTargetPath,
+		SRX:                       o.srx,
 	}
 	if renderer != nil {
 		input.OnEvent = func(event runsvc.Event) {

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -1634,6 +1634,30 @@ func TestRunMaxTranslationsFlagPlumbedToServiceInput(t *testing.T) {
 	}
 }
 
+func TestRunSRXFlagPlumbedToServiceInput(t *testing.T) {
+	originalRunFunc := runFunc
+	t.Cleanup(func() { runFunc = originalRunFunc })
+
+	var gotInput runsvc.Input
+	runFunc = func(_ context.Context, input runsvc.Input) (runsvc.Report, error) {
+		gotInput = input
+		return runsvc.Report{}, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--srx", "markdown"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run with srx: %v", err)
+	}
+	if gotInput.SRX != "markdown" {
+		t.Fatalf("expected Input.SRX=markdown, got %q", gotInput.SRX)
+	}
+}
+
 func TestRunRejectsNegativeMaxTranslationsFlag(t *testing.T) {
 	cmd := newRootCmd("")
 	out := bytes.NewBuffer(nil)

--- a/apps/cli/internal/i18n/runsvc/BUILD.bazel
+++ b/apps/cli/internal/i18n/runsvc/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//internal/mt",
         "//internal/pathguard",
         "//internal/i18n/segmentvalidate",
+        "//internal/i18n/srx",
         "//internal/i18n/translationfileparser",
         "//internal/i18n/translator",
         "//pkg/i18nconfig",

--- a/apps/cli/internal/i18n/runsvc/cache_key.go
+++ b/apps/cli/internal/i18n/runsvc/cache_key.go
@@ -211,6 +211,9 @@ func lockTaskHashWithContextFingerprint(task Task, sourceContextFingerprint stri
 		"parser_mode="+strings.TrimSpace(task.ParserMode),
 		"source_context_fingerprint="+sourceContextFingerprint,
 	)
+	if fingerprint := strings.TrimSpace(task.SRXFingerprint); fingerprint != "" {
+		parts = append(parts, "srx_fingerprint="+fingerprint)
+	}
 	if includeLegacyDefaults {
 		parts = append(parts, "retrieval_corpus_snapshot_version="+legacyDefaultRetrievalSnapshot())
 	}

--- a/apps/cli/internal/i18n/runsvc/executor.go
+++ b/apps/cli/internal/i18n/runsvc/executor.go
@@ -45,6 +45,8 @@ type stagedOutput struct {
 	sourcePath   string
 	sourceLocale string
 	targetLocale string
+	srxSpec      string
+	parserMode   string
 	binary       []byte
 	binaryOutput bool
 }
@@ -85,7 +87,16 @@ func newExecutorState(tasks []Task, projectRoot string, initialStaged map[string
 		entries := map[string]string{}
 		maps.Copy(entries, output.entries)
 		binary := append([]byte(nil), output.binary...)
-		staged[targetPath] = stagedOutput{entries: entries, sourcePath: output.sourcePath, sourceLocale: output.sourceLocale, targetLocale: output.targetLocale, binary: binary, binaryOutput: output.binaryOutput}
+		staged[targetPath] = stagedOutput{
+			entries:      entries,
+			sourcePath:   output.sourcePath,
+			sourceLocale: output.sourceLocale,
+			targetLocale: output.targetLocale,
+			srxSpec:      output.srxSpec,
+			parserMode:   output.parserMode,
+			binary:       binary,
+			binaryOutput: output.binaryOutput,
+		}
 	}
 
 	state := &executorState{
@@ -535,7 +546,7 @@ func (s *Service) processTask(ctx context.Context, task Task, completions chan<-
 			markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
 			return false
 		}
-		if err := stageTaskOutput(state.staged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, translated, &state.stageMu); err != nil {
+		if err := stageTaskOutput(state.staged, task, translated, &state.stageMu); err != nil {
 			recordTaskFailure(&state.report, &state.reportMu, state.total, task, err, emitter)
 			markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
 			return false
@@ -656,15 +667,28 @@ func recordTaskFailure(report *executionReport, reportMu *sync.Mutex, total int,
 	}, tokenUsage))
 }
 
-func stageTaskOutput(staged map[string]stagedOutput, targetPath, sourcePath, sourceLocale, targetLocale, entryKey, value string, stageMu *sync.Mutex) error {
+func stageTaskOutput(staged map[string]stagedOutput, task Task, value string, stageMu *sync.Mutex) error {
 	if stageMu != nil {
 		stageMu.Lock()
 		defer stageMu.Unlock()
 	}
 
+	targetPath := task.TargetPath
+	sourcePath := task.SourcePath
+	sourceLocale := task.SourceLocale
+	targetLocale := task.TargetLocale
+	entryKey := task.EntryKey
+
 	bucket, ok := staged[targetPath]
 	if !ok {
-		bucket = stagedOutput{entries: map[string]string{}, sourcePath: sourcePath, sourceLocale: sourceLocale, targetLocale: targetLocale}
+		bucket = stagedOutput{
+			entries:      map[string]string{},
+			sourcePath:   sourcePath,
+			sourceLocale: sourceLocale,
+			targetLocale: targetLocale,
+			srxSpec:      task.SRXSpec,
+			parserMode:   task.ParserMode,
+		}
 		staged[targetPath] = bucket
 	} else if bucket.sourcePath != sourcePath {
 		return fmt.Errorf("output staging conflict: %s has conflicting source paths", targetPath)
@@ -672,9 +696,17 @@ func stageTaskOutput(staged map[string]stagedOutput, targetPath, sourcePath, sou
 		return fmt.Errorf("output staging conflict: %s has conflicting source locales", targetPath)
 	} else if bucket.targetLocale != "" && bucket.targetLocale != targetLocale {
 		return fmt.Errorf("output staging conflict: %s has conflicting target locales", targetPath)
+	} else if bucket.srxSpec != "" && task.SRXSpec != "" && bucket.srxSpec != task.SRXSpec {
+		return fmt.Errorf("output staging conflict: %s has conflicting srx specs", targetPath)
 	}
 	if bucket.binaryOutput {
 		return fmt.Errorf("output staging conflict: %s mixes image and text outputs", targetPath)
+	}
+	if bucket.srxSpec == "" {
+		bucket.srxSpec = task.SRXSpec
+	}
+	if bucket.parserMode == "" {
+		bucket.parserMode = task.ParserMode
 	}
 
 	if existing, exists := bucket.entries[entryKey]; exists && existing != value {

--- a/apps/cli/internal/i18n/runsvc/lock_filter_test.go
+++ b/apps/cli/internal/i18n/runsvc/lock_filter_test.go
@@ -208,6 +208,20 @@ func TestLockTaskHashStillIncludesNonMarkdownSourceContext(t *testing.T) {
 	}
 }
 
+func TestLockTaskHashChangesWhenSRXFingerprintChanges(t *testing.T) {
+	task := baseLockTask()
+	without := lockTaskHash(task)
+	task.SRXFingerprint = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	with := lockTaskHash(task)
+	if with == without {
+		t.Fatal("expected srx fingerprint to change lock hash")
+	}
+	task.SRXFingerprint = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	if lockTaskHash(task) == with {
+		t.Fatal("expected different fingerprints to change lock hash")
+	}
+}
+
 func TestLockTaskHashReusesCachedNonMarkdownContextFingerprint(t *testing.T) {
 	task := baseLockTask()
 	task.TargetPath = "/tmp/out.json"

--- a/apps/cli/internal/i18n/runsvc/output_flush.go
+++ b/apps/cli/internal/i18n/runsvc/output_flush.go
@@ -82,6 +82,14 @@ func (s *Service) flushOutputForTarget(targetPath string, output stagedOutput, k
 	if err != nil {
 		return nil, err
 	}
+	stagedEntries := output.entries
+	if strings.TrimSpace(output.srxSpec) != "" {
+		joined, joinErr := s.joinStagedSRXOutput(output, values)
+		if joinErr != nil {
+			return nil, joinErr
+		}
+		stagedEntries = joined
+	}
 	if keep != nil {
 		for key := range values {
 			if _, ok := keep[key]; !ok {
@@ -90,16 +98,16 @@ func (s *Service) flushOutputForTarget(targetPath string, output stagedOutput, k
 		}
 	}
 	if keep == nil {
-		maps.Copy(values, output.entries)
+		maps.Copy(values, stagedEntries)
 	} else {
-		for key, value := range output.entries {
+		for key, value := range stagedEntries {
 			if _, ok := keep[key]; ok {
 				values[key] = value
 			}
 		}
 	}
 
-	content, warnings, err := s.marshalTargetFile(targetPath, output.sourcePath, output.sourceLocale, output.targetLocale, values, output.entries, keep)
+	content, warnings, err := s.marshalTargetFile(targetPath, output.sourcePath, output.sourceLocale, output.targetLocale, values, stagedEntries, keep)
 	if err != nil {
 		return nil, err
 	}
@@ -139,6 +147,37 @@ func (s *Service) loadExistingTargetWithWarnings(path, targetLocale string) (map
 		return nil, nil, fmt.Errorf("flush outputs: parse target file %q: %w", path, err)
 	}
 	return entries, nil, nil
+}
+
+func (s *Service) joinStagedSRXOutput(output stagedOutput, existing map[string]string) (map[string]string, error) {
+	doc, _, err := s.compileSRX(output.srxSpec)
+	if err != nil {
+		return nil, fmt.Errorf("flush outputs: compile srx %q: %w", output.srxSpec, err)
+	}
+	sourceEntries, parserMode, err := s.loadSourceEntriesForJoin(output.sourcePath)
+	if err != nil {
+		return nil, err
+	}
+	if mode := strings.TrimSpace(output.parserMode); mode != "" {
+		parserMode = mode
+	}
+	return joinSRXStagedEntries(doc, output.sourcePath, parserMode, output.sourceLocale, output.targetLocale, sourceEntries, output.entries, existing), nil
+}
+
+func (s *Service) loadSourceEntriesForJoin(sourcePath string) (map[string]string, string, error) {
+	content, err := s.readProjectFile(sourcePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, "", fmt.Errorf("flush outputs: source file %q does not exist", sourcePath)
+		}
+		return nil, "", fmt.Errorf("flush outputs: read source file %q: %w", sourcePath, err)
+	}
+	parser := s.newParser()
+	entries, _, parseErr := parser.ParseWithContext(sourcePath, content)
+	if parseErr != nil {
+		return nil, "", fmt.Errorf("flush outputs: parse source file %q: %w", sourcePath, parseErr)
+	}
+	return entries, parserModeForSource(sourcePath, content), nil
 }
 
 func parseExistingTargetEntries(path string, content []byte, targetLocale string, parser *translationfileparser.Strategy) (map[string]string, error) {

--- a/apps/cli/internal/i18n/runsvc/output_prune.go
+++ b/apps/cli/internal/i18n/runsvc/output_prune.go
@@ -20,6 +20,8 @@ func buildPlannedTargetMetadata(planned []Task) (map[string]stagedOutput, error)
 				sourcePath:   task.SourcePath,
 				sourceLocale: task.SourceLocale,
 				targetLocale: task.TargetLocale,
+				srxSpec:      task.SRXSpec,
+				parserMode:   task.ParserMode,
 			}
 			continue
 		}
@@ -32,6 +34,16 @@ func buildPlannedTargetMetadata(planned []Task) (map[string]stagedOutput, error)
 		if existing.targetLocale != "" && existing.targetLocale != task.TargetLocale {
 			return nil, fmt.Errorf("output staging conflict: %s has conflicting target locales", task.TargetPath)
 		}
+		if existing.srxSpec != "" && task.SRXSpec != "" && existing.srxSpec != task.SRXSpec {
+			return nil, fmt.Errorf("output staging conflict: %s has conflicting srx specs", task.TargetPath)
+		}
+		if existing.srxSpec == "" && task.SRXSpec != "" {
+			existing.srxSpec = task.SRXSpec
+		}
+		if existing.parserMode == "" && task.ParserMode != "" {
+			existing.parserMode = task.ParserMode
+		}
+		metadata[task.TargetPath] = existing
 	}
 	return metadata, nil
 }
@@ -47,7 +59,7 @@ func buildPlannedTargetKeySet(planned []Task) map[string]map[string]struct{} {
 			bucket = map[string]struct{}{}
 			keep[task.TargetPath] = bucket
 		}
-		bucket[task.EntryKey] = struct{}{}
+		bucket[plannedFileKey(task.EntryKey)] = struct{}{}
 	}
 	return keep
 }

--- a/apps/cli/internal/i18n/runsvc/output_prune_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_prune_test.go
@@ -6,6 +6,39 @@ import (
 	"testing"
 )
 
+func TestBuildPlannedTargetKeySetCollapsesSRXSpanKeys(t *testing.T) {
+	planned := []Task{
+		{TargetPath: "/tmp/a.json", EntryKey: "hello#srx.0"},
+		{TargetPath: "/tmp/a.json", EntryKey: "hello#srx.1"},
+		{TargetPath: "/tmp/a.json", EntryKey: "bye"},
+	}
+
+	got := buildPlannedTargetKeySet(planned)
+	if _, ok := got["/tmp/a.json"]["hello"]; !ok {
+		t.Fatalf("expected original file key hello, got %#v", got)
+	}
+	if _, ok := got["/tmp/a.json"]["hello#srx.0"]; ok {
+		t.Fatalf("span key should not stay in prune keep-set: %#v", got)
+	}
+	if _, ok := got["/tmp/a.json"]["bye"]; !ok {
+		t.Fatalf("missing key bye: %#v", got)
+	}
+}
+
+func TestBuildPlannedTargetMetadataCopiesSRXSpec(t *testing.T) {
+	planned := []Task{
+		{TargetPath: "/tmp/a.json", SourcePath: "/tmp/en.json", SourceLocale: "en", TargetLocale: "fr", SRXSpec: "default", ParserMode: "json"},
+		{TargetPath: "/tmp/a.json", SourcePath: "/tmp/en.json", SourceLocale: "en", TargetLocale: "fr", SRXSpec: "default", ParserMode: "json"},
+	}
+	got, err := buildPlannedTargetMetadata(planned)
+	if err != nil {
+		t.Fatalf("metadata: %v", err)
+	}
+	if got["/tmp/a.json"].srxSpec != "default" || got["/tmp/a.json"].parserMode != "json" {
+		t.Fatalf("unexpected metadata: %+v", got["/tmp/a.json"])
+	}
+}
+
 func TestBuildPlannedTargetKeySet(t *testing.T) {
 	planned := []Task{
 		{TargetPath: "/tmp/a.json", EntryKey: "hello"},

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -49,6 +49,7 @@ func (s *Service) run(ctx context.Context, in Input) (report Report, err error) 
 		endRunSpan(planSpan, err, "config_path_root")
 		return Report{}, err
 	}
+	s.srxOverride = strings.TrimSpace(in.SRX)
 
 	planned, planWarnings, err := s.planTasks(cfg, in.Bucket, in.Group, in.TargetLocales, in.SourcePaths, in.FixTargets, in.FixMarkdownScopes)
 	if err != nil {
@@ -275,7 +276,7 @@ func applyFlatPrefilledEntries(tasks []Task, staged map[string]stagedOutput, ent
 			filtered = append(filtered, task)
 			continue
 		}
-		if err := stageTaskOutput(staged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, value, nil); err != nil {
+		if err := stageTaskOutput(staged, task, value, nil); err != nil {
 			return nil, 0, fmt.Errorf("stage prefilled output for %s: %w", taskIdentity(task.TargetPath, task.EntryKey), err)
 		}
 		reused++
@@ -304,7 +305,7 @@ func applyLocaleKeyedPrefilledEntries(tasks []Task, staged map[string]stagedOutp
 			filtered = append(filtered, task)
 			continue
 		}
-		if err := stageTaskOutput(staged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, value, nil); err != nil {
+		if err := stageTaskOutput(staged, task, value, nil); err != nil {
 			return nil, 0, nil, fmt.Errorf("stage prefilled output for %s: %w", taskIdentity(task.TargetPath, task.EntryKey), err)
 		}
 		reused++
@@ -409,7 +410,7 @@ func applyLockFilterWithReader(planned []Task, completed map[string]lockfile.Run
 				}
 				stageErr = stageImageOutput(checkpointStaged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, content, nil)
 			} else {
-				stageErr = stageTaskOutput(checkpointStaged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, cp.Value, nil)
+				stageErr = stageTaskOutput(checkpointStaged, task, cp.Value, nil)
 			}
 			if stageErr != nil {
 				return Report{}, nil, nil, false, fmt.Errorf("stage checkpoint output for %s: %w", identity, stageErr)

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hyperlocalise/hyperlocalise/apps/cli/internal/i18n/lockfile"
 	"github.com/hyperlocalise/hyperlocalise/apps/cli/internal/i18n/pathresolver"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/srx"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translator"
 	"github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
@@ -56,6 +57,9 @@ type Input struct {
 	// The CLI defaults to summary; an empty value normalizes to full for backward compatibility with
 	// library callers that omit the field. Run applies NormalizeReportJSONDetail again (idempotent).
 	ReportJSONDetail string
+	// SRX overrides buckets.*.files[].srx for this invocation. Accepts a built-in
+	// template name (default, html, markdown) or a project-relative SRX 2.0 file.
+	SRX string
 	// PrefilledEntries is the legacy flat map keyed by entry id. Requires PrefilledTargetPath.
 	PrefilledEntries map[string]string
 	// PrefilledByLocale is locale -> entry id -> value. Mutually exclusive with PrefilledEntries.
@@ -201,6 +205,8 @@ type Task struct {
 	ParserMode      string `json:"-"`
 	PromptVersion   string `json:"-"`
 	OutputFormat    string `json:"-"`
+	SRXSpec         string `json:"-"`
+	SRXFingerprint  string `json:"-"`
 
 	sourceTextHash           string
 	sourceContextFingerprint string
@@ -320,6 +326,14 @@ type Service struct {
 
 	lockPersistBatchSize     int
 	lockPersistFlushInterval time.Duration
+
+	srxOverride string
+	srxDocs     map[string]*compiledSRX
+}
+
+type compiledSRX struct {
+	doc         *srx.Document
+	fingerprint string
 }
 
 func New() *Service {
@@ -408,6 +422,7 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 	filterFixes := len(fixSet) > 0 || len(markdownScopeSet) > 0
 
 	tasks := make([]Task, 0)
+	var planWarnings []string
 
 	for _, groupName := range groups {
 		if filteredGroup != "" && groupName != filteredGroup {
@@ -559,6 +574,18 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 					sourceEntries := snapshot.entries
 					sourceContextByKey := snapshot.entryContext
 					parserMode := snapshot.parserMode
+					srxSpec := resolveMappingSRXSpec(s.srxOverride, file.SRX)
+					var srxFingerprint string
+					if srxSpec != "" {
+						doc, fingerprint, compileErr := s.compileSRX(srxSpec)
+						if compileErr != nil {
+							return nil, nil, fmt.Errorf("planning tasks: %w", compileErr)
+						}
+						var srxWarnings []string
+						sourceEntries, sourceContextByKey, srxWarnings = applySRXToEntries(doc, sourcePath, parserMode, cfg.Locales.Source, sourceEntries, sourceContextByKey)
+						planWarnings = append(planWarnings, srxWarnings...)
+						srxFingerprint = fingerprint
+					}
 					keys := sortedEntryKeys(sourceEntries)
 
 					// Fix runs keep only a small matching subset after filterFixes;
@@ -599,6 +626,8 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 								PromptVersion:            promptVersion,
 								sourceTextHash:           snapshot.sourceTextHashes[key],
 								sourceContextFingerprint: snapshot.sourceContextFingerprints[key],
+								SRXSpec:                  srxSpec,
+								SRXFingerprint:           srxFingerprint,
 							}
 
 							switch selection.Type {
@@ -661,7 +690,6 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 		}
 	}
 
-	var planWarnings []string
 	if len(fixSet) > 0 {
 		seen := make(map[string]struct{})
 		for _, ft := range fixTargets {

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -582,7 +582,11 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 							return nil, nil, fmt.Errorf("planning tasks: %w", compileErr)
 						}
 						var srxWarnings []string
-						sourceEntries, sourceContextByKey, srxWarnings = applySRXToEntries(doc, sourcePath, parserMode, cfg.Locales.Source, sourceEntries, sourceContextByKey)
+						var applyErr error
+						sourceEntries, sourceContextByKey, srxWarnings, applyErr = applySRXToEntries(doc, sourcePath, parserMode, cfg.Locales.Source, sourceEntries, sourceContextByKey)
+						if applyErr != nil {
+							return nil, nil, fmt.Errorf("planning tasks: %w", applyErr)
+						}
 						planWarnings = append(planWarnings, srxWarnings...)
 						srxFingerprint = fingerprint
 					}

--- a/apps/cli/internal/i18n/runsvc/srx.go
+++ b/apps/cli/internal/i18n/runsvc/srx.go
@@ -51,14 +51,17 @@ func (s *Service) compileSRX(spec string) (*srx.Document, string, error) {
 	return compiled.doc, compiled.fingerprint, nil
 }
 
-func applySRXToEntries(doc *srx.Document, sourcePath, parserMode, language string, entries, contextByKey map[string]string) (map[string]string, map[string]string, []string) {
+func applySRXToEntries(doc *srx.Document, sourcePath, parserMode, language string, entries, contextByKey map[string]string) (map[string]string, map[string]string, []string, error) {
 	if doc == nil || len(entries) == 0 {
-		return entries, contextByKey, nil
+		return entries, contextByKey, nil, nil
 	}
 	if !srx.FormatSupports(sourcePath, parserMode) {
 		return entries, contextByKey, []string{
 			fmt.Sprintf("srx ignored for %s: format is already segmented or incompatible", sourcePath),
-		}
+		}, nil
+	}
+	if reserved := srx.ReservedSpanKeys(entries); len(reserved) > 0 {
+		return nil, nil, nil, fmt.Errorf("source %q has keys that collide with reserved srx span keys: %s", sourcePath, strings.Join(reserved, ", "))
 	}
 
 	splitEntries := make(map[string]string, len(entries))
@@ -87,7 +90,7 @@ func applySRXToEntries(doc *srx.Document, sourcePath, parserMode, language strin
 			}
 		}
 	}
-	return splitEntries, splitContext, nil
+	return splitEntries, splitContext, nil, nil
 }
 
 func joinSRXStagedEntries(doc *srx.Document, sourcePath, parserMode, sourceLocale, targetLocale string, sourceEntries, staged, existing map[string]string) map[string]string {

--- a/apps/cli/internal/i18n/runsvc/srx.go
+++ b/apps/cli/internal/i18n/runsvc/srx.go
@@ -1,0 +1,165 @@
+package runsvc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/srx"
+)
+
+func resolveMappingSRXSpec(override, mapping string) string {
+	if spec := strings.TrimSpace(override); spec != "" {
+		return spec
+	}
+	return strings.TrimSpace(mapping)
+}
+
+func (s *Service) compileSRX(spec string) (*srx.Document, string, error) {
+	spec = srx.NormalizeSpec(spec)
+	if spec == "" {
+		return nil, "", nil
+	}
+	if srx.IsNamedTemplate(spec) {
+		spec = strings.ToLower(spec)
+	}
+	if s.srxDocs == nil {
+		s.srxDocs = map[string]*compiledSRX{}
+	}
+	if cached, ok := s.srxDocs[spec]; ok {
+		return cached.doc, cached.fingerprint, nil
+	}
+
+	var (
+		doc *srx.Document
+		err error
+	)
+	if srx.IsNamedTemplate(spec) {
+		doc, err = srx.LoadTemplate(spec)
+	} else {
+		path := s.resolveProjectPattern(spec)
+		content, readErr := s.readProjectFile(path)
+		if readErr != nil {
+			return nil, "", fmt.Errorf("read srx %q: %w", spec, readErr)
+		}
+		doc, err = srx.Parse(content)
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("compile srx %q: %w", spec, err)
+	}
+	compiled := &compiledSRX{doc: doc, fingerprint: doc.Fingerprint()}
+	s.srxDocs[spec] = compiled
+	return compiled.doc, compiled.fingerprint, nil
+}
+
+func applySRXToEntries(doc *srx.Document, sourcePath, parserMode, language string, entries, contextByKey map[string]string) (map[string]string, map[string]string, []string) {
+	if doc == nil || len(entries) == 0 {
+		return entries, contextByKey, nil
+	}
+	if !srx.FormatSupports(sourcePath, parserMode) {
+		return entries, contextByKey, []string{
+			fmt.Sprintf("srx ignored for %s: format is already segmented or incompatible", sourcePath),
+		}
+	}
+
+	splitEntries := make(map[string]string, len(entries))
+	splitContext := make(map[string]string, len(contextByKey))
+	for key, text := range entries {
+		if srx.ShouldSkipValue(text, parserMode) {
+			splitEntries[key] = text
+			if ctx, ok := contextByKey[key]; ok {
+				splitContext[key] = ctx
+			}
+			continue
+		}
+		spans := doc.Segment(text, language)
+		if len(spans) <= 1 {
+			splitEntries[key] = text
+			if ctx, ok := contextByKey[key]; ok {
+				splitContext[key] = ctx
+			}
+			continue
+		}
+		for index, span := range spans {
+			spanKey := srx.SpanKey(key, index)
+			splitEntries[spanKey] = span.Text
+			if ctx, ok := contextByKey[key]; ok {
+				splitContext[spanKey] = ctx
+			}
+		}
+	}
+	return splitEntries, splitContext, nil
+}
+
+func joinSRXStagedEntries(doc *srx.Document, sourcePath, parserMode, sourceLocale, targetLocale string, sourceEntries, staged, existing map[string]string) map[string]string {
+	if doc == nil || !srx.FormatSupports(sourcePath, parserMode) {
+		return staged
+	}
+
+	joined := make(map[string]string, len(sourceEntries))
+	for fileKey, sourceText := range sourceEntries {
+		if srx.ShouldSkipValue(sourceText, parserMode) {
+			if value, ok := staged[fileKey]; ok {
+				joined[fileKey] = value
+			}
+			continue
+		}
+		spans := doc.Segment(sourceText, sourceLocale)
+		if len(spans) <= 1 {
+			if value, ok := staged[fileKey]; ok {
+				joined[fileKey] = value
+			}
+			continue
+		}
+
+		translations := make([]string, len(spans))
+		haveStaged := false
+		for index := range spans {
+			if value, ok := staged[srx.SpanKey(fileKey, index)]; ok {
+				translations[index] = value
+				haveStaged = true
+			}
+		}
+		if !haveStaged {
+			if value, ok := staged[fileKey]; ok {
+				joined[fileKey] = value
+			}
+			continue
+		}
+
+		if existingValue, ok := existing[fileKey]; ok && existingValue != "" {
+			existingSpans := doc.Segment(existingValue, firstNonEmptyLocale(targetLocale, sourceLocale))
+			if len(existingSpans) == len(spans) {
+				for index := range translations {
+					if translations[index] == "" {
+						translations[index] = existingSpans[index].Text
+					}
+				}
+			}
+		}
+		joined[fileKey] = srx.Join(spans, translations)
+	}
+
+	for key, value := range staged {
+		if _, _, isSpan := srx.SplitSpanKey(key); isSpan {
+			continue
+		}
+		if _, already := joined[key]; already {
+			continue
+		}
+		joined[key] = value
+	}
+	return joined
+}
+
+func firstNonEmptyLocale(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func plannedFileKey(entryKey string) string {
+	return srx.FileKey(entryKey)
+}

--- a/apps/cli/internal/i18n/runsvc/srx_test.go
+++ b/apps/cli/internal/i18n/runsvc/srx_test.go
@@ -656,12 +656,33 @@ func TestCompileSRXReadsProjectFile(t *testing.T) {
 	}
 }
 
+func TestPlanTasksRejectsReservedSRXSpanKeys(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(`{"hello":"Hello. World.","hello#srx.0":"Already a key."}`), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	_, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected reserved span key error")
+	}
+	if !strings.Contains(err.Error(), "hello#srx.0") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestApplySRXToEntriesCopiesContextToSpans(t *testing.T) {
 	doc, err := srx.LoadTemplate("default")
 	if err != nil {
 		t.Fatalf("template: %v", err)
 	}
-	entries, contextByKey, warnings := applySRXToEntries(
+	entries, contextByKey, warnings, err := applySRXToEntries(
 		doc,
 		"en.json",
 		"json",
@@ -669,6 +690,9 @@ func TestApplySRXToEntriesCopiesContextToSpans(t *testing.T) {
 		map[string]string{"hello": "Hello. World."},
 		map[string]string{"hello": "Greeting"},
 	)
+	if err != nil {
+		t.Fatalf("apply srx: %v", err)
+	}
 	if len(warnings) != 0 {
 		t.Fatalf("warnings: %#v", warnings)
 	}

--- a/apps/cli/internal/i18n/runsvc/srx_test.go
+++ b/apps/cli/internal/i18n/runsvc/srx_test.go
@@ -1,0 +1,718 @@
+package runsvc
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/srx"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translator"
+	"github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
+)
+
+const (
+	srxHelloWorldJSON = `{"hello":"Hello. World."}`
+	srxNumberedJSON   = `{"list":"1. First item. Second sentence."}`
+)
+
+func withMappingSRX(cfg config.I18NConfig, spec string) config.I18NConfig {
+	bucket := cfg.Buckets["ui"]
+	bucket.Files[0].SRX = spec
+	cfg.Buckets["ui"] = bucket
+	return cfg
+}
+
+func TestResolveMappingSRXSpecOverrideWins(t *testing.T) {
+	if got := resolveMappingSRXSpec(" default ", "markdown"); got != "default" {
+		t.Fatalf("override = %q", got)
+	}
+	if got := resolveMappingSRXSpec("", "markdown"); got != "markdown" {
+		t.Fatalf("mapping = %q", got)
+	}
+	if got := resolveMappingSRXSpec("  ", ""); got != "" {
+		t.Fatalf("empty = %q", got)
+	}
+}
+
+func TestPlanTasksSplitsJSONWithDefaultSRX(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(srxHelloWorldJSON), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, warnings, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("task count=%d, want 2: %+v", len(tasks), tasks)
+	}
+	got := map[string]string{}
+	for _, task := range tasks {
+		got[task.EntryKey] = task.SourceText
+		if task.SRXSpec != "default" {
+			t.Fatalf("SRXSpec=%q", task.SRXSpec)
+		}
+		if task.SRXFingerprint == "" {
+			t.Fatal("expected SRX fingerprint")
+		}
+	}
+	want := map[string]string{
+		"hello#srx.0": "Hello.",
+		"hello#srx.1": " World.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("spans mismatch\nwant %#v\ngot %#v", want, got)
+	}
+}
+
+func TestPlanTasksSplitsNestedJSONKeys(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(`{"home":{"title":"Hello. World."}}`), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	got := map[string]string{}
+	for _, task := range tasks {
+		got[task.EntryKey] = task.SourceText
+	}
+	want := map[string]string{
+		"home.title#srx.0": "Hello.",
+		"home.title#srx.1": " World.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("nested spans mismatch\nwant %#v\ngot %#v", want, got)
+	}
+}
+
+func TestPlanTasksSplitsYAMLLeaves(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.yaml"
+	targetPath := "/tmp/out.yaml"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte("hello: Hello. World.\n"), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected yaml to split, got %+v", tasks)
+	}
+}
+
+func TestPlanTasksDoesNotSplitWithoutSRX(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := testConfig(sourcePath, targetPath)
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(srxHelloWorldJSON), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].EntryKey != "hello" || tasks[0].SourceText != "Hello. World." {
+		t.Fatalf("expected one unsplit task, got %+v", tasks)
+	}
+	if tasks[0].SRXSpec != "" || tasks[0].SRXFingerprint != "" {
+		t.Fatalf("expected empty srx fields, got spec=%q fp=%q", tasks[0].SRXSpec, tasks[0].SRXFingerprint)
+	}
+}
+
+func TestPlanTasksCLIOverrideSplitsWhenMappingEmpty(t *testing.T) {
+	svc := newTestService()
+	svc.srxOverride = "default"
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := testConfig(sourcePath, targetPath)
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(srxHelloWorldJSON), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected override to split, got %+v", tasks)
+	}
+}
+
+func TestPlanTasksOverrideWinsOverMappingTemplate(t *testing.T) {
+	svc := newTestService()
+	svc.srxOverride = "default"
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "markdown")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(srxNumberedJSON), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	keys := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		keys = append(keys, task.EntryKey)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("override default should produce 3 numbered spans, got %d keys=%v", len(tasks), keys)
+	}
+}
+
+func TestPlanTasksMarkdownTemplateKeepsNumberedListPrefix(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "markdown")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(srxNumberedJSON), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	got := map[string]string{}
+	for _, task := range tasks {
+		got[task.EntryKey] = task.SourceText
+	}
+	want := map[string]string{
+		"list#srx.0": "1. First item.",
+		"list#srx.1": " Second sentence.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("markdown spans mismatch\nwant %#v\ngot %#v", want, got)
+	}
+}
+
+func TestPlanTasksSkipsICUPrintfAndFluentValues(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(`{
+				"icu":"Hello {name}. World.",
+				"plural":"{count, plural, one {# item} other {# items}}",
+				"printf":"Saved %s to disk. Done.",
+				"fluent":"Hello { $name }. World.",
+				"plain":"Hello. World."
+			}`), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	keys := map[string]string{}
+	for _, task := range tasks {
+		keys[task.EntryKey] = task.SourceText
+	}
+	for _, key := range []string{"icu", "plural", "printf", "fluent"} {
+		if _, ok := keys[key]; !ok {
+			t.Fatalf("expected unsplit key %q, got %#v", key, keys)
+		}
+	}
+	if _, ok := keys["plain#srx.0"]; !ok {
+		t.Fatalf("expected plain to split, got %#v", keys)
+	}
+}
+
+func TestPlanTasksWarnsAndSkipsFormatJS(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(`{"hello":{"defaultMessage":"Hello. World.","description":"Greeting"}}`), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	tasks, warnings, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].EntryKey != "hello" {
+		t.Fatalf("expected one FormatJS key, got %+v", tasks)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "srx ignored") {
+		t.Fatalf("expected format warning, got %#v", warnings)
+	}
+}
+
+func TestPlanTasksWarnsAndSkipsXLIFF(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/catalog.xliff"
+	targetPath := "/tmp/catalog.fr.xliff"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path != sourcePath {
+			return nil, filepath.ErrBadPattern
+		}
+		return []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="messages">
+    <body>
+      <trans-unit id="hello">
+        <source>Hello. World.</source>
+        <target>Hello. World.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>`), nil
+	}
+
+	tasks, warnings, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan tasks: %v", err)
+	}
+	if len(tasks) == 0 {
+		t.Fatal("expected xliff tasks")
+	}
+	for _, task := range tasks {
+		if _, _, isSpan := srx.SplitSpanKey(task.EntryKey); isSpan {
+			t.Fatalf("xliff should not split, got %q", task.EntryKey)
+		}
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "srx ignored") {
+		t.Fatalf("expected format warning, got %#v", warnings)
+	}
+}
+
+func TestPlanTasksInvalidSRXFileFails(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "rules/bad.srx")
+	svc.readFile = func(path string) ([]byte, error) {
+		switch path {
+		case sourcePath:
+			return []byte(srxHelloWorldJSON), nil
+		case "rules/bad.srx":
+			return []byte("not xml"), nil
+		default:
+			return nil, filepath.ErrBadPattern
+		}
+	}
+
+	_, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected invalid srx compile error")
+	}
+	if !strings.Contains(err.Error(), "srx") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPlanTasksMissingSRXFileFails(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	cfg := withMappingSRX(testConfig(sourcePath, targetPath), "missing.srx")
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(srxHelloWorldJSON), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	_, _, err := svc.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected missing srx file error")
+	}
+}
+
+func TestRunJoinsSRXSpansToOriginalJSONKeys(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		switch path {
+		case sourcePath:
+			return []byte(srxHelloWorldJSON), nil
+		case targetPath:
+			return []byte(`{}`), nil
+		default:
+			return nil, filepath.ErrBadPattern
+		}
+	}
+	var written []byte
+	svc.writeFile = func(path string, content []byte) error {
+		if path != targetPath {
+			t.Fatalf("unexpected write path %s", path)
+		}
+		written = append([]byte(nil), content...)
+		return nil
+	}
+
+	report, err := svc.Run(context.Background(), Input{Workers: 1})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if report.PlannedTotal != 2 || report.Succeeded != 2 {
+		t.Fatalf("planned/succeeded = %d/%d, want 2/2", report.PlannedTotal, report.Succeeded)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(written, &payload); err != nil {
+		t.Fatalf("decode written: %v\n%s", err, written)
+	}
+	if _, ok := payload["hello#srx.0"]; ok {
+		t.Fatalf("span key leaked into target: %#v", payload)
+	}
+	if payload["hello"] != "HELLO. WORLD." {
+		t.Fatalf("joined hello = %q, want HELLO. WORLD.", payload["hello"])
+	}
+}
+
+func TestRunSRXInputOverrideJoinsOriginalKeys(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := testConfig(sourcePath, targetPath)
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		switch path {
+		case sourcePath:
+			return []byte(srxHelloWorldJSON), nil
+		case targetPath:
+			return []byte(`{}`), nil
+		default:
+			return nil, filepath.ErrBadPattern
+		}
+	}
+	var written []byte
+	svc.writeFile = func(_ string, content []byte) error {
+		written = append([]byte(nil), content...)
+		return nil
+	}
+
+	report, err := svc.Run(context.Background(), Input{Workers: 1, SRX: "default"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if report.PlannedTotal != 2 {
+		t.Fatalf("planned = %d, want 2", report.PlannedTotal)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(written, &payload); err != nil {
+		t.Fatalf("decode written: %v", err)
+	}
+	if payload["hello"] != "HELLO. WORLD." {
+		t.Fatalf("joined hello = %q", payload["hello"])
+	}
+}
+
+func TestRunDryRunReportsSRXSpanKeys(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(srxHelloWorldJSON), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	report, err := svc.Run(context.Background(), Input{DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if report.PlannedTotal != 2 || len(report.Executable) != 2 {
+		t.Fatalf("planned/executable = %d/%d", report.PlannedTotal, len(report.Executable))
+	}
+	keys := map[string]struct{}{}
+	for _, task := range report.Executable {
+		keys[task.EntryKey] = struct{}{}
+	}
+	if _, ok := keys["hello#srx.0"]; !ok {
+		t.Fatalf("missing span keys: %+v", report.Executable)
+	}
+}
+
+func TestLockTaskHashIncludesSRXFingerprint(t *testing.T) {
+	base := baseLockTask()
+	base.SourceText = "Hello"
+	without := lockTaskHash(base)
+
+	defaultDoc, err := srx.LoadTemplate("default")
+	if err != nil {
+		t.Fatalf("default template: %v", err)
+	}
+	markdownDoc, err := srx.LoadTemplate("markdown")
+	if err != nil {
+		t.Fatalf("markdown template: %v", err)
+	}
+
+	withDefault := base
+	withDefault.SRXSpec = "default"
+	withDefault.SRXFingerprint = defaultDoc.Fingerprint()
+	withMarkdown := base
+	withMarkdown.SRXSpec = "markdown"
+	withMarkdown.SRXFingerprint = markdownDoc.Fingerprint()
+
+	if lockTaskHash(withDefault) == without {
+		t.Fatal("expected srx fingerprint to change lock hash")
+	}
+	if lockTaskHash(withDefault) == lockTaskHash(withMarkdown) {
+		t.Fatal("expected different templates to produce different lock hashes")
+	}
+}
+
+func TestJoinSRXStagedEntriesMergesExistingWhenSpanCountsMatch(t *testing.T) {
+	doc, err := srx.LoadTemplate("default")
+	if err != nil {
+		t.Fatalf("template: %v", err)
+	}
+	source := map[string]string{"hello": "Hello. World."}
+	staged := map[string]string{"hello#srx.0": "Bonjour."}
+	existing := map[string]string{"hello": "Salut. Monde."}
+
+	got := joinSRXStagedEntries(doc, "en.json", "json", "en", "fr", source, staged, existing)
+	if got["hello"] != "Bonjour. Monde." {
+		t.Fatalf("joined = %#v", got)
+	}
+}
+
+func TestJoinSRXStagedEntriesFallsBackToSourceWhenCountsDiverge(t *testing.T) {
+	doc, err := srx.LoadTemplate("default")
+	if err != nil {
+		t.Fatalf("template: %v", err)
+	}
+	source := map[string]string{"hello": "Hello. World."}
+	staged := map[string]string{"hello#srx.0": "Bonjour."}
+	existing := map[string]string{"hello": "Salut tout le monde"}
+
+	got := joinSRXStagedEntries(doc, "en.json", "json", "en", "fr", source, staged, existing)
+	if got["hello"] != "Bonjour. World." {
+		t.Fatalf("joined = %#v", got)
+	}
+}
+
+func TestJoinSRXStagedEntriesRestoresLeadingWhitespace(t *testing.T) {
+	doc, err := srx.LoadTemplate("default")
+	if err != nil {
+		t.Fatalf("template: %v", err)
+	}
+	source := map[string]string{"hello": "Hello. World."}
+	staged := map[string]string{
+		"hello#srx.0": "Bonjour.",
+		"hello#srx.1": "Monde.",
+	}
+
+	got := joinSRXStagedEntries(doc, "en.json", "json", "en", "fr", source, staged, nil)
+	if got["hello"] != "Bonjour. Monde." {
+		t.Fatalf("joined = %q", got["hello"])
+	}
+}
+
+func TestFlushOutputForTargetJoinsSRXSpans(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	targetPath := filepath.Join(dir, "fr.json")
+	if err := os.WriteFile(sourcePath, []byte(srxHelloWorldJSON), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"hello":"Salut. Monde.","stale":"x"}`), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	svc := newTestService()
+	svc.readFile = os.ReadFile
+	var written []byte
+	svc.writeFile = func(path string, content []byte) error {
+		if path != targetPath {
+			t.Fatalf("write path %s", path)
+		}
+		written = append([]byte(nil), content...)
+		return nil
+	}
+
+	_, err := svc.flushOutputForTarget(targetPath, stagedOutput{
+		entries:      map[string]string{"hello#srx.0": "Bonjour."},
+		sourcePath:   sourcePath,
+		sourceLocale: "en",
+		targetLocale: "fr",
+		srxSpec:      "default",
+		parserMode:   "json",
+	}, map[string]struct{}{"hello": {}})
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(written, &payload); err != nil {
+		t.Fatalf("decode: %v\n%s", err, written)
+	}
+	if payload["hello"] != "Bonjour. Monde." {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if _, ok := payload["stale"]; ok {
+		t.Fatalf("stale key survived prune: %#v", payload)
+	}
+	if _, ok := payload["hello#srx.0"]; ok {
+		t.Fatalf("span key leaked: %#v", payload)
+	}
+}
+
+func TestCompileSRXCachesNamedTemplates(t *testing.T) {
+	svc := newTestService()
+	first, fp1, err := svc.compileSRX("DEFAULT")
+	if err != nil || first == nil || fp1 == "" {
+		t.Fatalf("first compile: doc=%v fp=%q err=%v", first, fp1, err)
+	}
+	second, fp2, err := svc.compileSRX("default")
+	if err != nil {
+		t.Fatalf("second compile: %v", err)
+	}
+	if first != second || fp1 != fp2 {
+		t.Fatal("expected compiled document cache hit")
+	}
+}
+
+func TestCompileSRXReadsProjectFile(t *testing.T) {
+	svc := newTestService()
+	custom := []byte(`<srx><body><languagerules>
+      <languagerule languagename="Custom">
+        <rule break="yes"><beforebreak>\.</beforebreak><afterbreak>\s</afterbreak></rule>
+      </languagerule>
+    </languagerules></body></srx>`)
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == "rules/custom.srx" {
+			return custom, nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+	doc, fp, err := svc.compileSRX("rules/custom.srx")
+	if err != nil {
+		t.Fatalf("compile custom: %v", err)
+	}
+	if doc == nil || fp == "" {
+		t.Fatal("expected compiled custom document")
+	}
+	spans := doc.Segment("Hello. World.", "en")
+	if len(spans) != 2 {
+		t.Fatalf("custom spans = %#v", spans)
+	}
+}
+
+func TestApplySRXToEntriesCopiesContextToSpans(t *testing.T) {
+	doc, err := srx.LoadTemplate("default")
+	if err != nil {
+		t.Fatalf("template: %v", err)
+	}
+	entries, contextByKey, warnings := applySRXToEntries(
+		doc,
+		"en.json",
+		"json",
+		"en",
+		map[string]string{"hello": "Hello. World."},
+		map[string]string{"hello": "Greeting"},
+	)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings: %#v", warnings)
+	}
+	if contextByKey["hello#srx.0"] != "Greeting" || contextByKey["hello#srx.1"] != "Greeting" {
+		t.Fatalf("context = %#v", contextByKey)
+	}
+	if _, ok := entries["hello"]; ok {
+		t.Fatalf("original key should be replaced by spans: %#v", entries)
+	}
+}
+
+func TestRunDoesNotSplitWhenTranslationUsesICUOnlyFile(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := withMappingSRX(testConfig(sourcePath, targetPath), "default")
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		switch path {
+		case sourcePath:
+			return []byte(`{"hello":"Hello {name}."}`), nil
+		case targetPath:
+			return []byte(`{}`), nil
+		default:
+			return nil, filepath.ErrBadPattern
+		}
+	}
+	var sources []string
+	svc.translate = func(_ context.Context, req translator.Request) (string, error) {
+		sources = append(sources, req.Source)
+		return "Bonjour {name}.", nil
+	}
+
+	report, err := svc.Run(context.Background(), Input{Workers: 1})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if report.PlannedTotal != 1 {
+		t.Fatalf("planned = %d", report.PlannedTotal)
+	}
+	if len(sources) != 1 || sources[0] != "Hello {name}." {
+		t.Fatalf("sources = %#v", sources)
+	}
+}
+

--- a/apps/cli/internal/i18n/runsvc/srx_test.go
+++ b/apps/cli/internal/i18n/runsvc/srx_test.go
@@ -715,4 +715,3 @@ func TestRunDoesNotSplitWhenTranslationUsesICUOnlyFile(t *testing.T) {
 		t.Fatalf("sources = %#v", sources)
 	}
 }
-

--- a/docs/cli/commands/run.mdx
+++ b/docs/cli/commands/run.mdx
@@ -6,7 +6,7 @@ description: "Plan and execute local translation generation from configured sour
 ## Usage
 
 ```bash
-hyperlocalise run [--config <path>] [--group <name>] [--bucket <name>] [--file <path>] [--locale <locale>] [--dry-run] [--workers <count>] [--output <report.json>] [--experimental-context-memory] [--context-memory-scope <file|bucket|group>] [--context-memory-max-chars <count>]
+hyperlocalise run [--config <path>] [--group <name>] [--bucket <name>] [--file <path>] [--locale <locale>] [--dry-run] [--workers <count>] [--output <report.json>] [--srx <default|html|markdown|path>] [--experimental-context-memory] [--context-memory-scope <file|bucket|group>] [--context-memory-max-chars <count>]
 ```
 
 ## Behavior
@@ -185,9 +185,18 @@ For generic XML (`.xml`, `.resx`), `run` translates text-only leaf elements and 
 - `--workers`: number of parallel translation workers (defaults to CPU cores)
 - `--progress`: progress rendering mode (`auto|on|off`, default: `auto`)
 - `--output`: write machine-readable JSON run report to the given path
+- `--srx`: override `buckets.*.files[].srx` for this invocation. Accepts a built-in template (`default`, `html`, `markdown`) or a project-relative SRX 2.0 file. Mapping `srx` stays off unless you set this flag or the file mapping.
 - `--experimental-context-memory`: enable two-stage context memory generation before translating each scope
 - `--context-memory-scope`: context sharing scope (`file|bucket|group`, default `file`)
 - `--context-memory-max-chars`: maximum context memory length injected into each translation request (default `1200`)
+
+## Sentence segmentation (`srx`)
+
+`run` can split string values with SRX 2.0 before translation. This is a text-level segmenter, not a JSON parser: each leaf stays one file key, and `run` writes the joined translation back to that key.
+
+Enable it per mapping with `buckets.*.files[].srx`, or override every mapping for one invocation with `--srx`. Both accept `default`, `html`, `markdown`, or a project-relative SRX 2.0 file. Segmentation stays off when neither is set.
+
+`run` skips already-segmented formats (XLIFF, PO, SRT, VTT, xcstrings, stringsdict) and FormatJS/ARB parser modes. Values that contain ICU, printf, or Fluent `{ $var }` placeholders stay one unit. Changing the SRX rules changes the lock hash so those tasks run again.
 
 ## Prompt contract for `run`
 

--- a/docs/cli/configuration/i18n-config.mdx
+++ b/docs/cli/configuration/i18n-config.mdx
@@ -61,8 +61,24 @@ Each file mapping uses:
 
 - `from`: source path template
 - `to`: target path template
+- optional `srx`: built-in sentence-break template (`default`, `html`, `markdown`) or a project-relative SRX 2.0 file. When set, `run` splits string values into sentence spans before translation and joins them back to the original keys on write. JSON and YAML stay unsplit unless `srx` is set. Already-segmented formats (XLIFF, PO, SRT, VTT, xcstrings, stringsdict) and FormatJS/ARB parser modes ignore `srx`. ICU, printf, and Fluent `{ $var }` values stay one unit. `hl run --srx` overrides this field for the whole invocation.
 
 Use `{{source}}`, `{{target}}`, and `{{localeDir}}` in templates. `{{localeDir}}` resolves to an empty segment when target equals source, and to the target locale otherwise.
+
+```yaml
+buckets:
+  docs:
+    files:
+      - from: docs/{{source}}.md
+        to: docs/{{target}}.md
+        srx: markdown
+      - from: emails/{{source}}.html
+        to: emails/{{target}}.html
+        srx: html
+      - from: lang/{{source}}.json
+        to: lang/{{target}}.json
+        srx: rules/product.srx
+```
 
 ### PHP array locale mapping patterns
 

--- a/docs/cli/reference/config-schema.mdx
+++ b/docs/cli/reference/config-schema.mdx
@@ -21,7 +21,7 @@ description: "Concise reference for the hyperlocalise i18n config schema."
 ## `buckets`
 
 - map of bucket name -> bucket definition
-- `files` array with `from` and `to` templates
+- `files` array with `from` and `to` templates, and optional `srx` (`default` | `html` | `markdown` | project-relative SRX 2.0 file)
 
 ## `groups`
 

--- a/internal/i18n/srx/BUILD.bazel
+++ b/internal/i18n/srx/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "srx",
+    srcs = [
+        "skip.go",
+        "srx.go",
+        "templates.go",
+    ],
+    importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/srx",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "srx_test",
+    srcs = [
+        "skip_test.go",
+        "srx_test.go",
+        "templates_test.go",
+    ],
+    embed = [":srx"],
+)

--- a/internal/i18n/srx/skip.go
+++ b/internal/i18n/srx/skip.go
@@ -1,0 +1,62 @@
+package srx
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	icuMessagePattern = regexp.MustCompile(`\{[A-Za-z_][A-Za-z0-9_]*\s*,\s*(plural|select|selectordinal)\b`)
+	icuPlaceholder    = regexp.MustCompile(`\{[A-Za-z_][A-Za-z0-9_]*\}`)
+	printfPattern     = regexp.MustCompile(`%(?:\d+\$)?[-+#0 ]*\d*(?:\.\d+)?[sdifFeEgGxXucpo@]`)
+	fluentVarPattern  = regexp.MustCompile(`\{\s*\$[A-Za-z_][A-Za-z0-9_]*`)
+)
+
+// FormatSupports reports whether a source path/parser mode may apply SRX.
+func FormatSupports(path, parserMode string) bool {
+	switch strings.ToLower(strings.TrimSpace(parserMode)) {
+	case "formatjs", "arb":
+		return false
+	}
+
+	normalized := strings.ToLower(filepath.ToSlash(strings.TrimSpace(path)))
+	switch {
+	case strings.HasSuffix(normalized, ".xlf"),
+		strings.HasSuffix(normalized, ".xlif"),
+		strings.HasSuffix(normalized, ".xliff"),
+		strings.HasSuffix(normalized, ".po"),
+		strings.HasSuffix(normalized, ".pot"),
+		strings.HasSuffix(normalized, ".srt"),
+		strings.HasSuffix(normalized, ".vtt"),
+		strings.HasSuffix(normalized, ".xcstrings"),
+		strings.HasSuffix(normalized, ".stringsdict"):
+		return false
+	default:
+		return true
+	}
+}
+
+// ShouldSkipValue reports whether a leaf value should stay a single translation unit.
+func ShouldSkipValue(text, parserMode string) bool {
+	if !FormatSupports("", parserMode) {
+		return true
+	}
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return true
+	}
+	if icuMessagePattern.MatchString(trimmed) {
+		return true
+	}
+	if icuPlaceholder.MatchString(trimmed) {
+		return true
+	}
+	if fluentVarPattern.MatchString(trimmed) {
+		return true
+	}
+	if printfPattern.MatchString(trimmed) {
+		return true
+	}
+	return false
+}

--- a/internal/i18n/srx/skip_test.go
+++ b/internal/i18n/srx/skip_test.go
@@ -5,9 +5,9 @@ import "testing"
 func TestFormatSupports(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		path   string
-		mode   string
-		want   bool
+		path string
+		mode string
+		want bool
 	}{
 		{path: "lang/en.json", want: true},
 		{path: "docs/guide.md", want: true},

--- a/internal/i18n/srx/skip_test.go
+++ b/internal/i18n/srx/skip_test.go
@@ -1,0 +1,61 @@
+package srx
+
+import "testing"
+
+func TestFormatSupports(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path   string
+		mode   string
+		want   bool
+	}{
+		{path: "lang/en.json", want: true},
+		{path: "docs/guide.md", want: true},
+		{path: "emails/welcome.html", want: true},
+		{path: "strings.xml", want: true},
+		{path: "catalog.xliff", want: false},
+		{path: "messages.po", want: false},
+		{path: "captions.srt", want: false},
+		{path: "captions.vtt", want: false},
+		{path: "Localizable.xcstrings", want: false},
+		{path: "Localizable.stringsdict", want: false},
+		{path: "messages.json", mode: "formatjs", want: false},
+		{path: "app.arb", mode: "arb", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path+"/"+tc.mode, func(t *testing.T) {
+			t.Parallel()
+			if got := FormatSupports(tc.path, tc.mode); got != tc.want {
+				t.Fatalf("FormatSupports(%q, %q) = %v, want %v", tc.path, tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldSkipValue(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		text string
+		mode string
+		want bool
+	}{
+		{name: "plain prose", text: "Hello. Welcome back.", want: false},
+		{name: "empty", text: "   ", want: true},
+		{name: "icu placeholder", text: "Hello {name}.", want: true},
+		{name: "icu plural", text: "{count, plural, one {# item} other {# items}}", want: true},
+		{name: "printf", text: "Saved %s to disk.", want: true},
+		{name: "positional printf", text: "Hello %1$s.", want: true},
+		{name: "fluent var", text: "Hello { $name }.", want: true},
+		{name: "formatjs mode", text: "Hello there.", mode: "formatjs", want: true},
+		{name: "braces without placeholder", text: "Use { only as decoration. Next.", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ShouldSkipValue(tc.text, tc.mode); got != tc.want {
+				t.Fatalf("ShouldSkipValue(%q, %q) = %v, want %v", tc.text, tc.mode, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/srx/srx.go
+++ b/internal/i18n/srx/srx.go
@@ -1,0 +1,604 @@
+package srx
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	// TemplateDefault is the built-in general sentence-break ruleset.
+	TemplateDefault = "default"
+	// TemplateHTML is the built-in HTML-oriented ruleset.
+	TemplateHTML = "html"
+	// TemplateMarkdown is the built-in Markdown-oriented ruleset.
+	TemplateMarkdown = "markdown"
+
+	spanKeyInfix = "#srx."
+)
+
+// Document is a compiled SRX 2.0 ruleset.
+type Document struct {
+	languageRules []languageRule
+	languageMaps  []languageMap
+	fingerprint   string
+}
+
+type languageRule struct {
+	name  string
+	rules []rule
+}
+
+type languageMap struct {
+	pattern *regexp.Regexp
+	rule    string
+}
+
+type rule struct {
+	breakAt bool
+	before  *regexp.Regexp
+	after   *regexp.Regexp
+}
+
+// Span is one contiguous slice of the source text.
+type Span struct {
+	Start int
+	End   int
+	Text  string
+}
+
+type srxXML struct {
+	XMLName xml.Name `xml:"srx"`
+	Body    srxBodyXML
+}
+
+type srxBodyXML struct {
+	XMLName        xml.Name `xml:"body"`
+	LanguageRules  []srxLanguageRuleXML
+	LanguageMaps   []srxLanguageMapXML
+}
+
+func (b *srxBodyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch localName(t.Name) {
+			case "languagerules":
+				if err := decodeLanguageRules(d, t, b); err != nil {
+					return err
+				}
+			case "maprules":
+				if err := decodeMapRules(d, t, b); err != nil {
+					return err
+				}
+			default:
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			if localName(t.Name) == localName(start.Name) {
+				return nil
+			}
+		}
+	}
+}
+
+type srxLanguageRuleXML struct {
+	Name  string
+	Rules []srxRuleXML
+}
+
+type srxRuleXML struct {
+	Break  string
+	Before string
+	After  string
+}
+
+type srxLanguageMapXML struct {
+	Pattern string
+	Rule    string
+}
+
+func localName(name xml.Name) string {
+	if name.Local != "" {
+		return name.Local
+	}
+	return name.Space
+}
+
+func attrValue(attrs []xml.Attr, key string) string {
+	for _, attr := range attrs {
+		if localName(attr.Name) == key {
+			return attr.Value
+		}
+	}
+	return ""
+}
+
+func decodeLanguageRules(d *xml.Decoder, start xml.StartElement, body *srxBodyXML) error {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if localName(t.Name) != "languagerule" {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
+			rule, err := decodeLanguageRule(d, t)
+			if err != nil {
+				return err
+			}
+			body.LanguageRules = append(body.LanguageRules, rule)
+		case xml.EndElement:
+			if localName(t.Name) == localName(start.Name) {
+				return nil
+			}
+		}
+	}
+}
+
+func decodeLanguageRule(d *xml.Decoder, start xml.StartElement) (srxLanguageRuleXML, error) {
+	out := srxLanguageRuleXML{Name: strings.TrimSpace(attrValue(start.Attr, "languagename"))}
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return srxLanguageRuleXML{}, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if localName(t.Name) != "rule" {
+				if err := d.Skip(); err != nil {
+					return srxLanguageRuleXML{}, err
+				}
+				continue
+			}
+			rule, err := decodeRule(d, t)
+			if err != nil {
+				return srxLanguageRuleXML{}, err
+			}
+			out.Rules = append(out.Rules, rule)
+		case xml.EndElement:
+			if localName(t.Name) == localName(start.Name) {
+				return out, nil
+			}
+		}
+	}
+}
+
+func decodeRule(d *xml.Decoder, start xml.StartElement) (srxRuleXML, error) {
+	out := srxRuleXML{Break: strings.TrimSpace(attrValue(start.Attr, "break"))}
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return srxRuleXML{}, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			name := localName(t.Name)
+			text, err := decodeCharData(d, t)
+			if err != nil {
+				return srxRuleXML{}, err
+			}
+			switch name {
+			case "beforebreak":
+				out.Before = text
+			case "afterbreak":
+				out.After = text
+			}
+		case xml.EndElement:
+			if localName(t.Name) == localName(start.Name) {
+				return out, nil
+			}
+		}
+	}
+}
+
+func decodeMapRules(d *xml.Decoder, start xml.StartElement, body *srxBodyXML) error {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if localName(t.Name) != "languagemap" {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
+			body.LanguageMaps = append(body.LanguageMaps, srxLanguageMapXML{
+				Pattern: attrValue(t.Attr, "languagepattern"),
+				Rule:    attrValue(t.Attr, "languagerulename"),
+			})
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		case xml.EndElement:
+			if localName(t.Name) == localName(start.Name) {
+				return nil
+			}
+		}
+	}
+}
+
+func decodeCharData(d *xml.Decoder, start xml.StartElement) (string, error) {
+	var b strings.Builder
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return "", err
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			b.Write(t)
+		case xml.StartElement:
+			if err := d.Skip(); err != nil {
+				return "", err
+			}
+		case xml.EndElement:
+			if localName(t.Name) == localName(start.Name) {
+				return string(b.String()), nil
+			}
+		}
+	}
+}
+
+// Parse compiles an SRX 2.0 document.
+func Parse(data []byte) (*Document, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, fmt.Errorf("srx: empty document")
+	}
+	var raw srxXML
+	if err := xml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("srx decode: %w", err)
+	}
+	if localName(raw.XMLName) != "srx" {
+		return nil, fmt.Errorf("srx: root element must be srx")
+	}
+	if len(raw.Body.LanguageRules) == 0 {
+		return nil, fmt.Errorf("srx: languagerules must not be empty")
+	}
+
+	doc := &Document{
+		languageRules: make([]languageRule, 0, len(raw.Body.LanguageRules)),
+		languageMaps:  make([]languageMap, 0, len(raw.Body.LanguageMaps)),
+	}
+	seen := make(map[string]struct{}, len(raw.Body.LanguageRules))
+	for i, rawRule := range raw.Body.LanguageRules {
+		name := strings.TrimSpace(rawRule.Name)
+		if name == "" {
+			return nil, fmt.Errorf("srx: languagerules[%d]: languagename is required", i)
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("srx: duplicate languagerule %q", name)
+		}
+		seen[name] = struct{}{}
+		compiled := languageRule{name: name, rules: make([]rule, 0, len(rawRule.Rules))}
+		for j, item := range rawRule.Rules {
+			rule, err := compileRule(item, i, j)
+			if err != nil {
+				return nil, err
+			}
+			compiled.rules = append(compiled.rules, rule)
+		}
+		doc.languageRules = append(doc.languageRules, compiled)
+	}
+	for i, rawMap := range raw.Body.LanguageMaps {
+		pattern := strings.TrimSpace(rawMap.Pattern)
+		if pattern == "" {
+			return nil, fmt.Errorf("srx: maprules[%d]: languagepattern is required", i)
+		}
+		re, err := regexp.Compile("(?i)" + pattern)
+		if err != nil {
+			return nil, fmt.Errorf("srx: maprules[%d]: invalid languagepattern: %w", i, err)
+		}
+		ruleName := strings.TrimSpace(rawMap.Rule)
+		if ruleName == "" {
+			return nil, fmt.Errorf("srx: maprules[%d]: languagerulename is required", i)
+		}
+		if _, ok := seen[ruleName]; !ok {
+			return nil, fmt.Errorf("srx: maprules[%d]: unknown languagerulename %q", i, ruleName)
+		}
+		doc.languageMaps = append(doc.languageMaps, languageMap{pattern: re, rule: ruleName})
+	}
+	doc.fingerprint = fingerprintDocument(data)
+	return doc, nil
+}
+
+func compileRule(raw srxRuleXML, languageIdx, ruleIdx int) (rule, error) {
+	breakAt := true
+	switch strings.ToLower(strings.TrimSpace(raw.Break)) {
+	case "", "yes":
+		breakAt = true
+	case "no":
+		breakAt = false
+	default:
+		return rule{}, fmt.Errorf("srx: languagerules[%d].rules[%d]: invalid break %q", languageIdx, ruleIdx, raw.Break)
+	}
+	before := strings.TrimSpace(raw.Before)
+	after := strings.TrimSpace(raw.After)
+	if before == "" && after == "" {
+		return rule{}, fmt.Errorf("srx: languagerules[%d].rules[%d]: beforebreak or afterbreak is required", languageIdx, ruleIdx)
+	}
+	out := rule{breakAt: breakAt}
+	if before != "" {
+		re, err := regexp.Compile(before)
+		if err != nil {
+			return rule{}, fmt.Errorf("srx: languagerules[%d].rules[%d]: invalid beforebreak: %w", languageIdx, ruleIdx, err)
+		}
+		out.before = re
+	}
+	if after != "" {
+		re, err := regexp.Compile(after)
+		if err != nil {
+			return rule{}, fmt.Errorf("srx: languagerules[%d].rules[%d]: invalid afterbreak: %w", languageIdx, ruleIdx, err)
+		}
+		out.after = re
+	}
+	return out, nil
+}
+
+func fingerprintDocument(data []byte) string {
+	sum := sha512.Sum512(data)
+	return hex.EncodeToString(sum[:16])
+}
+
+// Fingerprint returns a stable hash of the compiled source document.
+func (d *Document) Fingerprint() string {
+	if d == nil {
+		return ""
+	}
+	return d.fingerprint
+}
+
+// Segment splits text using the language-matched SRX rules.
+func (d *Document) Segment(text, language string) []Span {
+	if d == nil || text == "" {
+		if text == "" {
+			return nil
+		}
+		return []Span{{Start: 0, End: len(text), Text: text}}
+	}
+	rules := d.rulesForLanguage(language)
+	if len(rules) == 0 {
+		return []Span{{Start: 0, End: len(text), Text: text}}
+	}
+
+	type hit struct {
+		pos       int
+		ruleIndex int
+		breakAt   bool
+	}
+	hits := make([]hit, 0, 8)
+	for ruleIdx, item := range rules {
+		positions := matchBreakPositions(text, item)
+		for _, pos := range positions {
+			hits = append(hits, hit{pos: pos, ruleIndex: ruleIdx, breakAt: item.breakAt})
+		}
+	}
+	if len(hits) == 0 {
+		return []Span{{Start: 0, End: len(text), Text: text}}
+	}
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].pos != hits[j].pos {
+			return hits[i].pos < hits[j].pos
+		}
+		return hits[i].ruleIndex < hits[j].ruleIndex
+	})
+
+	chosen := make(map[int]bool, len(hits))
+	for _, item := range hits {
+		if _, ok := chosen[item.pos]; ok {
+			continue
+		}
+		chosen[item.pos] = item.breakAt
+	}
+	positions := make([]int, 0, len(chosen))
+	for pos, brk := range chosen {
+		if brk && pos > 0 && pos < len(text) {
+			positions = append(positions, pos)
+		}
+	}
+	sort.Ints(positions)
+
+	spans := make([]Span, 0, len(positions)+1)
+	start := 0
+	for _, pos := range positions {
+		if pos <= start {
+			continue
+		}
+		spans = append(spans, Span{Start: start, End: pos, Text: text[start:pos]})
+		start = pos
+	}
+	if start < len(text) {
+		spans = append(spans, Span{Start: start, End: len(text), Text: text[start:]})
+	}
+	if len(spans) == 0 {
+		return []Span{{Start: 0, End: len(text), Text: text}}
+	}
+	return spans
+}
+
+func matchBreakPositions(text string, item rule) []int {
+	if item.before == nil && item.after == nil {
+		return nil
+	}
+	if item.before == nil {
+		locs := item.after.FindAllStringIndex(text, -1)
+		out := make([]int, 0, len(locs))
+		for _, loc := range locs {
+			if loc[0] > 0 {
+				out = append(out, loc[0])
+			}
+		}
+		return out
+	}
+
+	locs := item.before.FindAllStringIndex(text, -1)
+	out := make([]int, 0, len(locs))
+	for _, loc := range locs {
+		end := loc[1]
+		if end <= 0 || end > len(text) {
+			continue
+		}
+		if item.after != nil {
+			rest := text[end:]
+			after := item.after.FindStringIndex(rest)
+			if after == nil || after[0] != 0 {
+				continue
+			}
+		}
+		out = append(out, end)
+	}
+	return out
+}
+
+func (d *Document) rulesForLanguage(language string) []rule {
+	normalized := normalizeLanguage(language)
+	candidates := []string{normalized, language}
+	if dash := strings.IndexAny(normalized, "-_"); dash > 0 {
+		candidates = append(candidates, normalized[:dash])
+	}
+	for _, mapping := range d.languageMaps {
+		for _, candidate := range candidates {
+			if candidate == "" {
+				continue
+			}
+			if mapping.pattern.MatchString(candidate) {
+				return d.rulesNamed(mapping.rule)
+			}
+		}
+	}
+	if len(d.languageRules) == 1 {
+		return d.languageRules[0].rules
+	}
+	for _, item := range d.languageRules {
+		if strings.EqualFold(item.name, "Default") || strings.EqualFold(item.name, TemplateDefault) {
+			return item.rules
+		}
+	}
+	if len(d.languageRules) > 0 {
+		return d.languageRules[0].rules
+	}
+	return nil
+}
+
+func (d *Document) rulesNamed(name string) []rule {
+	for _, item := range d.languageRules {
+		if item.name == name {
+			return item.rules
+		}
+	}
+	return nil
+}
+
+func normalizeLanguage(language string) string {
+	trimmed := strings.TrimSpace(language)
+	trimmed = strings.ReplaceAll(trimmed, "_", "-")
+	return trimmed
+}
+
+// Join concatenates translations in span order and restores source leading whitespace
+// when a translation trims it.
+func Join(spans []Span, translations []string) string {
+	if len(spans) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, span := range spans {
+		translated := ""
+		if i < len(translations) {
+			translated = translations[i]
+		}
+		if translated == "" && span.Text != "" && (i >= len(translations) || translations[i] == "") {
+			translated = span.Text
+		}
+		b.WriteString(restoreLeadingWhitespace(span.Text, translated))
+	}
+	return b.String()
+}
+
+func restoreLeadingWhitespace(source, translated string) string {
+	lead := leadingWhitespace(source)
+	if lead == "" || strings.HasPrefix(translated, lead) {
+		return translated
+	}
+	trimmed := strings.TrimLeftFunc(translated, unicode.IsSpace)
+	if trimmed == translated {
+		return lead + translated
+	}
+	return lead + trimmed
+}
+
+func leadingWhitespace(text string) string {
+	if text == "" {
+		return ""
+	}
+	width := 0
+	for width < len(text) {
+		r, size := utf8.DecodeRuneInString(text[width:])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		width += size
+	}
+	return text[:width]
+}
+
+// IsNamedTemplate reports whether spec is a built-in SRX template name.
+func IsNamedTemplate(spec string) bool {
+	switch strings.ToLower(strings.TrimSpace(spec)) {
+	case TemplateDefault, TemplateHTML, TemplateMarkdown:
+		return true
+	default:
+		return false
+	}
+}
+
+// SpanKey builds a stable per-span entry key from a parser file key.
+func SpanKey(fileKey string, index int) string {
+	return fileKey + spanKeyInfix + strconv.Itoa(index)
+}
+
+// SplitSpanKey extracts the original file key and span index.
+func SplitSpanKey(entryKey string) (fileKey string, index int, ok bool) {
+	idx := strings.LastIndex(entryKey, spanKeyInfix)
+	if idx <= 0 {
+		return "", 0, false
+	}
+	suffix := entryKey[idx+len(spanKeyInfix):]
+	if suffix == "" {
+		return "", 0, false
+	}
+	parsed, err := strconv.Atoi(suffix)
+	if err != nil || parsed < 0 {
+		return "", 0, false
+	}
+	return entryKey[:idx], parsed, true
+}
+
+// FileKey returns the original parser key for a possibly segmented entry key.
+func FileKey(entryKey string) string {
+	if fileKey, _, ok := SplitSpanKey(entryKey); ok {
+		return fileKey
+	}
+	return entryKey
+}

--- a/internal/i18n/srx/srx.go
+++ b/internal/i18n/srx/srx.go
@@ -60,9 +60,9 @@ type srxXML struct {
 }
 
 type srxBodyXML struct {
-	XMLName        xml.Name `xml:"body"`
-	LanguageRules  []srxLanguageRuleXML
-	LanguageMaps   []srxLanguageMapXML
+	XMLName       xml.Name `xml:"body"`
+	LanguageRules []srxLanguageRuleXML
+	LanguageMaps  []srxLanguageMapXML
 }
 
 func (b *srxBodyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
@@ -324,7 +324,7 @@ func Parse(data []byte) (*Document, error) {
 }
 
 func compileRule(raw srxRuleXML, languageIdx, ruleIdx int) (rule, error) {
-	breakAt := true
+	var breakAt bool
 	switch strings.ToLower(strings.TrimSpace(raw.Break)) {
 	case "", "yes":
 		breakAt = true

--- a/internal/i18n/srx/srx.go
+++ b/internal/i18n/srx/srx.go
@@ -28,6 +28,7 @@ const (
 type Document struct {
 	languageRules []languageRule
 	languageMaps  []languageMap
+	cascade       bool
 	fingerprint   string
 }
 
@@ -56,7 +57,44 @@ type Span struct {
 
 type srxXML struct {
 	XMLName xml.Name `xml:"srx"`
+	Header  srxHeaderXML
 	Body    srxBodyXML
+}
+
+type srxHeaderXML struct {
+	Cascade string
+}
+
+func (s *srxXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	s.XMLName = start.Name
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch localName(t.Name) {
+			case "header":
+				s.Header.Cascade = strings.TrimSpace(attrValue(t.Attr, "cascade"))
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			case "body":
+				if err := s.Body.UnmarshalXML(d, t); err != nil {
+					return err
+				}
+			default:
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			if localName(t.Name) == localName(start.Name) {
+				return nil
+			}
+		}
+	}
 }
 
 type srxBodyXML struct {
@@ -276,10 +314,15 @@ func Parse(data []byte) (*Document, error) {
 	if len(raw.Body.LanguageRules) == 0 {
 		return nil, fmt.Errorf("srx: languagerules must not be empty")
 	}
+	cascade, err := parseCascade(raw.Header.Cascade)
+	if err != nil {
+		return nil, err
+	}
 
 	doc := &Document{
 		languageRules: make([]languageRule, 0, len(raw.Body.LanguageRules)),
 		languageMaps:  make([]languageMap, 0, len(raw.Body.LanguageMaps)),
+		cascade:       cascade,
 	}
 	seen := make(map[string]struct{}, len(raw.Body.LanguageRules))
 	for i, rawRule := range raw.Body.LanguageRules {
@@ -321,6 +364,17 @@ func Parse(data []byte) (*Document, error) {
 	}
 	doc.fingerprint = fingerprintDocument(data)
 	return doc, nil
+}
+
+func parseCascade(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "no":
+		return false, nil
+	case "yes":
+		return true, nil
+	default:
+		return false, fmt.Errorf("srx: header cascade must be yes or no")
+	}
 }
 
 func compileRule(raw srxRuleXML, languageIdx, ruleIdx int) (rule, error) {
@@ -477,14 +531,27 @@ func (d *Document) rulesForLanguage(language string) []rule {
 	if dash := strings.IndexAny(normalized, "-_"); dash > 0 {
 		candidates = append(candidates, normalized[:dash])
 	}
-	for _, mapping := range d.languageMaps {
-		for _, candidate := range candidates {
-			if candidate == "" {
+	if len(d.languageMaps) > 0 {
+		accumulated := make([]rule, 0)
+		seen := make(map[string]struct{})
+		for _, mapping := range d.languageMaps {
+			if !languageMapMatches(mapping, candidates) {
 				continue
 			}
-			if mapping.pattern.MatchString(candidate) {
-				return d.rulesNamed(mapping.rule)
+			if _, dup := seen[mapping.rule]; dup {
+				if !d.cascade {
+					break
+				}
+				continue
 			}
+			seen[mapping.rule] = struct{}{}
+			accumulated = append(accumulated, d.rulesNamed(mapping.rule)...)
+			if !d.cascade {
+				return accumulated
+			}
+		}
+		if len(accumulated) > 0 {
+			return accumulated
 		}
 	}
 	if len(d.languageRules) == 1 {
@@ -499,6 +566,18 @@ func (d *Document) rulesForLanguage(language string) []rule {
 		return d.languageRules[0].rules
 	}
 	return nil
+}
+
+func languageMapMatches(mapping languageMap, candidates []string) bool {
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if mapping.pattern.MatchString(candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *Document) rulesNamed(name string) []rule {
@@ -576,6 +655,30 @@ func IsNamedTemplate(spec string) bool {
 // SpanKey builds a stable per-span entry key from a parser file key.
 func SpanKey(fileKey string, index int) string {
 	return fileKey + spanKeyInfix + strconv.Itoa(index)
+}
+
+// IsReservedSpanKey reports whether a parser key already uses the reserved SRX span suffix.
+func IsReservedSpanKey(entryKey string) bool {
+	_, _, ok := SplitSpanKey(entryKey)
+	return ok
+}
+
+// ReservedSpanKeys returns sorted source keys that collide with synthetic span keys.
+func ReservedSpanKeys(entries map[string]string) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+	reserved := make([]string, 0)
+	for key := range entries {
+		if IsReservedSpanKey(key) {
+			reserved = append(reserved, key)
+		}
+	}
+	if len(reserved) == 0 {
+		return nil
+	}
+	sort.Strings(reserved)
+	return reserved
 }
 
 // SplitSpanKey extracts the original file key and span index.

--- a/internal/i18n/srx/srx_test.go
+++ b/internal/i18n/srx/srx_test.go
@@ -1,0 +1,265 @@
+package srx
+
+import (
+	"strings"
+	"testing"
+)
+
+const twoLangSRX = `<?xml version="1.0"?>
+<srx xmlns="http://www.lisa.org/srx20" version="2.0">
+  <body>
+    <languagerules>
+      <languagerule languagename="English">
+        <rule break="no">
+          <beforebreak>Mr\.</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+        <rule break="yes">
+          <beforebreak>[\.!\?]</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+      </languagerule>
+      <languagerule languagename="French">
+        <rule break="yes">
+          <beforebreak>!</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+      </languagerule>
+    </languagerules>
+    <maprules>
+      <languagemap languagepattern="en.*" languagerulename="English"/>
+      <languagemap languagepattern="fr.*" languagerulename="French"/>
+    </maprules>
+  </body>
+</srx>`
+
+func TestParseRejectsEmptyAndInvalid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{name: "empty", input: "  ", wantErr: "empty document"},
+		{name: "not xml", input: "hello", wantErr: "srx decode"},
+		{name: "no language rules", input: `<srx><body></body></srx>`, wantErr: "languagerules must not be empty"},
+		{name: "missing language name", input: `<srx><body><languagerules><languagerule><rule break="yes"><beforebreak>\.</beforebreak></rule></languagerule></languagerules></body></srx>`, wantErr: "languagename is required"},
+		{name: "duplicate language", input: `<srx><body><languagerules><languagerule languagename="A"/><languagerule languagename="A"/></languagerules></body></srx>`, wantErr: "duplicate languagerule"},
+		{name: "invalid break", input: `<srx><body><languagerules><languagerule languagename="A"><rule break="maybe"><beforebreak>\.</beforebreak></rule></languagerule></languagerules></body></srx>`, wantErr: "invalid break"},
+		{name: "empty rule", input: `<srx><body><languagerules><languagerule languagename="A"><rule break="yes"></rule></languagerule></languagerules></body></srx>`, wantErr: "beforebreak or afterbreak is required"},
+		{name: "invalid before regex", input: `<srx><body><languagerules><languagerule languagename="A"><rule break="yes"><beforebreak>(</beforebreak></rule></languagerule></languagerules></body></srx>`, wantErr: "invalid beforebreak"},
+		{name: "invalid after regex", input: `<srx><body><languagerules><languagerule languagename="A"><rule break="yes"><afterbreak>(</afterbreak></rule></languagerule></languagerules></body></srx>`, wantErr: "invalid afterbreak"},
+		{name: "unknown map target", input: `<srx><body><languagerules><languagerule languagename="A"/></languagerules><maprules><languagemap languagepattern=".*" languagerulename="Missing"/></maprules></body></srx>`, wantErr: "unknown languagerulename"},
+		{name: "invalid language pattern", input: `<srx><body><languagerules><languagerule languagename="A"/></languagerules><maprules><languagemap languagepattern="(" languagerulename="A"/></maprules></body></srx>`, wantErr: "invalid languagepattern"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parse([]byte(tc.input))
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseNamespacedDocument(t *testing.T) {
+	t.Parallel()
+	doc, err := Parse([]byte(twoLangSRX))
+	if err != nil {
+		t.Fatalf("parse namespaced srx: %v", err)
+	}
+	if doc.Fingerprint() == "" {
+		t.Fatal("expected fingerprint")
+	}
+}
+
+func TestSegmentSplitsSentencesAndKeepsAbbreviations(t *testing.T) {
+	t.Parallel()
+	doc, err := Parse([]byte(twoLangSRX))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	text := "Mr. Smith arrived. Hello world! Done?"
+	spans := doc.Segment(text, "en-US")
+	got := spanTexts(spans)
+	want := []string{"Mr. Smith arrived.", " Hello world!", " Done?"}
+	if !equalStrings(got, want) {
+		t.Fatalf("spans = %#v, want %#v", got, want)
+	}
+	if joined := Join(spans, got); joined != text {
+		t.Fatalf("join original = %q, want %q", joined, text)
+	}
+}
+
+func TestSegmentLanguageMapSelectsFrenchRules(t *testing.T) {
+	t.Parallel()
+	doc, err := Parse([]byte(twoLangSRX))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	text := "Bonjour. Merci! Encore."
+	fr := spanTexts(doc.Segment(text, "fr-FR"))
+	if !equalStrings(fr, []string{"Bonjour. Merci!", " Encore."}) {
+		t.Fatalf("french spans = %#v", fr)
+	}
+	en := spanTexts(doc.Segment(text, "en"))
+	if !equalStrings(en, []string{"Bonjour.", " Merci!", " Encore."}) {
+		t.Fatalf("english spans = %#v", en)
+	}
+}
+
+func TestSegmentFallsBackWhenLanguageUnmapped(t *testing.T) {
+	t.Parallel()
+	doc, err := Parse([]byte(`<srx><body><languagerules>
+      <languagerule languagename="Default">
+        <rule break="yes"><beforebreak>\.</beforebreak><afterbreak>\s</afterbreak></rule>
+      </languagerule>
+    </languagerules></body></srx>`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := spanTexts(doc.Segment("One. Two.", "zh-CN"))
+	if !equalStrings(got, []string{"One.", " Two."}) {
+		t.Fatalf("fallback spans = %#v", got)
+	}
+}
+
+func TestSegmentFirstMatchingRuleWins(t *testing.T) {
+	t.Parallel()
+	doc, err := Parse([]byte(`<srx><body><languagerules>
+      <languagerule languagename="Default">
+        <rule break="no"><beforebreak>Dr\.</beforebreak><afterbreak>\s</afterbreak></rule>
+        <rule break="yes"><beforebreak>\.</beforebreak><afterbreak>\s</afterbreak></rule>
+      </languagerule>
+    </languagerules></body></srx>`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := spanTexts(doc.Segment("Dr. Lee left. Next.", "en"))
+	if !equalStrings(got, []string{"Dr. Lee left.", " Next."}) {
+		t.Fatalf("spans = %#v", got)
+	}
+}
+
+func TestSegmentDecimalDoesNotBreakWhenRuled(t *testing.T) {
+	t.Parallel()
+	doc, err := LoadTemplate(TemplateDefault)
+	if err != nil {
+		t.Fatalf("load default: %v", err)
+	}
+	got := spanTexts(doc.Segment("Version 1.2 shipped. Next.", "en"))
+	if !equalStrings(got, []string{"Version 1.2 shipped.", " Next."}) {
+		t.Fatalf("spans = %#v", got)
+	}
+}
+
+func TestSegmentEmptyAndSingleSentence(t *testing.T) {
+	t.Parallel()
+	doc, err := LoadTemplate(TemplateDefault)
+	if err != nil {
+		t.Fatalf("load default: %v", err)
+	}
+	if spans := doc.Segment("", "en"); spans != nil {
+		t.Fatalf("empty text spans = %#v", spans)
+	}
+	text := "Just one sentence"
+	got := spanTexts(doc.Segment(text, "en"))
+	if !equalStrings(got, []string{text}) {
+		t.Fatalf("single sentence spans = %#v", got)
+	}
+}
+
+func TestSegmentNilDocumentReturnsWholeText(t *testing.T) {
+	t.Parallel()
+	var doc *Document
+	got := spanTexts(doc.Segment("Hello. World.", "en"))
+	if !equalStrings(got, []string{"Hello. World."}) {
+		t.Fatalf("nil document spans = %#v", got)
+	}
+}
+
+func TestJoinRestoresLeadingWhitespace(t *testing.T) {
+	t.Parallel()
+	spans := []Span{
+		{Text: "Hello."},
+		{Text: " World."},
+	}
+	got := Join(spans, []string{"Bonjour.", "Monde."})
+	if got != "Bonjour. Monde." {
+		t.Fatalf("join = %q", got)
+	}
+}
+
+func TestJoinFallsBackToSourceWhenTranslationMissing(t *testing.T) {
+	t.Parallel()
+	spans := []Span{{Text: "Hello."}, {Text: " World."}}
+	got := Join(spans, []string{"Bonjour."})
+	if got != "Bonjour. World." {
+		t.Fatalf("join = %q", got)
+	}
+}
+
+func TestSpanKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+	key := SpanKey("home.title", 2)
+	if key != "home.title#srx.2" {
+		t.Fatalf("span key = %q", key)
+	}
+	fileKey, index, ok := SplitSpanKey(key)
+	if !ok || fileKey != "home.title" || index != 2 {
+		t.Fatalf("split = %q %d %v", fileKey, index, ok)
+	}
+	if FileKey(key) != "home.title" {
+		t.Fatalf("file key = %q", FileKey(key))
+	}
+	if FileKey("plain") != "plain" {
+		t.Fatalf("plain file key = %q", FileKey("plain"))
+	}
+	if _, _, ok := SplitSpanKey("home#srx."); ok {
+		t.Fatal("expected invalid empty index to fail")
+	}
+	if _, _, ok := SplitSpanKey("#srx.1"); ok {
+		t.Fatal("expected missing file key to fail")
+	}
+}
+
+func TestFingerprintChangesWhenRulesChange(t *testing.T) {
+	t.Parallel()
+	a, err := Parse([]byte(`<srx><body><languagerules><languagerule languagename="A"><rule break="yes"><beforebreak>\.</beforebreak></rule></languagerule></languagerules></body></srx>`))
+	if err != nil {
+		t.Fatalf("parse a: %v", err)
+	}
+	b, err := Parse([]byte(`<srx><body><languagerules><languagerule languagename="A"><rule break="yes"><beforebreak>!</beforebreak></rule></languagerule></languagerules></body></srx>`))
+	if err != nil {
+		t.Fatalf("parse b: %v", err)
+	}
+	if a.Fingerprint() == b.Fingerprint() {
+		t.Fatal("expected fingerprints to differ")
+	}
+}
+
+func spanTexts(spans []Span) []string {
+	out := make([]string, len(spans))
+	for i, span := range spans {
+		out[i] = span.Text
+	}
+	return out
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/i18n/srx/srx_test.go
+++ b/internal/i18n/srx/srx_test.go
@@ -51,6 +51,7 @@ func TestParseRejectsEmptyAndInvalid(t *testing.T) {
 		{name: "invalid after regex", input: `<srx><body><languagerules><languagerule languagename="A"><rule break="yes"><afterbreak>(</afterbreak></rule></languagerule></languagerules></body></srx>`, wantErr: "invalid afterbreak"},
 		{name: "unknown map target", input: `<srx><body><languagerules><languagerule languagename="A"/></languagerules><maprules><languagemap languagepattern=".*" languagerulename="Missing"/></maprules></body></srx>`, wantErr: "unknown languagerulename"},
 		{name: "invalid language pattern", input: `<srx><body><languagerules><languagerule languagename="A"/></languagerules><maprules><languagemap languagepattern="(" languagerulename="A"/></maprules></body></srx>`, wantErr: "invalid languagepattern"},
+		{name: "invalid cascade", input: `<srx><header cascade="maybe"/><body><languagerules><languagerule languagename="A"/></languagerules></body></srx>`, wantErr: "cascade must be yes or no"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -226,6 +227,58 @@ func TestSpanKeyRoundTrip(t *testing.T) {
 	}
 	if _, _, ok := SplitSpanKey("#srx.1"); ok {
 		t.Fatal("expected missing file key to fail")
+	}
+}
+
+func TestSegmentCascadesMatchingLanguageMaps(t *testing.T) {
+	t.Parallel()
+	const rules = `
+    <languagerules>
+      <languagerule languagename="FrenchExceptions">
+        <rule break="no"><beforebreak>M\.</beforebreak><afterbreak>\s</afterbreak></rule>
+      </languagerule>
+      <languagerule languagename="Default">
+        <rule break="yes"><beforebreak>[\.!\?]</beforebreak><afterbreak>\s</afterbreak></rule>
+      </languagerule>
+    </languagerules>
+    <maprules>
+      <languagemap languagepattern="fr.*" languagerulename="FrenchExceptions"/>
+      <languagemap languagepattern=".*" languagerulename="Default"/>
+    </maprules>`
+	cascade, err := Parse([]byte(`<srx><header segmentsubflows="yes" cascade="yes"/><body>` + rules + `</body></srx>`))
+	if err != nil {
+		t.Fatalf("parse cascade yes: %v", err)
+	}
+	noCascade, err := Parse([]byte(`<srx><header cascade="no"/><body>` + rules + `</body></srx>`))
+	if err != nil {
+		t.Fatalf("parse cascade no: %v", err)
+	}
+
+	text := "M. Dupont partit. Ensuite."
+	if got := spanTexts(cascade.Segment(text, "fr-FR")); !equalStrings(got, []string{"M. Dupont partit.", " Ensuite."}) {
+		t.Fatalf("cascade yes spans = %#v", got)
+	}
+	if got := spanTexts(noCascade.Segment(text, "fr-FR")); !equalStrings(got, []string{text}) {
+		t.Fatalf("cascade no should use only the first map, got %#v", got)
+	}
+	if got := spanTexts(cascade.Segment(text, "en")); !equalStrings(got, []string{"M.", " Dupont partit.", " Ensuite."}) {
+		t.Fatalf("english cascade spans = %#v", got)
+	}
+}
+
+func TestReservedSpanKeys(t *testing.T) {
+	t.Parallel()
+	got := ReservedSpanKeys(map[string]string{
+		"hello":      "Hello",
+		"foo#srx.0":  "span",
+		"bar#srx.10": "later",
+	})
+	want := []string{"bar#srx.10", "foo#srx.0"}
+	if !equalStrings(got, want) {
+		t.Fatalf("reserved = %#v, want %#v", got, want)
+	}
+	if IsReservedSpanKey("hello") || !IsReservedSpanKey("hello#srx.0") {
+		t.Fatal("IsReservedSpanKey mismatch")
 	}
 }
 

--- a/internal/i18n/srx/templates.go
+++ b/internal/i18n/srx/templates.go
@@ -1,0 +1,119 @@
+package srx
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	defaultTemplateXML = `<?xml version="1.0" encoding="UTF-8"?>
+<srx version="2.0">
+  <body>
+    <languagerules>
+      <languagerule languagename="Default">
+        <rule break="no">
+          <beforebreak>(?i)(Mr|Mrs|Ms|Dr|Prof|Sr|Jr|vs|etc|e\.g|i\.e)\.</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+        <rule break="no">
+          <beforebreak>\d\.</beforebreak>
+          <afterbreak>\d</afterbreak>
+        </rule>
+        <rule break="yes">
+          <beforebreak>[\.!\?]+["']?</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+      </languagerule>
+    </languagerules>
+    <maprules>
+      <languagemap languagepattern=".*" languagerulename="Default"/>
+    </maprules>
+  </body>
+</srx>`
+
+	htmlTemplateXML = `<?xml version="1.0" encoding="UTF-8"?>
+<srx version="2.0">
+  <body>
+    <languagerules>
+      <languagerule languagename="HTML">
+        <rule break="no">
+          <beforebreak>(?i)(Mr|Mrs|Ms|Dr|Prof|Sr|Jr|vs|etc|e\.g|i\.e)\.</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+        <rule break="no">
+          <beforebreak>(?i)(www|https?)</beforebreak>
+          <afterbreak>:</afterbreak>
+        </rule>
+        <rule break="no">
+          <beforebreak>\d\.</beforebreak>
+          <afterbreak>\d</afterbreak>
+        </rule>
+        <rule break="yes">
+          <beforebreak>[\.!\?]+["']?</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+      </languagerule>
+    </languagerules>
+    <maprules>
+      <languagemap languagepattern=".*" languagerulename="HTML"/>
+    </maprules>
+  </body>
+</srx>`
+
+	markdownTemplateXML = `<?xml version="1.0" encoding="UTF-8"?>
+<srx version="2.0">
+  <body>
+    <languagerules>
+      <languagerule languagename="Markdown">
+        <rule break="no">
+          <beforebreak>(?i)(Mr|Mrs|Ms|Dr|Prof|Sr|Jr|vs|etc|e\.g|i\.e)\.</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+        <rule break="no">
+          <beforebreak>\d+\.</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+        <rule break="no">
+          <beforebreak>\d\.</beforebreak>
+          <afterbreak>\d</afterbreak>
+        </rule>
+        <rule break="yes">
+          <beforebreak>[\.!\?]+["']?</beforebreak>
+          <afterbreak>\s</afterbreak>
+        </rule>
+      </languagerule>
+    </languagerules>
+    <maprules>
+      <languagemap languagepattern=".*" languagerulename="Markdown"/>
+    </maprules>
+  </body>
+</srx>`
+)
+
+// LoadTemplate compiles a built-in SRX template.
+func LoadTemplate(name string) (*Document, error) {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	source, ok := templateSource(normalized)
+	if !ok {
+		return nil, fmt.Errorf("srx: unknown template %q", name)
+	}
+	return Parse([]byte(source))
+}
+
+// NormalizeSpec trims an SRX spec. Named templates are compared case-insensitively.
+func NormalizeSpec(spec string) string {
+	return strings.TrimSpace(spec)
+}
+
+func templateSource(name string) (string, bool) {
+	switch name {
+	case TemplateDefault:
+		return defaultTemplateXML, true
+	case TemplateHTML:
+		return htmlTemplateXML, true
+	case TemplateMarkdown:
+		return markdownTemplateXML, true
+	default:
+		return "", false
+	}
+}

--- a/internal/i18n/srx/templates_test.go
+++ b/internal/i18n/srx/templates_test.go
@@ -1,0 +1,49 @@
+package srx
+
+import "testing"
+
+func TestLoadTemplateRejectsUnknown(t *testing.T) {
+	t.Parallel()
+	if _, err := LoadTemplate("icu"); err == nil {
+		t.Fatal("expected unknown template error")
+	}
+}
+
+func TestNamedTemplatesSegmentDifferently(t *testing.T) {
+	t.Parallel()
+	def, err := LoadTemplate("DEFAULT")
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	md, err := LoadTemplate("Markdown")
+	if err != nil {
+		t.Fatalf("markdown: %v", err)
+	}
+	html, err := LoadTemplate("html")
+	if err != nil {
+		t.Fatalf("html: %v", err)
+	}
+
+	numbered := "1. First item. Second sentence."
+	if got := spanTexts(def.Segment(numbered, "en")); !equalStrings(got, []string{"1.", " First item.", " Second sentence."}) {
+		t.Fatalf("default numbered spans = %#v", got)
+	}
+	if got := spanTexts(md.Segment(numbered, "en")); !equalStrings(got, []string{"1. First item.", " Second sentence."}) {
+		t.Fatalf("markdown numbered spans = %#v", got)
+	}
+
+	urlText := "See http: docs. Next."
+	if got := spanTexts(html.Segment(urlText, "en")); !equalStrings(got, []string{"See http: docs.", " Next."}) {
+		t.Fatalf("html url spans = %#v", got)
+	}
+}
+
+func TestIsNamedTemplate(t *testing.T) {
+	t.Parallel()
+	if !IsNamedTemplate(" default ") || !IsNamedTemplate("HTML") || !IsNamedTemplate("markdown") {
+		t.Fatal("expected named templates to match")
+	}
+	if IsNamedTemplate("rules/custom.srx") || IsNamedTemplate("") {
+		t.Fatal("did not expect path or empty spec to be a template")
+	}
+}

--- a/pkg/i18nconfig/i18n.go
+++ b/pkg/i18nconfig/i18n.go
@@ -68,6 +68,9 @@ type BucketConfig struct {
 type BucketFileMapping struct {
 	From string `json:"from" jsonschema:"required"`
 	To   string `json:"to" jsonschema:"required"`
+	// SRX is an optional sentence-segmentation spec for `run`.
+	// Use a built-in template name (default, html, markdown) or a project-relative SRX 2.0 file.
+	SRX string `json:"srx,omitempty"`
 }
 
 // GroupConfig selects locales and buckets.
@@ -458,6 +461,9 @@ func (c I18NConfig) validateProjectPaths(configDir string) error {
 			if err := validateProjectPath(root, file.To); err != nil {
 				return fmt.Errorf("buckets.%s.files[%d].to: %w", bucketName, i, err)
 			}
+			if err := validateSRXPath(root, file.SRX); err != nil {
+				return fmt.Errorf("buckets.%s.files[%d].srx: %w", bucketName, i, err)
+			}
 		}
 	}
 
@@ -613,8 +619,70 @@ func validateBucket(name string, bucket BucketConfig) error {
 		if !containsPlaceholder(fromSuffix) && !containsPlaceholder(toSuffix) && fromSuffix != toSuffix && !isSupportedImageSuffixPair(fromSuffix, toSuffix) {
 			return fmt.Errorf("buckets.%s.files[%d]: file suffix mismatch: from=%q and to=%q must have the same extension", name, i, file.From, file.To)
 		}
+		if err := validateSRXSpec(name, i, file.SRX); err != nil {
+			return err
+		}
 	}
 
+	return nil
+}
+
+func validateSRXSpec(bucketName string, index int, spec string) error {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" || isNamedSRXTemplate(trimmed) {
+		return nil
+	}
+	if err := validateRelativeConfigPath(trimmed); err != nil {
+		return fmt.Errorf("buckets.%s.files[%d].srx: %w", bucketName, index, err)
+	}
+	return nil
+}
+
+func validateSRXPath(root, spec string) error {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" || isNamedSRXTemplate(trimmed) {
+		return nil
+	}
+	if err := validateProjectPath(root, trimmed); err != nil {
+		return err
+	}
+	candidate := trimmed
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(root, candidate)
+	}
+	cleaned, err := canonicalPathForContainment(candidate)
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+	info, err := os.Stat(cleaned)
+	if err != nil {
+		return fmt.Errorf("file %q does not exist", trimmed)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("path %q must be a file", trimmed)
+	}
+	return nil
+}
+
+func isNamedSRXTemplate(spec string) bool {
+	switch strings.ToLower(strings.TrimSpace(spec)) {
+	case "default", "html", "markdown":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateRelativeConfigPath(value string) error {
+	normalized := filepath.ToSlash(strings.TrimSpace(value))
+	if normalized == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	for _, segment := range strings.Split(normalized, "/") {
+		if segment == ".." {
+			return fmt.Errorf("path must not contain parent directory traversal")
+		}
+	}
 	return nil
 }
 

--- a/pkg/i18nconfig/i18n_test.go
+++ b/pkg/i18nconfig/i18n_test.go
@@ -1300,6 +1300,106 @@ func TestLoadRejectsUnsafeLocaleForPathTemplates(t *testing.T) {
 	}
 }
 
+func TestLoadAcceptsNamedSRXTemplates(t *testing.T) {
+	path := writeConfigFile(t, `{
+	  "locales": {"source": "en-US", "targets": ["fr-FR"]},
+	  "buckets": {"docs": {"files": [
+	    {"from": "docs/{{source}}.md", "to": "docs/{{target}}.md", "srx": "markdown"},
+	    {"from": "emails/{{source}}.html", "to": "emails/{{target}}.html", "srx": "HTML"}
+	  ]}},
+	  "llm": {"profiles": {"default": {"provider": "openai", "model": "gpt-5.2"}}}
+	}`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load named srx config: %v", err)
+	}
+	if got := cfg.Buckets["docs"].Files[0].SRX; got != "markdown" {
+		t.Fatalf("first srx = %q, want markdown", got)
+	}
+	if got := cfg.Buckets["docs"].Files[1].SRX; got != "HTML" {
+		t.Fatalf("second srx = %q, want HTML", got)
+	}
+}
+
+func TestLoadAcceptsSRXFileUnderConfigDirectory(t *testing.T) {
+	dir := t.TempDir()
+	srxPath := filepath.Join(dir, "rules", "custom.srx")
+	if err := os.MkdirAll(filepath.Dir(srxPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(srxPath, []byte(`<srx><body><languagerules><languagerule languagename="A"/></languagerules></body></srx>`), 0o600); err != nil {
+		t.Fatalf("write srx: %v", err)
+	}
+	configPath := filepath.Join(dir, "i18n.yml")
+	content := "locales:\n  source: en-US\n  targets: [fr-FR]\nbuckets:\n  ui:\n    files:\n      - from: lang/{{source}}.json\n        to: lang/{{target}}.json\n        srx: rules/custom.srx\nllm:\n  profiles:\n    default:\n      provider: openai\n      model: gpt-5.2\n"
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load srx file config: %v", err)
+	}
+	if got := cfg.Buckets["ui"].Files[0].SRX; got != "rules/custom.srx" {
+		t.Fatalf("srx = %q", got)
+	}
+}
+
+func TestLoadRejectsMissingSRXFile(t *testing.T) {
+	path := writeConfigFile(t, `{
+	  "locales": {"source": "en-US", "targets": ["fr-FR"]},
+	  "buckets": {"ui": {"files": [{"from": "a.json", "to": "b.json", "srx": "missing.srx"}]}},
+	  "llm": {"profiles": {"default": {"provider": "openai", "model": "gpt-5.2"}}}
+	}`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected missing srx file to fail")
+	}
+	if !strings.Contains(err.Error(), "srx") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestLoadRejectsSRXPathTraversal(t *testing.T) {
+	path := writeConfigFile(t, `{
+	  "locales": {"source": "en-US", "targets": ["fr-FR"]},
+	  "buckets": {"ui": {"files": [{"from": "a.json", "to": "b.json", "srx": "../secrets.srx"}]}},
+	  "llm": {"profiles": {"default": {"provider": "openai", "model": "gpt-5.2"}}}
+	}`)
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected srx traversal to be rejected")
+	}
+}
+
+func TestValidateAcceptsNamedSRXTemplates(t *testing.T) {
+	for _, spec := range []string{"default", "HTML", "markdown"} {
+		cfg := I18NConfig{
+			Locales: LocaleConfig{Source: "en-US", Targets: []string{"fr-FR"}},
+			Buckets: map[string]BucketConfig{
+				"ui": {Files: []BucketFileMapping{{From: "a.json", To: "b.json", SRX: spec}}},
+			},
+			LLM: LLMConfig{Profiles: map[string]LLMProfile{"default": {Provider: "openai", Model: "x"}}},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate(%q): %v", spec, err)
+		}
+	}
+}
+
+func TestValidateRejectsUnknownNamedSRXWithoutFilesystem(t *testing.T) {
+	cfg := I18NConfig{
+		Locales: LocaleConfig{Source: "en-US", Targets: []string{"fr-FR"}},
+		Buckets: map[string]BucketConfig{
+			"ui": {Files: []BucketFileMapping{{From: "a.json", To: "b.json", SRX: "../x.srx"}}},
+		},
+		LLM: LLMConfig{Profiles: map[string]LLMProfile{"default": {Provider: "openai", Model: "x"}}},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected traversal spec to fail Validate")
+	}
+}
+
 func writeConfigFile(t *testing.T, content string) string {
 	t.Helper()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`hl run` can now split string values with SRX 2.0 before translation and join the spans back to the original file keys on write.

- New `internal/i18n/srx` engine: SRX 2.0 parse, first-matching-rule-wins, built-in `default` / `html` / `markdown` templates, span keys (`fileKey#srx.N`), lossless join with leading-whitespace restore.
- `buckets.*.files[].srx` accepts a template name or a project-relative SRX file. `hl run --srx` overrides every mapping for that invocation.
- Segmentation stays off unless SRX is set. Already-segmented formats (XLIFF, PO, SRT, VTT, xcstrings, stringsdict) and FormatJS/ARB modes are skipped. ICU, printf, and Fluent `{ $var }` values stay one unit.
- Lock hashes include the SRX fingerprint so rule changes rerun tasks. Prune keep-sets use original file keys, not span keys.

This is a text-level segmenter for `run`. It does not implement Crowdin `srxStorageId` passthrough.

## How to test

```bash
go test ./internal/i18n/srx/ ./pkg/i18nconfig/ ./apps/cli/internal/i18n/runsvc/ ./apps/cli/cmd/
make fmt
make lint
make test
```

Config example:

```yaml
buckets:
  docs:
    files:
      - from: docs/{{source}}.md
        to: docs/{{target}}.md
        srx: markdown
```

Or `hl run --srx default` to override every mapping.

## Checklist

- [x] I ran relevant checks locally (`go test` on the changed packages; `make fmt` / `make lint` / `make test` follow)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a090b6-8311-7be8-9e09-fa95dec459fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a090b6-8311-7be8-9e09-fa95dec459fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

