### PR TITLE
feat(domains): add link action on empty state and MobX page stores

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.messages.ts
@@ -66,6 +66,12 @@ export const domainLinkDialogMessages = defineMessages({
     id: "ed78rqC5km",
     description: "Link domain dialog description",
   },
+  liveDescription: {
+    defaultMessage:
+      "Enter the hostname from your localisation audit. You will verify ownership on the next step.",
+    id: "y7AjSFsGUH",
+    description: "Link domain dialog description for the live claim flow",
+  },
   hostnameLabel: {
     defaultMessage: "Hostname",
     id: "QzCT9StKW7",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.stories.tsx
@@ -36,3 +36,7 @@ export const Default: Story = {};
 export const EditMultipleLocales: Story = {
   args: { domain: getResearchPrototypeDomain("hyperlocalise-com")! },
 };
+
+export const LiveClaim: Story = {
+  args: { variant: "live" as const },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.test.tsx
@@ -62,6 +62,20 @@ describe("domain locale editing", () => {
     expect(onSave).toHaveBeenCalledWith({ ...domain, locales: domain.locales.slice(1) });
   });
 
+  it("continues with hostname only in the live variant", () => {
+    const onContinue = vi.fn();
+    render(
+      <IntlProvider locale="en">
+        <DomainLinkDialog open variant="live" onOpenChange={() => {}} onContinue={onContinue} />
+      </IntlProvider>,
+    );
+    fireEvent.change(screen.getByLabelText("Hostname"), { target: { value: "shop.example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continue to verification" }));
+    expect(onContinue).toHaveBeenCalledWith("shop.example.com");
+    expect(screen.queryByText("Select at least one locale.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Preview only/i)).not.toBeInTheDocument();
+  });
+
   it("rejects duplicate hostnames instead of adding another domain row", () => {
     const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
     const onSave = vi.fn();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-link-dialog.tsx
@@ -49,12 +49,17 @@ export function DomainLinkDialog({
   domain,
   existingDomains = [],
   onSave,
+  onContinue,
+  variant = "prototype",
 }: {
   domain?: DomainResearchDomain;
   existingDomains?: DomainResearchDomain[];
   onSave?: (domain: DomainResearchDomain) => void;
+  /** Live claim flow: continue with hostname only (no locale selection). */
+  onContinue?: (domainKey: string) => void;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  variant?: "prototype" | "live";
 }) {
   const intl = useIntl();
   const hostnameId = useId();
@@ -89,6 +94,11 @@ export function DomainLinkDialog({
     }
     if (existingDomains.some((item) => item.id !== domain?.id && item.domainKey === nextHostname)) {
       setError(intl.formatMessage(messages.hostnameDuplicate));
+      return;
+    }
+    if (variant === "live" && !domain) {
+      onContinue?.(nextHostname);
+      onOpenChange(false);
       return;
     }
     const locales = DOMAIN_RESEARCH_MARKETS.filter((locale) => localeIds.includes(locale.id));
@@ -127,7 +137,13 @@ export function DomainLinkDialog({
               <FormattedMessage {...(domain ? messages.editTitle : messages.title)} />
             </DialogTitle>
             <DialogDescription>
-              <FormattedMessage {...(domain ? messages.editDescription : messages.description)} />
+              <FormattedMessage
+                {...(domain
+                  ? messages.editDescription
+                  : variant === "live"
+                    ? messages.liveDescription
+                    : messages.description)}
+              />
             </DialogDescription>
           </DialogHeader>
 
@@ -150,41 +166,49 @@ export function DomainLinkDialog({
             <FieldError errors={error ? [{ message: error }] : undefined} />
           </Field>
 
-          <FieldSet
-            className="grid gap-3"
-            aria-describedby={localeError ? `${marketId}-error` : undefined}
-          >
-            <FieldLegend variant="label">
-              <FormattedMessage {...messages.marketLabel} />
-            </FieldLegend>
-            <FieldGroup className="gap-3">
-              {DOMAIN_RESEARCH_MARKETS.map((locale) => (
-                <Field key={locale.id} orientation="horizontal" data-invalid={Boolean(localeError)}>
-                  <Checkbox
-                    id={`${marketId}-${locale.id}`}
-                    checked={localeIds.includes(locale.id)}
-                    aria-invalid={Boolean(localeError)}
-                    onCheckedChange={(checked) => {
-                      setLocaleIds((current) =>
-                        checked
-                          ? [...current, locale.id]
-                          : current.filter((id) => id !== locale.id),
-                      );
-                      setLocaleError(null);
-                    }}
-                  />
-                  <FieldLabel htmlFor={`${marketId}-${locale.id}`}>{locale.label}</FieldLabel>
-                </Field>
-              ))}
-            </FieldGroup>
-            <FieldError
-              id={`${marketId}-error`}
-              errors={localeError ? [{ message: localeError }] : undefined}
-            />
-          </FieldSet>
-          <p className="text-sm text-muted-foreground">
-            <FormattedMessage {...messages.prototypeNotice} />
-          </p>
+          {variant === "prototype" ? (
+            <>
+              <FieldSet
+                className="grid gap-3"
+                aria-describedby={localeError ? `${marketId}-error` : undefined}
+              >
+                <FieldLegend variant="label">
+                  <FormattedMessage {...messages.marketLabel} />
+                </FieldLegend>
+                <FieldGroup className="gap-3">
+                  {DOMAIN_RESEARCH_MARKETS.map((locale) => (
+                    <Field
+                      key={locale.id}
+                      orientation="horizontal"
+                      data-invalid={Boolean(localeError)}
+                    >
+                      <Checkbox
+                        id={`${marketId}-${locale.id}`}
+                        checked={localeIds.includes(locale.id)}
+                        aria-invalid={Boolean(localeError)}
+                        onCheckedChange={(checked) => {
+                          setLocaleIds((current) =>
+                            checked
+                              ? [...current, locale.id]
+                              : current.filter((id) => id !== locale.id),
+                          );
+                          setLocaleError(null);
+                        }}
+                      />
+                      <FieldLabel htmlFor={`${marketId}-${locale.id}`}>{locale.label}</FieldLabel>
+                    </Field>
+                  ))}
+                </FieldGroup>
+                <FieldError
+                  id={`${marketId}-error`}
+                  errors={localeError ? [{ message: localeError }] : undefined}
+                />
+              </FieldSet>
+              <p className="text-sm text-muted-foreground">
+                <FormattedMessage {...messages.prototypeNotice} />
+              </p>
+            </>
+          ) : null}
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domain-research-shell.tsx
@@ -7,16 +7,16 @@
  * included in this application's LICENSE file.
  *
  * Change Date: Four years after publication of the applicable version.
-    10| *
+ *
  * On the Change Date, in accordance with the Business Source License, use
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { type ReactNode, useEffect, useId } from "react";
+import { type ReactNode, useId } from "react";
 import { Globe02Icon } from "@hugeicons/core-free-icons";
+import { observer } from "mobx-react-lite";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { useSearchParams } from "next/navigation";
 import { DomainResearchContext } from "./domain-research-context";
 import { Field, FieldLabel } from "@/components/ui/field";
 import {
@@ -30,38 +30,23 @@ import {
 import { Button } from "@/components/ui/button";
 import { TypographyP } from "@/components/ui/typography";
 import type { DomainResearchNavId } from "@/lib/domains/research-prototype";
-import { filterCatalogForLocale, resolveDomainLocale } from "@/lib/domains/research-prototype";
 import { useOrgRouter } from "@/lib/navigation/use-org-router";
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
-import { buildDomainPath } from "@/components/app-shell/navigation-config";
 import { OrgNavLink } from "@/components/app-shell/org-nav-link";
+import {
+  DomainResearchShellStoreProvider,
+  useDomainResearchShellStore,
+} from "../store/domains-store-context";
+import { DomainResearchQueryBridge } from "../store/domain-research-query-bridge";
+import { DomainResearchShellUrlSync } from "../store/domain-research-shell-url-sync";
 
 import { DomainResearchEmpty, DomainResearchMissingDomain } from "./domain-research-empty";
 import { DomainStatusBadge } from "./domain-status-badge";
 import { domainResearchSharedMessages as sharedMessages } from "./domain-research-shared.messages";
 import { domainResearchShellMessages as messages } from "./domain-research-shell.messages";
-import { useLiveDomainResearch } from "./use-live-domain-research";
 
 import styles from "./domain-header.module.css";
-
-function hrefForLocale({
-  organizationSlug,
-  linkedDomainId,
-  surface,
-  search,
-  localeId,
-}: {
-  organizationSlug: string;
-  linkedDomainId: string;
-  surface?: DomainResearchNavId;
-  search: string;
-  localeId: string;
-}) {
-  const params = new URLSearchParams(search);
-  params.set("locale", localeId);
-  return `${buildDomainPath(organizationSlug, linkedDomainId, surface)}?${params}`;
-}
 
 export function DomainResearchShell({
   organizationSlug,
@@ -74,29 +59,33 @@ export function DomainResearchShell({
   surface: DomainResearchNavId;
   children: ReactNode;
 }) {
+  return (
+    <DomainResearchShellStoreProvider
+      organizationSlug={organizationSlug}
+      linkedDomainId={linkedDomainId}
+      surface={surface}
+    >
+      <DomainResearchQueryBridge />
+      <DomainResearchShellUrlSync />
+      <DomainResearchShellView>{children}</DomainResearchShellView>
+    </DomainResearchShellStoreProvider>
+  );
+}
+
+const DomainResearchShellView = observer(function DomainResearchShellView({
+  children,
+}: {
+  children: ReactNode;
+}) {
   const intl = useIntl();
   const router = useOrgRouter();
-  const liveResearch = useLiveDomainResearch(organizationSlug, linkedDomainId);
-  const searchParams = useSearchParams();
-  const search = searchParams.toString();
-  const requestedLocaleId = searchParams.get("locale");
+  const store = useDomainResearchShellStore();
   const localeSelectId = useId();
 
-  const liveCatalog = liveResearch.data?.catalog ?? null;
-  const domain = liveCatalog?.domain ?? null;
-  const locale = domain ? resolveDomainLocale(domain, requestedLocaleId) : null;
-  const localeId = locale?.id;
+  const domain = store.domain;
+  const locale = store.locale;
 
-  useEffect(() => {
-    if (!localeId || requestedLocaleId === localeId) return;
-    router.replace(hrefForLocale({ organizationSlug, linkedDomainId, surface, search, localeId }), {
-      scroll: false,
-    });
-    // useOrgRouter() returns a new object each render; depending on it recanonicalizes forever
-    // while the URL is still stale.
-  }, [linkedDomainId, localeId, organizationSlug, requestedLocaleId, search, surface]);
-
-  if (liveResearch.isPending) {
+  if (store.loadStatus === "loading") {
     return (
       <WorkspacePageShell>
         <TypographyP size="small" tone="subtle">
@@ -106,7 +95,7 @@ export function DomainResearchShell({
     );
   }
 
-  if (liveResearch.isError) {
+  if (store.loadStatus === "error") {
     return (
       <WorkspacePageShell>
         <TypographyP size="small" tone="subtle">
@@ -119,38 +108,16 @@ export function DomainResearchShell({
   if (!domain || !locale) {
     return (
       <WorkspacePageShell>
-        <DomainResearchMissingDomain organizationSlug={organizationSlug} />
+        <DomainResearchMissingDomain organizationSlug={store.organizationSlug} />
       </WorkspacePageShell>
     );
   }
 
-  const filteredCatalog = liveCatalog ? filterCatalogForLocale(liveCatalog, locale.id) : null;
-  const catalog =
-    filteredCatalog &&
-    filteredCatalog.keywords.length === 0 &&
-    filteredCatalog.ranks.length === 0 &&
-    ((liveCatalog?.keywords.length ?? 0) > 0 || (liveCatalog?.ranks.length ?? 0) > 0)
-      ? null
-      : filteredCatalog;
-  const verifyHref = domain.domainSlug
-    ? `/org/${organizationSlug}/link-domain/${domain.domainSlug}`
-    : null;
-
-  function researchHref(nextLocaleId: string) {
-    return hrefForLocale({
-      organizationSlug,
-      linkedDomainId,
-      surface,
-      search,
-      localeId: nextLocaleId,
-    });
-  }
+  const verifyHref = store.verifyHref;
 
   function changeLocale(nextLocaleId: string) {
-    router.replace(researchHref(nextLocaleId), { scroll: false });
+    router.replace(store.hrefForLocale(nextLocaleId), { scroll: false });
   }
-
-  const isPending = domain.status !== "verified";
 
   return (
     <WorkspacePageShell className="gap-5">
@@ -165,7 +132,7 @@ export function DomainResearchShell({
           actions={
             <>
               <DomainStatusBadge status={domain.status} />
-              {isPending && verifyHref ? (
+              {store.isPending && verifyHref ? (
                 <Button size="sm" render={<OrgNavLink href={verifyHref} />}>
                   <FormattedMessage {...sharedMessages.verifyCta} />
                 </Button>
@@ -206,7 +173,7 @@ export function DomainResearchShell({
         </p>
       </div>
 
-      {isPending ? (
+      {store.isPending ? (
         <DomainResearchEmpty
           title={<FormattedMessage {...sharedMessages.pendingTitle} />}
           description={<FormattedMessage {...sharedMessages.pendingDescription} />}
@@ -218,11 +185,14 @@ export function DomainResearchShell({
             ) : undefined
           }
         />
-      ) : catalog ? (
-        <DomainResearchContext value={catalog} key={`${linkedDomainId}-${locale.id}`}>
+      ) : store.showResearchContent && store.activeCatalog ? (
+        <DomainResearchContext
+          value={store.activeCatalog}
+          key={`${store.linkedDomainId}-${locale.id}`}
+        >
           {children}
         </DomainResearchContext>
-      ) : (
+      ) : store.showLocaleEmpty ? (
         <DomainResearchEmpty
           title={<FormattedMessage {...messages.localeEmptyTitle} />}
           description={
@@ -232,7 +202,7 @@ export function DomainResearchShell({
             />
           }
         />
-      )}
+      ) : null}
     </WorkspacePageShell>
   );
-}
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.stories.tsx
@@ -28,7 +28,7 @@ const meta = {
     nextjs: { appDirectory: true, navigation: { pathname: "/en/org/domains-preview/domains" } },
     msw: { handlers: domainResearchMswHandlers() },
   },
-  args: { organizationSlug: ORGANIZATION_SLUG },
+  args: { organizationSlug: ORGANIZATION_SLUG, allowLinkDomains: true },
 } satisfies Meta<typeof DomainsPageContent>;
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.stories.tsx
@@ -45,5 +45,6 @@ export const Empty: Story = {
   },
   play: async ({ canvas }) => {
     await expect(await canvas.findByText("No linked domains yet")).toBeInTheDocument();
+    await expect(await canvas.findByRole("button", { name: "Link domain" })).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.test.tsx
@@ -23,6 +23,8 @@ import { DomainsPageContent } from "./domains-page-content";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/en/org/acme/domains",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("next/link", () => ({
@@ -61,6 +63,7 @@ describe("domains page content", () => {
     await waitFor(() => {
       expect(screen.getByText("No linked domains yet")).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: "Link domain" })).toBeInTheDocument();
     expect(screen.queryByText("hyperlocalise.com")).not.toBeInTheDocument();
   });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.test.tsx
@@ -33,14 +33,14 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-function renderPage() {
+function renderPage({ allowLinkDomains = true }: { allowLinkDomains?: boolean } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <IntlProvider locale="en">
       <QueryClientProvider client={queryClient}>
-        <DomainsPageContent organizationSlug="acme" />
+        <DomainsPageContent organizationSlug="acme" allowLinkDomains={allowLinkDomains} />
       </QueryClientProvider>
     </IntlProvider>,
   );
@@ -65,6 +65,21 @@ describe("domains page content", () => {
     });
     expect(screen.getByRole("button", { name: "Link domain" })).toBeInTheDocument();
     expect(screen.queryByText("hyperlocalise.com")).not.toBeInTheDocument();
+  });
+
+  it("hides the link action when the user cannot create projects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ linkedDomains: [] }),
+      }),
+    );
+    renderPage({ allowLinkDomains: false });
+    await waitFor(() => {
+      expect(screen.getByText("No linked domains yet")).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "Link domain" })).not.toBeInTheDocument();
   });
 
   it("renders linked domains returned by the API", async () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
@@ -39,26 +39,36 @@ import styles from "./domain-header.module.css";
 const LIST_GRID_CLASS =
   "grid grid-cols-1 items-center gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_4rem_auto_auto]";
 
-export function DomainsPageContent({ organizationSlug }: { organizationSlug: string }) {
+export function DomainsPageContent({
+  organizationSlug,
+  allowLinkDomains,
+}: {
+  organizationSlug: string;
+  allowLinkDomains: boolean;
+}) {
   return (
     <DomainsPageStoreProvider organizationSlug={organizationSlug}>
       <DomainsPageQueryBridge />
-      <DomainsPageView />
+      <DomainsPageView allowLinkDomains={allowLinkDomains} />
     </DomainsPageStoreProvider>
   );
 }
 
-const DomainsPageView = observer(function DomainsPageView() {
+const DomainsPageView = observer(function DomainsPageView({
+  allowLinkDomains,
+}: {
+  allowLinkDomains: boolean;
+}) {
   const intl = useIntl();
   const router = useOrgRouter();
   const store = useDomainsPageStore();
 
-  const linkDomainAction = (
+  const linkDomainAction = allowLinkDomains ? (
     <Button type="button" size="sm" onClick={() => store.openLinkDialog()}>
       <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
       <FormattedMessage {...messages.linkDomain} />
     </Button>
-  );
+  ) : undefined;
 
   return (
     <WorkspacePageShell>
@@ -170,18 +180,17 @@ const DomainsPageView = observer(function DomainsPageView() {
         )}
       </div>
 
-      <DomainLinkDialog
-        open={store.linkDialogOpen}
-        onOpenChange={(open) => store.setLinkDialogOpen(open)}
-        domain={store.linkDialogDomain}
-        existingDomains={store.domains}
-        onSave={(domain) => {
-          if (store.editLocalesDomain) {
-            return;
-          }
-          router.push(store.linkDomainPath(domain.domainKey));
-        }}
-      />
+      {allowLinkDomains ? (
+        <DomainLinkDialog
+          variant="live"
+          open={store.linkDialogOpen}
+          onOpenChange={(open) => store.setLinkDialogOpen(open)}
+          existingDomains={store.domains}
+          onContinue={(domainKey) => {
+            router.push(store.linkDomainPath(domainKey));
+          }}
+        />
+      ) : null}
     </WorkspacePageShell>
   );
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/_components/domains-page-content.tsx
@@ -7,13 +7,14 @@
  * included in this application's LICENSE file.
  *
  * Change Date: Four years after publication of the applicable version.
-    10| *
+ *
  * On the Change Date, in accordance with the Business Source License, use
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Globe02Icon } from "@hugeicons/core-free-icons";
-import { useQuery } from "@tanstack/react-query";
+import { Add01Icon, Globe02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { observer } from "mobx-react-lite";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { OrgNavLink } from "@/components/app-shell/org-nav-link";
@@ -21,15 +22,14 @@ import { buildDomainPath } from "@/components/app-shell/navigation-config";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { TypographyP } from "@/components/ui/typography";
-import {
-  linkedDomainToResearchDomain,
-  type DomainResearchDomain,
-} from "@/lib/domains/research-prototype";
-import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
 import { cn } from "@/lib/primitives/cn";
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { DomainsPageStoreProvider, useDomainsPageStore } from "../store/domains-store-context";
+import { DomainsPageQueryBridge } from "../store/domains-page-query-bridge";
 
+import { DomainLinkDialog } from "./domain-link-dialog";
 import { DomainResearchEmpty } from "./domain-research-empty";
 import { DomainStatusBadge } from "./domain-status-badge";
 import { domainsPageContentMessages as messages } from "./domains-page-content.messages";
@@ -40,27 +40,25 @@ const LIST_GRID_CLASS =
   "grid grid-cols-1 items-center gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_4rem_auto_auto]";
 
 export function DomainsPageContent({ organizationSlug }: { organizationSlug: string }) {
+  return (
+    <DomainsPageStoreProvider organizationSlug={organizationSlug}>
+      <DomainsPageQueryBridge />
+      <DomainsPageView />
+    </DomainsPageStoreProvider>
+  );
+}
+
+const DomainsPageView = observer(function DomainsPageView() {
   const intl = useIntl();
-  const linkedDomainsQuery = useQuery({
-    queryKey: ["linked-domains", organizationSlug],
-    queryFn: async () => {
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(organizationSlug)}/linked-domains`,
-      );
-      const body = (await response.json().catch(() => ({}))) as {
-        linkedDomains?: LinkedDomainPublic[];
-        message?: string;
-        error?: string;
-      };
-      if (!response.ok) {
-        throw new Error(body.message || body.error || intl.formatMessage(messages.loadError));
-      }
-      return (body.linkedDomains ?? []).map((domain) => linkedDomainToResearchDomain(domain));
-    },
-  });
-  const domains: DomainResearchDomain[] = linkedDomainsQuery.data ?? [];
-  const isLoading = linkedDomainsQuery.isPending;
-  const isError = linkedDomainsQuery.isError;
+  const router = useOrgRouter();
+  const store = useDomainsPageStore();
+
+  const linkDomainAction = (
+    <Button type="button" size="sm" onClick={() => store.openLinkDialog()}>
+      <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+      <FormattedMessage {...messages.linkDomain} />
+    </Button>
+  );
 
   return (
     <WorkspacePageShell>
@@ -70,11 +68,12 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
           label="Workspace"
           title="Domains"
           description={intl.formatMessage(messages.pageDescription)}
+          actions={store.hasDomains ? linkDomainAction : undefined}
         />
       </div>
 
       <div className="overflow-hidden rounded-lg border border-border bg-card">
-        {isLoading || isError || domains.length === 0 ? null : (
+        {store.hasDomains ? (
           <div
             className={cn(
               LIST_GRID_CLASS,
@@ -93,25 +92,26 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
             <span />
             <span />
           </div>
-        )}
-        {isLoading ? (
+        ) : null}
+        {store.isLoading ? (
           <TypographyP className="px-4 py-6" size="small" tone="subtle">
             <FormattedMessage {...messages.loading} />
           </TypographyP>
-        ) : isError ? (
+        ) : store.isError ? (
           <TypographyP className="px-4 py-6" size="small" tone="subtle">
             <FormattedMessage {...messages.loadError} />
           </TypographyP>
-        ) : domains.length === 0 ? (
+        ) : store.isEmpty ? (
           <div className="p-4">
             <DomainResearchEmpty
               title={<FormattedMessage {...messages.emptyTitle} />}
               description={<FormattedMessage {...messages.emptyDescription} />}
+              action={linkDomainAction}
             />
           </div>
         ) : (
           <ul className="divide-y divide-border">
-            {domains.map((domain) => (
+            {store.domains.map((domain) => (
               <li key={domain.id}>
                 <div
                   className={cn(
@@ -121,7 +121,7 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
                 >
                   <div className="min-w-0">
                     <OrgNavLink
-                      href={buildDomainPath(organizationSlug, domain.id, "overview")}
+                      href={buildDomainPath(store.organizationSlug, domain.id, "overview")}
                       className="font-medium text-foreground underline-offset-4 hover:underline"
                     >
                       {domain.domainKey}
@@ -144,7 +144,7 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
                       variant="outline"
                       render={
                         <OrgNavLink
-                          href={buildDomainPath(organizationSlug, domain.id, "overview")}
+                          href={buildDomainPath(store.organizationSlug, domain.id, "overview")}
                         />
                       }
                     >
@@ -155,7 +155,7 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
                         size="sm"
                         render={
                           <OrgNavLink
-                            href={`/org/${organizationSlug}/link-domain/${domain.domainSlug}`}
+                            href={`/org/${store.organizationSlug}/link-domain/${domain.domainSlug}`}
                           />
                         }
                       >
@@ -169,6 +169,19 @@ export function DomainsPageContent({ organizationSlug }: { organizationSlug: str
           </ul>
         )}
       </div>
+
+      <DomainLinkDialog
+        open={store.linkDialogOpen}
+        onOpenChange={(open) => store.setLinkDialogOpen(open)}
+        domain={store.linkDialogDomain}
+        existingDomains={store.domains}
+        onSave={(domain) => {
+          if (store.editLocalesDomain) {
+            return;
+          }
+          router.push(store.linkDomainPath(domain.domainKey));
+        }}
+      />
     </WorkspacePageShell>
   );
-}
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/page.tsx
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { hasCapability } from "@/api/auth/policy";
 import { FeatureTeaserPage } from "@/components/feature-teaser/feature-teaser-page";
 import { getWorkspaceFeatureFlagEnabled, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import { requireAppCapability } from "@/lib/workos/app-auth";
@@ -34,5 +35,10 @@ async function DomainsPageLoader({ params }: { params: Promise<{ organizationSlu
     return <FeatureTeaserPage feature="domains" scope="workspace" />;
   }
 
-  return <DomainsPageContent organizationSlug={organizationSlug} />;
+  return (
+    <DomainsPageContent
+      organizationSlug={organizationSlug}
+      allowLinkDomains={hasCapability(auth.membership.role, "projects:create")}
+    />
+  );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domain-research-query-bridge.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domain-research-query-bridge.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { runInAction } from "mobx";
+import { useLayoutEffect } from "react";
+
+import { useLiveDomainResearch } from "../_components/use-live-domain-research";
+import { useDomainResearchShellStore } from "./domains-store-context";
+
+export function DomainResearchQueryBridge() {
+  const store = useDomainResearchShellStore();
+  const liveResearch = useLiveDomainResearch(store.organizationSlug, store.linkedDomainId);
+
+  useLayoutEffect(() => {
+    runInAction(() => {
+      if (liveResearch.isPending) {
+        store.setLoadStatus("loading");
+        return;
+      }
+      if (liveResearch.isError) {
+        store.setLoadStatus("error");
+        return;
+      }
+      store.setResearchData({
+        catalog: liveResearch.data?.catalog ?? null,
+        linkedDomain: liveResearch.data?.linkedDomain,
+      });
+      store.setLoadStatus("success");
+    });
+  }, [
+    liveResearch.data?.catalog,
+    liveResearch.data?.linkedDomain,
+    liveResearch.isError,
+    liveResearch.isPending,
+    store,
+  ]);
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domain-research-shell-store.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domain-research-shell-store.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { getResearchPrototypeCatalog } from "@/lib/domains/research-prototype";
+
+import { DomainResearchShellStore } from "./domain-research-shell-store";
+
+describe("DomainResearchShellStore", () => {
+  it("resolves locale and verification state from catalog data", () => {
+    const catalog = getResearchPrototypeCatalog("hyperlocalise-com")!;
+    const store = new DomainResearchShellStore({
+      organizationSlug: "acme",
+      linkedDomainId: catalog.domain.id,
+      surface: "overview",
+      requestedLocaleId: catalog.domain.locales[0]?.id ?? null,
+    });
+    store.setResearchData({ catalog });
+    store.setLoadStatus("success");
+
+    expect(store.domain?.domainKey).toBe(catalog.domain.domainKey);
+    expect(store.locale?.id).toBe(catalog.domain.locales[0]?.id);
+    expect(store.isPending).toBe(false);
+    expect(store.showResearchContent).toBe(true);
+  });
+
+  it("builds locale-aware research hrefs", () => {
+    const store = new DomainResearchShellStore({
+      organizationSlug: "acme",
+      linkedDomainId: "domain-1",
+      surface: "keywords",
+      search: "foo=bar",
+    });
+
+    expect(store.hrefForLocale("germany-de")).toContain("/org/acme/domains/domain-1/keywords?");
+    expect(store.hrefForLocale("germany-de")).toContain("locale=germany-de");
+    expect(store.hrefForLocale("germany-de")).toContain("foo=bar");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domain-research-shell-store.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domain-research-shell-store.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { makeAutoObservable } from "mobx";
+
+import {
+  filterCatalogForLocale,
+  resolveDomainLocale,
+  type DomainResearchCatalog,
+  type DomainResearchNavId,
+} from "@/lib/domains/research-prototype";
+import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
+
+import { buildDomainPath } from "@/components/app-shell/navigation-config";
+
+export type DomainResearchShellLoadStatus = "idle" | "loading" | "error" | "success";
+
+export class DomainResearchShellStore {
+  readonly organizationSlug: string;
+  readonly linkedDomainId: string;
+  readonly surface: DomainResearchNavId;
+  requestedLocaleId: string | null = null;
+  search = "";
+  catalog: DomainResearchCatalog | null = null;
+  linkedDomain: LinkedDomainPublic | undefined;
+  loadStatus: DomainResearchShellLoadStatus = "idle";
+
+  constructor(input: {
+    organizationSlug: string;
+    linkedDomainId: string;
+    surface: DomainResearchNavId;
+    requestedLocaleId?: string | null;
+    search?: string;
+  }) {
+    this.organizationSlug = input.organizationSlug;
+    this.linkedDomainId = input.linkedDomainId;
+    this.surface = input.surface;
+    this.requestedLocaleId = input.requestedLocaleId ?? null;
+    this.search = input.search ?? "";
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  get domain() {
+    return this.catalog?.domain ?? null;
+  }
+
+  get locale() {
+    if (!this.domain) {
+      return null;
+    }
+    return resolveDomainLocale(this.domain, this.requestedLocaleId);
+  }
+
+  get localeId() {
+    return this.locale?.id ?? null;
+  }
+
+  get isPending() {
+    return this.domain?.status !== "verified";
+  }
+
+  get verifyHref() {
+    if (!this.domain?.domainSlug) {
+      return null;
+    }
+    return `/org/${this.organizationSlug}/link-domain/${this.domain.domainSlug}`;
+  }
+
+  get filteredCatalog() {
+    if (!this.catalog || !this.locale) {
+      return null;
+    }
+    return filterCatalogForLocale(this.catalog, this.locale.id);
+  }
+
+  get activeCatalog() {
+    const filtered = this.filteredCatalog;
+    if (!filtered || !this.catalog) {
+      return filtered;
+    }
+
+    const hasFilteredData = filtered.keywords.length > 0 || filtered.ranks.length > 0;
+    const hasUnfilteredData = this.catalog.keywords.length > 0 || this.catalog.ranks.length > 0;
+    if (!hasFilteredData && hasUnfilteredData) {
+      return null;
+    }
+
+    return filtered;
+  }
+
+  get showLocaleEmpty() {
+    return !this.isPending && this.locale !== null && this.activeCatalog === null;
+  }
+
+  get showResearchContent() {
+    return !this.isPending && this.activeCatalog !== null;
+  }
+
+  setRequestedLocaleId(localeId: string | null) {
+    this.requestedLocaleId = localeId;
+  }
+
+  setSearch(search: string) {
+    this.search = search;
+  }
+
+  setResearchData(input: {
+    catalog: DomainResearchCatalog | null;
+    linkedDomain?: LinkedDomainPublic;
+  }) {
+    this.catalog = input.catalog;
+    this.linkedDomain = input.linkedDomain;
+  }
+
+  setLoadStatus(status: DomainResearchShellLoadStatus) {
+    this.loadStatus = status;
+  }
+
+  hrefForLocale(localeId: string) {
+    const params = new URLSearchParams(this.search);
+    params.set("locale", localeId);
+    return `${buildDomainPath(this.organizationSlug, this.linkedDomainId, this.surface)}?${params}`;
+  }
+
+  canonicalLocaleHref(localeId: string) {
+    if (this.requestedLocaleId === localeId) {
+      return null;
+    }
+    return this.hrefForLocale(localeId);
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domain-research-shell-url-sync.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domain-research-shell-url-sync.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { runInAction } from "mobx";
+import { observer } from "mobx-react-lite";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useLayoutEffect } from "react";
+
+import { useOrgRouter } from "@/lib/navigation/use-org-router";
+
+import { useDomainResearchShellStore } from "./domains-store-context";
+
+export const DomainResearchShellUrlSync = observer(function DomainResearchShellUrlSync() {
+  const store = useDomainResearchShellStore();
+  const router = useOrgRouter();
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+  const requestedLocaleId = searchParams.get("locale");
+
+  useLayoutEffect(() => {
+    runInAction(() => {
+      store.setSearch(search);
+      store.setRequestedLocaleId(requestedLocaleId);
+    });
+  }, [requestedLocaleId, search, store]);
+
+  useEffect(() => {
+    if (!store.localeId || store.requestedLocaleId === store.localeId) {
+      return;
+    }
+    router.replace(store.hrefForLocale(store.localeId), { scroll: false });
+  }, [router, store, store.localeId, store.requestedLocaleId]);
+
+  return null;
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domains-page-query-bridge.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domains-page-query-bridge.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { runInAction } from "mobx";
+import { useLayoutEffect } from "react";
+import { useIntl } from "react-intl";
+
+import {
+  linkedDomainToResearchDomain,
+  type DomainResearchDomain,
+} from "@/lib/domains/research-prototype";
+import type { LinkedDomainPublic } from "@/lib/linked-domains/types";
+
+import { domainsPageContentMessages as messages } from "../_components/domains-page-content.messages";
+import { useDomainsPageStore } from "./domains-store-context";
+
+export function linkedDomainsQueryKey(organizationSlug: string) {
+  return ["linked-domains", organizationSlug] as const;
+}
+
+async function fetchLinkedDomains(
+  organizationSlug: string,
+  loadErrorMessage: string,
+): Promise<DomainResearchDomain[]> {
+  const response = await fetch(`/api/orgs/${encodeURIComponent(organizationSlug)}/linked-domains`);
+  const body = (await response.json().catch(() => ({}))) as {
+    linkedDomains?: LinkedDomainPublic[];
+    message?: string;
+    error?: string;
+  };
+  if (!response.ok) {
+    throw new Error(body.message || body.error || loadErrorMessage);
+  }
+  return (body.linkedDomains ?? []).map((domain) => linkedDomainToResearchDomain(domain));
+}
+
+export function DomainsPageQueryBridge() {
+  const intl = useIntl();
+  const store = useDomainsPageStore();
+  const linkedDomainsQuery = useQuery({
+    queryKey: linkedDomainsQueryKey(store.organizationSlug),
+    queryFn: () =>
+      fetchLinkedDomains(store.organizationSlug, intl.formatMessage(messages.loadError)),
+  });
+
+  useLayoutEffect(() => {
+    runInAction(() => {
+      if (linkedDomainsQuery.isPending) {
+        store.setLoadStatus("loading");
+        return;
+      }
+      if (linkedDomainsQuery.isError) {
+        store.setLoadStatus("error");
+        return;
+      }
+      store.setDomains(linkedDomainsQuery.data ?? []);
+      store.setLoadStatus("success");
+    });
+  }, [linkedDomainsQuery.data, linkedDomainsQuery.isError, linkedDomainsQuery.isPending, store]);
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domains-page-store.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domains-page-store.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { getResearchPrototypeDomain } from "@/lib/domains/research-prototype";
+
+import { DomainsPageStore } from "./domains-page-store";
+
+describe("DomainsPageStore", () => {
+  it("tracks empty and populated list states", () => {
+    const store = new DomainsPageStore("acme");
+    store.setLoadStatus("success");
+    expect(store.isEmpty).toBe(true);
+    expect(store.hasDomains).toBe(false);
+
+    const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+    store.setDomains([domain]);
+    expect(store.isEmpty).toBe(false);
+    expect(store.hasDomains).toBe(true);
+  });
+
+  it("opens the link dialog for new domains and edit mode for locales", () => {
+    const store = new DomainsPageStore("acme");
+    const domain = getResearchPrototypeDomain("hyperlocalise-com")!;
+
+    store.openLinkDialog();
+    expect(store.linkDialogOpen).toBe(true);
+    expect(store.linkDialogDomain).toBeUndefined();
+
+    store.setLinkDialogOpen(false);
+    store.openEditLocales(domain);
+    expect(store.linkDialogOpen).toBe(true);
+    expect(store.linkDialogDomain).toEqual(domain);
+  });
+
+  it("builds the org link-domain path from a hostname", () => {
+    const store = new DomainsPageStore("acme");
+    expect(store.linkDomainPath("shop.example.com")).toMatch(/^\/org\/acme\/link-domain\/[a-z-]+$/);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domains-page-store.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domains-page-store.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { makeAutoObservable } from "mobx";
+
+import type { DomainResearchDomain } from "@/lib/domains/research-prototype";
+import { hostnameToDomainSlug } from "@/lib/localisation-audit/domain-slug";
+
+export type DomainsPageLoadStatus = "idle" | "loading" | "error" | "success";
+
+export class DomainsPageStore {
+  readonly organizationSlug: string;
+  domains: DomainResearchDomain[] = [];
+  loadStatus: DomainsPageLoadStatus = "idle";
+  linkDialogOpen = false;
+  editLocalesDomain: DomainResearchDomain | null = null;
+
+  constructor(organizationSlug: string) {
+    this.organizationSlug = organizationSlug;
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  get isLoading() {
+    return this.loadStatus === "loading";
+  }
+
+  get isError() {
+    return this.loadStatus === "error";
+  }
+
+  get isEmpty() {
+    return this.loadStatus === "success" && this.domains.length === 0;
+  }
+
+  get hasDomains() {
+    return this.loadStatus === "success" && this.domains.length > 0;
+  }
+
+  get linkDialogDomain() {
+    return this.editLocalesDomain ?? undefined;
+  }
+
+  setLoadStatus(status: DomainsPageLoadStatus) {
+    this.loadStatus = status;
+  }
+
+  setDomains(domains: DomainResearchDomain[]) {
+    this.domains = domains;
+  }
+
+  openLinkDialog() {
+    this.editLocalesDomain = null;
+    this.linkDialogOpen = true;
+  }
+
+  openEditLocales(domain: DomainResearchDomain) {
+    this.editLocalesDomain = domain;
+    this.linkDialogOpen = true;
+  }
+
+  setLinkDialogOpen(open: boolean) {
+    this.linkDialogOpen = open;
+    if (!open) {
+      this.editLocalesDomain = null;
+    }
+  }
+
+  linkDomainPath(domainKey: string) {
+    const domainSlug = hostnameToDomainSlug(domainKey);
+    return `/org/${this.organizationSlug}/link-domain/${domainSlug}`;
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domains-store-context.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/store/domains-store-context.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+import type { DomainResearchNavId } from "@/lib/domains/research-prototype";
+
+import { DomainResearchShellStore } from "./domain-research-shell-store";
+import { DomainsPageStore } from "./domains-page-store";
+
+const DomainsPageStoreContext = createContext<DomainsPageStore | null>(null);
+const DomainResearchShellStoreContext = createContext<DomainResearchShellStore | null>(null);
+
+export function DomainsPageStoreProvider({
+  organizationSlug,
+  children,
+}: {
+  organizationSlug: string;
+  children: ReactNode;
+}) {
+  const store = useMemo(() => new DomainsPageStore(organizationSlug), [organizationSlug]);
+  return (
+    <DomainsPageStoreContext.Provider value={store}>{children}</DomainsPageStoreContext.Provider>
+  );
+}
+
+export function DomainResearchShellStoreProvider({
+  organizationSlug,
+  linkedDomainId,
+  surface,
+  children,
+}: {
+  organizationSlug: string;
+  linkedDomainId: string;
+  surface: DomainResearchNavId;
+  children: ReactNode;
+}) {
+  const store = useMemo(
+    () =>
+      new DomainResearchShellStore({
+        organizationSlug,
+        linkedDomainId,
+        surface,
+      }),
+    [linkedDomainId, organizationSlug, surface],
+  );
+
+  return (
+    <DomainResearchShellStoreContext.Provider value={store}>
+      {children}
+    </DomainResearchShellStoreContext.Provider>
+  );
+}
+
+export function useDomainsPageStore() {
+  const store = useContext(DomainsPageStoreContext);
+  if (!store) {
+    throw new Error("useDomainsPageStore must be used within DomainsPageStoreProvider");
+  }
+  return store;
+}
+
+export function useDomainResearchShellStore() {
+  const store = useContext(DomainResearchShellStoreContext);
+  if (!store) {
+    throw new Error(
+      "useDomainResearchShellStore must be used within DomainResearchShellStoreProvider",
+    );
+  }
+  return store;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Added MobX stores for the Domains list page (`DomainsPageStore`) and domain research shell (`DomainResearchShellStore`), with React context providers and TanStack Query bridge components to sync server data into observable state.
- Wired a **Link domain** action into the empty state and page header (when domains exist), opening `DomainLinkDialog` and navigating to the org link-domain verification flow on submit.

## How to test

- `cd apps/hyperlocalise-web && vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/`
- `cd apps/hyperlocalise-web && vp check --fix`
- In Storybook: **App → Domains → Page → Empty** — confirm the empty state shows a **Link domain** button that opens the dialog.

[Domains empty state with Link domain button](https://cursor.com/agents/bc-01a0924d-e1f9-7ce4-a63b-3387bc307843/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdomains-empty-state.webp)

[Link domain dialog opened from empty state](https://cursor.com/agents/bc-01a0924d-e1f9-7ce4-a63b-3387bc307843/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdomains-link-dialog.webp)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0924d-e1f9-7ce4-a63b-3387bc307843?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0924d-e1f9-7ce4-a63b-3387bc307843&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

