### PR TITLE
test(e2e): add local-only smoke flows

### DIFF
--- a/apps/hyperlocalise-web/src/e2e/constants.ts
+++ b/apps/hyperlocalise-web/src/e2e/constants.ts
@@ -14,10 +14,19 @@ export const E2E_BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 
 export const E2E_DEFAULT_LOCALE = "en";
 
+export function e2eUrl(path: string) {
+  return new URL(path, E2E_BASE_URL).toString();
+}
+
+export function organizationPath(organizationSlug: string, suffix = "") {
+  const normalized = suffix === "" || suffix.startsWith("/") ? suffix : `/${suffix}`;
+  return `/${E2E_DEFAULT_LOCALE}/org/${organizationSlug}${normalized}`;
+}
+
 export function organizationDashboardPath(organizationSlug: string) {
-  return `/${E2E_DEFAULT_LOCALE}/org/${organizationSlug}/dashboard`;
+  return organizationPath(organizationSlug, "/dashboard");
 }
 
 export function organizationProjectsPath(organizationSlug: string) {
-  return `/${E2E_DEFAULT_LOCALE}/org/${organizationSlug}/projects`;
+  return organizationPath(organizationSlug, "/projects");
 }

--- a/apps/hyperlocalise-web/src/e2e/flows/auth-guards.e2e.ts
+++ b/apps/hyperlocalise-web/src/e2e/flows/auth-guards.e2e.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, it } from "vite-plus/test";
+
+import { E2E_DEFAULT_LOCALE, e2eUrl } from "../constants";
+import { getE2ePage, useE2eBrowser } from "../fixtures/browser";
+
+describe("auth guards", () => {
+  useE2eBrowser();
+
+  it("sends unauthenticated dashboard visits to the sign-in form", async () => {
+    const page = getE2ePage();
+    await page.goto(e2eUrl(`/${E2E_DEFAULT_LOCALE}/dashboard`), {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.locator('input[name="email"]').waitFor({ state: "visible", timeout: 30_000 });
+  });
+
+  it("renders the public access denied page", async () => {
+    const page = getE2ePage();
+    await page.goto(e2eUrl("/auth/access-denied"), { waitUntil: "domcontentloaded" });
+
+    await page
+      .getByRole("heading", { name: "Access denied" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("link", { name: "Choose organization" }).waitFor({ state: "visible" });
+    await page.getByRole("link", { name: "Sign out" }).waitFor({ state: "visible" });
+    await page.getByRole("link", { name: "Back to site" }).waitFor({ state: "visible" });
+  });
+});

--- a/apps/hyperlocalise-web/src/e2e/flows/marketing.e2e.ts
+++ b/apps/hyperlocalise-web/src/e2e/flows/marketing.e2e.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, it } from "vite-plus/test";
+
+import { E2E_DEFAULT_LOCALE, e2eUrl } from "../constants";
+import { getE2ePage, useE2eBrowser } from "../fixtures/browser";
+
+describe("marketing pages", () => {
+  useE2eBrowser();
+
+  it("renders the homepage hero without sign-in", async () => {
+    const page = getE2ePage();
+    await page.goto(e2eUrl(`/${E2E_DEFAULT_LOCALE}`), { waitUntil: "domcontentloaded" });
+
+    await page
+      .getByRole("heading", {
+        name: "AI-native infrastructure for multilingual content operations",
+      })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("link", { name: /Explore the platform/i }).waitFor({ state: "visible" });
+  });
+
+  it("renders pricing, legal, and contact pages from local copy", async () => {
+    const page = getE2ePage();
+
+    await page.goto(e2eUrl(`/${E2E_DEFAULT_LOCALE}/pricing`), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "Scale localisation. Control your costs." })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("heading", { name: "Compare plans" }).waitFor({ state: "visible" });
+
+    await page.goto(e2eUrl(`/${E2E_DEFAULT_LOCALE}/privacy`), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "Privacy policy" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+
+    await page.goto(e2eUrl(`/${E2E_DEFAULT_LOCALE}/terms`), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "Terms of service" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+
+    await page.goto(e2eUrl(`/${E2E_DEFAULT_LOCALE}/contact`), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "Talk with the Hyperlocalise team" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("link", { name: "Email support" }).waitFor({ state: "visible" });
+  });
+});

--- a/apps/hyperlocalise-web/src/e2e/flows/project-pages.e2e.ts
+++ b/apps/hyperlocalise-web/src/e2e/flows/project-pages.e2e.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, it } from "vite-plus/test";
+
+import { e2eUrl, organizationPath } from "../constants";
+import { getE2ePage, loginAsAdmin, useE2eBrowser } from "../fixtures/browser";
+import { provisionNativeProjectFixture } from "../helpers/issue-sheet-fixture";
+
+describe("project pages", () => {
+  useE2eBrowser();
+
+  it("shows empty overview and files, then creates an issue from Queries", async () => {
+    const page = getE2ePage();
+    const identity = await loginAsAdmin(page);
+    const fixture = await provisionNativeProjectFixture(identity);
+    const projectPath = (suffix: string) =>
+      organizationPath(fixture.organizationSlug, `/projects/${fixture.projectId}${suffix}`);
+
+    await page.goto(e2eUrl(projectPath("")), { waitUntil: "domcontentloaded" });
+    await page.getByText(fixture.projectName).waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByText("No jobs yet").waitFor({ state: "visible" });
+
+    await page.goto(e2eUrl(projectPath("/files")), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("button", { name: "Add files" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByText("No files yet").waitFor({ state: "visible" });
+
+    const issueTitle = `E2E issue ${Date.now()}`;
+    await page.goto(e2eUrl(projectPath("/issue-sheet")), { waitUntil: "domcontentloaded" });
+    await page.getByText("Queries").waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("button", { name: "Issue" }).click();
+    await page.getByRole("heading", { name: "New issue" }).waitFor({ state: "visible" });
+    await page.getByLabel("Title").fill(issueTitle);
+
+    const createResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/issue-sheet") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByRole("button", { name: "Create issue" }).click();
+    await createResponsePromise;
+
+    await page.getByText(issueTitle).waitFor({ state: "visible", timeout: 30_000 });
+  }, 120_000);
+});

--- a/apps/hyperlocalise-web/src/e2e/flows/sign-out.e2e.ts
+++ b/apps/hyperlocalise-web/src/e2e/flows/sign-out.e2e.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, it } from "vite-plus/test";
+
+import { E2E_DEFAULT_LOCALE, e2eUrl } from "../constants";
+import { getE2ePage, loginAsAdmin, useE2eBrowser } from "../fixtures/browser";
+
+describe("sign out", () => {
+  useE2eBrowser();
+
+  it("clears the session from the account menu and returns to sign-in", async () => {
+    const page = getE2ePage();
+    await loginAsAdmin(page);
+
+    await page.getByRole("button", { name: /Open account menu/i }).click();
+    await page.getByRole("menuitem", { name: "Log out" }).click();
+
+    await page
+      .getByRole("heading", {
+        name: "AI-native infrastructure for multilingual content operations",
+      })
+      .waitFor({ state: "visible", timeout: 30_000 });
+
+    await page.goto(e2eUrl(`/${E2E_DEFAULT_LOCALE}/dashboard`), {
+      waitUntil: "domcontentloaded",
+    });
+    await page.locator('input[name="email"]').waitFor({ state: "visible", timeout: 30_000 });
+  });
+});

--- a/apps/hyperlocalise-web/src/e2e/flows/workspace-pages.e2e.ts
+++ b/apps/hyperlocalise-web/src/e2e/flows/workspace-pages.e2e.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, it } from "vite-plus/test";
+
+import { e2eUrl, organizationPath } from "../constants";
+import { getE2ePage, loginAsAdmin, useE2eBrowser } from "../fixtures/browser";
+
+describe("workspace pages", () => {
+  useE2eBrowser();
+
+  it("opens members, jobs, settings, and teams without third-party APIs", async () => {
+    const page = getE2ePage();
+    const identity = await loginAsAdmin(page);
+    const orgPath = (suffix: string) => organizationPath(identity.organizationSlug, suffix);
+
+    await page.goto(e2eUrl(orgPath("/members")), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "Members" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("button", { name: "Invite member" }).waitFor({ state: "visible" });
+    await page.getByText("You", { exact: true }).waitFor({ state: "visible" });
+
+    await page.goto(e2eUrl(orgPath("/jobs")), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "Jobs" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByText("No Hyperlocalise jobs found for this workspace.").waitFor({
+      state: "visible",
+    });
+
+    await page.goto(e2eUrl(orgPath("/settings")), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "General" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByLabel("Organization name").waitFor({ state: "visible" });
+
+    await page.goto(e2eUrl(orgPath("/settings/account")), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "Account" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByDisplayValue(identity.email).waitFor({ state: "visible" });
+
+    await page.goto(e2eUrl(orgPath("/teams")), { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("heading", { name: "Teams" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("button", { name: "Create team" }).waitFor({ state: "visible" });
+    await page.getByText("No teams yet").waitFor({ state: "visible" });
+  });
+});

--- a/apps/hyperlocalise-web/src/e2e/helpers/issue-sheet-fixture.ts
+++ b/apps/hyperlocalise-web/src/e2e/helpers/issue-sheet-fixture.ts
@@ -25,15 +25,21 @@ import { toAuthOrganization, withMembershipAccessSource } from "@/test/auth-seed
 import { createEmulatorWorkosClient, roleSlugForE2e } from "./emulator-client";
 import type { EmulatorIdentity } from "./emulator-identity";
 
+export type NativeProjectFixture = {
+  organizationId: string;
+  organizationSlug: string;
+  projectId: string;
+  projectName: string;
+  userId: string;
+};
+
 export type IssueSheetBulkFixture = {
   organizationSlug: string;
   projectId: string;
   issueTitles: [string, string];
 };
 
-export async function provisionIssueSheetBulkFixture(
-  identity: EmulatorIdentity,
-): Promise<IssueSheetBulkFixture> {
+async function resolveIdentityOrganizationAndUser(identity: EmulatorIdentity) {
   const [organization] = await db
     .select({ id: schema.organizations.id, slug: schema.organizations.slug })
     .from(schema.organizations)
@@ -54,36 +60,58 @@ export async function provisionIssueSheetBulkFixture(
     throw new Error(`E2E user not found for WorkOS user ${identity.workosUserId}`);
   }
 
+  return { organization, user };
+}
+
+export async function provisionNativeProjectFixture(
+  identity: EmulatorIdentity,
+  namePrefix = "E2E Project",
+): Promise<NativeProjectFixture> {
+  const { organization, user } = await resolveIdentityOrganizationAndUser(identity);
   const team = await ensureDefaultWorkspaceTeam(organization.id);
   const projectId = `project_${randomUUID()}`;
+  const projectName = `${namePrefix} ${Date.now()}`;
 
   await db.insert(schema.projects).values({
     id: projectId,
     organizationId: organization.id,
     teamId: team.id,
     createdByUserId: user.id,
-    name: `Bulk E2E ${Date.now()}`,
+    name: projectName,
     description: "",
     translationContext: "",
     sourceLocale: "en-US",
     targetLocales: ["fr-FR"],
   });
 
+  return {
+    organizationId: organization.id,
+    organizationSlug: organization.slug,
+    projectId,
+    projectName,
+    userId: user.id,
+  };
+}
+
+export async function provisionIssueSheetBulkFixture(
+  identity: EmulatorIdentity,
+): Promise<IssueSheetBulkFixture> {
+  const project = await provisionNativeProjectFixture(identity, "Bulk E2E");
   const issueSheetService = new IssueSheetService(db);
   const issueTitles = ["Bulk issue one", "Bulk issue two"] as const;
 
   for (const title of issueTitles) {
     await issueSheetService.createIssue({
-      organizationId: organization.id,
-      projectId,
-      actorUserId: user.id,
+      organizationId: project.organizationId,
+      projectId: project.projectId,
+      actorUserId: project.userId,
       body: { title },
     });
   }
 
   return {
-    organizationSlug: organization.slug,
-    projectId,
+    organizationSlug: project.organizationSlug,
+    projectId: project.projectId,
     issueTitles,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Add browser e2e coverage for flows that stay on localhost: Postgres, the WorkOS emulator, and the app. No Autumn, GitHub, Slack, or AI Gateway calls.

New specs:

- Marketing homepage, pricing, privacy, terms, and contact
- Unauthenticated dashboard redirect and the public access-denied page
- Members, jobs, general/account settings, and teams empty states after emulator login
- Sign-out from the account menu
- Seeded native project overview, files empty state, and creating an issue from Queries

Shared helpers now expose org URL builders and a DB-seeded native project fixture, so project create via the UI is not required when billing is unset.

## How to test

From `apps/hyperlocalise-web`:

1. Start Postgres and migrate (`vp run db:migrate`)
2. Start the emulator: `vp run e2e:emulator`
3. Copy `.env.e2e.example` to `.env.e2e` and serve the app with those vars
4. `vp run e2e:install` once
5. `vp run test:e2e`

These new flows do not need a live Autumn key. Existing `projects.e2e.ts` still creates a project through the UI and can 503 without billing.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a097c5-ab15-73bf-94db-19e32c6518d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a097c5-ab15-73bf-94db-19e32c6518d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

