### PR TITLE
feat(analytics): add activation and core-loop product events

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.route.ts
@@ -19,6 +19,8 @@ import { validator } from "hono/validator";
 import { isIntegrationsReadAllowed } from "@/api/auth/capability-guards";
 import { type AuthVariables, workosAuthMiddleware } from "@/api/auth/workos";
 import { forbiddenResponse } from "@/api/response.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database/client";
 import { assertProviderCredentialAdmin } from "@/lib/providers/credentials/organization-provider-credentials";
 
@@ -183,6 +185,7 @@ export function createAgentEmailRoutes() {
           return c.json({ error: "organization_not_found" as const }, 404);
         }
 
+        const wasEnabled = connectorWithAlias.enabled;
         const [connector] = await db
           .update(schema.connectors)
           .set({ enabled: true, updatedAt: new Date() })
@@ -196,6 +199,13 @@ export function createAgentEmailRoutes() {
 
         if (!connector) {
           return c.json({ error: "organization_not_found" as const }, 404);
+        }
+
+        if (!wasEnabled) {
+          serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected, {
+            status: "created",
+            source: "email",
+          });
         }
 
         const config = (connector.config ?? {}) as { inboundEmailAlias?: string };

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -317,6 +317,7 @@ export function createAgentSlackRoutes() {
             {
               organizationId,
               featureId: workspaceResourceFeatureIds.integrations,
+              analyticsSource: "slack",
             },
             upsertSlackConnector,
           );

--- a/apps/hyperlocalise-web/src/api/routes/ahrefs-connection/ahrefs-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/ahrefs-connection/ahrefs-connection.route.ts
@@ -26,6 +26,8 @@ import {
   forbiddenResponse,
   notFoundResponse,
 } from "@/api/response.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import {
   createAhrefsConnection,
   deleteAhrefsConnection,
@@ -131,6 +133,11 @@ export function createAhrefsConnectionRoutes() {
       if (isErr(result)) {
         return mapAhrefsConnectionError(c, result.error);
       }
+
+      serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected, {
+        status: "created",
+        source: "ahrefs",
+      });
 
       return c.json({ ahrefsConnection: result.value }, 201);
     })

--- a/apps/hyperlocalise-web/src/api/routes/canva-connection/canva-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/canva-connection/canva-connection.route.ts
@@ -16,6 +16,8 @@ import { validator } from "hono/validator";
 import { hasCapability } from "@/api/auth/policy";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { badRequestResponse, forbiddenResponse, notFoundResponse } from "@/api/response.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { completeCanvaConnectionClaim } from "@/lib/canva/connection-claims";
 import {
   createCanvaConnection,
@@ -140,6 +142,11 @@ export function createCanvaConnectionRoutes() {
           sourceLocale: payload.sourceLocale,
           targetLocales: payload.targetLocales,
           enabled: payload.enabled,
+        });
+
+        serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected, {
+          status: "created",
+          source: "canva",
         });
 
         return c.json(

--- a/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
@@ -213,6 +213,7 @@ export function createContentfulConnectionRoutes() {
           {
             organizationId,
             featureId: workspaceResourceFeatureIds.integrations,
+            analyticsSource: "contentful",
           },
           (tx) => createContentfulConnection({ ...connectionInput, db: tx }),
         );
@@ -289,6 +290,7 @@ export function createContentfulConnectionRoutes() {
           {
             organizationId,
             featureId: workspaceResourceFeatureIds.integrations,
+            analyticsSource: "contentful",
           },
           (tx) => updateContentfulConnection({ ...updateInput, db: tx }),
         );

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -20,6 +20,8 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
 import type { AppType } from "@/api/typed-app";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database/client";
 import type { FileStorageAdapter } from "@/lib/file-storage/types";
 import { getWebConversationRepositorySession } from "@/lib/agent-runtime/loops/conversation-repository-session";
@@ -168,6 +170,7 @@ describe("conversation creation", () => {
   });
 
   it("creates a chat UI conversation with the initial user message", async () => {
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
     const identity = createWorkosIdentity();
     const projectResponse = await createProjectViaApi(identity);
     const projectBody = (await projectResponse.json()) as { project: { id: string } };
@@ -195,6 +198,15 @@ describe("conversation creation", () => {
       text: "Translate this to fr-FR",
       senderType: "user",
     });
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.conversationCreated, {
+      status: "created",
+      source: "web",
+    });
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.conversationMessageSent, {
+      status: "sent",
+      source: "web",
+    });
+    trackSpy.mockRestore();
   });
 
   it("rejects chat streams when AI features are not allowed", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -146,6 +146,7 @@ async function withNewIntegrationLimit<T>(
     {
       organizationId: input.organizationId,
       featureId: workspaceResourceFeatureIds.integrations,
+      analyticsSource: input.providerKind,
     },
     run,
   );

--- a/apps/hyperlocalise-web/src/api/routes/intercom-connection/intercom-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/intercom-connection/intercom-connection.route.ts
@@ -20,6 +20,8 @@ import { validator } from "hono/validator";
 import { hasCapability } from "@/api/auth/policy";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { badRequestResponse, forbiddenResponse, notFoundResponse } from "@/api/response.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import {
   createIntercomConnection,
   deleteIntercomConnection,
@@ -123,6 +125,11 @@ export function createIntercomConnectionRoutes() {
       if (isErr(result)) {
         return mapIntercomConnectionError(c, result.error);
       }
+
+      serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected, {
+        status: "created",
+        source: "intercom",
+      });
 
       return c.json({ intercomConnection: result.value }, 201);
     })

--- a/apps/hyperlocalise-web/src/api/routes/mcp-server-connection/mcp-server-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp-server-connection/mcp-server-connection.route.ts
@@ -21,6 +21,8 @@ import {
   forbiddenResponse,
   notFoundResponse,
 } from "@/api/response.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import {
   createMcpServerConnection,
   deleteMcpServerConnection,
@@ -128,6 +130,11 @@ export function createMcpServerConnectionRoutes() {
       if (isErr(result)) {
         return mapMcpServerConnectionError(c, result.error);
       }
+
+      serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected, {
+        status: "created",
+        source: "mcp",
+      });
 
       return c.json({ mcpServerConnection: result.value }, 201);
     })

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -34,6 +34,8 @@ import {
   notFoundResponse,
   serviceUnavailableResponse,
 } from "@/api/response.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database/client";
 import {
   ensureRepositorySourceFileVersionForStoredFile,
@@ -1413,6 +1415,11 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         )
         .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
         .limit(1);
+
+      serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.jobRetried, {
+        feature: "translation",
+        source: "web",
+      });
 
       return c.json({ job: updatedJob }, 200);
     })

--- a/apps/hyperlocalise-web/src/api/routes/semrush-connection/semrush-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/semrush-connection/semrush-connection.route.ts
@@ -21,6 +21,8 @@ import {
   forbiddenResponse,
   notFoundResponse,
 } from "@/api/response.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import {
   createSemrushConnection,
   deleteSemrushConnection,
@@ -126,6 +128,11 @@ export function createSemrushConnectionRoutes() {
       if (isErr(result)) {
         return mapSemrushConnectionError(c, result.error);
       }
+
+      serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected, {
+        status: "created",
+        source: "semrush",
+      });
 
       return c.json({ semrushConnection: result.value }, 201);
     })

--- a/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.ts
@@ -161,6 +161,7 @@ export function createSlackOAuthRoutes() {
           {
             organizationId: org.id,
             featureId: workspaceResourceFeatureIds.integrations,
+            analyticsSource: "slack",
           },
           upsertSlackConnector,
         );

--- a/apps/hyperlocalise-web/src/api/routes/zernio-connection/zernio-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/zernio-connection/zernio-connection.route.ts
@@ -21,6 +21,8 @@ import {
   forbiddenResponse,
   notFoundResponse,
 } from "@/api/response.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import {
   createZernioConnection,
   deleteZernioConnection,
@@ -125,6 +127,11 @@ export function createZernioConnectionRoutes() {
       if (isErr(result)) {
         return mapZernioConnectionError(c, result.error);
       }
+
+      serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected, {
+        status: "created",
+        source: "zernio",
+      });
 
       return c.json({ zernioConnection: result.value }, 201);
     })

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
@@ -24,6 +24,9 @@ import { Row } from "@/components/ui/layout/row";
 import { Rows } from "@/components/ui/layout/rows";
 import { TypographyP } from "@/components/ui/typography";
 import { PlanUsageHashScroll } from "@/components/billing/plan-usage-hash-scroll";
+import { clientAnalytics } from "@/lib/analytics/client";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { apiClient } from "@/lib/api-client-instance";
 import {
   getActiveSubscription,
   availablePlansSectionId,
@@ -34,7 +37,6 @@ import {
 } from "@/lib/billing/plan-usage";
 import { autumnFeatureIds } from "@/lib/billing/autumn-ids";
 import { billingBalanceFeatureIds } from "@/lib/billing/usage-feature-labels";
-import { apiClient } from "@/lib/api-client-instance";
 
 import { billingSettingsContentMessages } from "./billing-settings-content.messages";
 import { SettingsPageBody, SettingsPageHeader } from "../../_components/settings-page-chrome";
@@ -310,7 +312,17 @@ function ConfiguredBillingSettingsPanel({
   }
 
   async function handleAttachPlan(planId: string) {
-    await runBillingAction(`attach-${planId}`, () => attach({ planId }));
+    clientAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.checkoutStarted, {
+      status: "started",
+      source: "billing",
+    });
+    await runBillingAction(`attach-${planId}`, async () => {
+      await attach({ planId });
+      clientAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.planAttached, {
+        status: "succeeded",
+        source: "billing",
+      });
+    });
   }
 
   async function handleCancelSubscription() {

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-auth-actions.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-auth-actions.test.tsx
@@ -13,8 +13,19 @@
 // @vitest-environment happy-dom
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vite-plus/test";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { IntlProvider } from "react-intl";
+
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+
+const { trackMarketingCtaClickMock } = vi.hoisted(() => ({
+  trackMarketingCtaClickMock: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/marketing-cta", () => ({
+  trackMarketingCtaClick: trackMarketingCtaClickMock,
+}));
 
 import { NavbarDesktopAuthActions } from "./navbar-auth-actions";
 
@@ -41,5 +52,17 @@ describe("NavbarDesktopAuthActions", () => {
     expect(screen.getByRole("button", { name: "Sign in" }).getAttribute("href")).toBe(
       "/auth/sign-in",
     );
+  });
+
+  it("tracks marketing CTA clicks for sign-in and request demo", async () => {
+    const user = userEvent.setup();
+    renderActions(false);
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await user.click(screen.getByRole("button", { name: "Request a Demo" }));
+
+    expect(trackMarketingCtaClickMock).toHaveBeenCalledWith("sign_in", "navbar");
+    expect(trackMarketingCtaClickMock).toHaveBeenCalledWith("request_demo", "navbar");
+    expect(PRODUCT_USAGE_ANALYTICS_EVENTS.marketingCtaClick).toBe("marketing_cta_click");
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-auth-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar-auth-actions.tsx
@@ -19,6 +19,7 @@ import Link from "next/link";
 import { FormattedMessage } from "react-intl";
 
 import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { trackMarketingCtaClick } from "@/lib/analytics/marketing-cta";
 import type { AppLocale } from "@/lib/app-i18n/locales";
 import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
 
@@ -65,12 +66,14 @@ export function NavbarDesktopAuthActions({
         variant="ghost"
         nativeButton={false}
         render={<Link href={signInHref} prefetch={false} />}
+        onClick={() => trackMarketingCtaClick("sign_in", "navbar")}
       >
         <FormattedMessage {...navbarMessages.signIn} />
       </Button>
       <Button
         nativeButton={false}
         render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+        onClick={() => trackMarketingCtaClick("request_demo", "navbar")}
       >
         <FormattedMessage {...navbarMessages.joinWaitlist} />
       </Button>
@@ -106,6 +109,7 @@ export function NavbarMobileAuthCta({
       className="px-3.5"
       nativeButton={false}
       render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+      onClick={() => trackMarketingCtaClick("request_demo", "navbar")}
     >
       <FormattedMessage {...navbarMessages.joinWaitlist} />
     </Button>
@@ -143,7 +147,11 @@ export function NavbarMobileAuthFooter({
 
   return (
     <>
-      <SheetClose render={<Link href={signInHref} prefetch={false} />} className="w-full">
+      <SheetClose
+        render={<Link href={signInHref} prefetch={false} />}
+        className="w-full"
+        onClick={() => trackMarketingCtaClick("sign_in", "navbar")}
+      >
         <Button variant="ghost" size="lg" className="w-full" nativeButton={false} render={<span />}>
           <FormattedMessage {...navbarMessages.signIn} />
         </Button>
@@ -151,6 +159,7 @@ export function NavbarMobileAuthFooter({
       <SheetClose
         render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
         className="w-full"
+        onClick={() => trackMarketingCtaClick("request_demo", "navbar")}
       >
         <Button size="lg" className="w-full" nativeButton={false} render={<span />}>
           <FormattedMessage {...navbarMessages.joinWaitlist} />

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-plans-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-plans-section.tsx
@@ -19,6 +19,7 @@ import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { TypographyH2, TypographyP } from "@/components/ui/typography";
+import { trackMarketingCtaClick } from "@/lib/analytics/marketing-cta";
 import { cn } from "@/lib/primitives/cn";
 
 import type { PricingPlan } from "./pricing-page-content";
@@ -36,6 +37,7 @@ function PlanCta({ plan }: { plan: PricingPlan }) {
         variant="outline"
         nativeButton={false}
         render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+        onClick={() => trackMarketingCtaClick("request_demo", "pricing")}
       >
         {plan.cta.label}
       </Button>

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-undecided-cta.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-undecided-cta.tsx
@@ -10,12 +10,15 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+"use client";
+
 import Link from "next/link";
 
 import { contactUrl } from "@/components/marketing/marketing-page-content";
 import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 import { Button } from "@/components/ui/button";
 import { TypographyH2 } from "@/components/ui/typography";
+import { trackMarketingCtaClick } from "@/lib/analytics/marketing-cta";
 import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { rewriteAppLocalePath } from "@/lib/app-i18n/rewrite-app-locale-path";
 
@@ -50,12 +53,14 @@ export function PricingUndecidedCta({
           variant="outline"
           nativeButton={false}
           render={<Link href={rewriteAppLocalePath(contactUrl, appLocale)} />}
+          onClick={() => trackMarketingCtaClick("contact", "pricing")}
         >
           {talkToSalesLabel}
         </Button>
         <Button
           nativeButton={false}
           render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+          onClick={() => trackMarketingCtaClick("request_demo", "pricing")}
         >
           {requestDemoLabel}
         </Button>

--- a/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.test.ts
@@ -27,6 +27,13 @@ vi.mock("./activity-log-writer", () => ({
   enqueueActivityLogEvent: vi.fn(),
 }));
 
+vi.mock("@/lib/analytics/server", () => ({
+  serverAnalytics: { track: vi.fn() },
+}));
+
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
+
 const enqueueMock = vi.mocked(enqueueActivityLogEvent);
 
 const actor = {
@@ -74,6 +81,10 @@ describe("file and segment activity helpers", () => {
     });
     expect(JSON.stringify(enqueueMock.mock.calls)).not.toContain("sourceText");
     expect(JSON.stringify(enqueueMock.mock.calls)).not.toContain("targetText");
+    expect(serverAnalytics.track).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.fileUploaded, {
+      status: "created",
+      source: "web",
+    });
   });
 
   it("records a translation import against the file", async () => {

--- a/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.test.ts
@@ -23,16 +23,19 @@ import {
   uploadActivityActor,
 } from "./file-segment-events";
 
+const { trackMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+}));
+
 vi.mock("./activity-log-writer", () => ({
   enqueueActivityLogEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/analytics/server", () => ({
-  serverAnalytics: { track: vi.fn() },
+  serverAnalytics: { track: trackMock },
 }));
 
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
-import { serverAnalytics } from "@/lib/analytics/server";
 
 const enqueueMock = vi.mocked(enqueueActivityLogEvent);
 
@@ -81,7 +84,7 @@ describe("file and segment activity helpers", () => {
     });
     expect(JSON.stringify(enqueueMock.mock.calls)).not.toContain("sourceText");
     expect(JSON.stringify(enqueueMock.mock.calls)).not.toContain("targetText");
-    expect(serverAnalytics.track).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.fileUploaded, {
+    expect(trackMock).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.fileUploaded, {
       status: "created",
       source: "web",
     });

--- a/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/file-segment-events.ts
@@ -12,6 +12,11 @@
  */
 import "server-only";
 
+import {
+  PRODUCT_USAGE_ANALYTICS_EVENTS,
+  productUsageSourceForActorKind,
+} from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { normalizeSourcePath } from "@/lib/file-storage/records";
 
 import type { ActivityActorKind } from "./activity-log-contract";
@@ -87,6 +92,10 @@ type FileActivityInput = ActivityActor & {
 };
 
 export async function enqueueFileUploadedActivity(input: FileActivityInput) {
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.fileUploaded, {
+    status: "created",
+    source: productUsageSourceForActorKind(input.actorKind),
+  });
   const payload = filePayload(input);
   return enqueueActivityLogEvent({
     ...activityActor(input),

--- a/apps/hyperlocalise-web/src/lib/activity-log/job-automation-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/job-automation-events.test.ts
@@ -20,6 +20,15 @@ vi.mock("./activity-log-writer", () => ({
   enqueueActivityLogEvent: enqueueActivityLogEventMock,
 }));
 
+const { trackMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/server", () => ({
+  serverAnalytics: { track: trackMock },
+}));
+
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import {
   enqueueAutomationRunStartedActivity,
   enqueueAutomationStatusActivity,
@@ -83,6 +92,14 @@ describe("job and automation activity events", () => {
       },
       targetId: "job_1",
       targetKind: "job",
+    });
+    expect(trackMock).toHaveBeenNthCalledWith(1, PRODUCT_USAGE_ANALYTICS_EVENTS.jobCreated, {
+      feature: "translation",
+      source: "web",
+    });
+    expect(trackMock).toHaveBeenNthCalledWith(2, PRODUCT_USAGE_ANALYTICS_EVENTS.jobCancelled, {
+      feature: "translation",
+      source: "web",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/activity-log/job-automation-events.ts
+++ b/apps/hyperlocalise-web/src/lib/activity-log/job-automation-events.ts
@@ -12,6 +12,13 @@
  */
 import "server-only";
 
+import {
+  PRODUCT_USAGE_ANALYTICS_EVENTS,
+  productUsageJobFeature,
+  productUsageSourceForActorKind,
+} from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
+
 import type { ActivityActorKind } from "./activity-log-contract";
 import { enqueueActivityLogEvent } from "./activity-log-writer";
 
@@ -54,6 +61,10 @@ export function stableJobFailureCode(value: unknown): string {
 }
 
 export async function enqueueJobCreatedActivity(input: JobActivityInput) {
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.jobCreated, {
+    feature: productUsageJobFeature(input.kind),
+    source: productUsageSourceForActorKind(input.actorKind),
+  });
   return enqueueActivityLogEvent({
     ...activityActor(input),
     eventType: "job_created",
@@ -67,6 +78,10 @@ export async function enqueueJobCreatedActivity(input: JobActivityInput) {
 export async function enqueueJobCancelledActivity(
   input: Omit<JobActivityInput, "status"> & { status: "cancelled" },
 ) {
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.jobCancelled, {
+    feature: productUsageJobFeature(input.kind),
+    source: productUsageSourceForActorKind(input.actorKind),
+  });
   return enqueueActivityLogEvent({
     ...activityActor(input),
     eventType: "job_cancelled",

--- a/apps/hyperlocalise-web/src/lib/agents/github/install-callback.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/install-callback.ts
@@ -355,6 +355,7 @@ export async function handleGitHubInstallCallback(
         {
           organizationId: org.id,
           featureId: workspaceResourceFeatureIds.integrations,
+          analyticsSource: "github",
         },
         async (tx) => {
           const [inserted] = await tx

--- a/apps/hyperlocalise-web/src/lib/analytics/events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/events.test.ts
@@ -17,7 +17,10 @@ import {
   LOCALISATION_AUDIT_ANALYTICS_EVENTS,
   PRODUCT_USAGE_ANALYTICS_EVENTS,
   productUsageEventForAutumnEventName,
+  productUsageJobFeature,
+  productUsageSourceForActorKind,
   productUsageSourceForAutumnEventName,
+  productUsageSourceForConversation,
   productUsageSourceForMeterSource,
   sanitizeAnalyticsProperties,
   scoreBand,
@@ -105,6 +108,23 @@ describe("analytics sanitization", () => {
     expect(productUsageSourceForMeterSource("translation_job_complete")).toBe("translation_job");
     expect(productUsageSourceForMeterSource("agent_runtime_complete")).toBe("agent_run");
     expect(productUsageSourceForMeterSource("seat_added")).toBe("other");
+  });
+
+  it("maps actor, conversation, and job kinds onto product usage properties", () => {
+    expect(productUsageSourceForActorKind("user")).toBe("web");
+    expect(productUsageSourceForActorKind("api_key")).toBe("api");
+    expect(productUsageSourceForActorKind("agent")).toBe("agent");
+    expect(productUsageSourceForActorKind("system")).toBe("system");
+    expect(productUsageSourceForConversation("chat_ui")).toBe("web");
+    expect(productUsageSourceForConversation("web_chat")).toBe("web_chat");
+    expect(productUsageSourceForConversation("email_agent")).toBe("email");
+    expect(productUsageSourceForConversation("github_agent")).toBe("github");
+    expect(productUsageSourceForConversation("slack_agent")).toBe("slack");
+    expect(productUsageSourceForConversation("unknown")).toBe("other");
+    expect(productUsageJobFeature("translation")).toBe("translation");
+    expect(productUsageJobFeature("proofread")).toBe("proofread");
+    expect(productUsageJobFeature("research")).toBe("research");
+    expect(productUsageJobFeature("mystery")).toBe("other");
   });
 
   it("fans out to every adapter and isolates provider failures", () => {

--- a/apps/hyperlocalise-web/src/lib/analytics/events.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/events.ts
@@ -37,6 +37,7 @@ export const PRODUCT_USAGE_ANALYTICS_EVENTS = {
   translationJobCreated: "translation_job_created",
   agentRunCompleted: "agent_run_completed",
   agentRunFailed: "agent_run_failed",
+  agentRunCancelled: "agent_run_cancelled",
   aiTokensConsumed: "ai_tokens_consumed",
   projectCreated: "project_created",
   automationCreated: "automation_created",
@@ -51,6 +52,16 @@ export const PRODUCT_USAGE_ANALYTICS_EVENTS = {
   glossaryCreated: "glossary_created",
   glossaryTermCreated: "glossary_term_created",
   memoryCreated: "memory_created",
+  workspaceCreated: "workspace_created",
+  checkoutStarted: "checkout_started",
+  planAttached: "plan_attached",
+  marketingCtaClick: "marketing_cta_click",
+  conversationCreated: "conversation_created",
+  conversationMessageSent: "conversation_message_sent",
+  fileUploaded: "file_uploaded",
+  jobCreated: "job_created",
+  jobCancelled: "job_cancelled",
+  jobRetried: "job_retried",
 } as const;
 
 export type ProductUsageAnalyticsEvent =
@@ -128,5 +139,35 @@ export function productUsageSourceForAutumnEventName(autumnEventName: string): s
 export function productUsageSourceForMeterSource(source: string): string {
   if (source.includes("translation")) return "translation_job";
   if (source.includes("agent")) return "agent_run";
+  return "other";
+}
+
+export function productUsageSourceForActorKind(actorKind: string): string {
+  if (actorKind === "api_key") return "api";
+  if (actorKind === "agent") return "agent";
+  if (actorKind === "system") return "system";
+  return "web";
+}
+
+export function productUsageSourceForConversation(source: string): string {
+  if (source === "chat_ui") return "web";
+  if (source === "web_chat") return "web_chat";
+  if (source === "email_agent") return "email";
+  if (source === "github_agent") return "github";
+  if (source === "slack_agent") return "slack";
+  return "other";
+}
+
+export function productUsageJobFeature(kind: string): string {
+  if (
+    kind === "translation" ||
+    kind === "proofread" ||
+    kind === "research" ||
+    kind === "review" ||
+    kind === "sync" ||
+    kind === "asset_management"
+  ) {
+    return kind;
+  }
   return "other";
 }

--- a/apps/hyperlocalise-web/src/lib/analytics/marketing-cta.test.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/marketing-cta.test.ts
@@ -29,9 +29,9 @@ describe("trackMarketingCtaClick", () => {
   it("emits the marketing CTA event with cta and source", () => {
     trackMarketingCtaClick("sign_in", "navbar");
 
-    expect(trackMock).toHaveBeenCalledWith(
-      PRODUCT_USAGE_ANALYTICS_EVENTS.marketingCtaClick,
-      { cta: "sign_in", source: "navbar" },
-    );
+    expect(trackMock).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.marketingCtaClick, {
+      cta: "sign_in",
+      source: "navbar",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/analytics/marketing-cta.test.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/marketing-cta.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const { trackMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+}));
+
+vi.mock("./client", () => ({
+  clientAnalytics: {
+    track: trackMock,
+  },
+}));
+
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "./events";
+import { trackMarketingCtaClick } from "./marketing-cta";
+
+describe("trackMarketingCtaClick", () => {
+  it("emits the marketing CTA event with cta and source", () => {
+    trackMarketingCtaClick("sign_in", "navbar");
+
+    expect(trackMock).toHaveBeenCalledWith(
+      PRODUCT_USAGE_ANALYTICS_EVENTS.marketingCtaClick,
+      { cta: "sign_in", source: "navbar" },
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/analytics/marketing-cta.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/marketing-cta.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+"use client";
+
+import { clientAnalytics } from "./client";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "./events";
+
+export function trackMarketingCtaClick(cta: string, source: string) {
+  clientAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.marketingCtaClick, { cta, source });
+}

--- a/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.test.ts
@@ -200,4 +200,25 @@ describe("workspace resource limits", () => {
       source: workspaceResourceFeatureIds.projects,
     });
   });
+
+  it("uses an explicit analytics source for integrations", async () => {
+    const { organization } = await createOrganization();
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+
+    const result = await withWorkspaceResourceLimit(
+      {
+        organizationId: organization.id,
+        featureId: workspaceResourceFeatureIds.integrations,
+        autumnApiKey: "",
+        analyticsSource: "github",
+      },
+      async () => ({ id: "integration-1" }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected, {
+      status: "created",
+      source: "github",
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.ts
@@ -13,13 +13,13 @@
 import { Autumn } from "autumn-js";
 import { and, count, eq, ne, sql } from "drizzle-orm";
 
-import { autumnFeatureIds } from "@/lib/billing/autumn-ids";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { getAutumnSecretKey } from "@/lib/billing/autumn-config";
+import { autumnFeatureIds } from "@/lib/billing/autumn-ids";
 import type { DatabaseClient, DatabaseTransaction } from "@/lib/database/client";
 import { db, schema } from "@/lib/database/client";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
-import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
-import { serverAnalytics } from "@/lib/analytics/server";
 
 export const workspaceResourceFeatureIds = {
   seats: autumnFeatureIds.seats,
@@ -307,6 +307,7 @@ export async function withWorkspaceResourceLimit<T>(
     additionalUsage?: number;
     autumnApiKey?: string;
     db?: DatabaseTransaction;
+    analyticsSource?: string;
   },
   fn: (tx: DatabaseTransaction) => Promise<T>,
 ): Promise<Result<T, WorkspaceResourceLimitError>> {
@@ -326,7 +327,7 @@ export async function withWorkspaceResourceLimit<T>(
     const eventName = WORKSPACE_RESOURCE_ANALYTICS_EVENTS[input.featureId];
     serverAnalytics.track(eventName, {
       status: "created",
-      source: input.featureId,
+      source: input.analyticsSource ?? input.featureId,
     });
     return ok(value);
   };

--- a/apps/hyperlocalise-web/src/lib/conversations/interactions.ts
+++ b/apps/hyperlocalise-web/src/lib/conversations/interactions.ts
@@ -13,6 +13,11 @@
 import { and, eq } from "drizzle-orm";
 import type { UIMessage } from "ai";
 
+import {
+  PRODUCT_USAGE_ANALYTICS_EVENTS,
+  productUsageSourceForConversation,
+} from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database/client";
 
 const sourceFileIdPattern = /\bsourceFileId=/;
@@ -27,8 +32,8 @@ type CreateInteractionInput = {
 
 export async function createInteraction(input: CreateInteractionInput) {
   const now = new Date();
-  return db.transaction(async (tx) => {
-    const [interaction] = await tx
+  const interaction = await db.transaction(async (tx) => {
+    const [created] = await tx
       .insert(schema.interactions)
       .values({
         organizationId: input.organizationId,
@@ -44,7 +49,7 @@ export async function createInteraction(input: CreateInteractionInput) {
 
     // Every interaction creates exactly one inbox item.
     await tx.insert(schema.inboxItems).values({
-      interactionId: interaction.id,
+      interactionId: created.id,
       organizationId: input.organizationId,
       projectId: input.projectId ?? null,
       status: "active",
@@ -52,8 +57,14 @@ export async function createInteraction(input: CreateInteractionInput) {
       updatedAt: now,
     });
 
-    return interaction;
+    return created;
   });
+
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.conversationCreated, {
+    status: "created",
+    source: productUsageSourceForConversation(input.source),
+  });
+  return interaction;
 }
 
 type AddMessageInput = {
@@ -80,15 +91,23 @@ export async function addInteractionMessage(input: AddMessageInput) {
     })
     .returning();
 
-  await db
+  const [interaction] = await db
     .update(schema.interactions)
     .set({ lastMessageAt: now, updatedAt: now })
-    .where(eq(schema.interactions.id, input.interactionId));
+    .where(eq(schema.interactions.id, input.interactionId))
+    .returning({ source: schema.interactions.source });
 
   await db
     .update(schema.inboxItems)
     .set({ updatedAt: now })
     .where(eq(schema.inboxItems.interactionId, input.interactionId));
+
+  if (input.senderType === "user" && interaction) {
+    serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.conversationMessageSent, {
+      status: "sent",
+      source: productUsageSourceForConversation(interaction.source),
+    });
+  }
 
   return message;
 }

--- a/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/memory/ensure-default-native-project-memory.ts
@@ -98,7 +98,7 @@ export async function ensureDefaultNativeProjectMemory(input: {
 
     serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.memoryCreated, {
       status: "created",
-      source: "project",
+      source: "bootstrap",
     });
 
     return [memory.id];

--- a/apps/hyperlocalise-web/src/lib/onboarding/workspace.test.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/workspace.test.ts
@@ -25,6 +25,15 @@ vi.mock("@/lib/workos/provision-workspace-in-workos", () => ({
   deleteProvisionedWorkosOrganization: deleteProvisionedWorkosOrganizationMock,
 }));
 
+const { trackMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/server", () => ({
+  serverAnalytics: { track: trackMock },
+}));
+
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { db, schema } from "@/lib/database/client";
 import { DEFAULT_WORKSPACE_TEAM_SLUG } from "@/lib/teams/default-workspace-team";
 
@@ -94,5 +103,9 @@ describe("createWorkspaceForSessionUser", () => {
       .limit(1);
 
     expect(membership?.role).toBe("manager");
+    expect(trackMock).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.workspaceCreated, {
+      status: "created",
+      source: "onboarding",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/onboarding/workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/workspace.ts
@@ -15,6 +15,8 @@ import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 
 import { syncWorkosUser } from "@/api/auth/workos-sync";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database/client";
 import { slugifyOrganizationName } from "@/lib/onboarding/slugify-organization-name";
 import { ensureDefaultWorkspaceTeamMembership } from "@/lib/teams/default-workspace-team";
@@ -121,6 +123,11 @@ export async function createWorkspaceForSessionUser(input: {
           userId: user.id,
           role: "manager",
           database: tx,
+        });
+
+        serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.workspaceCreated, {
+          status: "created",
+          source: "onboarding",
         });
 
         return {

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.test.ts
@@ -15,9 +15,9 @@ import "dotenv/config";
 import { eq } from "drizzle-orm";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { db, schema } from "@/lib/database/client";
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
+import { db, schema } from "@/lib/database/client";
 
 import { createProjectTestFixture } from "../../../api/routes/project/project.fixture";
 import {
@@ -273,6 +273,7 @@ describe("agent runs", () => {
 
   it("cancels a running run", async () => {
     const { project } = await createTestProject();
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
 
     const created = await createAgentRun({
       organizationId: project.organizationId,
@@ -293,6 +294,10 @@ describe("agent runs", () => {
 
     expect(cancelled.status).toBe("cancelled");
     expect(cancelled.completedAt).toBeTruthy();
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.agentRunCancelled, {
+      status: "cancelled",
+      source: "translate",
+    });
   });
 
   it("cancels a queued run", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.ts
@@ -12,14 +12,14 @@
  */
 import { and, desc, eq, inArray, sql, type SQL } from "drizzle-orm";
 
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import {
   completeAndTrackBillableUsage,
   formatUsageControlError,
   reserveUsageEvent,
   usageFeatureIds,
 } from "@/lib/billing/usage-control";
-import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
-import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database/client";
 import type { AgentRunKind, AgentRunStatus } from "@/lib/database/types";
 import { isErr } from "@/lib/primitives/result/results";
@@ -262,6 +262,10 @@ export async function cancelAgentRun(input: { runId: string; organizationId: str
     throw new Error("Agent run not found or not in cancellable state");
   }
 
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.agentRunCancelled, {
+    status: "cancelled",
+    source: run.kind,
+  });
   return run;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Implements the approved product-analytics catalog so we can see activation and the core loop, not just billable usage and the localisation-audit funnel.

New product events (still max 2 non-PII properties):

- Activation: `workspace_created`, `checkout_started`, `plan_attached`, `marketing_cta_click`
- Core loop: `conversation_created`, `conversation_message_sent`, `file_uploaded`, `job_created`, `job_cancelled`, `job_retried`
- Hygiene: `agent_run_cancelled`

Wiring notes:

- `job_created` / `job_cancelled` emit from the existing activity-log helpers, so every job kind (translation, proofread, research, review, sync, asset management) is counted. `translation_job_created` stays on billable reservation only.
- `integration_connected` now uses a provider `source` (`github`, `slack`, `contentful`, `crowdin` / `phrase` / `lokalise`, `canva`, and the remaining connect paths).
- Default translation-memory bootstrap uses `source: "bootstrap"` so it does not look like a user-created memory.
- Marketing navbar and pricing CTAs emit `marketing_cta_click` with `cta` + `source`.

## How to test

- `vp test` and `vp check --fix` in `apps/hyperlocalise-web` (both passed: 7099 tests, no lint/type errors)
- Targeted coverage: analytics helpers, job/file activity helpers, workspace create, agent cancel, conversation create, navbar CTA clicks, integration `analyticsSource`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09828-65df-7b2e-bdbb-3567731c5ce4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09828-65df-7b2e-bdbb-3567731c5ce4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

