### PR TITLE
feat(hyperlab): add MobX stores for detail page drafts

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audience-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-audience-detail.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useState } from "react";
+import { observer } from "mobx-react-lite";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -26,6 +26,11 @@ import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 
+import { HyperlabAudienceQueryBridge } from "../store/hyperlab-query-bridge";
+import {
+  HyperlabWorkspaceProvider,
+  useHyperlabWorkspace,
+} from "../store/hyperlab-workspace-context";
 import { hyperlabMessages as messages } from "./hyperlab.messages";
 import {
   hyperlabClient,
@@ -33,12 +38,7 @@ import {
   readHyperlabJson,
   type HyperlabAudience,
 } from "./hyperlab-api";
-import {
-  criterionToRuleGroup,
-  emptyRuleGroup,
-  ruleGroupToCriterion,
-  type HyperlabRuleGroup,
-} from "./hyperlab-criterion";
+import { ruleGroupToCriterion } from "./hyperlab-criterion";
 import { HyperlabCriterionBuilder } from "./hyperlab-criterion-builder";
 import { HyperlabPageShell } from "./hyperlab-page-shell";
 import { HyperlabLoadError } from "./hyperlab-ui";
@@ -52,13 +52,30 @@ export function HyperlabAudienceDetail({
   audienceId: string;
   canWrite: boolean;
 }) {
+  return (
+    <HyperlabWorkspaceProvider>
+      <HyperlabAudienceDetailConnected
+        organizationSlug={organizationSlug}
+        audienceId={audienceId}
+        canWrite={canWrite}
+      />
+    </HyperlabWorkspaceProvider>
+  );
+}
+
+const HyperlabAudienceDetailConnected = observer(function HyperlabAudienceDetailConnected({
+  organizationSlug,
+  audienceId,
+  canWrite,
+}: {
+  organizationSlug: string;
+  audienceId: string;
+  canWrite: boolean;
+}) {
   const intl = useIntl();
   const queryClient = useQueryClient();
   const client = hyperlabClient();
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [group, setGroup] = useState<HyperlabRuleGroup>(emptyRuleGroup);
-  const [baseline, setBaseline] = useState("");
+  const { audience: audienceStore } = useHyperlabWorkspace();
 
   const detailQuery = useQuery({
     queryKey: hyperlabQueryKeys.audience(organizationSlug, audienceId),
@@ -73,40 +90,20 @@ export function HyperlabAudienceDetail({
     },
   });
 
-  useEffect(() => {
-    if (!detailQuery.data) {
-      return;
-    }
-    const audience = detailQuery.data.audience;
-    const nextGroup = criterionToRuleGroup(audience.criterion);
-    setName(audience.name);
-    setDescription(audience.description ?? "");
-    setGroup(nextGroup);
-    setBaseline(
-      JSON.stringify({
-        name: audience.name,
-        description: audience.description ?? "",
-        group: nextGroup,
-      }),
-    );
-  }, [detailQuery.data]);
-
-  const current = JSON.stringify({ name, description, group });
-  const dirty = current !== baseline && Boolean(detailQuery.data);
-
   const saveMutation = useMutation({
     mutationFn: async () => {
       const response = await client.audiences[":audienceId"].$put({
         param: { organizationSlug, audienceId },
         json: {
-          name,
-          description: description || null,
-          criterion: ruleGroupToCriterion(group),
+          name: audienceStore.name,
+          description: audienceStore.description || null,
+          criterion: ruleGroupToCriterion(audienceStore.group),
         },
       });
       return readHyperlabJson(response, intl.formatMessage(messages.loadError));
     },
     onSuccess: async () => {
+      audienceStore.markSaved();
       toast.success(intl.formatMessage(messages.saveSuccess));
       await queryClient.invalidateQueries({
         queryKey: hyperlabQueryKeys.audience(organizationSlug, audienceId),
@@ -123,77 +120,87 @@ export function HyperlabAudienceDetail({
   const audience = detailQuery.data?.audience;
 
   return (
-    <HyperlabPageShell
-      title={audience?.name ?? intl.formatMessage(messages.audiencesTitle)}
-      description={intl.formatMessage(messages.audiencesDescription)}
-      backHref={`/org/${organizationSlug}/hyperlab/audiences`}
-    >
-      <Rows spacing="2u">
-        {detailQuery.isError ? (
-          <HyperlabLoadError error={detailQuery.error} onRetry={() => void detailQuery.refetch()} />
-        ) : null}
-        {audience ? (
-          <Card className={dirty ? "ring-foreground/40" : undefined}>
-            <CardHeader>
-              <CardTitle>
-                <FormattedMessage {...messages.audienceRulesTitle} />
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Rows spacing="2u">
-                <FieldGroup>
-                  <Field>
-                    <FieldLabel htmlFor="hyperlab-audience-name">
-                      <FormattedMessage {...messages.audienceNameLabel} />
-                    </FieldLabel>
-                    <Input
-                      id="hyperlab-audience-name"
-                      value={name}
-                      onChange={(event) => setName(event.target.value)}
-                      disabled={!canWrite}
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="hyperlab-audience-note">
-                      <FormattedMessage {...messages.audienceDescriptionLabel} />
-                    </FieldLabel>
-                    <Textarea
-                      id="hyperlab-audience-note"
-                      value={description}
-                      onChange={(event) => setDescription(event.target.value)}
-                      rows={3}
-                      disabled={!canWrite}
-                    />
-                  </Field>
-                </FieldGroup>
-                <TypographyP size="small" tone="subtle">
-                  <FormattedMessage {...messages.audienceRulesHint} />
-                </TypographyP>
-                <HyperlabCriterionBuilder group={group} onChange={setGroup} disabled={!canWrite} />
-              </Rows>
-            </CardContent>
-            {canWrite ? (
-              <CardFooter className="gap-3">
-                <Button
-                  type="button"
-                  onClick={() => saveMutation.mutate()}
-                  disabled={saveMutation.isPending || !dirty}
-                >
-                  {saveMutation.isPending ? <Spinner data-icon="inline-start" /> : null}
-                  <FormattedMessage
-                    {...(saveMutation.isPending ? messages.saving : messages.save)}
-                  />
-                </Button>
-                {dirty ? (
+    <>
+      <HyperlabAudienceQueryBridge audience={audience} />
+      <HyperlabPageShell
+        title={audience?.name ?? intl.formatMessage(messages.audiencesTitle)}
+        description={intl.formatMessage(messages.audiencesDescription)}
+        backHref={`/org/${organizationSlug}/hyperlab/audiences`}
+      >
+        <Rows spacing="2u">
+          {detailQuery.isError ? (
+            <HyperlabLoadError
+              error={detailQuery.error}
+              onRetry={() => void detailQuery.refetch()}
+            />
+          ) : null}
+          {audience ? (
+            <Card className={audienceStore.isDirty ? "ring-foreground/40" : undefined}>
+              <CardHeader>
+                <CardTitle>
+                  <FormattedMessage {...messages.audienceRulesTitle} />
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Rows spacing="2u">
+                  <FieldGroup>
+                    <Field>
+                      <FieldLabel htmlFor="hyperlab-audience-name">
+                        <FormattedMessage {...messages.audienceNameLabel} />
+                      </FieldLabel>
+                      <Input
+                        id="hyperlab-audience-name"
+                        value={audienceStore.name}
+                        onChange={(event) => audienceStore.setName(event.target.value)}
+                        disabled={!canWrite}
+                      />
+                    </Field>
+                    <Field>
+                      <FieldLabel htmlFor="hyperlab-audience-note">
+                        <FormattedMessage {...messages.audienceDescriptionLabel} />
+                      </FieldLabel>
+                      <Textarea
+                        id="hyperlab-audience-note"
+                        value={audienceStore.description}
+                        onChange={(event) => audienceStore.setDescription(event.target.value)}
+                        rows={3}
+                        disabled={!canWrite}
+                      />
+                    </Field>
+                  </FieldGroup>
                   <TypographyP size="small" tone="subtle">
-                    <FormattedMessage {...messages.unsavedChanges} />
+                    <FormattedMessage {...messages.audienceRulesHint} />
                   </TypographyP>
-                ) : null}
-              </CardFooter>
-            ) : null}
-          </Card>
-        ) : null}
-      </Rows>
-    </HyperlabPageShell>
+                  <HyperlabCriterionBuilder
+                    group={audienceStore.group}
+                    onChange={(group) => audienceStore.setGroup(group)}
+                    disabled={!canWrite}
+                  />
+                </Rows>
+              </CardContent>
+              {canWrite ? (
+                <CardFooter className="gap-3">
+                  <Button
+                    type="button"
+                    onClick={() => saveMutation.mutate()}
+                    disabled={saveMutation.isPending || !audienceStore.isDirty}
+                  >
+                    {saveMutation.isPending ? <Spinner data-icon="inline-start" /> : null}
+                    <FormattedMessage
+                      {...(saveMutation.isPending ? messages.saving : messages.save)}
+                    />
+                  </Button>
+                  {audienceStore.isDirty ? (
+                    <TypographyP size="small" tone="subtle">
+                      <FormattedMessage {...messages.unsavedChanges} />
+                    </TypographyP>
+                  ) : null}
+                </CardFooter>
+              ) : null}
+            </Card>
+          ) : null}
+        </Rows>
+      </HyperlabPageShell>
+    </>
   );
-}
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiment-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-experiment-detail.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Add01Icon, Delete02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { observer } from "mobx-react-lite";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -69,6 +70,11 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TypographyP } from "@/components/ui/typography";
 
+import { HyperlabExperimentQueryBridge } from "../store/hyperlab-query-bridge";
+import {
+  HyperlabWorkspaceProvider,
+  useHyperlabWorkspace,
+} from "../store/hyperlab-workspace-context";
 import { hyperlabMessages as messages } from "./hyperlab.messages";
 import {
   hyperlabClient,
@@ -83,13 +89,7 @@ import {
 import { HyperlabAudienceSelector } from "./hyperlab-audience-selector";
 import { HyperlabPageShell } from "./hyperlab-page-shell";
 import { HyperlabRolloutControl } from "./hyperlab-rollout-control";
-import {
-  equalVariantRollouts,
-  inspectWallTime,
-  isoToWallTime,
-  rolloutToPercent,
-  timezoneSelectItems,
-} from "./hyperlab-schedule";
+import { equalVariantRollouts, rolloutToPercent, timezoneSelectItems } from "./hyperlab-schedule";
 import { HyperlabStatusBadge } from "./hyperlab-status-badge";
 import { HyperlabLoadError } from "./hyperlab-ui";
 
@@ -111,23 +111,31 @@ export function HyperlabExperimentDetail({
   experimentId: string;
   canWrite: boolean;
 }) {
+  return (
+    <HyperlabWorkspaceProvider>
+      <HyperlabExperimentDetailConnected
+        organizationSlug={organizationSlug}
+        experimentId={experimentId}
+        canWrite={canWrite}
+      />
+    </HyperlabWorkspaceProvider>
+  );
+}
+
+const HyperlabExperimentDetailConnected = observer(function HyperlabExperimentDetailConnected({
+  organizationSlug,
+  experimentId,
+  canWrite,
+}: {
+  organizationSlug: string;
+  experimentId: string;
+  canWrite: boolean;
+}) {
   const intl = useIntl();
   const router = useRouter();
   const queryClient = useQueryClient();
   const client = hyperlabClient();
-  const [name, setName] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [startTime, setStartTime] = useState("09:00");
-  const [endDate, setEndDate] = useState("");
-  const [endTime, setEndTime] = useState("17:00");
-  const [timezone, setTimezone] = useState("UTC");
-  const [audienceId, setAudienceId] = useState("");
-  const [rolloutPercentage, setRolloutPercentage] = useState(10000);
-  const [detailsBaseline, setDetailsBaseline] = useState("");
-  const [rolloutBaseline, setRolloutBaseline] = useState("");
-  const [variantSplits, setVariantSplits] = useState<Record<string, number>>({});
-  const [addVariantOpen, setAddVariantOpen] = useState(false);
-  const [variantKey, setVariantKey] = useState("");
+  const { experiment: experimentStore, ui: uiStore } = useHyperlabWorkspace();
 
   const detailQuery = useQuery({
     queryKey: hyperlabQueryKeys.experiment(organizationSlug, experimentId),
@@ -164,45 +172,6 @@ export function HyperlabExperimentDetail({
   const experiment = detailQuery.data?.experiment;
   const variants = detailQuery.data?.variants ?? EMPTY_VARIANTS;
 
-  useEffect(() => {
-    if (!experiment) {
-      return;
-    }
-    const zone = experiment.timezone || "UTC";
-    const start = isoToWallTime(experiment.startAt, zone);
-    const end = isoToWallTime(experiment.endAt, zone);
-    setName(experiment.name);
-    setTimezone(zone);
-    setStartDate(start.date);
-    setStartTime(start.time);
-    setEndDate(end.date);
-    setEndTime(end.time);
-    setAudienceId(experiment.audienceId ?? "");
-    setRolloutPercentage(experiment.rolloutPercentage);
-    setDetailsBaseline(
-      JSON.stringify({
-        name: experiment.name,
-        zone,
-        start: start.date,
-        startTime: start.time,
-        end: end.date,
-        endTime: end.time,
-      }),
-    );
-    setRolloutBaseline(
-      JSON.stringify({
-        audienceId: experiment.audienceId ?? "",
-        rolloutPercentage: experiment.rolloutPercentage,
-      }),
-    );
-  }, [experiment]);
-
-  useEffect(() => {
-    setVariantSplits(
-      Object.fromEntries(variants.map((variant) => [variant.id, variant.rolloutPercentage])),
-    );
-  }, [variants]);
-
   async function refresh() {
     await queryClient.invalidateQueries({
       queryKey: hyperlabQueryKeys.experiment(organizationSlug, experimentId),
@@ -213,41 +182,24 @@ export function HyperlabExperimentDetail({
     await queryClient.invalidateQueries({ queryKey: hyperlabQueryKeys.flags(organizationSlug) });
   }
 
-  const detailsDirty =
-    JSON.stringify({
-      name,
-      zone: timezone,
-      start: startDate,
-      startTime,
-      end: endDate,
-      endTime,
-    }) !== detailsBaseline;
-  const rolloutDirty = JSON.stringify({ audienceId, rolloutPercentage }) !== rolloutBaseline;
-  const splitDirty = variants.some(
-    (variant) => variantSplits[variant.id] !== variant.rolloutPercentage,
-  );
-  const splitTotal = variants.reduce((sum, variant) => sum + (variantSplits[variant.id] ?? 0), 0);
-  const startWall = inspectWallTime(startDate, startTime, timezone);
-  const endWall = inspectWallTime(endDate, endTime, timezone);
-  const scheduleReady = Boolean(startWall.iso && endWall.iso);
-
   const saveDetails = useMutation({
     mutationFn: async () => {
-      if (!startWall.iso || !endWall.iso) {
+      if (!experimentStore.startWall.iso || !experimentStore.endWall.iso) {
         throw new Error(intl.formatMessage(messages.scheduleNonexistent));
       }
       const response = await client.experiments[":experimentId"].$put({
         param: { organizationSlug, experimentId },
         json: {
-          name,
-          timezone,
-          startAt: startWall.iso,
-          endAt: endWall.iso,
+          name: experimentStore.name,
+          timezone: experimentStore.timezone,
+          startAt: experimentStore.startWall.iso,
+          endAt: experimentStore.endWall.iso,
         },
       });
       return readHyperlabJson(response, intl.formatMessage(messages.loadError));
     },
     onSuccess: async () => {
+      experimentStore.markDetailsSaved();
       toast.success(intl.formatMessage(messages.saveSuccess));
       await refresh();
     },
@@ -261,13 +213,14 @@ export function HyperlabExperimentDetail({
       const response = await client.experiments[":experimentId"].$put({
         param: { organizationSlug, experimentId },
         json: {
-          audienceId: audienceId || null,
-          rolloutPercentage,
+          audienceId: experimentStore.audienceId || null,
+          rolloutPercentage: experimentStore.rolloutPercentage,
         },
       });
       return readHyperlabJson(response, intl.formatMessage(messages.loadError));
     },
     onSuccess: async () => {
+      experimentStore.markRolloutSaved();
       toast.success(intl.formatMessage(messages.saveSuccess));
       await refresh();
     },
@@ -278,7 +231,7 @@ export function HyperlabExperimentDetail({
 
   const saveSplits = useMutation({
     mutationFn: async () => {
-      if (splitTotal !== 10000) {
+      if (experimentStore.splitTotal !== 10000) {
         throw new Error(intl.formatMessage(messages.variantSplitWarning));
       }
       const response = await client.experiments[":experimentId"].rollouts.$put({
@@ -286,13 +239,15 @@ export function HyperlabExperimentDetail({
         json: {
           rollouts: variants.map((variant) => ({
             variantId: variant.id,
-            rolloutPercentage: variantSplits[variant.id] ?? variant.rolloutPercentage,
+            rolloutPercentage:
+              experimentStore.variantSplits[variant.id] ?? variant.rolloutPercentage,
           })),
         },
       });
       return readHyperlabJson(response, intl.formatMessage(messages.loadError));
     },
     onSuccess: async () => {
+      experimentStore.markSplitsSaved();
       toast.success(intl.formatMessage(messages.saveSuccess));
       await refresh();
     },
@@ -337,7 +292,7 @@ export function HyperlabExperimentDetail({
       const response = await client.experiments[":experimentId"].variants.$post({
         param: { organizationSlug, experimentId },
         json: {
-          key: variantKey,
+          key: uiStore.variantKey,
           isControl: variants.length === 0,
           rolloutPercentage: shares[shares.length - 1] ?? 10000,
           siblingRollouts: variants.map((variant, index) => ({
@@ -350,8 +305,7 @@ export function HyperlabExperimentDetail({
     },
     onSuccess: async () => {
       toast.success(intl.formatMessage(messages.createSuccess));
-      setAddVariantOpen(false);
-      setVariantKey("");
+      uiStore.resetAddVariantDialog();
       await refresh();
     },
     onError: (error) => {
@@ -382,7 +336,7 @@ export function HyperlabExperimentDetail({
     { value: "active", label: intl.formatMessage(messages.statusActive) },
     { value: "archived", label: intl.formatMessage(messages.statusArchived) },
   ];
-  const timezoneItems = timezoneSelectItems(timezone);
+  const timezoneItems = timezoneSelectItems(experimentStore.timezone);
   const flags = flagsQuery.data ?? EMPTY_FLAGS;
   const assignmentsByVariant = useMemo(() => {
     const map = new Map<string, HyperlabAssignment[]>();
@@ -395,418 +349,448 @@ export function HyperlabExperimentDetail({
   }, [assignmentsQuery.data]);
 
   return (
-    <HyperlabPageShell
-      title={experiment?.name ?? intl.formatMessage(messages.experimentsTitle)}
-      description={intl.formatMessage(messages.experimentsDescription)}
-      backHref={`/org/${organizationSlug}/hyperlab/experiments`}
-      actions={
-        experiment && canWrite ? (
-          <Row spacing="1u" alignY="center">
-            {experiment ? (
-              <HyperlabStatusBadge status={experiment.status} endAt={experiment.endAt} />
-            ) : null}
-            <Select
-              value={experiment.status}
-              items={statusItems}
-              onValueChange={(next) => {
-                if (next === "draft" || next === "active" || next === "archived") {
-                  changeStatus.mutate(next);
-                }
-              }}
-            >
-              <SelectTrigger
-                className="w-36"
-                aria-label={intl.formatMessage(messages.experimentStatusLabel)}
+    <>
+      <HyperlabExperimentQueryBridge snapshot={detailQuery.data} />
+      <HyperlabPageShell
+        title={experiment?.name ?? intl.formatMessage(messages.experimentsTitle)}
+        description={intl.formatMessage(messages.experimentsDescription)}
+        backHref={`/org/${organizationSlug}/hyperlab/experiments`}
+        actions={
+          experiment && canWrite ? (
+            <Row spacing="1u" alignY="center">
+              {experiment ? (
+                <HyperlabStatusBadge status={experiment.status} endAt={experiment.endAt} />
+              ) : null}
+              <Select
+                value={experiment.status}
+                items={statusItems}
+                onValueChange={(next) => {
+                  if (next === "draft" || next === "active" || next === "archived") {
+                    changeStatus.mutate(next);
+                  }
+                }}
               >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  {statusItems.map((item) => (
-                    <SelectItem key={item.value} value={item.value} label={item.label}>
-                      {item.label}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            {experiment.status !== "active" ? (
-              <AlertDialog>
-                <AlertDialogTrigger render={<Button variant="destructive" />}>
-                  <FormattedMessage {...messages.delete} />
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      <FormattedMessage {...messages.deleteExperimentTitle} />
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      <FormattedMessage
-                        {...messages.deleteExperimentBody}
-                        values={{ name: experiment.name }}
-                      />
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>
-                      <FormattedMessage {...messages.cancel} />
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      variant="destructive"
-                      onClick={() => deleteExperiment.mutate()}
-                      disabled={deleteExperiment.isPending}
-                    >
-                      <FormattedMessage {...messages.deleteExperiment} />
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            ) : null}
-          </Row>
-        ) : experiment ? (
-          <HyperlabStatusBadge status={experiment.status} endAt={experiment.endAt} />
-        ) : null
-      }
-    >
-      <Rows spacing="2u">
-        {detailQuery.isError ? (
-          <HyperlabLoadError error={detailQuery.error} onRetry={() => void detailQuery.refetch()} />
-        ) : null}
-        {experiment ? (
-          <>
-            <Card className={detailsDirty ? "ring-foreground/40" : undefined}>
-              <CardHeader>
-                <CardTitle>
-                  <FormattedMessage {...messages.detailsCardTitle} />
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <FieldGroup>
-                  <Field>
-                    <FieldLabel htmlFor="hyperlab-experiment-name">
-                      <FormattedMessage {...messages.experimentNameLabel} />
-                    </FieldLabel>
-                    <Input
-                      id="hyperlab-experiment-name"
-                      value={name}
-                      onChange={(event) => setName(event.target.value)}
-                      disabled={!canWrite}
-                    />
-                  </Field>
-                  <Columns spacing="1.5u" collapseBelow="small">
-                    <Column width="1/3">
-                      <Field>
-                        <FieldLabel htmlFor="hyperlab-start-date">
-                          <FormattedMessage {...messages.startDateLabel} />
-                        </FieldLabel>
-                        <Input
-                          id="hyperlab-start-date"
-                          type="date"
-                          value={startDate}
-                          onChange={(event) => setStartDate(event.target.value)}
-                          disabled={!canWrite}
+                <SelectTrigger
+                  className="w-36"
+                  aria-label={intl.formatMessage(messages.experimentStatusLabel)}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {statusItems.map((item) => (
+                      <SelectItem key={item.value} value={item.value} label={item.label}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              {experiment.status !== "active" ? (
+                <AlertDialog>
+                  <AlertDialogTrigger render={<Button variant="destructive" />}>
+                    <FormattedMessage {...messages.delete} />
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        <FormattedMessage {...messages.deleteExperimentTitle} />
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        <FormattedMessage
+                          {...messages.deleteExperimentBody}
+                          values={{ name: experiment.name }}
                         />
-                      </Field>
-                    </Column>
-                    <Column width="1/3">
-                      <Field>
-                        <FieldLabel htmlFor="hyperlab-start-time">
-                          <FormattedMessage {...messages.startTimeLabel} />
-                        </FieldLabel>
-                        <Input
-                          id="hyperlab-start-time"
-                          type="time"
-                          value={startTime}
-                          onChange={(event) => setStartTime(event.target.value)}
-                          disabled={!canWrite}
-                        />
-                        {startWall.status === "nonexistent" || startWall.status === "invalid" ? (
-                          <FieldDescription>
-                            <FormattedMessage {...messages.scheduleNonexistent} />
-                          </FieldDescription>
-                        ) : null}
-                        {startWall.status === "ambiguous" ? (
-                          <FieldDescription>
-                            <FormattedMessage {...messages.scheduleAmbiguous} />
-                          </FieldDescription>
-                        ) : null}
-                      </Field>
-                    </Column>
-                    <Column width="1/3">
-                      <Field>
-                        <FieldLabel>
-                          <FormattedMessage {...messages.timezoneLabel} />
-                        </FieldLabel>
-                        <Select
-                          value={timezone}
-                          items={timezoneItems}
-                          onValueChange={(next) => {
-                            if (next) {
-                              setTimezone(next);
-                            }
-                          }}
-                          disabled={!canWrite}
-                        >
-                          <SelectTrigger className="w-full">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectGroup>
-                              {timezoneItems.map((item) => (
-                                <SelectItem key={item.value} value={item.value} label={item.label}>
-                                  {item.label}
-                                </SelectItem>
-                              ))}
-                            </SelectGroup>
-                          </SelectContent>
-                        </Select>
-                      </Field>
-                    </Column>
-                  </Columns>
-                  <Columns spacing="1.5u" collapseBelow="small">
-                    <Column width="1/3">
-                      <Field>
-                        <FieldLabel htmlFor="hyperlab-end-date">
-                          <FormattedMessage {...messages.endDateLabel} />
-                        </FieldLabel>
-                        <Input
-                          id="hyperlab-end-date"
-                          type="date"
-                          value={endDate}
-                          onChange={(event) => setEndDate(event.target.value)}
-                          disabled={!canWrite}
-                        />
-                      </Field>
-                    </Column>
-                    <Column width="1/3">
-                      <Field>
-                        <FieldLabel htmlFor="hyperlab-end-time">
-                          <FormattedMessage {...messages.endTimeLabel} />
-                        </FieldLabel>
-                        <Input
-                          id="hyperlab-end-time"
-                          type="time"
-                          value={endTime}
-                          onChange={(event) => setEndTime(event.target.value)}
-                          disabled={!canWrite}
-                        />
-                        {endWall.status === "nonexistent" || endWall.status === "invalid" ? (
-                          <FieldDescription>
-                            <FormattedMessage {...messages.scheduleNonexistent} />
-                          </FieldDescription>
-                        ) : null}
-                        {endWall.status === "ambiguous" ? (
-                          <FieldDescription>
-                            <FormattedMessage {...messages.scheduleAmbiguous} />
-                          </FieldDescription>
-                        ) : null}
-                      </Field>
-                    </Column>
-                  </Columns>
-                </FieldGroup>
-              </CardContent>
-              {canWrite ? (
-                <CardFooter className="gap-3">
-                  <Button
-                    type="button"
-                    onClick={() => saveDetails.mutate()}
-                    disabled={saveDetails.isPending || !detailsDirty || !scheduleReady}
-                  >
-                    {saveDetails.isPending ? <Spinner data-icon="inline-start" /> : null}
-                    <FormattedMessage
-                      {...(saveDetails.isPending ? messages.saving : messages.save)}
-                    />
-                  </Button>
-                  {detailsDirty ? (
-                    <TypographyP size="small" tone="subtle">
-                      <FormattedMessage {...messages.unsavedChanges} />
-                    </TypographyP>
-                  ) : null}
-                </CardFooter>
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>
+                        <FormattedMessage {...messages.cancel} />
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        variant="destructive"
+                        onClick={() => deleteExperiment.mutate()}
+                        disabled={deleteExperiment.isPending}
+                      >
+                        <FormattedMessage {...messages.deleteExperiment} />
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               ) : null}
-            </Card>
-
-            <Card className={rolloutDirty ? "ring-foreground/40" : undefined}>
-              <CardHeader>
-                <CardTitle>
-                  <FormattedMessage {...messages.rolloutCardTitle} />
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <Rows spacing="2u">
-                  <HyperlabAudienceSelector
-                    organizationSlug={organizationSlug}
-                    value={audienceId}
-                    onChange={setAudienceId}
-                    disabled={!canWrite}
-                    hint={intl.formatMessage(messages.audienceRolloutHint)}
-                  />
-                  <HyperlabRolloutControl
-                    id="hyperlab-experiment-rollout"
-                    value={rolloutPercentage}
-                    onChange={setRolloutPercentage}
-                    disabled={!canWrite}
-                  />
-                  <TypographyP size="small" tone="subtle">
-                    <FormattedMessage {...messages.rolloutHint} />
-                  </TypographyP>
-                </Rows>
-              </CardContent>
-              {canWrite ? (
-                <CardFooter className="gap-3">
-                  <Button
-                    type="button"
-                    onClick={() => saveRollout.mutate()}
-                    disabled={saveRollout.isPending || !rolloutDirty}
-                  >
-                    {saveRollout.isPending ? <Spinner data-icon="inline-start" /> : null}
-                    <FormattedMessage
-                      {...(saveRollout.isPending ? messages.saving : messages.saveRollout)}
-                    />
-                  </Button>
-                  {rolloutDirty ? (
-                    <TypographyP size="small" tone="subtle">
-                      <FormattedMessage {...messages.unsavedChanges} />
-                    </TypographyP>
-                  ) : null}
-                </CardFooter>
-              ) : null}
-            </Card>
-
-            {experiment.kind === "ab" && variants.length > 0 ? (
-              <Card className={splitDirty ? "ring-foreground/40" : undefined}>
+            </Row>
+          ) : experiment ? (
+            <HyperlabStatusBadge status={experiment.status} endAt={experiment.endAt} />
+          ) : null
+        }
+      >
+        <Rows spacing="2u">
+          {detailQuery.isError ? (
+            <HyperlabLoadError
+              error={detailQuery.error}
+              onRetry={() => void detailQuery.refetch()}
+            />
+          ) : null}
+          {experiment ? (
+            <>
+              <Card className={experimentStore.detailsDirty ? "ring-foreground/40" : undefined}>
                 <CardHeader>
                   <CardTitle>
-                    <FormattedMessage {...messages.variantSplitTitle} />
+                    <FormattedMessage {...messages.detailsCardTitle} />
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <FieldGroup>
+                    <Field>
+                      <FieldLabel htmlFor="hyperlab-experiment-name">
+                        <FormattedMessage {...messages.experimentNameLabel} />
+                      </FieldLabel>
+                      <Input
+                        id="hyperlab-experiment-name"
+                        value={experimentStore.name}
+                        onChange={(event) => experimentStore.setName(event.target.value)}
+                        disabled={!canWrite}
+                      />
+                    </Field>
+                    <Columns spacing="1.5u" collapseBelow="small">
+                      <Column width="1/3">
+                        <Field>
+                          <FieldLabel htmlFor="hyperlab-start-date">
+                            <FormattedMessage {...messages.startDateLabel} />
+                          </FieldLabel>
+                          <Input
+                            id="hyperlab-start-date"
+                            type="date"
+                            value={experimentStore.startDate}
+                            onChange={(event) => experimentStore.setStartDate(event.target.value)}
+                            disabled={!canWrite}
+                          />
+                        </Field>
+                      </Column>
+                      <Column width="1/3">
+                        <Field>
+                          <FieldLabel htmlFor="hyperlab-start-time">
+                            <FormattedMessage {...messages.startTimeLabel} />
+                          </FieldLabel>
+                          <Input
+                            id="hyperlab-start-time"
+                            type="time"
+                            value={experimentStore.startTime}
+                            onChange={(event) => experimentStore.setStartTime(event.target.value)}
+                            disabled={!canWrite}
+                          />
+                          {experimentStore.startWall.status === "nonexistent" ||
+                          experimentStore.startWall.status === "invalid" ? (
+                            <FieldDescription>
+                              <FormattedMessage {...messages.scheduleNonexistent} />
+                            </FieldDescription>
+                          ) : null}
+                          {experimentStore.startWall.status === "ambiguous" ? (
+                            <FieldDescription>
+                              <FormattedMessage {...messages.scheduleAmbiguous} />
+                            </FieldDescription>
+                          ) : null}
+                        </Field>
+                      </Column>
+                      <Column width="1/3">
+                        <Field>
+                          <FieldLabel>
+                            <FormattedMessage {...messages.timezoneLabel} />
+                          </FieldLabel>
+                          <Select
+                            value={experimentStore.timezone}
+                            items={timezoneItems}
+                            onValueChange={(next) => {
+                              if (next) {
+                                experimentStore.setTimezone(next);
+                              }
+                            }}
+                            disabled={!canWrite}
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                {timezoneItems.map((item) => (
+                                  <SelectItem
+                                    key={item.value}
+                                    value={item.value}
+                                    label={item.label}
+                                  >
+                                    {item.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        </Field>
+                      </Column>
+                    </Columns>
+                    <Columns spacing="1.5u" collapseBelow="small">
+                      <Column width="1/3">
+                        <Field>
+                          <FieldLabel htmlFor="hyperlab-end-date">
+                            <FormattedMessage {...messages.endDateLabel} />
+                          </FieldLabel>
+                          <Input
+                            id="hyperlab-end-date"
+                            type="date"
+                            value={experimentStore.endDate}
+                            onChange={(event) => experimentStore.setEndDate(event.target.value)}
+                            disabled={!canWrite}
+                          />
+                        </Field>
+                      </Column>
+                      <Column width="1/3">
+                        <Field>
+                          <FieldLabel htmlFor="hyperlab-end-time">
+                            <FormattedMessage {...messages.endTimeLabel} />
+                          </FieldLabel>
+                          <Input
+                            id="hyperlab-end-time"
+                            type="time"
+                            value={experimentStore.endTime}
+                            onChange={(event) => experimentStore.setEndTime(event.target.value)}
+                            disabled={!canWrite}
+                          />
+                          {experimentStore.endWall.status === "nonexistent" ||
+                          experimentStore.endWall.status === "invalid" ? (
+                            <FieldDescription>
+                              <FormattedMessage {...messages.scheduleNonexistent} />
+                            </FieldDescription>
+                          ) : null}
+                          {experimentStore.endWall.status === "ambiguous" ? (
+                            <FieldDescription>
+                              <FormattedMessage {...messages.scheduleAmbiguous} />
+                            </FieldDescription>
+                          ) : null}
+                        </Field>
+                      </Column>
+                    </Columns>
+                  </FieldGroup>
+                </CardContent>
+                {canWrite ? (
+                  <CardFooter className="gap-3">
+                    <Button
+                      type="button"
+                      onClick={() => saveDetails.mutate()}
+                      disabled={
+                        saveDetails.isPending ||
+                        !experimentStore.detailsDirty ||
+                        !experimentStore.scheduleReady
+                      }
+                    >
+                      {saveDetails.isPending ? <Spinner data-icon="inline-start" /> : null}
+                      <FormattedMessage
+                        {...(saveDetails.isPending ? messages.saving : messages.save)}
+                      />
+                    </Button>
+                    {experimentStore.detailsDirty ? (
+                      <TypographyP size="small" tone="subtle">
+                        <FormattedMessage {...messages.unsavedChanges} />
+                      </TypographyP>
+                    ) : null}
+                  </CardFooter>
+                ) : null}
+              </Card>
+
+              <Card className={experimentStore.rolloutDirty ? "ring-foreground/40" : undefined}>
+                <CardHeader>
+                  <CardTitle>
+                    <FormattedMessage {...messages.rolloutCardTitle} />
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <Rows spacing="2u">
-                    {variants.map((variant) => (
-                      <HyperlabRolloutControl
-                        key={variant.id}
-                        id={`hyperlab-variant-split-${variant.id}`}
-                        value={variantSplits[variant.id] ?? variant.rolloutPercentage}
-                        onChange={(next) =>
-                          setVariantSplits((current) => ({ ...current, [variant.id]: next }))
-                        }
-                        disabled={!canWrite}
-                        label={
-                          variant.isControl ? intl.formatMessage(messages.control) : variant.key
-                        }
-                      />
-                    ))}
-                    <TypographyP size="small" tone={splitTotal === 10000 ? "subtle" : "critical"}>
-                      <FormattedMessage
-                        {...(splitTotal === 10000
-                          ? messages.variantSplitTotal
-                          : messages.variantSplitWarning)}
-                        values={{ value: rolloutToPercent(splitTotal) }}
-                      />
-                    </TypographyP>
+                    <HyperlabAudienceSelector
+                      organizationSlug={organizationSlug}
+                      value={experimentStore.audienceId}
+                      onChange={(value) => experimentStore.setAudienceId(value)}
+                      disabled={!canWrite}
+                      hint={intl.formatMessage(messages.audienceRolloutHint)}
+                    />
+                    <HyperlabRolloutControl
+                      id="hyperlab-experiment-rollout"
+                      value={experimentStore.rolloutPercentage}
+                      onChange={(value) => experimentStore.setRolloutPercentage(value)}
+                      disabled={!canWrite}
+                    />
                     <TypographyP size="small" tone="subtle">
-                      <FormattedMessage {...messages.variantRolloutHint} />
+                      <FormattedMessage {...messages.rolloutHint} />
                     </TypographyP>
                   </Rows>
                 </CardContent>
                 {canWrite ? (
-                  <CardFooter>
+                  <CardFooter className="gap-3">
                     <Button
                       type="button"
-                      onClick={() => saveSplits.mutate()}
-                      disabled={saveSplits.isPending || !splitDirty || splitTotal !== 10000}
+                      onClick={() => saveRollout.mutate()}
+                      disabled={saveRollout.isPending || !experimentStore.rolloutDirty}
                     >
-                      {saveSplits.isPending ? <Spinner data-icon="inline-start" /> : null}
+                      {saveRollout.isPending ? <Spinner data-icon="inline-start" /> : null}
                       <FormattedMessage
-                        {...(saveSplits.isPending ? messages.saving : messages.saveVariantSplits)}
+                        {...(saveRollout.isPending ? messages.saving : messages.saveRollout)}
                       />
                     </Button>
+                    {experimentStore.rolloutDirty ? (
+                      <TypographyP size="small" tone="subtle">
+                        <FormattedMessage {...messages.unsavedChanges} />
+                      </TypographyP>
+                    ) : null}
                   </CardFooter>
                 ) : null}
               </Card>
-            ) : null}
 
-            <Rows spacing="1.5u">
-              <Row spacing="1.5u" align="spaceBetween" alignY="center">
-                <TypographyP weight="medium">
-                  <FormattedMessage {...messages.variantsTitle} />
-                </TypographyP>
-                {canWrite && experiment.kind === "ab" ? (
-                  <Dialog open={addVariantOpen} onOpenChange={setAddVariantOpen}>
-                    <DialogTrigger render={<Button variant="secondary" />}>
-                      <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} data-icon="inline-start" />
-                      <FormattedMessage {...messages.addVariant} />
-                    </DialogTrigger>
-                    <DialogContent>
-                      <form
-                        className="flex flex-col gap-4"
-                        onSubmit={(event) => {
-                          event.preventDefault();
-                          addVariant.mutate();
-                        }}
+              {experiment.kind === "ab" && variants.length > 0 ? (
+                <Card className={experimentStore.splitDirty ? "ring-foreground/40" : undefined}>
+                  <CardHeader>
+                    <CardTitle>
+                      <FormattedMessage {...messages.variantSplitTitle} />
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <Rows spacing="2u">
+                      {variants.map((variant) => (
+                        <HyperlabRolloutControl
+                          key={variant.id}
+                          id={`hyperlab-variant-split-${variant.id}`}
+                          value={
+                            experimentStore.variantSplits[variant.id] ?? variant.rolloutPercentage
+                          }
+                          onChange={(next) => experimentStore.setVariantSplit(variant.id, next)}
+                          disabled={!canWrite}
+                          label={
+                            variant.isControl ? intl.formatMessage(messages.control) : variant.key
+                          }
+                        />
+                      ))}
+                      <TypographyP
+                        size="small"
+                        tone={experimentStore.splitTotal === 10000 ? "subtle" : "critical"}
                       >
-                        <DialogHeader>
-                          <DialogTitle>
-                            <FormattedMessage {...messages.addVariantTitle} />
-                          </DialogTitle>
-                          <DialogDescription>
-                            <FormattedMessage {...messages.addVariantDescription} />
-                          </DialogDescription>
-                        </DialogHeader>
-                        <Field>
-                          <FieldLabel htmlFor="hyperlab-new-variant-key">
-                            <FormattedMessage {...messages.variantKeyLabel} />
-                          </FieldLabel>
-                          <Input
-                            id="hyperlab-new-variant-key"
-                            value={variantKey}
-                            onChange={(event) => setVariantKey(event.target.value)}
-                            placeholder={intl.formatMessage(messages.variantKeyPlaceholder)}
-                            required
-                          />
-                        </Field>
-                        <DialogFooter>
-                          <Button
-                            type="submit"
-                            disabled={!variantKey.trim() || addVariant.isPending}
-                          >
-                            {addVariant.isPending ? <Spinner data-icon="inline-start" /> : null}
-                            <FormattedMessage {...messages.addVariant} />
-                          </Button>
-                        </DialogFooter>
-                      </form>
-                    </DialogContent>
-                  </Dialog>
-                ) : null}
-              </Row>
-              {variants.length === 0 ? (
-                <TypographyP size="small" tone="subtle">
-                  <FormattedMessage {...messages.noVariants} />
-                </TypographyP>
-              ) : (
-                variants.map((variant) => (
-                  <HyperlabVariantCard
-                    key={variant.id}
-                    organizationSlug={organizationSlug}
-                    experiment={experiment}
-                    variant={variant}
-                    flags={flags}
-                    assignments={assignmentsByVariant.get(variant.id) ?? []}
-                    canWrite={canWrite}
-                    canDeleteVariant={experiment.kind === "ab" && variants.length > 1}
-                    onRefresh={refresh}
-                  />
-                ))
-              )}
-            </Rows>
-          </>
-        ) : null}
-      </Rows>
-    </HyperlabPageShell>
-  );
-}
+                        <FormattedMessage
+                          {...(experimentStore.splitTotal === 10000
+                            ? messages.variantSplitTotal
+                            : messages.variantSplitWarning)}
+                          values={{ value: rolloutToPercent(experimentStore.splitTotal) }}
+                        />
+                      </TypographyP>
+                      <TypographyP size="small" tone="subtle">
+                        <FormattedMessage {...messages.variantRolloutHint} />
+                      </TypographyP>
+                    </Rows>
+                  </CardContent>
+                  {canWrite ? (
+                    <CardFooter>
+                      <Button
+                        type="button"
+                        onClick={() => saveSplits.mutate()}
+                        disabled={
+                          saveSplits.isPending ||
+                          !experimentStore.splitDirty ||
+                          experimentStore.splitTotal !== 10000
+                        }
+                      >
+                        {saveSplits.isPending ? <Spinner data-icon="inline-start" /> : null}
+                        <FormattedMessage
+                          {...(saveSplits.isPending ? messages.saving : messages.saveVariantSplits)}
+                        />
+                      </Button>
+                    </CardFooter>
+                  ) : null}
+                </Card>
+              ) : null}
 
-function HyperlabVariantCard({
+              <Rows spacing="1.5u">
+                <Row spacing="1.5u" align="spaceBetween" alignY="center">
+                  <TypographyP weight="medium">
+                    <FormattedMessage {...messages.variantsTitle} />
+                  </TypographyP>
+                  {canWrite && experiment.kind === "ab" ? (
+                    <Dialog
+                      open={uiStore.addVariantOpen}
+                      onOpenChange={(open) => uiStore.setAddVariantOpen(open)}
+                    >
+                      <DialogTrigger render={<Button variant="secondary" />}>
+                        <HugeiconsIcon
+                          icon={Add01Icon}
+                          strokeWidth={1.8}
+                          data-icon="inline-start"
+                        />
+                        <FormattedMessage {...messages.addVariant} />
+                      </DialogTrigger>
+                      <DialogContent>
+                        <form
+                          className="flex flex-col gap-4"
+                          onSubmit={(event) => {
+                            event.preventDefault();
+                            addVariant.mutate();
+                          }}
+                        >
+                          <DialogHeader>
+                            <DialogTitle>
+                              <FormattedMessage {...messages.addVariantTitle} />
+                            </DialogTitle>
+                            <DialogDescription>
+                              <FormattedMessage {...messages.addVariantDescription} />
+                            </DialogDescription>
+                          </DialogHeader>
+                          <Field>
+                            <FieldLabel htmlFor="hyperlab-new-variant-key">
+                              <FormattedMessage {...messages.variantKeyLabel} />
+                            </FieldLabel>
+                            <Input
+                              id="hyperlab-new-variant-key"
+                              value={uiStore.variantKey}
+                              onChange={(event) => uiStore.setVariantKey(event.target.value)}
+                              placeholder={intl.formatMessage(messages.variantKeyPlaceholder)}
+                              required
+                            />
+                          </Field>
+                          <DialogFooter>
+                            <Button
+                              type="submit"
+                              disabled={!uiStore.variantKey.trim() || addVariant.isPending}
+                            >
+                              {addVariant.isPending ? <Spinner data-icon="inline-start" /> : null}
+                              <FormattedMessage {...messages.addVariant} />
+                            </Button>
+                          </DialogFooter>
+                        </form>
+                      </DialogContent>
+                    </Dialog>
+                  ) : null}
+                </Row>
+                {variants.length === 0 ? (
+                  <TypographyP size="small" tone="subtle">
+                    <FormattedMessage {...messages.noVariants} />
+                  </TypographyP>
+                ) : (
+                  variants.map((variant) => (
+                    <HyperlabVariantCard
+                      key={variant.id}
+                      organizationSlug={organizationSlug}
+                      experiment={experiment}
+                      variant={variant}
+                      flags={flags}
+                      assignments={assignmentsByVariant.get(variant.id) ?? []}
+                      canWrite={canWrite}
+                      canDeleteVariant={experiment.kind === "ab" && variants.length > 1}
+                      onRefresh={refresh}
+                    />
+                  ))
+                )}
+              </Rows>
+            </>
+          ) : null}
+        </Rows>
+      </HyperlabPageShell>
+    </>
+  );
+});
+
+const HyperlabVariantCard = observer(function HyperlabVariantCard({
   organizationSlug,
   experiment,
   variant,
@@ -827,13 +811,10 @@ function HyperlabVariantCard({
 }) {
   const intl = useIntl();
   const client = hyperlabClient();
-  const [sheetOpen, setSheetOpen] = useState(false);
-  const [audienceId, setAudienceId] = useState(variant.audienceId ?? "");
+  const { ui: uiStore } = useHyperlabWorkspace();
+  const audienceId = uiStore.getVariantAudienceDraft(variant.id, variant.audienceId ?? "");
+  const sheetOpen = uiStore.isVariantSheetOpen(variant.id);
   const flagsById = new Map(flags.map((flag) => [flag.id, flag]));
-
-  useEffect(() => {
-    setAudienceId(variant.audienceId ?? "");
-  }, [variant.audienceId]);
 
   const saveAudience = useMutation({
     mutationFn: async () => {
@@ -964,7 +945,7 @@ function HyperlabVariantCard({
               <HyperlabAudienceSelector
                 organizationSlug={organizationSlug}
                 value={audienceId}
-                onChange={setAudienceId}
+                onChange={(value) => uiStore.setVariantAudienceDraft(variant.id, value)}
                 disabled={!canWrite}
                 hint={intl.formatMessage(messages.variantAudienceHint)}
               />
@@ -991,7 +972,7 @@ function HyperlabVariantCard({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => setSheetOpen(true)}
+                  onClick={() => uiStore.setVariantSheetOpen(variant.id, true)}
                 >
                   <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} data-icon="inline-start" />
                   <FormattedMessage {...messages.attachFlag} />
@@ -1047,7 +1028,7 @@ function HyperlabVariantCard({
       </CardContent>
       <AttachFlagSheet
         open={sheetOpen}
-        onOpenChange={setSheetOpen}
+        onOpenChange={(open) => uiStore.setVariantSheetOpen(variant.id, open)}
         organizationSlug={organizationSlug}
         variant={variant}
         flags={flags}
@@ -1056,7 +1037,7 @@ function HyperlabVariantCard({
       />
     </Card>
   );
-}
+});
 
 function AttachFlagSheet({
   open,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flag-detail.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-flag-detail.tsx
@@ -12,9 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { observer } from "mobx-react-lite";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -39,6 +39,11 @@ import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 
+import { HyperlabFlagQueryBridge } from "../store/hyperlab-query-bridge";
+import {
+  HyperlabWorkspaceProvider,
+  useHyperlabWorkspace,
+} from "../store/hyperlab-workspace-context";
 import { hyperlabMessages as messages } from "./hyperlab.messages";
 import {
   hyperlabClient,
@@ -62,12 +67,32 @@ export function HyperlabFlagDetail({
   flagId: string;
   canWrite: boolean;
 }) {
+  return (
+    <HyperlabWorkspaceProvider>
+      <HyperlabFlagDetailConnected
+        organizationSlug={organizationSlug}
+        flagId={flagId}
+        canWrite={canWrite}
+      />
+    </HyperlabWorkspaceProvider>
+  );
+}
+
+const HyperlabFlagDetailConnected = observer(function HyperlabFlagDetailConnected({
+  organizationSlug,
+  flagId,
+  canWrite,
+}: {
+  organizationSlug: string;
+  flagId: string;
+  canWrite: boolean;
+}) {
   const intl = useIntl();
   const router = useRouter();
   const queryClient = useQueryClient();
   const client = hyperlabClient();
-  const [description, setDescription] = useState("");
-  const [configText, setConfigText] = useState("{}");
+  const store = useHyperlabWorkspace();
+  const { flag: flagStore } = store;
 
   const detailQuery = useQuery({
     queryKey: hyperlabQueryKeys.flag(organizationSlug, flagId),
@@ -104,25 +129,15 @@ export function HyperlabFlagDetail({
     },
   });
 
-  useEffect(() => {
-    if (!detailQuery.data) {
-      return;
-    }
-    setDescription(detailQuery.data.flag.description ?? "");
-    if (detailQuery.data.config.value !== null && detailQuery.data.config.value !== undefined) {
-      setConfigText(JSON.stringify(detailQuery.data.config.value, null, 2));
-    }
-  }, [detailQuery.data]);
-
   const saveMutation = useMutation({
     mutationFn: async () => {
       const response = await client.flags[":flagId"].$put({
         param: { organizationSlug, flagId },
-        json: { description },
+        json: { description: flagStore.description },
       });
       await readHyperlabJson(response, intl.formatMessage(messages.loadError));
       if (detailQuery.data?.flag.kind === "config") {
-        const parsed = JSON.parse(configText) as unknown;
+        const parsed = JSON.parse(flagStore.configText) as unknown;
         const configResponse = await client.flags[":flagId"].config.$put({
           param: { organizationSlug, flagId },
           json: { value: parsed },
@@ -131,6 +146,7 @@ export function HyperlabFlagDetail({
       }
     },
     onSuccess: async () => {
+      flagStore.markSaved();
       toast.success(intl.formatMessage(messages.saveSuccess));
       await queryClient.invalidateQueries({
         queryKey: hyperlabQueryKeys.flag(organizationSlug, flagId),
@@ -169,138 +185,144 @@ export function HyperlabFlagDetail({
   const assignments = assignmentsQuery.data ?? [];
 
   return (
-    <HyperlabPageShell
-      title={flag?.key ?? intl.formatMessage(messages.flagsTitle)}
-      description={intl.formatMessage(messages.flagsDescription)}
-      backHref={`/org/${organizationSlug}/hyperlab/flags`}
-      actions={
-        canWrite ? (
-          <AlertDialog>
-            <AlertDialogTrigger render={<Button variant="outline" />}>
-              <FormattedMessage {...messages.delete} />
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  <FormattedMessage {...messages.deleteFlagTitle} />
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  <FormattedMessage
-                    {...messages.deleteFlagBody}
-                    values={{ name: flag?.key ?? "" }}
-                  />
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>
-                  <FormattedMessage {...messages.cancel} />
-                </AlertDialogCancel>
-                <AlertDialogAction
-                  variant="destructive"
-                  onClick={() => deleteMutation.mutate()}
-                  disabled={deleteMutation.isPending}
-                >
-                  <FormattedMessage {...messages.delete} />
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        ) : null
-      }
-    >
-      <Rows spacing="2u">
-        {detailQuery.isError ? (
-          <HyperlabLoadError error={detailQuery.error} onRetry={() => void detailQuery.refetch()} />
-        ) : null}
-        {flag ? (
-          <>
-            <Card>
-              <CardHeader>
-                <CardTitle>
-                  <FormattedMessage {...messages.generalCardTitle} />
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <FieldGroup>
-                  <Field>
-                    <FieldLabel htmlFor="hyperlab-flag-key">
-                      <FormattedMessage {...messages.flagKeyLabel} />
-                    </FieldLabel>
-                    <Input id="hyperlab-flag-key" value={flag.key} disabled />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="hyperlab-flag-description">
-                      <FormattedMessage {...messages.flagDescriptionLabel} />
-                    </FieldLabel>
-                    <Input
-                      id="hyperlab-flag-description"
-                      value={description}
-                      onChange={(event) => setDescription(event.target.value)}
-                      disabled={!canWrite}
+    <>
+      <HyperlabFlagQueryBridge flag={flag} config={detailQuery.data?.config} />
+      <HyperlabPageShell
+        title={flag?.key ?? intl.formatMessage(messages.flagsTitle)}
+        description={intl.formatMessage(messages.flagsDescription)}
+        backHref={`/org/${organizationSlug}/hyperlab/flags`}
+        actions={
+          canWrite ? (
+            <AlertDialog>
+              <AlertDialogTrigger render={<Button variant="outline" />}>
+                <FormattedMessage {...messages.delete} />
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    <FormattedMessage {...messages.deleteFlagTitle} />
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    <FormattedMessage
+                      {...messages.deleteFlagBody}
+                      values={{ name: flag?.key ?? "" }}
                     />
-                  </Field>
-                  {flag.kind === "config" ? (
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>
+                    <FormattedMessage {...messages.cancel} />
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    variant="destructive"
+                    onClick={() => deleteMutation.mutate()}
+                    disabled={deleteMutation.isPending}
+                  >
+                    <FormattedMessage {...messages.delete} />
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          ) : null
+        }
+      >
+        <Rows spacing="2u">
+          {detailQuery.isError ? (
+            <HyperlabLoadError
+              error={detailQuery.error}
+              onRetry={() => void detailQuery.refetch()}
+            />
+          ) : null}
+          {flag ? (
+            <>
+              <Card>
+                <CardHeader>
+                  <CardTitle>
+                    <FormattedMessage {...messages.generalCardTitle} />
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <FieldGroup>
                     <Field>
-                      <FieldLabel htmlFor="hyperlab-flag-config">
-                        <FormattedMessage {...messages.configJsonLabel} />
+                      <FieldLabel htmlFor="hyperlab-flag-key">
+                        <FormattedMessage {...messages.flagKeyLabel} />
                       </FieldLabel>
-                      <Textarea
-                        id="hyperlab-flag-config"
-                        value={configText}
-                        onChange={(event) => setConfigText(event.target.value)}
-                        rows={8}
+                      <Input id="hyperlab-flag-key" value={flag.key} disabled />
+                    </Field>
+                    <Field>
+                      <FieldLabel htmlFor="hyperlab-flag-description">
+                        <FormattedMessage {...messages.flagDescriptionLabel} />
+                      </FieldLabel>
+                      <Input
+                        id="hyperlab-flag-description"
+                        value={flagStore.description}
+                        onChange={(event) => flagStore.setDescription(event.target.value)}
                         disabled={!canWrite}
                       />
-                      <FieldDescription>
-                        <FormattedMessage {...messages.configJsonHint} />
-                      </FieldDescription>
                     </Field>
-                  ) : null}
-                </FieldGroup>
-              </CardContent>
-              {canWrite ? (
-                <CardFooter>
-                  <Button
-                    type="button"
-                    onClick={() => saveMutation.mutate()}
-                    disabled={saveMutation.isPending}
-                  >
-                    {saveMutation.isPending ? <Spinner data-icon="inline-start" /> : null}
-                    <FormattedMessage
-                      {...(saveMutation.isPending ? messages.saving : messages.save)}
+                    {flag.kind === "config" ? (
+                      <Field>
+                        <FieldLabel htmlFor="hyperlab-flag-config">
+                          <FormattedMessage {...messages.configJsonLabel} />
+                        </FieldLabel>
+                        <Textarea
+                          id="hyperlab-flag-config"
+                          value={flagStore.configText}
+                          onChange={(event) => flagStore.setConfigText(event.target.value)}
+                          rows={8}
+                          disabled={!canWrite}
+                        />
+                        <FieldDescription>
+                          <FormattedMessage {...messages.configJsonHint} />
+                        </FieldDescription>
+                      </Field>
+                    ) : null}
+                  </FieldGroup>
+                </CardContent>
+                {canWrite ? (
+                  <CardFooter>
+                    <Button
+                      type="button"
+                      onClick={() => saveMutation.mutate()}
+                      disabled={saveMutation.isPending || !flagStore.isDirty}
+                    >
+                      {saveMutation.isPending ? <Spinner data-icon="inline-start" /> : null}
+                      <FormattedMessage
+                        {...(saveMutation.isPending ? messages.saving : messages.save)}
+                      />
+                    </Button>
+                  </CardFooter>
+                ) : null}
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>
+                    <FormattedMessage {...messages.assignmentsTitle} />
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {assignments.length === 0 ? (
+                    <TypographyP size="small" tone="subtle">
+                      <FormattedMessage {...messages.noAssignments} />
+                    </TypographyP>
+                  ) : (
+                    <FlagAssignmentList
+                      organizationSlug={organizationSlug}
+                      assignments={assignments}
+                      experiments={experimentsQuery.data ?? []}
+                      client={client}
+                      loadError={intl.formatMessage(messages.loadError)}
                     />
-                  </Button>
-                </CardFooter>
-              ) : null}
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle>
-                  <FormattedMessage {...messages.assignmentsTitle} />
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                {assignments.length === 0 ? (
-                  <TypographyP size="small" tone="subtle">
-                    <FormattedMessage {...messages.noAssignments} />
-                  </TypographyP>
-                ) : (
-                  <FlagAssignmentList
-                    organizationSlug={organizationSlug}
-                    assignments={assignments}
-                    experiments={experimentsQuery.data ?? []}
-                    client={client}
-                    loadError={intl.formatMessage(messages.loadError)}
-                  />
-                )}
-              </CardContent>
-            </Card>
-          </>
-        ) : null}
-      </Rows>
-    </HyperlabPageShell>
+                  )}
+                </CardContent>
+              </Card>
+            </>
+          ) : null}
+        </Rows>
+      </HyperlabPageShell>
+    </>
   );
-}
+});
 
 function FlagAssignmentList({
   organizationSlug,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-keys-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/_components/hyperlab-keys-page.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useState } from "react";
+import { observer } from "mobx-react-lite";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -24,6 +24,10 @@ import { Row } from "@/components/ui/layout/row";
 import { Rows } from "@/components/ui/layout/rows";
 import { TypographyP } from "@/components/ui/typography";
 
+import {
+  HyperlabWorkspaceProvider,
+  useHyperlabWorkspace,
+} from "../store/hyperlab-workspace-context";
 import { hyperlabMessages as messages } from "./hyperlab.messages";
 import {
   hyperlabClient,
@@ -49,10 +53,24 @@ export function HyperlabKeysPage({
   organizationSlug: string;
   canWrite: boolean;
 }) {
+  return (
+    <HyperlabWorkspaceProvider>
+      <HyperlabKeysPageConnected organizationSlug={organizationSlug} canWrite={canWrite} />
+    </HyperlabWorkspaceProvider>
+  );
+}
+
+const HyperlabKeysPageConnected = observer(function HyperlabKeysPageConnected({
+  organizationSlug,
+  canWrite,
+}: {
+  organizationSlug: string;
+  canWrite: boolean;
+}) {
   const intl = useIntl();
   const queryClient = useQueryClient();
   const client = hyperlabClient();
-  const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+  const { ui: uiStore } = useHyperlabWorkspace();
   const keysQuery = useQuery({
     queryKey: hyperlabQueryKeys.keys(organizationSlug),
     queryFn: async () => {
@@ -66,7 +84,10 @@ export function HyperlabKeysPage({
   });
   const keys = keysQuery.data ?? [];
   const createAction = canWrite ? (
-    <HyperlabCreateKeyDialog organizationSlug={organizationSlug} onCreated={setCreatedSecret} />
+    <HyperlabCreateKeyDialog
+      organizationSlug={organizationSlug}
+      onCreated={(secret) => uiStore.setCreatedSecret(secret)}
+    />
   ) : null;
 
   const revokeMutation = useMutation({
@@ -92,20 +113,20 @@ export function HyperlabKeysPage({
       actions={createAction}
     >
       <Rows spacing="2u">
-        {createdSecret ? (
+        {uiStore.createdSecret ? (
           <Box border="standard" borderRadius="standard" background="muted" padding="2u">
             <Rows spacing="1u">
               <TypographyP wrapStyle="pretty" size="small" weight="medium">
                 <FormattedMessage {...messages.copySecret} />
               </TypographyP>
-              <code className="overflow-x-auto text-sm">{createdSecret}</code>
+              <code className="overflow-x-auto text-sm">{uiStore.createdSecret}</code>
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 className="w-fit"
                 onClick={() => {
-                  void navigator.clipboard.writeText(createdSecret);
+                  void navigator.clipboard.writeText(uiStore.createdSecret ?? "");
                   toast.success(intl.formatMessage(messages.copied));
                 }}
               >
@@ -169,4 +190,4 @@ export function HyperlabKeysPage({
       </Rows>
     </HyperlabPageShell>
   );
-}
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-audience-store.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-audience-store.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { makeAutoObservable } from "mobx";
+
+import type { HyperlabAudience } from "../_components/hyperlab-api";
+import {
+  criterionToRuleGroup,
+  emptyRuleGroup,
+  type HyperlabRuleGroup,
+} from "../_components/hyperlab-criterion";
+
+type SavedAudienceDraft = {
+  name: string;
+  description: string;
+  group: HyperlabRuleGroup;
+};
+
+function cloneRuleGroup(group: HyperlabRuleGroup): HyperlabRuleGroup {
+  return JSON.parse(JSON.stringify(group)) as HyperlabRuleGroup;
+}
+
+function audienceDraftEqual(left: SavedAudienceDraft, right: SavedAudienceDraft) {
+  return (
+    left.name === right.name &&
+    left.description === right.description &&
+    JSON.stringify(left.group) === JSON.stringify(right.group)
+  );
+}
+
+export class HyperlabAudienceStore {
+  name = "";
+  description = "";
+  group: HyperlabRuleGroup = emptyRuleGroup();
+  saved: SavedAudienceDraft = {
+    name: "",
+    description: "",
+    group: emptyRuleGroup(),
+  };
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  get isDirty() {
+    return !audienceDraftEqual(this.currentDraft, this.saved);
+  }
+
+  get currentDraft(): SavedAudienceDraft {
+    return {
+      name: this.name,
+      description: this.description,
+      group: this.group,
+    };
+  }
+
+  setName(value: string) {
+    this.name = value;
+  }
+
+  setDescription(value: string) {
+    this.description = value;
+  }
+
+  setGroup(value: HyperlabRuleGroup) {
+    this.group = value;
+  }
+
+  applyServer(audience: HyperlabAudience) {
+    const nextGroup = criterionToRuleGroup(audience.criterion);
+    const nextDraft: SavedAudienceDraft = {
+      name: audience.name,
+      description: audience.description ?? "",
+      group: nextGroup,
+    };
+
+    if (
+      audienceDraftEqual(this.currentDraft, nextDraft) &&
+      audienceDraftEqual(this.saved, nextDraft)
+    ) {
+      return;
+    }
+
+    this.name = nextDraft.name;
+    this.description = nextDraft.description;
+    this.group = cloneRuleGroup(nextDraft.group);
+    this.saved = {
+      name: nextDraft.name,
+      description: nextDraft.description,
+      group: cloneRuleGroup(nextDraft.group),
+    };
+  }
+
+  markSaved() {
+    this.saved = {
+      name: this.name,
+      description: this.description,
+      group: cloneRuleGroup(this.group),
+    };
+  }
+
+  clear() {
+    this.name = "";
+    this.description = "";
+    this.group = emptyRuleGroup();
+    this.saved = {
+      name: "",
+      description: "",
+      group: emptyRuleGroup(),
+    };
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-domain-stores.test.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import type {
+  HyperlabAudience,
+  HyperlabExperiment,
+  HyperlabFlag,
+  HyperlabFlagConfig,
+  HyperlabVariant,
+} from "../_components/hyperlab-api";
+import { emptyRuleGroup } from "../_components/hyperlab-criterion";
+import { HyperlabAudienceStore } from "./hyperlab-audience-store";
+import { HyperlabExperimentStore } from "./hyperlab-experiment-store";
+import { HyperlabFlagStore } from "./hyperlab-flag-store";
+import { createHyperlabWorkspace } from "./hyperlab-orchestrator";
+import { HyperlabUiStore } from "./hyperlab-ui-store";
+
+const sampleFlag: HyperlabFlag = {
+  id: "flag-1",
+  key: "checkout-cta",
+  description: "Checkout CTA copy",
+  kind: "config",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const sampleConfig: HyperlabFlagConfig = {
+  flagId: "flag-1",
+  value: { label: "Buy now" },
+};
+
+const sampleAudience: HyperlabAudience = {
+  id: "audience-1",
+  name: "Pro customers",
+  description: "Paid plans",
+  criterion: {
+    type: "attribute",
+    name: "plan",
+    match: "exact",
+    value: "pro",
+  },
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const sampleExperiment: HyperlabExperiment = {
+  id: "experiment-1",
+  name: "Homepage hero",
+  status: "draft",
+  kind: "ab",
+  audienceId: "audience-1",
+  rolloutPercentage: 5000,
+  startAt: "2026-06-01T09:00:00.000Z",
+  endAt: "2026-06-30T17:00:00.000Z",
+  timezone: "UTC",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const sampleVariants: HyperlabVariant[] = [
+  {
+    id: "variant-control",
+    experimentId: "experiment-1",
+    key: "control",
+    isControl: true,
+    audienceId: null,
+    rolloutPercentage: 5000,
+  },
+  {
+    id: "variant-b",
+    experimentId: "experiment-1",
+    key: "variant-b",
+    isControl: false,
+    audienceId: null,
+    rolloutPercentage: 5000,
+  },
+];
+
+describe("HyperlabFlagStore", () => {
+  it("tracks dirty state for description and config text", () => {
+    const store = new HyperlabFlagStore();
+    store.applyServer(sampleFlag, sampleConfig);
+
+    expect(store.isDirty).toBe(false);
+
+    store.setDescription("Updated");
+    expect(store.isDirty).toBe(true);
+
+    store.markSaved();
+    expect(store.isDirty).toBe(false);
+
+    store.setConfigText('{"label":"Updated"}');
+    expect(store.isDirty).toBe(true);
+  });
+});
+
+describe("HyperlabAudienceStore", () => {
+  it("hydrates from server data and tracks criterion edits", () => {
+    const store = new HyperlabAudienceStore();
+    store.applyServer(sampleAudience);
+
+    expect(store.name).toBe("Pro customers");
+    expect(store.isDirty).toBe(false);
+
+    store.setName("Enterprise customers");
+    expect(store.isDirty).toBe(true);
+
+    store.markSaved();
+    expect(store.isDirty).toBe(false);
+  });
+
+  it("resets cleanly", () => {
+    const store = new HyperlabAudienceStore();
+    store.applyServer(sampleAudience);
+    store.clear();
+
+    expect(store.name).toBe("");
+    expect(JSON.stringify(store.group)).toBe(JSON.stringify(emptyRuleGroup()));
+    expect(store.isDirty).toBe(false);
+  });
+});
+
+describe("HyperlabExperimentStore", () => {
+  it("tracks details, rollout, and split dirty state independently", () => {
+    const store = new HyperlabExperimentStore();
+    store.applyServer(sampleExperiment, sampleVariants);
+
+    expect(store.detailsDirty).toBe(false);
+    expect(store.rolloutDirty).toBe(false);
+    expect(store.splitDirty).toBe(false);
+    expect(store.splitTotal).toBe(10000);
+
+    store.setName("Updated experiment");
+    expect(store.detailsDirty).toBe(true);
+    expect(store.rolloutDirty).toBe(false);
+
+    store.markDetailsSaved();
+    expect(store.detailsDirty).toBe(false);
+
+    store.setRolloutPercentage(2500);
+    expect(store.rolloutDirty).toBe(true);
+
+    store.markRolloutSaved();
+    expect(store.rolloutDirty).toBe(false);
+
+    store.setVariantSplit("variant-b", 4000);
+    expect(store.splitDirty).toBe(true);
+    expect(store.splitTotal).toBe(9000);
+
+    store.setVariantSplit("variant-b", 5000);
+    store.markSplitsSaved();
+    expect(store.splitDirty).toBe(false);
+  });
+});
+
+describe("HyperlabUiStore", () => {
+  it("tracks ephemeral UI state", () => {
+    const store = new HyperlabUiStore();
+
+    store.setCreatedSecret("hlk_secret_value");
+    store.setAddVariantOpen(true);
+    store.setVariantKey("variant-c");
+    store.setVariantAudienceDraft("variant-b", "audience-2");
+    store.setVariantSheetOpen("variant-b", true);
+
+    expect(store.createdSecret).toBe("hlk_secret_value");
+    expect(store.addVariantOpen).toBe(true);
+    expect(store.variantKey).toBe("variant-c");
+    expect(store.getVariantAudienceDraft("variant-b")).toBe("audience-2");
+    expect(store.isVariantSheetOpen("variant-b")).toBe(true);
+
+    store.resetAddVariantDialog();
+    expect(store.addVariantOpen).toBe(false);
+    expect(store.variantKey).toBe("");
+  });
+});
+
+describe("HyperlabWorkspaceOrchestrator", () => {
+  it("routes server snapshots to domain stores", () => {
+    const workspace = createHyperlabWorkspace();
+
+    workspace.ingestFlag(sampleFlag, sampleConfig);
+    workspace.ingestAudience(sampleAudience);
+    workspace.ingestExperiment(sampleExperiment, sampleVariants);
+
+    expect(workspace.flag.description).toBe("Checkout CTA copy");
+    expect(workspace.audience.name).toBe("Pro customers");
+    expect(workspace.experiment.name).toBe("Homepage hero");
+    expect(workspace.ui.getVariantAudienceDraft("variant-control")).toBe("");
+
+    workspace.clear();
+    expect(workspace.flag.isDirty).toBe(false);
+    expect(workspace.audience.name).toBe("");
+    expect(workspace.experiment.name).toBe("");
+    expect(workspace.ui.createdSecret).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-domain-stores.test.ts
@@ -162,6 +162,33 @@ describe("HyperlabExperimentStore", () => {
     store.markSplitsSaved();
     expect(store.splitDirty).toBe(false);
   });
+
+  it("preserves dirty splits when unrelated experiment metadata refreshes", () => {
+    const store = new HyperlabExperimentStore();
+    store.applyServer(sampleExperiment, sampleVariants);
+
+    store.setVariantSplit("variant-b", 4000);
+    expect(store.splitDirty).toBe(true);
+
+    store.applyServer({ ...sampleExperiment, name: "Renamed on server" }, sampleVariants);
+
+    expect(store.name).toBe("Renamed on server");
+    expect(store.variantSplits["variant-b"]).toBe(4000);
+    expect(store.splitDirty).toBe(true);
+  });
+
+  it("preserves dirty details when rollout metadata refreshes", () => {
+    const store = new HyperlabExperimentStore();
+    store.applyServer(sampleExperiment, sampleVariants);
+
+    store.setName("Pending name edit");
+    store.applyServer({ ...sampleExperiment, rolloutPercentage: 2500 }, sampleVariants);
+
+    expect(store.name).toBe("Pending name edit");
+    expect(store.detailsDirty).toBe(true);
+    expect(store.rolloutPercentage).toBe(2500);
+    expect(store.rolloutDirty).toBe(false);
+  });
 });
 
 describe("HyperlabUiStore", () => {
@@ -184,6 +211,21 @@ describe("HyperlabUiStore", () => {
     expect(store.addVariantOpen).toBe(false);
     expect(store.variantKey).toBe("");
   });
+
+  it("preserves pending variant audience drafts on refresh", () => {
+    const store = new HyperlabUiStore();
+
+    store.applyVariantAudience("variant-b", null);
+    store.setVariantAudienceDraft("variant-b", "audience-2");
+
+    store.applyVariantAudience("variant-b", null);
+
+    expect(store.getVariantAudienceDraft("variant-b")).toBe("audience-2");
+
+    store.applyVariantAudience("variant-b", "audience-2");
+
+    expect(store.getVariantAudienceDraft("variant-b")).toBe("audience-2");
+  });
 });
 
 describe("HyperlabWorkspaceOrchestrator", () => {
@@ -204,5 +246,16 @@ describe("HyperlabWorkspaceOrchestrator", () => {
     expect(workspace.audience.name).toBe("");
     expect(workspace.experiment.name).toBe("");
     expect(workspace.ui.createdSecret).toBeNull();
+  });
+
+  it("preserves pending variant audience drafts during experiment refresh", () => {
+    const workspace = createHyperlabWorkspace();
+
+    workspace.ingestExperiment(sampleExperiment, sampleVariants);
+    workspace.ui.setVariantAudienceDraft("variant-b", "audience-2");
+
+    workspace.ingestExperiment(sampleExperiment, sampleVariants);
+
+    expect(workspace.ui.getVariantAudienceDraft("variant-b")).toBe("audience-2");
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-experiment-store.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-experiment-store.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { makeAutoObservable } from "mobx";
+
+import type { HyperlabExperiment, HyperlabVariant } from "../_components/hyperlab-api";
+import { inspectWallTime, isoToWallTime } from "../_components/hyperlab-schedule";
+
+type ExperimentDetailsDraft = {
+  name: string;
+  timezone: string;
+  startDate: string;
+  startTime: string;
+  endDate: string;
+  endTime: string;
+};
+
+type ExperimentRolloutDraft = {
+  audienceId: string;
+  rolloutPercentage: number;
+};
+
+function detailsEqual(left: ExperimentDetailsDraft, right: ExperimentDetailsDraft) {
+  return (
+    left.name === right.name &&
+    left.timezone === right.timezone &&
+    left.startDate === right.startDate &&
+    left.startTime === right.startTime &&
+    left.endDate === right.endDate &&
+    left.endTime === right.endTime
+  );
+}
+
+function rolloutEqual(left: ExperimentRolloutDraft, right: ExperimentRolloutDraft) {
+  return left.audienceId === right.audienceId && left.rolloutPercentage === right.rolloutPercentage;
+}
+
+function cloneVariantSplits(splits: Record<string, number>) {
+  return { ...splits };
+}
+
+export class HyperlabExperimentStore {
+  name = "";
+  startDate = "";
+  startTime = "09:00";
+  endDate = "";
+  endTime = "17:00";
+  timezone = "UTC";
+  audienceId = "";
+  rolloutPercentage = 10000;
+  variantSplits: Record<string, number> = {};
+  savedVariantSplits: Record<string, number> = {};
+  savedDetails: ExperimentDetailsDraft = {
+    name: "",
+    timezone: "UTC",
+    startDate: "",
+    startTime: "09:00",
+    endDate: "",
+    endTime: "17:00",
+  };
+  savedRollout: ExperimentRolloutDraft = {
+    audienceId: "",
+    rolloutPercentage: 10000,
+  };
+  serverVariants: HyperlabVariant[] = [];
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  get detailsDraft(): ExperimentDetailsDraft {
+    return {
+      name: this.name,
+      timezone: this.timezone,
+      startDate: this.startDate,
+      startTime: this.startTime,
+      endDate: this.endDate,
+      endTime: this.endTime,
+    };
+  }
+
+  get rolloutDraft(): ExperimentRolloutDraft {
+    return {
+      audienceId: this.audienceId,
+      rolloutPercentage: this.rolloutPercentage,
+    };
+  }
+
+  get detailsDirty() {
+    return !detailsEqual(this.detailsDraft, this.savedDetails);
+  }
+
+  get rolloutDirty() {
+    return !rolloutEqual(this.rolloutDraft, this.savedRollout);
+  }
+
+  get splitDirty() {
+    return this.serverVariants.some(
+      (variant) => this.variantSplits[variant.id] !== variant.rolloutPercentage,
+    );
+  }
+
+  get splitTotal() {
+    return this.serverVariants.reduce(
+      (sum, variant) => sum + (this.variantSplits[variant.id] ?? 0),
+      0,
+    );
+  }
+
+  get startWall() {
+    return inspectWallTime(this.startDate, this.startTime, this.timezone);
+  }
+
+  get endWall() {
+    return inspectWallTime(this.endDate, this.endTime, this.timezone);
+  }
+
+  get scheduleReady() {
+    return Boolean(this.startWall.iso && this.endWall.iso);
+  }
+
+  setName(value: string) {
+    this.name = value;
+  }
+
+  setStartDate(value: string) {
+    this.startDate = value;
+  }
+
+  setStartTime(value: string) {
+    this.startTime = value;
+  }
+
+  setEndDate(value: string) {
+    this.endDate = value;
+  }
+
+  setEndTime(value: string) {
+    this.endTime = value;
+  }
+
+  setTimezone(value: string) {
+    this.timezone = value;
+  }
+
+  setAudienceId(value: string) {
+    this.audienceId = value;
+  }
+
+  setRolloutPercentage(value: number) {
+    this.rolloutPercentage = value;
+  }
+
+  setVariantSplit(variantId: string, value: number) {
+    this.variantSplits = {
+      ...this.variantSplits,
+      [variantId]: value,
+    };
+  }
+
+  applyServer(experiment: HyperlabExperiment, variants: HyperlabVariant[]) {
+    const zone = experiment.timezone || "UTC";
+    const start = isoToWallTime(experiment.startAt, zone);
+    const end = isoToWallTime(experiment.endAt, zone);
+    const nextDetails: ExperimentDetailsDraft = {
+      name: experiment.name,
+      timezone: zone,
+      startDate: start.date,
+      startTime: start.time,
+      endDate: end.date,
+      endTime: end.time,
+    };
+    const nextRollout: ExperimentRolloutDraft = {
+      audienceId: experiment.audienceId ?? "",
+      rolloutPercentage: experiment.rolloutPercentage,
+    };
+    const nextSplits = Object.fromEntries(
+      variants.map((variant) => [variant.id, variant.rolloutPercentage]),
+    );
+
+    this.name = nextDetails.name;
+    this.timezone = nextDetails.timezone;
+    this.startDate = nextDetails.startDate;
+    this.startTime = nextDetails.startTime;
+    this.endDate = nextDetails.endDate;
+    this.endTime = nextDetails.endTime;
+    this.audienceId = nextRollout.audienceId;
+    this.rolloutPercentage = nextRollout.rolloutPercentage;
+    this.savedDetails = { ...nextDetails };
+    this.savedRollout = { ...nextRollout };
+    this.serverVariants = variants;
+    this.variantSplits = cloneVariantSplits(nextSplits);
+    this.savedVariantSplits = cloneVariantSplits(nextSplits);
+  }
+
+  markDetailsSaved() {
+    this.savedDetails = { ...this.detailsDraft };
+  }
+
+  markRolloutSaved() {
+    this.savedRollout = { ...this.rolloutDraft };
+  }
+
+  markSplitsSaved() {
+    this.savedVariantSplits = cloneVariantSplits(this.variantSplits);
+    this.serverVariants = this.serverVariants.map((variant) => ({
+      ...variant,
+      rolloutPercentage: this.variantSplits[variant.id] ?? variant.rolloutPercentage,
+    }));
+  }
+
+  clear() {
+    this.name = "";
+    this.startDate = "";
+    this.startTime = "09:00";
+    this.endDate = "";
+    this.endTime = "17:00";
+    this.timezone = "UTC";
+    this.audienceId = "";
+    this.rolloutPercentage = 10000;
+    this.variantSplits = {};
+    this.savedVariantSplits = {};
+    this.savedDetails = {
+      name: "",
+      timezone: "UTC",
+      startDate: "",
+      startTime: "09:00",
+      endDate: "",
+      endTime: "17:00",
+    };
+    this.savedRollout = {
+      audienceId: "",
+      rolloutPercentage: 10000,
+    };
+    this.serverVariants = [];
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-experiment-store.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-experiment-store.ts
@@ -187,19 +187,32 @@ export class HyperlabExperimentStore {
       variants.map((variant) => [variant.id, variant.rolloutPercentage]),
     );
 
-    this.name = nextDetails.name;
-    this.timezone = nextDetails.timezone;
-    this.startDate = nextDetails.startDate;
-    this.startTime = nextDetails.startTime;
-    this.endDate = nextDetails.endDate;
-    this.endTime = nextDetails.endTime;
-    this.audienceId = nextRollout.audienceId;
-    this.rolloutPercentage = nextRollout.rolloutPercentage;
-    this.savedDetails = { ...nextDetails };
-    this.savedRollout = { ...nextRollout };
+    const preserveDetails = this.detailsDirty;
+    const preserveRollout = this.rolloutDirty;
+    const preserveSplits = this.splitDirty;
+
+    if (!preserveDetails) {
+      this.name = nextDetails.name;
+      this.timezone = nextDetails.timezone;
+      this.startDate = nextDetails.startDate;
+      this.startTime = nextDetails.startTime;
+      this.endDate = nextDetails.endDate;
+      this.endTime = nextDetails.endTime;
+      this.savedDetails = { ...nextDetails };
+    }
+
+    if (!preserveRollout) {
+      this.audienceId = nextRollout.audienceId;
+      this.rolloutPercentage = nextRollout.rolloutPercentage;
+      this.savedRollout = { ...nextRollout };
+    }
+
     this.serverVariants = variants;
-    this.variantSplits = cloneVariantSplits(nextSplits);
-    this.savedVariantSplits = cloneVariantSplits(nextSplits);
+
+    if (!preserveSplits) {
+      this.variantSplits = cloneVariantSplits(nextSplits);
+      this.savedVariantSplits = cloneVariantSplits(nextSplits);
+    }
   }
 
   markDetailsSaved() {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-flag-store.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-flag-store.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { makeAutoObservable } from "mobx";
+
+import type { HyperlabFlag, HyperlabFlagConfig } from "../_components/hyperlab-api";
+
+export class HyperlabFlagStore {
+  description = "";
+  configText = "{}";
+  savedDescription = "";
+  savedConfigText = "{}";
+  flagKind: HyperlabFlag["kind"] | null = null;
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  get isDirty() {
+    return this.description !== this.savedDescription || this.configText !== this.savedConfigText;
+  }
+
+  setDescription(value: string) {
+    this.description = value;
+  }
+
+  setConfigText(value: string) {
+    this.configText = value;
+  }
+
+  applyServer(flag: HyperlabFlag, config: HyperlabFlagConfig) {
+    const nextDescription = flag.description ?? "";
+    const nextConfigText =
+      flag.kind === "config" && config.value !== null && config.value !== undefined
+        ? JSON.stringify(config.value, null, 2)
+        : "{}";
+
+    if (
+      this.description === nextDescription &&
+      this.configText === nextConfigText &&
+      this.savedDescription === nextDescription &&
+      this.savedConfigText === nextConfigText &&
+      this.flagKind === flag.kind
+    ) {
+      return;
+    }
+
+    this.description = nextDescription;
+    this.configText = nextConfigText;
+    this.savedDescription = nextDescription;
+    this.savedConfigText = nextConfigText;
+    this.flagKind = flag.kind;
+  }
+
+  markSaved() {
+    this.savedDescription = this.description;
+    this.savedConfigText = this.configText;
+  }
+
+  clear() {
+    this.description = "";
+    this.configText = "{}";
+    this.savedDescription = "";
+    this.savedConfigText = "{}";
+    this.flagKind = null;
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-orchestrator.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type {
+  HyperlabAudience,
+  HyperlabExperiment,
+  HyperlabFlag,
+  HyperlabFlagConfig,
+  HyperlabVariant,
+} from "../_components/hyperlab-api";
+import { HyperlabAudienceStore } from "./hyperlab-audience-store";
+import { HyperlabExperimentStore } from "./hyperlab-experiment-store";
+import { HyperlabFlagStore } from "./hyperlab-flag-store";
+import { HyperlabUiStore } from "./hyperlab-ui-store";
+
+export class HyperlabWorkspaceOrchestrator {
+  readonly flag = new HyperlabFlagStore();
+  readonly audience = new HyperlabAudienceStore();
+  readonly experiment = new HyperlabExperimentStore();
+  readonly ui = new HyperlabUiStore();
+
+  ingestFlag(flag: HyperlabFlag, config: HyperlabFlagConfig) {
+    this.flag.applyServer(flag, config);
+  }
+
+  ingestAudience(audience: HyperlabAudience) {
+    this.audience.applyServer(audience);
+  }
+
+  ingestExperiment(experiment: HyperlabExperiment, variants: HyperlabVariant[]) {
+    this.experiment.applyServer(experiment, variants);
+    for (const variant of variants) {
+      this.ui.applyVariantAudience(variant.id, variant.audienceId);
+    }
+  }
+
+  clear() {
+    this.flag.clear();
+    this.audience.clear();
+    this.experiment.clear();
+    this.ui.clear();
+  }
+}
+
+export function createHyperlabWorkspace() {
+  return new HyperlabWorkspaceOrchestrator();
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-query-bridge.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-query-bridge.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useLayoutEffect } from "react";
+
+import type {
+  HyperlabAudience,
+  HyperlabExperiment,
+  HyperlabFlag,
+  HyperlabFlagConfig,
+  HyperlabVariant,
+} from "../_components/hyperlab-api";
+import { useHyperlabWorkspace } from "./hyperlab-workspace-context";
+
+export function HyperlabFlagQueryBridge({
+  flag,
+  config,
+}: {
+  flag: HyperlabFlag | undefined;
+  config: HyperlabFlagConfig | undefined;
+}) {
+  const store = useHyperlabWorkspace();
+
+  useLayoutEffect(() => {
+    if (!flag || !config) {
+      return;
+    }
+
+    store.ingestFlag(flag, config);
+  }, [config, flag, store]);
+
+  return null;
+}
+
+export function HyperlabAudienceQueryBridge({
+  audience,
+}: {
+  audience: HyperlabAudience | undefined;
+}) {
+  const store = useHyperlabWorkspace();
+
+  useLayoutEffect(() => {
+    if (!audience) {
+      return;
+    }
+
+    store.ingestAudience(audience);
+  }, [audience, store]);
+
+  return null;
+}
+
+type ExperimentDetailSnapshot = {
+  experiment: HyperlabExperiment;
+  variants: HyperlabVariant[];
+};
+
+export function HyperlabExperimentQueryBridge({
+  snapshot,
+}: {
+  snapshot: ExperimentDetailSnapshot | undefined;
+}) {
+  const store = useHyperlabWorkspace();
+
+  useLayoutEffect(() => {
+    if (!snapshot) {
+      return;
+    }
+
+    store.ingestExperiment(snapshot.experiment, snapshot.variants);
+  }, [snapshot, store]);
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-ui-store.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-ui-store.ts
@@ -49,7 +49,12 @@ export class HyperlabUiStore {
   }
 
   applyVariantAudience(variantId: string, audienceId: string | null) {
-    this.variantAudienceDrafts.set(variantId, audienceId ?? "");
+    const serverAudience = audienceId ?? "";
+    const draft = this.variantAudienceDrafts.get(variantId);
+    const hasPendingDraft = draft !== undefined && draft !== serverAudience;
+    if (!hasPendingDraft) {
+      this.variantAudienceDrafts.set(variantId, serverAudience);
+    }
   }
 
   isVariantSheetOpen(variantId: string) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-ui-store.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-ui-store.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { makeAutoObservable } from "mobx";
+
+export class HyperlabUiStore {
+  createdSecret: string | null = null;
+  addVariantOpen = false;
+  variantKey = "";
+  variantAudienceDrafts = new Map<string, string>();
+  variantSheetOpen = new Map<string, boolean>();
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  setCreatedSecret(value: string | null) {
+    this.createdSecret = value;
+  }
+
+  setAddVariantOpen(value: boolean) {
+    this.addVariantOpen = value;
+  }
+
+  setVariantKey(value: string) {
+    this.variantKey = value;
+  }
+
+  resetAddVariantDialog() {
+    this.addVariantOpen = false;
+    this.variantKey = "";
+  }
+
+  setVariantAudienceDraft(variantId: string, audienceId: string) {
+    this.variantAudienceDrafts.set(variantId, audienceId);
+  }
+
+  getVariantAudienceDraft(variantId: string, fallback = "") {
+    return this.variantAudienceDrafts.get(variantId) ?? fallback;
+  }
+
+  applyVariantAudience(variantId: string, audienceId: string | null) {
+    this.variantAudienceDrafts.set(variantId, audienceId ?? "");
+  }
+
+  isVariantSheetOpen(variantId: string) {
+    return this.variantSheetOpen.get(variantId) ?? false;
+  }
+
+  setVariantSheetOpen(variantId: string, open: boolean) {
+    this.variantSheetOpen.set(variantId, open);
+  }
+
+  clear() {
+    this.createdSecret = null;
+    this.addVariantOpen = false;
+    this.variantKey = "";
+    this.variantAudienceDrafts.clear();
+    this.variantSheetOpen.clear();
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-workspace-context.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/store/hyperlab-workspace-context.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+import {
+  createHyperlabWorkspace,
+  type HyperlabWorkspaceOrchestrator,
+} from "./hyperlab-orchestrator";
+
+const HyperlabWorkspaceContext = createContext<HyperlabWorkspaceOrchestrator | null>(null);
+
+export function HyperlabWorkspaceProvider({ children }: { children: ReactNode }) {
+  const store = useMemo(
+    () => createHyperlabWorkspace(),
+    // Store is scoped to page mount; parent key handles remounts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return (
+    <HyperlabWorkspaceContext.Provider value={store}>{children}</HyperlabWorkspaceContext.Provider>
+  );
+}
+
+export function useHyperlabWorkspace() {
+  const store = useContext(HyperlabWorkspaceContext);
+  if (!store) {
+    throw new Error("useHyperlabWorkspace must be used within HyperlabWorkspaceProvider");
+  }
+
+  return store;
+}
+
+export function useOptionalHyperlabWorkspace() {
+  return useContext(HyperlabWorkspaceContext);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Hyperlab detail pages previously kept editable form state in local `useState` with manual `JSON.stringify` baselines for dirty tracking. This PR introduces a composed MobX workspace following the same pattern as the Content Editor:

- **Domain stores** for flag, audience, and experiment drafts with computed `isDirty` / section dirty getters
- **`HyperlabUiStore`** for ephemeral UI state (created key secret, add-variant dialog, variant audience drafts, attach-flag sheets)
- **`HyperlabWorkspaceOrchestrator`** composing the domain stores
- **React Query bridges** syncing server snapshots into MobX on fetch/invalidation
- **Refactored pages**: flag detail, audience detail, experiment detail, and keys page now use `HyperlabWorkspaceProvider`, `observer()`, and store actions

Server fetch/mutation logic stays in TanStack Query; MobX owns editable drafts and UI chrome.

### Codex feedback addressed

- **Preserve unsaved variant splits** during unrelated experiment refreshes (details/rollout/status saves)
- **Preserve pending variant audience selections** when experiment snapshots refresh before the per-variant Save click
- Section-aware hydration: only reapply server values for experiment sections that are not locally dirty

## How to test

```bash
cd apps/hyperlocalise-web
vp test 'src/app/[lang]/(authenticated)/org/[organizationSlug]/hyperlab/'
vp check --fix
```

Manual checks in Hyperlab (requires auth + `workspace-hyperlab` flag):

1. Edit variant splits, then save experiment details — split edits should remain
2. Change a variant audience without saving, then save experiment rollout — audience selector should keep the pending value
3. Edit a flag description/config JSON — save button enables only when dirty
4. Edit an audience name/rules — unsaved ring + disabled save until changed

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09250-b5ae-7ccc-9330-cca2cc8cc7b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09250-b5ae-7ccc-9330-cca2cc8cc7b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

