### PR TITLE
fix(files): force-translate untranslated strings past stale TM

### DIFF
--- a/apps/hyperlocalise-web/lang/de-DE.json
+++ b/apps/hyperlocalise-web/lang/de-DE.json
@@ -8408,6 +8408,9 @@
   "JemgHUamHh": {
     "defaultMessage": "Begriffe konnten nicht geladen werden"
   },
+  "Jf8jVutxI7": {
+    "defaultMessage": "Force translate untranslated strings"
+  },
   "JfG/xfnGBv": {
     "defaultMessage": "Oder folgen Sie {link}, um einen Agenten bei AuthKit zu registrieren."
   },
@@ -16364,6 +16367,9 @@
   "ejzfGTXY46": {
     "defaultMessage": "Automatisierung aktiviert"
   },
+  "ekPpWZOtVl": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
+  },
   "ekU8Q0suHQ": {
     "defaultMessage": "Benutzerdefinierte Header"
   },
@@ -16651,12 +16657,6 @@
   },
   "fT5jl51yo3": {
     "defaultMessage": "{percent}%"
-  },
-  "fTmUntr8k1": {
-    "defaultMessage": "Force translate untranslated strings"
-  },
-  "fTmUntr8k2": {
-    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
   },
   "fU9GF3etrw": {
     "defaultMessage": "Audit blockiert"

--- a/apps/hyperlocalise-web/lang/de-DE.json
+++ b/apps/hyperlocalise-web/lang/de-DE.json
@@ -16652,6 +16652,12 @@
   "fT5jl51yo3": {
     "defaultMessage": "{percent}%"
   },
+  "fTmUntr8k1": {
+    "defaultMessage": "Force translate untranslated strings"
+  },
+  "fTmUntr8k2": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
+  },
   "fU9GF3etrw": {
     "defaultMessage": "Audit blockiert"
   },

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -9759,6 +9759,10 @@
     "defaultMessage": "Unable to load terms",
     "description": "Fallback error when glossary terms fail to load"
   },
+  "Jf8jVutxI7": {
+    "defaultMessage": "Force translate untranslated strings",
+    "description": "Checkbox to ignore translation memory and send untranslated strings to the agent"
+  },
   "JfG/xfnGBv": {
     "defaultMessage": "Or follow {link} to register an agent with AuthKit.",
     "description": "Overview card link to the WorkOS agent registration skill document"
@@ -19035,6 +19039,10 @@
     "defaultMessage": "Automation Enabled",
     "description": "Activity log event type label for enabling automations"
   },
+  "ekPpWZOtVl": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay.",
+    "description": "Explains the force-translate untranslated strings option"
+  },
   "ekU8Q0suHQ": {
     "defaultMessage": "Custom headers",
     "description": "MCP auth kind option: headers"
@@ -19354,14 +19362,6 @@
   "fT5jl51yo3": {
     "defaultMessage": "{percent}%",
     "description": "Percentage of tests passed in the test results summary"
-  },
-  "fTmUntr8k1": {
-    "defaultMessage": "Force translate untranslated strings",
-    "description": "Checkbox to ignore translation memory and send untranslated strings to the agent"
-  },
-  "fTmUntr8k2": {
-    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay.",
-    "description": "Explains the force-translate untranslated strings option"
   },
   "fU9GF3etrw": {
     "defaultMessage": "Audit blocked",

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -19355,6 +19355,14 @@
     "defaultMessage": "{percent}%",
     "description": "Percentage of tests passed in the test results summary"
   },
+  "fTmUntr8k1": {
+    "defaultMessage": "Force translate untranslated strings",
+    "description": "Checkbox to ignore translation memory and send untranslated strings to the agent"
+  },
+  "fTmUntr8k2": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay.",
+    "description": "Explains the force-translate untranslated strings option"
+  },
   "fU9GF3etrw": {
     "defaultMessage": "Audit blocked",
     "description": "Title when a domain blocks the public localisation audit crawler"

--- a/apps/hyperlocalise-web/lang/fr-FR.json
+++ b/apps/hyperlocalise-web/lang/fr-FR.json
@@ -16652,6 +16652,12 @@
   "fT5jl51yo3": {
     "defaultMessage": "{percent} %"
   },
+  "fTmUntr8k1": {
+    "defaultMessage": "Force translate untranslated strings"
+  },
+  "fTmUntr8k2": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
+  },
   "fU9GF3etrw": {
     "defaultMessage": "Audit bloqué"
   },

--- a/apps/hyperlocalise-web/lang/fr-FR.json
+++ b/apps/hyperlocalise-web/lang/fr-FR.json
@@ -8408,6 +8408,9 @@
   "JemgHUamHh": {
     "defaultMessage": "Impossible de charger les termes"
   },
+  "Jf8jVutxI7": {
+    "defaultMessage": "Force translate untranslated strings"
+  },
   "JfG/xfnGBv": {
     "defaultMessage": "Ou suivez {link} pour enregistrer un agent avec AuthKit."
   },
@@ -16364,6 +16367,9 @@
   "ejzfGTXY46": {
     "defaultMessage": "Automatisation activée"
   },
+  "ekPpWZOtVl": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
+  },
   "ekU8Q0suHQ": {
     "defaultMessage": "En-têtes personnalisés"
   },
@@ -16651,12 +16657,6 @@
   },
   "fT5jl51yo3": {
     "defaultMessage": "{percent} %"
-  },
-  "fTmUntr8k1": {
-    "defaultMessage": "Force translate untranslated strings"
-  },
-  "fTmUntr8k2": {
-    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
   },
   "fU9GF3etrw": {
     "defaultMessage": "Audit bloqué"

--- a/apps/hyperlocalise-web/lang/vi-VN.json
+++ b/apps/hyperlocalise-web/lang/vi-VN.json
@@ -16652,6 +16652,12 @@
   "fT5jl51yo3": {
     "defaultMessage": "{percent}%"
   },
+  "fTmUntr8k1": {
+    "defaultMessage": "Force translate untranslated strings"
+  },
+  "fTmUntr8k2": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
+  },
   "fU9GF3etrw": {
     "defaultMessage": "Kiểm tra bị chặn"
   },

--- a/apps/hyperlocalise-web/lang/vi-VN.json
+++ b/apps/hyperlocalise-web/lang/vi-VN.json
@@ -8408,6 +8408,9 @@
   "JemgHUamHh": {
     "defaultMessage": "Không thể tải các thuật ngữ"
   },
+  "Jf8jVutxI7": {
+    "defaultMessage": "Force translate untranslated strings"
+  },
   "JfG/xfnGBv": {
     "defaultMessage": "Hoặc truy cập {link} để đăng ký một agent với AuthKit."
   },
@@ -16364,6 +16367,9 @@
   "ejzfGTXY46": {
     "defaultMessage": "Đã bật tự động hóa"
   },
+  "ekPpWZOtVl": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
+  },
   "ekU8Q0suHQ": {
     "defaultMessage": "Tiêu đề tùy chỉnh"
   },
@@ -16651,12 +16657,6 @@
   },
   "fT5jl51yo3": {
     "defaultMessage": "{percent}%"
-  },
-  "fTmUntr8k1": {
-    "defaultMessage": "Force translate untranslated strings"
-  },
-  "fTmUntr8k2": {
-    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
   },
   "fU9GF3etrw": {
     "defaultMessage": "Kiểm tra bị chặn"

--- a/apps/hyperlocalise-web/lang/zh-CN.json
+++ b/apps/hyperlocalise-web/lang/zh-CN.json
@@ -16652,6 +16652,12 @@
   "fT5jl51yo3": {
     "defaultMessage": "{percent}%"
   },
+  "fTmUntr8k1": {
+    "defaultMessage": "Force translate untranslated strings"
+  },
+  "fTmUntr8k2": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
+  },
   "fU9GF3etrw": {
     "defaultMessage": "审计已被阻止"
   },

--- a/apps/hyperlocalise-web/lang/zh-CN.json
+++ b/apps/hyperlocalise-web/lang/zh-CN.json
@@ -8408,6 +8408,9 @@
   "JemgHUamHh": {
     "defaultMessage": "无法加载术语"
   },
+  "Jf8jVutxI7": {
+    "defaultMessage": "Force translate untranslated strings"
+  },
   "JfG/xfnGBv": {
     "defaultMessage": "或者按照 {link} 使用 AuthKit 注册代理。"
   },
@@ -16364,6 +16367,9 @@
   "ejzfGTXY46": {
     "defaultMessage": "自动化已启用"
   },
+  "ekPpWZOtVl": {
+    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
+  },
   "ekU8Q0suHQ": {
     "defaultMessage": "自定义标头"
   },
@@ -16651,12 +16657,6 @@
   },
   "fT5jl51yo3": {
     "defaultMessage": "{percent}%"
-  },
-  "fTmUntr8k1": {
-    "defaultMessage": "Force translate untranslated strings"
-  },
-  "fTmUntr8k2": {
-    "defaultMessage": "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay."
   },
   "fU9GF3etrw": {
     "defaultMessage": "审计已被阻止"

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -663,6 +663,51 @@ describe("project job create", () => {
     });
   });
 
+  it("stores ignoreTranslationMemory on native file create", async () => {
+    const { identity, organization, project } = await createFixture.createStoredProjectFixture();
+    const headers = await createFixture.authHeadersFor(identity);
+    const sourceFile = await insertStoredSourceFile({
+      organizationId: organization.id,
+      projectId: project.id,
+      filename: "messages.json",
+      contentType: "application/json",
+    });
+
+    const response = await createClient.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          type: "file",
+          fileInput: {
+            sourceFileId: sourceFile.id,
+            fileFormat: "json",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+            ignoreTranslationMemory: true,
+          },
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { job: { id: string } };
+    const [job] = await db
+      .select({ inputPayload: schema.jobs.inputPayload })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.id, body.job.id))
+      .limit(1);
+
+    expect(job?.inputPayload).toMatchObject({
+      ignoreTranslationMemory: true,
+    });
+  });
+
   it("stores description and proofread kind on native create", async () => {
     const { identity, organization, project } = await createFixture.createStoredProjectFixture();
     const headers = await createFixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.test.ts
@@ -77,6 +77,20 @@ describe("createJobBodySchema kind and description", () => {
     ).toBe(false);
   });
 
+  it("accepts ignoreTranslationMemory on file jobs", () => {
+    const parsed = createJobBodySchema.safeParse({
+      ...fileBase,
+      fileInput: {
+        ...fileBase.fileInput,
+        ignoreTranslationMemory: true,
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.type === "file") {
+      expect(parsed.data.fileInput.ignoreTranslationMemory).toBe(true);
+    }
+  });
+
   it("counts waiting_for_review as an open job status", () => {
     expect(openJobStatusValues).toContain("waiting_for_review");
   });

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -55,6 +55,8 @@ export const fileTranslationJobInputSchema = z.object({
   sourceLocale: z.string().trim().min(1).max(32),
   targetLocales: z.array(z.string().trim().min(1).max(32)).min(1).max(maxTranslationTargetLocales),
   metadata: metadataSchema,
+  /** Skip TM reuse so the agent translates untranslated strings. */
+  ignoreTranslationMemory: z.boolean().optional(),
 });
 
 const createJobSharedFields = {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.messages.ts
@@ -65,6 +65,17 @@ export const createTranslationJobDialogMessages = defineMessages({
     id: "8kFDR1/eiv",
     description: "Validation error when creating a translation job without target locales",
   },
+  forceUntranslated: {
+    defaultMessage: "Force translate untranslated strings",
+    id: "fTmUntr8k1",
+    description: "Checkbox to ignore translation memory and send untranslated strings to the agent",
+  },
+  forceUntranslatedDescription: {
+    defaultMessage:
+      "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay.",
+    id: "fTmUntr8k2",
+    description: "Explains the force-translate untranslated strings option",
+  },
   createFailed: {
     defaultMessage: "Failed to create translation job",
     id: "c5EgJTB1mI",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.messages.ts
@@ -67,13 +67,13 @@ export const createTranslationJobDialogMessages = defineMessages({
   },
   forceUntranslated: {
     defaultMessage: "Force translate untranslated strings",
-    id: "fTmUntr8k1",
+    id: "Jf8jVutxI7",
     description: "Checkbox to ignore translation memory and send untranslated strings to the agent",
   },
   forceUntranslatedDescription: {
     defaultMessage:
       "Skip translation memory matches. The agent translates empty and rejected strings. Existing translations stay.",
-    id: "fTmUntr8k2",
+    id: "ekPpWZOtVl",
     description: "Explains the force-translate untranslated strings option",
   },
   createFailed: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.test.tsx
@@ -84,7 +84,9 @@ describe("CreateTranslationJobDialog", () => {
 
     renderDialog();
 
-    expect(screen.getByRole("checkbox", { name: /Force translate untranslated strings/i })).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: /Force translate untranslated strings/i }),
+    ).toBeChecked();
 
     await userEvent.click(screen.getByRole("button", { name: "Translate with agent" }));
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { createProjectFileRecord } from "./project-files.fixture";
+import { CreateTranslationJobDialog } from "./create-translation-job-dialog";
+
+const apiMocks = vi.hoisted(() => ({
+  jobsPost: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client-instance", () => ({
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          projects: {
+            ":projectId": {
+              jobs: { $post: apiMocks.jobsPost },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: apiMocks.toastSuccess,
+    error: apiMocks.toastError,
+  },
+}));
+
+function renderDialog() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={{}}>
+        <CreateTranslationJobDialog
+          open
+          onOpenChange={() => undefined}
+          organizationSlug="acme"
+          projectId="project_1"
+          file={createProjectFileRecord()}
+          sourceLocale="en-US"
+          targetLocales={["fr-FR", "de-DE"]}
+        />
+      </IntlProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CreateTranslationJobDialog", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends ignoreTranslationMemory by default so untranslated strings are forced", async () => {
+    apiMocks.jobsPost.mockResolvedValue(
+      new Response(JSON.stringify({ job: { id: "job_1" } }), { status: 200 }),
+    );
+
+    renderDialog();
+
+    expect(screen.getByRole("checkbox", { name: /Force translate untranslated strings/i })).toBeChecked();
+
+    await userEvent.click(screen.getByRole("button", { name: "Translate with agent" }));
+
+    expect(apiMocks.jobsPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: {
+          type: "file",
+          fileInput: expect.objectContaining({
+            ignoreTranslationMemory: true,
+            targetLocales: ["fr-FR", "de-DE"],
+          }),
+        },
+      }),
+    );
+  });
+
+  it("can keep translation memory reuse when the force option is turned off", async () => {
+    apiMocks.jobsPost.mockResolvedValue(
+      new Response(JSON.stringify({ job: { id: "job_1" } }), { status: 200 }),
+    );
+
+    renderDialog();
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: /Force translate untranslated strings/i }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Translate with agent" }));
+
+    expect(apiMocks.jobsPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: {
+          type: "file",
+          fileInput: expect.objectContaining({
+            ignoreTranslationMemory: false,
+          }),
+        },
+      }),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.tsx
@@ -58,10 +58,12 @@ export function CreateTranslationJobDialog({
   const intl = useIntl();
   const queryClient = useQueryClient();
   const [selectedLocales, setSelectedLocales] = useState<string[]>(targetLocales);
+  const [ignoreTranslationMemory, setIgnoreTranslationMemory] = useState(true);
 
   useEffect(() => {
     if (open) {
       setSelectedLocales(targetLocales);
+      setIgnoreTranslationMemory(true);
     }
   }, [open, targetLocales]);
 
@@ -91,6 +93,7 @@ export function CreateTranslationJobDialog({
             fileFormat,
             sourceLocale,
             targetLocales: selectedLocales,
+            ignoreTranslationMemory,
           },
         },
       });
@@ -178,6 +181,22 @@ export function CreateTranslationJobDialog({
                 </label>
               ))}
             </div>
+            <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border px-3 py-2 text-sm">
+              <input
+                type="checkbox"
+                className="mt-0.5 size-4 rounded border border-input accent-primary"
+                checked={ignoreTranslationMemory}
+                onChange={() => setIgnoreTranslationMemory((current) => !current)}
+              />
+              <span className="space-y-1">
+                <span className="block font-medium text-foreground">
+                  <FormattedMessage {...messages.forceUntranslated} />
+                </span>
+                <span className="block text-muted-foreground">
+                  <FormattedMessage {...messages.forceUntranslatedDescription} />
+                </span>
+              </span>
+            </label>
           </div>
         )}
 

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
@@ -279,6 +279,35 @@ describe("enqueueFileTranslationJob", () => {
     }
   });
 
+  it("stores ignoreTranslationMemory on the job payload when requested", async () => {
+    getStoredFileForJobScopeMock.mockResolvedValue({
+      id: "file_json",
+      filename: "messages.json",
+    });
+
+    const result = await createFileTranslationJob({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourceFileId: "file_json",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      fileFormat: "json",
+      ignoreTranslationMemory: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      jobId: "job_test",
+      projectId: "project_1",
+      sourceFileVersionId: "version_1",
+    });
+    expect(capturedJobValues?.inputPayload).toEqual(
+      expect.objectContaining({
+        ignoreTranslationMemory: true,
+      }),
+    );
+  });
+
   it("keeps a caller-supplied metadata title", async () => {
     getStoredFileForJobScopeMock.mockResolvedValue({
       id: "file_json",

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
@@ -52,6 +52,7 @@ export type CreateFileTranslationJobInput = {
   targetLocales: string[];
   fileFormat?: SupportedTranslationFileFormat;
   metadata?: Record<string, string>;
+  ignoreTranslationMemory?: boolean;
 };
 
 export type CreateFileTranslationJobResult =
@@ -284,6 +285,7 @@ export async function createFileTranslationJob(
     sourceLocale: input.sourceLocale,
     targetLocales: input.targetLocales,
     metadata: mergeNativeFileTranslationJobMetadata(sourceFile.filename, input.metadata),
+    ...(input.ignoreTranslationMemory ? { ignoreTranslationMemory: true } : {}),
   };
 
   const jobId = `job_${randomUUID()}`;

--- a/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts
@@ -13,9 +13,39 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  isSameAsSourceMemoryPrefill,
   mergeTranslationPrefills,
   shouldRetrySameAsSourcePrefill,
 } from "./should-retry-same-as-source-prefill";
+
+describe("isSameAsSourceMemoryPrefill", () => {
+  it("skips multi-word source copies left in translation memory", () => {
+    expect(
+      isSameAsSourceMemoryPrefill({
+        sourceText: "Enable workspace knowledge",
+        targetText: "Enable workspace knowledge",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps single-word copies that are often intentional", () => {
+    expect(
+      isSameAsSourceMemoryPrefill({
+        sourceText: "Hyperlocalise",
+        targetText: "Hyperlocalise",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps real translations", () => {
+    expect(
+      isSameAsSourceMemoryPrefill({
+        sourceText: "Enable workspace knowledge",
+        targetText: "Activer les connaissances",
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("shouldRetrySameAsSourcePrefill", () => {
   it("retries needs-review copies of multi-word source text", () => {

--- a/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.ts
@@ -23,6 +23,24 @@ function countSourceWords(sourceText: string): number {
 }
 
 /**
+ * Multi-word source copies are not useful translations. Failed file jobs often
+ * persist the source text into TM as an "approved" match, which then skips AI.
+ * Single-word copies often stay untranslated on purpose (brands, codes).
+ */
+export function isSameAsSourceMemoryPrefill(input: {
+  sourceText: string;
+  targetText: string;
+}): boolean {
+  const sourceText = input.sourceText.trim();
+  const targetText = input.targetText.trim();
+  if (!sourceText || sourceText !== targetText) {
+    return false;
+  }
+
+  return countSourceWords(sourceText) >= MIN_SOURCE_WORDS_FOR_SAME_AS_SOURCE_RETRY;
+}
+
+/**
  * Prefill skips these rows so translate-with-agent can try again.
  * Single-word copies often stay untranslated on purpose (brands, codes).
  */
@@ -35,13 +53,7 @@ export function shouldRetrySameAsSourcePrefill(input: {
     return false;
   }
 
-  const sourceText = input.sourceText.trim();
-  const targetText = input.targetText.trim();
-  if (!sourceText || sourceText !== targetText) {
-    return false;
-  }
-
-  return countSourceWords(sourceText) >= MIN_SOURCE_WORDS_FOR_SAME_AS_SOURCE_RETRY;
+  return isSameAsSourceMemoryPrefill(input);
 }
 
 /** Project translations win; TM fills untranslated keys when a reusable match exists. */

--- a/apps/hyperlocalise-web/src/lib/translation/file-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-memory.ts
@@ -29,6 +29,7 @@ import {
   toAgentRunTranslationMemoryMatchUsage,
 } from "@/lib/providers/contracts/translation-memory-match";
 import { listHiddenProjectTranslationKeysForSourcePath } from "@/lib/projects/translations/project-translation-service";
+import { isSameAsSourceMemoryPrefill } from "@/lib/projects/translations/should-retry-same-as-source-prefill";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
 export type FileTranslationMemoryReuseResult = {
@@ -160,6 +161,14 @@ export class FileTranslationMemoryStore {
       for (const memoryId of memoryIds) {
         const row = reusableByUnit.get([memoryId, unit.sourceText, input.targetLocale].join("\0"));
         if (!row) {
+          continue;
+        }
+        if (
+          isSameAsSourceMemoryPrefill({
+            sourceText: unit.sourceText,
+            targetText: row.targetText,
+          })
+        ) {
           continue;
         }
 

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
@@ -463,4 +463,62 @@ describe("reuseFileTranslationMemoryEntries", () => {
       }),
     ]);
   });
+
+  it("does not reuse multi-word source copies from translation memory", async () => {
+    whereMock.mockResolvedValueOnce([
+      {
+        id: "entry_1",
+        memoryId: "memory_1",
+        sourceText: "Enable workspace knowledge",
+        sourceLocale: "en",
+        provenance: "file_job",
+        matchScore: 100,
+        externalKey: "job:fr:workspace",
+        memoryName: "Project TM",
+        externalProviderKind: null,
+        externalMemoryId: null,
+        metadata: {
+          segmentKey: "workspace",
+          sourceTextHash: createHash("sha256")
+            .update("Enable workspace knowledge", "utf8")
+            .digest("hex"),
+        },
+        normalizedSourceText: "enable workspace knowledge",
+        targetLocale: "fr",
+        targetText: "Enable workspace knowledge",
+      },
+      {
+        id: "entry_2",
+        memoryId: "memory_1",
+        sourceText: "Hyperlocalise",
+        sourceLocale: "en",
+        provenance: "file_job",
+        matchScore: 100,
+        externalKey: "job:fr:brand",
+        memoryName: "Project TM",
+        externalProviderKind: null,
+        externalMemoryId: null,
+        metadata: {
+          segmentKey: "brand",
+          sourceTextHash: createHash("sha256").update("Hyperlocalise", "utf8").digest("hex"),
+        },
+        normalizedSourceText: "hyperlocalise",
+        targetLocale: "fr",
+        targetText: "Hyperlocalise",
+      },
+    ]);
+
+    const result = await reuseFileTranslationMemoryEntries({
+      projectId: "project_1",
+      sourceEntries: {
+        workspace: "Enable workspace knowledge",
+        brand: "Hyperlocalise",
+      },
+      sourceLocale: "en",
+      targetLocale: "fr",
+    });
+
+    expect(result.prefilled).toEqual({ brand: "Hyperlocalise" });
+    expect(result.matchesByKey.workspace).toBeUndefined();
+  });
 });

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -630,6 +630,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           sourceLocale: string;
           targetLocales: string[];
           metadata?: Record<string, string>;
+          ignoreTranslationMemory?: boolean;
         })
       : null;
 
@@ -901,24 +902,33 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
                   sourceEntries,
                 });
               }
-              const tmReuse = await reuseFileTranslationMemoryEntriesStep({
-                projectId: claim.job.projectId,
-                sourceLocale: parsedInput.sourceLocale,
-                targetLocale,
-                sourceEntries,
-              });
-              tmPrefilled = tmReuse.prefilled;
-              if (Object.keys(tmPrefilled).length > 0) {
-                console.info(
-                  "[file-translation-workflow] matched reusable translation memory entries",
-                  {
-                    jobId: claim.job.id,
-                    projectId: claim.job.projectId,
-                    targetLocale,
-                    reusedEntryCount: Object.keys(tmPrefilled).length,
-                    sourceEntryCount: Object.keys(sourceEntries).length,
-                  },
-                );
+              if (!parsedInput.ignoreTranslationMemory) {
+                const tmReuse = await reuseFileTranslationMemoryEntriesStep({
+                  projectId: claim.job.projectId,
+                  sourceLocale: parsedInput.sourceLocale,
+                  targetLocale,
+                  sourceEntries,
+                });
+                tmPrefilled = tmReuse.prefilled;
+                if (Object.keys(tmPrefilled).length > 0) {
+                  console.info(
+                    "[file-translation-workflow] matched reusable translation memory entries",
+                    {
+                      jobId: claim.job.id,
+                      projectId: claim.job.projectId,
+                      targetLocale,
+                      reusedEntryCount: Object.keys(tmPrefilled).length,
+                      sourceEntryCount: Object.keys(sourceEntries).length,
+                    },
+                  );
+                }
+              } else {
+                console.info("[file-translation-workflow] skipping translation memory reuse", {
+                  jobId: claim.job.id,
+                  projectId: claim.job.projectId,
+                  targetLocale,
+                  sourceEntryCount: Object.keys(sourceEntries).length,
+                });
               }
             }
 

--- a/apps/hyperlocalise-web/src/workflows/file-translation-progress.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-progress.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { collectCompletedTranslationPageEntries } from "./file-translation-progress";
+
+describe("collectCompletedTranslationPageEntries", () => {
+  it("keeps completed translations from the extracted output", () => {
+    expect(
+      collectCompletedTranslationPageEntries({
+        keys: ["greeting"],
+        extracted: { greeting: "Bonjour" },
+        prefills: {},
+      }),
+    ).toEqual({ greeting: "Bonjour" });
+  });
+
+  it("skips prefill-only keys that are missing from the output", () => {
+    expect(
+      collectCompletedTranslationPageEntries({
+        keys: ["greeting", "workspace"],
+        extracted: { greeting: "Bonjour" },
+        prefills: { workspace: "Enable workspace knowledge" },
+      }),
+    ).toEqual({ greeting: "Bonjour" });
+  });
+
+  it("throws when a lockfile-completed key is missing from the output", () => {
+    expect(() =>
+      collectCompletedTranslationPageEntries({
+        keys: ["greeting"],
+        extracted: {},
+        prefills: {},
+      }),
+    ).toThrow("completed translation is missing from output");
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/file-translation-progress.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-progress.ts
@@ -25,6 +25,28 @@ const lockSchema = z.object({
 
 /** Read the grouped completion format written by the pinned CLI. File contents alone
  * cannot identify completed keys: template-based outputs include source fallbacks. */
+export function collectCompletedTranslationPageEntries(input: {
+  keys: string[];
+  extracted: Record<string, string>;
+  prefills: Record<string, string>;
+}): Record<string, string> {
+  const collected: Record<string, string> = {};
+  for (const key of input.keys) {
+    const value = input.extracted[key];
+    if (value?.trim()) {
+      collected[key] = value;
+      continue;
+    }
+    // TM/project prefills are unioned into the key set even when hl run
+    // never wrote them. Missing prefill-only keys must not fail the page.
+    if (key in input.prefills) {
+      continue;
+    }
+    throw new Error("completed translation is missing from output");
+  }
+  return collected;
+}
+
 export function completedFileTranslationKeys(lock: unknown, outputFilename: string): string[] {
   const parsed = lockSchema.parse(lock);
   const entries = Object.entries(parsed.run_completed ?? {}).find(
@@ -62,14 +84,14 @@ export async function collectFileTranslationPageStep(input: {
       sourcePath: input.inputFilename,
     });
     if (!extracted.ok) throw new Error("failed to extract completed translations");
-    const entries = hlEntriesPayloadToStringMap(extracted.entries);
-    delta[locale] = Object.fromEntries(
-      keys.map((key) => {
-        const value = entries[key];
-        if (!value?.trim()) throw new Error("completed translation is missing from output");
-        return [key, value];
-      }),
-    );
+    const collected = collectCompletedTranslationPageEntries({
+      keys,
+      extracted: hlEntriesPayloadToStringMap(extracted.entries),
+      prefills: input.prefills[locale] ?? {},
+    });
+    if (Object.keys(collected).length > 0) {
+      delta[locale] = collected;
+    }
   }
   return delta;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Translate with Agent on a native file skipped AI whenever translation memory had an exact source match. After a failed file job, TM often stores the source text as an "approved" translation. The next run prefills those keys, the agent does nothing, and CAT still shows untranslated strings.

This change:

- Skips multi-word same-as-source TM matches automatically (brands and single-word codes still reuse).
- Adds **Force translate untranslated strings** to the Translate with Agent dialog. It is on by default. The agent ignores TM and translates empty or rejected strings. Existing project translations stay.
- Stops a missing TM/project prefill in the sandbox output from failing the whole job page.

Uncheck the option to keep 100% TM reuse.

## How to test

1. Open a native project file that still has untranslated strings after a failed translation job.
2. Click **Translate with Agent**.
3. Confirm **Force translate untranslated strings** is checked.
4. Submit and confirm the new job translates empty/rejected strings instead of completing with nothing to do.
5. Optional: uncheck the option on a file with good TM matches and confirm those matches are still reused.

Automated:

```
cd apps/hyperlocalise-web
vp test src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts src/lib/translation/file-translation-memory.test.ts src/workflows/file-translation-progress.test.ts src/api/routes/project/job.schema.test.ts src/lib/projects/jobs/enqueue-file-translation-job.test.ts src/api/routes/project/job.route.test.ts
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp test` on changed files, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0982c-bfc6-7f39-86b8-545ea546fc81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0982c-bfc6-7f39-86b8-545ea546fc81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

