### PR TITLE
feat(web): add team selection to member invite flow

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -125,13 +125,20 @@ async function reconcileMemberMembershipFromWorkos(input: {
   });
 }
 
+type CreatedTeamMembership = {
+  teamId: string;
+  userId: string;
+};
+
 async function ensureTeamAccessForInvitedMember(input: {
   organizationId: string;
   userId: string;
   role: OrganizationMembershipRole;
   teamId?: string;
   database: DatabaseClient;
-}): Promise<{ error: "team_not_found" } | undefined> {
+}): Promise<
+  { error: "team_not_found" } | { createdTeamMembership?: CreatedTeamMembership } | undefined
+> {
   // Operators already see every project via teams:write. Non-operators need an
   // explicit team membership or projects they create stay invisible.
   if (hasCapability(input.role, "teams:write") && !input.teamId) {
@@ -154,21 +161,33 @@ async function ensureTeamAccessForInvitedMember(input: {
       return { error: "team_not_found" };
     }
 
-    await ensureTeamMembership({
+    const membershipResult = await ensureTeamMembership({
       teamId: team.id,
       userId: input.userId,
       role: "member",
       database: input.database,
     });
-    return;
+
+    return membershipResult.created
+      ? { createdTeamMembership: { teamId: team.id, userId: input.userId } }
+      : {};
   }
 
-  await ensureDefaultWorkspaceTeamMembership({
+  const defaultTeamResult = await ensureDefaultWorkspaceTeamMembership({
     organizationId: input.organizationId,
     userId: input.userId,
     role: "member",
     database: input.database,
   });
+
+  return defaultTeamResult.created
+    ? {
+        createdTeamMembership: {
+          teamId: defaultTeamResult.team.id,
+          userId: input.userId,
+        },
+      }
+    : {};
 }
 
 async function inviteOrganizationMember(input: {
@@ -229,7 +248,7 @@ async function inviteOrganizationMember(input: {
       teamId: input.teamId,
       database,
     });
-    if (teamAccessResult?.error) {
+    if (teamAccessResult && "error" in teamAccessResult) {
       return teamAccessResult;
     }
 
@@ -240,6 +259,7 @@ async function inviteOrganizationMember(input: {
       membershipId: existingMembership.membershipId,
       localUserId: existingMembership.localUserId,
       isNewUser: false,
+      createdTeamMembership: teamAccessResult?.createdTeamMembership,
       member: toMemberSummary(
         {
           userId: existingMembership.localUserId,
@@ -309,7 +329,7 @@ async function inviteOrganizationMember(input: {
     teamId: input.teamId,
     database,
   });
-  if (teamAccessResult?.error) {
+  if (teamAccessResult && "error" in teamAccessResult) {
     return teamAccessResult;
   }
 
@@ -317,6 +337,7 @@ async function inviteOrganizationMember(input: {
     membershipId: membership.id,
     localUserId: user.id,
     isNewUser,
+    createdTeamMembership: teamAccessResult?.createdTeamMembership,
     member: toMemberSummary(
       {
         userId: user.id,
@@ -468,6 +489,17 @@ async function deliverWorkosInvitation(input: {
   }
 
   await sendWorkosInvitation(workos, invitationPayload);
+}
+
+async function rollbackCreatedTeamMembership(input: CreatedTeamMembership) {
+  await db
+    .delete(schema.teamMemberships)
+    .where(
+      and(
+        eq(schema.teamMemberships.teamId, input.teamId),
+        eq(schema.teamMemberships.userId, input.userId),
+      ),
+    );
 }
 
 async function rollbackPendingInvite(input: {
@@ -682,6 +714,10 @@ export function createMemberRoutes() {
             .update(schema.organizationMemberships)
             .set({ role: pendingInvite.previousRole })
             .where(eq(schema.organizationMemberships.id, pendingInvite.membershipId));
+        }
+
+        if ("createdTeamMembership" in pendingInvite && pendingInvite.createdTeamMembership) {
+          await rollbackCreatedTeamMembership(pendingInvite.createdTeamMembership);
         }
 
         if (isWorkosInvitationRevokedNotDeliveredError(error)) {

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -27,6 +27,7 @@ import {
 import {
   conflictResponse,
   internalErrorResponse,
+  notFoundResponse,
   serviceUnavailableResponse,
 } from "@/api/response.schema";
 import {
@@ -43,7 +44,10 @@ import type { ActivityLogEventInput } from "@/lib/activity-log/activity-log-cont
 import { db, schema, type DatabaseClient } from "@/lib/database/client";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { createLogger, serializeErrorForLog } from "@/lib/log";
-import { ensureDefaultWorkspaceTeamMembership } from "@/lib/teams/default-workspace-team";
+import {
+  ensureDefaultWorkspaceTeamMembership,
+  ensureTeamMembership,
+} from "@/lib/teams/default-workspace-team";
 import { membershipRoleToWorkosRoleSlug } from "@/lib/workos/membership-role";
 import { getWorkosServerClient } from "@/lib/workos/server-client";
 
@@ -121,15 +125,41 @@ async function reconcileMemberMembershipFromWorkos(input: {
   });
 }
 
-async function ensureDefaultTeamAccessForInvitedMember(input: {
+async function ensureTeamAccessForInvitedMember(input: {
   organizationId: string;
   userId: string;
   role: OrganizationMembershipRole;
+  teamId?: string;
   database: DatabaseClient;
-}) {
+}): Promise<{ error: "team_not_found" } | undefined> {
   // Operators already see every project via teams:write. Non-operators need an
-  // explicit default-team membership or projects they create stay invisible.
-  if (hasCapability(input.role, "teams:write")) {
+  // explicit team membership or projects they create stay invisible.
+  if (hasCapability(input.role, "teams:write") && !input.teamId) {
+    return;
+  }
+
+  if (input.teamId) {
+    const [team] = await input.database
+      .select({ id: schema.teams.id })
+      .from(schema.teams)
+      .where(
+        and(
+          eq(schema.teams.id, input.teamId),
+          eq(schema.teams.organizationId, input.organizationId),
+        ),
+      )
+      .limit(1);
+
+    if (!team) {
+      return { error: "team_not_found" };
+    }
+
+    await ensureTeamMembership({
+      teamId: team.id,
+      userId: input.userId,
+      role: "member",
+      database: input.database,
+    });
     return;
   }
 
@@ -145,6 +175,7 @@ async function inviteOrganizationMember(input: {
   organizationId: string;
   email: string;
   role: OrganizationMembershipRole;
+  teamId?: string;
   placeholderWorkosUserId: string;
   db?: DatabaseClient;
 }) {
@@ -191,12 +222,16 @@ async function inviteOrganizationMember(input: {
         .where(eq(schema.organizationMemberships.id, existingMembership.membershipId));
     }
 
-    await ensureDefaultTeamAccessForInvitedMember({
+    const teamAccessResult = await ensureTeamAccessForInvitedMember({
       organizationId: input.organizationId,
       userId: existingMembership.localUserId,
       role: input.role,
+      teamId: input.teamId,
       database,
     });
+    if (teamAccessResult?.error) {
+      return teamAccessResult;
+    }
 
     return {
       resend: true as const,
@@ -267,12 +302,16 @@ async function inviteOrganizationMember(input: {
       createdAt: schema.organizationMemberships.createdAt,
     });
 
-  await ensureDefaultTeamAccessForInvitedMember({
+  const teamAccessResult = await ensureTeamAccessForInvitedMember({
     organizationId: input.organizationId,
     userId: user.id,
     role: input.role,
+    teamId: input.teamId,
     database,
   });
+  if (teamAccessResult?.error) {
+    return teamAccessResult;
+  }
 
   return {
     membershipId: membership.id,
@@ -511,6 +550,24 @@ export function createMemberRoutes() {
       }
 
       const normalizedEmail = payload.email.trim().toLowerCase();
+
+      if (payload.teamId) {
+        const [team] = await db
+          .select({ id: schema.teams.id })
+          .from(schema.teams)
+          .where(
+            and(
+              eq(schema.teams.id, payload.teamId),
+              eq(schema.teams.organizationId, organizationId),
+            ),
+          )
+          .limit(1);
+
+        if (!team) {
+          return notFoundResponse(c, "team_not_found", "Team not found");
+        }
+      }
+
       const [existingMembershipForEmail] = await db
         .select({ id: schema.organizationMemberships.id })
         .from(schema.users)
@@ -541,6 +598,7 @@ export function createMemberRoutes() {
               organizationId,
               email: normalizedEmail,
               role: payload.role,
+              teamId: payload.teamId,
               placeholderWorkosUserId: `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`,
               db: tx,
             }),
@@ -568,11 +626,16 @@ export function createMemberRoutes() {
           organizationId,
           email: normalizedEmail,
           role: payload.role,
+          teamId: payload.teamId,
           placeholderWorkosUserId: `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`,
         });
       }
 
       if ("error" in pendingInvite) {
+        if (pendingInvite.error === "team_not_found") {
+          return notFoundResponse(c, "team_not_found", "Team not found");
+        }
+
         return memberAlreadyExistsResponse(c);
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/member/member.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.schema.ts
@@ -28,6 +28,7 @@ export const memberWorkosUserIdParamsSchema = z.object({
 export const inviteMemberBodySchema = z.object({
   email: z.string().trim().email().max(320),
   role: organizationMembershipRoleSchema.default("member"),
+  teamId: z.string().uuid().optional(),
 });
 
 export const updateMemberBodySchema = z.object({

--- a/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
@@ -700,6 +700,69 @@ describe("memberRoutes", () => {
     expect(member?.role).toBe("admin");
   });
 
+  it("rolls back a newly selected team when resend delivery fails", async () => {
+    resendInvitationMock.mockReset();
+    listInvitationsMock.mockReset();
+
+    listInvitationsMock.mockImplementation(async () => ({
+      data: [{ id: "invitation_mock", state: "pending" }],
+    }));
+    resendInvitationMock.mockRejectedValueOnce(new Error("workos unavailable"));
+
+    const ownerIdentity = createWorkosIdentity();
+    const headers = await authHeadersFor(ownerIdentity);
+
+    const organization = (
+      await db
+        .select({ id: schema.organizations.id })
+        .from(schema.organizations)
+        .where(eq(schema.organizations.slug, ownerIdentity.organization.slug ?? ""))
+        .limit(1)
+    )[0]!;
+
+    const [customTeam] = await db
+      .insert(schema.teams)
+      .values({
+        organizationId: organization.id,
+        slug: "rollback-team",
+        name: "Rollback team",
+      })
+      .returning({ id: schema.teams.id });
+
+    await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "rollback-team@example.com", role: "developer" },
+      headers,
+    );
+
+    const invitedUser = (
+      await db
+        .select({ id: schema.users.id })
+        .from(schema.users)
+        .where(eq(schema.users.email, "rollback-team@example.com"))
+        .limit(1)
+    )[0]!;
+
+    const failedResend = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "rollback-team@example.com", role: "developer", teamId: customTeam.id },
+      headers,
+    );
+    expect(failedResend.status).toBe(500);
+
+    const customTeamMembership = await db
+      .select({ id: schema.teamMemberships.id })
+      .from(schema.teamMemberships)
+      .where(
+        and(
+          eq(schema.teamMemberships.teamId, customTeam.id),
+          eq(schema.teamMemberships.userId, invitedUser.id),
+        ),
+      );
+
+    expect(customTeamMembership).toEqual([]);
+  });
+
   it("rolls back a role change when resend delivery fails", async () => {
     sendInvitationMock.mockReset();
     listInvitationsMock.mockReset();

--- a/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
@@ -217,6 +217,57 @@ describe("memberRoutes", () => {
     expect(membership?.role).toBe("member");
   });
 
+  it("adds invited members to the selected team", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const headers = await authHeadersFor(ownerIdentity);
+
+    const organization = (
+      await db
+        .select({ id: schema.organizations.id })
+        .from(schema.organizations)
+        .where(eq(schema.organizations.slug, ownerIdentity.organization.slug ?? ""))
+        .limit(1)
+    )[0]!;
+
+    const [customTeam] = await db
+      .insert(schema.teams)
+      .values({
+        organizationId: organization.id,
+        slug: "localization",
+        name: "Localization",
+      })
+      .returning({ id: schema.teams.id });
+
+    const response = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "localization-invite@example.com", role: "translator", teamId: customTeam.id },
+      headers,
+    );
+
+    expect(response.status).toBe(201);
+
+    const invitedUser = (
+      await db
+        .select({ id: schema.users.id })
+        .from(schema.users)
+        .where(eq(schema.users.email, "localization-invite@example.com"))
+        .limit(1)
+    )[0]!;
+
+    const [membership] = await db
+      .select({ role: schema.teamMemberships.role })
+      .from(schema.teamMemberships)
+      .where(
+        and(
+          eq(schema.teamMemberships.teamId, customTeam.id),
+          eq(schema.teamMemberships.userId, invitedUser.id),
+        ),
+      )
+      .limit(1);
+
+    expect(membership?.role).toBe("member");
+  });
+
   it("does not add invited operators to the default workspace team", async () => {
     const ownerIdentity = createWorkosIdentity();
     const headers = await authHeadersFor(ownerIdentity);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.messages.ts
@@ -222,6 +222,12 @@ export const membersPageContentMessages = defineMessages({
     id: "CE4Mjxv5Pv",
     description: "Help text for the invite member team field",
   },
+  teamEmptyFallback: {
+    defaultMessage:
+      "No teams are listed yet. The default team will be created automatically when you send the invitation.",
+    id: "PR5FHHiklX",
+    description: "Help text when the workspace has no teams to select during invite",
+  },
   teamsLoadFailed: {
     defaultMessage: "Failed to load teams",
     id: "q+KBl5AglO",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.messages.ts
@@ -212,6 +212,21 @@ export const membersPageContentMessages = defineMessages({
     id: "rcANTRobpQ",
     description: "Label for the invite member role field",
   },
+  teamLabel: {
+    defaultMessage: "Team",
+    id: "8Dn6LPaujp",
+    description: "Label for the invite member team field",
+  },
+  teamDescription: {
+    defaultMessage: "Invited members are added to this team so they can access projects.",
+    id: "CE4Mjxv5Pv",
+    description: "Help text for the invite member team field",
+  },
+  teamsLoadFailed: {
+    defaultMessage: "Failed to load teams",
+    id: "q+KBl5AglO",
+    description: "Error when the teams list request fails for the invite dialog",
+  },
   cancel: {
     defaultMessage: "Cancel",
     id: "R1l6Bs+7Ss",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
@@ -12,13 +12,16 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
+import { hasCapability } from "@/api/auth/policy";
+import { createTeamsApi } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-api";
 import { apiClient } from "@/lib/api-client-instance";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
+import { DEFAULT_WORKSPACE_TEAM_SLUG } from "@/lib/teams/default-workspace-team-constants";
 
 import { membersPageContentMessages } from "./members-page-content.messages";
 import { MembersPageView } from "./members-page-view";
@@ -29,6 +32,12 @@ import {
 } from "./members-settings-view-model";
 
 const membersQueryKey = (organizationSlug: string) => ["workspace-members", organizationSlug];
+const teamsQueryKey = (organizationSlug: string) => ["workspace-teams", organizationSlug];
+const teamsApi = createTeamsApi(apiClient);
+
+function resolveDefaultTeamId(teams: { id: string; slug: string }[]) {
+  return teams.find((team) => team.slug === DEFAULT_WORKSPACE_TEAM_SLUG)?.id ?? teams[0]?.id ?? "";
+}
 
 async function readMemberError(response: Response, fallback: string) {
   const body = await response.json().catch(() => null);
@@ -50,8 +59,14 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<OrganizationMembershipRole>("member");
+  const [inviteTeamId, setInviteTeamId] = useState("");
   const [removingMember, setRemovingMember] = useState<MembersListMember | null>(null);
   const [editingMember, setEditingMember] = useState<MembersListMember | null>(null);
+
+  const teamsQuery = useQuery({
+    queryKey: teamsQueryKey(organizationSlug),
+    queryFn: () => teamsApi.listTeams(organizationSlug),
+  });
 
   const membersQuery = useQuery({
     queryKey: membersQueryKey(organizationSlug),
@@ -73,9 +88,30 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
 
   const pageState = resolveMembersPageState(membersQuery.data, intl);
   const { members, assignableRoles, canInvite } = pageState;
+  const inviteTeams = teamsQuery.data ?? [];
+  const defaultInviteTeamId = resolveDefaultTeamId(inviteTeams);
+  const inviteRequiresTeam = !hasCapability(inviteRole, "teams:write");
+
+  useEffect(() => {
+    if (!isInviteOpen || inviteTeams.length === 0) {
+      return;
+    }
+
+    setInviteTeamId((currentTeamId) => {
+      if (currentTeamId && inviteTeams.some((team) => team.id === currentTeamId)) {
+        return currentTeamId;
+      }
+
+      return defaultInviteTeamId;
+    });
+  }, [defaultInviteTeamId, inviteTeams, isInviteOpen]);
 
   const inviteMember = useMutation({
-    mutationFn: async (input: { email: string; role: OrganizationMembershipRole }) => {
+    mutationFn: async (input: {
+      email: string;
+      role: OrganizationMembershipRole;
+      teamId?: string;
+    }) => {
       const response = await apiClient.api.orgs[":organizationSlug"].members.$post({
         param: { organizationSlug },
         json: input,
@@ -93,6 +129,7 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
     onSuccess: async () => {
       setInviteEmail("");
       setInviteRole("member");
+      setInviteTeamId(defaultInviteTeamId);
       setIsInviteOpen(false);
       await queryClient.invalidateQueries({ queryKey: membersQueryKey(organizationSlug) });
       toast.success(intl.formatMessage(membersPageContentMessages.invitationSentToast));
@@ -169,7 +206,18 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
       return;
     }
 
-    inviteMember.mutate({ email: inviteEmail.trim(), role: inviteRole });
+    inviteMember.mutate({
+      email: inviteEmail.trim(),
+      role: inviteRole,
+      ...(inviteRequiresTeam && inviteTeamId ? { teamId: inviteTeamId } : {}),
+    });
+  }
+
+  function handleInviteOpenChange(open: boolean) {
+    setIsInviteOpen(open);
+    if (open && defaultInviteTeamId) {
+      setInviteTeamId(defaultInviteTeamId);
+    }
   }
 
   return (
@@ -189,14 +237,26 @@ export function MembersPageContent({ organizationSlug }: { organizationSlug: str
       isInviteOpen={isInviteOpen}
       inviteEmail={inviteEmail}
       inviteRole={inviteRole}
+      inviteTeams={inviteTeams}
+      inviteTeamId={inviteTeamId}
+      inviteRequiresTeam={inviteRequiresTeam}
+      isLoadingTeams={teamsQuery.isLoading}
+      teamsLoadError={
+        teamsQuery.isError
+          ? teamsQuery.error instanceof Error
+            ? teamsQuery.error.message
+            : intl.formatMessage(membersPageContentMessages.teamsLoadFailed)
+          : null
+      }
       isInviting={inviteMember.isPending}
       removingMember={removingMember}
       isRemoving={removeMember.isPending}
       editingMember={editingMember}
       isUpdatingRole={updateRole.isPending}
-      onInviteOpenChange={setIsInviteOpen}
+      onInviteOpenChange={handleInviteOpenChange}
       onInviteEmailChange={setInviteEmail}
       onInviteRoleChange={setInviteRole}
+      onInviteTeamIdChange={setInviteTeamId}
       onInviteSubmit={handleInviteSubmit}
       onRemovingMemberChange={setRemovingMember}
       onRemoveMember={(workosUserId) => removeMember.mutate(workosUserId)}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.stories.tsx
@@ -80,6 +80,30 @@ const meta = {
     isInviteOpen: false,
     inviteEmail: "",
     inviteRole: "member",
+    inviteTeams: [
+      {
+        id: "team-default",
+        slug: "default",
+        name: "Default team",
+        memberCount: 3,
+        currentUserRole: "manager",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "team-localization",
+        slug: "localization",
+        name: "Localization",
+        memberCount: 2,
+        currentUserRole: "manager",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    inviteTeamId: "team-default",
+    inviteRequiresTeam: true,
+    isLoadingTeams: false,
+    teamsLoadError: null,
     isInviting: false,
     removingMember: null,
     isRemoving: false,
@@ -88,6 +112,7 @@ const meta = {
     onInviteOpenChange: fn(),
     onInviteEmailChange: fn(),
     onInviteRoleChange: fn(),
+    onInviteTeamIdChange: fn(),
     onInviteSubmit: fn(),
     onRemovingMemberChange: fn(),
     onRemoveMember: fn(),
@@ -125,5 +150,16 @@ export const OpensChangeRoleFromMenu: Story = {
     await userEvent.click(canvas.getByRole("button", { name: "Actions for Mina Chen" }));
     await userEvent.click(await canvas.findByText("Change role..."));
     await expect(args.onEditingMemberChange).toHaveBeenCalledWith(mina);
+  },
+};
+
+export const InviteDialogOpen: Story = {
+  args: {
+    isInviteOpen: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Invite member" })).toBeInTheDocument();
+    await expect(canvas.getByText("Team")).toBeInTheDocument();
+    await expect(canvas.getByText("Default team")).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
@@ -176,6 +176,21 @@ describe("MembersPageView", () => {
     ).toBeInTheDocument();
   });
 
+  it("allows sending an invitation when no teams are listed", () => {
+    renderMembersPage({
+      isInviteOpen: true,
+      inviteTeams: [],
+      inviteTeamId: "",
+    });
+
+    expect(
+      screen.getByText(
+        "No teams are listed yet. The default team will be created automatically when you send the invitation.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send invitation" })).toBeEnabled();
+  });
+
   it("hides the team selector when inviting an operator role", () => {
     renderMembersPage({
       isInviteOpen: true,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx
@@ -60,7 +60,7 @@ const assignableRoles: OrganizationMembershipRole[] = [
 ];
 
 function renderMembersPage(overrides: Partial<Parameters<typeof MembersPageView>[0]> = {}) {
-  const props = {
+  const props: Parameters<typeof MembersPageView>[0] = {
     organizationSlug: "acme",
     members: [createMember()],
     assignableRoles,
@@ -70,6 +70,21 @@ function renderMembersPage(overrides: Partial<Parameters<typeof MembersPageView>
     isInviteOpen: false,
     inviteEmail: "",
     inviteRole: "member" as const,
+    inviteTeams: [
+      {
+        id: "team-default",
+        slug: "default",
+        name: "Default team",
+        memberCount: 1,
+        currentUserRole: "manager",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    inviteTeamId: "team-default",
+    inviteRequiresTeam: true,
+    isLoadingTeams: false,
+    teamsLoadError: null,
     isInviting: false,
     removingMember: null,
     isRemoving: false,
@@ -78,6 +93,7 @@ function renderMembersPage(overrides: Partial<Parameters<typeof MembersPageView>
     onInviteOpenChange: vi.fn(),
     onInviteEmailChange: vi.fn(),
     onInviteRoleChange: vi.fn(),
+    onInviteTeamIdChange: vi.fn(),
     onInviteSubmit: vi.fn(),
     onRemovingMemberChange: vi.fn(),
     onRemoveMember: vi.fn(),
@@ -148,6 +164,26 @@ describe("MembersPageView", () => {
     await user.click(await screen.findByText("Remove member..."));
 
     expect(props.onRemovingMemberChange).toHaveBeenCalledWith(member);
+  });
+
+  it("shows the team selector in the invite dialog for non-operator roles", () => {
+    renderMembersPage({ isInviteOpen: true });
+
+    expect(screen.getByText("Team")).toBeInTheDocument();
+    expect(screen.getByText("Default team")).toBeInTheDocument();
+    expect(
+      screen.getByText("Invited members are added to this team so they can access projects."),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the team selector when inviting an operator role", () => {
+    renderMembersPage({
+      isInviteOpen: true,
+      inviteRole: "admin",
+      inviteRequiresTeam: false,
+    });
+
+    expect(screen.queryByText("Team")).not.toBeInTheDocument();
   });
 
   it("hides the actions menu when the member cannot be managed", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
@@ -610,6 +610,10 @@ export function MembersPageView({
                   <TypographyP className="text-flame-100" size="small">
                     {teamsLoadError}
                   </TypographyP>
+                ) : inviteTeams.length === 0 && !isLoadingTeams ? (
+                  <TypographyP size="small" tone="subtle">
+                    <FormattedMessage {...membersPageContentMessages.teamEmptyFallback} />
+                  </TypographyP>
                 ) : (
                   <Select
                     value={inviteTeamId}
@@ -618,7 +622,7 @@ export function MembersPageView({
                         onInviteTeamIdChange(value);
                       }
                     }}
-                    disabled={isInviting || isLoadingTeams || inviteTeams.length === 0}
+                    disabled={isInviting || isLoadingTeams}
                   >
                     <SelectTrigger className="border-border bg-muted">
                       <SelectValue>
@@ -635,9 +639,11 @@ export function MembersPageView({
                     </SelectContent>
                   </Select>
                 )}
-                <FieldDescription>
-                  <FormattedMessage {...membersPageContentMessages.teamDescription} />
-                </FieldDescription>
+                {inviteTeams.length > 0 ? (
+                  <FieldDescription>
+                    <FormattedMessage {...membersPageContentMessages.teamDescription} />
+                  </FieldDescription>
+                ) : null}
               </Field>
             ) : null}
             <DialogFooter>
@@ -647,9 +653,7 @@ export function MembersPageView({
               <Button
                 type="submit"
                 disabled={
-                  isInviting ||
-                  (inviteRequiresTeam &&
-                    (isLoadingTeams || Boolean(teamsLoadError) || !inviteTeamId))
+                  isInviting || (inviteRequiresTeam && (isLoadingTeams || Boolean(teamsLoadError)))
                 }
               >
                 <FormattedMessage {...membersPageContentMessages.sendInvitation} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.tsx
@@ -54,6 +54,8 @@ import { TypographyP } from "@/components/ui/typography";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { cn } from "@/lib/primitives/cn";
 
+import type { TeamSummaryRow } from "../../teams/_components/teams-api";
+
 import { WorkspacePeopleNav } from "../../_components/workspace-people-nav";
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 
@@ -375,6 +377,11 @@ export function MembersPageView({
   isInviteOpen,
   inviteEmail,
   inviteRole,
+  inviteTeams,
+  inviteTeamId,
+  inviteRequiresTeam,
+  isLoadingTeams,
+  teamsLoadError,
   isInviting,
   removingMember,
   isRemoving,
@@ -383,6 +390,7 @@ export function MembersPageView({
   onInviteOpenChange,
   onInviteEmailChange,
   onInviteRoleChange,
+  onInviteTeamIdChange,
   onInviteSubmit,
   onRemovingMemberChange,
   onRemoveMember,
@@ -398,6 +406,11 @@ export function MembersPageView({
   isInviteOpen: boolean;
   inviteEmail: string;
   inviteRole: OrganizationMembershipRole;
+  inviteTeams: TeamSummaryRow[];
+  inviteTeamId: string;
+  inviteRequiresTeam: boolean;
+  isLoadingTeams: boolean;
+  teamsLoadError: string | null;
   isInviting: boolean;
   removingMember: MembersListMember | null;
   isRemoving: boolean;
@@ -406,6 +419,7 @@ export function MembersPageView({
   onInviteOpenChange: (open: boolean) => void;
   onInviteEmailChange: (email: string) => void;
   onInviteRoleChange: (role: OrganizationMembershipRole) => void;
+  onInviteTeamIdChange: (teamId: string) => void;
   onInviteSubmit: (event: React.SyntheticEvent) => void;
   onRemovingMemberChange: (member: MembersListMember | null) => void;
   onRemoveMember: (workosUserId: string) => void;
@@ -587,11 +601,57 @@ export function MembersPageView({
               </Select>
               <FieldDescription>{getRoleDescription(inviteRole, intl)}</FieldDescription>
             </Field>
+            {inviteRequiresTeam ? (
+              <Field>
+                <FieldLabel>
+                  <FormattedMessage {...membersPageContentMessages.teamLabel} />
+                </FieldLabel>
+                {teamsLoadError ? (
+                  <TypographyP className="text-flame-100" size="small">
+                    {teamsLoadError}
+                  </TypographyP>
+                ) : (
+                  <Select
+                    value={inviteTeamId}
+                    onValueChange={(value) => {
+                      if (value) {
+                        onInviteTeamIdChange(value);
+                      }
+                    }}
+                    disabled={isInviting || isLoadingTeams || inviteTeams.length === 0}
+                  >
+                    <SelectTrigger className="border-border bg-muted">
+                      <SelectValue>
+                        {inviteTeams.find((team) => team.id === inviteTeamId)?.name ??
+                          intl.formatMessage(membersPageContentMessages.loading)}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {inviteTeams.map((team) => (
+                        <SelectItem key={team.id} value={team.id} label={team.name}>
+                          {team.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                <FieldDescription>
+                  <FormattedMessage {...membersPageContentMessages.teamDescription} />
+                </FieldDescription>
+              </Field>
+            ) : null}
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => onInviteOpenChange(false)}>
                 <FormattedMessage {...membersPageContentMessages.cancel} />
               </Button>
-              <Button type="submit" disabled={isInviting}>
+              <Button
+                type="submit"
+                disabled={
+                  isInviting ||
+                  (inviteRequiresTeam &&
+                    (isLoadingTeams || Boolean(teamsLoadError) || !inviteTeamId))
+                }
+              >
                 <FormattedMessage {...membersPageContentMessages.sendInvitation} />
               </Button>
             </DialogFooter>

--- a/apps/hyperlocalise-web/src/lib/teams/default-workspace-team.ts
+++ b/apps/hyperlocalise-web/src/lib/teams/default-workspace-team.ts
@@ -84,19 +84,31 @@ export async function ensureTeamMembership(input: {
   userId: string;
   role?: TeamMembershipRole;
   database?: DatabaseClient;
-}) {
+}): Promise<{ created: boolean }> {
   const database = input.database ?? db;
 
-  await database
-    .insert(schema.teamMemberships)
-    .values({
-      teamId: input.teamId,
-      userId: input.userId,
-      role: input.role ?? "member",
-    })
-    .onConflictDoNothing({
-      target: [schema.teamMemberships.teamId, schema.teamMemberships.userId],
-    });
+  const [existingMembership] = await database
+    .select({ id: schema.teamMemberships.id })
+    .from(schema.teamMemberships)
+    .where(
+      and(
+        eq(schema.teamMemberships.teamId, input.teamId),
+        eq(schema.teamMemberships.userId, input.userId),
+      ),
+    )
+    .limit(1);
+
+  if (existingMembership) {
+    return { created: false };
+  }
+
+  await database.insert(schema.teamMemberships).values({
+    teamId: input.teamId,
+    userId: input.userId,
+    role: input.role ?? "member",
+  });
+
+  return { created: true };
 }
 
 export async function ensureDefaultWorkspaceTeamMembership(input: {
@@ -108,14 +120,14 @@ export async function ensureDefaultWorkspaceTeamMembership(input: {
   const database = input.database ?? db;
   const team = await ensureDefaultWorkspaceTeam(input.organizationId, database);
 
-  await ensureTeamMembership({
+  const membershipResult = await ensureTeamMembership({
     teamId: team.id,
     userId: input.userId,
     role: input.role,
     database,
   });
 
-  return team;
+  return { team, created: membershipResult.created };
 }
 
 export async function backfillOrganizationProjectTeams(organizationId: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The invite member dialog now includes a **Team** selector so inviters can choose which team a new member joins. The default workspace team is pre-selected when the dialog opens.

The members invite API accepts an optional `teamId` and creates team membership at invite time (for non-operator roles that need explicit team access).

**Review fixes:**
- Invitations work when the workspace has no teams yet — the UI explains that the default team will be created server-side.
- Newly added team memberships are rolled back if WorkOS invitation delivery fails (including on resend).

## How to test

- Open **Members → Invite member** and confirm the Team field shows with **Default team** selected.
- Invite a non-operator role (e.g. Developer) and verify they are added to the selected team in **Teams**.
- In a workspace with no teams, confirm **Send invitation** stays enabled and the fallback message appears.
- Run `vp test src/api/routes/member/member.test.ts` and `vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-view.test.tsx`.

## Checklist

- [x] I ran relevant checks locally (`vp check`, `vp test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

[Invite dialog with team selector](https://cursor.com/agents/bc-01a09265-871b-72e6-b741-f56a8aefd02e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finvite-dialog-team-selector.webp)

[invite-member-team-selection-demo.mp4](https://cursor.com/agents/bc-01a09265-871b-72e6-b741-f56a8aefd02e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finvite-member-team-selection-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09265-871b-72e6-b741-f56a8aefd02e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09265-871b-72e6-b741-f56a8aefd02e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

